### PR TITLE
fix(trajectory): skip unreadable tool descriptors

### DIFF
--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -105,6 +105,31 @@ describe("trajectory runtime", () => {
     expect(JSON.stringify(parsed.data)).not.toContain("abcd-efgh-ijkl-mnop");
   });
 
+  it("skips unreadable trajectory tool descriptors while preserving healthy siblings", () => {
+    const unreadableName = Object.defineProperty({ parameters: { type: "object" } }, "name", {
+      get() {
+        throw new Error("trajectory tool name getter exploded");
+      },
+    });
+    const unreadableParameters = Object.defineProperty(
+      { name: "broken_parameters" },
+      "parameters",
+      {
+        get() {
+          throw new Error("trajectory tool parameters getter exploded");
+        },
+      },
+    );
+
+    expect(
+      toTrajectoryToolDefinitions([
+        unreadableName,
+        unreadableParameters,
+        { name: "healthy_tool", description: "usable", parameters: { type: "object" } },
+      ]),
+    ).toEqual([{ name: "healthy_tool", description: "usable", parameters: { type: "object" } }]);
+  });
+
   it("bounds large runtime event fields before serialization", () => {
     const writes: string[] = [];
     const recorder = createTrajectoryRuntimeRecorder({

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -459,19 +459,44 @@ export function toTrajectoryToolDefinitions(
 ): TrajectoryToolDefinition[] {
   return tools
     .flatMap((tool) => {
-      const name = tool.name?.trim();
+      const name = readTrajectoryToolString(tool, "name")?.trim();
       if (!name) {
+        return [];
+      }
+      const parameters = readTrajectoryToolField(tool, "parameters");
+      if (!parameters.readable) {
         return [];
       }
       return [
         {
           name,
-          description: tool.description,
-          parameters: sanitizeDiagnosticPayload(limitTrajectoryPayloadValue(tool.parameters)),
+          description: readTrajectoryToolString(tool, "description"),
+          parameters: sanitizeDiagnosticPayload(limitTrajectoryPayloadValue(parameters.value)),
         },
       ];
     })
     .toSorted((left, right) => left.name.localeCompare(right.name));
+}
+
+function readTrajectoryToolField<TField extends "description" | "name" | "parameters">(
+  tool: { name?: string; description?: string; parameters?: unknown },
+  field: TField,
+):
+  | { readable: true; value: { name?: string; description?: string; parameters?: unknown }[TField] }
+  | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function readTrajectoryToolString(
+  tool: { name?: string; description?: string; parameters?: unknown },
+  field: "description" | "name",
+): string | undefined {
+  const value = readTrajectoryToolField(tool, field);
+  return value.readable && typeof value.value === "string" ? value.value : undefined;
 }
 
 export function createTrajectoryRuntimeRecorder(


### PR DESCRIPTION
## Summary

- make shared trajectory tool-definition capture tolerate unreadable tool descriptors
- skip tools with unreadable `name` or `parameters` while preserving healthy siblings
- add regression coverage for hostile descriptor getters in trajectory runtime capture

## Verification

- pre-fix repro: `node scripts/run-vitest.mjs src/trajectory/runtime.test.ts --reporter=dot` failed with `trajectory tool name getter exploded`
- `node scripts/run-vitest.mjs src/trajectory/runtime.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/runtime.ts src/trajectory/runtime.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/trajectory/runtime.ts src/trajectory/runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"` (`aws`, `cbx_765f5f37329a`, `run_d0eb8ab4fbaf`, exit 0)
- post-rebase sanity: `node scripts/run-vitest.mjs src/trajectory/runtime.test.ts --reporter=dot`

## Real behavior proof

Behavior addressed: trajectory capture should not crash diagnostic/runtime event recording when a tool descriptor has a hostile `name` or `parameters` getter; readable sibling tools should still be captured.

Real environment tested: local targeted Vitest on macOS plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/trajectory/runtime.test.ts --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: the regression test feeds unreadable `name` and `parameters` descriptors into `toTrajectoryToolDefinitions()` and receives only the healthy `healthy_tool` entry. AWS Crabbox `cbx_765f5f37329a` / `run_d0eb8ab4fbaf` completed `pnpm check:changed` with exit 0.

Observed result after fix: focused trajectory runtime suite passed 13 tests; changed gate passed lanes `core, coreTests`.

What was not tested: full live trajectory capture during a model turn.
