### PR TITLE
[codex] fix message send loop detection

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -197,7 +197,7 @@ describe("before_tool_call loop detection behavior", () => {
   function expectCriticalLoopEvent(
     loopEvent: DiagnosticToolLoopEvent | undefined,
     params: {
-      detector: "ping_pong" | "known_poll_no_progress";
+      detector: "generic_repeat" | "ping_pong" | "known_poll_no_progress";
       toolName: string;
       count?: number;
     },
@@ -318,6 +318,75 @@ describe("before_tool_call loop detection behavior", () => {
 
     const result = await tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined);
     expectToolLoopBlockedResult(result, "identical outcomes");
+  });
+
+  it("blocks repeated message sends when delivery ids are the only changing result field", async () => {
+    await withToolLoopEvents(async (emitted) => {
+      const execute = vi.fn().mockImplementation(async (toolCallId: string) => {
+        const messageId = `om_${toolCallId}`;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                channel: "feishu",
+                to: "chat:oc_123",
+                via: "gateway",
+                result: { messageId, chatId: "oc_123" },
+              }),
+            },
+          ],
+          details: {
+            channel: "feishu",
+            to: "chat:oc_123",
+            via: "gateway",
+            result: {
+              messageId,
+              chatId: "oc_123",
+              receipt: {
+                primaryPlatformMessageId: messageId,
+                platformMessageIds: [messageId],
+                parts: [{ platformMessageId: messageId, kind: "text", index: 0 }],
+                sentAt: Date.now(),
+                raw: [{ channel: "feishu", messageId, chatId: "oc_123" }],
+              },
+            },
+          },
+        };
+      });
+      const tool = createWrappedTool("message", execute);
+      const params = {
+        action: "send",
+        channel: "feishu",
+        target: "chat:oc_123",
+        message: "hello",
+      };
+
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        await expectUnblockedToolExecution(tool, `message-${i}`, params);
+      }
+
+      const result = await tool.execute(
+        `message-${CRITICAL_THRESHOLD}`,
+        params,
+        undefined,
+        undefined,
+      );
+      expectToolLoopBlockedResult(result, "identical outcomes");
+      expectCriticalLoopEvent(emitted.at(-1), {
+        detector: "generic_repeat",
+        toolName: "message",
+      });
+
+      const retryResult = await tool.execute(
+        `message-${CRITICAL_THRESHOLD + 1}`,
+        params,
+        undefined,
+        undefined,
+      );
+      expectToolLoopBlockedResult(retryResult, "identical outcomes");
+      expect(execute).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+    });
   });
 
   it("does not carry loop history across run ids", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -1140,13 +1140,16 @@ export function wrapToolWithBeforeToolCallHook(
           reason: outcome.reason,
           deniedReason: outcome.deniedReason ?? "plugin-before-tool-call",
         });
