### PR TITLE
fix(doctor): exclude platform-incompatible skills from missing requirements count

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -6,6 +6,7 @@ import {
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
+  isPlatformMismatchOnly,
   resolveSkillStatusEntry,
   type SkillStatusEntry,
   type SkillStatusReport,
@@ -339,7 +340,20 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     (s) => s.eligible && !s.blockedByAgentFilter && !s.modelVisible,
   );
   const missingReqs = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist && !s.blockedByAgentFilter,
+    (s) =>
+      !s.eligible &&
+      !s.disabled &&
+      !s.blockedByAllowlist &&
+      !s.blockedByAgentFilter &&
+      !isPlatformMismatchOnly(s),
+  );
+  const platformMismatch = report.skills.filter(
+    (s) =>
+      !s.eligible &&
+      !s.disabled &&
+      !s.blockedByAllowlist &&
+      !s.blockedByAgentFilter &&
+      isPlatformMismatchOnly(s),
   );
   const agentId = report.agentId ?? opts.agent;
 
@@ -360,6 +374,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           agentFiltered: agentFiltered.length,
           notInjected: promptHidden.length,
           missingRequirements: missingReqs.length,
+          platformIncompatible: platformMismatch.length,
         },
         eligible: eligible.map((s) => s.name),
         modelVisible: modelVisible.map((s) => s.name),
@@ -375,6 +390,10 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           name: s.name,
           missing: s.missing,
           install: s.install,
+        })),
+        platformIncompatible: platformMismatch.map((s) => ({
+          name: s.name,
+          required: s.requirements.os,
         })),
       }),
       null,
@@ -411,6 +430,11 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     );
   }
   lines.push(`${theme.error("✗")} ${theme.muted("Missing requirements:")} ${missingReqs.length}`);
+  if (platformMismatch.length > 0) {
+    lines.push(
+      `${theme.warn("⟳")} ${theme.muted("Platform incompatible:")} ${platformMismatch.length}`,
+    );
+  }
 
   if (modelVisible.length > 0 || commandVisible.length > 0 || promptHidden.length > 0) {
     lines.push("");
@@ -477,6 +501,18 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
       const missing = formatSkillMissingSummary(skill);
       lines.push(
         `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(${missing})`)}`,
+      );
+    }
+  }
+
+  if (platformMismatch.length > 0) {
+    lines.push("");
+    lines.push(theme.heading("Platform incompatible (not designed for this OS):"));
+    for (const skill of platformMismatch) {
+      const emoji = normalizeSkillEmoji(skill.emoji);
+      const osList = skill.requirements.os.join(", ");
+      lines.push(
+        `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(requires: ${osList})`)}`,
       );
     }
   }

--- a/src/commands/doctor-skills-core.ts
+++ b/src/commands/doctor-skills-core.ts
@@ -1,13 +1,23 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
+import {
+  isPlatformMismatchOnly,
+  type SkillStatusEntry,
+  type SkillStatusReport,
+} from "../skills/discovery/status.js";
 
+/**
+ * Collect skills that are unavailable for the agent (ineligible, not
+ * disabled/blocked).  Platform-mismatch-only skills are excluded because
+ * they are not broken installs — they were never designed for this OS.
+ */
 export function collectUnavailableAgentSkills(report: SkillStatusReport): SkillStatusEntry[] {
   return report.skills.filter(
     (skill) =>
       !skill.eligible &&
       !skill.disabled &&
       !skill.blockedByAllowlist &&
-      !skill.blockedByAgentFilter,
+      !skill.blockedByAgentFilter &&
+      !isPlatformMismatchOnly(skill),
   );
 }
 

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -6,7 +6,10 @@ import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
 } from "../plugins/status.js";
-import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
+import {
+  buildWorkspaceSkillStatus,
+  isPlatformMismatchOnly,
+} from "../skills/discovery/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";
@@ -60,17 +63,18 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig) {
   }
 
   const skillsReport = buildWorkspaceSkillStatus(workspaceDir, { config: cfg });
