### PR TITLE
fix(bedrock): guard tool config projection

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -115,3 +115,93 @@ describe("Bedrock thinking effort mapping", () => {
     ).toBe("max");
   });
 });
+
+describe("Bedrock tool config projection", () => {
+  it("skips unreadable tool descriptors while preserving healthy siblings", () => {
+    const brokenTool = {
+      get name() {
+        throw new Error("bedrock tool name getter exploded");
+      },
+      description: "broken",
+      parameters: { type: "object", properties: {} },
+    };
+    const healthyTool = {
+      name: "read_context",
+      description: "Read context",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+    };
+
+    expect(
+      testing.convertToolConfig([brokenTool, healthyTool] as never, {
+        type: "tool",
+        name: "read_context",
+      }),
+    ).toEqual({
+      tools: [
+        {
+          toolSpec: {
+            name: "read_context",
+            description: "Read context",
+            inputSchema: {
+              json: { type: "object", properties: { path: { type: "string" } } },
+            },
+          },
+        },
+      ],
+      toolChoice: { tool: { name: "read_context" } },
+    });
+  });
+
+  it("fails closed when a pinned tool choice is not projectable", () => {
+    const brokenTool = {
+      name: "broken_tool",
+      description: "broken",
+      get parameters() {
+        throw new Error("bedrock tool parameters getter exploded");
+      },
+    };
+    const healthyTool = {
+      name: "read_context",
+      description: "Read context",
+      parameters: { type: "object", properties: {} },
+    };
+
+    expect(() =>
+      testing.convertToolConfig([brokenTool, healthyTool] as never, {
+        type: "tool",
+        name: "broken_tool",
+      }),
+    ).toThrow('Bedrock tool choice "broken_tool" was not projected');
+  });
+
+  it("fails closed when every tool is skipped and a pinned tool choice was requested", () => {
+    const brokenTool = {
+      name: "broken_tool",
+      description: "broken",
+      get parameters() {
+        throw new Error("bedrock tool parameters getter exploded");
+      },
+    };
+
+    expect(() =>
+      testing.convertToolConfig([brokenTool] as never, {
+        type: "tool",
+        name: "broken_tool",
+      }),
+    ).toThrow('Bedrock tool choice "broken_tool" was not projected');
+  });
+
+  it("fails closed when every tool is skipped and any tool was required", () => {
+    const brokenTool = {
+      name: "broken_tool",
+      description: "broken",
+      get parameters() {
+        throw new Error("bedrock tool parameters getter exploded");
+      },
+    };
+
+    expect(() => testing.convertToolConfig([brokenTool] as never, "any")).toThrow(
+      "Bedrock required tool choice had no projected tools",
+    );
+  });
+});

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -40,16 +40,35 @@ import {
   type SimpleStreamOptions,
   type StopReason,
   type StreamFunction,
-  type TextContent,
-  type ThinkingContent,
   type ThinkingLevel,
   type Tool,
-  type ToolCall,
   type ToolResultMessage,
 } from "openclaw/plugin-sdk/llm";
 import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-options.js";
 
-type Block = (TextContent | ThinkingContent | ToolCall) & { index?: number; partialJson?: string };
+type TextBlock = {
+  type: "text";
+  text: string;
+  index?: number;
+};
+
+type ThinkingBlock = {
+  type: "thinking";
+  thinking: string;
+  thinkingSignature?: string;
+  index?: number;
+};
+
+type ToolCallBlock = {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  index?: number;
+  partialJson?: string;
+};
+
+type Block = TextBlock | ThinkingBlock | ToolCallBlock;
 
 export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> = (
   model: Model<"bedrock-converse-stream">,
@@ -222,10 +241,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
     } catch (error) {
-      for (const block of output.content) {
-        delete (block as Block).index;
+      for (const block of blocks) {
+        delete block.index;
         // partialJson is only a streaming scratch buffer; never persist it.
-        delete (block as Block).partialJson;
+        if (block.type === "toolCall") {
+          delete block.partialJson;
+        }
       }
       output.stopReason = options.signal?.aborted ? "aborted" : "error";
       output.errorMessage = formatBedrockError(error);
@@ -451,7 +472,7 @@ function handleContentBlockStop(
       block.arguments = parseStreamingJson(block.partialJson);
       // Finalize in-place and strip the scratch buffer so replay only
       // carries parsed arguments.
-      delete (block as Block).partialJson;
+      delete block.partialJson;
       stream.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: output });
       break;
   }
