### PR TITLE
fix(context-engine): forward isHeartbeat to afterTurn hook [AI-assisted]

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2344,6 +2344,7 @@ export async function runCodexAppServerAttempt(
         sessionFile: activeSessionFile,
         messagesSnapshot: finalMessages,
         prePromptMessageCount,
+        ...(params.trigger === "heartbeat" ? { isHeartbeat: true } : {}),
         tokenBudget: params.contextTokenBudget,
         runtimeContext: buildHarnessContextEngineRuntimeContextFromUsage({
           attempt: buildActiveRunAttemptParams(),

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -313,6 +313,7 @@ import {
   remapInjectedContextFilesToWorkspace,
 } from "./attempt.bootstrap-context.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
+import { getAgentRunContext } from "../../../infra/agent-events.js";
 import {
   rotateTranscriptAfterCompaction,
   shouldRotateCompactionTranscript,
@@ -2348,6 +2349,7 @@ export async function runEmbeddedAttempt(
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
+          ...(params.trigger === "heartbeat" ? { isHeartbeat: true } : {}),
           getPrePromptMessageCount: () => prePromptMessageCount,
           onAfterTurnCheckpoint: (messageCount) => {
             contextEngineAfterTurnCheckpoint = messageCount;
@@ -4536,6 +4538,7 @@ export async function runEmbeddedAttempt(
             prePromptMessageCount: contextEngineAfterTurnCheckpoint ?? prePromptMessageCount,
             tokenBudget: params.contextTokenBudget,
             runtimeContext: afterTurnRuntimeContext,
+            ...(params.trigger === "heartbeat" ? { isHeartbeat: true } : {}),
             runMaintenance: async (contextParams) =>
               await runContextEngineMaintenance({
                 contextEngine: contextParams.contextEngine as never,

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -1029,4 +1029,56 @@ describe("installContextEngineLoopHook", () => {
     expect(retryResult).toBe(compactedView);
     expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    { label: "forwards isHeartbeat=true to loop hook afterTurn", isHeartbeat: true },
+    { label: "forwards isHeartbeat=false to loop hook afterTurn", isHeartbeat: false },
+  ])("$label", async ({ isHeartbeat }) => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    const remove = installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      isHeartbeat,
+      getPrePromptMessageCount: () => 1,
+    });
+    await callAfterInitialToolResult(agent);
+    remove();
+    const afterTurnCalls = (engine.afterTurn as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(afterTurnCalls.length).toBeGreaterThan(0);
+    for (const call of afterTurnCalls) {
+      const callParams = call[0] as { isHeartbeat?: boolean } | undefined;
+      expect(callParams?.isHeartbeat).toBe(isHeartbeat);
+    }
+  });
+
+  it("omits isHeartbeat from loop hook afterTurn when caller does not provide it", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    const remove = installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      getPrePromptMessageCount: () => 1,
+    });
+    await callAfterInitialToolResult(agent);
+    remove();
+    const afterTurnCalls = (engine.afterTurn as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(afterTurnCalls.length).toBeGreaterThan(0);
+    for (const call of afterTurnCalls) {
+      const callParams = call[0] as Record<string, unknown> | undefined;
+      expect(callParams && "isHeartbeat" in callParams).toBe(false);
+    }
+  });
 });

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -330,6 +330,8 @@ export function installContextEngineLoopHook(params: {
     messages: AgentMessage[];
     prePromptMessageCount: number;
   }) => ContextEngineRuntimeContext | undefined;
+  /** True when this run is a heartbeat run. Forwarded to contextEngine.afterTurn. */
+  isHeartbeat?: boolean;
 }): () => void {
   const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
   const mutableAgent = params.agent as GuardableAgentRecord;
@@ -394,6 +396,7 @@ export function installContextEngineLoopHook(params: {
             messages: transcriptMessages,
             prePromptMessageCount,
           }),
+          ...(params.isHeartbeat !== undefined ? { isHeartbeat: params.isHeartbeat } : {}),
         });
       } else {
         const newMessages = transcriptMessages.slice(prePromptMessageCount);

--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -211,4 +211,50 @@ describe("harness context engine lifecycle", () => {
     const ingestBatchParams = ingestBatchCalls[0]?.[0] as { messages?: AgentMessage[] } | undefined;
     expect(ingestBatchParams?.messages).toEqual([turnUser, turnAssistant]);
   });
+
+  it.each([
+    { label: "heartbeat run forwards isHeartbeat=true", isHeartbeat: true },
+    { label: "non-heartbeat run forwards isHeartbeat=false", isHeartbeat: false },
+  ])("$label", async ({ isHeartbeat }) => {
+    const userMsg = textMessage("user", "ask", 1);
+    const asstMsg = textMessage("assistant", "answer", 2);
+    const afterTurn = vi.fn(async () => {});
+    await finalizeHarnessContextEngineTurn({
+      contextEngine: createContextEngine({ afterTurn }),
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+      sessionIdUsed: sessionParams.sessionIdUsed,
+      sessionKey: sessionParams.sessionKey,
+      sessionFile: sessionParams.sessionFile,
+      messagesSnapshot: [userMsg, asstMsg],
+      prePromptMessageCount: 1,
+      isHeartbeat,
+      warn: () => {},
+    });
+    const calls = (afterTurn as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const callParams = calls[0]?.[0] as { isHeartbeat?: boolean } | undefined;
+    expect(callParams?.isHeartbeat).toBe(isHeartbeat);
+  });
+
+  it("omits isHeartbeat from afterTurn payload when caller does not provide it", async () => {
+    const userMsg = textMessage("user", "ask", 1);
+    const asstMsg = textMessage("assistant", "answer", 2);
+    const afterTurn = vi.fn(async () => {});
+    await finalizeHarnessContextEngineTurn({
+      contextEngine: createContextEngine({ afterTurn }),
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+      sessionIdUsed: sessionParams.sessionIdUsed,
+      sessionKey: sessionParams.sessionKey,
+      sessionFile: sessionParams.sessionFile,
+      messagesSnapshot: [userMsg, asstMsg],
+      prePromptMessageCount: 1,
+      warn: () => {},
+    });
+    const calls = (afterTurn as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const callParams = calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(callParams && "isHeartbeat" in callParams).toBe(false);
+  });
 });

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -140,6 +140,8 @@ export async function finalizeHarnessContextEngineTurn(params: {
   prePromptMessageCount: number;
   tokenBudget?: number;
   runtimeContext?: ContextEngineRuntimeContext;
+  /** True when this turn belongs to a heartbeat run. Forwarded to contextEngine.afterTurn. */
+  isHeartbeat?: boolean;
   runMaintenance?: typeof runHarnessContextEngineMaintenance;
   sessionManager?: unknown;
   config?: SessionWriteLockAcquireTimeoutConfig;
@@ -165,6 +167,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
         prePromptMessageCount: conversationSnapshot.prePromptMessageCount,
         tokenBudget: params.tokenBudget,
         runtimeContext: params.runtimeContext,
+        ...(params.isHeartbeat !== undefined ? { isHeartbeat: params.isHeartbeat } : {}),
       });
     } catch (afterTurnErr) {
       postTurnFinalizationSucceeded = false;


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration; reviewer = 麻酱, code review = Codex CLI). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `ContextEngine.afterTurn()` SDK type declares `isHeartbeat?: boolean`, but every runtime call site omitted the field, leaving plugins unable to distinguish heartbeat turns from real user turns.
- Solution: Thread `isHeartbeat` through `finalizeHarnessContextEngineTurn` and `installContextEngineLoopHook`, and forward it from the embedded attempt runner and the Codex app-server harness using each attempt's existing `trigger === "heartbeat"` signal.
- What changed: 4 production files + 2 test files, ~108 added lines, no deletions. Only the `afterTurn` call paths got a new optional field; absence-vs-`false` is preserved by spreading conditionally.
- What did NOT change (scope boundary): No change to `ingest` / `ingestBatch` / `assemble` / `compact` signatures. No change to engine implementations. No change to heartbeat detection logic in `auto-reply/heartbeat-filter.ts` or `infra/agent-events.ts`. No change to channel/provider plugins.