-  note(
-    [
-      `Eligible: ${skillsReport.skills.filter((s) => s.eligible).length}`,
-      `Missing requirements: ${
-        skillsReport.skills.filter((s) => !s.eligible && !s.disabled && !s.blockedByAllowlist)
-          .length
-      }`,
-      `Blocked by allowlist: ${skillsReport.skills.filter((s) => s.blockedByAllowlist).length}`,
-    ].join("\n"),
-    "Skills status",
+  const ineligibleSkills = skillsReport.skills.filter(
+    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
   );
+  const platformMismatchSkills = ineligibleSkills.filter(isPlatformMismatchOnly);
+  const genuinelyMissing = ineligibleSkills.filter((s) => !isPlatformMismatchOnly(s));
+  const lines = [
+    `Eligible: ${skillsReport.skills.filter((s) => s.eligible).length}`,
+    `Missing requirements: ${genuinelyMissing.length}`,
+    `Platform incompatible: ${platformMismatchSkills.length}`,
+    `Blocked by allowlist: ${skillsReport.skills.filter((s) => s.blockedByAllowlist).length}`,
+  ];
+  note(lines.join("\n"), "Skills status");
 
   const pluginRegistry = buildPluginRegistrySnapshotReport({
     config: cfg,

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -6,10 +6,7 @@ import {
   buildPluginCompatibilityWarnings,
   buildPluginRegistrySnapshotReport,
 } from "../plugins/status.js";
-import {
-  buildWorkspaceSkillStatus,
-  isPlatformMismatchOnly,
-} from "../skills/discovery/status.js";
+import { buildWorkspaceSkillStatus, isPlatformMismatchOnly } from "../skills/discovery/status.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { listTaskFlowRecords } from "../tasks/task-flow-runtime-internal.js";
 import { detectLegacyWorkspaceDirs, formatLegacyWorkspaceWarning } from "./doctor-workspace.js";

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -17,9 +17,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 // Module under test imports these at module scope.
-vi.mock("../skills/discovery/status.js", () => ({
-  buildWorkspaceSkillStatus: mocks.buildWorkspaceSkillStatus,
-}));
+vi.mock("../skills/discovery/status.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../skills/discovery/status.js")>();
+  return {
+    ...actual,
+    buildWorkspaceSkillStatus: mocks.buildWorkspaceSkillStatus,
+  };
+});
 vi.mock("../skills/lifecycle/install.js", () => ({
   installSkill: mocks.installSkill,
 }));

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -4,7 +4,10 @@ import { resolveBrewExecutable } from "../infra/brew.js";
 import { isContainerEnvironment } from "../infra/container-environment.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { patchSkillConfigEntry } from "../skills/config/mutations.js";
-import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
+import {
+  buildWorkspaceSkillStatus,
+  isPlatformMismatchOnly,
+} from "../skills/discovery/status.js";
 import { installSkill } from "../skills/lifecycle/install.js";
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -52,12 +55,11 @@ export async function setupSkills(
 ): Promise<OpenClawConfig> {
   const report = buildWorkspaceSkillStatus(workspaceDir, { config: cfg });
   const eligible = report.skills.filter((s) => s.eligible);
-  const unsupportedOs = report.skills.filter(
-    (s) => !s.disabled && !s.blockedByAllowlist && s.missing.os.length > 0,
+  const allIneligible = report.skills.filter(
+    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
   );
-  const missing = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist && s.missing.os.length === 0,
-  );
+  const unsupportedOs = allIneligible.filter(isPlatformMismatchOnly);
+  const missing = allIneligible.filter((s) => !isPlatformMismatchOnly(s));
   const blocked = report.skills.filter((s) => s.blockedByAllowlist);
 
   await prompter.note(

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -4,10 +4,7 @@ import { resolveBrewExecutable } from "../infra/brew.js";
 import { isContainerEnvironment } from "../infra/container-environment.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { patchSkillConfigEntry } from "../skills/config/mutations.js";
-import {
-  buildWorkspaceSkillStatus,
-  isPlatformMismatchOnly,
-} from "../skills/discovery/status.js";
+import { buildWorkspaceSkillStatus, isPlatformMismatchOnly } from "../skills/discovery/status.js";
 import { installSkill } from "../skills/lifecycle/install.js";
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -78,6 +78,22 @@ export type SkillStatusReport = {
   skills: SkillStatusEntry[];
 };
 
+/**
+ * Skills whose ONLY missing requirement is an OS platform mismatch (e.g. a
+ * macOS-only skill running on Windows) are not broken installs — the skill
+ * was never designed for this platform.  Callers should surface these as
+ * "platform incompatible" rather than "missing requirements".
+ */
+export function isPlatformMismatchOnly(skill: SkillStatusEntry): boolean {
+  return (
+    skill.missing.os.length > 0 &&
+    skill.missing.bins.length === 0 &&
+    skill.missing.anyBins.length === 0 &&
+    skill.missing.env.length === 0 &&
+    skill.missing.config.length === 0
+  );
+}
+
 export function resolveSkillStatusEntry(
   skills: readonly SkillStatusEntry[],
   requestedName: string,


### PR DESCRIPTION
On Windows, openclaw doctor reports ~37 macOS-only skills (apple-notes, bear-notes, imsg, homebrew, etc.) as "missing requirements". These skills are not broken installs -- they were never designed for this platform. Counting them drowns out genuinely-broken installs that DO need attention.

## Changes

- Surface platform-incompatible skills as a separate informational count ("Platform incompatible") in doctor, skills check, and onboarding output
- Exclude platform-mismatch-only skills from collectUnavailableAgentSkills so they are not proposed for auto-disable
- Extract shared isPlatformMismatchOnly() to src/skills/discovery/status.ts

## Verification

- All existing tests pass (skills-cli: 25/25, doctor-workspace-status: 6/6, doctor-skills: 9/9, onboard-skills: 5/5)
- Lint clean

Closes #89232