### PR TITLE
docs: document command auth compatibility contracts

### DIFF
--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -24,6 +24,7 @@ export function createAccountListHelpers(
     hasImplicitDefaultAccount?: (cfg: OpenClawConfig) => boolean;
   },
 ) {
+  /** Check top-level credentials/env that imply the default account exists without accounts.default. */
   function hasImplicitDefaultAccount(cfg: OpenClawConfig): boolean {
     if (options?.hasImplicitDefaultAccount?.(cfg)) {
       return true;
@@ -42,6 +43,7 @@ export function createAccountListHelpers(
     return false;
   }
 
+  /** Resolve a configured defaultAccount only when it is allowed by the visible account list. */
   function resolveConfiguredDefaultAccountId(cfg: OpenClawConfig): string | undefined {
     const channel = cfg.channels?.[channelKey] as Record<string, unknown> | undefined;
     const preferred = normalizeOptionalAccountId(
@@ -60,6 +62,7 @@ export function createAccountListHelpers(
     return undefined;
   }
 
+  /** List account ids declared in channels.<id>.accounts, after optional plugin normalization. */
   function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
     const channel = cfg.channels?.[channelKey];
     const accounts = (channel as Record<string, unknown> | undefined)?.accounts;
@@ -74,6 +77,7 @@ export function createAccountListHelpers(
     return normalizeUniqueStringEntries(ids.map((id) => normalizeConfiguredAccountId(id)));
   }
 
+  /** Combine configured ids with implicit/default accounts so channel setup has a stable list. */
   function listAccountIds(cfg: OpenClawConfig): string[] {
     return listCombinedAccountIds({
       configuredAccountIds: listConfiguredAccountIds(cfg),
@@ -82,6 +86,7 @@ export function createAccountListHelpers(
     });
   }
 
+  /** Resolve the effective default account id from configured preference and account availability. */
   function resolveDefaultAccountId(cfg: OpenClawConfig): string {
     return resolveListedDefaultAccountId({
       accountIds: listAccountIds(cfg),
@@ -93,6 +98,7 @@ export function createAccountListHelpers(
   return { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId };
 }
 
+/** Treat non-empty strings and present non-string values as configured account fields. */
 export function hasConfiguredAccountValue(value: unknown): boolean {
   if (typeof value === "string") {
     return value.trim().length > 0;
@@ -100,6 +106,7 @@ export function hasConfiguredAccountValue(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
+/** Merge configured, additional, implicit, and fallback account ids into a sorted unique list. */
 export function listCombinedAccountIds(params: {
   configuredAccountIds: Iterable<string>;
   additionalAccountIds?: Iterable<string>;
@@ -128,6 +135,7 @@ export function listCombinedAccountIds(params: {
   return [...ids].toSorted((a, b) => a.localeCompare(b));
 }
 
+/** Pick the default account from a listed account set and optional configured preference. */
 export function resolveListedDefaultAccountId(params: {
   accountIds: readonly string[];
   configuredDefaultAccountId?: string | undefined;
@@ -153,6 +161,7 @@ export function resolveListedDefaultAccountId(params: {
   return params.accountIds[0] ?? DEFAULT_ACCOUNT_ID;
 }
 
+/** Merge top-level channel defaults with account-specific overrides. */
 export function mergeAccountConfig<TConfig extends Record<string, unknown>>(params: {
   channelConfig: TConfig | undefined;
   accountConfig: Partial<TConfig> | undefined;
@@ -180,6 +189,8 @@ export function mergeAccountConfig<TConfig extends Record<string, unknown>>(para
       accountValue != null &&
       !Array.isArray(accountValue)
     ) {
+      // Selected nested objects are merged so account overrides can replace one
+      // field without discarding sibling channel-level defaults.
       (merged as Record<string, unknown>)[key] = {
         ...(baseValue as Record<string, unknown>),
         ...(accountValue as Record<string, unknown>),
@@ -189,6 +200,7 @@ export function mergeAccountConfig<TConfig extends Record<string, unknown>>(para
   return merged;
 }
 
+/** Resolve an account entry by id, then merge it with top-level channel defaults. */
 export function resolveMergedAccountConfig<TConfig extends Record<string, unknown>>(params: {
   channelConfig: TConfig | undefined;
   accounts: Record<string, Partial<TConfig>> | undefined;
@@ -228,6 +240,7 @@ export function describeAccountSnapshot(params: {
   };
 }
 
+/** Describe webhook-style account state with a default mode for channel status surfaces. */
 export function describeWebhookAccountSnapshot(params: {
   account: AccountSnapshotInput;
   configured?: boolean | undefined;

--- a/src/channels/plugins/binding-targets.ts
+++ b/src/channels/plugins/binding-targets.ts
@@ -19,6 +19,8 @@ export async function ensureConfiguredBindingTargetReady(params: {
   const driverId = params.bindingResolution.statefulTarget.driverId;
   let driver = getStatefulBindingTargetDriver(driverId);
   if (!driver && isStatefulTargetBuiltinDriverId(driverId)) {
+    // Built-in drivers are registered lazily so callers that do not use
+    // configured bindings avoid loading their target runtime.
     await ensureStatefulTargetBuiltinsRegistered();
     driver = getStatefulBindingTargetDriver(driverId);
   }
@@ -34,6 +36,7 @@ export async function ensureConfiguredBindingTargetReady(params: {
   });
 }
 
+/** Reset an existing stateful binding target in place when its driver supports it. */
 export async function resetConfiguredBindingTargetInPlace(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -45,6 +48,8 @@ export async function resetConfiguredBindingTargetInPlace(params: {
     sessionKey: params.sessionKey,
   });
   if (!resolved) {
+    // Session-key reset can arrive before built-in drivers are loaded; retry
+    // once after registration before treating the target as unknown.
     await ensureStatefulTargetBuiltinsRegistered();
     resolved = resolveStatefulBindingTargetBySessionKey({
       cfg: params.cfg,
@@ -52,6 +57,8 @@ export async function resetConfiguredBindingTargetInPlace(params: {
     });
   }
   if (!resolved?.driver.resetInPlace) {
+    // Missing reset support is a non-error skip so command handlers can fall
+    // back to creating a fresh session when appropriate.
     return {
       ok: false,
       skipped: true,
@@ -63,6 +70,7 @@ export async function resetConfiguredBindingTargetInPlace(params: {
   });
 }
 
+/** Ensure the stateful target session exists for a resolved configured binding. */
 export async function ensureConfiguredBindingTargetSession(params: {
   cfg: OpenClawConfig;
   bindingResolution: ConfiguredBindingResolution;
@@ -70,6 +78,7 @@ export async function ensureConfiguredBindingTargetSession(params: {
   const driverId = params.bindingResolution.statefulTarget.driverId;
   let driver = getStatefulBindingTargetDriver(driverId);
   if (!driver && isStatefulTargetBuiltinDriverId(driverId)) {
+    // Keep readiness and session creation on the same lazy built-in driver path.
     await ensureStatefulTargetBuiltinsRegistered();
     driver = getStatefulBindingTargetDriver(driverId);
   }

--- a/src/channels/plugins/configured-binding-compiler.ts
+++ b/src/channels/plugins/configured-binding-compiler.ts
@@ -18,6 +18,7 @@ import type {
 // from runtime plugin-owned conversation bindings.
 
 export type CompiledConfiguredBindingRegistry = {
+  /** Compiled binding rules grouped by normalized channel id for cheap runtime lookup. */
   rulesByChannel: Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>;
 };
 
@@ -29,6 +30,7 @@ function resolveLoadedChannelPlugin(channel: string) {
   return getChannelPlugin(normalized as ConfiguredBindingChannel);
 }
 
+/** Resolve a loaded channel plugin that can compile and match configured bindings. */
 function resolveConfiguredBindingAdapter(channel: string): {
   channel: ConfiguredBindingChannel;
   provider: ChannelConfiguredBindingProvider;
@@ -53,12 +55,14 @@ function resolveConfiguredBindingAdapter(channel: string): {
   };
 }
 
+/** Extract the configured peer id used as the provider-facing binding conversation id. */
 function resolveBindingConversationId(binding: {
   match?: { peer?: { id?: string } };
 }): string | null {
   return normalizeOptionalString(binding.match?.peer?.id) ?? null;
 }
 
+/** Let the channel provider compile config into its canonical conversation reference. */
 function compileConfiguredBindingTarget(params: {
   provider: ChannelConfiguredBindingProvider;
   binding: CompiledConfiguredBinding["binding"];
@@ -70,6 +74,7 @@ function compileConfiguredBindingTarget(params: {
   });
 }
 
+/** Build the compiled rule only when a consumer can materialize a runtime target. */
 function compileConfiguredBindingRule(params: {
   cfg: OpenClawConfig;
   channel: ConfiguredBindingChannel;
@@ -106,6 +111,7 @@ function compileConfiguredBindingRule(params: {
   };
 }
 
+/** Preserve config order inside each channel bucket for deterministic tie handling. */
 function pushCompiledRule(
   target: Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>,
   rule: CompiledConfiguredBinding,
@@ -126,11 +132,14 @@ function compileConfiguredBindingRegistry(params: {
   for (const binding of listConfiguredBindings(params.cfg)) {
     const bindingConversationId = resolveBindingConversationId(binding);
     if (!bindingConversationId) {
+      // Bindings without a peer id cannot be matched from inbound conversation refs.
       continue;
     }
 
     const resolvedChannel = resolveConfiguredBindingAdapter(binding.match.channel);
     if (!resolvedChannel) {
+      // Avoid late plugin discovery here; only already loaded channel plugins
+      // participate in configured binding resolution.
       continue;
     }
 
@@ -162,18 +171,21 @@ function compileConfiguredBindingRegistry(params: {
   };
 }
 
+/** Compile the current configured binding registry from loaded channel plugins. */
 export function resolveCompiledBindingRegistry(
   cfg: OpenClawConfig,
 ): CompiledConfiguredBindingRegistry {
   return compileConfiguredBindingRegistry({ cfg });
 }
 
+/** Eagerly compile configured bindings so callers can measure registry size. */
 export function primeCompiledBindingRegistry(
   cfg: OpenClawConfig,
 ): CompiledConfiguredBindingRegistry {
   return compileConfiguredBindingRegistry({ cfg });
 }
 
+/** Count compiled binding rules and occupied channel buckets for diagnostics. */
 export function countCompiledBindingRegistry(registry: CompiledConfiguredBindingRegistry): {
   bindingCount: number;
   channelCount: number;

--- a/src/channels/plugins/configured-binding-match.ts
+++ b/src/channels/plugins/configured-binding-match.ts
@@ -17,6 +17,8 @@ import type {
 export function resolveAccountMatchPriority(match: string | undefined, actual: string): 0 | 1 | 2 {
   const trimmed = (match ?? "").trim();
   if (!trimmed) {
+    // Missing account pattern means the default account only; non-default
+    // conversations must opt in with an exact account id or wildcard.
     return actual === DEFAULT_ACCOUNT_ID ? 2 : 0;
   }
   if (trimmed === "*") {
@@ -25,6 +27,7 @@ export function resolveAccountMatchPriority(match: string | undefined, actual: s
   return normalizeAccountId(trimmed) === actual ? 2 : 0;
 }
 
+/** Delegate channel-specific conversation matching to the compiled binding provider. */
 function matchCompiledBindingConversation(params: {
   rule: CompiledConfiguredBinding;
   conversationId: string;
@@ -38,11 +41,13 @@ function matchCompiledBindingConversation(params: {
   });
 }
 
+/** Normalize configured binding channel ids, rejecting empty channel strings. */
 export function resolveCompiledBindingChannel(raw: string): ConfiguredBindingChannel | null {
   const normalized = normalizeOptionalLowercaseString(raw);
   return normalized ? (normalized as ConfiguredBindingChannel) : null;
 }
 
+/** Convert an outbound conversation ref into the normalized configured-binding match shape. */
 export function toConfiguredBindingConversationRef(conversation: ConversationRef): {
   channel: ConfiguredBindingChannel;
   accountId: string;
@@ -62,6 +67,7 @@ export function toConfiguredBindingConversationRef(conversation: ConversationRef
   };
 }
 
+/** Materialize the binding record after account and conversation matching has selected a rule. */
 export function materializeConfiguredBindingRecord(params: {
   rule: CompiledConfiguredBinding;
   accountId: string;
@@ -73,6 +79,7 @@ export function materializeConfiguredBindingRecord(params: {
   });
 }
 
+/** Resolve the best configured binding, preferring exact account matches over wildcard matches. */
 export function resolveMatchingConfiguredBinding(params: {
   rules: CompiledConfiguredBinding[];
   conversation: ReturnType<typeof toConfiguredBindingConversationRef>;
@@ -106,6 +113,8 @@ export function resolveMatchingConfiguredBinding(params: {
     }
     const matchPriority = match.matchPriority ?? 0;
     if (accountMatchPriority === 2) {
+      // Exact account bindings beat wildcard bindings even when both providers
+      // match the same conversation shape.
       if (!exactMatch || matchPriority > (exactMatch.match.matchPriority ?? 0)) {
         exactMatch = { rule, match };
       }

--- a/src/channels/plugins/configured-binding-registry.ts
+++ b/src/channels/plugins/configured-binding-registry.ts
@@ -20,6 +20,8 @@ function resolveMaterializedConfiguredBinding(params: {
   cfg: OpenClawConfig;
   conversation: ConversationRef;
 }) {
+  // Normalize once before registry lookup so every resolver path compares
+  // channel/account/conversation ids against the compiled binding shape.
   const conversation = toConfiguredBindingConversationRef(params.conversation);
   if (!conversation) {
     return null;
@@ -46,6 +48,7 @@ function resolveMaterializedConfiguredBinding(params: {
   };
 }
 
+/** Precompile configured bindings for loaded channel plugins and report registry size. */
 export function primeConfiguredBindingRegistry(params: { cfg: OpenClawConfig }): {
   bindingCount: number;
   channelCount: number;
@@ -53,6 +56,7 @@ export function primeConfiguredBindingRegistry(params: { cfg: OpenClawConfig }):
   return countCompiledBindingRegistry(primeCompiledBindingRegistry(params.cfg));
 }
 
+/** Resolve a configured binding record from raw channel/account/conversation id fields. */
 export function resolveConfiguredBindingRecord(params: {
   cfg: OpenClawConfig;
   channel: string;
@@ -75,6 +79,7 @@ export function resolveConfiguredBindingRecord(params: {
   });
 }
 
+/** Resolve a configured binding record from an already canonical conversation reference. */
 export function resolveConfiguredBindingRecordForConversation(params: {
   cfg: OpenClawConfig;
   conversation: ConversationRef;
@@ -86,6 +91,7 @@ export function resolveConfiguredBindingRecordForConversation(params: {
   return resolved.materializedTarget;
 }
 
+/** Resolve the configured binding plus compiled rule and match metadata for routing callers. */
 export function resolveConfiguredBinding(params: {
   cfg: OpenClawConfig;
   conversation: ConversationRef;
@@ -102,6 +108,7 @@ export function resolveConfiguredBinding(params: {
   };
 }
 
+/** Resolve a configured binding record by its materialized target session key. */
 export function resolveConfiguredBindingRecordBySessionKey(params: {
   cfg: OpenClawConfig;
   sessionKey: string;

--- a/src/channels/plugins/configured-binding-session-lookup.ts
+++ b/src/channels/plugins/configured-binding-session-lookup.ts
@@ -16,6 +16,8 @@ export function resolveConfiguredBindingRecordBySessionKeyFromRegistry(params: {
     return null;
   }
 
+  // Consumers own their session-key grammar; the registry only supplies the
+  // compiled binding rules that may materialize into that parsed target.
   for (const consumer of listConfiguredBindingConsumers()) {
     const parsed = consumer.parseSessionKey?.({ sessionKey });
     if (!parsed) {
@@ -56,6 +58,8 @@ export function resolveConfiguredBindingRecordBySessionKeyFromRegistry(params: {
         }) ?? materializedTarget.record.targetSessionKey === sessionKey;
       if (matchesSessionKey) {
         if (accountMatchPriority === 2) {
+          // Exact account matches can return immediately because wildcard rules
+          // are only fallback candidates for parsed non-default session keys.
           exactMatch = materializedTarget;
           break;
         }

--- a/src/channels/plugins/stateful-target-drivers.ts
+++ b/src/channels/plugins/stateful-target-drivers.ts
@@ -12,20 +12,25 @@ export type StatefulBindingTargetResetResult =
   | { ok: true }
   | { ok: false; skipped?: boolean; error?: string };
 
+/** Driver contract for creating, locating, and resetting stateful configured binding targets. */
 export type StatefulBindingTargetDriver = {
   id: string;
+  /** Validate prerequisites before a routed turn tries to use the target session. */
   ensureReady: (params: {
     cfg: OpenClawConfig;
     bindingResolution: ConfiguredBindingResolution;
   }) => Promise<StatefulBindingTargetReadyResult>;
+  /** Create or locate the backing session for a resolved configured binding. */
   ensureSession: (params: {
     cfg: OpenClawConfig;
     bindingResolution: ConfiguredBindingResolution;
   }) => Promise<StatefulBindingTargetSessionResult>;
+  /** Parse a session key back into this driver's target descriptor when possible. */
   resolveTargetBySessionKey?: (params: {
     cfg: OpenClawConfig;
     sessionKey: string;
   }) => StatefulBindingTargetDescriptor | null;
+  /** Reset an existing target without replacing its configured binding record. */
   resetInPlace?: (params: {
     cfg: OpenClawConfig;
     sessionKey: string;
@@ -49,6 +54,8 @@ export function registerStatefulBindingTargetDriver(driver: StatefulBindingTarge
   const normalized = { ...driver, id };
   const existing = registeredStatefulBindingTargetDrivers.get(id);
   if (existing) {
+    // Registration is idempotent so built-in lazy loading and test setup can
+    // call through the same path without replacing an active driver instance.
     return;
   }
   registeredStatefulBindingTargetDrivers.set(id, normalized);
@@ -74,6 +81,8 @@ export function resolveStatefulBindingTargetBySessionKey(params: {
   if (!sessionKey) {
     return null;
   }
+  // Drivers own session-key parsing. Probe registered drivers in registration
+  // order and return the first target that recognizes the key.
   for (const driver of listStatefulBindingTargetDrivers()) {
     const bindingTarget = driver.resolveTargetBySessionKey?.({
       cfg: params.cfg,

--- a/src/plugin-sdk/access-groups.ts
+++ b/src/plugin-sdk/access-groups.ts
@@ -11,11 +11,17 @@ export { ACCESS_GROUP_ALLOW_FROM_PREFIX, parseAccessGroupAllowFromEntry };
 
 /** Resolves membership for an access group using the full OpenClaw config. */
 export type AccessGroupMembershipResolver = (params: {
+  /** Canonical config for dynamic group membership lookups. */
   cfg: OpenClawConfig;
+  /** Access group name without the `accessGroup:` prefix. */
   name: string;
+  /** Selected group config from `cfg.accessGroups[name]`. */
   group: AccessGroupConfig;
+  /** Channel whose allowlist is being evaluated. */
   channel: ChannelId;
+  /** Account scope for channel-specific membership lookups. */
   accountId: string;
+  /** Sender id being tested against the group. */
   senderId: string;
 }) => boolean | Promise<boolean>;
 
@@ -30,11 +36,17 @@ export type AccessGroupMembershipLookup = (params: {
 
 /** Reports how access-group allowlist entries resolved for a channel sender. */
 export type ResolvedAccessGroupAllowFromState = {
+  /** Unique access group names referenced by the original allowlist. */
   referenced: string[];
+  /** Referenced groups that authorized the sender. */
   matched: string[];
+  /** Referenced groups absent from current config. */
   missing: string[];
+  /** Referenced groups needing dynamic membership when no resolver was supplied. */
   unsupported: string[];
+  /** Referenced groups whose dynamic membership resolver threw. */
   failed: string[];
+  /** Matched entries re-rendered as `accessGroup:<name>` allowlist values. */
   matchedAllowFromEntries: string[];
   hasReferences: boolean;
   hasMatch: boolean;
@@ -52,12 +64,19 @@ function resolveMessageSenderGroupEntries(params: {
 
 /** Resolves `accessGroup:<name>` allowlist entries without changing the original allowlist. */
 export async function resolveAccessGroupAllowFromState(params: {
+  /** Configured access groups keyed by name. Undefined makes all references missing. */
   accessGroups?: Record<string, AccessGroupConfig>;
+  /** Original allowlist entries, including optional `accessGroup:<name>` references. */
   allowFrom: Array<string | number> | null | undefined;
+  /** Channel id for static message.senders channel-specific entries. */
   channel: ChannelId;
+  /** Account scope passed to dynamic membership resolver. */
   accountId: string;
+  /** Sender id tested against static and dynamic group membership. */
   senderId: string;
+  /** Channel matcher used for static message.senders entries. */
   isSenderAllowed?: (senderId: string, allowFrom: string[]) => boolean;
+  /** Optional dynamic resolver for non-static group types. */
   resolveMembership?: AccessGroupMembershipLookup;
 }): Promise<ResolvedAccessGroupAllowFromState> {
   const names = Array.from(
@@ -98,6 +117,8 @@ export async function resolveAccessGroupAllowFromState(params: {
     }
 
     if (!params.resolveMembership) {
+      // `message.senders` can resolve locally. Other group types require a channel/plugin-owned
+      // resolver, so mark them unsupported instead of guessing membership.
       if (group.type !== "message.senders") {
         state.unsupported.push(name);
       }

--- a/src/plugin-sdk/account-core.ts
+++ b/src/plugin-sdk/account-core.ts
@@ -22,16 +22,23 @@ export { listConfiguredAccountIds } from "./account-configured-ids.js";
 
 /** Resolve an account by id, then fall back to the default account when the primary lacks credentials. */
 export function resolveAccountWithDefaultFallback<TAccount>(params: {
+  /** Requested account id; omitted means callers may prefer a credentialed default account. */
   accountId?: string | null;
+  /** Channel-owned normalization keeps account aliases consistent with that plugin's config shape. */
   normalizeAccountId: (accountId?: string | null) => string;
+  /** Resolve the normalized account without applying default-account credential fallback. */
   resolvePrimary: (accountId: string) => TAccount;
+  /** True when the resolved account has usable auth material for runtime or status paths. */
   hasCredential: (account: TAccount) => boolean;
+  /** Resolve the configured default account id after plugin-specific default selection rules. */
   resolveDefaultAccountId: () => string;
 }): TAccount {
   const hasExplicitAccountId = Boolean(params.accountId?.trim());
   const normalizedAccountId = params.normalizeAccountId(params.accountId);
   const primary = params.resolvePrimary(normalizedAccountId);
   if (hasExplicitAccountId || params.hasCredential(primary)) {
+    // Explicit account requests must not borrow credentials from another account;
+    // only omitted ids get the default-account credential fallback.
     return primary;
   }
 

--- a/src/plugin-sdk/allow-from.ts
+++ b/src/plugin-sdk/allow-from.ts
@@ -78,7 +78,11 @@ type ParsedChatAllowTarget =
   | { kind: "chat_identifier"; chatIdentifier: string }
   | { kind: "handle"; handle: string };
 
-/** Match allowlist entries against senders, with conversation targets requiring explicit opt-in. */
+/**
+ * Match allowlist entries against senders, with conversation targets requiring explicit opt-in.
+ * Handles are sender identities; chat ids/guids/identifiers are thread targets and stay disabled
+ * unless the channel deliberately allows group/thread scoped entries.
+ */
 export function isAllowedParsedChatSender(params: {
   allowFrom: Array<string | number>;
   sender: string;
@@ -93,7 +97,9 @@ export function isAllowedParsedChatSender(params: {
 }
 
 export type BasicAllowlistResolutionEntry = {
+  /** Original user-configured allowlist input. */
   input: string;
+  /** Whether resolver lookup produced a stable sender/account id. */
   resolved: boolean;
   id?: string;
   name?: string;
@@ -113,7 +119,10 @@ export function mapBasicAllowlistResolutionEntries(
   }));
 }
 
-/** Map allowlist inputs sequentially so resolver side effects stay ordered and predictable. */
+/**
+ * Map allowlist inputs sequentially so resolver side effects stay ordered and predictable.
+ * Provider/contact resolvers can rate-limit, cache, or emit diagnostics in input order.
+ */
 export async function mapAllowlistResolutionInputs<T>(params: {
   inputs: string[];
   mapInput: (input: string) => Promise<T> | T;

--- a/src/plugin-sdk/allowlist-config-edit.ts
+++ b/src/plugin-sdk/allowlist-config-edit.ts
@@ -166,6 +166,8 @@ function resolveAccountScopedWriteTarget(
   const channel = (channels[channelId] ??= {}) as Record<string, unknown>;
   const normalizedAccountId = normalizeAccountId(accountId);
   if (isBlockedObjectKey(normalizedAccountId)) {
+    // Blocked object keys fall back to channel-level writes so untrusted account ids cannot shape
+    // prototype-bearing config objects.
     return {
       target: channel,
       pathPrefix: `channels.${channelId}`,
@@ -175,6 +177,8 @@ function resolveAccountScopedWriteTarget(
   const hasAccounts = Boolean(channel.accounts && typeof channel.accounts === "object");
   const useAccount = normalizedAccountId !== DEFAULT_ACCOUNT_ID || hasAccounts;
   if (!useAccount) {
+    // Default account stays on the channel object until an accounts map already exists, preserving
+    // the compact config shape for single-account channels.
     return {
       target: channel,
       pathPrefix: `channels.${channelId}`,
@@ -253,12 +257,19 @@ function deleteNestedValue(root: Record<string, unknown>, path: string[]) {
 }
 
 function applyAccountScopedAllowlistConfigEdit(params: {
+  /** Parsed mutable config object that receives the allowlist edit. */
   parsedConfig: Record<string, unknown>;
+  /** Channel config bucket to edit under `channels.<id>`. */
   channelId: ChannelId;
+  /** Optional account scope. Non-default accounts write under `channels.<id>.accounts`. */
   accountId?: string | null;
+  /** Add or remove the normalized entry from the chosen allowlist path. */
   action: "add" | "remove";
+  /** User-supplied allowlist entry before channel-specific normalization. */
   entry: string;
+  /** Channel-specific allowlist normalizer used for duplicate detection and removal matching. */
   normalize: (values: Array<string | number>) => string[];
+  /** Read/write/cleanup paths for DM, group, or legacy allowlist storage. */
   paths: AllowlistConfigPaths;
 }): NonNullable<Awaited<ReturnType<NonNullable<ChannelAllowlistAdapter["applyConfigEdit"]>>>> {
   const resolvedTarget = resolveAccountScopedWriteTarget(
@@ -317,6 +328,7 @@ function applyAccountScopedAllowlistConfigEdit(params: {
       setNestedValue(resolvedTarget.target, params.paths.writePath, next);
     }
     for (const path of params.paths.cleanupPaths ?? []) {
+      // Legacy read paths are cleaned only after a real write so no-op edits do not churn config.
       deleteNestedValue(resolvedTarget.target, path);
     }
   }
@@ -331,8 +343,11 @@ function applyAccountScopedAllowlistConfigEdit(params: {
 
 /** Build the default account-scoped allowlist editor used by channel plugins with config-backed lists. */
 export function buildAccountScopedAllowlistConfigEditor(params: {
+  /** Channel id for config writes and write-target reporting. */
   channelId: ChannelId;
+  /** Channel-specific normalization for ids/usernames before comparison. */
   normalize: AllowlistNormalizer;
+  /** Scope-to-path resolver; returning null marks a scope unsupported. */
   resolvePaths: (scope: "dm" | "group") => AllowlistConfigPaths | null;
 }): NonNullable<ChannelAllowlistAdapter["applyConfigEdit"]> {
   return ({ cfg, parsedConfig, accountId, scope, action, entry }) => {
@@ -377,8 +392,11 @@ function buildAccountAllowlistAdapter<ResolvedAccount>(params: {
 
 /** Build the common DM/group allowlist adapter used by channels that store both lists in config. */
 export function buildDmGroupAccountAllowlistAdapter<ResolvedAccount>(params: {
+  /** Channel id whose account-scoped config should be read and edited. */
   channelId: ChannelId;
+  /** Resolve the channel account snapshot used for reads. */
   resolveAccount: AllowlistAccountResolver<ResolvedAccount>;
+  /** Channel-specific normalization for write comparisons. */
   normalize: AllowlistNormalizer;
   resolveDmAllowFrom: (
     account: ResolvedAccount,
@@ -407,8 +425,11 @@ export function buildDmGroupAccountAllowlistAdapter<ResolvedAccount>(params: {
 
 /** Build the common DM-only allowlist adapter for channels with legacy dm.allowFrom fallback paths. */
 export function buildLegacyDmAccountAllowlistAdapter<ResolvedAccount>(params: {
+  /** Channel id whose account-scoped config should be read and edited. */
   channelId: ChannelId;
+  /** Resolve the channel account snapshot used for reads. */
   resolveAccount: AllowlistAccountResolver<ResolvedAccount>;
+  /** Channel-specific normalization for write comparisons. */
   normalize: AllowlistNormalizer;
   resolveDmAllowFrom: (
     account: ResolvedAccount,

--- a/src/plugin-sdk/approval-auth-helpers.ts
+++ b/src/plugin-sdk/approval-auth-helpers.ts
@@ -11,6 +11,7 @@ const IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION = Symbol(
 );
 
 export function markImplicitSameChatApprovalAuthorization(
+  /** Authorization result returned when no explicit approver list exists. */
   result: ApprovalAuthorizationResult,
 ): ApprovalAuthorizationResult {
   // Keep this non-enumerable to avoid changing auth payload shape.
@@ -25,6 +26,7 @@ export function markImplicitSameChatApprovalAuthorization(
 }
 
 export function isImplicitSameChatApprovalAuthorization(
+  /** Result object returned from approval authorization; cloned results intentionally lose marker state. */
   result: ApprovalAuthorizationResult | null | undefined,
 ): boolean {
   return Boolean(
@@ -38,8 +40,11 @@ export function isImplicitSameChatApprovalAuthorization(
 }
 
 export function createResolvedApproverActionAuthAdapter(params: {
+  /** Human channel name used in denial copy. */
   channelLabel: string;
+  /** Resolve configured approvers for the channel/account before sender normalization. */
   resolveApprovers: (params: { cfg: OpenClawConfig; accountId?: string | null }) => string[];
+  /** Channel-specific sender normalization; defaults to optional string trimming. */
   normalizeSenderId?: (value: string) => string | undefined;
 }) {
   const normalizeSenderId = params.normalizeSenderId ?? normalizeOptionalString;
@@ -51,10 +56,14 @@ export function createResolvedApproverActionAuthAdapter(params: {
       senderId,
       approvalKind,
     }: {
+      /** Canonical OpenClaw config used by the approver resolver. */
       cfg: OpenClawConfig;
+      /** Optional account scope for multi-account channel approver lists. */
       accountId?: string | null;
+      /** Raw channel actor id for the user taking the approval action. */
       senderId?: string | null;
       action: "approve";
+      /** Approval family used only for denial copy. */
       approvalKind: ApprovalKind;
     }) {
       const approvers = params.resolveApprovers({ cfg, accountId });

--- a/src/plugin-sdk/approval-client-helpers.ts
+++ b/src/plugin-sdk/approval-client-helpers.ts
@@ -37,6 +37,7 @@ function isApprovalTargetsMode(cfg: OpenClawConfig): boolean {
 
 export { getExecApprovalReplyMetadata, matchesApprovalRequestFilters };
 
+/** Enable channel-side approval clients only when configured and at least one approver exists. */
 export function isChannelExecApprovalClientEnabledFromConfig(params: {
   enabled?: ChannelExecApprovalEnableMode;
   approverCount: number;
@@ -47,6 +48,10 @@ export function isChannelExecApprovalClientEnabledFromConfig(params: {
   return params.enabled === true || params.enabled === "auto";
 }
 
+/**
+ * Match an inbound sender against configured approval forward targets for one channel/account.
+ * Channel adapters own target syntax, so callers provide `matchTarget` after shared mode checks.
+ */
 export function isChannelExecApprovalTargetRecipient(params: {
   cfg: OpenClawConfig;
   senderId?: string | null;
@@ -97,6 +102,7 @@ export function createChannelExecApprovalProfile(params: {
   matchesRequestAccount?: (params: ApprovalProfileParams & { request: ApprovalRequest }) => boolean;
   // Some channels encode the effective agent only in sessionKey for forwarded approvals.
   fallbackAgentIdFromSessionKey?: boolean;
+  /** Local prompt suppression can be reused by fallback paths before channel clients are enabled. */
   requireClientEnabledForLocalPromptSuppression?: boolean;
 }) {
   const normalizeSenderId = params.normalizeSenderId ?? normalizeOptionalString;
@@ -143,6 +149,7 @@ export function createChannelExecApprovalProfile(params: {
     ) {
       return false;
     }
+    // Account gates run before shared request filters so cross-account approvals never leak through.
     return matchesApprovalRequestFilters({
       request: input.request.request,
       agentFilter: config?.agentFilter,

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -28,18 +28,27 @@ type DeliverySuppressionParams = {
 };
 
 type ApproverRestrictedNativeApprovalParams = {
+  /** Canonical channel id used for native delivery/fallback suppression matching. */
   channel: string;
+  /** Human channel name used in denial copy and setup descriptions. */
   channelLabel: string;
+  /** Account ids considered when checking whether any configured approver DM route exists. */
   listAccountIds: (cfg: OpenClawConfig) => string[];
+  /** True when an account has explicit approvers configured for approval actions. */
   hasApprovers: (params: ApprovalAdapterParams) => boolean;
+  /** Exec approval sender authorization for the current account. */
   isExecAuthorizedSender: (params: ApprovalAdapterParams) => boolean;
+  /** Optional plugin approval sender authorization; defaults to exec auth for older channels. */
   isPluginAuthorizedSender?: (params: ApprovalAdapterParams) => boolean;
+  /** Native delivery transport gate; separate from action availability. */
   isNativeDeliveryEnabled: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
   resolveNativeDeliveryMode: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => NativeApprovalDeliveryMode;
+  /** Require fallback suppression to prove the request originated on this same channel. */
   requireMatchingTurnSourceChannel?: boolean;
+  /** Override the account used for native-delivery suppression, often from turn-source metadata. */
   resolveSuppressionAccountId?: (params: DeliverySuppressionParams) => string | undefined;
   resolveOriginTarget?: (params: {
     cfg: OpenClawConfig;
@@ -153,6 +162,8 @@ function buildApproverRestrictedNativeApprovalCapability(
           }
         }
         const resolvedAccountId = params.resolveSuppressionAccountId?.(input);
+        // Undefined means "use the forwarding target account"; empty string means "unscoped".
+        // This lets channels deliberately switch suppression checks to turn-source account facts.
         const accountId =
           (resolvedAccountId === undefined
             ? input.target.accountId?.trim()
@@ -189,14 +200,18 @@ function buildApproverRestrictedNativeApprovalCapability(
 }
 
 export function createApproverRestrictedNativeApprovalAdapter(
+  /** Full native approval capability parameters; result is split for legacy adapter consumers. */
   params: ApproverRestrictedNativeApprovalParams,
 ) {
   return splitChannelApprovalCapability(buildApproverRestrictedNativeApprovalCapability(params));
 }
 
 export function createChannelApprovalCapability(params: {
+  /** Authorization surface for approve actions. */
   authorizeActorAction?: ChannelApprovalCapability["authorizeActorAction"];
+  /** Generic approval action availability, independent of native delivery. */
   getActionAvailabilityState?: ChannelApprovalCapability["getActionAvailabilityState"];
+  /** Native exec initiating surface availability, including native-delivery transport gate. */
   getExecInitiatingSurfaceState?: ChannelApprovalCapability["getExecInitiatingSurfaceState"];
   resolveApproveCommandBehavior?: ChannelApprovalCapability["resolveApproveCommandBehavior"];
   describeExecApprovalSetup?: ChannelApprovalCapability["describeExecApprovalSetup"];

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -74,16 +74,24 @@ type ApprovalOriginOrSessionTargetChecker =
   ChannelApprovalForwardingEvaluatorParams["hasOriginOrSessionTarget"];
 
 export type ChannelApprovalForwardingEligibilityParams = {
+  /** Canonical config containing exec/plugin approval forwarding policy. */
   cfg: OpenClawConfig;
+  /** Optional channel account scope for multi-account native delivery. */
   accountId?: string | null;
+  /** Approval family whose forwarding policy should be evaluated. */
   approvalKind: ApprovalKind;
+  /** Approval request carrying session, turn-source, and filter facts. */
   request: ApprovalRequest;
 };
 
 export type ChannelApprovalPotentialRouteParams = {
+  /** Canonical config containing exec/plugin approval forwarding policy. */
   cfg: OpenClawConfig;
+  /** Optional channel account scope for multi-account native delivery. */
   accountId?: string | null;
+  /** Approval family whose forwarding policy should be evaluated. */
   approvalKind: ApprovalKind;
+  /** True when callers need a session-origin route and must ignore explicit targets. */
   nativeSessionOnly?: boolean;
 };
 
@@ -221,8 +229,11 @@ export type NativeApprovalTarget = {
 };
 
 export function nativeApprovalTargetsMatch(params: {
+  /** Channel id used to apply shared route comparison semantics. */
   channel?: string | null;
+  /** First normalized native target. Missing account/thread values are exact-match significant. */
   left: NativeApprovalTarget;
+  /** Second normalized native target. Numeric thread ids compare by normalized string value. */
   right: NativeApprovalTarget;
 }): boolean {
   return channelRouteTargetsMatchExact({
@@ -242,9 +253,13 @@ export function nativeApprovalTargetsMatch(params: {
 }
 
 export function shouldSuppressLocalNativeExecApprovalPrompt(params: {
+  /** Canonical config used for native approval enablement, mode, and filters. */
   cfg: OpenClawConfig;
+  /** Optional channel account scope for native delivery checks. */
   accountId?: string | null;
+  /** Pending approval reply payload containing exec approval metadata. */
   payload: ReplyPayload;
+  /** Outbound hint proving a native exec route is active for this payload. */
   hint?: ChannelOutboundPayloadHint;
   isTransportEnabled?: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
   isNativeDeliveryEnabled?: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
@@ -254,6 +269,7 @@ export function shouldSuppressLocalNativeExecApprovalPrompt(params: {
     metadata: ExecApprovalReplyMetadata;
   }) => LocalNativeExecApprovalConfig | undefined;
   requireApprovalConfigEnabled?: boolean;
+  /** When true, target-only forwarding suppresses local prompt only with exact target proof. */
   enforceForwardingMode?: boolean;
   isSessionRouteEligible?: (params: {
     cfg: OpenClawConfig;
@@ -585,6 +601,8 @@ export function createNativeApprovalChannelRouteGates<TTarget extends NativeAppr
     if (!accountId) {
       return true;
     }
+    // Unscoped configured targets belong to the default account unless exactly one account is
+    // transport-enabled, which preserves single-account setups without cross-account leakage.
     const normalizedAccountId = normalizeAccountId(accountId);
     const defaultAccountId = normalizeAccountId(params.resolveDefaultAccountId(input.cfg));
     if (normalizedAccountId === defaultAccountId) {

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -38,8 +38,11 @@ type InMemoryApprovalReactionTarget<TTarget> = {
 };
 
 export type ApprovalReactionTargetStore<TTarget> = {
+  /** Associate a channel message/reaction key with an approval target until TTL expiry. */
   register(key: string, target: TTarget, opts?: { ttlMs?: number }): void;
+  /** Resolve a previously registered target; expired/missing/persistence failures return null. */
   lookup(key: string): Promise<TTarget | null>;
+  /** Remove the target from memory and best-effort persistent storage. */
   delete(key: string): void;
   clearForTest(): void;
 };
@@ -148,7 +151,9 @@ export function resolveApprovalReactionDecision(params: {
 }
 
 export function resolveApprovalReactionTarget<TRoute = unknown>(params: {
+  /** Stored target record attached to the reacted channel message. */
   target: ApprovalReactionTargetRecord<TRoute> | null | undefined;
+  /** Raw transport reaction key before emoji normalization. */
   reactionKey: string;
 }): ApprovalReactionTargetResolution<TRoute> | null {
   const target = params.target;
@@ -168,6 +173,8 @@ export function resolveApprovalReactionTarget<TRoute = unknown>(params: {
   }
   return {
     approvalId,
+    // Plugin approvals carry a stable prefix in shipped ids. Preserve explicit kind when the
+    // target store already resolved it, then fall back to the id contract for compatibility.
     approvalKind: target.approvalKind ?? (approvalId.startsWith("plugin:") ? "plugin" : "exec"),
     decision: decision.decision,
     normalizedEmoji: decision.normalizedEmoji,
@@ -329,8 +336,11 @@ function buildMetadataPayload(params: {
 }
 
 export function buildApprovalPendingPromptPayload(params: {
+  /** Original approval request; metadata is kept for channelData and fallback commands. */
   request: ApprovalRequest;
+  /** Canonical pending view. Passing a view lets tests/plugins keep prompt text stable. */
   view: PendingApprovalView;
+  /** Clock used for the relative expiry text embedded in the prompt. */
   nowMs: number;
 }): ApprovalReactionPromptPayload {
   const allowedDecisions = listDecisionActions(params.view.actions);
@@ -419,8 +429,11 @@ export function buildApprovalReactionPendingContentForRequest(params: {
 }
 
 export function createApprovalReactionTargetStore<TTarget>(params: {
+  /** Persistent namespace for channel-message-to-approval reaction targets. */
   namespace: string;
+  /** Maximum in-memory entries; oldest entries are evicted after TTL pruning. */
   maxEntries: number;
+  /** Default target lifetime when a caller does not provide a per-entry TTL. */
   defaultTtlMs: number;
   openStore?: (params: {
     namespace: string;
@@ -494,6 +507,8 @@ export function createApprovalReactionTargetStore<TTarget>(params: {
       if (!store) {
         return;
       }
+      // Memory is authoritative for the current process; persistence extends reaction handling
+      // across restarts but is disabled permanently after the first store error.
       void store
         .register(normalizedKey, { version: 1, target }, { ttlMs })
         .catch(disablePersistentStore);

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -14,7 +14,10 @@ import type { ReplyPayload } from "./reply-payload.js";
 
 const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
 
-/** Build a pending approval reply payload using the portable presentation API. */
+/**
+ * Build a pending approval reply payload using the portable presentation API.
+ * The execApproval channelData is the suppression/resolution marker consumed by shared delivery code.
+ */
 export function buildApprovalPendingReplyPayload(params: {
   approvalKind?: "exec" | "plugin";
   approvalId: string;
@@ -47,7 +50,7 @@ export function buildApprovalPendingReplyPayload(params: {
   };
 }
 
-/** Build a resolved approval reply payload with approval metadata but no controls. */
+/** Build a resolved approval reply payload with approval metadata but no interactive controls. */
 export function buildApprovalResolvedReplyPayload(params: {
   approvalId: string;
   approvalSlug: string;
@@ -80,6 +83,7 @@ export function buildPluginApprovalPendingReplyPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.approvalSlug ?? params.request.id.slice(0, 8),
     text: params.text ?? buildPluginApprovalRequestMessage(params.request, params.nowMs),
+    // Plugin requests can narrow decisions; generic approvals default to the full exec set.
     allowedDecisions:
       params.allowedDecisions ??
       resolvePluginApprovalRequestAllowedDecisions(params.request.request),

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -106,15 +106,24 @@ type MultiAccountChannelConfigAdapterParams<
   AccessorAccount = ResolvedAccount,
   Config extends OpenClawConfig = OpenClawConfig,
 > = {
+  /** Channel config section key under `cfg.channels`. */
   sectionKey: string;
+  /** List configured account ids for status/config UI surfaces. */
   listAccountIds: (cfg: Config) => string[];
+  /** Resolve the runtime account shape used by CRUD and optional accessors. */
   resolveAccount: (cfg: Config, accountId?: string | null) => ResolvedAccount;
+  /** Optional read-only account shape for allowlist/default target accessors. */
   resolveAccessorAccount?: (params: ChannelConfigAccessorParams<Config>) => AccessorAccount;
+  /** Default account id for channels that expose named accounts. */
   defaultAccountId: (cfg: Config) => string;
   inspectAccount?: (cfg: Config, accountId?: string | null) => unknown;
+  /** Base/root fields removed when deleting an account or clearing top-level account data. */
   clearBaseFields: string[];
+  /** Raw allowlist entries from the accessor account. */
   resolveAllowFrom: (account: AccessorAccount) => Array<string | number> | null | undefined;
+  /** Channel-specific formatter for presenting/storing allowlist entries. */
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
+  /** Optional default outbound target selector. */
   resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
 };
 
@@ -166,9 +175,13 @@ export function createScopedAccountConfigAccessors<
   // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Config preserves caller-specific config subtype for account resolvers.
   Config extends OpenClawConfig = OpenClawConfig,
 >(params: {
+  /** Resolve the account snapshot used only for read-only config accessors. */
   resolveAccount: (params: { cfg: Config; accountId?: string | null }) => ResolvedAccount;
+  /** Extract raw allowlist entries from the resolved account. */
   resolveAllowFrom: (account: ResolvedAccount) => Array<string | number> | null | undefined;
+  /** Format allowlist entries for command/status display. */
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
+  /** Optional default outbound target selector; omitted means the adapter exposes no default target. */
   resolveDefaultTo?: (account: ResolvedAccount) => string | number | null | undefined;
 }): Pick<
   ChannelConfigAdapter<ResolvedAccount>,
@@ -269,6 +282,8 @@ function createChannelConfigAdapterWithAccessors<
 }): ChannelConfigAdapterWithAccessors<ResolvedAccount> {
   return {
     ...params.base,
+    // Accessor accounts can intentionally differ from runtime account objects so read-only helpers
+    // do not instantiate heavyweight channel clients or require secrets.
     ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
       resolveAccount: resolveAccessorAccountWithFallback(
         params.resolveAccessorAccount,
@@ -427,12 +442,16 @@ export function createTopLevelChannelConfigBase<
   ResolvedAccount,
   Config extends OpenClawConfig = OpenClawConfig,
 >(params: {
+  /** Channel config section key under `cfg.channels`. */
   sectionKey: string;
+  /** Resolve the single top-level account snapshot. */
   resolveAccount: (cfg: Config) => ResolvedAccount;
   listAccountIds?: (cfg: Config) => string[];
   defaultAccountId?: (cfg: Config) => string;
   inspectAccount?: (cfg: Config) => unknown;
+  /** remove-section deletes the channel config; clear-fields preserves unrelated channel settings. */
   deleteMode?: "remove-section" | "clear-fields";
+  /** Fields removed when deleteMode is clear-fields. */
   clearBaseFields?: string[];
 }): Pick<
   ChannelConfigAdapter<ResolvedAccount>,
@@ -605,8 +624,11 @@ export function createHybridChannelConfigAdapter<
 export function createScopedDmSecurityResolver<
   ResolvedAccount extends { accountId?: string | null },
 >(params: {
+  /** Channel key used for DM policy paths and pairing approval hints. */
   channelKey: string;
+  /** Resolve account-specific DM policy before shared defaults are applied. */
   resolvePolicy: (account: ResolvedAccount) => string | null | undefined;
+  /** Resolve account-specific DM allowlist before shared defaults are applied. */
   resolveAllowFrom: (account: ResolvedAccount) => Array<string | number> | null | undefined;
   resolveAccess?: (params: {
     cfg: OpenClawConfig;

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -321,6 +321,7 @@ function formatBundledEntryModuleOpenFailure(params: {
 
 function createBundledEntryModulePathCacheKey(importMetaUrl: string, specifier: string): string {
   const sourceFallbackDisabled = isTruthyEnvFlag(process.env[disableBundledEntrySourceFallbackEnv]);
+  // The fallback flag changes the candidate list, so it must participate in path-cache identity.
   return `${sourceFallbackDisabled ? "1" : "0"}\0${importMetaUrl}\0${specifier}`;
 }
 
@@ -342,6 +343,7 @@ function resolveBundledEntryModulePath(importMetaUrl: string, specifier: string)
   } | null = null;
 
   for (const candidate of candidates) {
+    // Validate every resolved sidecar against its plugin root before any loader sees the path.
     const opened = openRootFileSync({
       absolutePath: candidate.path,
       rootPath: candidate.boundaryRoot,
@@ -400,6 +402,7 @@ function canTryNodeRequireBuiltModule(modulePath: string): boolean {
   const isBuiltBundledArtifact =
     modulePath.includes(`${path.sep}dist${path.sep}`) ||
     modulePath.includes(`${path.sep}dist-runtime${path.sep}`);
+  // Built sidecars should stay on the native require path when possible to avoid source transforms.
   return (
     isBuiltBundledArtifact &&
     [".js", ".mjs", ".cjs"].includes(normalizeLowercaseStringOrEmpty(path.extname(modulePath)))

--- a/src/plugin-sdk/channel-pairing.ts
+++ b/src/plugin-sdk/channel-pairing.ts
@@ -17,6 +17,7 @@ type ScopedPairingAccess = ReturnType<typeof createScopedPairingAccess>;
 
 /** Pairing helpers scoped to one channel account. */
 export type ChannelPairingController = ScopedPairingAccess & {
+  /** Issues a challenge through the same normalized channel/account store as read/write helpers. */
   issueChallenge: (
     params: Omit<Parameters<typeof issuePairingChallenge>[0], "channel" | "upsertPairingRequest">,
   ) => ReturnType<typeof issuePairingChallenge>;
@@ -49,6 +50,7 @@ export function createChannelPairingController(params: {
   const access = createScopedPairingAccess(params);
   return {
     ...access,
+    // Use the scoped upsert sink so challenge issuance preserves normalized account ids.
     issueChallenge: createChannelPairingChallengeIssuer({
       channel: params.channel,
       upsertPairingRequest: access.upsertPairingRequest,

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -80,7 +80,9 @@ export function coerceNativeSetting(value: unknown): boolean | "auto" | undefine
 
 /** Candidate mutable allowlist path inspected for dangerous name-matching warnings. */
 export type ChannelMutableAllowlistCandidate = {
+  /** Config path shown in doctor/operator warnings. */
   pathLabel: string;
+  /** Raw allowlist value; non-arrays are ignored by the collector. */
   list: unknown;
 };
 
@@ -134,6 +136,7 @@ export function createDangerousNameMatchingMutableAllowlistWarningCollector(para
         continue;
       }
       for (const candidate of params.collectLists(scope)) {
+        // Only real configured arrays are actionable; malformed config is handled by schema/doctor paths.
         if (!Array.isArray(candidate.list)) {
           continue;
         }
@@ -154,7 +157,10 @@ export function createDangerousNameMatchingMutableAllowlistWarningCollector(para
   };
 }
 
-/** Compose the common DM policy resolver with restrict-senders group warnings. */
+/**
+ * Compose the common DM policy resolver with restrict-senders group warnings.
+ * Channels pass account-specific accessors here so DM policy inheritance and group-risk warnings stay aligned.
+ */
 export function createRestrictSendersChannelSecurity<
   ResolvedAccount extends { accountId?: string | null },
 >(params: {

--- a/src/plugin-sdk/channel-route.ts
+++ b/src/plugin-sdk/channel-route.ts
@@ -91,6 +91,8 @@ export function normalizeChannelRouteRef(
   if (!channel && !to && !accountId && threadId == null) {
     return undefined;
   }
+  // `rawTo` is diagnostic/provider input only. Route identity uses normalized `to` so callers do
+  // not split sessions when a channel preserves both parsed and original target strings.
   return {
     ...(channel ? { channel } : {}),
     ...(accountId ? { accountId } : {}),
@@ -181,12 +183,16 @@ export function channelRouteIdentityKey(input?: ChannelRouteTargetInput | null):
 }
 
 function threadIdsEqual(left?: string | number, right?: string | number): boolean {
+  // Numeric and numeric-string thread ids are equivalent across transports that deserialize ids
+  // differently; provider string ids remain distinct after stringification.
   const normalizedLeft = stringifyRouteThreadId(left);
   const normalizedRight = stringifyRouteThreadId(right);
   return normalizedLeft === normalizedRight;
 }
 
 function accountsCompatible(left?: string, right?: string): boolean {
+  // Conversation sharing accepts a parent route without account scope. Exact equality below keeps
+  // missing account separate from explicit account for dedupe and native target binding.
   return !left || !right || left === right;
 }
 
@@ -195,7 +201,9 @@ function accountsEqual(left?: string, right?: string): boolean {
 }
 
 export function channelRoutesMatchExact(params: {
+  /** Fully normalized left route. Missing account must stay different from explicit account. */
   left?: ChannelRouteRef | null;
+  /** Fully normalized right route. Thread ids compare by normalized string value. */
   right?: ChannelRouteRef | null;
 }): boolean {
   const { left, right } = params;
@@ -213,7 +221,9 @@ export function channelRoutesMatchExact(params: {
 
 /** Checks whether two normalized routes point at the same conversation or parent route. */
 export function channelRoutesShareConversation(params: {
+  /** Candidate route; missing thread means parent conversation when channel/target/account match. */
   left?: ChannelRouteRef | null;
+  /** Candidate route; missing account is compatible with any explicit account in this check. */
   right?: ChannelRouteRef | null;
 }): boolean {
   const { left, right } = params;
@@ -282,6 +292,8 @@ export function channelRouteCompactKey(route?: ChannelRouteKeyInput | null): str
   if (!normalized?.channel || !normalized.target?.to) {
     return undefined;
   }
+  // Compact keys are for logs/maps that require a real destination. Dedupe paths use the JSON key
+  // above so separator characters inside route parts cannot collide.
   return [
     normalized.channel,
     normalized.target.to,

--- a/src/plugin-sdk/channel-send-result.ts
+++ b/src/plugin-sdk/channel-send-result.ts
@@ -13,7 +13,12 @@ export type ChannelSendRawResult = {
 };
 
 /** Attaches the channel id to a single outbound send result. */
-export function attachChannelToResult<T extends object>(channel: string, result: T) {
+export function attachChannelToResult<T extends object>(
+  /** Stable channel id stamped on outbound delivery results. */
+  channel: string,
+  /** Channel-specific result payload; its fields are preserved after the channel stamp. */
+  result: T,
+) {
   return {
     channel,
     ...result,
@@ -27,7 +32,9 @@ export function attachChannelToResults<T extends object>(channel: string, result
 
 /** Creates an empty outbound delivery result for send paths that produced no platform id. */
 export function createEmptyChannelResult(
+  /** Stable channel id for the outbound path that could not produce a platform message id. */
   channel: string,
+  /** Optional delivery metadata such as chat/thread ids; messageId defaults to the legacy sentinel. */
   result: Partial<Omit<OutboundDeliveryResult, "channel" | "messageId">> & {
     messageId?: string;
   } = {},
@@ -46,9 +53,13 @@ type SendPollParams = Parameters<NonNullable<ChannelOutboundAdapter["sendPoll"]>
 
 /** Wraps outbound send methods that already return delivery-shaped results without channel ids. */
 export function createAttachedChannelResultAdapter(params: {
+  /** Channel id added to every wrapped send result. */
   channel: string;
+  /** Modern text sender returning outbound delivery fields except channel. */
   sendText?: (ctx: SendTextParams) => MaybePromise<Omit<OutboundDeliveryResult, "channel">>;
+  /** Modern media sender returning outbound delivery fields except channel. */
   sendMedia?: (ctx: SendMediaParams) => MaybePromise<Omit<OutboundDeliveryResult, "channel">>;
+  /** Modern poll sender returning poll delivery fields except channel. */
   sendPoll?: (ctx: SendPollParams) => MaybePromise<Omit<ChannelPollResult, "channel">>;
 }): Pick<ChannelOutboundAdapter, "sendText" | "sendMedia" | "sendPoll"> {
   return {
@@ -66,8 +77,11 @@ export function createAttachedChannelResultAdapter(params: {
 
 /** Wraps legacy raw text/media send methods and normalizes their results. */
 export function createRawChannelSendResultAdapter(params: {
+  /** Channel id added while converting raw ok/messageId/error payloads. */
   channel: string;
+  /** Legacy text sender that reports primitive success/error fields. */
   sendText?: (ctx: SendTextParams) => MaybePromise<ChannelSendRawResult>;
+  /** Legacy media sender that reports primitive success/error fields. */
   sendMedia?: (ctx: SendMediaParams) => MaybePromise<ChannelSendRawResult>;
 }): Pick<ChannelOutboundAdapter, "sendText" | "sendMedia"> {
   return {
@@ -81,7 +95,12 @@ export function createRawChannelSendResultAdapter(params: {
 }
 
 /** Normalize raw channel send results into the shape shared outbound callers expect. */
-export function buildChannelSendResult(channel: string, result: ChannelSendRawResult) {
+export function buildChannelSendResult(
+  /** Channel id for the adapter that produced the raw send result. */
+  channel: string,
+  /** Legacy primitive result; null/undefined message ids map to the empty-id sentinel. */
+  result: ChannelSendRawResult,
+) {
   return {
     channel,
     ok: result.ok,

--- a/src/plugin-sdk/channel-setup.ts
+++ b/src/plugin-sdk/channel-setup.ts
@@ -18,7 +18,9 @@ export {
 
 /** Metadata used to advertise an optional channel plugin during setup flows. */
 type OptionalChannelSetupParams = {
+  /** Stable channel id used by setup routes and status reporting. */
   channel: string;
+  /** Human label used in install/docs guidance. */
   label: string;
   npmSpec?: string;
   docsPath?: string;
@@ -26,7 +28,9 @@ type OptionalChannelSetupParams = {
 
 /** Paired setup adapter + setup wizard for channels that may not be installed yet. */
 export type OptionalChannelSetupSurface = {
+  /** Runtime setup adapter that reports the optional plugin as unavailable until installed. */
   setupAdapter: ChannelSetupAdapter;
+  /** CLI wizard facade that shows the same unavailable/install guidance. */
   setupWizard: ChannelSetupWizard;
 };
 

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -111,18 +111,29 @@ export type { StoredModelOverride } from "../auto-reply/reply/stored-model-overr
 
 /** @deprecated Use `resolveChannelMessageIngress` from `openclaw/plugin-sdk/channel-ingress-runtime`. */
 export type ResolveSenderCommandAuthorizationParams = {
+  /** Canonical host config; command access-group policy is read from `commands.useAccessGroups`. */
   cfg: OpenClawConfig;
+  /** Raw channel text before command parsing. Non-command input must not emit a command decision. */
   rawBody: string;
+  /** Group messages use only configured group allowlists for command authorization. */
   isGroup: boolean;
+  /** Direct-message access mode; pairing-style modes may add stored DM owners for DM commands only. */
   dmPolicy: string;
+  /** Configured direct-message owners before channel access-group expansion. */
   configuredAllowFrom: string[];
+  /** Configured group command senders before channel access-group expansion. */
   configuredGroupAllowFrom?: string[];
+  /** Transport-local sender id passed through the channel matcher unchanged. */
   senderId: string;
+  /** Channel matcher owns id normalization and wildcard/provider-specific matching. */
   isSenderAllowed: (senderId: string, allowFrom: string[]) => boolean;
+  /** Channel/account scope for expanding access-group entries; omitted keeps raw allowlists. */
   channel?: ChannelId;
   accountId?: string;
   resolveAccessGroupMembership?: AccessGroupMembershipResolver;
+  /** Pairing-store direct-message owners; ignored for groups, open policy, and allowlist policy. */
   readAllowFromStore: () => Promise<string[]>;
+  /** Runtime command detector. False preserves access facts without producing command auth. */
   shouldComputeCommandAuthorized: (rawBody: string, cfg: OpenClawConfig) => boolean;
   /** @deprecated Command authorization is resolved by channel ingress. Kept for runtime injection compatibility. */
   resolveCommandAuthorizedFromAuthorizers?: (params: {
@@ -188,6 +199,8 @@ export async function resolveSenderCommandAuthorization(
   commandAuthorized: boolean | undefined;
 }> {
   const shouldComputeAuth = params.shouldComputeCommandAuthorized(params.rawBody, params.cfg);
+  // Pairing-store owners authorize direct-message command replies only. Groups and open/allowlist
+  // policies must rely on configured allowlists so a paired DM cannot become group command access.
   const storeAllowFrom =
     !params.isGroup && params.dmPolicy !== "allowlist" && params.dmPolicy !== "open"
       ? await params.readAllowFromStore().catch(() => [])
@@ -198,6 +211,8 @@ export async function resolveSenderCommandAuthorization(
   let configuredGroupAllowFrom = params.configuredGroupAllowFrom ?? [];
   let dmStoreAllowFrom = storeAllowFrom;
   if (channel) {
+    // Expand each allowlist independently; configured DM, configured group, and stored DM owners
+    // feed different authorizers and must not collapse into one shared sender list.
     [configuredAllowFrom, configuredGroupAllowFrom] = await Promise.all([
       expandAllowFromWithAccessGroups({
         cfg: params.cfg,
@@ -251,6 +266,8 @@ export async function resolveSenderCommandAuthorization(
   const commandAuthorized = shouldComputeAuth
     ? (params.resolveCommandAuthorizedFromAuthorizers?.({
         useAccessGroups,
+        // Empty configured lists are treated as absent authorizers. This preserves the legacy
+        // fallback where direct sender access decides only when no runtime authorizer is injected.
         authorizers: [
           { configured: effectiveAllowFrom.length > 0, allowed: ownerAllowedForCommands },
           { configured: effectiveGroupAllowFrom.length > 0, allowed: groupAllowedForCommands },

--- a/src/plugin-sdk/delivery-queue-runtime.ts
+++ b/src/plugin-sdk/delivery-queue-runtime.ts
@@ -8,16 +8,19 @@ type DrainPendingDeliveriesOptions = Omit<
   Parameters<typeof coreDrainPendingDeliveries>[0],
   "deliver"
 > & {
+  /** Optional test/plugin-owned sender; omitted callers get the core outbound runtime lazily. */
   deliver?: DeliverFn;
 };
 
 let outboundDeliverRuntimePromise: Promise<OutboundDeliverRuntimeModule> | null = null;
 
 async function loadOutboundDeliverRuntime(): Promise<OutboundDeliverRuntimeModule> {
+  // Cache the dynamic import so reconnect drains do not reload the outbound runtime boundary.
   outboundDeliverRuntimePromise ??= import("../infra/outbound/deliver-runtime.js");
   return await outboundDeliverRuntimePromise;
 }
 
+/** Drain queued outbound payloads without statically pulling the full delivery runtime into plugins. */
 export async function drainPendingDeliveries(opts: DrainPendingDeliveriesOptions): Promise<void> {
   const deliver =
     opts.deliver ?? (await loadOutboundDeliverRuntime()).deliverOutboundPayloadsInternal;

--- a/src/plugin-sdk/fetch-auth.ts
+++ b/src/plugin-sdk/fetch-auth.ts
@@ -4,6 +4,7 @@ import {
 } from "../infra/fetch-headers.js";
 
 export type ScopeTokenProvider = {
+  /** Return an access token for the requested provider scope. */
   getAccessToken: (scope: string) => Promise<string>;
 };
 
@@ -40,6 +41,7 @@ export async function fetchWithBearerAuthScopeFallback(params: {
       ...(headers ? { headers } : {}),
     });
 
+  // Preserve public-resource behavior by trying the request once before attaching credentials.
   const firstAttempt = await fetchOnce();
   if (firstAttempt.ok) {
     return firstAttempt;
@@ -60,6 +62,7 @@ export async function fetchWithBearerAuthScopeFallback(params: {
   for (const scope of params.scopes) {
     try {
       const token = await params.tokenProvider.getAccessToken(scope);
+      // Rebuild Headers so retry attempts do not retain symbol-bearing or non-fetch metadata.
       const authHeaders = new Headers(normalizeHeadersInitForFetch(requestInit?.headers));
       authHeaders.set("Authorization", `Bearer ${token}`);
       const authAttempt = await fetchOnce(authHeaders);

--- a/src/plugin-sdk/fetch-runtime.ts
+++ b/src/plugin-sdk/fetch-runtime.ts
@@ -1,5 +1,3 @@
-// Public fetch/proxy helpers for plugins that need wrapped fetch behavior.
-
 import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 
 export { resolveFetch, wrapFetchWithAbortSignal } from "../infra/fetch.js";
@@ -31,6 +29,7 @@ type GuardedFetchPresetOptions = Omit<
   "mode" | "proxy" | "dangerouslyAllowEnvProxyWithoutPinnedDns"
 >;
 
+/** Preset guarded fetch options for plugin calls that trust managed environment proxy routing. */
 export function withTrustedEnvProxyGuardedFetchMode(
   params: GuardedFetchPresetOptions,
 ): GuardedFetchOptions {

--- a/src/plugin-sdk/file-lock.ts
+++ b/src/plugin-sdk/file-lock.ts
@@ -8,6 +8,7 @@ import { shouldRemoveDeadOwnerOrExpiredLock } from "../infra/stale-lock-file.js"
 import { getProcessStartTime } from "../shared/pid-alive.js";
 
 export type FileLockOptions = {
+  /** Retry policy applied while another process owns the sidecar lock. */
   retries: {
     retries: number;
     factor: number;
@@ -19,6 +20,7 @@ export type FileLockOptions = {
 };
 
 export type FileLockHandle = {
+  /** Absolute path to the `.lock` sidecar currently held. */
   lockPath: string;
   release: () => Promise<void>;
 };
@@ -44,6 +46,7 @@ async function shouldReclaimPluginLock(params: {
   staleMs: number;
   nowMs: number;
 }): Promise<boolean> {
+  // Reclaim only when the recorded owner is dead or the lock is past its stale window.
   return shouldRemoveDeadOwnerOrExpiredLock({
     payload: params.payload,
     staleMs: params.staleMs,
@@ -92,6 +95,7 @@ export async function acquireFileLock(
           pid: process.pid,
           createdAt: new Date().toISOString(),
         };
+        // starttime differentiates a live owner from pid reuse after process restart.
         const starttime = getProcessStartTime(process.pid);
         if (starttime !== null) {
           payload.starttime = starttime;

--- a/src/plugin-sdk/keyed-async-queue.ts
+++ b/src/plugin-sdk/keyed-async-queue.ts
@@ -1,5 +1,7 @@
 export type KeyedAsyncQueueHooks = {
+  /** Called immediately when a task joins a key queue. */
   onEnqueue?: () => void;
+  /** Called when that task settles, before tail cleanup may remove the key. */
   onSettle?: () => void;
 };
 
@@ -13,6 +15,7 @@ export function enqueueKeyedTask<T>(params: {
   params.hooks?.onEnqueue?.();
   const previous = params.tails.get(params.key) ?? Promise.resolve();
   const current = previous
+    // Prior task failures must not poison later work for the same key.
     .catch(() => undefined)
     .then(params.task)
     .finally(() => {
@@ -24,6 +27,7 @@ export function enqueueKeyedTask<T>(params: {
   );
   params.tails.set(params.key, tail);
   const cleanup = () => {
+    // Only the latest tail owns cleanup; newer enqueues replace the map entry.
     if (params.tails.get(params.key) === tail) {
       params.tails.delete(params.key);
     }

--- a/src/plugin-sdk/lazy-value.ts
+++ b/src/plugin-sdk/lazy-value.ts
@@ -1,6 +1,8 @@
 type LazyValue<T> = T | (() => T);
 
+/** Return a getter that resolves a value or factory once, then reuses the cached result. */
 export function createCachedLazyValueGetter<T>(value: LazyValue<T>): () => T;
+/** Return a getter that substitutes `fallback` when the lazy source resolves nullish. */
 export function createCachedLazyValueGetter<T>(
   value: LazyValue<T | null | undefined>,
   fallback: T,
@@ -16,6 +18,7 @@ export function createCachedLazyValueGetter<T>(
     if (!resolved) {
       const nextValue =
         typeof value === "function" ? (value as () => T | null | undefined)() : value;
+      // Cache nullish fallback selection too; callers rely on factories running only once.
       cached = nextValue ?? fallback;
       resolved = true;
     }

--- a/src/plugin-sdk/pair-loop-guard-runtime.ts
+++ b/src/plugin-sdk/pair-loop-guard-runtime.ts
@@ -43,11 +43,17 @@ type PairLoopGuardEntry = {
 /** In-memory guard for suppressing repeated bidirectional bot pair loops. */
 export type PairLoopGuard = {
   recordAndCheck: (params: {
+    /** Channel/account/plugin scope. Same participants in different scopes are independent. */
     scopeId: string;
+    /** Conversation or room id that bounds a detected bot-to-bot loop. */
     conversationId: string;
+    /** Sender id for this event; direction is normalized with `receiverId`. */
     senderId: string;
+    /** Receiver id for this event; self-pairs are ignored because they are not bidirectional loops. */
     receiverId: string;
+    /** Resolved runtime thresholds. Disabled or invalid thresholds short-circuit without tracking. */
     settings: PairLoopGuardSettings;
+    /** Test/runtime clock override. Older reordered events must not inherit future cooldowns. */
     nowMs?: number;
   }) => PairLoopGuardResult;
   clear: () => void;
@@ -114,8 +120,11 @@ function positiveInteger(value: unknown): number | undefined {
 
 /** Resolves runtime loop guard settings from config/defaults and the channel default-enabled gate. */
 export function resolvePairLoopGuardSettings(params: {
+  /** Narrow channel/account/group config. Valid fields override shared defaults field-by-field. */
   config?: PairLoopGuardConfig;
+  /** Broader shared channel default config used when narrow config leaves a field unset. */
   defaultsConfig?: PairLoopGuardConfig;
+  /** Channel capability gate; false disables the guard even when config says enabled. */
   defaultEnabled: boolean;
 }): PairLoopGuardSettings {
   const configuredEnabled =
@@ -159,10 +168,14 @@ function buildPairKey(params: {
 
 function pruneRecentTimestamps(entry: PairLoopGuardEntry, nowMs: number, windowMs: number): void {
   const cutoff = nowMs - windowMs;
+  // Strictly greater than the cutoff keeps the active window bounded and avoids retaining the
+  // event that has just aged out at exactly `windowMs`.
   entry.recentMs = entry.recentMs.filter((timestampMs) => timestampMs > cutoff);
 }
 
 function countCurrentWindowEvents(entry: PairLoopGuardEntry, nowMs: number): number {
+  // Reordered older events should not count future timestamps. The later event remains stored so
+  // normal time flow can still trip the guard when the runtime reaches that point.
   return entry.recentMs.filter((timestampMs) => timestampMs <= nowMs).length;
 }
 

--- a/src/plugin-sdk/provider-oauth-runtime.ts
+++ b/src/plugin-sdk/provider-oauth-runtime.ts
@@ -30,6 +30,7 @@ export type OAuthAuthorizationInput = {
   state?: string;
 };
 
+/** Browser redirect target plus optional CLI-facing instructions for manual OAuth flows. */
 export type OAuthAuthInfo = {
   url: string;
   instructions?: string;
@@ -46,7 +47,9 @@ export type OAuthSelectPrompt = {
 };
 
 export interface OAuthLoginCallbacks {
+  /** Announce the provider authorization URL before waiting for browser or manual input. */
   onAuth: (info: OAuthAuthInfo) => void;
+  /** Ask for manual input when the provider flow cannot finish from callback data alone. */
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
   onManualCodeInput?: () => Promise<string>;
@@ -222,6 +225,10 @@ export function generateOAuthState(): string {
   return base64urlEncode(stateBytes);
 }
 
+/**
+ * Normalizes callback input from browsers, copied query strings, or raw manual codes.
+ * `code#state` is a CLI shortcut for providers whose redirect URL is hard to paste intact.
+ */
 export function parseOAuthAuthorizationInput(input: string): OAuthAuthorizationInput {
   const value = input.trim();
   if (!value) {
@@ -258,6 +265,7 @@ export function resolveOAuthTokenLifetimeMs(value: unknown): number | undefined 
   return positiveSecondsToSafeMilliseconds(value);
 }
 
+/** Converts provider `expires_in` seconds to an absolute refresh time, applying optional skew. */
 export function resolveOAuthTokenExpiresAt(
   value: unknown,
   options: { nowMs?: number; refreshSkewMs?: number } = {},
@@ -313,12 +321,14 @@ export function withOAuthLoginAbort<T>(
       },
       (error: unknown) => {
         cleanup();
+        // Some provider SDKs reject with strings or plain objects; normalize for strict catch sites.
         reject(toLintErrorObject(error, "Non-Error rejection"));
       },
     );
   });
 }
 
+/** Combines caller cancellation with a clamped timeout signal for provider HTTP requests. */
 export function buildOAuthRequestSignal(options: {
   signal?: AbortSignal;
   timeoutMs: number;

--- a/src/plugin-sdk/provider-selection-runtime.ts
+++ b/src/plugin-sdk/provider-selection-runtime.ts
@@ -1,13 +1,18 @@
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 
 export type AutoSelectableProvider = {
+  /** Canonical provider id used for lookup and provider config keys. */
   id: string;
+  /** Lower numbers win during automatic provider selection. */
   autoSelectOrder?: number;
 };
 
 export type ProviderSelection<TProvider> = {
+  /** Trimmed explicit provider id, when one was configured. */
   configuredProviderId?: string;
+  /** True only when an explicit id was configured but no provider exists for it. */
   missingConfiguredProvider: boolean;
+  /** Explicit provider or first auto-selected provider; undefined when explicit lookup failed. */
   provider: TProvider | undefined;
 };
 
@@ -26,8 +31,11 @@ export type ResolvedConfiguredProvider<TProvider, TConfig> =
     };
 
 export function selectConfiguredOrAutoProvider<TProvider extends AutoSelectableProvider>(params: {
+  /** Optional configured provider id; blank strings are treated as absent. */
   configuredProviderId?: string;
+  /** Lookup for explicit provider ids. */
   getConfiguredProvider: (providerId: string | undefined) => TProvider | undefined;
+  /** Registered provider candidates for automatic selection. */
   listProviders: () => Iterable<TProvider>;
 }): ProviderSelection<TProvider> {
   const configuredProviderId = normalizeOptionalString(params.configuredProviderId);
@@ -51,8 +59,11 @@ export function selectConfiguredOrAutoProvider<TProvider extends AutoSelectableP
 }
 
 export function resolveProviderRawConfig(params: {
+  /** Canonical provider id whose defaults should apply first. */
   providerId: string;
+  /** Optional selected/alias provider id whose config overrides canonical defaults. */
   configuredProviderId?: string;
+  /** Provider config map keyed by canonical and selected ids. */
   providerConfigs?: Record<string, Record<string, unknown> | undefined>;
 }): Record<string, unknown> {
   const canonicalProviderConfig = readProviderConfig(params.providerConfigs, params.providerId);
@@ -62,6 +73,8 @@ export function resolveProviderRawConfig(params: {
   );
 
   return {
+    // Canonical provider config supplies shared defaults; selected/alias config intentionally wins
+    // so users can override model-specific fields without duplicating secrets.
     ...canonicalProviderConfig,
     ...selectedProviderConfig,
   };
@@ -72,9 +85,12 @@ export function resolveConfiguredCapabilityProvider<
   TFullConfig,
   TProvider extends AutoSelectableProvider,
 >(params: {
+  /** Optional explicit provider id; when present, missing provider is a hard error. */
   configuredProviderId?: string;
   providerConfigs?: Record<string, Record<string, unknown> | undefined>;
+  /** Current full config, possibly undefined while callers probe setup state. */
   cfg: TFullConfig | undefined;
+  /** Non-null config object used to resolve provider-specific defaults. */
   cfgForResolve: TFullConfig;
   getConfiguredProvider: (providerId: string | undefined) => TProvider | undefined;
   listProviders: () => Iterable<TProvider>;

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -46,12 +46,19 @@ export {
 } from "./provider-stream-shared.js";
 
 export type ProviderStreamFamily =
+  /** Google payload wrapper that maps OpenClaw thinking levels to Gemini thinking config. */
   | "google-thinking"
+  /** Proxy wrapper for Kilocode models; unsupported auto/router models intentionally drop reasoning. */
   | "kilocode-thinking"
+  /** Moonshot thinking wrapper; explicit tool_choice forces thinking off for API compatibility. */
   | "moonshot-thinking"
+  /** MiniMax wrapper that rewrites eligible model ids into high-speed mode when requested. */
   | "minimax-fast-mode"
+  /** OpenAI Responses wrapper stack for headers, extra params, web search, and reasoning cleanup. */
   | "openai-responses-defaults"
+  /** OpenRouter proxy wrapper; model capability gaps suppress unsupported reasoning payloads. */
   | "openrouter-thinking"
+  /** Tool-stream wrapper that defaults on unless the caller explicitly sends tool_stream=false. */
   | "tool-stream-default-on";
 
 type ProviderStreamFamilyHooks = Pick<ProviderPlugin, "wrapStreamFn">;
@@ -81,6 +88,8 @@ export function buildProviderStreamFamilyHooks(
     case "kilocode-thinking":
       return {
         wrapStreamFn: (ctx: ProviderWrapStreamFnContext) => {
+          // Auto/proxy models that cannot advertise reasoning must see the untouched payload.
+          // Sending a best-effort reasoning object there causes provider-side schema failures.
           const thinkingLevel =
             ctx.modelId === "kilo/auto" || isProxyReasoningUnsupported(ctx.modelId)
               ? undefined
@@ -117,6 +126,8 @@ export function buildProviderStreamFamilyHooks(
             agentDir: ctx.agentDir,
           });
           nextStreamFn = createOpenAIStringContentWrapper(nextStreamFn);
+          // Keep context management outermost so the final payload shape already includes
+          // compatibility rewrites, thinking-level normalization, and string-content cleanup.
           return createOpenAIResponsesContextManagementWrapper(
             createOpenAIReasoningCompatibilityWrapper(
               createOpenAIThinkingLevelWrapper(nextStreamFn, ctx.thinkingLevel),
@@ -128,6 +139,8 @@ export function buildProviderStreamFamilyHooks(
     case "openrouter-thinking":
       return {
         wrapStreamFn: (ctx: ProviderWrapStreamFnContext) => {
+          // OpenRouter accepts provider-family reasoning only for models with a known payload
+          // contract. Unknown/unsupported models keep the caller payload untouched.
           const thinkingLevel =
             ctx.modelId === "auto" || isProxyReasoningUnsupported(ctx.modelId)
               ? undefined

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -119,6 +119,8 @@ function shouldApplyOpenAIToolCompat(ctx: ProviderNormalizeToolSchemasContext): 
   const api = (ctx.model?.api ?? ctx.modelApi ?? "").trim().toLowerCase();
   const baseUrl = (ctx.model?.baseUrl ?? "").trim().toLowerCase();
 
+  // Strict-schema promotion is native OpenAI Responses only. Proxy/OpenAI-compatible routes can
+  // have different schema contracts, so leave their tool payloads unchanged.
   if (provider === "openai") {
     if (api === "openai-responses") {
       return !baseUrl || isOpenAIResponsesBaseUrl(baseUrl);
@@ -229,6 +231,8 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
     if (!options.promoteEmptyObject) {
       return schema;
     }
+    // Root parameter-free tools need an explicit strict object shape. Nested empty schemas are
+    // annotations/placeholders and must stay untouched so provider intent is not over-tightened.
     return {
       type: "object",
       properties: {},
@@ -280,6 +284,8 @@ export function findOpenAIStrictSchemaViolations(
   path: string,
   options?: { requireObjectRoot?: boolean },
 ): string[] {
+  // Diagnostics mirror the strict=true subset, but native transports may still choose strict:false.
+  // Keep this as a pure inspector so callers can decide whether violations should block a route.
   if (Array.isArray(schema)) {
     if (options?.requireObjectRoot) {
       return [`${path}.type`];
@@ -444,6 +450,8 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     return normalized;
   }
 
+  // DeepSeek rejects anyOf/oneOf in tool schemas. Keep the first non-null schema as the callable
+  // shape and carry nullability separately so optional unions remain representable.
   const merged = {
     ...(selected as Record<string, unknown>),
     ...normalized,
@@ -495,7 +503,13 @@ export function inspectDeepSeekToolSchemas(
   });
 }
 
-export type ProviderToolCompatFamily = "deepseek" | "gemini" | "openai";
+export type ProviderToolCompatFamily =
+  /** DeepSeek/OpenAI-compatible route that rejects anyOf/oneOf in tool parameters. */
+  | "deepseek"
+  /** Gemini route that rejects provider-specific unsupported schema keywords. */
+  | "gemini"
+  /** Native OpenAI Responses/Codex route with strict object-shape compatibility rules. */
+  | "openai";
 
 export function buildProviderToolCompatFamilyHooks(family: ProviderToolCompatFamily): {
   normalizeToolSchemas: (ctx: ProviderNormalizeToolSchemasContext) => AnyAgentTool[];

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -20,7 +20,9 @@ export {
 
 export type OutboundReplyPayload = {
   text?: string;
+  /** Preferred multi-attachment field for channel sends. */
   mediaUrls?: string[];
+  /** Legacy single-attachment field normalized into mediaUrls by helper APIs. */
   mediaUrl?: string;
   presentation?: InternalReplyPayload["presentation"];
   /**
@@ -38,8 +40,11 @@ export type ReasoningReplyPayload = {
 };
 
 export type SendableOutboundReplyParts = {
+  /** Original text chosen for delivery, before whitespace trimming. */
   text: string;
+  /** Text used for send/no-send decisions. */
   trimmedText: string;
+  /** Normalized media list after legacy mediaUrl fallback and empty-string filtering. */
   mediaUrls: string[];
   mediaCount: number;
   hasText: boolean;
@@ -207,6 +212,7 @@ export async function sendPayloadWithChunkedTextAndMedia<
       text,
       mediaUrl: urls[0],
     });
+    // Only the first media item carries the caption; later attachments are part of the same reply.
     for (let i = 1; i < urls.length; i++) {
       lastResult = await params.sendMedia({
         ...params.ctx,
@@ -320,6 +326,7 @@ export async function sendTextMediaPayload(params: {
       : [text];
   let lastResult: Awaited<ReturnType<NonNullable<typeof params.adapter.sendText>>>;
   for (const chunk of chunks) {
+    // Explicit reply ids fan out to every chunk; implicit first-reply ids are consumed after one send.
     lastResult = await params.adapter.sendText!({
       ...params.ctx,
       text: chunk,

--- a/src/plugin-sdk/request-url.ts
+++ b/src/plugin-sdk/request-url.ts
@@ -1,4 +1,4 @@
-/** Extract a string URL from the common request-like inputs accepted by fetch helpers. */
+/** Extract a string URL from fetch-like inputs; unsupported shapes return an empty URL sentinel. */
 export function resolveRequestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") {
     return input;

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -4,10 +4,12 @@ const pluginRuntimeStoreRegistryKey = Symbol.for("openclaw.plugin-sdk.runtime-st
 
 type PluginRuntimeStoreRegistry = Map<string, { runtime: unknown }>;
 type PluginRuntimeStoreKeyOptions = {
+  /** Explicit registry key shared by callers that intentionally coordinate one runtime slot. */
   key: string;
   errorMessage: string;
 };
 type PluginRuntimeStorePluginOptions = {
+  /** Stable plugin id normalized into a cross-module runtime slot key. */
   pluginId: string;
   errorMessage: string;
 };
@@ -17,6 +19,7 @@ function getPluginRuntimeStoreRegistry(): PluginRuntimeStoreRegistry {
   const globalRecord = globalThis as typeof globalThis & {
     [pluginRuntimeStoreRegistryKey]?: PluginRuntimeStoreRegistry;
   };
+  // Store on globalThis so duplicated SDK module instances still share plugin runtime slots.
   globalRecord[pluginRuntimeStoreRegistryKey] ??= new Map();
   return globalRecord[pluginRuntimeStoreRegistryKey];
 }
@@ -66,7 +69,8 @@ export function createPluginRuntimeStore<T>(options: string | PluginRuntimeStore
   const resolved = resolvePluginRuntimeStoreOptions(options);
   const slot =
     typeof options === "string"
-      ? { runtime: null }
+      ? // Legacy string callers intentionally get isolated slots for each store instance.
+        { runtime: null }
       : (() => {
           const registry = getPluginRuntimeStoreRegistry();
           let existingSlot = registry.get(resolved.key);

--- a/src/plugin-sdk/status-helpers.ts
+++ b/src/plugin-sdk/status-helpers.ts
@@ -54,10 +54,15 @@ type ComputedAccountStatusBase = {
 };
 
 type ComputedAccountStatusAdapterParams<ResolvedAccount, Probe, Audit> = {
+  /** Resolved channel account metadata from config. */
   account: ResolvedAccount;
+  /** Canonical config used by status/probe/audit helpers. */
   cfg: OpenClawConfig;
+  /** Runtime lifecycle snapshot for this account, if the channel has started. */
   runtime?: ChannelAccountSnapshot;
+  /** Optional probe result already collected by the status adapter. */
   probe?: Probe;
+  /** Optional audit result already collected by the status adapter. */
   audit?: Audit;
 };
 
@@ -168,15 +173,19 @@ export function buildWebhookChannelStatusSummary<TExtra extends StatusSnapshotEx
 /** Build the standard per-account status payload from config metadata plus runtime state. */
 export function buildBaseAccountStatusSnapshot<TExtra extends StatusSnapshotExtra>(
   params: {
+    /** Account metadata fields copied before runtime defaults and extras. */
     account: {
       accountId: string;
       name?: string;
       enabled?: boolean;
       configured?: boolean;
     };
+    /** Runtime lifecycle state; missing values become stable false/null defaults. */
     runtime?: RuntimeLifecycleSnapshot | null;
+    /** Probe result attached to the shared account snapshot shape. */
     probe?: unknown;
   },
+  /** Channel-specific fields appended after shared status fields. */
   extra?: TExtra,
 ) {
   const { account, runtime, probe } = params;
@@ -228,6 +237,7 @@ export function createComputedAccountStatusAdapter<
   TExtra extends StatusSnapshotExtra = StatusSnapshotExtra,
 >(
   options: Omit<ChannelStatusAdapter<ResolvedAccount, Probe, Audit>, "buildAccountSnapshot"> & {
+    /** Compute account configured fields and extras before shared runtime/probe fields are merged. */
     resolveAccountSnapshot: (
       params: ComputedAccountStatusAdapterParams<ResolvedAccount, Probe, Audit>,
     ) => ComputedAccountStatusSnapshot<TExtra>;
@@ -291,9 +301,12 @@ export function createAsyncComputedAccountStatusAdapter<
 /** Normalize runtime-only account state into the shared status snapshot fields. */
 export function buildRuntimeAccountStatusSnapshot<TExtra extends StatusSnapshotExtra>(
   params: {
+    /** Runtime lifecycle state; missing fields normalize to false/null defaults. */
     runtime?: RuntimeLifecycleSnapshot | null;
+    /** Probe result carried through without interpretation. */
     probe?: unknown;
   },
+  /** Channel-specific runtime fields appended after standard lifecycle metadata. */
   extra?: TExtra,
 ) {
   const { runtime, probe } = params;
@@ -336,6 +349,7 @@ export function buildTokenChannelStatusSummary(
     probe?: unknown;
     lastProbeAt?: number | null;
   },
+  /** includeMode=false keeps channels without mode state from emitting a synthetic mode field. */
   opts?: { includeMode?: boolean },
 ) {
   const base = {

--- a/src/plugin-sdk/telegram-command-config.ts
+++ b/src/plugin-sdk/telegram-command-config.ts
@@ -1,19 +1,16 @@
-/**
- * @deprecated Public SDK subpath has no bundled extension production imports.
- * Use plugin-local Telegram command config handling for new plugin code.
- */
-
 import {
   normalizeCommandDescription,
   normalizeSlashCommandName,
   resolveCustomCommands,
 } from "../shared/custom-command-config.js";
 
+/** Deprecated Telegram SDK command config input retained for external callers. */
 export type TelegramCustomCommandInput = {
   command?: string | null;
   description?: string | null;
 };
 
+/** Validation issue shape returned alongside accepted Telegram custom commands. */
 export type TelegramCustomCommandIssue = {
   index: number;
   field: "command" | "description";
@@ -43,26 +40,34 @@ function resolveTelegramCustomCommandsImpl(params: {
   commands: Array<{ command: string; description: string }>;
   issues: TelegramCustomCommandIssue[];
 } {
+  // Keep Telegram's deprecated SDK surface on the shared command resolver so
+  // normalization, duplicate detection, and reserved-command wording do not
+  // drift from newer plugin-local command config paths.
   return resolveCustomCommands({
     ...params,
     config: TELEGRAM_CUSTOM_COMMAND_CONFIG,
   });
 }
 
+/** Return the legacy Telegram command-name pattern object for identity-based callers. */
 export function getTelegramCommandNamePattern(): RegExp {
   return TELEGRAM_COMMAND_NAME_PATTERN_VALUE;
 }
 
+/** Legacy Telegram command-name regex: lowercase ASCII letters, digits, and underscores. */
 export const TELEGRAM_COMMAND_NAME_PATTERN = TELEGRAM_COMMAND_NAME_PATTERN_VALUE;
 
+/** Normalize slash-prefixed Telegram command names to the stored lowercase form. */
 export function normalizeTelegramCommandName(value: string): string {
   return normalizeTelegramCommandNameImpl(value);
 }
 
+/** Trim Telegram command descriptions without applying provider-specific text policy. */
 export function normalizeTelegramCommandDescription(value: string): string {
   return normalizeTelegramCommandDescriptionImpl(value);
 }
 
+/** Resolve accepted Telegram custom commands plus indexed validation issues. */
 export function resolveTelegramCustomCommands(params: {
   commands?: TelegramCustomCommandInput[] | null;
   reservedCommands?: Set<string>;

--- a/src/plugin-sdk/text-chunking.ts
+++ b/src/plugin-sdk/text-chunking.ts
@@ -1,6 +1,10 @@
 import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
 
-/** Chunk outbound text while preferring newline boundaries over spaces. */
+/**
+ * Splits outbound channel text into non-empty chunks no longer than `limit`.
+ * Newlines win over spaces so message adapters preserve paragraph boundaries
+ * when a provider-specific character cap forces chunking.
+ */
 export function chunkTextForOutbound(text: string, limit: number): string[] {
   return chunkTextByBreakResolver(text, limit, (window) => {
     const lastNewline = window.lastIndexOf("\n");

--- a/src/plugin-sdk/webhook-memory-guards.ts
+++ b/src/plugin-sdk/webhook-memory-guards.ts
@@ -12,12 +12,14 @@ type CounterState = {
 };
 
 export type FixedWindowRateLimiter = {
+  /** Increment a key and return true only after it exceeds the configured window budget. */
   isRateLimited: (key: string, nowMs?: number) => boolean;
   size: () => number;
   clear: () => void;
 };
 
 export type BoundedCounter = {
+  /** Increment a key and return its current count; empty keys intentionally count as zero. */
   increment: (key: string, nowMs?: number) => number;
   size: () => number;
   clear: () => void;
@@ -38,6 +40,7 @@ export const WEBHOOK_ANOMALY_COUNTER_DEFAULTS = Object.freeze({
 export const WEBHOOK_ANOMALY_STATUS_CODES = Object.freeze([400, 401, 408, 413, 415, 429]);
 
 export type WebhookAnomalyTracker = {
+  /** Record a tracked status code and optionally emit sampled log messages. */
   record: (params: {
     key: string;
     statusCode: number;
@@ -80,6 +83,7 @@ export function createFixedWindowRateLimiter(options: {
   let lastPruneMs = 0;
 
   const touch = (key: string, value: FixedWindowState) => {
+    // Refresh insertion order so max-size pruning drops the coldest tracked keys.
     state.delete(key);
     state.set(key, value);
   };
@@ -143,6 +147,7 @@ export function createBoundedCounter(options: {
   let lastPruneMs = 0;
 
   const touch = (key: string, value: CounterState) => {
+    // Refresh insertion order so the bounded counter keeps recently active keys.
     counters.delete(key);
     counters.set(key, value);
   };
@@ -217,6 +222,8 @@ export function createWebhookAnomalyTracker(options?: {
       }
       const next = counter.increment(key, nowMs);
       if (log && (next === 1 || next % logEvery === 0)) {
+        // Log the first hit and then sample by cadence so noisy webhook probes
+        // stay visible without producing one log line per rejected request.
         log(message(next));
       }
       return next;

--- a/src/plugin-sdk/webhook-numeric-options.ts
+++ b/src/plugin-sdk/webhook-numeric-options.ts
@@ -1,3 +1,4 @@
+/** Resolve webhook numeric options by rejecting non-finite input, flooring fractions, and enforcing a minimum. */
 export function resolveWebhookIntegerOption(
   value: number | undefined,
   fallback: number,

--- a/src/plugin-sdk/webhook-path.ts
+++ b/src/plugin-sdk/webhook-path.ts
@@ -1,9 +1,4 @@
-/**
- * @deprecated Compatibility subpath. Import webhook path helpers from
- * `openclaw/plugin-sdk/webhook-ingress` instead.
- */
-
-/** @deprecated Import from `openclaw/plugin-sdk/webhook-ingress` instead. */
+/** @deprecated Normalize webhook route paths via `openclaw/plugin-sdk/webhook-ingress` instead. */
 export function normalizeWebhookPath(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -16,7 +11,7 @@ export function normalizeWebhookPath(raw: string): string {
   return withSlash;
 }
 
-/** @deprecated Import from `openclaw/plugin-sdk/webhook-ingress` instead. */
+/** @deprecated Resolve configured webhook paths via `openclaw/plugin-sdk/webhook-ingress` instead. */
 export function resolveWebhookPath(params: {
   webhookPath?: string;
   webhookUrl?: string;

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -11,6 +11,7 @@ import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 import { resolveWebhookIntegerOption } from "./webhook-numeric-options.js";
 
+/** Body read limit profile: strict before auth, roomier after target authentication. */
 export type WebhookBodyReadProfile = "pre-auth" | "post-auth";
 
 export {
@@ -22,10 +23,12 @@ export {
 } from "../infra/http-body.js";
 
 export const WEBHOOK_BODY_READ_DEFAULTS = Object.freeze({
+  /** Small pre-auth cap limits unauthenticated memory and socket hold time. */
   preAuth: {
     maxBytes: 64 * 1024,
     timeoutMs: 5_000,
   },
+  /** Larger post-auth cap allows legitimate webhook payloads after target selection. */
   postAuth: {
     maxBytes: 1024 * 1024,
     timeoutMs: 30_000,
@@ -38,7 +41,9 @@ export const WEBHOOK_IN_FLIGHT_DEFAULTS = Object.freeze({
 });
 
 export type WebhookInFlightLimiter = {
+  /** Try to reserve one active handler slot; empty keys intentionally fail open. */
   tryAcquire: (key: string) => boolean;
+  /** Release a previously acquired slot. Extra releases for a key are ignored. */
   release: (key: string) => void;
   size: () => number;
   clear: () => void;
@@ -66,6 +71,7 @@ function resolveWebhookBodyReadLimits(params: {
   return { maxBytes, timeoutMs };
 }
 
+/** Translate low-level body read errors into the webhook HTTP response contract. */
 function respondWebhookBodyReadError(params: {
   res: ServerResponse;
   code: string;
@@ -112,6 +118,8 @@ export function createWebhookInFlightLimiter(options?: {
   return {
     tryAcquire: (key: string) => {
       if (!key) {
+        // Unknown callers should not share a global bucket; let the request path
+        // decide whether an empty in-flight key is acceptable.
         return true;
       }
       const current = active.get(key) ?? 0;
@@ -236,6 +244,8 @@ export function beginWebhookRequestPipelineOrReject(params: {
         return;
       }
       released = true;
+      // The caller owns this release hook and must call it from a finally block;
+      // idempotence keeps nested cleanup paths from underflowing the limiter.
       if (inFlightLimiter && inFlightKey) {
         inFlightLimiter.release(inFlightKey);
       }

--- a/src/plugin-sdk/webhook-targets.ts
+++ b/src/plugin-sdk/webhook-targets.ts
@@ -8,12 +8,16 @@ import {
 } from "./webhook-request-guards.js";
 
 export type RegisteredWebhookTarget<T> = {
+  /** Normalized target stored in the caller's path bucket. */
   target: T;
+  /** Idempotent cleanup handle for removing this target from its path bucket. */
   unregister: () => void;
 };
 
 export type RegisterWebhookTargetOptions<T extends { path: string }> = {
+  /** Called only when the first target for a normalized path is registered. */
   onFirstPathTarget?: (params: { path: string; target: T }) => void | (() => void);
+  /** Called after the final target for a normalized path has been removed. */
   onLastPathTargetRemoved?: (params: { path: string }) => void;
 };
 
@@ -68,6 +72,8 @@ export function registerWebhookTarget<T extends { path: string }>(
   const existing = targetsByPath.get(key) ?? [];
 
   if (existing.length === 0) {
+    // The path bucket owns route setup/teardown, not individual targets, so
+    // sibling targets can share one plugin HTTP route until the last unregister.
     const onFirstPathResult = opts?.onFirstPathTarget?.({
       path: key,
       target: normalizedTarget,
@@ -141,7 +147,9 @@ export async function withResolvedWebhookRequestPipeline<T>(params: {
   const inFlightKey =
     typeof params.inFlightKey === "function"
       ? params.inFlightKey({ req: params.req, path: resolved.path, targets: resolved.targets })
-      : (params.inFlightKey ?? `${resolved.path}:${params.req.socket?.remoteAddress ?? "unknown"}`);
+      : // Default to path plus remote address so one slow sender does not block
+        // unrelated webhook paths or callers behind different source addresses.
+        (params.inFlightKey ?? `${resolved.path}:${params.req.socket?.remoteAddress ?? "unknown"}`);
   const requestLifecycle = beginWebhookRequestPipelineOrReject({
     req: params.req,
     res: params.res,
@@ -168,8 +176,11 @@ export async function withResolvedWebhookRequestPipeline<T>(params: {
 }
 
 export type WebhookTargetMatchResult<T> =
+  /** No registered target matched the request authentication material. */
   | { kind: "none" }
+  /** Exactly one target matched and can handle the request. */
   | { kind: "single"; target: T }
+  /** More than one target matched; callers must reject instead of guessing. */
   | { kind: "ambiguous" };
 
 function updateMatchedWebhookTarget<T>(
@@ -271,6 +282,8 @@ function resolveWebhookTargetMatchOrReject<T>(
     return match.target;
   }
   if (match.kind === "ambiguous") {
+    // Ambiguous auth is rejected as unauthorized; selecting one matching target
+    // would let one tenant's valid secret route another tenant's webhook.
     params.res.statusCode = params.ambiguousStatusCode ?? 401;
     params.res.end(params.ambiguousMessage ?? "ambiguous webhook target");
     return null;

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -1,5 +1,6 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
+/** Resolve an account config entry by exact key first, then lowercase-normalized key match. */
 export function resolveAccountEntry<T>(
   accounts: Record<string, T> | undefined,
   accountId: string,
@@ -8,6 +9,8 @@ export function resolveAccountEntry<T>(
     return undefined;
   }
   if (Object.hasOwn(accounts, accountId)) {
+    // Exact own-key lookup takes precedence so an intentionally cased account id
+    // is not shadowed by another key that normalizes to the same value.
     return accounts[accountId];
   }
   const normalized = normalizeLowercaseStringOrEmpty(accountId);
@@ -17,6 +20,7 @@ export function resolveAccountEntry<T>(
   return matchKey ? accounts[matchKey] : undefined;
 }
 
+/** Resolve account entries with a plugin-provided normalizer for channel-specific aliases. */
 export function resolveNormalizedAccountEntry<T>(
   accounts: Record<string, T> | undefined,
   accountId: string,
@@ -26,6 +30,7 @@ export function resolveNormalizedAccountEntry<T>(
     return undefined;
   }
   if (Object.hasOwn(accounts, accountId)) {
+    // Keep direct own-key lookup ahead of normalized scans for duplicate-normalized maps.
     return accounts[accountId];
   }
   const normalized = normalizeAccountId(accountId);

--- a/src/shared/custom-command-config.ts
+++ b/src/shared/custom-command-config.ts
@@ -1,16 +1,19 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
+/** Raw custom command entry accepted from config or legacy SDK callers. */
 export type CustomCommandInput = {
   command?: string | null;
   description?: string | null;
 };
 
+/** Indexed validation issue that callers can map back onto their config path. */
 export type CustomCommandIssue = {
   index: number;
   field: "command" | "description";
   message: string;
 };
 
+/** Channel-specific command validation policy shared by config schemas and SDK shims. */
 export type CustomCommandConfig = {
   label: string;
   pattern: RegExp;
@@ -20,6 +23,7 @@ export type CustomCommandConfig = {
 
 const DEFAULT_PREFIX = "/";
 
+/** Normalize slash command names before validation and storage. */
 export function normalizeSlashCommandName(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -29,10 +33,12 @@ export function normalizeSlashCommandName(value: string): string {
   return normalizeLowercaseStringOrEmpty(withoutSlash).replace(/-/g, "_");
 }
 
+/** Normalize command descriptions without applying channel-specific length or content policy. */
 export function normalizeCommandDescription(value: string): string {
   return value.trim();
 }
 
+/** Resolve valid custom commands and collect validation issues without throwing. */
 export function resolveCustomCommands(params: {
   commands?: CustomCommandInput[] | null;
   reservedCommands?: Set<string>;
@@ -98,6 +104,8 @@ export function resolveCustomCommands(params: {
       continue;
     }
     if (checkDuplicates) {
+      // Only accepted commands enter duplicate tracking so invalid earlier
+      // entries do not block a later valid definition for the same name.
       seen.add(normalized);
     }
     resolved.push({ command: normalized, description });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -1,4 +1,8 @@
-/** Splits text into bounded chunks using caller-owned soft-break selection. */
+/**
+ * Splits text into bounded chunks using caller-owned soft-break selection.
+ * Empty input returns no chunks; non-positive limits intentionally leave the
+ * original text intact for adapters that disable chunking with `0`.
+ */
 export function chunkTextByBreakResolver(
   text: string,
   limit: number,


### PR DESCRIPTION
## Summary
- Documents the deprecated command authorization SDK compatibility params.
- Captures the direct-DM pairing-store versus group allowlist boundary and authorizer-list fallback behavior.
- Continues the inline contract-comment work after #88554 was already merged to main, now covering stateful target driver contracts.

## Verification
- `git diff --check`
- `pnpm test src/channels/plugins/binding-targets.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`

Behavior addressed: stateful target driver comments now explain driver responsibilities, readiness/session/reset contracts, session-key parsing, idempotent registration, and registration-order session-key probing.
Real environment tested: local OpenClaw checkout on Node/Vitest via repo test wrapper.
Exact steps or command run after this patch: git diff --check; pnpm test src/channels/plugins/binding-targets.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts.
Evidence after fix: latest pushed commit 85e6e3edbbe documents stateful binding target driver responsibilities, readiness/session/reset contracts, session-key parsing, idempotent registration, and registration-order session-key probing; binding target tests passed with 3 tests and plugin-contract tests passed with 18 tests.
Observed result after fix: continuation PR branch pushed after the stateful target driver contracts slice.
What was not tested: full repository test/check suite.