@@ -766,13 +787,27 @@ function convertToolConfig(
     return undefined;
   }
 
-  const bedrockTools: BedrockTool[] = tools.map((tool) => ({
-    toolSpec: {
-      name: tool.name,
-      description: tool.description,
-      inputSchema: { json: tool.parameters as unknown as DocumentType },
-    },
-  }));
+  const bedrockTools: BedrockTool[] = [];
+  const bedrockToolNames = new Set<string>();
+  for (const tool of tools) {
+    const projected = readBedrockTool(tool);
+    if (!projected) {
+      continue;
+    }
+    bedrockTools.push(projected.bedrockTool);
+    bedrockToolNames.add(projected.name);
+  }
+  const pinnedToolChoice =
+    typeof toolChoice === "object" && toolChoice?.type === "tool" ? toolChoice.name : undefined;
+  if (pinnedToolChoice && !bedrockToolNames.has(pinnedToolChoice)) {
+    throw new Error(`Bedrock tool choice "${pinnedToolChoice}" was not projected`);
+  }
+  if (toolChoice === "any" && bedrockTools.length === 0) {
+    throw new Error("Bedrock required tool choice had no projected tools");
+  }
+  if (bedrockTools.length === 0) {
+    return undefined;
+  }
 
   let bedrockToolChoice: ToolChoice | undefined;
   switch (toolChoice) {
@@ -783,12 +818,35 @@ function convertToolConfig(
       bedrockToolChoice = { any: {} };
       break;
     default:
-      if (typeof toolChoice === "object" && toolChoice?.type === "tool") {
-        bedrockToolChoice = { tool: { name: toolChoice.name } };
+      if (pinnedToolChoice) {
+        bedrockToolChoice = { tool: { name: pinnedToolChoice } };
       }
   }
 
   return { tools: bedrockTools, toolChoice: bedrockToolChoice };
+}
+
+function readBedrockTool(tool: Tool): { name: string; bedrockTool: BedrockTool } | undefined {
+  try {
+    const name = tool.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return undefined;
+    }
+    const description = tool.description;
+    const parameters = tool.parameters;
+    return {
+      name,
+      bedrockTool: {
+        toolSpec: {
+          name,
+          description,
+          inputSchema: { json: parameters as unknown as DocumentType },
+        },
+      },
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function mapStopReason(reason: string | undefined): StopReason {
@@ -949,6 +1007,7 @@ function createImageBlock(mimeType: string, data: string) {
 }
 
 export const testing = {
+  convertToolConfig,
   convertMessages,
   getConfiguredBedrockRegion,
   hasConfiguredBedrockProfile,


### PR DESCRIPTION
Summary
- Guard Bedrock Converse tool-config projection against unreadable tool descriptor fields.
- Preserve healthy sibling tools when one descriptor is unreadable.
- Fail closed for pinned or required tool choices when the selected/required tool cannot be projected.

Verification
- CI=1 node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts --reporter=dot
- ./node_modules/.bin/oxfmt --check --threads=1 extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts
- OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/amazon-bedrock/stream.runtime.ts extensions/amazon-bedrock/stream.runtime.test.ts
- git diff --check origin/main...HEAD
- AWS Crabbox: provider aws, lease cbx_b5df87e222a2, run run_5c4a7027756e, command pnpm check:changed, exit 0
- Local autoreview: clean, no accepted/actionable findings

Behavior addressed
Bedrock provider tool projection no longer crashes the request when a single tool descriptor has an unreadable name, description, or parameters field.

Real environment tested
Local focused provider tests on macOS, plus AWS Crabbox linux changed gate.

Exact steps or command run after this patch
pnpm check:changed via AWS Crabbox run run_5c4a7027756e.

Evidence after fix
Focused Bedrock test passes 1 file / 9 tests. AWS Crabbox changed gate exits 0.

Observed result after fix
Healthy Bedrock tools remain projected when an unreadable sibling is skipped, and forced tool choices reject locally when the forced tool cannot be projected.

What was not tested
Live AWS Bedrock API call with real credentials.