## Motivation
Bundled and third-party context-engine plugins (e.g. OpenViking) already check `afterTurnParams.isHeartbeat` defensively to avoid polluting persistent context with heartbeat turns. Because the runtime never sent that field, those plugins silently treated heartbeats as normal turns, growing memory state with no real user content. Fixing this honors the published SDK contract and unblocks heartbeat-aware engines on existing OpenClaw releases.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR
- Closes #89302
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: `contextEngine.afterTurn` was never receiving `isHeartbeat` despite the SDK type declaring it.
- Real environment tested: local OpenClaw checkout @ upstream/main `0e16e720915de385d2a6b6471fecbee9cd121a93`, macOS, Node v22.15.0. Repro drives the real `finalizeHarnessContextEngineTurn` and `installContextEngineLoopHook` source modules via `tsx` (no mocks of the modules under test).
- Exact steps or command run after this patch:
  1. Write `repro-89302.mjs` that imports `src/agents/harness/context-engine-lifecycle.ts` and `src/agents/embedded-agent-runner/tool-result-context-guard.ts` directly, installs a fake `ContextEngine` whose `afterTurn` records its params, and invokes both finalize paths with `isHeartbeat: true`.
  2. `node_modules/.bin/tsx repro-89302.mjs`
- Evidence after fix (redacted terminal capture):
  ```text
  === BEFORE the fix (current main) ===
  captured: [
    { "where": "harness" },
    { "where": "loop" }
  ]
  ❌ Bug #89302 reproduced: isHeartbeat not forwarded to contextEngine.afterTurn

  === AFTER the fix (this branch) ===
  captured: [
    { "where": "harness", "isHeartbeat": true },
    { "where": "loop",    "isHeartbeat": true }
  ]
  ✅ isHeartbeat forwarded from both harness and loop afterTurn call sites
  ```
