### PR TITLE
fix: remove dangerouslyForceUnsafeInstall gateway override

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -587,16 +587,12 @@ extension GatewayConnection {
     func skillsInstall(
         name: String,
         installId: String,
-        dangerouslyForceUnsafeInstall: Bool? = nil,
         timeoutMs: Int? = nil) async throws -> SkillInstallResult
     {
         var params: [String: AnyCodable] = [
             "name": AnyCodable(name),
             "installId": AnyCodable(installId),
         ]
-        if let dangerouslyForceUnsafeInstall {
-            params["dangerouslyForceUnsafeInstall"] = AnyCodable(dangerouslyForceUnsafeInstall)
-        }
         if let timeoutMs {
             params["timeoutMs"] = AnyCodable(timeoutMs)
         }

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -159,6 +159,8 @@ is available, then fall back to `latest`.
   <Accordion title="--dangerously-force-unsafe-install">
     `--dangerously-force-unsafe-install` is a break-glass option for false positives in the built-in dangerous-code scanner. It allows the install to continue even when the built-in scanner reports `critical` findings, but it does **not** bypass plugin `before_install` hook policy blocks and does **not** bypass scan failures.
 
+    Install scans ignore common test files and directories such as `tests/`, `__tests__/`, `*.test.*`, and `*.spec.*` to avoid blocking packaged test mocks; declared plugin runtime entrypoints are still scanned even if they use one of those names.
+
     This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs always enforce scans and do not accept the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
 
     If a plugin you published on ClawHub is hidden or blocked by a registry scan, use the publisher steps in [ClawHub publishing](/clawhub/publishing). `--dangerously-force-unsafe-install` only affects installs on your own machine; it does not ask ClawHub to rescan the plugin or make a blocked release public.

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -159,9 +159,7 @@ is available, then fall back to `latest`.
   <Accordion title="--dangerously-force-unsafe-install">
     `--dangerously-force-unsafe-install` is a break-glass option for false positives in the built-in dangerous-code scanner. It allows the install to continue even when the built-in scanner reports `critical` findings, but it does **not** bypass plugin `before_install` hook policy blocks and does **not** bypass scan failures.
 
-    Install scans ignore common test files and directories such as `tests/`, `__tests__/`, `*.test.*`, and `*.spec.*` to avoid blocking packaged test mocks; declared plugin runtime entrypoints are still scanned even if they use one of those names.
-
-    This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs use the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
+    This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs always enforce scans and do not accept the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
 
     If a plugin you published on ClawHub is hidden or blocked by a registry scan, use the publisher steps in [ClawHub publishing](/clawhub/publishing). `--dangerously-force-unsafe-install` only affects installs on your own machine; it does not ask ClawHub to rescan the plugin or make a blocked release public.
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -612,8 +612,10 @@ terminal summary, and sanitized error text.
     `skills.upload.begin` request. This mode is rejected unless
     `skills.install.allowUploadedArchives` is enabled. The setting does not
     affect ClawHub installs.
-  - Gateway installer mode: `{ name, installId, dangerouslyForceUnsafeInstall?, timeoutMs? }`
+  - Gateway installer mode: `{ name, installId, timeoutMs? }`
     runs a declared `metadata.openclaw.install` action on the gateway host.
+    Gateway installs always enforce plugin security scans; the legacy
+    `dangerouslyForceUnsafeInstall` gateway override is no longer supported.
 - Operators may call `skills.update` (`operator.admin`) in two modes:
   - ClawHub mode updates one tracked slug or all tracked ClawHub installs in
     the default agent workspace.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -542,7 +542,7 @@ Plugins run **in-process** with the Gateway. Treat them as trusted code:
   - npm and git plugin installs run package-manager dependency convergence only during the explicit install/update flow. Local paths and archives are treated as self-contained plugin packages; OpenClaw copies/references them without running `npm install`.
   - Prefer pinned, exact versions (`@scope/pkg@1.2.3`), and inspect the unpacked code on disk before enabling.
   - `--dangerously-force-unsafe-install` is break-glass only for built-in scan false positives on plugin install/update flows. It does not bypass plugin `before_install` hook policy blocks and does not bypass scan failures.
-  - Gateway-backed skill dependency installs follow the same dangerous/suspicious split: built-in `critical` findings block unless the caller explicitly sets `dangerouslyForceUnsafeInstall`, while suspicious findings still warn only. `openclaw skills install` remains the separate ClawHub skill download/install flow.
+  - Gateway-backed skill dependency installs always enforce the built-in dangerous/suspicious split on the gateway host: `critical` findings block and the gateway no longer accepts the `dangerouslyForceUnsafeInstall` override. `openclaw skills install` remains the separate ClawHub skill download/install flow.
 
 Details: [Plugins](/tools/plugin)
 

--- a/docs/platforms/mac/skills.md
+++ b/docs/platforms/mac/skills.md
@@ -18,7 +18,7 @@ The macOS app surfaces OpenClaw skills via the gateway; it does not parse skills
 
 - `metadata.openclaw.install` defines install options (brew/node/go/uv).
 - The app calls `skills.install` to run installers on the gateway host.
-- Built-in dangerous-code `critical` findings block `skills.install` by default; suspicious findings still warn only. The dangerous override exists on the gateway request, but the default app flow stays fail-closed.
+- Built-in dangerous-code `critical` findings block `skills.install`, and suspicious findings warn. Scanning is strictly enforced and cannot be bypassed via the gateway.
 - If every install option is `download`, the gateway surfaces all download
   choices.
 - Otherwise, the gateway picks one preferred installer using the current

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -288,7 +288,7 @@ export const SkillsInstallParamsSchema = Type.Union([
     {
       name: NonEmptyString,
       installId: NonEmptyString,
-      dangerouslyForceUnsafeInstall: Type.Optional(Type.Boolean()),
+      dangerouslyForceUnsafeInstall: Type.Optional(Type.Literal(false)),
       timeoutMs: Type.Optional(Type.Integer({ minimum: 1000 })),
     },
     { additionalProperties: false },

--- a/packages/gateway-protocol/src/skills.schema.test.ts
+++ b/packages/gateway-protocol/src/skills.schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { validateSkillsInstallParams } from "./index.js";
+
+describe("skills.install schema", () => {
+  it("accepts legacy dangerouslyForceUnsafeInstall=false in skills.install params", () => {
+    const params = { name: "calendar", installId: "deps", dangerouslyForceUnsafeInstall: false };
+    expect(validateSkillsInstallParams(params)).toBe(true);
+  });
+
+  it("accepts valid skills.install params without the flag", () => {
+    const params = { name: "calendar", installId: "deps" };
+    expect(validateSkillsInstallParams(params)).toBe(true);
+  });
+
+  it("rejects dangerouslyForceUnsafeInstall=true at the schema layer", () => {
+    const params = { name: "calendar", installId: "deps", dangerouslyForceUnsafeInstall: true };
+    expect(validateSkillsInstallParams(params)).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -259,7 +259,7 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(result?.version).toBe("1.2.3");
   });
 
-  it("forwards dangerous override for local skill installs", async () => {
+  it("tolerates legacy false-valued dangerous override via gateway", async () => {
     installSkillMock.mockResolvedValue({
       ok: true,
       message: "Installed",
@@ -271,7 +271,7 @@ describe("skills gateway handlers (clawhub)", () => {
     const { ok, response, error } = await callSkillsHandler("skills.install", {
       name: "calendar",
       installId: "deps",
-      dangerouslyForceUnsafeInstall: true,
+      dangerouslyForceUnsafeInstall: false,
       timeoutMs: 120_000,
     });
 
@@ -279,7 +279,7 @@ describe("skills gateway handlers (clawhub)", () => {
       workspaceDir: "/tmp/workspace",
       skillName: "calendar",
       installId: "deps",
-      dangerouslyForceUnsafeInstall: true,
+      dangerouslyForceUnsafeInstall: false,
       timeoutMs: 120_000,
       config: {},
     });
@@ -288,6 +288,27 @@ describe("skills gateway handlers (clawhub)", () => {
     const result = response as { ok?: boolean; message?: string } | undefined;
     expect(result?.ok).toBe(true);
     expect(result?.message).toBe("Installed");
+  });
+
+  it("rejects true-valued dangerous override via gateway", async () => {
+    installSkillMock.mockResolvedValue({
+      ok: true,
+      message: "Installed",
+      stdout: "",
+      stderr: "",
+      code: 0,
+    });
+
+    const { ok, error } = await callSkillsHandler("skills.install", {
+      name: "calendar",
+      installId: "deps",
+      dangerouslyForceUnsafeInstall: true,
+      timeoutMs: 120_000,
+    });
+
+    expect(installSkillMock).not.toHaveBeenCalled();
+    expect(ok).toBe(false);
+    expect((error as { message?: string })?.message).toContain("must be equal to constant");
   });
 
   it("updates ClawHub skills through skills.update", async () => {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -495,11 +495,22 @@ export const skillsHandlers: GatewayRequestHandlers = {
       dangerouslyForceUnsafeInstall?: boolean;
       timeoutMs?: number;
     };
+    if (p.dangerouslyForceUnsafeInstall === true) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "invalid skills.install params: dangerouslyForceUnsafeInstall=true is not supported on the gateway; omit the field or send false",
+        ),
+      );
+      return;
+    }
     const result = await installSkill({
       workspaceDir: workspaceDirRaw,
       skillName: p.name,
       installId: p.installId,
-      dangerouslyForceUnsafeInstall: p.dangerouslyForceUnsafeInstall,
+      dangerouslyForceUnsafeInstall: false,
       timeoutMs: p.timeoutMs,
       config: cfg,
     });

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -513,7 +513,6 @@ describe("skill mutations", () => {
         {
           name: "GitHub",
           installId: "install-123",
-          dangerouslyForceUnsafeInstall: true,
           timeoutMs: 120000,
         },
       ],

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -344,13 +344,12 @@ export async function installSkill(
   skillKey: string,
   name: string,
   installId: string,
-  dangerouslyForceUnsafeInstall = false,
+  _dangerouslyForceUnsafeInstall = false,
 ) {
   await runSkillMutation(state, skillKey, async (client) => {
     const result = await client.request<{ message?: string }>("skills.install", {
       name,
       installId,
-      dangerouslyForceUnsafeInstall,
       timeoutMs: 120000,
     });
     return {


### PR DESCRIPTION
## Summary

Remove the `dangerouslyForceUnsafeInstall` gateway override from `skills.install`. The gateway protocol previously accepted an optional `dangerouslyForceUnsafeInstall` boolean that allowed callers to bypass plugin security scans on the gateway host. This change tightens the schema to reject `true`-valued requests and hardcodes `false` at the handler level, making gateway-based skill installs always enforce security scans.

### Changes

- **Schema** (`packages/gateway-protocol`): `Type.Optional(Type.Boolean())` → `Type.Optional(Type.Literal(false))` — rejects any truthy override at validation
- **Gateway handler** (`skills.ts`): explicit runtime rejection of `true` plus hardcoded `false` for install calls (defense-in-depth)
- **Web UI client** (`skills.ts`): stopped sending the field over the gateway
- **macOS client** (`GatewayConnection.swift`): removed the parameter entirely
- **Docs**: updated gateway protocol, security, CLI, and macOS skill docs to reflect the change; scanner exception note preserved
- **Tests**: schema-level validation tests + gateway handler rejection tests

## Real behavior proof (required for external PRs)

- **Behavior addressed**: Gateway `skills.install` no longer accepts `dangerouslyForceUnsafeInstall=true`. Schema rejects at validation layer; handler additionally rejects at runtime. UI and macOS clients no longer send the field.
- **Real environment tested**: Linux workstation (Pop!_OS 22.04), Node.js 22.22.1, pnpm, OpenClaw workspace built from this branch.
- **Exact steps or command run after this patch**:
  1. Built the project: `pnpm build`
  2. Invoked the live gateway `skills.install` handler directly (same code path the gateway uses at runtime) with `dangerouslyForceUnsafeInstall=true`:
     ```
     npx tsx -e "..."  # invokes skillsHandlers['skills.install'] with dangerouslyForceUnsafeInstall: true
     ```
  3. Also validated the built protocol package directly:
     ```
     node -e "const { validateSkillsInstallParams } = await import('./packages/gateway-protocol/dist/index.mjs'); ..."
     ```
  4. Ran full test suite for changed surfaces: 27/27 passing
- **Evidence after fix**:
  **Live gateway handler output (real RPC code path):**
  ```
  === Live gateway skills.install RPC ===
  Request: { name: "calendar", installId: "deps", dangerouslyForceUnsafeInstall: true, timeoutMs: 120000 }

  Gateway response:
    ok: false
    code: INVALID_REQUEST
    message: invalid skills.install params: at /dangerouslyForceUnsafeInstall: must be equal to constant
  ```
  **Built package validator output:**
  ```
  true  -> rejected: true ✓
  omit  -> accepted: true ✓
  false -> accepted: true ✓
  ```
  The gateway handler responds with `ok: false` and `code: INVALID_REQUEST` when the unsafe override is sent, confirming the rejection at the live RPC level — not just unit tests.
- **Observed result after fix**: The gateway `skills.install` handler rejects requests containing `dangerouslyForceUnsafeInstall=true` with code `INVALID_REQUEST` at both the schema validation layer and the handler layer. Omission and `false` are accepted. All 27 tests pass.
- **What was not tested**: Live gateway WebSocket deployment, iOS physical device, macOS native app end-to-end runtime

## Verification

- [x] Live gateway handler proof: RPC rejection confirmed (see Evidence above)
- [x] Built package validation: true rejected, false/omit accepted
- [x] Unit tests: 27/27 passing (schema 3, gateway handler 9, UI 15)
- [x] CHANGELOG.md untouched (release-owned per CONTRIBUTING.md)
- [x] Scanner exception note restored in docs/cli/plugins.md
- [x] No unrelated docs churn; upload-mode docs preserved
- [x] Branch is clean, rebased on latest `origin/main`
