### PR TITLE
fix(diagnostics): re-queue pending messages after stuck-session recovery aborts ghost run

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -385,6 +385,42 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it("releases the session lane when abort+drain succeeds but queued messages remain (ghost run + queued messages)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("ghost-run-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+    // Bug scenario: ghost run aborted+drained successfully, but user sent messages during the stall
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:ghost:ghost",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "ghost-run-session",
+      sessionKey: "agent:ghost:ghost",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("ghost-run-session");
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:ghost:ghost");
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      released: 1,
+      queuedCount: 1,
+    });
+  });
+
   it("reports queued lane work when aborting active work releases a lane", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -242,7 +242,9 @@ export async function recoverStuckDiagnosticSession(
 
     const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
     const released =
-      sessionLane && (!activeSessionId || !aborted || !drained) ? resetCommandLane(sessionLane) : 0;
+      sessionLane && (queuedCount > 0 || !activeSessionId || !aborted || !drained)
+        ? resetCommandLane(sessionLane)
+        : 0;
 
     const clearStaleQueuedSession = !aborted && released === 0 && (params.queueDepth ?? 0) > 0;
 


### PR DESCRIPTION
## Summary

- When stuck-session recovery successfully aborts a ghost embedded run (`aborted=true`, `drained=true`) and the command lane has queued user messages (`queuedCount > 0`), the lane-reset condition `(!activeSessionId || !aborted || !drained)` evaluates to `false`, skipping `resetCommandLane`. Queued messages are silently discarded — the user gets no response.
- Adds `queuedCount > 0` to the lane-reset condition so when pending queued messages exist, the lane is always reset and drained after recovery, allowing the next run to process them.
- Adds a dedicated regression test for the exact bug scenario.

## Verification

- All 20 stuck-session recovery tests pass (19 existing + 1 new regression test).
- The fix adds one condition term to an existing boolean expression — no new code paths or side effects.
- This PR contains only 2 files — no CHANGELOG edits, no unrelated changes.

## Real behavior proof

**Behavior addressed:** After stuck-session recovery successfully aborts a ghost embedded run (`aborted=true`, `drained=true`), queued user messages in the command lane are discarded instead of being re-queued for the next run.

**Environment tested:** Node 22.22.0 on Linux, pnpm test, production source via `node --import tsx`.

**Steps run after the patch:**

1. Verified the fix is present in the production source file:

```bash
node --import tsx --no-warnings -e "
import fs from 'node:fs';
const src = fs.readFileSync('./src/logging/diagnostic-stuck-session-recovery.runtime.ts', 'utf8');
console.log('Fix present:', src.includes('queuedCount > 0 || !activeSessionId'));
console.log('Old condition gone:', !src.includes('(!activeSessionId || !aborted || !drained) ? resetCommandLane'));
"
```

2. Ran the full test suite:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
```

**Evidence after fix:**

```text
Fix present: true
Old condition gone: true

Test Files  1 passed (1)
     Tests  20 passed (20)
```

The changed condition at `diagnostic-stuck-session-recovery.runtime.ts:244-247`:

```typescript
const released =
  sessionLane && (queuedCount > 0 || !activeSessionId || !aborted || !drained)
    ? resetCommandLane(sessionLane)
    : 0;
```

Logic trace for the ghost-run scenario (`aborted=true, drained=true, activeSessionId=present, queuedCount=1`):

```text
Before fix: (!activeSessionId || !aborted || !drained)
  = (!true || !true || !true) = (false || false || false) = false
  → resetCommandLane NOT called → messages LOST

After fix:  (queuedCount > 0 || !activeSessionId || !aborted || !drained)
  = (true || !true || !true || !true) = (true || ...) = true
  → resetCommandLane called → messages REQUEUED
```

**Reproduction confirmation** — the new regression test FAILS without the fix:

```
 FAIL  stuck session recovery > releases the session lane when abort+drain
       succeeds but queued messages remain (ghost run + queued messages)
AssertionError: expected "vi.fn()" to be called with arguments: [ 'session:agent:ghost:ghost' ]
Number of calls: 0
```

Same test PASSES after applying the fix (`released: 1, queuedCount: 1`).

**Observed result:** `resetCommandLane` is now called when `queuedCount > 0`, regardless of the abort/drain outcome. Queued messages are released back to the lane for processing by the next run.

**Not tested:** Live gateway session with real Slack ghost-run scenario.

Closes #89208.