-        await recordLoopOutcome({
-          ctx,
-          toolName: normalizedToolName,
-          toolParams: outcome.params ?? hookParams,
-          toolCallId,
-          result: blockedResult,
-        });
+        if (outcome.deniedReason !== "tool-loop") {
+          // 循环阻断本身不是工具进展；记录它会覆盖上一条成功结果，让下一次同参调用重新放行。
+          await recordLoopOutcome({
+            ctx,
+            toolName: normalizedToolName,
+            toolParams: outcome.params ?? hookParams,
+            toolCallId,
+            result: blockedResult,
+          });
+        }
         return blockedResult;
       }
       const executeParams = reconcileCodeModeExecBeforeHookParams({

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -586,6 +586,62 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks repeated message sends despite volatile delivery receipts", () => {
+      const state = createState();
+      const params = {
+        action: "send",
+        channel: "feishu",
+        target: "chat:oc_123",
+        message: "hello",
+      };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        const messageId = `om_${index}`;
+        recordSuccessfulCall(
+          state,
+          "message",
+          params,
+          {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  channel: "feishu",
+                  to: "chat:oc_123",
+                  via: "gateway",
+                  result: { messageId, chatId: "oc_123" },
+                }),
+              },
+            ],
+            details: {
+              channel: "feishu",
+              to: "chat:oc_123",
+              via: "gateway",
+              result: {
+                messageId,
+                chatId: "oc_123",
+                receipt: {
+                  primaryPlatformMessageId: messageId,
+                  platformMessageIds: [messageId],
+                  parts: [{ platformMessageId: messageId, kind: "text", index: 0 }],
+                  sentAt: 1_000 + index,
+                  raw: [{ channel: "feishu", messageId, chatId: "oc_123" }],
+                },
+              },
+            },
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "message", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
     it("blocks repeated running exec calls despite volatile session details and text", () => {
       const state = createState();
       const params = { command: "tail -f /var/log/app.log", yieldMs: 1000 };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -48,6 +48,27 @@ const DEFAULT_LOOP_DETECTION_CONFIG = {
     pingPong: true,
   },
 };
+const MESSAGE_SEND_VOLATILE_RESULT_KEYS = new Set([
+  "messageId",
+  "message_id",
+  "primaryPlatformMessageId",
+  "primary_platform_message_id",
+  "platformMessageId",
+  "platform_message_id",
+  "platformMessageIds",
+  "platform_message_ids",
+  "sentAt",
+  "sent_at",
+  "timestamp",
+]);
+const MESSAGE_SEND_TEXT_VOLATILE_PATTERNS: Array<[RegExp, string]> = [
+  [/("messageId"\s*:\s*)"[^"]*"/g, '$1"<message-id>"'],
+  [/("message_id"\s*:\s*)"[^"]*"/g, '$1"<message-id>"'],
+  [/("primaryPlatformMessageId"\s*:\s*)"[^"]*"/g, '$1"<message-id>"'],
+  [/("platformMessageId"\s*:\s*)"[^"]*"/g, '$1"<message-id>"'],
+  [/("platformMessageIds"\s*:\s*)\[[^\]]*\]/g, '$1["<message-id>"]'],
+  [/(Message ID:\s*)[^\s,.)\]}]+/gi, "$1<message-id>"],
+];
 
 type ResolvedLoopDetectionConfig = {
   enabled: boolean;
@@ -191,6 +212,45 @@ function stringField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function isMessageSendToolCall(toolName: string, params: unknown): boolean {
+  return toolName === "message" && isPlainObject(params) && stringField(params.action) === "send";
+}
+
+function normalizeMessageSendOutcomeForHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeMessageSendOutcomeForHash(entry));
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (MESSAGE_SEND_VOLATILE_RESULT_KEYS.has(key)) {
+      continue;
+    }
+    normalized[key] = normalizeMessageSendOutcomeForHash(entry);
+  }
+  return normalized;
+}
+
+function normalizeMessageSendTextForHash(text: string): string {
+  let normalized = text;
+  for (const [pattern, replacement] of MESSAGE_SEND_TEXT_VOLATILE_PATTERNS) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+  return normalized;
+}
+
+function hashMessageSendToolOutcome(details: Record<string, unknown>, text: string): string {
+  // 发送结果会携带每次不同的投递 ID；循环检测只保留语义结果，避免重复发送绕过 critical 阻断。
+  const normalizedDetails = normalizeMessageSendOutcomeForHash(details);
+  if (Object.keys(details).length > 0) {
+    return digestStable({ details: normalizedDetails });
+  }
+  return digestStable({ text: normalizeMessageSendTextForHash(text) });
+}
+
 function hashExecToolOutcome(details: Record<string, unknown>, text: string): string | undefined {
   const status = stringField(details.status);
   if (!status) {
@@ -245,6 +305,9 @@ function hashToolOutcome(
 
   const details = isPlainObject(result.details) ? result.details : {};
   const text = extractTextContent(result);
+  if (isMessageSendToolCall(toolName, params)) {
+    return { resultHash: hashMessageSendToolOutcome(details, text) };
+  }
   if (toolName === "exec") {
     const execHash = hashExecToolOutcome(details, text);
     if (execHash) {


### PR DESCRIPTION
## Summary
- Normalize `message` tool send outcomes before loop-detection hashing so volatile delivery IDs do not hide repeated identical sends.
- Keep loop-blocked pseudo-results out of no-progress history so a critical block remains sticky on the next identical call.
- Add focused regression coverage for volatile message receipts and wrapper-level repeated veto behavior.

Fixes #89090.

## Verification
- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: repeated `message` tool sends with identical args but changing delivery IDs now escalate from warning to critical block.

Real environment tested: local OpenClaw checkout with targeted Vitest shards and Codex autoreview.

Exact steps or command run after this patch: `node --import tsx` direct OpenClaw loop-detection proof using the current checkout's `src/agents/tool-loop-detection.ts` runtime path, plus targeted Vitest regression checks.

Evidence after fix: copied terminal output from the direct OpenClaw runtime proof:

```text
[agents/loop-detection] Critical generic loop detected: message repeated 20 times
{
  "command": "node --import tsx direct OpenClaw loop-detection proof",
  "repeatedSends": 20,
  "latestDeliveryIdChanged": "om_live_19",
  "stuck": true,
  "level": "critical",
  "detector": "generic_repeat",
  "count": 20,
  "result": "duplicate send blocked"
}
```

Observed result after fix: repeated `message` send results with volatile `messageId`/receipt fields reach `generic_repeat` critical, and the next retry remains blocked without calling the underlying message tool again.

What was not tested: no live Feishu delivery was run; this change was validated at the core loop-detection and before-tool-call wrapper boundaries.
