### PR TITLE
fix(copilot): quarantine malformed bridged tools

### DIFF
--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -160,6 +160,52 @@ describe("createCopilotToolBridge", () => {
     expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool-a", "tool-b"]);
   });
 
+  it("quarantines malformed source tool descriptors before SDK registration", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const unreadableNameTool = Object.defineProperty(makeTool({ name: "bad" }), "name", {
+      get() {
+        throw new Error("copilot bridge tool name getter exploded");
+      },
+    });
+    const dynamicSchemaTool = makeTool({
+      name: "dofbot_move_angles",
+      parameters: {
+        properties: {
+          target: { $dynamicRef: "#/$defs/angleTarget" },
+        },
+        type: "object",
+      } as never,
+    });
+    const unreadablePrepareTool = Object.defineProperty(
+      makeTool({ name: "needs_prepare" }),
+      "prepareArguments",
+      {
+        get() {
+          throw new Error("copilot bridge prepareArguments getter exploded");
+        },
+      },
+    );
+
+    const result = await createCopilotToolBridge({
+      agentId: "agent-1",
+      createOpenClawCodingTools: async () => [
+        unreadableNameTool,
+        dynamicSchemaTool,
+        unreadablePrepareTool,
+        makeTool({ name: "read" }),
+      ],
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    });
+
+    expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read"]);
+    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["read"]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Tool "dofbot_move_angles" has unsupported runtime input schema'),
+    );
+  });
+
   it("throws when createOpenClawCodingTools returns a non-array", async () => {
     await expect(
       createCopilotToolBridge({

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -9,9 +9,11 @@ import {
   buildEmbeddedAttemptToolRunContext,
   getPluginToolMeta,
   isSubagentSessionKey,
+  projectRuntimeToolInputSchema,
   resolveAttemptSpawnWorkspaceDir,
   resolveEmbeddedAttemptToolConstructionPlan,
   resolveModelAuthMode,
+  type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 
 type CreateOpenClawCodingTools =
@@ -182,8 +184,11 @@ export async function createCopilotToolBridge(
     );
   }
 
+  const materializedToolProjection = materializeCopilotSourceTools(sourceTools as AnyAgentTool[]);
+  warnCopilotToolSchemaDiagnostics(materializedToolProjection.diagnostics);
+
   const plannedTools = filterCopilotToolsForConstructionPlan(
-    sourceTools as AnyAgentTool[],
+    materializedToolProjection.tools,
     effectiveToolPlan.codingToolConstructionPlan,
   );
   const filteredTools = filterCopilotToolsForAllowlist(
@@ -491,6 +496,186 @@ export function convertOpenClawToolToSdkTool(
     // (see `extensions/codex/src/app-server/dynamic-tools.ts`).
     skipPermission: true,
   };
+}
+
+type CopilotToolMaterialization =
+  | { ok: true; tool: AnyAgentTool }
+  | { diagnostic: RuntimeToolSchemaDiagnostic; ok: false };
+
+type CopilotToolField =
+  | "description"
+  | "execute"
+  | "executionMode"
+  | "name"
+  | "parameters"
+  | "prepareArguments";
+
+function materializeCopilotSourceTools(sourceTools: readonly AnyAgentTool[]): {
+  diagnostics: RuntimeToolSchemaDiagnostic[];
+  tools: AnyAgentTool[];
+} {
+  const tools: AnyAgentTool[] = [];
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  let changed = false;
+  for (const [toolIndex, sourceTool] of sourceTools.entries()) {
+    const materialized = materializeCopilotSourceTool(sourceTool, toolIndex);
+    if (materialized.ok) {
+      tools.push(materialized.tool);
+      changed ||= materialized.tool !== sourceTool;
+    } else {
+      changed = true;
+      diagnostics.push(materialized.diagnostic);
+    }
+  }
+  return { diagnostics, tools: changed ? tools : (sourceTools as AnyAgentTool[]) };
+}
+
+function materializeCopilotSourceTool(
+  sourceTool: AnyAgentTool,
+  toolIndex: number,
+): CopilotToolMaterialization {
+  if (!sourceTool || typeof sourceTool !== "object") {
+    return {
+      ok: false,
+      diagnostic: {
+        toolIndex,
+        toolName: `tool[${toolIndex}]`,
+        violations: [`tool[${toolIndex}] is not an object`],
+      },
+    };
+  }
+
+  const name = readCopilotToolField(sourceTool, "name");
+  const toolName =
+    name.readable && typeof name.value === "string" && name.value.trim()
+      ? name.value
+      : `tool[${toolIndex}]`;
+  if (!name.readable) {
+    return copilotToolDiagnostic(toolIndex, toolName, [`${toolName}.name is unreadable`]);
+  }
+  if (typeof name.value !== "string" || name.value.trim().length === 0) {
+    return copilotToolDiagnostic(toolIndex, toolName, [
+      `${toolName}.name must be a non-empty string`,
+    ]);
+  }
+
+  const execute = readCopilotToolField(sourceTool, "execute");
+  if (!execute.readable || typeof execute.value !== "function") {
+    return copilotToolDiagnostic(toolIndex, toolName, [`${toolName}.execute must be a function`]);
+  }
+
+  const parameters = readCopilotToolField(sourceTool, "parameters");
+  if (!parameters.readable) {
+    return copilotToolDiagnostic(toolIndex, toolName, [`${toolName}.parameters is unreadable`]);
+  }
+  const schemaProjection = projectRuntimeToolInputSchema(
+    parameters.value,
+    `${toolName}.parameters`,
+  );
+  if (schemaProjection.violations.length > 0) {
+    return copilotToolDiagnostic(toolIndex, toolName, [...schemaProjection.violations]);
+  }
+
+  const description = readCopilotToolField(sourceTool, "description");
+  const prepareArguments = readCopilotToolField(sourceTool, "prepareArguments");
+  if (!prepareArguments.readable) {
+    return copilotToolDiagnostic(toolIndex, toolName, [
+      `${toolName}.prepareArguments is unreadable`,
+    ]);
+  }
+  const executionMode = readCopilotToolField(sourceTool, "executionMode");
+  if (!executionMode.readable) {
+    return copilotToolDiagnostic(toolIndex, toolName, [`${toolName}.executionMode is unreadable`]);
+  }
+  const needsMaterializedDescriptor =
+    !description.readable ||
+    hasAccessorDescriptor(sourceTool, "name") ||
+    hasAccessorDescriptor(sourceTool, "parameters") ||
+    hasAccessorDescriptor(sourceTool, "description") ||
+    hasAccessorDescriptor(sourceTool, "execute") ||
+    hasAccessorDescriptor(sourceTool, "prepareArguments") ||
+    hasAccessorDescriptor(sourceTool, "executionMode");
+  if (!needsMaterializedDescriptor) {
+    return { ok: true, tool: sourceTool };
+  }
+
+  const pluginMeta = getPluginToolMeta(sourceTool);
+  return {
+    ok: true,
+    tool: Object.create(Object.getPrototypeOf(sourceTool), {
+      ...Object.getOwnPropertyDescriptors(sourceTool),
+      description: dataDescriptor(description.readable ? description.value : undefined),
+      execute: dataDescriptor(execute.value),
+      executionMode: dataDescriptor(executionMode.readable ? executionMode.value : undefined),
+      name: dataDescriptor(name.value),
+      parameters: dataDescriptor(schemaProjection.schema),
+      prepareArguments: dataDescriptor(prepareArguments.value),
+      ...(pluginMeta ? { pluginId: dataDescriptor(pluginMeta.pluginId) } : {}),
+    }) as AnyAgentTool,
+  };
+}
+
+function copilotToolDiagnostic(
+  toolIndex: number,
+  toolName: string,
+  violations: string[],
+): CopilotToolMaterialization {
+  return { ok: false, diagnostic: { toolIndex, toolName, violations } };
+}
+
+function readCopilotToolField<TField extends CopilotToolField>(
+  tool: AnyAgentTool,
+  field: TField,
+): { readable: true; value: AnyAgentTool[TField] } | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function hasAccessorDescriptor(tool: object, field: PropertyKey): boolean {
+  let target: object | null = tool;
+  while (target) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, field);
+    if (descriptor) {
+      return "get" in descriptor || "set" in descriptor;
+    }
+    target = Object.getPrototypeOf(target);
+  }
+  return false;
+}
+
+function dataDescriptor(value: unknown): PropertyDescriptor {
+  return {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  };
+}
+
+function warnCopilotToolSchemaDiagnostics(
+  diagnostics: readonly RuntimeToolSchemaDiagnostic[],
+): void {
+  for (const diagnostic of diagnostics) {
+    console.warn(
+      `[copilot-tool-bridge] Tool "${formatCopilotDiagnosticText(
+        diagnostic.toolName,
+      )}" has unsupported runtime input schema (${diagnostic.violations
+        .map(formatCopilotDiagnosticText)
+        .join(", ")}) and was skipped before Copilot SDK registration.`,
+    );
+  }
+}
+
+function formatCopilotDiagnosticText(value: string): string {
+  return (
+    value
+      .replace(/\p{C}+/gu, " ")
+      .trim()
+      .slice(0, 240) || "(unknown)"
+  );
 }
 
 function agentToolResultToSdk(result: AgentToolResultLike | undefined): ToolResultObject {


### PR DESCRIPTION
## Summary

- quarantine malformed Copilot bridge source tools before construction-plan filtering, duplicate detection, and SDK registration
- reject unreadable tool names, unreadable execution-affecting descriptors, and unsupported runtime input schemas such as `$dynamicRef`
- preserve healthy sibling tools and keep plugin allowlist fallback metadata on materialized descriptors

## Verification

- pre-fix repro: `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts --reporter=dot` failed with `copilot bridge tool name getter exploded`
- `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/copilot/src/tool-bridge.ts extensions/copilot/src/tool-bridge.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint extensions/copilot/src/tool-bridge.ts extensions/copilot/src/tool-bridge.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"` (`aws`, `cbx_d7db5fa1f575`, `run_505d098445b8`, exit 0)
- post-rebase sanity: `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts --reporter=dot`

## Real behavior proof

Behavior addressed: one malformed OpenClaw dynamic tool should not poison Copilot bridge startup before the assistant can produce content; unsupported runtime schemas should be skipped and healthy sibling tools should still register.

Real environment tested: local targeted Vitest on macOS plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/copilot/src/tool-bridge.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: the regression test feeds an unreadable `name` getter, a `$dynamicRef` schema tool named `dofbot_move_angles`, and an unreadable `prepareArguments` getter into the bridge; only `read` reaches `sourceTools` and `sdkTools`. AWS Crabbox `cbx_d7db5fa1f575` / `run_505d098445b8` completed `pnpm check:changed` with exit 0.

Observed result after fix: focused Copilot bridge suite passed 65 tests; changed gate passed lanes `extensions, extensionTests`.

What was not tested: a live GitHub Copilot model turn.
