### PR TITLE
docs: add ClawHub CLI page

### DIFF
--- a/docs/clawhub/cli.md
+++ b/docs/clawhub/cli.md
@@ -3,7 +3,7 @@ summary: "ClawHub CLI entry points for discovering, installing, publishing, and 
 read_when:
   - You want to use ClawHub from the command line
   - You want to install ClawHub skills or plugins through OpenClaw
-  - You want to publish or rescan ClawHub packages
+  - You want to publish ClawHub packages
 title: "ClawHub CLI"
 ---
 
@@ -14,7 +14,7 @@ OpenClaw has two command-line entry points for ClawHub:
 - `openclaw skills` and `openclaw plugins` install and manage ClawHub packages
   inside OpenClaw.
 - The standalone `clawhub` CLI handles publisher workflows such as login,
-  publish, transfer, sync, and rescan.
+  publish, transfer, and sync.
 
 ## Discover and install
 
@@ -55,20 +55,18 @@ clawhub package publish your-org/your-plugin
 clawhub package publish your-org/your-plugin@v1.0.0
 ```
 
-For skills, install the publishing helper skill and follow its current command
-shape:
+Publish skill folders with `clawhub skill publish`:
 
 ```bash
-openclaw skills install clawhub-publish
-clawhub publish
+clawhub skill publish ./skills/review-helper
+clawhub skill publish ./skills/review-helper --version 1.0.0
 ```
 
-When ClawHub scan state or ownership needs maintenance, use the relevant
-standalone command:
+When local skill scan state or package ownership needs maintenance, use the
+relevant standalone command:
 
 ```bash
 clawhub sync --all
-clawhub skill rescan <slug>
 clawhub package transfer @old-owner/package --to new-owner
 ```
 

--- a/docs/clawhub/cli.md
+++ b/docs/clawhub/cli.md
@@ -1,0 +1,83 @@
+---
+summary: "ClawHub CLI entry points for discovering, installing, publishing, and verifying OpenClaw skills and plugins."
+read_when:
+  - You want to use ClawHub from the command line
+  - You want to install ClawHub skills or plugins through OpenClaw
+  - You want to publish or rescan ClawHub packages
+title: "ClawHub CLI"
+---
+
+# ClawHub CLI
+
+OpenClaw has two command-line entry points for ClawHub:
+
+- `openclaw skills` and `openclaw plugins` install and manage ClawHub packages
+  inside OpenClaw.
+- The standalone `clawhub` CLI handles publisher workflows such as login,
+  publish, transfer, sync, and rescan.
+
+## Discover and install
+
+Use OpenClaw commands when you want to install or update packages for a local
+OpenClaw agent or Gateway.
+
+```bash
+openclaw skills search "calendar"
+openclaw skills install <slug>
+openclaw skills update <slug>
+openclaw skills verify <slug>
+
+openclaw plugins search "calendar"
+openclaw plugins install clawhub:<package>
+openclaw plugins update <id-or-npm-spec>
+```
+
+Skill installs target the active workspace `skills/` directory by default. Add
+`--global` to install into the shared managed skills directory.
+
+Plugin installs use the `clawhub:` prefix when you want ClawHub resolution
+instead of npm or another install source.
+
+## Publish and maintain
+
+Install the standalone ClawHub CLI for publisher workflows:
+
+```bash
+npm i -g clawhub
+clawhub login
+```
+
+Publish plugin packages with `clawhub package publish`:
+
+```bash
+clawhub package publish your-org/your-plugin --dry-run
+clawhub package publish your-org/your-plugin
+clawhub package publish your-org/your-plugin@v1.0.0
+```
+
+For skills, install the publishing helper skill and follow its current command
+shape:
+
+```bash
+openclaw skills install clawhub-publish
+clawhub publish
+```
+
+When ClawHub scan state or ownership needs maintenance, use the relevant
+standalone command:
+
+```bash
+clawhub skill rescan <slug>
+clawhub package transfer @old-owner/package --to new-owner
+```
+
+## Related
+
+- [`openclaw skills`](/cli/skills) - local skill search, install, update, and
+  verification
+- [`openclaw plugins`](/cli/plugins) - plugin search, install, update, and
+  inspection
+- [ClawHub publishing](/clawhub/publishing) - owner scope, release validation,
+  and review flow
+- [Creating skills](/tools/creating-skills) - skill authoring and publish flow
+- [Building plugins](/plugins/building-plugins) - plugin package authoring

--- a/docs/clawhub/cli.md
+++ b/docs/clawhub/cli.md
@@ -67,6 +67,7 @@ When ClawHub scan state or ownership needs maintenance, use the relevant
 standalone command:
 
 ```bash
+clawhub sync --all
 clawhub skill rescan <slug>
 clawhub package transfer @old-owner/package --to new-owner
 ```


### PR DESCRIPTION
## Summary

- Adds the missing `/clawhub/cli` docs page.
- Documents the OpenClaw and standalone ClawHub CLI entry points for install, verify, publish, rescan, and transfer workflows.
- Fixes existing internal docs references to `/clawhub/cli`.

AI-assisted: yes.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner?

No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Existing docs link to `/clawhub/cli`, but the page was missing.
- Real environment tested: Local Windows checkout, branch `docs/clawhub-cli-page`.
- Exact steps or command run after this patch: `node scripts/docs-link-audit.mjs`, `node scripts/check-docs-mdx.mjs docs\clawhub\cli.md`, and `corepack pnpm exec oxfmt --check --threads=1 --config .oxfmtrc.jsonc docs\clawhub\cli.md`.
- Evidence after fix: Copied live console output from the local checkout: `checked_internal_links=4559`, `broken_links=0`, `Docs MDX check passed (1 files, 23ms).`, and `All matched files use the correct format.`.
- Observed result after fix: The docs link audit no longer reports `/clawhub/cli` as a broken route, and the new page compiles as MDX.
- What was not tested: Full docs format check on Windows.
- Proof limitations or environment constraints: Full `format:docs:check` hit a Windows spawn issue in the repo script; targeted formatting for the changed file passed.