- Observed result after fix: Both runtime afterTurn paths now propagate `isHeartbeat` to the engine, matching the SDK type contract.
- What was not tested: End-to-end heartbeat wake against the full gateway with a real provider was not exercised; the regression tests and direct-source repro lock in the seam.
- Before evidence: same as the BEFORE block above (captured by reverting the patch and rerunning the same script).

## Root Cause (if applicable)
- Root cause: When `afterTurn` was introduced its call sites were copied without the heartbeat field, even though the SDK type and `ingest` / `ingestBatch` already documented `isHeartbeat`. The runtime already knows the heartbeat status via `EmbeddedRunAttemptParams.trigger === "heartbeat"` (also stored in `AgentRunContext.isHeartbeat`); the seam just never forwarded it.
- Missing detection / guardrail: A unit test asserting `isHeartbeat` round-trips through `finalizeHarnessContextEngineTurn` / `installContextEngineLoopHook` would have caught it.
- Contributing context: `afterTurn` is newer than `ingest`/`ingestBatch`, so its parameter coverage drifted from those siblings.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/harness/context-engine-lifecycle.test.ts`, `src/agents/embedded-agent-runner/tool-result-context-guard.test.ts`
- Scenario the test should lock in: When the caller sets `isHeartbeat=true|false`, the engine's `afterTurn` receives the same value; when the caller omits it, the field is absent on the payload (preserving the undefined contract). `it.each` parameterizes true/false plus a separate omitted case at each seam.
- Why this is the smallest reliable guardrail: Both seams are pure async functions taking the engine as an arg, so direct mock-engine assertions cover the contract without spinning up a session.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
None for runs without a context engine. For sessions with a context-engine plugin that branches on `afterTurnParams.isHeartbeat`, heartbeat turns are now correctly identified as heartbeat, matching the SDK type. Plugins that ignore the field are unaffected.

## Diagram (if applicable)
```text
Before: attempt.trigger="heartbeat" --> finalize... --> engine.afterTurn({ ... /* no isHeartbeat */ })
After:  attempt.trigger="heartbeat" --> finalize... --> engine.afterTurn({ ..., isHeartbeat: true })
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node v22.15.0, pnpm 11.2.2
- Model/provider: N/A (drove source modules directly via `tsx`)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps
1. `git fetch upstream && git checkout fix/context-engine-after-turn-heartbeat`
2. `node_modules/.bin/vitest run src/agents/harness/context-engine-lifecycle.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts` → 112/112 pass
3. `pnpm exec oxfmt --check <changed-files>` → clean
4. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false --incremental` → no errors
5. Repro driver script BEFORE → ❌ / AFTER → ✅ (see Real behavior proof above)
