### PR TITLE
fix(agents): guard client tool descriptors

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import {
   CLIENT_TOOL_NAME_CONFLICT_PREFIX,
+  collectClientToolDefinitionNames,
   createClientToolNameConflictError,
   findClientToolNameConflicts,
   isClientToolNameConflictError,
@@ -124,6 +125,39 @@ function makeClientTool(name: string): ClientToolDefinition {
   };
 }
 
+function makeClientToolWithThrowingFunction(message: string): ClientToolDefinition {
+  const tool = {} as ClientToolDefinition;
+  Object.defineProperty(tool, "function", {
+    get() {
+      throw new Error(message);
+    },
+  });
+  return tool;
+}
+
+function makeClientToolWithThrowingName(message: string): ClientToolDefinition {
+  const tool = {
+    type: "function",
+    function: {},
+  } as unknown as ClientToolDefinition;
+  Object.defineProperty(tool.function, "name", {
+    get() {
+      throw new Error(message);
+    },
+  });
+  return tool;
+}
+
+function makeClientToolWithThrowingFunctionTag(name: string): ClientToolDefinition {
+  const tool = makeClientTool(name);
+  Object.defineProperty(tool.function, Symbol.toStringTag, {
+    get() {
+      throw new Error("fuzzplugin client function tag getter exploded");
+    },
+  });
+  return tool;
+}
+
 async function executeClientTool(params: unknown): Promise<{
   calledWith: Record<string, unknown> | undefined;
   result: Awaited<ReturnType<ToolExecute>>;
@@ -140,6 +174,64 @@ async function executeClientTool(params: unknown): Promise<{
 }
 
 describe("toClientToolDefinitions – param coercion", () => {
+  it("skips unreadable client tool descriptors while preserving healthy siblings", async () => {
+    const unreadableParameters = {
+      type: "function",
+      function: {
+        name: "client_probe",
+        description: "Client probe",
+      },
+    } as ClientToolDefinition;
+    Object.defineProperty(unreadableParameters.function, "parameters", {
+      get() {
+        throw new Error("fuzzplugin client parameters getter exploded");
+      },
+    });
+
+    const completed: Array<{ name: string; params: Record<string, unknown> }> = [];
+    const defs = toClientToolDefinitions(
+      [
+        makeClientToolWithThrowingFunction("fuzzplugin client function getter exploded"),
+        makeClientToolWithThrowingName("fuzzplugin client name getter exploded"),
+        unreadableParameters,
+        makeClientToolWithThrowingFunctionTag("client_tagged"),
+        makeClientTool("client_lookup"),
+      ],
+      (name, params) => completed.push({ name, params }),
+    );
+
+    expect(defs.map((def) => def.name)).toEqual(["client_probe", "client_tagged", "client_lookup"]);
+    expect(defs[0]?.parameters).toBeUndefined();
+
+    await defs[0]?.execute(
+      "call-client-probe",
+      { q: "probe" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    await defs[1]?.execute(
+      "call-client-tagged",
+      { q: "tagged" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    await defs[2]?.execute(
+      "call-client-lookup",
+      { q: "lookup" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(completed).toEqual([
+      { name: "client_probe", params: { q: "probe" } },
+      { name: "client_tagged", params: { q: "tagged" } },
+      { name: "client_lookup", params: { q: "lookup" } },
+    ]);
+  });
+
   it("returns terminal pending results for each client tool in a batch", async () => {
     const completed: Array<{ id: string; name: string; params: Record<string, unknown> }> = [];
     const defs = toClientToolDefinitions([makeClientTool("search"), makeClientTool("lookup")], {
@@ -215,6 +307,31 @@ describe("toClientToolDefinitions – param coercion", () => {
 });
 
 describe("client tool name conflict checks", () => {
+  it("collects readable client tool names without traversing hostile function tags", () => {
+    expect(
+      collectClientToolDefinitionNames([
+        makeClientToolWithThrowingFunction("fuzzplugin collect function getter exploded"),
+        makeClientToolWithThrowingName("fuzzplugin collect name getter exploded"),
+        makeClientToolWithThrowingFunctionTag("client_tagged"),
+        makeClientTool("client_lookup"),
+      ]),
+    ).toEqual(["client_tagged", "client_lookup"]);
+  });
+
+  it("skips unreadable client tool names during conflict checks", () => {
+    expect(
+      findClientToolNameConflicts({
+        tools: [
+          makeClientToolWithThrowingFunction("fuzzplugin conflict function getter exploded"),
+          makeClientToolWithThrowingName("fuzzplugin conflict name getter exploded"),
+          makeClientToolWithThrowingFunctionTag("client_tagged"),
+          makeClientTool("exec"),
+        ],
+        existingToolNames: ["exec"],
+      }),
+    ).toEqual(["exec"]);
+  });
+
   it("detects collisions with existing built-in names after normalization", () => {
     expect(
       findClientToolNameConflicts({

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -42,6 +42,11 @@ type ToolExecuteArgs = ToolDefinition["execute"] extends (...args: infer P) => u
   ? P
   : ToolExecuteArgsCurrent;
 type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteArgsCurrent;
+type ClientToolDefinitionSnapshot = {
+  name: string;
+  description: string;
+  parameters: ToolDefinition["parameters"];
+};
 const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
@@ -66,6 +71,58 @@ function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteA
     return true;
   }
   return isAbortSignal(fifth);
+}
+
+function isClientToolFunctionRecord(value: unknown): value is Record<string, unknown> {
+  try {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  } catch {
+    return false;
+  }
+}
+
+function snapshotClientToolDefinition(
+  tool: ClientToolDefinition,
+): ClientToolDefinitionSnapshot | undefined {
+  let func: unknown;
+  try {
+    func = tool.function;
+  } catch {
+    return undefined;
+  }
+  if (!isClientToolFunctionRecord(func)) {
+    return undefined;
+  }
+
+  let name: unknown;
+  try {
+    name = func.name;
+  } catch {
+    return undefined;
+  }
+  if (typeof name !== "string" || !name.trim()) {
+    return undefined;
+  }
+
+  let description: unknown;
+  try {
+    description = func.description;
+  } catch {
+    description = undefined;
+  }
+
+  let parameters: unknown;
+  try {
+    parameters = func.parameters;
+  } catch {
+    parameters = undefined;
+  }
+
+  return {
+    name: name.trim(),
+    description: typeof description === "string" ? description : "",
+    parameters: parameters as ToolDefinition["parameters"],
+  };
 }
 
 function describeToolExecutionError(err: unknown): {
@@ -285,8 +342,7 @@ export function findClientToolNameConflicts(params: {
 
   const conflicts = new Set<string>();
   const seenClientNames = new Map<string, string>();
-  for (const tool of params.tools) {
-    const rawName = (tool.function?.name ?? "").trim();
+  for (const rawName of collectClientToolDefinitionNames(params.tools)) {
     if (!rawName) {
       continue;
     }
@@ -303,6 +359,13 @@ export function findClientToolNameConflicts(params: {
     seenClientNames.set(normalizedName, rawName);
   }
   return Array.from(conflicts);
+}
+
+export function collectClientToolDefinitionNames(tools: readonly ClientToolDefinition[]): string[] {
+  return tools.flatMap((tool) => {
+    const snapshot = snapshotClientToolDefinition(tool);
+    return snapshot ? [snapshot.name] : [];
+  });
 }
 
 export function createClientToolNameConflictError(conflicts: string[]): Error {
@@ -433,13 +496,16 @@ export function toClientToolDefinitions(
   onClientToolCall?: ClientToolCallRecorder,
   hookContext?: HookContext,
 ): ToolDefinition[] {
-  return tools.map((tool) => {
-    const func = tool.function;
+  return tools.flatMap((tool) => {
+    const func = snapshotClientToolDefinition(tool);
+    if (!func) {
+      return [];
+    }
     return {
       name: func.name,
       label: func.name,
-      description: func.description ?? "",
-      parameters: func.parameters as ToolDefinition["parameters"],
+      description: func.description,
+      parameters: func.parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
         if (onClientToolCall && typeof onClientToolCall !== "function") {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
@@ -4,6 +4,50 @@ import {
   buildCallableToolNamesForEmptyAllowlistCheck,
   buildToolSearchRunPlan,
 } from "./attempt.tool-search-run-plan.js";
+import type { ClientToolDefinition } from "./params.js";
+
+function clientTool(name: string): ClientToolDefinition {
+  return {
+    type: "function",
+    function: {
+      name,
+      parameters: { type: "object", properties: {} },
+    },
+  };
+}
+
+function unreadableClientFunction(message: string): ClientToolDefinition {
+  const tool = {} as ClientToolDefinition;
+  Object.defineProperty(tool, "function", {
+    get() {
+      throw new Error(message);
+    },
+  });
+  return tool;
+}
+
+function unreadableClientName(message: string): ClientToolDefinition {
+  const tool = {
+    type: "function",
+    function: {},
+  } as unknown as ClientToolDefinition;
+  Object.defineProperty(tool.function, "name", {
+    get() {
+      throw new Error(message);
+    },
+  });
+  return tool;
+}
+
+function clientToolWithHostileTag(name: string): ClientToolDefinition {
+  const tool = clientTool(name);
+  Object.defineProperty(tool.function, Symbol.toStringTag, {
+    get() {
+      throw new Error("fuzzplugin run plan function tag getter exploded");
+    },
+  });
+  return tool;
+}
 
 describe("buildCallableToolNamesForEmptyAllowlistCheck", () => {
   it("ignores auto-added Tool Search controls so bad allowlists still fail", () => {
@@ -111,6 +155,33 @@ describe("buildToolSearchRunPlan", () => {
     });
 
     expect(plan.emptyAllowlistCallableNames).toEqual(["tool-search-client:client_pick_file"]);
+  });
+
+  it("skips unreadable client tool descriptors while preserving readable client names", () => {
+    const plan = buildToolSearchRunPlan({
+      visibleTools: [{ name: "tool_search_code" }] as never,
+      uncompactedTools: [{ name: "tool_search_code" }] as never,
+      clientTools: [
+        unreadableClientFunction("fuzzplugin run plan function getter exploded"),
+        unreadableClientName("fuzzplugin run plan name getter exploded"),
+        clientToolWithHostileTag("client_tagged"),
+        clientTool("client_pick_file"),
+      ],
+      catalogRegistered: true,
+      catalogToolCount: 0,
+      controlsEnabled: true,
+      explicitAllowlistSources: [{ entries: ["client_tagged", "client_pick_file"] }],
+    });
+
+    expect([...plan.replayAllowedToolNames]).toEqual([
+      "tool_search_code",
+      "client_tagged",
+      "client_pick_file",
+    ]);
+    expect(plan.emptyAllowlistCallableNames).toEqual([
+      "tool-search-client:client_tagged",
+      "tool-search-client:client_pick_file",
+    ]);
   });
 
   it("keeps code-mode control tools in replay-safe names", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
@@ -1,3 +1,4 @@
+import { collectClientToolDefinitionNames } from "../../agent-tool-definition-adapter.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import {
   TOOL_CALL_RAW_TOOL_NAME,
@@ -68,8 +69,7 @@ function collectExplicitlyAllowedClientToolNames(params: {
       source.entries.map((entry) => normalizeToolName(entry)),
     ),
   );
-  return (params.clientTools ?? [])
-    .map((tool) => tool.function?.name)
+  return collectClientToolDefinitionNames(params.clientTools ?? [])
     .filter((name): name is string => Boolean(name?.trim()))
     .filter((name) => explicitNames.has(normalizeToolName(name)));
 }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -89,6 +89,7 @@ import {
   resolveEffectiveCompactionMode,
 } from "../../agent-settings.js";
 import {
+  collectClientToolDefinitionNames,
   createClientToolNameConflictError,
   findClientToolNameConflicts,
   toClientToolDefinitions,
@@ -1423,6 +1424,7 @@ export async function runEmbeddedAttempt(
         }),
     });
     const clientTools = toolsEnabled && !isRawModelRun ? params.clientTools : undefined;
+    const clientToolNames = collectClientToolDefinitionNames(clientTools ?? []);
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.disableTools || isRawModelRun,
@@ -1439,10 +1441,7 @@ export async function runEmbeddedAttempt(
     bundleMcpRuntime = bundleMcpSessionRuntime
       ? await materializeBundleMcpToolsForRun({
           runtime: bundleMcpSessionRuntime,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
-          ],
+          reservedToolNames: [...tools.map((tool) => tool.name), ...clientToolNames],
         })
       : undefined;
     const bundleLspEnabled = shouldCreateBundleLspRuntimeForAttempt({
@@ -1456,7 +1455,7 @@ export async function runEmbeddedAttempt(
           cfg: params.config,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+            ...clientToolNames,
             ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
           ],
         })

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.ts
@@ -1,3 +1,4 @@
+import { collectClientToolDefinitionNames } from "../agent-tool-definition-adapter.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { ClientToolDefinition } from "./run/params.js";
 
@@ -25,8 +26,8 @@ export function collectAllowedToolNames(params: {
   for (const tool of params.tools) {
     addName(names, tool.name);
   }
-  for (const tool of params.clientTools ?? []) {
-    addName(names, tool.function?.name);
+  for (const name of collectClientToolDefinitionNames(params.clientTools ?? [])) {
+    addName(names, name);
   }
   return names;
 }


### PR DESCRIPTION
## Summary

- snapshot client tool descriptors through guarded reads before conflict checks, Tool Search allowlist planning, bundle MCP/LSP reservation, and client tool-definition conversion
- skip unreadable required client `function`/`name` descriptors while preserving readable siblings, and treat unreadable optional description/parameters as absent
- add regressions for throwing client descriptor getters and hostile `Symbol.toStringTag` accessors

## Verification

- Pre-fix focused repro: `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.test.ts --reporter=dot` failed with raw `fuzzplugin client function getter exploded` / `fuzzplugin conflict function getter exploded` errors.
- `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`
- `git diff --check origin/main...HEAD`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_d11b429243bb`, run `run_9e6079ad5d8f`, exit 0, lease stopped
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Embedded runs no longer abort when a malformed client tool descriptor throws from `function`, `function.name`, `function.parameters`, or `Symbol.toStringTag`; readable client tools remain available for allowlists, Tool Search planning, reserved-name checks, and delegated execution.

Real environment tested: local macOS focused tests and AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `pnpm check:changed` through `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: Crabbox run `run_9e6079ad5d8f` completed with exit 0; focused local tests passed 2 files / 30 tests after the final rebase.

Observed result after fix: malformed client descriptors are skipped or degraded to absent optional metadata, and healthy sibling client tools are still collected and converted.

What was not tested: full local `run-oxlint.mjs` without `OPENCLAW_OXLINT_SKIP_PREPARE=1`; prepare failed before touched-file linting on unrelated Discord boundary DTS errors in `extensions/discord/src/voice/receive-recovery.ts`.
