### PR TITLE
docs: document acp stateful target contracts

### DIFF
--- a/packages/gateway-client/src/event-loop-ready.ts
+++ b/packages/gateway-client/src/event-loop-ready.ts
@@ -99,6 +99,8 @@ export async function waitForEventLoopReady(
       timer = setTimeout(() => {
         timer = null;
         checks += 1;
+        // Timer drift is the readiness signal: high drift means the process is
+        // still starved, so require consecutive low-drift checks before IO.
         const driftMs = Math.max(0, Date.now() - scheduledAt - delayMs);
         maxDriftMs = Math.max(maxDriftMs, driftMs);
         if (driftMs > driftThresholdMs) {

--- a/packages/gateway-client/src/readiness.ts
+++ b/packages/gateway-client/src/readiness.ts
@@ -32,6 +32,8 @@ function resolveGatewayClientStartReadinessTimeoutMs(
     return options.timeoutMs;
   }
   const clientOptions = options.clientOptions ?? {};
+  // Use the same timeout precedence as connect-challenge setup so readiness
+  // waiting cannot outlive or undercut the client's own handshake watchdog.
   const timeoutOverride =
     typeof clientOptions.connectChallengeTimeoutMs === "number" &&
     Number.isFinite(clientOptions.connectChallengeTimeoutMs)
@@ -55,6 +57,7 @@ export async function startGatewayClientWithReadinessWait(
     maxWaitMs: resolveGatewayClientStartReadinessTimeoutMs(options),
     signal: options.signal,
   });
+  // A late abort after the probe resolves should still prevent client start.
   if (readiness.ready && !readiness.aborted && options.signal?.aborted !== true) {
     client.start();
   }

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -50,6 +50,7 @@ export const ConnectErrorDetailCodes = {
   CLIENT_VERSION_MISMATCH: "CLIENT_VERSION_MISMATCH",
 } as const;
 
+/** Stable connect-error detail codes carried in gateway handshake failures. */
 export type ConnectErrorDetailCode =
   (typeof ConnectErrorDetailCodes)[keyof typeof ConnectErrorDetailCodes];
 
@@ -60,6 +61,7 @@ export const ConnectPairingRequiredReasons = {
   METADATA_UPGRADE: "metadata-upgrade",
 } as const;
 
+/** Pairing state that explains why a gateway connection must pause for approval. */
 export type ConnectPairingRequiredReason =
   (typeof ConnectPairingRequiredReasons)[keyof typeof ConnectPairingRequiredReasons];
 
@@ -75,6 +77,7 @@ export type ConnectErrorRecoveryAdvice = {
   recommendedNextStep?: ConnectRecoveryNextStep;
 };
 
+/** Structured pairing failure payload shared by Gateway, clients, and UI recovery flows. */
 export type PairingConnectErrorDetails = {
   code: typeof ConnectErrorDetailCodes.PAIRING_REQUIRED;
   reason?: ConnectPairingRequiredReason;
@@ -152,6 +155,7 @@ const CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON: Readonly<
   "metadata-upgrade": "device metadata change pending approval",
 };
 
+/** Map gateway auth failure reasons to protocol-stable connect error codes. */
 export function resolveAuthConnectErrorDetailCode(
   reason: string | undefined,
 ): ConnectErrorDetailCode {
@@ -191,6 +195,7 @@ export function resolveAuthConnectErrorDetailCode(
   }
 }
 
+/** Map device-auth verifier failure reasons to protocol-stable connect error codes. */
 export function resolveDeviceAuthConnectErrorDetailCode(
   reason: string | undefined,
 ): ConnectErrorDetailCode {
@@ -212,6 +217,7 @@ export function resolveDeviceAuthConnectErrorDetailCode(
   }
 }
 
+/** Read a detail code from an untrusted connect error details payload. */
 export function readConnectErrorDetailCode(details: unknown): string | null {
   if (!details || typeof details !== "object" || Array.isArray(details)) {
     return null;
@@ -220,6 +226,7 @@ export function readConnectErrorDetailCode(details: unknown): string | null {
   return typeof code === "string" && code.trim().length > 0 ? code : null;
 }
 
+/** Read supported recovery advice fields from untrusted connect error details. */
 export function readConnectErrorRecoveryAdvice(details: unknown): ConnectErrorRecoveryAdvice {
   if (!details || typeof details !== "object" || Array.isArray(details)) {
     return {};
@@ -249,6 +256,7 @@ function normalizePairingConnectReason(value: unknown): ConnectPairingRequiredRe
     : undefined;
 }
 
+/** Normalize pairing request ids accepted in details payloads and close reasons. */
 export function normalizePairingConnectRequestId(value: unknown): string | undefined {
   const normalized = normalizeOptionalString(value);
   return normalized && PAIRING_CONNECT_REQUEST_ID_PATTERN.test(normalized) ? normalized : undefined;
@@ -287,6 +295,7 @@ function createPairingConnectErrorDetails(params: {
   };
 }
 
+/** Return the human-readable approval requirement for a pairing reason. */
 export function describePairingConnectRequirement(
   reason: ConnectPairingRequiredReason | undefined,
 ): string {
@@ -295,6 +304,7 @@ export function describePairingConnectRequirement(
     : "device approval is required";
 }
 
+/** Build the canonical connect error message for a pairing-required failure. */
 export function buildPairingConnectErrorMessage(
   reason: ConnectPairingRequiredReason | undefined,
 ): string {
@@ -319,6 +329,7 @@ export function buildPairingConnectRecoveryTitle(
     : "Gateway pairing approval required.";
 }
 
+/** Build sanitized pairing-required details for connect failure payloads. */
 export function buildPairingConnectErrorDetails(params: {
   reason: ConnectPairingRequiredReason | undefined;
   requestId?: string;
@@ -356,6 +367,7 @@ export function buildPairingConnectErrorDetails(params: {
   });
 }
 
+/** Build a close reason string that legacy clients can still parse. */
 export function buildPairingConnectCloseReason(params: {
   reason: ConnectPairingRequiredReason | undefined;
   requestId?: string;
@@ -365,6 +377,7 @@ export function buildPairingConnectCloseReason(params: {
   return requestId ? `${message} (requestId: ${requestId})` : message;
 }
 
+/** Parse pairing-required details from an untrusted connect error payload. */
 export function readPairingConnectErrorDetails(
   details: unknown,
 ): PairingConnectErrorDetails | null {
@@ -417,6 +430,7 @@ export function readPairingConnectErrorDetails(
   });
 }
 
+/** Return only the pairing fields needed by older pairing-required consumers. */
 export function readConnectPairingRequiredDetails(
   details: unknown,
 ): ConnectPairingRequiredDetails | null {
@@ -430,6 +444,7 @@ export function readConnectPairingRequiredDetails(
   };
 }
 
+/** Parse legacy pairing-required information from a formatted error message. */
 export function readConnectPairingRequiredMessage(
   message: string | null | undefined,
 ): ConnectPairingRequiredDetails | null {
@@ -462,6 +477,7 @@ export function readConnectPairingRequiredMessage(
   };
 }
 
+/** Format pairing-required details for user-facing connect error messages. */
 export function formatConnectPairingRequiredMessage(details: unknown): string {
   const pairing = readPairingConnectErrorDetails(details);
   const base =
@@ -471,6 +487,7 @@ export function formatConnectPairingRequiredMessage(details: unknown): string {
   return pairing?.requestId ? `${base} (requestId: ${pairing.requestId})` : base;
 }
 
+/** Format connect errors using protocol-aware details when available. */
 export function formatConnectErrorMessage(params: { message?: string; details?: unknown }): string {
   if (readConnectErrorDetailCode(params.details) === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
     return formatConnectPairingRequiredMessage(params.details);

--- a/src/channels/plugins/acp-stateful-target-driver.ts
+++ b/src/channels/plugins/acp-stateful-target-driver.ts
@@ -19,6 +19,11 @@ import type {
   StatefulBindingTargetSessionResult,
 } from "./stateful-target-drivers.js";
 
+/**
+ * Resolves an ACP session key back to the stateful target descriptor used by
+ * native commands. Runtime metadata wins, configured binding records provide
+ * labels, and ACP-shaped keys remain resettable after metadata is cleared.
+ */
 function toAcpStatefulBindingTargetDescriptor(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -67,6 +72,11 @@ function toAcpStatefulBindingTargetDescriptor(params: {
   };
 }
 
+/**
+ * Validates that the configured ACP binding is available before a stateful
+ * target can accept work. The lifecycle helper owns process startup and auth
+ * recovery; the driver only adapts the configured binding record.
+ */
 async function ensureAcpTargetReady(params: {
   cfg: OpenClawConfig;
   bindingResolution: ConfiguredBindingResolution;
@@ -89,6 +99,10 @@ async function ensureAcpTargetReady(params: {
   });
 }
 
+/**
+ * Opens or reuses the ACP session for a configured binding target. The session
+ * helper remains the single owner for key allocation and persistent metadata.
+ */
 async function ensureAcpTargetSession(params: {
   cfg: OpenClawConfig;
   bindingResolution: ConfiguredBindingResolution;
@@ -107,6 +121,11 @@ async function ensureAcpTargetSession(params: {
   });
 }
 
+/**
+ * Resets the resolved ACP session without re-resolving channel bindings. Native
+ * command callers have already selected the target; gateway reset remains the
+ * authority for replacing the session entry in place.
+ */
 async function resetAcpTargetInPlace(params: {
   cfg: OpenClawConfig;
   sessionKey: string;

--- a/src/gateway/active-sessions-shutdown-tracker.ts
+++ b/src/gateway/active-sessions-shutdown-tracker.ts
@@ -1,18 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-// Module-level tracker of sessions that have received `session_start` but not
-// yet a paired `session_end`. The close handler drains this set on gateway
-// shutdown / restart so downstream `session_end` plugins (e.g. claude-mem)
-// can finalize sessions that were active when the process stopped, instead
-// of leaving ghost rows in `active` state across restarts (see #57790).
-//
-// Membership is keyed by `sessionId`. The existing session lifecycle paths
-// (`emitGatewaySessionStartPluginHook` /
-// `emitGatewaySessionEndPluginHook` in `session-reset-service.ts`) call into
-// this tracker so a session that has already been finalized by replace /
-// reset / delete / compaction is forgotten before the shutdown drain ever
-// runs. That is what keeps the shutdown finalizer from double-firing.
-
+/**
+ * Session state retained between `session_start` and `session_end` so shutdown
+ * can emit a final typed end event for still-active sessions.
+ */
 export type ActiveSessionForShutdown = {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -24,6 +15,11 @@ export type ActiveSessionForShutdown = {
 
 const trackedSessions = new Map<string, ActiveSessionForShutdown>();
 
+/**
+ * Marks a session as needing shutdown finalization. Membership is keyed by
+ * `sessionId`, so reset/delete/compaction can forget exactly the session that
+ * already received its paired `session_end`.
+ */
 export function noteActiveSessionForShutdown(entry: ActiveSessionForShutdown): void {
   if (!entry.sessionId) {
     return;
@@ -31,6 +27,11 @@ export function noteActiveSessionForShutdown(entry: ActiveSessionForShutdown): v
   trackedSessions.set(entry.sessionId, entry);
 }
 
+/**
+ * Removes a session from the shutdown drain set after a normal lifecycle end.
+ * This prevents reset/delete/compaction from double-firing `session_end` when
+ * the process later exits.
+ */
 export function forgetActiveSessionForShutdown(sessionId: string | undefined): void {
   if (!sessionId) {
     return;
@@ -38,10 +39,17 @@ export function forgetActiveSessionForShutdown(sessionId: string | undefined): v
   trackedSessions.delete(sessionId);
 }
 
+/**
+ * Returns a snapshot of sessions that started but have not yet ended. The
+ * shutdown drain consumes this list and clears entries as it emits hooks.
+ */
 export function listActiveSessionsForShutdown(): ActiveSessionForShutdown[] {
   return Array.from(trackedSessions.values());
 }
 
+/**
+ * Clears process-local shutdown tracking between tests or runtime resets.
+ */
 export function clearActiveSessionsForShutdownTracker(): void {
   trackedSessions.clear();
 }

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -1,5 +1,6 @@
 import type { AgentEventPayload } from "../infra/agent-events.js";
 
+/** Resolve assistant text from an agent event, preferring deltas for streaming clients. */
 export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string {
   const delta = evt.data.delta;
   const text = evt.data.text;

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -48,6 +48,7 @@ function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
     : sorted;
 }
 
+/** Build the lightweight agent list shared by status commands and local Gateway summaries. */
 export function listGatewayAgentsBasic(cfg: OpenClawConfig): {
   defaultId: string;
   mainKey: string;
@@ -73,6 +74,8 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): {
       .map((entry) => (entry?.id ? normalizeAgentId(entry.id) : ""))
       .filter(Boolean),
   );
+  // An explicit configured agent list is authoritative; disk-discovered agents
+  // only appear when the config leaves the agent set open.
   const allowedIds = explicitIds.size > 0 ? new Set([...explicitIds, defaultId]) : null;
   let agentIds = listConfiguredAgentIds(cfg).filter((id) =>
     allowedIds ? allowedIds.has(id) : true,

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -2,6 +2,7 @@ import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 
+/** Chat/history row plus role metadata used to build OpenAI-compatible agent prompts. */
 export type ConversationEntry = {
   role: "user" | "assistant" | "tool";
   entry: HistoryEntry;
@@ -19,6 +20,8 @@ function safeBody(body: unknown): string {
 
 function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
   const body = safeBody(entry.entry.body);
+  // Internal stream-error placeholders are user-visible fallback text, not real
+  // assistant history; keep them out of model prompts.
   if (
     entry.role === "assistant" &&
     entry.internalStreamError === true &&
@@ -32,6 +35,7 @@ function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
   };
 }
 
+/** Build the model prompt text from conversation entries, preserving prior turns as context. */
 export function buildAgentMessageFromConversationEntries(entries: ConversationEntry[]): string {
   if (entries.length === 0) {
     return "";

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -17,6 +17,7 @@ const MAX_ASSISTANT_NAME = 50;
 const MAX_ASSISTANT_AVATAR = 2_000_000;
 const MAX_ASSISTANT_EMOJI = 16;
 
+/** Fallback assistant presentation used when config and agent identity provide no usable fields. */
 export const DEFAULT_ASSISTANT_IDENTITY: AssistantIdentity = {
   agentId: "main",
   name: "Assistant",
@@ -81,6 +82,7 @@ function normalizeEmojiValue(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+/** Resolve the assistant identity shown by Gateway/UI surfaces for a specific agent. */
 export function resolveAssistantIdentity(params: {
   cfg: OpenClawConfig;
   agentId?: string | null;
@@ -97,6 +99,8 @@ export function resolveAssistantIdentity(params: {
   const uiName = coerceIdentityValue(configAssistant?.name, MAX_ASSISTANT_NAME);
   const agentName = coerceIdentityValue(agentIdentity?.name, MAX_ASSISTANT_NAME);
   const fileName = coerceIdentityValue(fileIdentity?.name, MAX_ASSISTANT_NAME);
+  // The default agent lets global UI branding win; named agents keep their own
+  // identity ahead of global branding so multi-agent surfaces stay distinct.
   const name =
     (isDefaultAgent ? (uiName ?? agentName ?? fileName) : (agentName ?? fileName ?? uiName)) ??
     DEFAULT_ASSISTANT_IDENTITY.name;

--- a/src/gateway/auth-config-utils.ts
+++ b/src/gateway/auth-config-utils.ts
@@ -21,7 +21,10 @@ type GatewayAuthSecretRefResolutionParams = {
   hasTokenCandidate: boolean;
 };
 
-/** Check whether a local Gateway auth input is configured directly or through defaults. */
+/**
+ * Checks whether a local Gateway auth field is configured directly, through an
+ * env template, or through SecretRef defaults.
+ */
 export function hasConfiguredGatewayAuthSecretInput(
   cfg: OpenClawConfig,
   path: GatewayAuthSecretInputPath,
@@ -98,7 +101,11 @@ async function resolveGatewayAuthSecretRefValue(params: {
   return value;
 }
 
-/** Resolve the Gateway auth token ref only when token auth can use it. */
+/**
+ * Resolves the Gateway auth token SecretRef only when token auth can use it.
+ * This keeps password/trusted-proxy startup from requiring unrelated token
+ * providers.
+ */
 export async function resolveGatewayTokenSecretRefValue(
   params: GatewayAuthSecretRefResolutionParams,
 ): Promise<string | undefined> {
@@ -110,7 +117,10 @@ export async function resolveGatewayTokenSecretRefValue(
   });
 }
 
-/** Resolve the Gateway auth password ref only when password auth can use it. */
+/**
+ * Resolves the Gateway auth password SecretRef only when password auth can use
+ * it. Token and no-auth modes intentionally leave password refs unresolved.
+ */
 export async function resolveGatewayPasswordSecretRefValue(
   params: GatewayAuthSecretRefResolutionParams,
 ): Promise<string | undefined> {
@@ -158,7 +168,11 @@ async function resolveGatewayPasswordSecretRef(params: {
   });
 }
 
-/** Materialize active local Gateway auth secret refs on a cloned config. */
+/**
+ * Materializes active local Gateway auth SecretRefs on a cloned config.
+ * The original config is preserved so startup can inject resolved credentials
+ * into runtime auth without rewriting persisted SecretRef-backed settings.
+ */
 export async function materializeGatewayAuthSecretRefs(
   params: GatewayAuthSecretRefResolutionParams,
 ): Promise<OpenClawConfig> {

--- a/src/gateway/auth-install-policy.ts
+++ b/src/gateway/auth-install-policy.ts
@@ -8,6 +8,8 @@ type GatewayInstallAuthMode = NonNullable<NonNullable<OpenClawConfig["gateway"]>
 function hasExplicitGatewayInstallAuthMode(
   mode: GatewayInstallAuthMode | undefined,
 ): boolean | undefined {
+  // Return undefined only when install must infer the auth family from durable
+  // credentials; explicit non-token modes opt out of token creation.
   if (mode === "token") {
     return true;
   }
@@ -32,6 +34,7 @@ function hasDurableGatewayPasswordEnvForInstall(
   );
 }
 
+/** Decide whether service install should create/require a durable Gateway token. */
 export function shouldRequireGatewayTokenForInstall(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,

--- a/src/gateway/auth-mode-policy.ts
+++ b/src/gateway/auth-mode-policy.ts
@@ -1,9 +1,11 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 
+/** Shared error text for surfaces that require an explicit auth mode when both secrets exist. */
 export const EXPLICIT_GATEWAY_AUTH_MODE_REQUIRED_ERROR =
   "Invalid config: gateway.auth.token and gateway.auth.password are both configured, but gateway.auth.mode is unset. Set gateway.auth.mode to token or password.";
 
+/** Detect configs where token and password auth are both usable but mode selection is absent. */
 export function hasAmbiguousGatewayAuthModeConfig(cfg: OpenClawConfig): boolean {
   const auth = cfg.gateway?.auth;
   if (!auth) {
@@ -13,11 +15,14 @@ export function hasAmbiguousGatewayAuthModeConfig(cfg: OpenClawConfig): boolean 
     return false;
   }
   const defaults = cfg.secrets?.defaults;
+  // Secret refs can inherit defaults, so ambiguity must use the same configured
+  // secret-input test as runtime auth rather than checking raw string fields.
   const tokenConfigured = hasConfiguredSecretInput(auth.token, defaults);
   const passwordConfigured = hasConfiguredSecretInput(auth.password, defaults);
   return tokenConfigured && passwordConfigured;
 }
 
+/** Enforce explicit token-vs-password selection before launching auth-sensitive flows. */
 export function assertExplicitGatewayAuthModeWhenBothConfigured(cfg: OpenClawConfig): void {
   if (!hasAmbiguousGatewayAuthModeConfig(cfg)) {
     return;

--- a/src/gateway/auth-resolve.ts
+++ b/src/gateway/auth-resolve.ts
@@ -20,8 +20,11 @@ export type ResolvedGatewayAuthModeSource =
 /** Fully resolved Gateway auth policy before startup validates required secrets. */
 export type ResolvedGatewayAuth = {
   mode: ResolvedGatewayAuthMode;
+  /** Source that selected mode; useful for diagnostics and install policy. */
   modeSource?: ResolvedGatewayAuthModeSource;
+  /** Resolved plaintext token, excluding unresolved SecretRef config values. */
   token?: string;
+  /** Resolved plaintext password, excluding unresolved SecretRef config values. */
   password?: string;
   allowTailscale: boolean;
   trustedProxy?: GatewayTrustedProxyConfig;
@@ -35,9 +38,13 @@ export type EffectiveSharedGatewayAuth = {
 
 /** Resolve Gateway auth mode, credentials, trusted-proxy policy, and Tailscale allowance. */
 export function resolveGatewayAuth(params: {
+  /** Persisted Gateway auth config. SecretRefs are treated as unresolved here. */
   authConfig?: GatewayAuthConfig | null;
+  /** Sparse runtime overlay used by startup and tests without mutating config. */
   authOverride?: GatewayAuthConfig | null;
+  /** Env map used for OPENCLAW_GATEWAY_TOKEN/PASSWORD fallback reads. */
   env?: NodeJS.ProcessEnv;
+  /** Tailscale serve can allow tokenless access unless stricter auth is selected. */
   tailscaleMode?: GatewayTailscaleMode;
 }): ResolvedGatewayAuth {
   const baseAuthConfig = params.authConfig ?? {};
@@ -119,7 +126,10 @@ export function resolveGatewayAuth(params: {
   };
 }
 
-/** Return the effective token/password secret for clients that cannot model every auth mode. */
+/**
+ * Returns the active token/password secret for clients that cannot model every
+ * auth mode. Non-shared modes return null instead of leaking stale credentials.
+ */
 export function resolveEffectiveSharedGatewayAuth(params: {
   authConfig?: GatewayAuthConfig | null;
   authOverride?: GatewayAuthConfig | null;

--- a/src/gateway/auth-surface-resolution.ts
+++ b/src/gateway/auth-surface-resolution.ts
@@ -43,6 +43,7 @@ function withDiagnostics<T extends object>(params: {
     : params.result;
 }
 
+/** Resolve best-effort credentials for non-interactive Gateway status/probe calls. */
 export async function resolveGatewayProbeSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -53,6 +54,8 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
   const authMode = params.config.gateway?.auth?.mode;
 
   if (params.surface === "remote") {
+    // Remote probes avoid password lookup when a token exists because remote
+    // gateway status uses one auth method and should not surface unused refs.
     const remoteToken = await resolveGatewayCredential({
       config: params.config,
       env,
@@ -141,6 +144,7 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
   });
 }
 
+/** Resolve Gateway credentials for interactive clients, returning a user-facing failure reason. */
 export async function resolveGatewayInteractiveSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -164,6 +168,9 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
     : trimToUndefined(env.OPENCLAW_GATEWAY_PASSWORD);
 
   if (params.surface === "remote") {
+    // Interactive remote clients accept explicit/env credentials as fallbacks
+    // even when configured secret refs are missing, so users can recover from
+    // broken remote config without editing files first.
     const remoteToken = explicitToken
       ? { value: explicitToken }
       : await resolveGatewayCredential({
@@ -271,6 +278,9 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
 
   const shouldUsePassword =
     Boolean(explicitPassword ?? envPassword) || (hasConfiguredPassword && !hasConfiguredToken);
+  // Without an explicit mode, password wins only when it is the only configured
+  // auth secret or the caller supplied one directly; otherwise token remains the
+  // local default to match startup/probe behavior.
   if (shouldUsePassword) {
     const password = await resolvePassword();
     return {

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -7,17 +7,27 @@ import {
 } from "./resolve-configured-secret-input-string.js";
 
 type GatewayAuthTokenResolutionSource = "explicit" | "config" | "secretRef" | "env";
+/** Controls whether OPENCLAW_GATEWAY_TOKEN may backfill missing or unresolved config. */
 type GatewayAuthTokenEnvFallback = "never" | "no-secret-ref" | "always";
 
+/**
+ * Resolves the Gateway auth token for install/status/doctor call sites.
+ * Precedence is explicit token, plaintext config, SecretRef, then optional env
+ * fallback; unresolved SecretRefs stay visible so callers can decide whether an
+ * env token is acceptable or whether the operator must fix the SecretRef.
+ */
 export async function resolveGatewayAuthToken(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  /** CLI or call-site supplied token; whitespace-only values are ignored. */
   explicitToken?: string;
+  /** Defaults to "always"; install paths use stricter modes to avoid persisting env fallbacks. */
   envFallback?: GatewayAuthTokenEnvFallback;
   unresolvedReasonStyle?: SecretInputUnresolvedReasonStyle;
 }): Promise<{
   token?: string;
   source?: GatewayAuthTokenResolutionSource;
+  /** True when gateway.auth.token was configured as a SecretRef or env template. */
   secretRefConfigured: boolean;
   unresolvedRefReason?: string;
 }> {

--- a/src/gateway/auth-token-source-conflict.ts
+++ b/src/gateway/auth-token-source-conflict.ts
@@ -5,6 +5,7 @@ import { normalizeSecretInputString, resolveSecretInputRef } from "../config/typ
 const GATEWAY_ENV_TOKEN = "OPENCLAW_GATEWAY_TOKEN";
 const GATEWAY_SERVICE_KIND = "gateway";
 
+/** Warning payload used when local env token precedence can diverge from service config. */
 export type GatewayAuthTokenSourceConflict = {
   checkId: "gateway.env_token_overrides_config";
   title: string;
@@ -14,6 +15,7 @@ export type GatewayAuthTokenSourceConflict = {
   diagnostic: string;
 };
 
+/** Detect when OPENCLAW_GATEWAY_TOKEN can make local clients use a different token source. */
 export function resolveGatewayAuthTokenSourceConflict(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -27,6 +29,8 @@ export function resolveGatewayAuthTokenSourceConflict(params: {
     return null;
   }
 
+  // Remote gateways and the managed gateway service have their own credential
+  // precedence; this warning is only for local clients versus local service.
   if (params.cfg.gateway?.mode === "remote") {
     return null;
   }

--- a/src/gateway/boot-echo-guard.ts
+++ b/src/gateway/boot-echo-guard.ts
@@ -1,15 +1,3 @@
-// Boot-run echo guard: tracks the active boot prompt per session key so that
-// downstream user-visible delivery paths (currently the message tool) can
-// suppress fallback-model echoes that copy substantial portions of the boot
-// prompt without preserving the internal-runtime-context delimiters.
-//
-// The marker-based strip in `stripInternalRuntimeContext` only catches
-// echoes that include the delimiter lines verbatim. A model that paraphrases
-// out the wrapper but reproduces a long contiguous chunk of the BOOT.md
-// content would slip past the marker strip and reach the user. This module
-// adds a defense-in-depth substantial-echo check using the active boot prompt
-// as the comparison source. Refs #53732.
-
 const MIN_ECHO_CHARS = 80;
 
 type BootEchoContext = {
@@ -35,6 +23,8 @@ function getBootPromptChunks(normalizedBootPrompt: string, minLen: number): Set<
     return cached;
   }
   const chunks = new Set<string>();
+  // Cache fixed-width chunks by prompt and threshold so repeated outbound
+  // delivery checks do not rebuild the same BOOT.md comparison window.
   for (let i = 0; i <= normalizedBootPrompt.length - minLen; i += 1) {
     chunks.add(normalizedBootPrompt.slice(i, i + minLen));
   }
@@ -42,6 +32,10 @@ function getBootPromptChunks(normalizedBootPrompt: string, minLen: number): Set<
   return chunks;
 }
 
+/**
+ * Store the active BOOT.md prompt for a session so user-visible send paths can
+ * suppress model echoes that no longer contain internal-context delimiters.
+ */
 export function setBootEchoContextForSession(sessionKey: string, bootPrompt: string): void {
   if (!sessionKey || !bootPrompt) {
     return;
@@ -53,6 +47,7 @@ export function setBootEchoContextForSession(sessionKey: string, bootPrompt: str
   bootContextBySessionKey.set(sessionKey, { bootPrompt, normalizedBootPrompt });
 }
 
+/** Clear the active boot-echo context and cached chunks for a finished session. */
 export function clearBootEchoContextForSession(sessionKey: string): void {
   if (!sessionKey) {
     return;
@@ -64,6 +59,7 @@ export function clearBootEchoContextForSession(sessionKey: string): void {
   bootContextBySessionKey.delete(sessionKey);
 }
 
+/** Return the active boot prompt for a session, if one is currently guarded. */
 export function getBootEchoContextForSession(sessionKey: string | undefined): string | undefined {
   if (!sessionKey) {
     return undefined;
@@ -72,11 +68,8 @@ export function getBootEchoContextForSession(sessionKey: string | undefined): st
 }
 
 /**
- * Returns true if `outboundText` contains a contiguous substring of
- * `bootPrompt` of at least `minLen` characters, ignoring leading/trailing
- * whitespace on the boot prompt itself. Short boot prompts (< minLen chars)
- * never trigger to avoid suppressing legitimate short BOOT.md-directed
- * sends like a literal "good morning".
+ * Return true when outbound text copies a long contiguous chunk of the active
+ * boot prompt, ignoring whitespace normalization but not fuzzy paraphrases.
  */
 export function containsSubstantialBootEcho(
   outboundText: string,
@@ -98,10 +91,8 @@ export function containsSubstantialBootEcho(
 }
 
 /**
- * Removes any user-supplied outbound text that substantially echoes the
- * active boot prompt. Returns an empty string when an echo is detected so
- * the caller can either drop the send entirely or treat the outbound text
- * as empty. The boot prompt itself is unchanged.
+ * Remove outbound text that substantially echoes the active boot prompt.
+ * Returning an empty string lets callers drop the send or treat it as empty.
  */
 export function stripBootEchoFromOutboundText(
   outboundText: string,
@@ -113,6 +104,7 @@ export function stripBootEchoFromOutboundText(
   return containsSubstantialBootEcho(outboundText, bootPrompt) ? "" : outboundText;
 }
 
+/** Reset boot-echo state between tests that share the module singleton. */
 export function resetBootEchoContextForTests(): void {
   bootContextBySessionKey.clear();
   bootChunksByNormalizedPrompt.clear();

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -32,6 +32,7 @@ export type ChannelHealthEvaluation = {
   reason: ChannelHealthEvaluationReason;
 };
 
+/** Inputs shared by channel health monitor, CLI health, and readiness probes. */
 export type ChannelHealthPolicy = {
   channelId: ChannelId;
   now: number;
@@ -51,6 +52,7 @@ const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
 export const DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
 export const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
 
+/** Classify a channel runtime snapshot without mutating channel or monitor state. */
 export function evaluateChannelHealth(
   snapshot: ChannelHealthSnapshot,
   policy: ChannelHealthPolicy,
@@ -101,6 +103,8 @@ export function evaluateChannelHealth(
   }
   if (snapshot.lastStartAt != null) {
     const upDuration = policy.now - snapshot.lastStartAt;
+    // Startup grace wins before disconnected/stale checks so newly restarted
+    // clients can connect without immediate monitor/readiness churn.
     if (upDuration < policy.channelConnectGraceMs) {
       return { healthy: true, reason: "startup-connect-grace" };
     }
@@ -127,6 +131,7 @@ export function evaluateChannelHealth(
   return { healthy: true, reason: "healthy" };
 }
 
+/** Convert a failed health classification into the restart reason used by monitors. */
 export function resolveChannelRestartReason(
   snapshot: ChannelHealthSnapshot,
   evaluation: ChannelHealthEvaluation,

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -12,6 +12,7 @@ import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
+/** Tracks the active abort/controller state for one chat or agent run. */
 export type ChatAbortControllerEntry = {
   controller: AbortController;
   sessionId: string;
@@ -51,6 +52,7 @@ type RegisteredChatAbortController = {
   cleanup: () => void;
 };
 
+/** Returns true for user text that should be treated as a stop/abort command. */
 export function isChatStopCommandText(text: string): boolean {
   return isAbortRequestText(text);
 }
@@ -64,6 +66,7 @@ function createChatAbortSignalReason(stopReason: string | undefined): Error | un
   return reason;
 }
 
+/** Computes the bounded expiry timestamp for chat.send abort-controller entries. */
 export function resolveChatRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -93,6 +96,7 @@ export function resolveChatRunExpiresAtMs(params: {
   return Math.min(max, Math.max(min, target));
 }
 
+/** Computes agent-run expiry without extending past the requested timeout plus grace. */
 export function resolveAgentRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -108,6 +112,7 @@ export function resolveAgentRunExpiresAtMs(params: {
   });
 }
 
+/** Registers a run abort controller and returns a cleanup hook scoped to that controller. */
 export function registerChatAbortController(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   runId: string;
@@ -127,6 +132,7 @@ export function registerChatAbortController(params: {
   const controller = new AbortController();
   const cleanup = () => {
     const entry = params.chatAbortControllers.get(params.runId);
+    // Only the creator's controller may delete the map entry; replacement runs own their cleanup.
     if (entry?.controller === controller) {
       params.chatAbortControllers.delete(params.runId);
     }
@@ -261,6 +267,7 @@ export function resolveInFlightRunSnapshot(params: {
   return { runId: best.runId, text: projected.suppress ? "" : projected.text };
 }
 
+/** Drops buffered partial text when keeping it would exceed the chat.history response budget. */
 export function boundInFlightRunSnapshotForChatHistory(params: {
   snapshot: { runId: string; text: string } | undefined;
   messages: unknown[];
@@ -280,6 +287,7 @@ export function boundInFlightRunSnapshotForChatHistory(params: {
   return { runId: params.snapshot.runId, text: "" };
 }
 
+/** Minimal operations needed to abort a run and clean all Gateway run state. */
 export type ChatAbortOps = {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunBuffers: Map<string, string>;
@@ -296,6 +304,7 @@ export type ChatAbortOps = {
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
 };
 
+/** Adapter shape for callers that keep abort state inside a composed chat-run state object. */
 export type TrackedChatRunAbortOps = {
   chatAbortControllers: ChatAbortOps["chatAbortControllers"];
   chatRunBuffers: ChatAbortOps["chatRunBuffers"];
@@ -309,6 +318,7 @@ export type TrackedChatRunAbortOps = {
   nodeSendToSession: ChatAbortOps["nodeSendToSession"];
 };
 
+/** Aborts a tracked chat run using the composed chat-run state adapter. */
 export function abortTrackedChatRunById(
   ops: TrackedChatRunAbortOps,
   params: Parameters<typeof abortChatRunById>[1],
@@ -382,6 +392,7 @@ function broadcastChatAborted(
       : undefined,
   };
   ops.broadcast("chat", payload);
+  // Global sessions also deliver to the agent-scoped node channel clients subscribed to.
   for (const deliverySessionKey of resolveChatAbortDeliverySessionKeys(
     ops,
     sessionKey,
@@ -396,6 +407,7 @@ function resolveDefaultGlobalAgentId(ops: ChatAbortOps): string | undefined {
   return cfg ? resolveDefaultAgentId(cfg) : undefined;
 }
 
+/** Aborts one active run, clears live buffers, emits aborted chat/lifecycle events, and forgets seq state. */
 export function abortChatRunById(
   ops: ChatAbortOps,
   params: {
@@ -453,6 +465,7 @@ export function abortChatRunById(
   return { aborted: true };
 }
 
+/** Updates provider ids on an already-registered run after provider resolution finishes. */
 export function updateChatRunProvider(
   chatAbortControllers: Map<string, ChatAbortControllerEntry>,
   params: {
@@ -470,6 +483,7 @@ export function updateChatRunProvider(
   return true;
 }
 
+/** Aborts all active runs currently associated with a provider or auth provider id. */
 export function abortChatRunsForProvider(
   ops: ChatAbortOps,
   params: {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -8,6 +8,11 @@ import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { deleteMediaBuffer, saveMediaBuffer } from "../media/store.js";
 
+/**
+ * Raw attachment shape accepted by Gateway chat entrypoints.
+ * content must be base64 when present; MIME and filename are hints that are
+ * validated against sniffed bytes before model/runtime delivery.
+ */
 export type ChatAttachment = {
   type?: string;
   mimeType?: string;
@@ -15,12 +20,20 @@ export type ChatAttachment = {
   content?: unknown;
 };
 
+/**
+ * Inline image block passed to model runtimes that accept native image inputs.
+ * Large images and all non-image files use media refs instead.
+ */
 export type ChatImageContent = {
   type: "image";
   data: string;
   mimeType: string;
 };
 
+/**
+ * Disk-backed attachment reference surfaced to agent runtimes as media:// URLs.
+ * The path is retained for host tools while message text carries only mediaRef.
+ */
 export type OffloadedRef = {
   mediaRef: string;
   id: string;
@@ -56,8 +69,14 @@ type SavedMedia = {
 const OFFLOAD_THRESHOLD_BYTES = 2_000_000;
 const TEXT_ONLY_OFFLOAD_LIMIT = 10;
 
+/** Default per-attachment upload ceiling when agent config has no media limit. */
 export const DEFAULT_CHAT_ATTACHMENT_MAX_MB = 20;
 
+/**
+ * Resolves the per-agent inbound attachment ceiling in bytes.
+ * Invalid or absent config falls back to the product default rather than
+ * disabling the upload guard.
+ */
 export function resolveChatAttachmentMaxBytes(cfg: OpenClawConfig): number {
   const configured = cfg.agents?.defaults?.mediaMaxMb;
   const mb =
@@ -73,6 +92,10 @@ type UnsupportedAttachmentReason =
   | "unsupported-non-image"
   | "non-image-too-large-for-sandbox";
 
+/**
+ * Signals caller-actionable attachment rejection, such as unsupported file
+ * kind or image input on a text-only entrypoint.
+ */
 export class UnsupportedAttachmentError extends Error {
   readonly reason: UnsupportedAttachmentReason;
   constructor(reason: UnsupportedAttachmentReason, message: string) {
@@ -82,6 +105,10 @@ export class UnsupportedAttachmentError extends Error {
   }
 }
 
+/**
+ * Wraps failures after validation when an accepted attachment cannot be saved
+ * into the inbound media store.
+ */
 export class MediaOffloadError extends Error {
   override readonly cause: unknown;
   constructor(message: string, options?: ErrorOptions) {
@@ -120,6 +147,8 @@ function resolveAttachmentMime(params: {
   providedMime?: string;
   labelMime?: string;
 }): string {
+  // Generic containers are useful fallback signals, but they must not let a
+  // caller-provided image hint turn a zip/octet payload into inline image input.
   const trustedProvidedMime = shouldIgnoreImageMimeHint({
     sniffedMime: params.sniffedMime,
     hintedMime: params.providedMime,
@@ -151,6 +180,9 @@ function isValidBase64(value: string): boolean {
 }
 
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {
+  // Buffer.from silently skips some invalid base64 characters. Compare the
+  // decoded byte count against the preflight estimate before the payload is
+  // saved or sent to model input.
   if (Math.abs(buffer.byteLength - estimatedBytes) > 3) {
     throw new Error(
       `attachment ${label}: base64 contains invalid characters ` +
@@ -180,6 +212,8 @@ function assertSavedMedia(value: unknown, label: string): SavedMedia {
   if (id.length === 0) {
     throw new Error(`attachment ${label}: saveMediaBuffer returned an empty media ID`);
   }
+  // saveMediaBuffer owns the storage root. Reject path-like IDs so media://
+  // references cannot escape the inbound media namespace if the store changes.
   if (id.includes("/") || id.includes("\\") || id.includes("\0")) {
     throw new Error(
       `attachment ${label}: saveMediaBuffer returned an unsafe media ID ` +
@@ -211,6 +245,8 @@ function normalizeAttachment(
 
   let base64 = content.trim();
   if (opts.stripDataUrlPrefix) {
+    // Chat clients commonly send data URLs. Strip only the wrapper here so the
+    // same base64 validator covers raw and data-URL attachment payloads.
     const dataUrlMatch = /^data:[^;]+;base64,(.*)$/.exec(base64);
     if (dataUrlMatch) {
       base64 = dataUrlMatch[1];
@@ -235,6 +271,10 @@ function validateAttachmentBase64OrThrow(
   return sizeBytes;
 }
 
+/**
+ * Converts client attachments into native image blocks and/or inbound media
+ * references while preserving image order for prompt construction.
+ */
 export async function parseMessageWithAttachments(
   message: string,
   attachments: ChatAttachment[] | undefined,
@@ -360,6 +400,8 @@ export async function parseMessageWithAttachments(
         shouldForceImageOffload || !isImage || sizeBytes > OFFLOAD_THRESHOLD_BYTES;
 
       if (!shouldOffload) {
+        // Preserve small images as native model inputs. imageOrder keeps their
+        // relative position next to later offloaded image refs for prompt order.
         images.push({ type: "image", data: b64, mimeType: finalMime });
         imageOrder.push("inline");
         continue;
@@ -390,6 +432,8 @@ export async function parseMessageWithAttachments(
 
       const mediaRef = `media://inbound/${savedMedia.id}`;
       if (isImage) {
+        // Text-only image offload still needs a prompt-visible placeholder;
+        // non-image files are exposed through offloadedRefs/tool context only.
         updatedMessage += `\n[media attached: ${mediaRef}]`;
       }
       log?.info?.(
@@ -415,6 +459,8 @@ export async function parseMessageWithAttachments(
     }
   } catch (err) {
     if (savedMediaIds.length > 0) {
+      // Treat parsing as all-or-nothing. A later invalid attachment must not
+      // leave earlier offloaded media reachable without a successful message.
       await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
     }
     throw err;
@@ -428,6 +474,10 @@ export async function parseMessageWithAttachments(
   };
 }
 
+/**
+ * Classifies an attachment before full parsing using the same MIME precedence
+ * as parseMessageWithAttachments.
+ */
 export async function resolveChatAttachmentLooksLikeImage(
   attachment: ChatAttachment,
   index = 0,

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -32,6 +32,7 @@ type PendingMessageToolVisibleReply = {
   succeeded: boolean;
 };
 
+/** Resolves the display text budget for chat history projections. */
 export function resolveEffectiveChatHistoryMaxChars(_cfg: unknown, maxChars?: number): number {
   if (typeof maxChars === "number") {
     return maxChars;
@@ -79,6 +80,7 @@ function sanitizeChatHistoryContentBlock(
   const preserveExactToolPayload =
     opts?.preserveExactToolPayload === true || isToolHistoryBlockType(entry.type);
   const maxChars = opts?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  // Tool payloads stay exact enough for replay/debug; display text still loses directive tags.
   if (typeof entry.text === "string") {
     const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
     if (preserveExactToolPayload) {
@@ -117,6 +119,7 @@ function sanitizeChatHistoryContentBlock(
     changed ||= res.truncated;
   }
   if ("thinkingSignature" in entry) {
+    // Reasoning signatures are model/provider internals and should not leak to chat displays.
     delete entry.thinkingSignature;
     changed = true;
   }
@@ -162,6 +165,7 @@ function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {
   if (!hasExplicitPhasedText) {
     return { content, changed: false };
   }
+  // When phased text exists, display only the final answer phase in history views.
   const filtered = content.filter((block) => {
     if (!block || typeof block !== "object") {
       return true;
@@ -192,6 +196,7 @@ function projectAssistantTextFromMixedToolContent(
     return null;
   }
 
+  // Mixed tool transcripts can contain display text plus tool internals; keep only visible text.
   const textBlocks: unknown[] = [];
   for (const block of content) {
     if (!block || typeof block !== "object") {
@@ -1183,6 +1188,7 @@ function filterVisibleProjectedHistoryMessages(
       continue;
     }
     if (isDuplicateAcpGatewayInjectedMessage(current, visible.at(-1))) {
+      // ACP runtimes may echo the same final text before Gateway injects a stopped-run row.
       changed = true;
       continue;
     }
@@ -1191,11 +1197,13 @@ function filterVisibleProjectedHistoryMessages(
   return changed ? visible : messages;
 }
 
+/** Projects raw transcript messages into the public Gateway chat-history display shape. */
 export function projectChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; stripEnvelope?: boolean },
 ): Array<Record<string, unknown>> {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
+  // Mirror in-chat message sends before visibility filtering so user-visible replies survive.
   const mirrored = mirrorMessageToolVisibleReplies(source);
   const merged = mergeTtsSupplementMessages(
     filterVisibleProjectedHistoryMessages(
@@ -1220,6 +1228,7 @@ function limitChatDisplayMessages<T>(messages: T[], maxMessages?: number): T[] {
   return messages.slice(-Math.floor(maxMessages));
 }
 
+/** Projects chat history and returns only the newest display rows when requested. */
 export function projectRecentChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; maxMessages?: number; stripEnvelope?: boolean },
@@ -1230,6 +1239,7 @@ export function projectRecentChatDisplayMessages(
   );
 }
 
+/** Projects one raw transcript message, returning undefined when it has no displayable row. */
 export function projectChatDisplayMessage(
   message: unknown,
   options?: { maxChars?: number; stripEnvelope?: boolean },

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -26,6 +26,8 @@ function extractMessageSenderLabel(entry: Record<string, unknown>): string | nul
       }
       const senderLabel = extractInboundSenderLabel(text);
       if (senderLabel) {
+        // Preserve sender attribution before stripping the visible envelope so
+        // projections can show who spoke without leaking inbound metadata text.
         return senderLabel;
       }
     }
@@ -49,6 +51,8 @@ function stripEnvelopeFromContentWithRole(
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
+    // Assistant/tool rows may carry internal metadata, but only user rows use
+    // the external sender envelope grammar.
     const stripped = stripUserEnvelope
       ? stripUserEnvelopeForDisplay(entry.text)
       : stripInternalMetadataForDisplay(entry.text);
@@ -64,6 +68,10 @@ function stripEnvelopeFromContentWithRole(
   return { content: next, changed };
 }
 
+/**
+ * Returns a display-safe message copy with user envelopes and internal
+ * metadata removed from string or text-block content.
+ */
 export function stripEnvelopeFromMessage(message: unknown): unknown {
   if (!message || typeof message !== "object") {
     return message;
@@ -107,6 +115,10 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   return changed ? next : message;
 }
 
+/**
+ * Applies stripEnvelopeFromMessage across a message list while preserving the
+ * original array identity when no entry changes.
+ */
 export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -47,6 +47,7 @@ function resolveClaudeProjectsDir(homeDir?: string): string {
   return path.join(resolveHistoryHomeDir(homeDir), CLAUDE_PROJECTS_RELATIVE_DIR);
 }
 
+/** Resolves the Claude CLI session id from current and legacy session-store binding fields. */
 export function resolveClaudeCliBindingSessionId(
   entry: SessionEntry | undefined,
 ): string | undefined {
@@ -120,9 +121,11 @@ function normalizeClaudeCliContent(
       const id = normalizeOptionalString(block.id) ?? "";
       const name = normalizeOptionalString(block.name) ?? "";
       if (id && name) {
+        // Claude writes tool results without names; remember names by tool_use id.
         toolNameRegistry.set(id, name);
       }
       if (block.input !== undefined && block.arguments === undefined) {
+        // Gateway display code expects Anthropic tool calls as `toolcall.arguments`.
         block.arguments = cloneJsonValue(block.input);
       }
       block.type = "toolcall";
@@ -204,6 +207,7 @@ function coalesceClaudeCliToolMessages(messages: TranscriptLikeMessage[]): Trans
       continue;
     }
 
+    // Rebuild Gateway-style assistant messages where tool call and result blocks share one turn.
     coalesced.push({
       ...current,
       content: [...callBlocks.map(cloneJsonValue), ...resultBlocks.map(cloneJsonValue)],
@@ -213,6 +217,7 @@ function coalesceClaudeCliToolMessages(messages: TranscriptLikeMessage[]): Trans
   return coalesced;
 }
 
+/** Converts one Claude CLI JSONL entry into OpenClaw's transcript message shape. */
 function parseClaudeCliHistoryEntry(
   entry: ClaudeCliProjectEntry,
   cliSessionId: string,
@@ -272,6 +277,7 @@ function parseClaudeCliHistoryEntry(
   ) as TranscriptLikeMessage;
 }
 
+/** Locates a Claude CLI project transcript by session id without allowing path traversal. */
 export function resolveClaudeCliSessionFilePath(params: {
   cliSessionId: string;
   homeDir?: string;
@@ -303,6 +309,7 @@ export function resolveClaudeCliSessionFilePath(params: {
     const candidate = path.resolve(projectDir, `${sessionId}.jsonl`);
     const resolvedProjectDir = path.resolve(projectDir);
     if (!candidate.startsWith(`${resolvedProjectDir}${path.sep}`)) {
+      // Keep lookup constrained to each Claude project directory even for odd ids.
       continue;
     }
     if (fs.existsSync(candidate)) {
@@ -312,6 +319,7 @@ export function resolveClaudeCliSessionFilePath(params: {
   return undefined;
 }
 
+/** Reads and normalizes Claude CLI JSONL transcript messages for Gateway history import. */
 export function readClaudeCliSessionMessages(params: {
   cliSessionId: string;
   homeDir?: string;
@@ -391,6 +399,7 @@ function extractSummaryText(entry: ClaudeCliProjectEntry): string | undefined {
   return typeof summary === "string" && summary.trim() ? summary.trim() : undefined;
 }
 
+/** Reads the last post-compaction summary plus recent turns for non-Claude fallback prompts. */
 export function readClaudeCliFallbackSeed(params: {
   cliSessionId: string;
   homeDir?: string;
@@ -434,6 +443,7 @@ export function readClaudeCliFallbackSeed(params: {
       lastSummary = pendingSummary;
       pendingSummary = undefined;
       lastBoundaryFallback = extractCompactBoundaryFallbackText(parsed) ?? lastBoundaryFallback;
+      // After a compact boundary, only later turns belong in the fallback recency window.
       windowedTurns = [];
       toolNameRegistry.clear();
       continue;

--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -38,6 +38,7 @@ function extractComparableText(message: unknown): string | undefined {
   if (!joined) {
     return undefined;
   }
+  // User messages may include channel metadata prefixes that the CLI never saw.
   const visible = role === "user" ? stripInboundMetadata(joined) : joined;
   const normalized = visible.replace(/\s+/g, " ").trim();
   return normalized || undefined;
@@ -116,6 +117,7 @@ function isEquivalentImportedMessage(existing: unknown, imported: unknown): bool
   const existingTimestamp = resolveComparableTimestamp(existing);
   const importedTimestamp = resolveComparableTimestamp(imported);
   if (existingTimestamp === undefined || importedTimestamp === undefined) {
+    // Text+role equality is enough when either side lacks CLI/import timestamp metadata.
     return true;
   }
 
@@ -134,6 +136,7 @@ function compareHistoryMessages(
   return a.order - b.order;
 }
 
+/** Merges imported CLI transcript messages into local history without duplicating mirrored turns. */
 export function mergeImportedChatHistoryMessages(params: {
   localMessages: unknown[];
   importedMessages: unknown[];
@@ -147,6 +150,7 @@ export function mergeImportedChatHistoryMessages(params: {
     if (merged.some((existing) => isEquivalentImportedMessage(existing.message, imported))) {
       continue;
     }
+    // Preserve stable append order for messages with equal or missing timestamps.
     merged.push({ message: imported, order: nextOrder });
     nextOrder += 1;
   }

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -21,6 +21,7 @@ export {
 };
 export type { ClaudeCliFallbackSeed };
 
+/** Adds bound CLI-session transcript history to Gateway chat history when provider ownership matches. */
 export function augmentChatHistoryWithCliSessionImports(params: {
   entry: SessionEntry | undefined;
   provider?: string;
@@ -39,6 +40,7 @@ export function augmentChatHistoryWithCliSessionImports(params: {
     normalizedProvider !== ANTHROPIC_PROVIDER &&
     params.localMessages.length > 0
   ) {
+    // Keep non-Claude local history authoritative once a provider-specific transcript exists.
     return params.localMessages;
   }
 

--- a/src/gateway/client-bootstrap.ts
+++ b/src/gateway/client-bootstrap.ts
@@ -3,6 +3,7 @@ import { resolveGatewayConnectionAuth } from "./connection-auth.js";
 import { buildGatewayConnectionDetailsWithResolvers } from "./connection-details.js";
 import type { ExplicitGatewayAuth } from "./credentials.js";
 
+/** Convert connection-detail source labels into credential lookup override sources. */
 export function resolveGatewayUrlOverrideSource(urlSource: string): "cli" | "env" | undefined {
   if (urlSource === "cli --url") {
     return "cli";
@@ -13,6 +14,11 @@ export function resolveGatewayUrlOverrideSource(urlSource: string): "cli" | "env
   return undefined;
 }
 
+/**
+ * Resolve the Gateway URL and auth material used by non-interactive clients.
+ * CLI/env URL overrides are passed into credential resolution so remote
+ * credential selection follows the same target that the client will dial.
+ */
 export async function resolveGatewayClientBootstrap(params: {
   config: OpenClawConfig;
   gatewayUrl?: string;
@@ -32,6 +38,8 @@ export async function resolveGatewayClientBootstrap(params: {
     url: params.gatewayUrl,
   });
   const urlOverrideSource = resolveGatewayUrlOverrideSource(connection.urlSource);
+  // Only CLI/env overrides become credential override context; config/default
+  // targets should use the normal Gateway auth precedence for that config.
   const auth = await resolveGatewayConnectionAuth({
     config: params.config,
     explicitAuth: params.explicitAuth,

--- a/src/gateway/client-start-readiness.ts
+++ b/src/gateway/client-start-readiness.ts
@@ -10,6 +10,7 @@ export type {
   GatewayClientStartReadinessOptions,
 } from "../../packages/gateway-client/src/readiness.js";
 
+/** Start a Gateway client only after the shared event-loop readiness probe succeeds. */
 export function startGatewayClientWhenEventLoopReady(
   client: GatewayClientStartable,
   options: GatewayClientStartReadinessOptions = {},

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -8,6 +8,7 @@ import { isPlainObject } from "../utils.js";
 
 export type ChannelKind = ChannelId;
 
+/** Reload decision returned for a batch of changed config paths. */
 export type GatewayReloadPlan = {
   changedPaths: string[];
   restartGateway: boolean;
@@ -157,6 +158,8 @@ function listReloadRules(): ReloadRule[] {
   if (cachedReloadRules) {
     return cachedReloadRules;
   }
+  // Dynamic plugin/channel rules sit between built-in specific rules and the
+  // broad tail fallbacks so integrations can narrow their own reload behavior.
   // Channel docking: plugins contribute hot reload/no-op prefixes here.
   const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) =>
     (plugin.reload?.configPrefixes ?? [])
@@ -230,6 +233,7 @@ function matchRule(path: string): ReloadRule | null {
   return null;
 }
 
+/** Resolve reload metadata for schema display and config editing surfaces. */
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {
   if (isPluginInstallTimestampPath(path)) {
     return { kind: "none" };
@@ -257,6 +261,7 @@ function getPluginInstallRecords(config: unknown): Record<string, unknown> {
   return isPlainObject(installs) ? installs : {};
 }
 
+/** List legacy plugin install timestamp paths that changed between two configs. */
 export function listPluginInstallTimestampMetadataPaths(
   prevConfig: unknown,
   nextConfig: unknown,
@@ -282,6 +287,7 @@ export function listPluginInstallTimestampMetadataPaths(
   return paths;
 }
 
+/** List legacy plugin install records added or removed between two configs. */
 export function listPluginInstallWholeRecordPaths(
   prevConfig: unknown,
   nextConfig: unknown,
@@ -302,6 +308,10 @@ export function listPluginInstallWholeRecordPaths(
   return paths;
 }
 
+/**
+ * Build the runtime reload plan for changed config paths, separating full
+ * restart reasons from hot-reload actions and explicit no-op metadata paths.
+ */
 export function buildGatewayReloadPlan(
   changedPaths: string[],
   options: GatewayReloadPlanOptions = {},

--- a/src/gateway/config-reload-settings.ts
+++ b/src/gateway/config-reload-settings.ts
@@ -11,6 +11,7 @@ const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
   debounceMs: 300,
 };
 
+/** Normalize Gateway reload config, keeping invalid mode/debounce values on safe defaults. */
 export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReloadSettings {
   const rawMode = cfg.gateway?.reload?.mode;
   const mode =

--- a/src/gateway/connection-auth.ts
+++ b/src/gateway/connection-auth.ts
@@ -10,17 +10,28 @@ import type {
 import { resolveGatewayCredentialsFromConfig } from "./credentials.js";
 
 export type GatewayConnectionAuthOptions = {
+  /** Runtime config snapshot used by Gateway clients and node-host startup. */
   config: OpenClawConfig;
+  /** Optional env override for tests and callers that resolve auth from a prepared env map. */
   env?: NodeJS.ProcessEnv;
+  /** CLI-provided credentials that must outrank config/env when present. */
   explicitAuth?: ExplicitGatewayAuth;
+  /** Remote URL override used to force remote credential surfaces without mutating config. */
   urlOverride?: string;
   urlOverrideSource?: "cli" | "env";
+  /** Credential mode override for call sites that know the connection target before config does. */
   modeOverride?: GatewayCredentialMode;
+  /** Local token selection order for env/config/local fallback resolution. */
   localTokenPrecedence?: GatewayCredentialPrecedence;
+  /** Local password selection order for env/config/local fallback resolution. */
   localPasswordPrecedence?: GatewayCredentialPrecedence;
+  /** Remote token selection order for env/remote/local fallback resolution. */
   remoteTokenPrecedence?: GatewayRemoteCredentialPrecedence;
+  /** Remote password selection order for env/remote/local fallback resolution. */
   remotePasswordPrecedence?: GatewayRemoteCredentialPrecedence;
+  /** Remote token fallback policy after the preferred remote source is empty. */
   remoteTokenFallback?: GatewayRemoteCredentialFallback;
+  /** Remote password fallback policy after the preferred remote source is empty. */
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
 
@@ -43,15 +54,25 @@ function toGatewayCredentialOptions(
   };
 }
 
+/**
+ * Resolves the token/password pair used when a client or node host connects to
+ * Gateway, including async SecretRef-backed credentials.
+ */
 export async function resolveGatewayConnectionAuth(
   params: GatewayConnectionAuthOptions,
 ): Promise<{ token?: string; password?: string }> {
+  // Connection startup can reference SecretRef-backed credentials, so this path
+  // must keep the async resolver even though most callers only read config/env.
   return await resolveGatewayCredentialsWithSecretInputs({
     config: params.config,
     ...toGatewayCredentialOptions({ ...params, cfg: params.config }),
   });
 }
 
+/**
+ * Resolves connection credentials without SecretRef lookup for callers that
+ * already operate on raw config/env values.
+ */
 export function resolveGatewayConnectionAuthFromConfig(
   params: Omit<GatewayConnectionAuthOptions, "config"> & { cfg: OpenClawConfig },
 ): { token?: string; password?: string } {

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -18,6 +18,10 @@ type GatewayConnectionDetailResolvers = {
   resolveGatewayPort?: (cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => number;
 };
 
+/**
+ * Build the Gateway target shown to CLI callers, applying CLI/env/config
+ * precedence and rejecting insecure remote ws:// URLs before connection attempts.
+ */
 export function buildGatewayConnectionDetailsWithResolvers(
   options: {
     config?: OpenClawConfig;

--- a/src/gateway/control-reply-text.ts
+++ b/src/gateway/control-reply-text.ts
@@ -27,7 +27,8 @@ function normalizeSuppressedControlReplyFragment(text: string): string {
 }
 
 /**
- * Return true when a chat-visible reply is exactly an internal control token.
+ * Return true when a chat-visible reply is exactly an internal control token
+ * that must be hidden from transcripts, projections, and persisted chat output.
  */
 export function isSuppressedControlReplyText(text: string): boolean {
   const normalized = text.trim();
@@ -35,7 +36,8 @@ export function isSuppressedControlReplyText(text: string): boolean {
 }
 
 /**
- * Return true when streamed assistant text looks like the leading fragment of a control token.
+ * Return true when streamed assistant text looks like the leading fragment of a
+ * control token, allowing live projections to wait before showing partial text.
  */
 export function isSuppressedControlReplyLeadFragment(text: string): boolean {
   const trimmed = text.trim();

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -32,6 +32,7 @@ function hasScriptSrcAttribute(openTag: string): boolean {
   );
 }
 
+/** Build the Control UI CSP header, optionally allowing known inline boot scripts by hash. */
 export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }): string {
   const hashes = opts?.inlineScriptHashes;
   const scriptSrc = hashes?.length

--- a/src/gateway/control-ui-http-utils.ts
+++ b/src/gateway/control-ui-http-utils.ts
@@ -1,15 +1,18 @@
 import type { ServerResponse } from "node:http";
 
+/** Return true for Control UI asset methods that must not mutate server state. */
 export function isReadHttpMethod(method: string | undefined): boolean {
   return method === "GET" || method === "HEAD";
 }
 
+/** Send a plain text response with the shared Control UI content type. */
 export function respondPlainText(res: ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.end(body);
 }
 
+/** Send the canonical Control UI 404 response used by router fallthroughs. */
 export function respondNotFound(res: ServerResponse): void {
   respondPlainText(res, 404, "Not Found");
 }

--- a/src/gateway/control-ui-links.ts
+++ b/src/gateway/control-ui-links.ts
@@ -5,6 +5,10 @@ import {
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { isValidIPv4 } from "./net.js";
 
+/**
+ * Resolve the user-visible HTTP and WebSocket URLs for the configured Control UI bind mode.
+ * The result is display/bootstrap data only; server bind authority still comes from Gateway config.
+ */
 export function resolveControlUiLinks(params: {
   port: number;
   bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -8,6 +8,10 @@ type ControlUiRequestClassification =
 
 const ROOT_MOUNTED_GATEWAY_PROBE_PATHS = new Set(["/health", "/healthz", "/ready", "/readyz"]);
 
+/**
+ * Classify a request before the Control UI handler serves static assets or SPA fallback.
+ * Root-mounted UI must yield gateway/plugin/API paths so those owners can answer first.
+ */
 export function classifyControlUiRequest(params: {
   basePath: string;
   pathname: string;
@@ -32,6 +36,8 @@ export function classifyControlUiRequest(params: {
     if (pathname === "/api" || pathname.startsWith("/api/")) {
       return { kind: "not-control-ui" };
     }
+    // Non-read methods are never SPA fallback candidates; leave them to API or
+    // plugin handlers so write attempts cannot be hidden behind index.html.
     if (!isReadHttpMethod(method)) {
       return { kind: "not-control-ui" };
     }

--- a/src/gateway/control-ui-shared.ts
+++ b/src/gateway/control-ui-shared.ts
@@ -6,6 +6,7 @@ import {
 
 const CONTROL_UI_AVATAR_PREFIX = "/avatar";
 
+/** Normalize configured Control UI mount paths to an empty root or slash-prefixed path. */
 export function normalizeControlUiBasePath(basePath?: string): string {
   if (!basePath) {
     return "";
@@ -26,12 +27,17 @@ export function normalizeControlUiBasePath(basePath?: string): string {
   return normalized;
 }
 
+/** Build the Control UI avatar endpoint URL for an agent under the active base path. */
 export function buildControlUiAvatarUrl(basePath: string, agentId: string): string {
   return basePath
     ? `${basePath}${CONTROL_UI_AVATAR_PREFIX}/${agentId}`
     : `${CONTROL_UI_AVATAR_PREFIX}/${agentId}`;
 }
 
+/**
+ * Resolve an assistant avatar value into either a safe external/data URL, a
+ * Control UI avatar endpoint, or the original symbolic avatar text.
+ */
 export function resolveAssistantAvatarUrl(params: {
   avatar?: string | null;
   agentId?: string | null;
@@ -65,4 +71,5 @@ export function resolveAssistantAvatarUrl(params: {
   return avatar;
 }
 
+/** Prefix owned by the Control UI avatar handler. */
 export { CONTROL_UI_AVATAR_PREFIX };

--- a/src/gateway/credential-planner.ts
+++ b/src/gateway/credential-planner.ts
@@ -131,6 +131,8 @@ export function createGatewayCredentialPlan(params: {
   const localTokenCanWin =
     authMode !== "password" && authMode !== "none" && authMode !== "trusted-proxy";
   const tokenCanWin = Boolean(envToken || localToken.configured || remoteToken.configured);
+  // Password can win only for explicit password/trusted-proxy modes, or when no
+  // token candidate exists in the implicit mode-selection path.
   const passwordCanWin =
     authMode === "password" ||
     authMode === "trusted-proxy" ||
@@ -145,6 +147,8 @@ export function createGatewayCredentialPlan(params: {
   const remoteUrlConfigured = Boolean(trimToUndefined(remote?.url));
   const tailscaleRemoteExposure =
     gateway?.tailscale?.mode === "serve" || gateway?.tailscale?.mode === "funnel";
+  // Remote credential surfaces activate for explicit remote config or Tailscale
+  // exposure, even when gateway.mode remains local.
   const remoteConfiguredSurface = remoteMode || remoteUrlConfigured || tailscaleRemoteExposure;
   // Remote credentials may borrow local auth credentials only when the remote
   // surface exists but no explicit remote/env candidate can satisfy the mode.

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -22,6 +22,7 @@ import {
 
 type GatewayCredentialSecretInputOptions = {
   config: OpenClawConfig;
+  /** Explicit CLI/caller credentials bypass SecretRef materialization entirely. */
   explicitAuth?: ExplicitGatewayAuth;
   urlOverride?: string;
   urlOverrideSource?: "cli" | "env";
@@ -162,6 +163,7 @@ function canGatewaySecretInputPathWin(params: {
   }
   // Inject one path at a time so normal credential precedence decides whether
   // that secret ref is on the active auth path without resolving real secrets.
+  // The sentinel is intentionally impossible as a real credential source.
   assignResolvedGatewaySecretInput({
     config: probeConfig,
     path: params.path,
@@ -189,7 +191,11 @@ function canGatewaySecretInputPathWin(params: {
   }
 }
 
-/** Test whether resolving a configured secret-ref path could affect selected credentials. */
+/**
+ * Tests whether a configured Gateway SecretRef path can affect selected auth.
+ * Doctor uses this to avoid executing inactive exec SecretRefs while still
+ * warning about refs on the credential path that would actually be used.
+ */
 export function gatewaySecretInputPathCanWin(
   params: GatewayCredentialSecretInputOptions & { path: SupportedGatewaySecretInputPath },
 ): boolean {
@@ -306,7 +312,10 @@ async function resolveGatewayCredentialsFromConfigWithSecretInputs(params: {
   }
 }
 
-/** Resolve Gateway credentials after materializing winning configured secret refs. */
+/**
+ * Resolves Gateway credentials after materializing only SecretRefs that can win
+ * under the same precedence rules used by raw config/env credential selection.
+ */
 export async function resolveGatewayCredentialsWithSecretInputs(
   params: GatewayCredentialSecretInputOptions,
 ): Promise<{ token?: string; password?: string }> {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -55,10 +55,12 @@ const MAX_EMBEDDING_TOTAL_CHARS = 65_536;
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 type EmbeddingProviderRequest = string;
 
+/** Coerces unknown JSON into the OpenAI-compatible embeddings request shape. */
 function coerceRequest(value: unknown): EmbeddingsRequest {
   return value && typeof value === "object" ? (value as EmbeddingsRequest) : {};
 }
 
+/** Accepts the OpenAI string-or-string-array input grammar. */
 function resolveInputTexts(input: unknown): string[] | null {
   if (typeof input === "string") {
     return [input];
@@ -72,11 +74,13 @@ function resolveInputTexts(input: unknown): string[] | null {
   return null;
 }
 
+/** Encodes float embeddings using the OpenAI base64 float32 format. */
 function encodeEmbeddingBase64(embedding: number[]): string {
   const float32 = Float32Array.from(embedding);
   return Buffer.from(float32.buffer).toString("base64");
 }
 
+/** Enforces Gateway-side input bounds before invoking embedding providers. */
 function validateInputTexts(texts: string[]): string | undefined {
   if (texts.length > MAX_EMBEDDING_INPUTS) {
     return `Too many inputs (max ${MAX_EMBEDDING_INPUTS}).`;
@@ -111,6 +115,8 @@ async function createConfiguredEmbeddingProvider(params: {
 }): Promise<MemoryEmbeddingProvider> {
   const providerId =
     params.provider === "auto" ? DEFAULT_MEMORY_EMBEDDING_PROVIDER : params.provider;
+  // Prefer memory-specific providers when present; fall back to generic
+  // embedding providers so configured OpenAI-compatible providers work here.
   const createWithAdapter = async (adapter: MemoryEmbeddingProviderAdapter) => {
     const result = await adapter.create({
       config: params.cfg,
@@ -179,6 +185,8 @@ function adaptGenericEmbeddingProvider(
     ...(typeof provider.maxInputTokens === "number"
       ? { maxInputTokens: provider.maxInputTokens }
       : {}),
+    // Memory search asks for query/document embeddings separately; generic
+    // providers use inputType options to preserve that distinction.
     embedQuery: async (text, options) =>
       await provider.embed(text, {
         ...options,
@@ -207,6 +215,8 @@ function resolveEmbeddingsTarget(params: {
     return { provider: configuredProvider, model: raw };
   }
 
+  // Provider-qualified overrides may only target the configured embedding
+  // provider for the resolved agent; cross-provider routing is rejected.
   const provider = normalizeLowercaseStringOrEmpty(raw.slice(0, slash));
   const model = raw.slice(slash + 1).trim();
   if (!model) {
@@ -222,6 +232,7 @@ function resolveEmbeddingsTarget(params: {
   return { provider: configuredProvider, model };
 }
 
+/** Handles the OpenAI-compatible /v1/embeddings endpoint. */
 export async function handleOpenAiEmbeddingsHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -290,6 +301,8 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     normalizeOptionalString(getHeader(req, "x-openclaw-model")) ||
     normalizeOptionalString(memorySearch?.model) ||
     "";
+  // The request model selects the OpenClaw agent; x-openclaw-model or memory
+  // config selects the actual embedding provider/model for that agent.
   const target = resolveEmbeddingsTarget({
     requestModel: overrideModel,
     configuredProvider,

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -98,6 +98,7 @@ function validateInputTexts(texts: string[]): string | undefined {
   return undefined;
 }
 
+/** Creates the agent-scoped embedding provider, falling back from memory-specific to generic adapters. */
 async function createConfiguredEmbeddingProvider(params: {
   cfg: OpenClawConfig;
   agentDir: string;
@@ -176,6 +177,7 @@ async function createConfiguredEmbeddingProvider(params: {
   return provider;
 }
 
+/** Adapts a generic embedding provider to the memory query/document embedding contract. */
 function adaptGenericEmbeddingProvider(
   provider: GenericEmbeddingProvider,
 ): MemoryEmbeddingProvider {
@@ -201,6 +203,7 @@ function adaptGenericEmbeddingProvider(
   };
 }
 
+/** Resolves the concrete embedding provider/model after the request has selected an agent. */
 function resolveEmbeddingsTarget(params: {
   requestModel: string;
   configuredProvider: EmbeddingProviderRequest;
@@ -232,7 +235,7 @@ function resolveEmbeddingsTarget(params: {
   return { provider: configuredProvider, model };
 }
 
-/** Handles the OpenAI-compatible /v1/embeddings endpoint. */
+/** Handles the OpenAI-compatible /v1/embeddings endpoint for Gateway agents. */
 export async function handleOpenAiEmbeddingsHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -326,6 +329,8 @@ export async function handleOpenAiEmbeddingsHttpRequest(
       memorySearch: memorySearch
         ? {
             ...memorySearch,
+            // OpenAI's dimensions option is per-request, but only within the
+            // selected agent's configured embedding provider.
             outputDimensionality:
               typeof payload.dimensions === "number" && payload.dimensions > 0
                 ? Math.floor(payload.dimensions)

--- a/src/gateway/hosted-plugin-surface-url.ts
+++ b/src/gateway/hosted-plugin-surface-url.ts
@@ -61,6 +61,11 @@ const parseForwardedHost = (value: HostSource | HostSource[]) => {
   return raw?.split(",")[0]?.trim();
 };
 
+/**
+ * Resolve the externally visible Gateway origin used for hosted plugin surfaces.
+ * Explicit host overrides win; forwarded/request hosts can contribute public
+ * ports, while loopback/local addresses are only fallbacks.
+ */
 export function resolveHostedPluginSurfaceUrl(params: HostedPluginSurfaceUrlParams) {
   const port = params.port;
   if (!port) {
@@ -74,6 +79,8 @@ export function resolveHostedPluginSurfaceUrl(params: HostedPluginSurfaceUrlPara
   const forwardedHostRaw = parseForwardedHost(params.forwardedHost);
   const parsedForwardedHost = parseHostHeader(forwardedHostRaw);
   const parsedRequestHost = parseHostHeader(params.requestHost);
+  // Once a stronger public host is present, reject weaker loopback fallbacks so
+  // plugin surface URLs do not accidentally advertise localhost to remote clients.
   const requestHost = normalizeHost(parsedRequestHost.host, Boolean(override));
   const forwardedHost = normalizeHost(parsedForwardedHost.host, Boolean(override));
   const advertisedHost = forwardedHost ? parsedForwardedHost : parsedRequestHost;

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -15,6 +15,7 @@ import { sendGatewayAuthFailure, sendMissingScopeForbidden } from "./http-common
 import { ADMIN_SCOPE, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
+/** Reads a request header using Node's normalized lowercase header map. */
 export function getHeader(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[normalizeLowercaseStringOrEmpty(name)];
   if (typeof raw === "string") {
@@ -26,6 +27,7 @@ export function getHeader(req: IncomingMessage, name: string): string | undefine
   return undefined;
 }
 
+/** Extracts a trimmed bearer token from Authorization, if the scheme matches. */
 export function getBearerToken(req: IncomingMessage): string | undefined {
   const raw = normalizeOptionalString(getHeader(req, "authorization")) ?? "";
   if (!normalizeLowercaseStringOrEmpty(raw).startsWith("bearer ")) {
@@ -35,11 +37,14 @@ export function getBearerToken(req: IncomingMessage): string | undefined {
 }
 
 type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
+
+/** Auth facts carried from HTTP authentication into endpoint scope checks. */
 export type AuthorizedGatewayHttpRequest = {
   authMethod?: GatewayAuthResult["method"];
   trustDeclaredOperatorScopes: boolean;
 };
 
+/** Result shape for pure auth checks that should not write to the response. */
 export type GatewayHttpRequestAuthCheckResult =
   | {
       ok: true;
@@ -50,6 +55,7 @@ export type GatewayHttpRequestAuthCheckResult =
       authResult: GatewayAuthResult;
     };
 
+/** Builds browser-origin auth inputs from the request and runtime config. */
 export function resolveHttpBrowserOriginPolicy(
   req: IncomingMessage,
   cfg = getRuntimeConfig(),
@@ -84,6 +90,7 @@ function shouldTrustDeclaredHttpOperatorScopes(
   return !isGatewayBearerHttpRequest(req, authOrRequest);
 }
 
+/** Authenticates a Gateway HTTP request, writing the failure envelope on denial. */
 export async function authorizeGatewayHttpRequestOrReply(params: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -100,6 +107,7 @@ export async function authorizeGatewayHttpRequestOrReply(params: {
   return result.requestAuth;
 }
 
+/** Authenticates a Gateway HTTP request without mutating the response. */
 export async function checkGatewayHttpRequestAuth(params: {
   req: IncomingMessage;
   auth: ResolvedGatewayAuth;
@@ -138,6 +146,7 @@ export async function checkGatewayHttpRequestAuth(params: {
   };
 }
 
+/** Authenticates a Gateway HTTP request and enforces operator scopes for a method. */
 export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -178,6 +187,7 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   return { cfg, requestAuth, operatorScopes };
 }
 
+/** Returns true when a request uses bearer auth against a shared gateway secret. */
 export function isGatewayBearerHttpRequest(
   req: IncomingMessage,
   auth?: SharedSecretGatewayAuth,
@@ -185,6 +195,7 @@ export function isGatewayBearerHttpRequest(
   return usesSharedSecretHttpAuth(auth) && Boolean(getBearerToken(req));
 }
 
+/** Resolves trusted operator scopes from HTTP headers or default CLI scopes. */
 export function resolveTrustedHttpOperatorScopes(
   req: IncomingMessage,
   authOrRequest?:
@@ -213,6 +224,7 @@ export function resolveTrustedHttpOperatorScopes(
     .filter((scope) => scope.length > 0);
 }
 
+/** Resolves operator scopes for OpenAI-compatible HTTP routes. */
 export function resolveOpenAiCompatibleHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
@@ -220,6 +232,7 @@ export function resolveOpenAiCompatibleHttpOperatorScopes(
   return resolveSharedSecretHttpOperatorScopes(req, requestAuth);
 }
 
+/** Resolves operator scopes for routes that opt into shared-secret trust. */
 export function resolveSharedSecretHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
@@ -234,6 +247,7 @@ export function resolveSharedSecretHttpOperatorScopes(
   return resolveTrustedHttpOperatorScopes(req, requestAuth);
 }
 
+/** Treats a trusted HTTP request as owner only when it carries admin scope. */
 export function resolveHttpSenderIsOwner(
   req: IncomingMessage,
   authOrRequest?:
@@ -243,6 +257,7 @@ export function resolveHttpSenderIsOwner(
   return resolveTrustedHttpOperatorScopes(req, authOrRequest).includes(ADMIN_SCOPE);
 }
 
+/** Resolves owner status for OpenAI-compatible HTTP routes. */
 export function resolveOpenAiCompatibleHttpSenderIsOwner(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -40,7 +40,9 @@ type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
 
 /** Auth facts carried from HTTP authentication into endpoint scope checks. */
 export type AuthorizedGatewayHttpRequest = {
+  /** Auth method that succeeded; shared-secret methods need explicit trust opt-in for scopes. */
   authMethod?: GatewayAuthResult["method"];
+  /** True only when route code may accept declared x-openclaw-scopes from the request. */
   trustDeclaredOperatorScopes: boolean;
 };
 
@@ -184,6 +186,8 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
     return null;
   }
 
+  // Return the same config snapshot used for auth inputs so route handlers do
+  // not re-read mutable runtime config after scope authorization succeeds.
   return { cfg, requestAuth, operatorScopes };
 }
 

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -25,18 +25,21 @@ export function setDefaultSecurityHeaders(
   }
 }
 
+/** Sends a JSON response with the Gateway-wide UTF-8 content type. */
 export function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(body));
 }
 
+/** Sends a plain-text response for method and simple error handlers. */
 export function sendText(res: ServerResponse, status: number, body: string) {
   res.statusCode = status;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.end(body);
 }
 
+/** Sends a 405 response and advertises the allowed method list. */
 export function sendMethodNotAllowed(res: ServerResponse, allow = "POST") {
   res.setHeader("Allow", allow);
   sendText(res, 405, "Method Not Allowed");
@@ -71,6 +74,7 @@ export function sendGatewayAuthFailure(res: ServerResponse, authResult: GatewayA
   sendUnauthorized(res);
 }
 
+/** Sends the OpenAI-compatible invalid_request_error envelope. */
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -42,12 +42,14 @@ export function sendMethodNotAllowed(res: ServerResponse, allow = "POST") {
   sendText(res, 405, "Method Not Allowed");
 }
 
+/** Sends the shared Gateway unauthorized envelope used by HTTP auth helpers. */
 export function sendUnauthorized(res: ServerResponse) {
   sendJson(res, 401, {
     error: { message: "Unauthorized", type: "unauthorized" },
   });
 }
 
+/** Sends a rate-limit auth failure and rounds Retry-After up to whole seconds. */
 export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
   if (retryAfterMs && retryAfterMs > 0) {
     res.setHeader("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
@@ -60,6 +62,7 @@ export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
   });
 }
 
+/** Projects a Gateway auth result into the public HTTP auth failure envelope. */
 export function sendGatewayAuthFailure(res: ServerResponse, authResult: GatewayAuthResult) {
   if (authResult.rateLimited) {
     sendRateLimited(res, authResult.retryAfterMs);
@@ -74,6 +77,7 @@ export function sendInvalidRequest(res: ServerResponse, message: string) {
   });
 }
 
+/** Builds the shared forbidden body used by JSON and embedded Control UI routes. */
 export function buildMissingScopeForbiddenBody(missingScope: string | undefined) {
   return {
     ok: false,
@@ -88,6 +92,7 @@ export function sendMissingScopeForbidden(res: ServerResponse, missingScope: str
   sendJson(res, 403, buildMissingScopeForbiddenBody(missingScope));
 }
 
+/** Reads a bounded JSON body or writes the matching HTTP error response. */
 export async function readJsonBodyOrError(
   req: IncomingMessage,
   res: ServerResponse,
@@ -96,6 +101,8 @@ export async function readJsonBodyOrError(
   const body = await readJsonBody(req, maxBytes);
   if (!body.ok) {
     if (body.error === "payload too large") {
+      // The body reader may stop before consuming all bytes, so the declared
+      // length is the best available diagnostic size for rejected payload logs.
       const contentLength = parseContentLengthHeader(req.headers?.["content-length"]);
       logRejectedLargePayload({
         surface: "gateway.http.json",
@@ -120,10 +127,12 @@ export async function readJsonBodyOrError(
   return body.value;
 }
 
+/** Writes the OpenAI-compatible streaming sentinel event. */
 export function writeDone(res: ServerResponse) {
   res.write("data: [DONE]\n\n");
 }
 
+/** Starts an SSE response with headers shared by OpenAI and session streams. */
 export function setSseHeaders(res: ServerResponse) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
@@ -132,6 +141,7 @@ export function setSseHeaders(res: ServerResponse) {
   res.flushHeaders?.();
 }
 
+/** Aborts long-running HTTP work when either request or response socket closes. */
 export function watchClientDisconnect(
   req: IncomingMessage,
   res: ServerResponse,
@@ -148,6 +158,8 @@ export function watchClientDisconnect(
   if (sockets.length === 0) {
     return () => {};
   }
+  // Request and response usually share a socket. De-duplicate so one close
+  // event triggers one abort and one optional disconnect callback.
   const handleClose = () => {
     onDisconnect?.();
     if (!abortController.signal.aborted) {

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -13,6 +13,11 @@ import {
 } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
+/**
+ * Handles the shared POST+JSON Gateway endpoint prelude.
+ * Returns false for non-matching paths, undefined after writing a response, or
+ * the parsed body plus auth facts when the caller should continue.
+ */
 export async function handleGatewayPostJsonEndpoint(
   req: IncomingMessage,
   res: ServerResponse,
@@ -30,6 +35,8 @@ export async function handleGatewayPostJsonEndpoint(
     ) => string[];
   },
 ): Promise<false | { body: unknown; requestAuth: AuthorizedGatewayHttpRequest } | undefined> {
+  // Use a fixed URL base so path matching cannot be influenced by malformed or
+  // attacker-controlled Host headers.
   const url = new URL(req.url ?? "/", "http://localhost");
   if (url.pathname !== opts.pathname) {
     return false;
@@ -53,6 +60,8 @@ export async function handleGatewayPostJsonEndpoint(
   }
 
   if (opts.requiredOperatorMethod) {
+    // Enforce operator scope before reading the body so unauthorized callers do
+    // not spend body parsing budget or trigger payload diagnostics.
     const requestedScopes =
       opts.resolveOperatorScopes?.(req, requestAuth) ??
       resolveTrustedHttpOperatorScopes(req, requestAuth);

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -22,13 +22,17 @@ export async function handleGatewayPostJsonEndpoint(
   req: IncomingMessage,
   res: ServerResponse,
   opts: {
+    /** Exact path this helper owns; matching is host-independent. */
     pathname: string;
     auth: ResolvedGatewayAuth;
+    /** Per-route JSON body ceiling passed through to the bounded reader. */
     maxBodyBytes: number;
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
+    /** Optional operator method checked before any request body bytes are read. */
     requiredOperatorMethod?: "chat.send" | (string & Record<never, never>);
+    /** Route-specific scope resolver; defaults to trusted HTTP operator scopes. */
     resolveOperatorScopes?: (
       req: IncomingMessage,
       requestAuth: AuthorizedGatewayHttpRequest,

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -72,6 +72,10 @@ export function resolveAgentIdFromModel(
   return normalizeAgentId(agentId);
 }
 
+/**
+ * Resolves the optional x-openclaw-model override for OpenAI-compatible routes
+ * after the request model has selected an agent.
+ */
 export async function resolveOpenAiCompatModelOverride(params: {
   req: IncomingMessage;
   agentId: string;
@@ -132,6 +136,10 @@ export async function resolveOpenAiCompatModelOverride(params: {
   return { modelOverride: raw };
 }
 
+/**
+ * Resolves the target agent from Gateway-native headers first, then from the
+ * OpenAI-compatible model id, and finally from the configured default agent.
+ */
 export function resolveAgentIdForRequest(params: {
   req: IncomingMessage;
   model: string | undefined;
@@ -166,8 +174,10 @@ function resolveSessionKey(params: {
 
 export function resolveGatewayRequestContext(params: {
   req: IncomingMessage;
+  /** OpenAI-compatible model field, which may encode an OpenClaw agent id. */
   model: string | undefined;
   user?: string | undefined;
+  /** Stable namespace used when deriving implicit main session keys. */
   sessionPrefix: string;
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -31,7 +31,9 @@ export {
   type GatewayHttpRequestAuthCheckResult,
 } from "./http-auth-utils.js";
 
+/** OpenAI-compatible model id that maps to the default OpenClaw agent. */
 export const OPENCLAW_MODEL_ID = "openclaw";
+/** Alias for the default OpenClaw agent's default model route. */
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
 
 function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
@@ -58,6 +60,8 @@ export function resolveAgentIdFromModel(
     return resolveDefaultAgentId(cfg);
   }
 
+  // OpenAI-compatible routes encode the agent in the model field so clients can
+  // select an agent without a custom header.
   const m =
     raw.match(/^openclaw[:/](?<agentId>[a-z0-9][a-z0-9_-]{0,63})$/i) ??
     raw.match(/^agent:(?<agentId>[a-z0-9][a-z0-9_-]{0,63})$/i);
@@ -75,6 +79,8 @@ export async function resolveOpenAiCompatModelOverride(params: {
 }): Promise<{ modelOverride?: string; errorMessage?: string }> {
   const requestModel = params.model?.trim();
   if (requestModel && !resolveAgentIdFromModel(requestModel)) {
+    // The OpenAI model field selects an OpenClaw agent here; provider/model
+    // selection belongs in x-openclaw-model after the agent is known.
     return {
       errorMessage: "Invalid `model`. Use `openclaw` or `openclaw/<agentId>`.",
     };
@@ -104,6 +110,8 @@ export async function resolveOpenAiCompatModelOverride(params: {
     return { errorMessage: "Invalid `x-openclaw-model`." };
   }
 
+  // x-openclaw-model is accepted only when it is visible to the resolved agent,
+  // matching the model picker instead of trusting arbitrary provider/model ids.
   const catalog = await loadGatewayModelCatalog();
   const policy = createModelVisibilityPolicy({
     cfg,
@@ -129,6 +137,8 @@ export function resolveAgentIdForRequest(params: {
   model: string | undefined;
 }): string {
   const cfg = getRuntimeConfig();
+  // Header selection wins over model-encoded selection so Gateway-native
+  // clients can keep model ids for provider routing.
   const fromHeader = resolveAgentIdFromHeader(params.req);
   if (fromHeader) {
     return fromHeader;
@@ -162,6 +172,8 @@ export function resolveGatewayRequestContext(params: {
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;
 }): { agentId: string; sessionKey: string; messageChannel: string } {
+  // Keep agent, session, and message-channel resolution together so OpenAI and
+  // Responses surfaces build identical Gateway routing context.
   const agentId = resolveAgentIdForRequest({ req: params.req, model: params.model });
   const sessionKey = resolveSessionKey({
     req: params.req,

--- a/src/gateway/input-allowlist.ts
+++ b/src/gateway/input-allowlist.ts
@@ -1,11 +1,9 @@
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 
 /**
- * Normalize optional gateway URL-input hostname allowlists.
- *
- * Semantics are intentionally:
- * - missing / empty / whitespace-only list => no hostname allowlist restriction
- * - deny-all URL fetching => use the corresponding `allowUrl: false` switch
+ * Normalize optional gateway URL-input hostname allowlists for OpenAI-compatible requests.
+ * Missing or whitespace-only lists mean unrestricted hostnames; callers that
+ * need deny-all URL fetching must use the owning `allowUrl: false` switch.
  */
 export function normalizeInputHostnameAllowlist(
   values: string[] | undefined,

--- a/src/gateway/known-weak-gateway-secrets.ts
+++ b/src/gateway/known-weak-gateway-secrets.ts
@@ -1,10 +1,12 @@
 import type { ResolvedGatewayAuth } from "./auth.js";
 
+/** Published token placeholders that must never be accepted as live Gateway auth. */
 export const KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS = [
   "change-me-to-a-long-random-token",
   "change-me-now",
 ] as const;
 
+/** Published password placeholders that must never be accepted as live Gateway auth. */
 export const KNOWN_WEAK_GATEWAY_PASSWORD_PLACEHOLDERS = ["change-me-to-a-strong-password"] as const;
 
 /**
@@ -23,6 +25,7 @@ const KNOWN_WEAK_GATEWAY_PASSWORDS: ReadonlySet<string> = new Set(
   KNOWN_WEAK_GATEWAY_PASSWORD_PLACEHOLDERS,
 );
 
+/** Reject resolved Gateway token/password credentials that match public example sentinels. */
 export function assertGatewayAuthNotKnownWeak(auth: ResolvedGatewayAuth): void {
   if (auth.mode === "token") {
     const token = auth.token?.trim() ?? "";

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -20,6 +20,10 @@ function capLiveAssistantBuffer(text: string): string {
   return text.slice(-MAX_LIVE_CHAT_BUFFER_CHARS);
 }
 
+/**
+ * Merge assistant full-text and delta updates into the live buffer while
+ * tolerating providers that resend a shorter prefix or switch between modes.
+ */
 export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
@@ -43,6 +47,7 @@ export function resolveMergedAssistantText(params: {
   return capLiveAssistantBuffer(previousText);
 }
 
+/** Strip internal context/directive markup from live assistant text and deltas. */
 export function normalizeLiveAssistantEventText(params: { text: string; delta?: unknown }): {
   text: string;
   delta: string;
@@ -56,6 +61,10 @@ export function normalizeLiveAssistantEventText(params: { text: string; delta?: 
   };
 }
 
+/**
+ * Project buffered assistant text into chat-visible live output, suppressing
+ * control tokens and their lead fragments until they resolve.
+ */
 export function projectLiveAssistantBufferedText(
   rawText: string,
   options?: { suppressLeadFragments?: boolean },
@@ -85,6 +94,7 @@ export function projectLiveAssistantBufferedText(
   return { text, suppress: false, pendingLeadFragment: false };
 }
 
+/** Return true for commentary-phase assistant events that live chat should hide. */
 export function shouldSuppressAssistantEventForLiveChat(data: unknown): boolean {
   return resolveAssistantEventPhase(data) === "commentary";
 }

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -35,6 +35,7 @@ const MANAGED_OUTGOING_ATTACHMENT_ID_RE =
 const DATA_URL_RE = /^data:/i;
 const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
 
+/** Default guardrails for Gateway-managed outgoing image storage and serving. */
 export const DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS = {
   maxBytes: 12 * 1024 * 1024,
   maxWidth: 4096,
@@ -42,6 +43,7 @@ export const DEFAULT_MANAGED_IMAGE_ATTACHMENT_LIMITS = {
   maxPixels: 20_000_000,
 } as const;
 
+/** Effective byte, dimension, and pixel limits applied before images become chat blocks. */
 export type ManagedImageAttachmentLimits = {
   maxBytes: number;
   maxWidth: number;
@@ -111,6 +113,7 @@ function buildSessionManagedOutgoingAttachmentIndexCacheKey(
   return sessionKey === "global" && agentId ? `agent:${agentId}:global` : sessionKey;
 }
 
+/** Merge optional managed-image limit config with the Gateway defaults. */
 export function resolveManagedImageAttachmentLimits(
   config?: ManagedImageAttachmentLimitsConfig | null,
 ): ManagedImageAttachmentLimits {
@@ -396,6 +399,7 @@ async function deleteOrphanManagedImageFiles(params: {
   return deletedFileCount;
 }
 
+/** Delete stale managed outgoing image records and unreferenced stored originals. */
 export async function cleanupManagedOutgoingImageRecords(params?: {
   stateDir?: string;
   nowMs?: number;
@@ -464,6 +468,8 @@ export async function cleanupManagedOutgoingImageRecords(params?: {
       continue;
     }
 
+    // History records live only while their message still references the
+    // managed URL; transient records age out when they never become history.
     let shouldDelete;
     if (
       forceDeleteSessionRecords &&
@@ -679,6 +685,8 @@ async function getSessionManagedOutgoingAttachmentIndex(
     return null;
   }
 
+  // Transcript reads are expensive during cleanup, so cache by file identity
+  // and invalidate on mtime/size changes instead of trusting session keys alone.
   let transcriptStat: { transcriptPath: string; mtimeMs: number; size: number } | null = null;
   const transcriptPath = typeof entry?.sessionFile === "string" ? entry.sessionFile.trim() : "";
   if (transcriptPath) {
@@ -748,6 +756,7 @@ async function recordMatchesTranscriptMessage(
   );
 }
 
+/** Promote managed outgoing image blocks from transient storage to message history. */
 export async function attachManagedOutgoingImagesToMessage(params: {
   messageId: string;
   blocks?: readonly Record<string, unknown>[];
@@ -783,6 +792,7 @@ export async function attachManagedOutgoingImagesToMessage(params: {
   );
 }
 
+/** Ingest outgoing image sources into managed storage and return safe chat image blocks. */
 export async function createManagedOutgoingImageBlocks(params: {
   sessionKey: string;
   agentId?: string;
@@ -820,6 +830,8 @@ export async function createManagedOutgoingImageBlocks(params: {
       if (parsedDataUrl.kind === "image-data-url") {
         validateManagedImageBuffer(parsedDataUrl.buffer, alt, limits);
       }
+      // Local and remote sources are copied into state-dir storage so chat
+      // blocks do not leak filesystem paths, signed URLs, or upstream hosts.
       let savedOriginal =
         parsedDataUrl.kind === "image-data-url"
           ? await saveMediaBuffer(
@@ -973,6 +985,7 @@ function safeAttachmentFilename(value: string | null) {
   return base || fallback;
 }
 
+/** Serve a managed outgoing image after Gateway auth, scope, owner, and transcript checks. */
 export async function handleManagedOutgoingImageHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -23,6 +23,8 @@ type McpTextContent = {
 function normalizeToolCallContent(result: unknown): McpTextContent[] {
   const content = (result as { content?: unknown })?.content;
   if (Array.isArray(content)) {
+    // MCP clients expect an array of content blocks; Gateway tools may still
+    // return plain strings or partial block-like objects from older helpers.
     return content.map((block: { type?: string; text?: string }) => ({
       type: (block.type ?? "text") as "text",
       text: block.text ?? (typeof block === "string" ? block : JSON.stringify(block)),
@@ -36,6 +38,10 @@ function normalizeToolCallContent(result: unknown): McpTextContent[] {
   ];
 }
 
+/**
+ * Handles one MCP JSON-RPC message for the loopback HTTP server.
+ * Notifications intentionally return null so batch handling can omit replies.
+ */
 export async function handleMcpJsonRpc(params: {
   message: JsonRpcRequest;
   tools: McpLoopbackTool[];
@@ -48,6 +54,8 @@ export async function handleMcpJsonRpc(params: {
   switch (method) {
     case "initialize": {
       const clientVersion = (methodParams?.protocolVersion as string) ?? "";
+      // Prefer the client's requested protocol when supported; otherwise use
+      // our first advertised version as the stable server default.
       const negotiated =
         MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS.find((version) => version === clientVersion) ??
         MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS[0];
@@ -80,6 +88,9 @@ export async function handleMcpJsonRpc(params: {
           isError: true,
         });
       }
+      // Schema visibility is the authorization boundary for loopback tools:
+      // anything omitted from tools/list must remain uncallable even if the
+      // executable object is present in the scoped runtime snapshot.
       const tool = params.tools.find(
         (candidate) => readMcpLoopbackToolName(candidate) === toolName,
       );
@@ -91,6 +102,8 @@ export async function handleMcpJsonRpc(params: {
       }
       const toolCallId = `mcp-${crypto.randomUUID()}`;
       try {
+        // Reuse the Gateway before-tool hook so MCP calls follow the same
+        // policy, parameter rewrite, and abort semantics as normal tool calls.
         const hookResult = await runBeforeToolCallHook({
           toolName,
           params: toolArgs,

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -6,14 +6,17 @@ type McpLoopbackRuntime = {
 
 let activeRuntime: McpLoopbackRuntime | undefined;
 
+/** Returns a snapshot of the currently running MCP loopback server, if any. */
 export function getActiveMcpLoopbackRuntime(): McpLoopbackRuntime | undefined {
   return activeRuntime ? { ...activeRuntime } : undefined;
 }
 
+/** Publishes the active MCP loopback server tokens for local agent-runner preparation. */
 export function setActiveMcpLoopbackRuntime(runtime: McpLoopbackRuntime): void {
   activeRuntime = { ...runtime };
 }
 
+/** Selects the bearer token that matches the caller's owner/non-owner tool scope. */
 export function resolveMcpLoopbackBearerToken(
   runtime: McpLoopbackRuntime,
   senderIsOwner: boolean,
@@ -21,12 +24,14 @@ export function resolveMcpLoopbackBearerToken(
   return senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken;
 }
 
+/** Clears the active runtime only for the server instance that owns the supplied token. */
 export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): void {
   if (activeRuntime?.ownerToken === ownerToken) {
     activeRuntime = undefined;
   }
 }
 
+/** Builds the local MCP server config with environment placeholders filled by the runner. */
 export function createMcpLoopbackServerConfig(port: number) {
   return {
     mcpServers: {

--- a/src/gateway/mcp-http.protocol.ts
+++ b/src/gateway/mcp-http.protocol.ts
@@ -1,5 +1,8 @@
+/** Server identity advertised by the Gateway-hosted MCP loopback endpoint. */
 export const MCP_LOOPBACK_SERVER_NAME = "openclaw";
+/** MCP loopback server version reported during initialize negotiation. */
 export const MCP_LOOPBACK_SERVER_VERSION = "0.1.0";
+/** Protocol versions supported by the loopback endpoint, ordered by preference. */
 export const MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
 
 type JsonRpcId = string | number | null | undefined;
@@ -11,10 +14,12 @@ export type JsonRpcRequest = {
   params?: Record<string, unknown>;
 };
 
+/** Builds a JSON-RPC 2.0 success response, normalizing notifications/missing ids to null. */
 export function jsonRpcResult(id: JsonRpcId, result: unknown) {
   return { jsonrpc: "2.0" as const, id: id ?? null, result };
 }
 
+/** Builds a JSON-RPC 2.0 error response for MCP loopback handlers. */
 export function jsonRpcError(id: JsonRpcId, code: number, message: string) {
   return { jsonrpc: "2.0" as const, id: id ?? null, error: { code, message } };
 }

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -80,6 +80,10 @@ function rejectsBrowserLoopbackRequest(req: IncomingMessage): boolean {
   }).ok;
 }
 
+/**
+ * Validates the MCP loopback HTTP envelope before JSON-RPC parsing and returns
+ * the owner/non-owner token scope that downstream tool resolution must use.
+ */
 export function validateMcpLoopbackRequest(params: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -165,6 +169,7 @@ export function validateMcpLoopbackRequest(params: {
   return { senderIsOwner };
 }
 
+/** Reads a bounded JSON-RPC request body from the loopback HTTP stream. */
 export async function readMcpHttpBody(req: IncomingMessage): Promise<string> {
   return await new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -188,6 +193,8 @@ export async function readMcpHttpBody(req: IncomingMessage): Promise<string> {
     const onData = (chunk: Buffer) => {
       received += chunk.length;
       if (received > MAX_MCP_BODY_BYTES) {
+        // Pause the stream once the cap is crossed; callers inspect the stable
+        // error code while the retained error listener absorbs late socket errors.
         req.pause();
         rejectOnce(createMcpHttpBodyTooLargeError(), { keepErrorListener: true });
         return;
@@ -227,6 +234,7 @@ export function isMcpHttpBodyTooLargeError(
   );
 }
 
+/** Projects loopback HTTP headers into the scoped Gateway tool-resolution context. */
 export function resolveMcpRequestContext(
   req: IncomingMessage,
   cfg: OpenClawConfig,

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -32,9 +32,11 @@ type McpLoopbackScopeParams = {
   senderIsOwner: boolean | undefined;
 };
 
-export function resolveMcpLoopbackScopedTools(
-  params: McpLoopbackScopeParams,
-): { agentId: string | undefined; tools: McpLoopbackTool[] } {
+/** Resolves Gateway tools available to the MCP loopback surface for one request scope. */
+export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
+  agentId: string | undefined;
+  tools: McpLoopbackTool[];
+} {
   const scoped = resolveGatewayScopedTools({
     ...params,
     surface: "loopback",
@@ -46,10 +48,14 @@ export function resolveMcpLoopbackScopedTools(
   };
 }
 
+/** Caches loopback tool catalogs for identical request scopes within one config snapshot. */
 export class McpLoopbackToolCache {
   #entries = new Map<string, CachedScopedTools>();
 
   resolve(params: McpLoopbackScopeParams): CachedScopedTools {
+    // Tool visibility depends on session, channel, account, inbound event, and
+    // owner mode. Keep each axis in the cache key so one caller's catalog cannot
+    // bleed into another caller's MCP tools/list response.
     const cacheKey = [
       params.sessionKey,
       params.messageProvider ?? "",
@@ -67,6 +73,8 @@ export class McpLoopbackToolCache {
       return cached;
     }
 
+    // The config object reference is the snapshot boundary; a hot reload gets a
+    // new object and forces fresh tool/schema projection without global polling.
     const next = resolveMcpLoopbackScopedTools(params);
     const nextEntry: CachedScopedTools = {
       agentId: next.agentId,

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -5,6 +5,7 @@ import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 export type McpLoopbackTool = ReturnType<typeof resolveGatewayScopedTools>["tools"][number];
 
+/** Tool descriptor shape returned by MCP `tools/list` for Gateway loopback tools. */
 export type McpToolSchemaEntry = {
   name: string;
   description: string | undefined;
@@ -19,6 +20,7 @@ function readLoopbackToolField(tool: McpLoopbackTool, key: "name" | "description
   }
 }
 
+/** Reads a non-empty loopback tool name without letting hostile getters break sibling tools. */
 export function readMcpLoopbackToolName(tool: McpLoopbackTool): string | undefined {
   const value = readLoopbackToolField(tool, "name");
   if (typeof value !== "string") {
@@ -55,6 +57,9 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
   if (!Array.isArray(variants) || variants.length === 0) {
     return raw;
   }
+  // MCP clients expect one object schema per tool. Collapse simple unions into
+  // a permissive object while keeping fields required only when every variant
+  // requires them.
   const mergedProps: Record<string, unknown> = {};
   const requiredSets: Set<string>[] = [];
   for (const variant of variants) {
@@ -136,6 +141,7 @@ function isPropertySchema(value: unknown): value is boolean | Record<string, unk
   return typeof value === "boolean" || isRecord(value);
 }
 
+/** Projects Gateway-scoped tools into MCP-compatible schema entries. */
 export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry[] {
   return tools.flatMap((tool) => {
     const name = readMcpLoopbackToolName(tool);

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -68,6 +68,9 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
       abort();
     }
   };
+  // Abort tool execution when the client disconnects before sending a full
+  // request or before receiving the response; normal completed responses keep
+  // the signal open for handlers that finish exactly as the socket closes.
   req.once("close", abortIfRequestIncomplete);
   res.once("close", abortIfResponseStillOpen);
   if (req.destroyed && !req.complete) {
@@ -82,6 +85,7 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
   };
 }
 
+/** Starts a Gateway-local MCP HTTP loopback server and publishes its bearer tokens. */
 export async function startMcpLoopbackServer(port = 0): Promise<{
   port: number;
   close: () => Promise<void>;
@@ -128,6 +132,8 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         });
         const responses: object[] = [];
         for (const message of messages) {
+          // Notifications return null and are intentionally omitted from JSON-RPC
+          // batch responses while still sharing request-scope tool resolution.
           const response = await handleMcpJsonRpc({
             message,
             tools: scopedTools.tools,
@@ -225,6 +231,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
   return server;
 }
 
+/** Returns the active MCP loopback singleton, starting it once when needed. */
 export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServer> {
   if (activeMcpLoopbackServer) {
     return activeMcpLoopbackServer;
@@ -242,6 +249,7 @@ export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServ
   return activeMcpLoopbackServerPromise;
 }
 
+/** Closes the active or currently-starting MCP loopback server if one exists. */
 export async function closeMcpLoopbackServer(): Promise<void> {
   const server =
     activeMcpLoopbackServer ??

--- a/src/gateway/models-http.ts
+++ b/src/gateway/models-http.ts
@@ -34,6 +34,7 @@ type OpenAiModelObject = {
   permission: [];
 };
 
+/** Projects an OpenClaw agent model id into the OpenAI /v1/models envelope. */
 function toOpenAiModel(id: string): OpenAiModelObject {
   return {
     id,
@@ -59,9 +60,12 @@ async function authorizeRequest(
   });
 }
 
+/** Lists the OpenAI-compatible model ids that route to configured agents. */
 function loadAgentModelIds(): string[] {
   const cfg = getRuntimeConfig();
   const defaultAgentId = resolveDefaultAgentId(cfg);
+  // Keep both generic aliases and concrete agent ids so OpenAI clients can use
+  // either "openclaw" defaults or stable "openclaw/<agentId>" routing.
   const ids = new Set<string>([OPENCLAW_MODEL_ID, OPENCLAW_DEFAULT_MODEL_ID]);
   ids.add(`openclaw/${defaultAgentId}`);
   for (const agentId of listAgentIds(cfg)) {
@@ -71,9 +75,11 @@ function loadAgentModelIds(): string[] {
 }
 
 function resolveRequestPath(req: IncomingMessage): string {
+  // Use a fixed URL base so malformed Host headers cannot affect route matching.
   return new URL(req.url ?? "/", "http://localhost").pathname;
 }
 
+/** Handles the OpenAI-compatible /v1/models list and lookup endpoints. */
 export async function handleOpenAiModelsHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -124,6 +130,8 @@ export async function handleOpenAiModelsHttpRequest(
     return true;
   }
 
+  // Validate the decoded id before checking membership so malformed agent ids
+  // get a 400 while well-formed but unavailable model ids get a 404.
   if (decodedId !== OPENCLAW_MODEL_ID && !resolveAgentIdFromModel(decodedId)) {
     sendInvalidRequest(res, "Invalid model id.");
     return true;

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -1,6 +1,7 @@
 import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
 import { describeFailoverError, resolveFailoverStatus } from "../agents/failover-error.js";
 
+/** Error envelope shared by OpenAI-compatible HTTP routes. */
 export type OpenAiCompatError = {
   status: number;
   error: {
@@ -23,6 +24,8 @@ const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
   timeout: "api_error",
 };
 
+// Provider server faults and timeouts should not leak raw 500/408 semantics to
+// OpenAI-compatible clients; keep them in the upstream-failure bucket.
 function statusForReason(reason: FailoverReason, status: number | undefined): number {
   if (reason === "server_error") {
     return status && status >= 400 && status < 500 ? status : 502;
@@ -50,6 +53,11 @@ function messageForReason(params: {
   return params.rawError?.trim() || params.message.trim() || "request failed";
 }
 
+/**
+ * Map internal provider failover errors onto the OpenAI-compatible error shape.
+ * Unknown reasons return undefined so route handlers can fall back to their
+ * generic 500 behavior without inventing unsupported OpenAI error types.
+ */
 export function resolveOpenAiCompatError(err: unknown): OpenAiCompatError | undefined {
   const described = describeFailoverError(err);
   const reason = described.reason;
@@ -76,6 +84,7 @@ export function resolveOpenAiCompatError(err: unknown): OpenAiCompatError | unde
   };
 }
 
+/** Validate OpenAI sampling parameters before routing them to provider adapters. */
 export function validateOpenAiSamplingParams(params: {
   temperature?: unknown;
   topP?: unknown;

--- a/src/gateway/openai-compatible-http.test-helpers.ts
+++ b/src/gateway/openai-compatible-http.test-helpers.ts
@@ -1,6 +1,10 @@
 type StartGatewayServer = typeof import("./server.js").startGatewayServer;
 type GatewayServerOptions = NonNullable<Parameters<StartGatewayServer>[1]>;
 
+/**
+ * Start the shared OpenAI-compatible test server with the Control UI disabled,
+ * keeping models, embeddings, and chat route tests on the same auth defaults.
+ */
 export async function startOpenAiCompatGatewayServer(options: {
   startGatewayServer: StartGatewayServer;
   port: number;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -113,6 +113,7 @@ type ResolvedOpenAiChatCompletionsLimits = {
   images: InputImageLimits;
 };
 
+/** Resolves Chat Completions request and image-ingest limits from Gateway config. */
 function resolveOpenAiChatCompletionsLimits(
   config: GatewayHttpChatCompletionsConfig | undefined,
 ): ResolvedOpenAiChatCompletionsLimits {
@@ -247,6 +248,8 @@ function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice
     }
     const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
     return {
+      // Keep the agent's visible tool list aligned with OpenAI's forced
+      // function choice, then verify a structured call after the run.
       tools: matched,
       extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
       constraint,
@@ -351,6 +354,8 @@ function writeAssistantToolCallsIncrementalChunks(
     });
 
     for (const argsDelta of splitArgumentsForStreaming(call.arguments)) {
+      // Stream function arguments as deltas after the call shell, matching the
+      // Chat Completions tool-call grammar consumed by OpenAI clients.
       writeSse(res, {
         id: params.runId,
         object: "chat.completion.chunk",
@@ -575,6 +580,7 @@ function resolveActiveTurnContext(messagesUnknown: unknown): ActiveTurnContext {
   return { activeTurnIndex: -1, activeUserMessageIndex: -1, urls: [] };
 }
 
+/** Resolves image_url parts from the active user turn and enforces image budgets. */
 async function resolveImagesForRequest(
   activeTurnContext: Pick<ActiveTurnContext, "urls">,
   limits: ResolvedOpenAiChatCompletionsLimits,
@@ -619,6 +625,7 @@ export const testOnlyOpenAiHttp = {
 };
 export { testOnlyOpenAiHttp as __testOnlyOpenAiHttp };
 
+/** Converts OpenAI chat messages into the internal agent prompt and system prompt. */
 function buildAgentPrompt(
   messagesUnknown: unknown,
   activeUserMessageIndex: number,
@@ -760,6 +767,8 @@ function resolveAgentRunUsage(result: unknown): NormalizedUsage | undefined {
   if (hasNonzeroUsage(primary)) {
     return primary;
   }
+  // Some providers only publish aggregate usage after the final call; prefer it
+  // when the run-level usage field is missing or all zero.
   const fallback = normalizeUsage(agentMeta?.lastCallUsage);
   if (hasNonzeroUsage(fallback)) {
     return fallback;
@@ -860,6 +869,7 @@ function resolveErrorMessage(err: unknown): string {
   return String(err);
 }
 
+/** Handles OpenAI-compatible /v1/chat/completions requests for Gateway agents. */
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,

--- a/src/gateway/openai-tool-choice.ts
+++ b/src/gateway/openai-tool-choice.ts
@@ -1,21 +1,14 @@
-// Shared OpenAI-compatible `tool_choice` contract for the Chat Completions
-// (`/v1/chat/completions`) and Responses (`/v1/responses`) HTTP endpoints. Both
-// accept `required` and pinned-function choices for caller-supplied client tools.
-// The agent runtime cannot force every upstream provider, so the HTTP boundary
-// narrows exposed tools, nudges the model, then rejects turns without a matching
-// structured client-tool call. Keeping this here keeps the endpoints aligned.
-
+/** Shared OpenAI-compatible tool_choice constraint used by chat and responses routes. */
 export type ToolChoiceConstraint = { type: "required" } | { type: "function"; name: string };
 
+/** Builds the prompt nudge paired with HTTP-side post-run tool_choice validation. */
 export function toolChoiceConstraintPrompt(constraint: ToolChoiceConstraint): string {
   return constraint.type === "function"
     ? `You must call the ${constraint.name} tool before responding.`
     : "You must call one of the available tools before responding.";
 }
 
-// True when no constraint is active, or the agent produced a structured tool
-// call that honors it: any call for `required`, a name match for a pinned
-// function. Callers reject the turn when this returns false.
+/** Checks whether the agent emitted the structured tool call required by tool_choice. */
 export function isToolChoiceConstraintSatisfied(params: {
   constraint: ToolChoiceConstraint | undefined;
   pendingToolCalls: ReadonlyArray<{ name: string }> | undefined;
@@ -33,6 +26,7 @@ export function isToolChoiceConstraintSatisfied(params: {
   return pendingToolCalls.some((call) => call.name === constraint.name);
 }
 
+/** Returns the OpenAI-compatible error detail for an unsatisfied tool_choice constraint. */
 export function resolveUnsatisfiedToolChoiceMessage(constraint: ToolChoiceConstraint): string {
   return constraint.type === "function"
     ? `tool_choice required a ${constraint.name} tool call, but the agent did not produce one`

--- a/src/gateway/openresponses-file-content.ts
+++ b/src/gateway/openresponses-file-content.ts
@@ -1,5 +1,6 @@
 import { wrapExternalContent } from "../security/external-content.js";
 
+/** Wrap file text as untrusted Responses input without adding an extra warning block. */
 export function wrapUntrustedFileContent(content: string): string {
   return wrapExternalContent(content, {
     source: "unknown",

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1,11 +1,3 @@
-/**
- * OpenResponses HTTP Handler
- *
- * Implements the OpenResponses `/v1/responses` endpoint for OpenClaw Gateway.
- *
- * @see https://www.open-responses.com/
- */
-
 import { createHash, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
@@ -95,6 +87,7 @@ type ResponseSessionEntry = ResponseSessionScope & {
 
 const responseSessionMap = new Map<string, ResponseSessionEntry>();
 
+/** Normalizes previous_response_id scope before storing or matching continuation state. */
 function normalizeResponseSessionScope(scope: ResponseSessionScope): ResponseSessionScope {
   const authSubject = scope.authSubject.trim();
   const requestedSessionKey = scope.requestedSessionKey?.trim();
@@ -111,6 +104,8 @@ function resolveResponseSessionAuthSubject(params: {
 }): string {
   const bearer = getBearerToken(params.req);
   if (bearer) {
+    // Partition continuation state by bearer without retaining the raw
+    // credential in the in-memory previous_response_id map.
     return `bearer:${createHash("sha256").update(bearer).digest("hex")}`;
   }
   if (params.auth.mode === "trusted-proxy" && params.auth.trustedProxy?.userHeader) {
@@ -250,6 +245,8 @@ function resolveResponsesLimits(
   const fileLimits = resolveInputFileLimits(files);
   return {
     maxBodyBytes: config?.maxBodyBytes ?? DEFAULT_BODY_BYTES,
+    // A single Responses request can mix file and image URLs, so URL fetches
+    // share one cap across all input part types.
     maxUrlParts: resolveIntegerOption(config?.maxUrlParts, DEFAULT_MAX_URL_PARTS, { min: 0 }),
     files: {
       ...fileLimits,
@@ -315,6 +312,8 @@ function applyToolChoice(params: {
     }
     const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
     return {
+      // Hide non-selected tools from the agent and add a prompt constraint so
+      // model-side selection matches the requested OpenResponses tool choice.
       tools: matched,
       extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
       constraint,
@@ -433,6 +432,7 @@ async function runResponsesAgentCommand(params: {
   );
 }
 
+/** Handles OpenResponses-compatible /v1/responses requests and owns response-session continuity. */
 export async function handleOpenResponsesHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,

--- a/src/gateway/openresponses-prompt.ts
+++ b/src/gateway/openresponses-prompt.ts
@@ -22,6 +22,10 @@ function extractTextContent(content: string | ContentPart[]): string {
     .join("\n");
 }
 
+/**
+ * Convert Responses input into the single agent prompt plus optional system
+ * overlay used by the Gateway OpenResponses compatibility endpoint.
+ */
 export function buildAgentPrompt(input: string | ItemParam[]): {
   message: string;
   extraSystemPrompt?: string;
@@ -58,7 +62,7 @@ export function buildAgentPrompt(input: string | ItemParam[]): {
         entry: { sender: `Tool:${item.call_id}`, body: item.output },
       });
     }
-    // Skip reasoning and item_reference for prompt building (Phase 1)
+    // Reasoning and item_reference entries do not add user-visible prompt text.
   }
 
   const message = buildAgentMessageFromConversationEntries(conversationEntries);

--- a/src/gateway/openresponses-shape.ts
+++ b/src/gateway/openresponses-shape.ts
@@ -1,5 +1,6 @@
 import type { OutputItem } from "./open-responses.schema.js";
 
+/** Build an assistant message item in the OpenAI Responses output shape. */
 export function createAssistantOutputItem(params: {
   id: string;
   text: string;
@@ -16,6 +17,10 @@ export function createAssistantOutputItem(params: {
   };
 }
 
+/**
+ * Build a function_call output item while preserving the exact serialized
+ * arguments string expected by Responses clients and stream deltas.
+ */
 export function createFunctionCallOutputItem(params: {
   id: string;
   callId: string;

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -23,6 +23,7 @@ export type PluginNodeCapabilityClient = {
   pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;
 };
 
+/** Indexes advertised node-capability surfaces, keeping the shortest lease TTL per surface. */
 export function indexPluginNodeCapabilitySurfaces(
   surfaces: readonly PluginNodeCapabilitySurface[],
 ): Record<string, PluginNodeCapabilitySurface> {
@@ -71,10 +72,12 @@ function resolvePluginNodeCapabilityStorageKey(surface: PluginNodeCapabilitySurf
   return scopeKey ? `${normalizedSurface}\0${scopeKey}` : normalizedSurface;
 }
 
+/** Resolves a node-capability lease TTL, using the default when plugins omit one. */
 export function resolvePluginNodeCapabilityTtlMs(surface: PluginNodeCapabilitySurface) {
   return asPositiveSafeInteger(surface.ttlMs) ?? DEFAULT_PLUGIN_NODE_CAPABILITY_TTL_MS;
 }
 
+/** Computes the absolute expiry time for a freshly minted node-capability lease. */
 export function resolvePluginNodeCapabilityExpiresAtMs(
   surface: PluginNodeCapabilitySurface,
   nowMs: number = Date.now(),
@@ -82,10 +85,12 @@ export function resolvePluginNodeCapabilityExpiresAtMs(
   return resolveExpiresAtMsFromDurationMs(resolvePluginNodeCapabilityTtlMs(surface), { nowMs });
 }
 
+/** Mints an unguessable token used in scoped plugin node-capability URLs. */
 export function mintPluginNodeCapabilityToken(): string {
   return randomBytes(18).toString("base64url");
 }
 
+/** Builds a host URL scoped with a node-capability token path segment. */
 export function buildPluginNodeCapabilityScopedHostUrl(
   baseUrl: string,
   capability: string,
@@ -107,6 +112,7 @@ export function buildPluginNodeCapabilityScopedHostUrl(
   }
 }
 
+/** Replaces the capability token inside an existing scoped host URL. */
 export function replacePluginNodeCapabilityInScopedHostUrl(
   scopedUrl: string,
   capability: string,
@@ -140,6 +146,7 @@ export function replacePluginNodeCapabilityInScopedHostUrl(
   }
 }
 
+/** Extracts and rewrites a node-capability scoped URL back to the plugin route path. */
 export function normalizePluginNodeCapabilityScopedUrl(
   rawUrl: string,
 ): NormalizedPluginNodeCapabilityUrl {
@@ -199,6 +206,7 @@ export function normalizePluginNodeCapabilityScopedUrl(
   };
 }
 
+/** Stores an active node-capability lease on a Gateway client. */
 export function setClientPluginNodeCapability(params: {
   client: PluginNodeCapabilityClient;
   surface: PluginNodeCapabilitySurface;
@@ -218,6 +226,7 @@ export function setClientPluginNodeCapability(params: {
   };
 }
 
+/** Refreshes a client's scoped surface URL and lease token for a plugin node capability. */
 export function refreshClientPluginNodeCapability(params: {
   client: PluginNodeCapabilityClient;
   surface: PluginNodeCapabilitySurface;
@@ -265,6 +274,7 @@ export function refreshClientPluginNodeCapability(params: {
   };
 }
 
+/** Validates and extends a client's active node-capability lease. */
 export function hasAuthorizedPluginNodeCapability(params: {
   clients: Iterable<PluginNodeCapabilityClient>;
   surface: PluginNodeCapabilitySurface;

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -40,6 +40,8 @@ function resolveGatewayProbeCredentialConfig(params: {
     return params.cfg;
   }
 
+  // Local probes must not borrow remote credentials; otherwise a configured
+  // remote token can mask missing local auth and make status/doctor lie.
   const remoteWithoutAuth = { ...remote };
   delete remoteWithoutAuth.token;
   delete remoteWithoutAuth.password;
@@ -76,6 +78,10 @@ function resolveGatewayProbeWarning(error: unknown): string | undefined {
   return buildUnresolvedProbeAuthWarning(error.path);
 }
 
+/**
+ * Resolves raw config/env probe credentials without SecretRef lookup for parity
+ * tests and lightweight status paths.
+ */
 export function resolveGatewayProbeAuth(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";
@@ -85,6 +91,11 @@ export function resolveGatewayProbeAuth(params: {
   return resolveGatewayProbeCredentialsFromConfig(policy);
 }
 
+/**
+ * Resolves auth for Gateway probes that may need SecretRef-backed credentials.
+ * Remote probes intentionally fall back only to remote credentials after env/CLI
+ * sources so a local token does not authorize the wrong Gateway surface.
+ */
 export async function resolveGatewayProbeAuthWithSecretInputs(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";
@@ -101,6 +112,10 @@ export async function resolveGatewayProbeAuthWithSecretInputs(params: {
   });
 }
 
+/**
+ * Best-effort async probe auth for status/doctor paths: explicit CLI auth wins,
+ * unresolved SecretRefs become warnings, and callers can still probe unauthenticated.
+ */
 export async function resolveGatewayProbeAuthSafeWithSecretInputs(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";
@@ -128,6 +143,10 @@ export async function resolveGatewayProbeAuthSafeWithSecretInputs(params: {
   }
 }
 
+/**
+ * Sync variant for callers that only inspect config/env credentials; unresolved
+ * SecretRefs produce the same warning shape as the async helper.
+ */
 export function resolveGatewayProbeAuthSafe(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";

--- a/src/gateway/rate-limit-attempt-serialization.ts
+++ b/src/gateway/rate-limit-attempt-serialization.ts
@@ -10,6 +10,7 @@ function buildSerializationKey(ip: string | undefined, scope: string | undefined
   return `${normalizeScope(scope)}:${normalizeRateLimitClientIp(ip)}`;
 }
 
+/** Serialize rate-limit-sensitive auth attempts for one normalized IP/scope bucket. */
 export async function withSerializedRateLimitAttempt<T>(params: {
   ip: string | undefined;
   scope: string | undefined;
@@ -21,6 +22,8 @@ export async function withSerializedRateLimitAttempt<T>(params: {
   const current = new Promise<void>((resolve) => {
     releaseCurrent = resolve;
   });
+  // Chain behind the previous tail but keep the current promise as the new
+  // tail so later attempts wait for this run even when earlier attempts fail.
   const tail = previous.catch(() => {}).then(() => current);
   pendingAttempts.set(key, tail);
 
@@ -29,6 +32,8 @@ export async function withSerializedRateLimitAttempt<T>(params: {
     return await params.run();
   } finally {
     releaseCurrent();
+    // Only the active tail may clean up the key; newer queued attempts replace
+    // it before this run finishes.
     if (pendingAttempts.get(key) === tail) {
       pendingAttempts.delete(key);
     }

--- a/src/gateway/resolve-configured-secret-input-string.ts
+++ b/src/gateway/resolve-configured-secret-input-string.ts
@@ -5,6 +5,7 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import { resolveSecretRefValues } from "../secrets/resolve.js";
 
+/** Selects operator-facing detail for unresolved SecretRef diagnostics. */
 export type SecretInputUnresolvedReasonStyle = "generic" | "detailed"; // pragma: allowlist secret
 type ConfiguredSecretInputSource =
   | "config"
@@ -29,6 +30,11 @@ function buildUnresolvedReason(params: {
   return `${params.path} SecretRef is unresolved (${params.refLabel}).`;
 }
 
+/**
+ * Resolves a config field that may be plaintext, an env-template string, or a
+ * SecretRef object while preserving unresolved reasons for callers that can
+ * continue with warnings.
+ */
 export async function resolveConfiguredSecretInputString(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -88,6 +94,11 @@ export async function resolveConfiguredSecretInputString(params: {
   }
 }
 
+/**
+ * Resolves a config secret input with caller-owned fallback metadata.
+ * Fallbacks remain distinguishable from config and SecretRef values so install,
+ * status, and plugin SDK paths can avoid persisting accidental env-only secrets.
+ */
 export async function resolveConfiguredSecretInputWithFallback(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -126,6 +137,8 @@ export async function resolveConfiguredSecretInputWithFallback(params: {
     return { secretRefConfigured: false };
   }
 
+  // A SecretRef-backed field may still use a caller fallback, but the result
+  // keeps secretRefConfigured=true so operators can see config still needs work.
   const resolved = await resolveConfiguredSecretInputString({
     config: params.config,
     env: params.env,
@@ -157,6 +170,10 @@ export async function resolveConfiguredSecretInputWithFallback(params: {
   };
 }
 
+/**
+ * Requires SecretRef-backed resolution only; plaintext config deliberately
+ * returns undefined so callers can patch just the SecretRef value in place.
+ */
 export async function resolveRequiredConfiguredSecretRefInputString(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;

--- a/src/gateway/security-path.ts
+++ b/src/gateway/security-path.ts
@@ -46,6 +46,11 @@ function pushNormalizedCandidate(candidates: string[], seen: Set<string>, value:
   candidates.push(normalized);
 }
 
+/**
+ * Builds every normalized path observed while repeatedly decoding a request path.
+ * Security callers check all candidates because an intermediate decoded form can
+ * reveal a protected prefix before the final canonical path resolves dot segments.
+ */
 export function buildCanonicalPathCandidates(
   pathname: string,
   maxDecodePasses = MAX_PATH_DECODE_PASSES,
@@ -93,6 +98,7 @@ export function buildCanonicalPathCandidates(
   };
 }
 
+/** Returns the final normalized path after bounded repeated decoding. */
 export function canonicalizePathVariant(pathname: string): string {
   const { candidates } = buildCanonicalPathCandidates(pathname);
   return candidates[candidates.length - 1] ?? "/";
@@ -107,6 +113,10 @@ function prefixMatch(pathname: string, prefix: string): boolean {
   );
 }
 
+/**
+ * Canonicalizes a request path for auth decisions and reports whether decoding
+ * was incomplete or malformed so callers can fail closed at protected prefixes.
+ */
 export function canonicalizePathForSecurity(pathname: string): SecurityPathCanonicalization {
   const { candidates, decodePasses, decodePassLimitReached, malformedEncoding } =
     buildCanonicalPathCandidates(pathname);
@@ -133,6 +143,10 @@ function getNormalizedPrefixes(prefixes: readonly string[]): readonly string[] {
   return normalized;
 }
 
+/**
+ * Checks a path against protected prefixes using every decoded candidate and
+ * fails closed when encoding cannot be fully resolved.
+ */
 export function isPathProtectedByPrefixes(pathname: string, prefixes: readonly string[]): boolean {
   const canonical = canonicalizePathForSecurity(pathname);
   const normalizedPrefixes = getNormalizedPrefixes(prefixes);
@@ -153,8 +167,10 @@ export function isPathProtectedByPrefixes(pathname: string, prefixes: readonly s
   return normalizedPrefixes.some((prefix) => prefixMatch(canonical.rawNormalizedPath, prefix));
 }
 
+/** Plugin HTTP routes under this prefix require Gateway auth even through encoded path variants. */
 export const PROTECTED_PLUGIN_ROUTE_PREFIXES = ["/api/channels"] as const;
 
+/** Returns whether a request path targets a protected plugin HTTP route. */
 export function isProtectedPluginRoutePath(pathname: string): boolean {
   return isPathProtectedByPrefixes(pathname, PROTECTED_PLUGIN_ROUTE_PREFIXES);
 }

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -56,6 +56,9 @@ function serializeFrameField(name: "payload" | "stateVersion", value: unknown): 
   const fieldJSON = JSON.stringify({ [name]: value });
   const keyJSON = JSON.stringify(name);
   const prefix = `{${keyJSON}:`;
+  // Reuse JSON.stringify for escaping, then splice the single field into the
+  // already-open event frame so large broadcasts don't allocate wrapper objects
+  // once per connected client.
   return fieldJSON.startsWith(prefix) ? `,${keyJSON}:${fieldJSON.slice(prefix.length, -1)}` : "";
 }
 
@@ -92,6 +95,10 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
   return required.some((scope) => scopes.includes(scope));
 }
 
+/**
+ * Creates broadcast helpers that enforce per-event scopes, outbound-buffer
+ * limits, and per-client sequence numbers for Gateway websocket events.
+ */
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {
   const clientSeq = new WeakMap<GatewayWsClient, number>();
   const reportedSlowPayloadClients = new WeakSet<GatewayWsClient>();
@@ -130,6 +137,8 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       | undefined;
     const getFrameBase = () => {
       if (!frameBase) {
+        // The event, payload, and stateVersion are identical for every eligible
+        // recipient; only the seq fragment differs for non-targeted broadcasts.
         frameBase = {
           eventJSON: JSON.stringify(event),
           payloadFragment: serializeFrameField("payload", payload),
@@ -163,6 +172,8 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       if (slow && opts?.dropIfSlow) {
         if (!isTargeted) {
+          // Global broadcasts advance seq even when dropped so clients can
+          // detect gaps and refresh state. Targeted sends intentionally omit seq.
           clientSeq.set(c, nextSeq);
         }
         continue;

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -6,12 +6,14 @@ export type ChatRunEntry = {
   clientRunId: string;
 };
 
+/** Buffered agent event metadata waiting for enough recipients or text state to flush. */
 export type BufferedAgentEvent = {
   sessionKey?: string;
   agentId?: string;
   payload: AgentEventPayload & { spawnedBy?: string };
 };
 
+/** FIFO registry that maps a runtime session id to one or more client-visible chat runs. */
 export type ChatRunRegistry = {
   add: (sessionId: string, entry: ChatRunEntry) => void;
   peek: (sessionId: string) => ChatRunEntry | undefined;
@@ -20,6 +22,7 @@ export type ChatRunRegistry = {
   clear: () => void;
 };
 
+/** Creates the per-session chat-run queue used to correlate runtime callbacks to RPC runs. */
 export function createChatRunRegistry(): ChatRunRegistry {
   const chatRunSessions = new Map<string, ChatRunEntry[]>();
 
@@ -89,6 +92,7 @@ export type ChatRunState = {
   clear: () => void;
 };
 
+/** Creates the in-memory chat streaming state shared by Gateway chat handlers. */
 export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
@@ -108,6 +112,7 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt.delete(runId);
     deltaLastBroadcastLen.delete(runId);
     deltaLastBroadcastText.delete(runId);
+    // Agent event buffers use suffixed keys for assistant/thinking streams owned by the same run.
     for (const key of [runId, `${runId}:assistant`, `${runId}:thinking`]) {
       agentDeltaSentAt.delete(key);
       bufferedAgentEvents.delete(key);
@@ -143,12 +148,14 @@ export function createChatRunState(): ChatRunState {
   };
 }
 
+/** Tracks temporary connection recipients for run-scoped tool events. */
 export type ToolEventRecipientRegistry = {
   add: (runId: string, connId: string) => void;
   get: (runId: string) => ReadonlySet<string> | undefined;
   markFinal: (runId: string) => void;
 };
 
+/** Tracks connections subscribed to coarse session list/update events. */
 export type SessionEventSubscriberRegistry = {
   subscribe: (connId: string) => void;
   unsubscribe: (connId: string) => void;
@@ -156,6 +163,7 @@ export type SessionEventSubscriberRegistry = {
   clear: () => void;
 };
 
+/** Tracks per-session message subscribers with reverse indexes for disconnect cleanup. */
 export type SessionMessageSubscriberRegistry = {
   subscribe: (connId: string, sessionKey: string) => void;
   unsubscribe: (connId: string, sessionKey: string) => void;
@@ -173,6 +181,7 @@ type ToolRecipientEntry = {
 const TOOL_EVENT_RECIPIENT_TTL_MS = 10 * 60 * 1000;
 const TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS = 30 * 1000;
 
+/** Creates a connection set for broadcast-only session lifecycle/list events. */
 export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRegistry {
   const connIds = new Set<string>();
   const empty = new Set<string>();
@@ -199,6 +208,7 @@ export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRe
   };
 }
 
+/** Creates a two-way subscription index for session-scoped transcript message events. */
 export function createSessionMessageSubscriberRegistry(): SessionMessageSubscriberRegistry {
   const sessionToConnIds = new Map<string, Set<string>>();
   const connToSessionKeys = new Map<string, Set<string>>();
@@ -251,6 +261,7 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
       if (!sessionKeys) {
         return;
       }
+      // Walk the reverse index so disconnect cleanup removes the connection from every session set.
       for (const sessionKey of sessionKeys) {
         const connIds = sessionToConnIds.get(sessionKey);
         if (!connIds) {
@@ -277,6 +288,7 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
   };
 }
 
+/** Creates run-scoped tool-event recipients with TTL and short final-event grace cleanup. */
 export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
   const recipients = new Map<string, ToolRecipientEntry>();
 

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
+/**
+ * Applies gateway config to process command lanes used by agents, subagents,
+ * and cron-triggered work.
+ */
 export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
   const cronMaxConcurrentRuns = resolveCronMaxConcurrentRuns(cfg.cron);
   setCommandLaneConcurrency(CommandLane.Cron, cronMaxConcurrentRuns);

--- a/src/gateway/server-live-state.ts
+++ b/src/gateway/server-live-state.ts
@@ -15,6 +15,10 @@ export type GatewayServerLiveState = GatewayServerMutableState & {
   gatewayMethods: string[];
 };
 
+/**
+ * Combines close/reload handles with runtime snapshots that can change after
+ * startup, such as hook config, cron state, plugin services, and method lists.
+ */
 export function createGatewayServerLiveState(params: {
   hooksConfig: HooksConfigResolved | null;
   hookClientIpConfig: HookClientIpConfig;

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -26,6 +26,7 @@ export type GatewayInjectedTtsSupplementMarker = {
   textSha256: string;
 };
 
+/** Builds the assistant content blocks while preserving caller-supplied media block ordering. */
 function resolveInjectedAssistantContent(params: {
   message: string;
   label?: string;
@@ -87,6 +88,7 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     label: params.label,
     content: params.content,
   });
+  // Use the shared transcript appender so injected rows advance the same parentId chain as model rows.
   const messageBody: AppendMessageArg & Record<string, unknown> = {
     role: "assistant",
     // Gateway-injected assistant messages can include non-model content blocks (e.g. embedded TTS audio).
@@ -104,6 +106,7 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     provider: "openclaw",
     model: "gateway-injected",
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    // TTS supplements and abort notices are transcript-side metadata, not model response fields.
     ...(params.ttsSupplement ? { openclawTtsSupplement: params.ttsSupplement } : {}),
     ...(params.abortMeta
       ? {
@@ -124,6 +127,7 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
       useRawWhenLinear: true,
       config: params.config,
     });
+    // Notify history/SSE consumers only after the append produced the stored message id.
     emitSessionTranscriptUpdate({
       sessionFile: params.transcriptPath,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -921,6 +921,7 @@ function stripDisallowedChatControlChars(message: string): string {
   return output;
 }
 
+/** Normalizes user chat input while preserving printable whitespace accepted by chat.send. */
 export function sanitizeChatSendMessageInput(
   message: string,
 ): { ok: true; message: string } | { ok: false; error: string } {
@@ -1364,6 +1365,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
     if (!preview) {
       continue;
     }
+    // Tool calls produce canvas previews; history displays attach them to the related assistant row.
     pending.push({
       preview,
       rawText: text ?? null,
@@ -1388,6 +1390,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
   return changed ? next : messages;
 }
 
+/** Builds a compact chat-history row that preserves role/seq identity for oversized entries. */
 export function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unknown> {
   const role =
     message &&
@@ -1424,6 +1427,7 @@ export function buildOversizedHistoryPlaceholder(message?: unknown): Record<stri
   };
 }
 
+/** Replaces individual oversized history entries before final response-size trimming. */
 export function replaceOversizedChatHistoryMessages(params: {
   messages: unknown[];
   maxSingleMessageBytes: number;
@@ -1443,6 +1447,7 @@ export function replaceOversizedChatHistoryMessages(params: {
   return { messages: replacedCount > 0 ? next : messages, replacedCount };
 }
 
+/** Enforces the final chat-history byte budget while keeping the newest useful row when possible. */
 export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
   messages: unknown[];
   placeholderCount: number;
@@ -2109,6 +2114,7 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
     };
   }
   const authorizedRunIdSet = new Set(authorizedRuns.map((run) => run.runId));
+  // Only live controller-backed runs have partial text buffers to persist after abort.
   const snapshots = collectSessionAbortPartials({
     chatAbortControllers: params.context.chatAbortControllers,
     chatRunBuffers: params.context.chatRunBuffers,
@@ -2128,6 +2134,7 @@ async function abortChatRunsForSessionKeyWithPartials(params: {
   }
   const endedAt = Date.now();
   const stopReason = params.stopReason ?? "rpc";
+  // Pre-registered agent runs can be aborted before their controller exists; mark dedupe state.
   for (const { runId, sessionKey, payload } of authorizedPendingAgentRuns) {
     writePreRegisteredAgentAbort({
       context: params.context,
@@ -2337,6 +2344,7 @@ function isChatHistoryAssistantMessage(message: unknown): boolean {
   return asOptionalRecord(message)?.role === "assistant";
 }
 
+/** Removes stale subagent announce prompts and their stale assistant echoes from fresh sessions. */
 export function dropPreSessionStartAnnouncePairs(
   messages: unknown[],
   sessionStartedAt: number | undefined,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -200,6 +200,7 @@ type SessionsRuntimeModule = typeof import("./sessions.runtime.js");
 
 let sessionsRuntimeModulePromise: Promise<SessionsRuntimeModule> | undefined;
 
+/** Lazily loads heavy session runtime helpers only for methods that need runtime mutation. */
 function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   sessionsRuntimeModulePromise ??= import("./sessions.runtime.js");
   return sessionsRuntimeModulePromise;
@@ -283,6 +284,7 @@ function shouldAttachPendingMessageSeq(params: { payload: unknown; cached?: bool
   return status === "started";
 }
 
+/** Emits the compact session row update consumed by Control UI and session subscribers. */
 function emitSessionsChanged(
   context: Pick<
     GatewayRequestContext,
@@ -380,6 +382,7 @@ function emitSessionsChanged(
   );
 }
 
+/** Emits operation progress for long-running session mutations such as compaction/restore. */
 function emitSessionOperation(
   context: Pick<GatewayRequestContext, "broadcastToConnIds" | "getSessionEventSubscriberConnIds">,
   payload: Omit<SessionOperationEvent, "ts">,
@@ -399,6 +402,7 @@ function emitSessionOperation(
   );
 }
 
+/** Blocks webchat-scoped clients from mutating stored sessions outside chat.send. */
 function rejectWebchatSessionMutation(params: {
   action: "patch" | "delete" | "compact" | "restore";
   client: GatewayClient | null;
@@ -467,6 +471,7 @@ function cloneCheckpointSessionEntry(params: {
   };
 }
 
+/** Resolves the transcript file/leaf that a checkpoint fork should copy from. */
 function resolveCheckpointForkSource(
   checkpoint: NonNullable<ReturnType<typeof getSessionCompactionCheckpoint>>,
 ): { sourceFile: string; sourceLeafId?: string; totalTokens?: number } | null {
@@ -502,6 +507,7 @@ function isAgentMainSessionKey(cfg: OpenClawConfig, sessionKey: string): boolean
   return sessionKey === resolveAgentMainSessionKey({ cfg, agentId: parsed.agentId });
 }
 
+/** Creates an agent main session on first send while preserving sessions.create side effects. */
 async function createAgentMainSessionForSend(params: {
   req: GatewayRequestHandlerOptions["req"];
   canonicalKey: string;
@@ -575,6 +581,7 @@ async function createAgentMainSessionForSend(params: {
   };
 }
 
+/** Ensures a session transcript exists before runtime helpers append or fork records. */
 function ensureSessionTranscriptFile(params: {
   sessionId: string;
   storePath: string;
@@ -613,6 +620,7 @@ function ensureSessionTranscriptFile(params: {
   }
 }
 
+/** Picks the visible key needed to abort an active run even when callers used an alias. */
 function resolveAbortSessionKey(params: {
   context: Pick<GatewayRequestContext, "chatAbortControllers">;
   requestedKey: string;
@@ -665,6 +673,7 @@ function sessionKeyBelongsToAgent(
   return Boolean(sessionAgentId && sessionAgentId === normalizeAgentId(agentId));
 }
 
+/** Maps an agent-scoped abort request to the stored key only when the agent owns it. */
 function resolveScopedAbortKey(params: {
   cfg: OpenClawConfig;
   key: string | undefined;
@@ -694,6 +703,7 @@ function resolveScopedAbortKey(params: {
   });
 }
 
+/** Resolves the subscriber channel for per-agent global-session message fanout. */
 function resolveSessionMessageSubscriptionKey(params: {
   canonicalKey: string;
   agentId?: string;
@@ -714,6 +724,7 @@ type RequestedGlobalAgentIdResolution =
   | { ok: true; agentId?: string }
   | { ok: false; error: ReturnType<typeof errorShape> };
 
+/** Validates explicit or key-derived agent routing for global session operations. */
 function resolveRequestedGlobalAgentId(
   cfg: OpenClawConfig,
   key: string,
@@ -765,6 +776,7 @@ function resolveRequestedGlobalAgentId(
   };
 }
 
+/** Interrupts visible active runs before steering, covering Gateway and embedded-agent trackers. */
 async function interruptSessionRunIfActive(params: {
   req: GatewayRequestHandlerOptions["req"];
   context: GatewayRequestContext;

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -68,6 +68,11 @@ export type GatewayRequestContextParams = {
   unavailableGatewayMethods: ReadonlySet<string>;
 };
 
+/**
+ * Builds the shared handler context used by Gateway RPC methods.
+ * Most fields are live references so config reloads and runtime swaps can
+ * update behavior without recreating every registered method closure.
+ */
 export function createGatewayRequestContext(
   params: GatewayRequestContextParams,
 ): GatewayRequestContext {
@@ -127,6 +132,8 @@ export function createGatewayRequestContext(
         if (!hasApprovalScope(gatewayClient)) {
           continue;
         }
+        // Approval routing may target a subset for a specific record, but the
+        // scope gate always runs first so non-approval clients never see it.
         if (opts.filter && !opts.filter(gatewayClient, opts.record)) {
           continue;
         }
@@ -143,6 +150,8 @@ export function createGatewayRequestContext(
         if (opts?.role && gatewayClient.connect.role !== opts.role) {
           continue;
         }
+        // Keep the socket open so callers can rotate or revoke one device
+        // credential while buffered RPCs fail through the invalidation flag.
         gatewayClient.invalidated = true;
         gatewayClient.invalidatedReason = reason;
       }

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -31,8 +31,14 @@ export type GatewayServerMutableState = {
   lifecycleUnsub: (() => void) | null;
 };
 
+/**
+ * Creates the lifecycle handles that close/reload code can always call safely,
+ * even before the corresponding subsystem has started.
+ */
 export function createGatewayServerMutableState(): GatewayServerMutableState {
   const noopInterval = () => {
+    // Use unref'd inert timers instead of null for always-present interval
+    // handles so shutdown code can clear them without guarding startup order.
     const timer = setInterval(() => {}, 1 << 30);
     timer.unref?.();
     return timer;

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -21,6 +21,11 @@ type GatewayRuntimeServiceLogger = {
 type GatewayPostReadyLogger = {
   warn: (message: string) => void;
 };
+
+/**
+ * Timer handles produced by post-ready maintenance startup and later adopted
+ * into mutable gateway state for normal shutdown cleanup.
+ */
 export type GatewayMaintenanceHandles = NonNullable<
   Awaited<ReturnType<typeof startGatewayMaintenanceTimers>>
 >;
@@ -46,6 +51,8 @@ function clearGatewayMaintenanceHandles(maintenance: GatewayMaintenanceHandles |
   if (!maintenance) {
     return;
   }
+  // The scheduler can lose the race with shutdown after maintenance allocates
+  // intervals. Clear every returned handle before the closing gateway forgets it.
   clearInterval(maintenance.tickInterval);
   clearInterval(maintenance.healthInterval);
   clearInterval(maintenance.dedupeCleanup);

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -23,6 +23,11 @@ import {
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
 
+/**
+ * Expands a session key into the message-subscription channels that should
+ * receive transcript events. Global sessions include an agent-scoped key so
+ * per-agent clients do not accidentally receive cross-agent fanout.
+ */
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   const normalizedAgentId = normalizeOptionalString(agentId);
   if (sessionKey === "global") {
@@ -38,6 +43,11 @@ function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string
   return [sessionKey];
 }
 
+/**
+ * Projects the current Gateway session row into event payload fields. The
+ * unscoped `global` payload hides goal state so agent-specific goals are only
+ * exposed on the matching scoped session channel.
+ */
 function buildGatewaySessionSnapshot(params: {
   sessionRow: GatewaySessionRow | null | undefined;
   agentId?: string;
@@ -111,6 +121,11 @@ function buildGatewaySessionSnapshot(params: {
   };
 }
 
+/**
+ * Creates the transcript update handler registered with the transcript event
+ * bus. Updates are serialized so message sequence fallback reads observe store
+ * state in the same order transcript mutations were emitted.
+ */
 export function createTranscriptUpdateBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;
@@ -124,6 +139,11 @@ export function createTranscriptUpdateBroadcastHandler(params: {
   };
 }
 
+/**
+ * Broadcasts a transcript update to session-message subscribers and the broader
+ * session-event subscribers. Non-displayable transcript records still emit a
+ * `sessions.changed` message-phase event so session lists refresh.
+ */
 async function handleTranscriptUpdateBroadcast(
   params: {
     broadcastToConnIds: GatewayBroadcastToConnIdsFn;
@@ -158,6 +178,8 @@ async function handleTranscriptUpdateBroadcast(
   }
   let messageSeq = asPositiveSafeInteger(update.messageSeq);
   if (messageSeq === undefined) {
+    // Transcript writers usually know the sequence number. Archive/import paths
+    // may not, so fall back to the indexed count before broadcasting.
     const { entry, storePath } = loadSessionEntry(sessionKey, { agentId: visibleAgentId });
     messageSeq = entry?.sessionId
       ? asPositiveSafeInteger(
@@ -215,6 +237,11 @@ async function handleTranscriptUpdateBroadcast(
   );
 }
 
+/**
+ * Creates the lifecycle event handler registered with the session lifecycle
+ * event bus. Lifecycle events only fan out through `sessions.changed`, because
+ * they update session rows rather than append transcript messages.
+ */
 export function createLifecycleEventBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;

--- a/src/gateway/server/http-listen.ts
+++ b/src/gateway/server/http-listen.ts
@@ -15,6 +15,11 @@ async function closeServerQuietly(httpServer: HttpServer): Promise<void> {
   });
 }
 
+/**
+ * Bind the Gateway HTTP server with the startup retry policy used by runtime state.
+ * EADDRINUSE becomes a gateway lock error after retries so callers report a
+ * product-level singleton conflict instead of a raw Node listen failure.
+ */
 export async function listenGatewayHttpServer(params: {
   httpServer: HttpServer;
   bindHost: string;

--- a/src/gateway/server/plugin-node-capability-auth.ts
+++ b/src/gateway/server/plugin-node-capability-auth.ts
@@ -12,6 +12,7 @@ import {
 } from "../plugin-node-capability.js";
 import type { GatewayWsClient } from "./ws-types.js";
 
+/** Authorizes a plugin node-capability request using gateway auth first, then leased capability tokens. */
 export async function authorizePluginNodeCapabilityRequest(params: {
   req: IncomingMessage;
   auth: ResolvedGatewayAuth;
@@ -35,6 +36,8 @@ export async function authorizePluginNodeCapabilityRequest(params: {
     rateLimiter,
   } = params;
   if (malformedScopedPath) {
+    // Scoped capability paths are bearer-like credentials; malformed scoped
+    // paths fail closed instead of falling back to unscoped route auth.
     return { ok: false, reason: "unauthorized" };
   }
 

--- a/src/gateway/server/plugin-route-runtime-scopes.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.ts
@@ -8,12 +8,15 @@ import { CLI_DEFAULT_OPERATOR_SCOPES, WRITE_SCOPE } from "../method-scopes.js";
 
 export type PluginRouteRuntimeScopeSurface = "write-default" | "trusted-operator";
 
+/** Resolves the operator scopes exposed to a gateway-authenticated plugin HTTP route. */
 export function resolvePluginRouteRuntimeOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
   surface: PluginRouteRuntimeScopeSurface = "write-default",
 ): string[] {
   if (surface === "trusted-operator") {
+    // trusted-operator routes inherit declared caller scopes when the auth
+    // method permits trusting them; otherwise they get the CLI default surface.
     if (!requestAuth.trustDeclaredOperatorScopes) {
       return [...CLI_DEFAULT_OPERATOR_SCOPES];
     }

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -37,6 +37,8 @@ function resolvePluginRoutePathContextForRequest(
   providedPathContext: PluginRoutePathContext | undefined,
 ): PluginRoutePathContext {
   if (providedPathContext) {
+    // Reuse upstream canonicalization so auth checks and runtime dispatch see
+    // the same decoded path candidates.
     return providedPathContext;
   }
   const url = new URL(req.url ?? "/", "http://localhost");
@@ -85,6 +87,7 @@ function getMissingPluginRouteRuntimeContext(
   return context.gatewayRequestOperatorScopes === undefined ? "caller scope context" : undefined;
 }
 
+/** Builds the Gateway runtime scope exposed while a plugin HTTP route runs. */
 function createPluginRouteRuntimeScope(params: {
   route: PluginHttpRouteRegistration;
   req: IncomingMessage;
@@ -136,6 +139,7 @@ export type PluginHttpUpgradeHandler = (
   dispatchContext?: PluginRouteDispatchContext,
 ) => Promise<boolean>;
 
+/** Creates the HTTP request dispatcher for registered plugin routes. */
 export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   getRouteRegistry?: () => PluginRegistry;
@@ -192,11 +196,15 @@ export function createGatewayPluginRequestHandler(params: {
           async () => route.handler(req, res),
         );
         if (handled !== false) {
+          // A route owns the response unless it explicitly returns false,
+          // allowing lower-priority matches to try the same path.
           return true;
         }
       } catch (err) {
         log.warn(`plugin http route failed (${route.pluginId ?? "unknown"}): ${String(err)}`);
         if (!res.headersSent) {
+          // Plugin handlers own their responses; synthesize a plain 500 only
+          // when the route failed before writing headers.
           res.statusCode = 500;
           res.setHeader("Content-Type", "text/plain; charset=utf-8");
           res.end("Internal Server Error");
@@ -208,6 +216,7 @@ export function createGatewayPluginRequestHandler(params: {
   };
 }
 
+/** Creates the WebSocket/upgrade dispatcher for registered plugin routes. */
 export function createGatewayPluginUpgradeHandler(params: {
   registry: PluginRegistry;
   getRouteRegistry?: () => PluginRegistry;

--- a/src/gateway/server/plugins-http/path-context.ts
+++ b/src/gateway/server/plugins-http/path-context.ts
@@ -13,6 +13,7 @@ export type PluginRoutePathContext = {
   rawNormalizedPath: string;
 };
 
+/** Normalizes protected plugin prefixes to the same lowercase slash form used for path candidates. */
 function normalizeProtectedPrefix(prefix: string): string {
   const collapsed = normalizeLowercaseStringOrEmpty(prefix).replace(/\/{2,}/g, "/");
   if (collapsed.length <= 1) {
@@ -21,6 +22,7 @@ function normalizeProtectedPrefix(prefix: string): string {
   return collapsed.replace(/\/+$/, "");
 }
 
+/** Matches exact prefixes plus encoded slash continuations that still target the same route family. */
 export function prefixMatchPath(pathname: string, prefix: string): boolean {
   return (
     pathname === prefix || pathname.startsWith(`${prefix}/`) || pathname.startsWith(`${prefix}%`)
@@ -30,6 +32,7 @@ export function prefixMatchPath(pathname: string, prefix: string): boolean {
 const NORMALIZED_PROTECTED_PLUGIN_ROUTE_PREFIXES =
   PROTECTED_PLUGIN_ROUTE_PREFIXES.map(normalizeProtectedPrefix);
 
+/** Returns true when any decoded path candidate reaches a reserved Gateway-owned plugin prefix. */
 export function isProtectedPluginRoutePathFromContext(context: PluginRoutePathContext): boolean {
   if (
     context.candidates.some((candidate) =>
@@ -48,6 +51,7 @@ export function isProtectedPluginRoutePathFromContext(context: PluginRoutePathCo
   );
 }
 
+/** Builds the canonical path candidate set used by plugin route matching and auth checks. */
 export function resolvePluginRoutePathContext(pathname: string): PluginRoutePathContext {
   const canonical = canonicalizePathForSecurity(pathname);
   return {

--- a/src/gateway/server/plugins-http/route-auth.ts
+++ b/src/gateway/server/plugins-http/route-auth.ts
@@ -6,12 +6,14 @@ import {
 } from "./path-context.js";
 import { findMatchingPluginHttpRoutes } from "./route-match.js";
 
+/** Returns true when any matched plugin route opted into Gateway auth. */
 export function matchedPluginRoutesRequireGatewayAuth(
   routes: readonly Pick<NonNullable<PluginRegistry["httpRoutes"]>[number], "auth">[],
 ): boolean {
   return routes.some((route) => route.auth === "gateway");
 }
 
+/** Decides whether a plugin HTTP path must be protected before runtime dispatch. */
 export function shouldEnforceGatewayAuthForPluginPath(
   registry: PluginRegistry,
   pathnameOrContext: string | PluginRoutePathContext,
@@ -21,6 +23,7 @@ export function shouldEnforceGatewayAuthForPluginPath(
       ? resolvePluginRoutePathContext(pathnameOrContext)
       : pathnameOrContext;
   if (pathContext.malformedEncoding || pathContext.decodePassLimitReached) {
+    // Ambiguous paths fail closed before checking plugin declarations.
     return true;
   }
   if (isProtectedPluginRoutePathFromContext(pathContext)) {

--- a/src/gateway/server/plugins-http/route-capability.ts
+++ b/src/gateway/server/plugins-http/route-capability.ts
@@ -12,10 +12,12 @@ export type PluginNodeCapabilityRoute = PluginHttpRouteEntry & {
   nodeCapability: PluginNodeCapabilitySurface;
 };
 
+/** Narrows plugin HTTP routes to those that declare a node-capability surface. */
 function hasNodeCapabilityRoute(route: PluginHttpRouteEntry): route is PluginNodeCapabilityRoute {
   return Boolean(route.nodeCapability?.surface?.trim());
 }
 
+/** Normalizes a route-declared node capability and scopes it to the owning plugin when possible. */
 function resolvePluginNodeCapabilityRouteSurface(
   route: PluginNodeCapabilityRoute,
 ): PluginNodeCapabilitySurface {
@@ -28,6 +30,7 @@ function resolvePluginNodeCapabilityRouteSurface(
   };
 }
 
+/** Returns matching plugin routes that require node-capability leasing for the path. */
 export function findMatchingPluginNodeCapabilityRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
@@ -41,6 +44,7 @@ export function findMatchingPluginNodeCapabilityRoutes(
     );
 }
 
+/** Resolves the highest-priority node-capability route for a request path. */
 export function findMatchingPluginNodeCapabilityRoute(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
@@ -48,10 +52,12 @@ export function findMatchingPluginNodeCapabilityRoute(
   return findMatchingPluginNodeCapabilityRoutes(registry, context)[0];
 }
 
+/** Lists unique node-capability surface names advertised by plugin HTTP routes. */
 export function listPluginNodeCapabilitySurfaces(registry: PluginRegistry): string[] {
   return listPluginNodeCapabilities(registry).map((entry) => entry.surface);
 }
 
+/** Lists unique plugin node-capability leases, keeping the shortest TTL per surface. */
 export function listPluginNodeCapabilities(
   registry: PluginRegistry,
 ): PluginNodeCapabilitySurface[] {

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -8,6 +8,7 @@ import {
 
 type PluginHttpRouteEntry = NonNullable<PluginRegistry["httpRoutes"]>[number];
 
+/** Checks one registered plugin route against every canonical path candidate. */
 export function doesPluginRouteMatchPath(
   route: PluginHttpRouteEntry,
   context: PluginRoutePathContext,
@@ -19,6 +20,7 @@ export function doesPluginRouteMatchPath(
   return context.candidates.some((candidate) => candidate === routeCanonicalPath);
 }
 
+/** Returns matching plugin HTTP routes with exact routes before longest-prefix fallbacks. */
 export function findMatchingPluginHttpRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
@@ -44,6 +46,7 @@ export function findMatchingPluginHttpRoutes(
   return [...exactMatches, ...prefixMatches];
 }
 
+/** Resolves the first registered plugin HTTP route for a request path. */
 export function findRegisteredPluginHttpRoute(
   registry: PluginRegistry,
   pathname: string,
@@ -52,6 +55,7 @@ export function findRegisteredPluginHttpRoute(
   return findMatchingPluginHttpRoutes(registry, pathContext)[0];
 }
 
+/** Fast predicate for callers that only need to know whether a plugin owns the path. */
 export function isRegisteredPluginHttpRoutePath(
   registry: PluginRegistry,
   pathname: string,

--- a/src/gateway/session-child-sessions.ts
+++ b/src/gateway/session-child-sessions.ts
@@ -8,6 +8,11 @@ export type DirectChildSessionEntry = {
   entry: SessionEntry;
 };
 
+/**
+ * Checks whether a store entry is a direct child of a parent session. Both
+ * `spawnedBy` and `parentSessionKey` are accepted because older and newer
+ * session creation paths record lineage under different fields.
+ */
 export function isDirectChildSessionEntry(params: {
   sessionKey: string;
   entry: SessionEntry | undefined;
@@ -23,6 +28,11 @@ export function isDirectChildSessionEntry(params: {
   );
 }
 
+/**
+ * Finds direct children across the combined Gateway session store. Parent reset
+ * and delete cleanup use this instead of one agent store so ACP children spawned
+ * under another agent are still closed.
+ */
 export function findDirectChildSessionsForParent(params: {
   cfg: OpenClawConfig;
   parentKey: string;

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -21,9 +21,12 @@ import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
 
 const log = createSubsystemLogger("gateway/session-compaction-checkpoints");
 const MAX_COMPACTION_CHECKPOINTS_PER_SESSION = 25;
+/** Max transcript tail bytes scanned to recover a stable pre-compaction leaf id. */
 export const MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES = 64 * 1024 * 1024;
+/** Max retained checkpoint transcript bytes per session before older artifacts are trimmed. */
 export const MAX_COMPACTION_CHECKPOINT_RETAINED_BYTES_PER_SESSION = 128 * 1024 * 1024;
 
+/** Stable identity captured before compaction so branch/restore can fork from the right leaf. */
 export type CapturedCompactionCheckpointSnapshot = {
   sessionId: string;
   sessionFile?: string;
@@ -73,6 +76,7 @@ function trimSessionCheckpoints(
     }
     const checkpointBytes = checkpointSnapshotBytes(checkpoint, snapshotBytesByPath);
     const keepNewestCheckpoint = keptNewestFirst.length === 0;
+    // Always keep the newest checkpoint, even if its artifact alone exceeds the byte budget.
     if (
       keepNewestCheckpoint ||
       retainedBytes + checkpointBytes <= MAX_COMPACTION_CHECKPOINT_RETAINED_BYTES_PER_SESSION
@@ -117,6 +121,7 @@ async function statCheckpointSnapshotBytes(
   return bytesByPath;
 }
 
+/** Maps compaction trigger state into the persisted checkpoint reason enum. */
 export function resolveSessionCompactionCheckpointReason(params: {
   trigger?: "budget" | "overflow" | "manual";
   timedOut?: boolean;
@@ -327,6 +332,7 @@ export async function readSessionLeafIdFromTranscriptAsync(
   return null;
 }
 
+/** Forks a checkpoint transcript through the stored leaf without rereading full session state. */
 export async function forkCompactionCheckpointTranscriptAsync(params: {
   sourceFile: string;
   sourceLeafId?: string;
@@ -372,6 +378,7 @@ export async function forkCompactionCheckpointTranscriptAsync(params: {
   try {
     await fs.mkdir(sessionDir, { recursive: true });
     const lines = [JSON.stringify(header)];
+    // Write a fresh session header, then copy only message entries from the source branch.
     for (const entry of forkEntries) {
       if ((entry as { type?: unknown }).type !== "session") {
         lines.push(JSON.stringify(entry));
@@ -423,6 +430,7 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
   };
 }
 
+/** Removes a retained legacy checkpoint transcript when its metadata is discarded. */
 export async function cleanupCompactionCheckpointSnapshot(
   snapshot: CapturedCompactionCheckpointSnapshot | null | undefined,
 ): Promise<void> {
@@ -488,6 +496,7 @@ export async function persistSessionCompactionCheckpoint(params: {
   const snapshotSessionFile = params.snapshot.sessionFile?.trim();
   const postSessionFile = params.postSessionFile?.trim();
   const postSourceLeafId = params.postLeafId?.trim() || params.postEntryId?.trim();
+  // Modern checkpoints fork from the compacted successor transcript; legacy snapshots are optional.
   if (!snapshotSessionFile && (!postSessionFile || !postSourceLeafId)) {
     log.warn("skipping compaction checkpoint persist: missing stable fork source", {
       sessionKey: params.sessionKey,
@@ -542,6 +551,7 @@ export async function persistSessionCompactionCheckpoint(params: {
     const checkpoints = sessionStoreCheckpoints(existing);
     checkpoints.push(checkpoint);
     const snapshotBytesByPath = await statCheckpointSnapshotBytes(checkpoints);
+    // Trim while holding the store mutation so list/get never observes over-budget metadata.
     trimmedCheckpoints = trimSessionCheckpoints(checkpoints, snapshotBytesByPath);
     store[target.canonicalKey] = {
       ...existing,
@@ -566,12 +576,14 @@ export async function persistSessionCompactionCheckpoint(params: {
   return checkpoint;
 }
 
+/** Lists checkpoints newest-first for RPC/UI callers. */
 export function listSessionCompactionCheckpoints(
   entry: Pick<SessionEntry, "compactionCheckpoints"> | undefined,
 ): SessionCompactionCheckpoint[] {
   return sessionStoreCheckpoints(entry).toSorted((a, b) => b.createdAt - a.createdAt);
 }
 
+/** Looks up a persisted checkpoint by id after applying the same ordering as list. */
 export function getSessionCompactionCheckpoint(params: {
   entry: Pick<SessionEntry, "compactionCheckpoints"> | undefined;
   checkpointId: string;

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -268,14 +268,15 @@ export class SessionHistorySseState {
       }
       const projectedMessage = addedMessages[0];
       if (projectedMessage !== undefined) {
-        const emittedMessage: SessionHistoryMessage =
+        // Mirrors and synthetic projections may drop seq metadata; restore the append seq.
+        const needsAppendSeq =
           isMessageToolMirrorMessage(projectedMessage) ||
-          resolveMessageSeq(projectedMessage) === undefined
-            ? // Mirrors and synthetic projections may drop seq metadata; restore the append seq.
-              (attachOpenClawTranscriptMeta(projectedMessage, {
-                seq: this.rawTranscriptSeq,
-              }) as SessionHistoryMessage)
-            : projectedMessage;
+          resolveMessageSeq(projectedMessage) === undefined;
+        const emittedMessage: SessionHistoryMessage = needsAppendSeq
+          ? (attachOpenClawTranscriptMeta(projectedMessage, {
+              seq: this.rawTranscriptSeq,
+            }) as SessionHistoryMessage)
+          : projectedMessage;
         const nextMessages = [...this.sentHistory.messages, emittedMessage];
         this.sentHistory = buildPaginatedSessionHistory({
           messages: nextMessages,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -47,6 +47,7 @@ type SessionHistoryRawSnapshot = {
   totalRawMessages?: number;
 };
 
+/** Expands a requested visible page into a raw transcript tail window for projection loss. */
 export function resolveSessionHistoryTailReadOptions(limit: number): {
   maxMessages: number;
   maxLines: number;
@@ -124,10 +125,12 @@ function paginateSessionMessages(
   return buildPaginatedSessionHistory({
     messages: paginatedMessages,
     hasMore: start > 0,
+    // Cursors point at the first currently returned seq, so the next page ends before it.
     ...(start > 0 && typeof firstSeq === "number" ? { nextCursor: String(firstSeq) } : {}),
   });
 }
 
+/** Projects raw transcript entries into the public session-history page shape. */
 export function buildSessionHistorySnapshot(params: {
   rawMessages: unknown[];
   maxChars?: number;
@@ -148,6 +151,7 @@ export function buildSessionHistorySnapshot(params: {
     params.totalRawMessages > params.rawMessages.length &&
     history.messages.length > 0
   ) {
+    // Tail reads can omit older raw lines even when projection produced a short visible page.
     const firstSeq = resolveMessageSeq(history.messages[0]);
     history.hasMore = true;
     if (typeof firstSeq === "number") {
@@ -164,6 +168,7 @@ export function buildSessionHistorySnapshot(params: {
   };
 }
 
+/** Keeps HTTP session-history SSE clients in sync without rereading on simple append events. */
 export class SessionHistorySseState {
   private readonly target: SessionHistoryTranscriptTarget;
   private readonly maxChars: number;
@@ -172,6 +177,7 @@ export class SessionHistorySseState {
   private sentHistory: PaginatedSessionHistory;
   private rawTranscriptSeq: number;
 
+  /** Seeds SSE state from the same raw snapshot used for the initial HTTP response. */
   static fromRawSnapshot(params: {
     target: SessionHistoryTranscriptTarget;
     rawMessages: unknown[];
@@ -222,6 +228,7 @@ export class SessionHistorySseState {
     return this.sentHistory;
   }
 
+  /** Applies an inline transcript append; returns null when the client needs no event. */
   appendInlineMessage(update: {
     message: unknown;
     messageId?: string;
@@ -233,6 +240,7 @@ export class SessionHistorySseState {
     const carriedSeq = asPositiveSafeInteger(update.messageSeq);
     if (carriedSeq !== undefined) {
       if (carriedSeq <= this.rawTranscriptSeq) {
+        // Out-of-order or duplicate seq means this SSE stream no longer owns a simple append.
         return { shouldRefresh: true };
       }
       this.rawTranscriptSeq = carriedSeq;
@@ -251,6 +259,7 @@ export class SessionHistorySseState {
     if (projectedMessages.length > this.sentHistory.messages.length) {
       const addedMessages = projectedMessages.slice(this.sentHistory.messages.length);
       if (addedMessages.length > 1) {
+        // Projection split one raw entry into multiple visible entries; refresh preserves order.
         this.sentHistory = buildPaginatedSessionHistory({
           messages: projectedMessages,
           hasMore: false,
@@ -262,7 +271,8 @@ export class SessionHistorySseState {
         const emittedMessage: SessionHistoryMessage =
           isMessageToolMirrorMessage(projectedMessage) ||
           resolveMessageSeq(projectedMessage) === undefined
-            ? (attachOpenClawTranscriptMeta(projectedMessage, {
+            ? // Mirrors and synthetic projections may drop seq metadata; restore the append seq.
+              (attachOpenClawTranscriptMeta(projectedMessage, {
                 seq: this.rawTranscriptSeq,
               }) as SessionHistoryMessage)
             : projectedMessage;
@@ -282,6 +292,7 @@ export class SessionHistorySseState {
     );
     if (!sanitizedMessage) {
       if (projectedMessages.length < this.sentHistory.messages.length) {
+        // Sanitization removed visible content and changed the page; force a full replacement.
         this.sentHistory = buildPaginatedSessionHistory({
           messages: projectedMessages,
           hasMore: false,
@@ -309,6 +320,7 @@ export class SessionHistorySseState {
     };
   }
 
+  /** Re-reads the transcript and replaces this SSE stream's page state. */
   async refreshAsync(): Promise<PaginatedSessionHistory> {
     const rawSnapshot = await this.readRawSnapshotAsync();
     const snapshot = this.buildSnapshot(rawSnapshot);
@@ -334,6 +346,7 @@ export class SessionHistorySseState {
 
   private async readRawSnapshotAsync(): Promise<SessionHistoryRawSnapshot> {
     if (this.cursor === undefined && typeof this.limit === "number") {
+      // Initial tail pages can use indexed stats; cursor pages need full history ordering.
       const snapshot = await readRecentSessionMessagesWithStatsAsync(
         this.target.sessionId,
         this.target.storePath,

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -22,6 +22,8 @@ import {
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { loadSessionEntry } from "./session-utils.js";
 
+// Remote callers can only kill a child run by proving the parent/requester
+// session that controls it; local direct requests use admin scope instead.
 const REQUESTER_SESSION_KEY_HEADER = "x-openclaw-requester-session-key";
 
 type SessionKeyPathResolution =
@@ -106,8 +108,9 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
-  // Remote requester kills only need abort/write authority and ownership proof;
-  // local admin kills require delete/admin authority and bypass ownership checks.
+  // Remote requester kills only need abort/write authority because
+  // subagent-control enforces ownership; local admin kills require delete/admin
+  // authority and intentionally bypass requester ownership checks.
   const requiredOperatorMethod =
     requesterSessionKey && !allowLocalAdminKill ? "sessions.abort" : "sessions.delete";
   const scopeAuth = authorizeOperatorScopesForMethod(requiredOperatorMethod, requestedScopes);

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -29,6 +29,7 @@ type SessionKeyPathResolution =
   | { matched: true; sessionKey: string }
   | { error: "invalid-session-key"; matched: true };
 
+/** Resolves /sessions/:sessionKey/kill without consulting Host headers. */
 function resolveSessionKeyFromPath(pathname: string): SessionKeyPathResolution {
   const match = pathname.match(/^\/sessions\/([^/]+)\/kill$/);
   if (!match) {
@@ -45,6 +46,7 @@ function resolveSessionKeyFromPath(pathname: string): SessionKeyPathResolution {
   }
 }
 
+/** Handles POST /sessions/:sessionKey/kill for admin and requester-owned kills. */
 export async function handleSessionKillHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -56,6 +58,7 @@ export async function handleSessionKillHttpRequest(
   },
 ): Promise<boolean> {
   const cfg = getRuntimeConfig();
+  // Use a fixed URL base so malformed Host headers cannot affect route matching.
   const url = new URL(req.url ?? "/", "http://localhost");
   const sessionKeyResolution = resolveSessionKeyFromPath(url.pathname);
   if (!sessionKeyResolution.matched) {
@@ -103,6 +106,8 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
+  // Remote requester kills only need abort/write authority and ownership proof;
+  // local admin kills require delete/admin authority and bypass ownership checks.
   const requiredOperatorMethod =
     requesterSessionKey && !allowLocalAdminKill ? "sessions.abort" : "sessions.delete";
   const scopeAuth = authorizeOperatorScopesForMethod(requiredOperatorMethod, requestedScopes);
@@ -125,6 +130,8 @@ export async function handleSessionKillHttpRequest(
 
   let killed = false;
   if (!allowLocalAdminKill && requesterSessionKey) {
+    // Requester-owned kills use the latest subagent run row for the canonical
+    // child session, then delegate ownership enforcement to subagent-control.
     const runEntry = getLatestSubagentRunByChildSessionKey(canonicalKey);
     if (runEntry) {
       const result = await killControlledSubagentRun({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -127,6 +127,12 @@ export function archiveSessionTranscriptsForSession(params: {
   return archiveSessionTranscriptsForSessionDetailed(params).map((entry) => entry.archivedPath);
 }
 
+/**
+ * Archives every transcript file known for a retired session and returns stable
+ * source/archive pairs for lifecycle hooks. Callers use the detailed form when
+ * hook payloads need to point at the archived transcript instead of the old
+ * live file path.
+ */
 export function archiveSessionTranscriptsForSessionDetailed(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -148,6 +154,11 @@ export function archiveSessionTranscriptsForSessionDetailed(params: {
   });
 }
 
+/**
+ * Emits `session_end` for a known Gateway session and removes it from shutdown
+ * tracking. Reset/delete/compaction paths call this after transcript archival
+ * so plugins receive the final stable transcript location.
+ */
 export function emitGatewaySessionEndPluginHook(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -202,6 +213,11 @@ export function emitGatewaySessionEndPluginHook(params: {
   });
 }
 
+/**
+ * Emits `session_start` for a new or resumed Gateway session and registers it
+ * for bounded shutdown finalization. The paired end hook may be emitted by
+ * reset/delete/compaction before shutdown ever runs.
+ */
 export function emitGatewaySessionStartPluginHook(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -333,6 +349,11 @@ export async function drainActiveSessionsForShutdown(params: {
   }
 }
 
+/**
+ * Unbinds a target session from channel/session binding state and optionally
+ * emits the subagent-ended compatibility hook used by existing lifecycle
+ * consumers.
+ */
 export async function emitSessionUnboundLifecycleEvent(params: {
   targetSessionKey: string;
   reason: "session-reset" | "session-delete";
@@ -366,6 +387,11 @@ export async function emitSessionUnboundLifecycleEvent(params: {
   );
 }
 
+/**
+ * Stops runtime-owned resources that can still write to the old session entry.
+ * Returning an error prevents the store mutation so active embedded runs cannot
+ * be reset out from under an in-flight provider/tool loop.
+ */
 async function ensureSessionRuntimeCleanup(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -420,6 +446,11 @@ async function ensureSessionRuntimeCleanup(params: {
   );
 }
 
+/**
+ * Runs one ACP cleanup operation under the reset/delete timeout budget. Timeout
+ * is reported separately from thrown errors because only a stuck runtime blocks
+ * the parent session mutation.
+ */
 async function runAcpCleanupStep(params: {
   op: () => Promise<void>;
 }): Promise<{ status: "ok" } | { status: "timeout" } | { status: "error"; error: unknown }> {
@@ -438,6 +469,11 @@ async function runAcpCleanupStep(params: {
   return outcome;
 }
 
+/**
+ * Cancels and closes the ACP runtime attached to a session key. Reset keeps
+ * enough metadata to create a fresh pending ACP session after the Gateway
+ * session id changes; delete removes the metadata instead.
+ */
 async function closeAcpRuntimeForSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -529,6 +565,11 @@ async function closeAcpRuntimeForSession(params: {
   return undefined;
 }
 
+/**
+ * Prepares persisted ACP metadata for the new post-reset session. Identity is
+ * downgraded to pending so the next ACP turn must rebind to a fresh runtime
+ * session instead of reusing IDs from the retired session.
+ */
 function buildPendingAcpMeta(base: SessionAcpMeta, now: number): SessionAcpMeta {
   const currentIdentity = base.identity;
   const nextIdentity = currentIdentity
@@ -645,6 +686,12 @@ async function closeChildAcpRuntimesForParent(params: {
   );
 }
 
+/**
+ * Performs all cleanup that must happen before a Gateway session store entry is
+ * replaced or deleted. Runtime cleanup failures can block the mutation; plugin
+ * host and child ACP cleanup failures are logged without preventing the parent
+ * operation.
+ */
 export async function cleanupSessionBeforeMutation(params: {
   cfg: OpenClawConfig;
   key: string;

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -742,6 +742,13 @@ export async function emitGatewayBeforeResetPluginHook(params: {
     });
 }
 
+/**
+ * Resets a gateway session in place and returns the newly allocated session
+ * entry. This is the shared reset authority for Gateway RPCs, TUI commands, and
+ * stateful plugin targets, so it performs target validation, runtime cleanup,
+ * store mutation, transcript archival, plugin hooks, and lifecycle unbinding in
+ * one ordered path.
+ */
 export async function performGatewaySessionReset(params: {
   key: string;
   agentId?: string;
@@ -751,6 +758,9 @@ export async function performGatewaySessionReset(params: {
   | { ok: true; key: string; entry: SessionEntry; agentId: string }
   | { ok: false; error: ReturnType<typeof errorShape> }
 > {
+  // Resolve the canonical store target before mutating anything. Global store
+  // keys can carry an agent id inside the session key; mismatched explicit
+  // agent ids must fail before hooks or cleanup observe the request.
   const resetTarget = (() => {
     const cfg = getRuntimeConfig();
     const explicitAgentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
@@ -810,6 +820,9 @@ export async function performGatewaySessionReset(params: {
     },
   );
   await triggerInternalHook(hookEvent);
+  // Cleanup runs before the store write so ACP runtimes, plugin hosts, browser
+  // sessions, CLI bindings, and child runtimes stop observing the soon-to-be
+  // retired session id.
   const mutationCleanupError = await cleanupSessionBeforeMutation({
     cfg,
     key: params.key,
@@ -946,6 +959,9 @@ export async function performGatewaySessionReset(params: {
     return nextEntry;
   });
   if (pendingAcpResetMeta) {
+    // ACP metadata may be discovered while closing the old runtime; reattach it
+    // to the newly allocated session id before plugin hooks can inspect reset
+    // state.
     writeAcpSessionMetaForMigration({
       sessionKey: pendingAcpResetMeta.sessionKey,
       sessionId: next.sessionId,
@@ -968,6 +984,9 @@ export async function performGatewaySessionReset(params: {
     agentId: target.agentId,
     reason: "reset",
   });
+  // Ensure the new transcript file exists immediately so subsequent channel,
+  // plugin, or Gateway events append to the fresh session instead of reviving
+  // the archived transcript.
   fs.mkdirSync(path.dirname(next.sessionFile as string), { recursive: true });
   if (!fs.existsSync(next.sessionFile as string)) {
     const header = {
@@ -982,6 +1001,9 @@ export async function performGatewaySessionReset(params: {
       mode: 0o600,
     });
   }
+  // End/start hooks intentionally fire after the new entry exists and the old
+  // transcript has been archived; consumers receive both the retired and new
+  // session ids without racing the store mutation.
   emitGatewaySessionEndPluginHook({
     cfg,
     sessionKey: target.canonicalKey ?? params.key,
@@ -1003,6 +1025,9 @@ export async function performGatewaySessionReset(params: {
     agentId: target.agentId,
   });
   if (hadExistingEntry) {
+    // Binding lifecycle unbind is only meaningful for a reset of an existing
+    // session. Creating the first entry should not look like a channel
+    // detachment.
     await emitSessionUnboundLifecycleEvent({
       targetSessionKey: target.canonicalKey ?? params.key,
       reason: "session-reset",

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -4,6 +4,7 @@ async function loadSessionSubagentReactivationRuntime() {
   return import("./session-subagent-reactivation.runtime.js");
 }
 
+/** Reactivates a completed child subagent session when a follow-up run is steered into it. */
 export async function reactivateCompletedSubagentSession(params: {
   sessionKey: string;
   runId?: string;
@@ -16,6 +17,7 @@ export async function reactivateCompletedSubagentSession(params: {
   if (!existing || typeof existing.endedAt !== "number") {
     return false;
   }
+  // Only ended rows are replaced; active rows still belong to their current run lifecycle.
   const { replaceSubagentRunAfterSteer } = await loadSessionSubagentReactivationRuntime();
   return replaceSubagentRunAfterSteer({
     previousRunId: existing.runId,

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -69,6 +69,12 @@ function canonicalizePathForComparison(filePath: string): string {
   }
 }
 
+/**
+ * Returns every plausible transcript path for a session, ordered from the
+ * caller-provided file toward generated and legacy locations. Reset and hook
+ * code rely on this order to prefer the live transcript while still finding
+ * stale/custom paths that need archival.
+ */
 export function resolveSessionTranscriptCandidates(
   sessionId: string,
   storePath: string | undefined,
@@ -125,6 +131,11 @@ export function resolveSessionTranscriptCandidates(
   return uniqueStrings(candidates);
 }
 
+/**
+ * Renames a transcript file with an archive suffix and emits the in-process
+ * transcript update event. The event keeps memory/session-history consumers in
+ * sync because archive renames are not discovered by directory watches.
+ */
 export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): string {
   const ts = formatSessionArchiveTimestamp();
   const archived = `${filePath}.${reason}.${ts}`;
@@ -142,6 +153,11 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
   return archived;
 }
 
+/**
+ * Archives all known transcript files for a session and returns only archive
+ * paths. Use `archiveSessionTranscriptsDetailed` when callers must preserve the
+ * source-to-archive mapping for lifecycle hook payloads.
+ */
 export function archiveSessionTranscripts(opts: {
   sessionId: string;
   storePath: string | undefined;
@@ -158,6 +174,11 @@ export function archiveSessionTranscripts(opts: {
   return archiveSessionTranscriptsDetailed(opts).map((entry) => entry.archivedPath);
 }
 
+/**
+ * Archives all existing transcript candidates for a session. Candidate failures
+ * are isolated through `onArchiveError` so one stale path does not prevent other
+ * transcripts from being archived.
+ */
 export function archiveSessionTranscriptsDetailed(opts: {
   sessionId: string;
   storePath: string | undefined;
@@ -208,6 +229,11 @@ export function archiveSessionTranscriptsDetailed(opts: {
   return archived;
 }
 
+/**
+ * Chooses the transcript path that should be sent with `session_end`. Archived
+ * paths win after reset/delete; otherwise the first existing live candidate is
+ * returned so shutdown hooks can still reference active transcripts.
+ */
 export function resolveStableSessionEndTranscript(params: {
   sessionId: string;
   storePath: string | undefined;
@@ -247,6 +273,11 @@ export function resolveStableSessionEndTranscript(params: {
   return {};
 }
 
+/**
+ * Removes archived transcript files older than the supplied retention window.
+ * Only filenames with a valid archive timestamp for the requested reason are
+ * counted, so unrelated files in the same directories are ignored.
+ */
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   olderThanMs: number;

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -9,6 +9,11 @@ const TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER = "[chat.history omitted: message
 
 type ParsedTranscriptRecord = Record<string, unknown>;
 
+/**
+ * Parsed transcript record plus byte metadata. Message readers use `offset` and
+ * `byteLength` to detect and describe oversized records without reparsing the
+ * full line.
+ */
 export type IndexedTranscriptEntry = {
   seq: number;
   id?: string;
@@ -40,6 +45,10 @@ type CacheEntry = {
   index: SessionTranscriptIndex;
 };
 
+/**
+ * Options for transcript index reads. `skip` bypasses cache reuse when a caller
+ * needs an uncached scan of the current file.
+ */
 type ReadSessionTranscriptIndexOptions = {
   cache?: "reuse" | "skip";
 };
@@ -119,6 +128,9 @@ function setCachedIndex(filePath: string, entry: CacheEntry): void {
   }
 }
 
+/**
+ * Clears cached and in-flight index builds between tests or runtime reset paths.
+ */
 export function clearSessionTranscriptIndexCache(): void {
   transcriptIndexCache.clear();
   transcriptIndexBuilds.clear();
@@ -136,6 +148,11 @@ function isTreeTranscriptRecord(record: ParsedTranscriptRecord): boolean {
   return record.type !== "session" && typeof record.id === "string" && "parentId" in record;
 }
 
+/**
+ * Builds a placeholder record for lines too large to parse safely. The prefix
+ * scan preserves id/parent/timestamp metadata so lookup and tree pruning still
+ * work without materializing the full message payload.
+ */
 function buildOversizedIndexedRawEntry(params: {
   line: string;
   offset: number;
@@ -214,6 +231,11 @@ async function visitTranscriptJsonLines(
   }
 }
 
+/**
+ * Reconstructs the active transcript branch from parent links. A cycle means
+ * the tree is corrupt, so the index returns no active tree entries instead of
+ * exposing an arbitrary partial branch.
+ */
 function buildActiveTreeEntries(params: {
   byId: Map<string, IndexedRawEntry>;
   leafId?: string;
@@ -255,6 +277,11 @@ function toIndexedEntries(rawEntries: IndexedRawEntry[]): IndexedTranscriptEntry
   return entries;
 }
 
+/**
+ * Builds the transcript index in one streaming pass. Tree-shaped transcripts
+ * expose only the active leaf branch; linear transcripts expose visible records
+ * in file order.
+ */
 async function buildSessionTranscriptIndex(
   filePath: string,
   stat: fs.Stats,
@@ -323,6 +350,11 @@ async function buildSessionTranscriptIndex(
   };
 }
 
+/**
+ * Reads or builds the cached transcript index for a file. Cache entries are
+ * invalidated by mtime/size, and concurrent readers for the same file version
+ * share a single in-flight build.
+ */
 export async function readSessionTranscriptIndex(
   filePath: string,
   opts: ReadSessionTranscriptIndexOptions = {},

--- a/src/gateway/session-transcript-key.ts
+++ b/src/gateway/session-transcript-key.ts
@@ -49,14 +49,24 @@ function sessionKeyMatchesTranscriptPath(params: {
     entry.sessionId,
     target.storePath,
     entry.sessionFile,
+    // Compare against the normalized agent id used by transcript candidate
+    // generation so per-agent and combined stores resolve the same paths.
     sessionAgentId,
   ).some((candidate) => resolveTranscriptPathForComparison(candidate) === params.targetPath);
 }
 
+/**
+ * Clears process-local transcript-key lookup cache between tests.
+ */
 export function clearSessionTranscriptKeyCacheForTests(): void {
   TRANSCRIPT_SESSION_KEY_CACHE.clear();
 }
 
+/**
+ * Resolves a transcript file path back to the Gateway session key that owns it.
+ * Event consumers use this to turn file-change notifications into session
+ * updates without scanning unrelated session state on every repeat event.
+ */
 export function resolveSessionKeyForTranscriptFile(sessionFile: string): string | undefined {
   const targetPath = resolveTranscriptPathForComparison(sessionFile);
   if (!targetPath) {
@@ -130,6 +140,9 @@ export function resolveSessionKeyForTranscriptFile(sessionFile: string): string 
       (a, b) => b.updatedAt - a.updatedAt,
     );
     const [freshestMatch, secondFreshestMatch] = sortedResolvedMatches;
+    // Duplicate keys for the same session id are reduced through the preferred
+    // key resolver. Different session ids sharing a transcript path are only
+    // safe when one has a strictly newer update timestamp.
     const resolvedKey =
       resolvedMatches.length === 1
         ? freshestMatch?.key

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -121,6 +121,11 @@ async function yieldTranscriptScan(): Promise<void> {
   });
 }
 
+/**
+ * Adds OpenClaw-owned metadata to a transcript message without replacing
+ * provider-authored fields. Readers use this for sequence numbers, record ids,
+ * compaction markers, and timing data that the UI and Gateway RPCs consume.
+ */
 export function attachOpenClawTranscriptMeta(
   message: unknown,
   meta: Record<string, unknown>,
@@ -144,6 +149,11 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
+/**
+ * Reads every message record for a session from the first existing transcript
+ * candidate. Synchronous callers use this for small/local paths; async indexed
+ * readers below are preferred when a full transcript can be large.
+ */
 export function readSessionMessages(
   sessionId: string,
   storePath: string | undefined,
@@ -187,6 +197,10 @@ type TailTranscriptRecord = {
   record: Record<string, unknown>;
 };
 
+/**
+ * Normalizes recent-message read limits to keep tail scans bounded even when a
+ * caller passes a large or partial option set.
+ */
 function normalizeRecentSessionReadOptions(opts?: Partial<ReadRecentSessionMessagesOptions>) {
   const maxMessages = resolveNonNegativeIntegerOption(opts?.maxMessages, 0);
   const maxBytes = resolveIntegerOption(opts?.maxBytes, RECENT_SESSION_MESSAGES_DEFAULT_MAX_BYTES, {
@@ -198,6 +212,11 @@ function normalizeRecentSessionReadOptions(opts?: Partial<ReadRecentSessionMessa
   return { maxMessages, maxBytes, maxLines };
 }
 
+/**
+ * Reads the tail of a transcript and returns up to `maxMessages` parsed
+ * messages. It scans from the end so channel previews and prompt contexts avoid
+ * loading full transcripts for long sessions.
+ */
 export function readRecentSessionMessages(
   sessionId: string,
   storePath: string | undefined,
@@ -546,6 +565,11 @@ export function visitSessionMessages(
   return messages.length;
 }
 
+/**
+ * Counts parsed message records while caching by transcript mtime/size. The
+ * cache is intentionally file-local metadata only, so transcript rewrites and
+ * archive rotations invalidate counts naturally.
+ */
 export function readSessionMessageCount(
   sessionId: string,
   storePath: string | undefined,
@@ -572,6 +596,10 @@ export function readSessionMessageCount(
   return count;
 }
 
+/**
+ * Async transcript reader used by Gateway RPCs and hooks. `full` mode uses the
+ * transcript index; `recent` mode delegates to the bounded tail scanner.
+ */
 export async function readSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -590,6 +618,11 @@ export async function readSessionMessagesAsync(
   return index?.entries.flatMap((entry) => indexedTranscriptEntryToMessages(entry)) ?? [];
 }
 
+/**
+ * Resolves one transcript message by provider/OpenClaw record id without
+ * parsing oversized lines. Oversized matches report sequence metadata so UI
+ * callers can show that the record exists without materializing it.
+ */
 export async function readSessionMessageByIdAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -615,6 +648,10 @@ export async function readSessionMessageByIdAsync(
   return { message, seq: entry.seq, oversized: false, found: true };
 }
 
+/**
+ * Visits indexed transcript messages in sequence order. This keeps full scans
+ * on the async index path and lets callers choose whether to reuse the cache.
+ */
 export async function visitSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -639,6 +676,10 @@ export async function visitSessionMessagesAsync(
   return index.entries.length;
 }
 
+/**
+ * Async message count using the transcript index and the same mtime/size cache
+ * as the synchronous count path.
+ */
 export async function readSessionMessageCountAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -666,6 +707,11 @@ export async function readSessionMessageCountAsync(
   return count;
 }
 
+/**
+ * Reads recent messages and annotates them with absolute sequence numbers. The
+ * total count lets consumers distinguish "first returned message" from "first
+ * transcript message".
+ */
 export function readRecentSessionMessagesWithStats(
   sessionId: string,
   storePath: string | undefined,
@@ -681,6 +727,9 @@ export function readRecentSessionMessagesWithStats(
   return { messages: messagesWithSeq, totalMessages };
 }
 
+/**
+ * Async bounded tail reader for recent transcript messages.
+ */
 export async function readRecentSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -713,6 +762,9 @@ export async function readRecentSessionMessagesAsync(
   return parseRecentTranscriptTailMessages(lines, maxMessages);
 }
 
+/**
+ * Async recent-message reader with total-count and absolute sequence metadata.
+ */
 export async function readRecentSessionMessagesWithStatsAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -728,6 +780,10 @@ export async function readRecentSessionMessagesWithStatsAsync(
   return { messages: messagesWithSeq, totalMessages };
 }
 
+/**
+ * Reads raw recent transcript lines for diagnostic and transcript-history
+ * callers that need line text instead of parsed message objects.
+ */
 export function readRecentSessionTranscriptLines(params: {
   sessionId: string;
   storePath: string | undefined;
@@ -818,6 +874,11 @@ export {
   resolveSessionTranscriptCandidates,
 } from "./session-transcript-files.fs.js";
 
+/**
+ * Keeps the newest suffix of an array whose JSON encoding fits `maxBytes`.
+ * Transcript and preview callers use this to preserve recent context while
+ * respecting Gateway payload limits.
+ */
 export function capArrayByJsonBytes<T>(
   items: T[],
   maxBytes: number,
@@ -844,6 +905,11 @@ type TranscriptMessage = {
   provenance?: unknown;
 };
 
+/**
+ * Extracts lightweight title fields from transcript head/tail chunks. The cache
+ * is keyed by file metadata and inter-session filtering so session lists can
+ * render titles without reparsing unchanged transcripts.
+ */
 export function readSessionTitleFieldsFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -916,6 +982,10 @@ export function readSessionTitleFieldsFromTranscript(
   }
 }
 
+/**
+ * Async title-field extractor for Gateway list/search surfaces that cannot
+ * block on synchronous file reads.
+ */
 export async function readSessionTitleFieldsFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1079,6 +1149,10 @@ function withOpenTranscriptFd<T>(filePath: string, read: (fd: number) => T | nul
   return null;
 }
 
+/**
+ * Reads the first user-authored message from a transcript candidate. Search and
+ * title code use this as a fallback when richer title fields are unavailable.
+ */
 export function readFirstUserMessageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1477,6 +1551,11 @@ function extractAggregateUsageFromTranscriptChunk(
   );
 }
 
+/**
+ * Aggregates the latest usage snapshot from the full transcript. This captures
+ * explicit usage records and transcript-derived estimates when providers do not
+ * emit fresh token totals.
+ */
 export function readLatestSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1498,6 +1577,10 @@ export function readLatestSessionUsageFromTranscript(
   });
 }
 
+/**
+ * Async full-transcript usage reader for RPC paths that should not block on
+ * large synchronous file reads.
+ */
 export async function readLatestSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1526,6 +1609,10 @@ export async function readLatestSessionUsageFromTranscriptAsync(
   }
 }
 
+/**
+ * Reads and aggregates usage from only the recent tail of a transcript. Callers
+ * use this when full transcript reads are too expensive for list/search refreshes.
+ */
 export async function readRecentSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1554,6 +1641,10 @@ export async function readRecentSessionUsageFromTranscriptAsync(
   }
 }
 
+/**
+ * Reads the most recent usage-like record from a bounded transcript tail
+ * without aggregating older records.
+ */
 export async function readLatestRecentSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1582,6 +1673,10 @@ export async function readLatestRecentSessionUsageFromTranscriptAsync(
   }
 }
 
+/**
+ * Synchronous bounded-tail usage reader for local callers that need an
+ * aggregate snapshot without loading the full transcript.
+ */
 export function readRecentSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1806,6 +1901,10 @@ function readRecentMessagesFromTranscript(
   }
 }
 
+/**
+ * Builds compact UI preview items from the newest transcript messages. It
+ * bounds both item count and text length so session list rows stay cheap.
+ */
 export function readSessionPreviewItemsFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1823,6 +1922,8 @@ export function readSessionPreviewItemsFromTranscript(
   const boundedItems = Math.max(1, Math.min(maxItems, 50));
   const boundedChars = Math.max(20, Math.min(maxChars, 2000));
 
+  // Try progressively larger tail windows so normal sessions return quickly,
+  // while sparse transcripts still have a chance to produce preview items.
   for (const readSize of PREVIEW_READ_SIZES) {
     const messages = readRecentMessagesFromTranscript(filePath, boundedItems, readSize);
     if (messages.length > 0 || readSize === PREVIEW_READ_SIZES[PREVIEW_READ_SIZES.length - 1]) {

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -95,6 +95,7 @@ function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
   res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
+/** Handles `/sessions/:key/history` JSON and SSE reads for the Gateway HTTP server. */
 export async function handleSessionHistoryHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -153,6 +154,7 @@ export async function handleSessionHistoryHttpRequest(
   const limit = resolveLimit(req);
   const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
   const effectiveMaxChars = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  // First pages can use a bounded indexed tail; cursor pages need full ordering before slicing.
   const boundedSnapshot =
     cursor === undefined && typeof limit === "number"
       ? await readRecentSessionMessagesWithStatsAsync(
@@ -183,6 +185,7 @@ export async function handleSessionHistoryHttpRequest(
   const history = historySnapshot.history;
 
   if (!shouldStreamSse(req)) {
+    // JSON callers get the same projection shape as the initial SSE `history` event.
     sendJson(res, 200, {
       sessionKey: target.canonicalKey,
       ...history,
@@ -192,6 +195,7 @@ export async function handleSessionHistoryHttpRequest(
 
   const transcriptCandidates = entry?.sessionId
     ? new Set(
+        // Archive/reset flows may move the active transcript; listen to every current candidate.
         resolveSessionTranscriptCandidates(
           entry.sessionId,
           target.storePath,
@@ -249,6 +253,7 @@ export async function handleSessionHistoryHttpRequest(
   };
 
   const queueStreamWork = (work: () => Promise<void>) => {
+    // Serialize async writes so reauth, refresh, and message events cannot interleave bytes.
     streamQueue = streamQueue
       .then(async () => {
         if (cleanedUp || res.writableEnded) {
@@ -266,6 +271,7 @@ export async function handleSessionHistoryHttpRequest(
   };
 
   const isStreamStillAuthorized = async (): Promise<boolean> => {
+    // Long-lived SSE streams re-check current auth/config before every heartbeat or event.
     const cfgLocal = getRuntimeConfig();
     const currentRequestAuth = await checkGatewayHttpRequestAuth({
       req,
@@ -320,6 +326,7 @@ export async function handleSessionHistoryHttpRequest(
       }
       if (update.message !== undefined) {
         if (limit === undefined && cursor === undefined) {
+          // Unbounded streams can emit a single message; paginated streams need page refreshes.
           const nextEvent = sseState.appendInlineMessage({
             message: update.message,
             messageId: update.messageId,

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -18,6 +18,10 @@ import {
   resolveGatewaySessionStoreTarget,
 } from "./session-utils.js";
 
+/**
+ * Canonical session-key lookup result used by Gateway RPC handlers and
+ * embedded agent tools before they read or mutate session state.
+ */
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
 
 function resolveSessionVisibilityFilterOptions(p: SessionsResolveParams) {
@@ -64,6 +68,8 @@ function isResolvedSessionKeyVisible(params: {
   if (typeof params.p.spawnedBy !== "string" || params.p.spawnedBy.trim().length === 0) {
     return true;
   }
+  // Exact key resolution still respects spawnedBy scoping. Use the shared list
+  // filter without a page limit so older child sessions remain addressable.
   return filterAndSortSessionEntries({
     cfg: params.cfg,
     store: params.store,
@@ -79,6 +85,8 @@ function findVisibleSessionIdMatches(params: {
   sessionId: string;
 }): Array<[string, SessionEntry]> {
   const now = Date.now();
+  // sessionId lookups need raw store entries for speed and ambiguity detection,
+  // but visibility rules still mirror the dashboard/session list filters.
   const entries = filterAndSortSessionEntries({
     cfg: params.cfg,
     store: params.store,
@@ -90,6 +98,11 @@ function findVisibleSessionIdMatches(params: {
   );
 }
 
+/**
+ * Resolves a caller-provided key, sessionId, or human label to the canonical
+ * stored session key, applying agent scope, visibility filters, and legacy key
+ * migration before returning a key to downstream session readers.
+ */
 export async function resolveSessionKeyFromResolveParams(params: {
   cfg: OpenClawConfig;
   p: SessionsResolveParams;
@@ -143,6 +156,8 @@ export async function resolveSessionKeyFromResolveParams(params: {
     if (!legacyKey) {
       return noSessionFoundResult(key);
     }
+    // Key callers may still pass older aliases. Canonicalize the store first so
+    // later reads, deletes, and embedded tools all converge on one key spelling.
     await updateSessionStore(target.storePath, (s) => {
       const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store: s });
       if (!s[primaryKey] && s[legacyKey]) {
@@ -203,6 +218,8 @@ export async function resolveSessionKeyFromResolveParams(params: {
   }
 
   const { storePath, store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
+  // Labels are user-facing and may collide. Reuse the list projection with
+  // limit 2 so the resolver can distinguish no-match, unique, and ambiguous.
   const list = listSessionsFromStore({
     cfg,
     storePath,

--- a/src/gateway/talk-handoff.ts
+++ b/src/gateway/talk-handoff.ts
@@ -103,6 +103,10 @@ type TalkHandoffRoomState = {
 
 const handoffs = new Map<string, TalkHandoffRecord>();
 
+/**
+ * Creates a short-lived Talk room handoff and returns the only plaintext token
+ * the caller can use to join or mutate that room.
+ */
 export function createTalkHandoff(params: TalkHandoffCreateParams): TalkHandoffCreateResult {
   pruneExpiredTalkHandoffs();
   const rawCreatedAt = Date.now();
@@ -146,11 +150,16 @@ export function createTalkHandoff(params: TalkHandoffCreateParams): TalkHandoffC
   return { ...toPublicTalkHandoffRecord(record), token };
 }
 
+/** Returns a live handoff record after pruning expired records from the in-memory registry. */
 export function getTalkHandoff(id: string): TalkHandoffRecord | undefined {
   pruneExpiredTalkHandoffs();
   return handoffs.get(id);
 }
 
+/**
+ * Authenticates a client into a handoff room and reports any displaced client
+ * events separately so callers can notify old and new connections differently.
+ */
 export function joinTalkHandoff(
   id: string,
   token: string,
@@ -181,6 +190,7 @@ export function joinTalkHandoff(
   };
 }
 
+/** Starts or adopts the active Talk turn for a token-authenticated handoff room. */
 export function startTalkHandoffTurn(
   id: string,
   token: string,
@@ -207,6 +217,7 @@ export function startTalkHandoffTurn(
   };
 }
 
+/** Ends the active Talk turn while preserving stale-turn errors from the controller. */
 export function endTalkHandoffTurn(
   id: string,
   token: string,
@@ -232,6 +243,7 @@ export function endTalkHandoffTurn(
   };
 }
 
+/** Cancels the active Talk turn with a room-scoped reason payload for observers. */
 export function cancelTalkHandoffTurn(
   id: string,
   token: string,
@@ -257,6 +269,7 @@ export function cancelTalkHandoffTurn(
   };
 }
 
+/** Closes a handoff room and returns the final event that active clients should receive. */
 export function revokeTalkHandoff(id: string): TalkHandoffRevokeResult {
   pruneExpiredTalkHandoffs();
   const record = handoffs.get(id);
@@ -277,6 +290,7 @@ export function revokeTalkHandoff(id: string): TalkHandoffRevokeResult {
   };
 }
 
+/** Verifies the caller-provided room token against the stored hash without exposing the token. */
 export function verifyTalkHandoffToken(record: TalkHandoffRecord, token: string): boolean {
   return record.tokenHash === hashTalkHandoffToken(token);
 }
@@ -299,6 +313,8 @@ function pruneExpiredTalkHandoffs(now = Date.now()): void {
   }
   for (const [id, record] of handoffs) {
     if (!isFutureDateTimestampMs(record.expiresAt, { nowMs: validNow })) {
+      // Emit a final room event before deletion so pollers do not silently lose
+      // the reason an otherwise valid handoff disappeared.
       appendTalkHandoffRoomEvent(record, {
         type: "session.closed",
         payload: { reason: "expired", handoffId: id, roomId: record.roomId },
@@ -357,6 +373,8 @@ function resolveTalkHandoffAccess(
     return { ok: false, reason: "not_found" };
   }
   if (!isFutureDateTimestampMs(record.expiresAt)) {
+    // Access checks also own lazy expiry cleanup; callers can treat "expired"
+    // as a terminal room state without separately revoking the handoff.
     appendTalkHandoffRoomEvent(record, {
       type: "session.closed",
       payload: { reason: "expired", handoffId: id, roomId: record.roomId },
@@ -378,6 +396,8 @@ function appendTalkHandoffRoomEvent(record: TalkHandoffRecord, input: TalkEventI
 function joinTalkHandoffRoom(record: TalkHandoffRecord, clientId: string | undefined): TalkEvent[] {
   const events: TalkEvent[] = [];
   if (record.room.activeClientId && record.room.activeClientId !== clientId) {
+    // A Talk handoff has one active room client. Replacement is explicit so the
+    // server can deliver the close notice to the old connection only.
     events.push(
       appendTalkHandoffRoomEvent(record, {
         type: "session.replaced",

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -142,12 +142,16 @@ function broadcastToOwner(
   connId: string,
   event: TalkTranscriptionRelayEvent,
 ): void {
+  // Relay events are connection-owned: a browser stream must not leak partial
+  // transcripts or audio activity to other Gateway clients.
   context.broadcastToConnIds(TRANSCRIPTION_EVENT, event, new Set([connId]), { dropIfSlow: true });
 }
 
 function ensureTranscriptionTurn(session: TranscriptionRelaySession): string {
   const turn = session.talk.ensureTurn();
   if (turn.event) {
+    // The STT provider can report speech before browser audio is explicitly
+    // forwarded, so turn creation also owns the user-visible speechStart event.
     broadcastToOwner(session.context, session.connId, {
       transcriptionSessionId: session.id,
       type: "speechStart",
@@ -164,6 +168,8 @@ function closeTranscriptionSession(
   if (session.closed) {
     return;
   }
+  // Close is idempotent because provider callbacks, explicit stop, and expiry
+  // timers can race while all need exactly one final session.closed event.
   session.closed = true;
   transcriptionSessions.delete(session.id);
   clearTimeout(session.cleanupTimer);
@@ -213,9 +219,12 @@ function enforceTranscriptionSessionLimits(connId: string): void {
   }
 }
 
+/** Creates a connection-owned Gateway relay session for browser-to-provider transcription audio. */
 export function createTalkTranscriptionRelaySession(
   params: CreateTalkTranscriptionRelaySessionParams,
 ): TalkTranscriptionRelaySessionResult {
+  // Browser relay currently accepts only Twilio-style 8 kHz mu-law audio; keep
+  // provider config honest before exposing a session id clients can stream to.
   enforceTranscriptionSessionLimits(params.connId);
   assertRelayInputAudioConfig(params.providerConfig);
   const transcriptionSessionId = randomUUID();
@@ -274,6 +283,8 @@ export function createTalkTranscriptionRelaySession(
       );
       const relay = relayRef.current;
       if (relay) {
+        // Provider final transcripts end the Talk turn, but the relay payload
+        // remains a transcript event so existing room clients stay on one feed.
         const ended = relay.talk.endTurn({ turnId, payload: {} });
         if (ended.ok) {
           broadcastToOwner(relay.context, relay.connId, {
@@ -326,6 +337,8 @@ export function createTalkTranscriptionRelaySession(
       emit({ transcriptionSessionId, type: "ready" }, { type: "session.ready", payload: null });
     })
     .catch((error: unknown) => {
+      // Surface connect failures through both the relay event and Talk event
+      // streams before closing so clients do not wait on a never-ready room.
       emit(
         {
           transcriptionSessionId,
@@ -372,6 +385,8 @@ function getTranscriptionSession(
     nowMs > expiresAtMs
   ) {
     if (session) {
+      // A stale or cross-connection lookup consumes the expired session so the
+      // registry cannot be used as a long-lived session-id oracle.
       closeTranscriptionSession(session, "completed");
     }
     throw new Error("Unknown transcription Talk session");
@@ -379,6 +394,7 @@ function getTranscriptionSession(
   return session;
 }
 
+/** Forwards one base64 browser audio frame into the owning STT provider session. */
 export function sendTalkTranscriptionRelayAudio(params: {
   transcriptionSessionId: string;
   connId: string;
@@ -403,6 +419,7 @@ export function sendTalkTranscriptionRelayAudio(params: {
   });
 }
 
+/** Commits any active relay turn, closes the provider session, and emits a final close event. */
 export function stopTalkTranscriptionRelaySession(params: {
   transcriptionSessionId: string;
   connId: string;
@@ -425,6 +442,7 @@ export function stopTalkTranscriptionRelaySession(params: {
   closeTranscriptionSession(session, "completed");
 }
 
+/** Cancels the current transcription turn and closes the relay session for the owner connection. */
 export function cancelTalkTranscriptionRelayTurn(params: {
   transcriptionSessionId: string;
   connId: string;

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -14,6 +14,7 @@ import { invokeGatewayTool, type ToolsInvokeInput } from "./tools-invoke-shared.
 
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
 
+/** Handles protocol-neutral HTTP tool invocation for Gateway/OpenAI-compatible callers. */
 export async function handleToolsInvokeHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -66,7 +67,8 @@ export async function handleToolsInvokeHttpRequest(
   }
   const body = (bodyUnknown ?? {}) as ToolsInvokeInput;
 
-  // Resolve message channel/account hints (optional headers) for policy inheritance.
+  // Carry optional channel/account hints into the shared invoker so tool policy
+  // inheritance matches the request's original delivery context.
   const messageChannel = normalizeMessageChannel(
     getHeader(req, "x-openclaw-message-channel") ?? "",
   );

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -18,6 +18,7 @@ import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 
+/** Raw request shape accepted by HTTP /tools/invoke and RPC tools.invoke. */
 export type ToolsInvokeInput = {
   tool?: unknown;
   name?: unknown;
@@ -66,6 +67,8 @@ function resolveMemoryToolDisableReasons(cfg: OpenClawConfig): string[] {
   if (!process.env.VITEST) {
     return [];
   }
+  // Tests disable memory by default to avoid implicit plugin startup; return
+  // explicit reasons so failed tool probes explain the exact config gate.
   const reasons: string[] = [];
   const plugins = cfg.plugins;
   const slotRaw = plugins?.slots?.memory;
@@ -94,6 +97,9 @@ function mergeActionIntoArgsIfSupported(params: {
   if (!action || args.action !== undefined) {
     return args;
   }
+  // Legacy HTTP callers can send action out-of-band. Only merge it when the
+  // target schema declares an action field, so tools without that contract do
+  // not receive surprising extra input.
   const schemaObj = toolSchema as { properties?: Record<string, unknown> } | null;
   const hasAction = Boolean(
     schemaObj &&
@@ -143,6 +149,11 @@ function resolveToolSource(tool: AnyAgentTool): "core" | "plugin" | "channel" {
   return "core";
 }
 
+/**
+ * Invokes a Gateway tool through the shared HTTP/RPC path.
+ * The returned outcome keeps transport status, approval state, and tool source
+ * separate so callers can project it into their protocol-specific envelope.
+ */
 export async function invokeGatewayTool(params: {
   cfg: OpenClawConfig;
   input: ToolsInvokeInput;
@@ -208,6 +219,8 @@ export async function invokeGatewayTool(params: {
       gatewayRequestedTools,
     });
 
+  // Core tool ids should not force plugin discovery; if policy only exposes the
+  // tool through normal Gateway resolution, retry with plugin tools enabled.
   let { agentId, tools } = resolveTools(knownCoreTool);
   if (knownCoreTool && !tools.some((candidate) => candidate.name === toolName)) {
     ({ agentId, tools } = resolveTools(false));
@@ -245,6 +258,8 @@ export async function invokeGatewayTool(params: {
       action,
       args,
     });
+    // The same before-tool hook mediates HTTP/RPC invokes and agent tool calls,
+    // preserving approval prompts, parameter rewrites, and loop detection.
     const hookResult = await runBeforeToolCallHook({
       toolName,
       params: toolArgs,

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -17,6 +17,11 @@ export type InputProvenance = {
   sourceTool?: string;
 };
 
+/**
+ * Literal marker prepended to model-visible text that came from another
+ * session or internal tool. Consumers also use this marker to hide or filter
+ * inter-session prompts from direct-user transcript views.
+ */
 export const INTER_SESSION_PROMPT_PREFIX_BASE = "[Inter-session message]";
 export const AGENT_MEDIATED_COMPLETION_SOURCE_TOOLS = [
   "agent_harness_task",
@@ -33,6 +38,10 @@ function isInputProvenanceKind(value: unknown): value is InputProvenanceKind {
   );
 }
 
+/**
+ * Normalizes untrusted provenance metadata from transcript records, tool
+ * payloads, and agent handoffs into the closed provenance shape.
+ */
 export function normalizeInputProvenance(value: unknown): InputProvenance | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -50,6 +59,11 @@ export function normalizeInputProvenance(value: unknown): InputProvenance | unde
   };
 }
 
+/**
+ * Attaches provenance to a user message only when it does not already carry
+ * valid provenance. This preserves the original source marker across nested
+ * forwarding paths.
+ */
 export function applyInputProvenanceToUserMessage(
   message: AgentMessage,
   inputProvenance: InputProvenance | undefined,
@@ -70,6 +84,9 @@ export function applyInputProvenanceToUserMessage(
   } as unknown as AgentMessage;
 }
 
+/**
+ * Checks whether metadata marks content as an inter-session handoff.
+ */
 export function isInterSessionInputProvenance(value: unknown): boolean {
   return normalizeInputProvenance(value)?.kind === "inter_session";
 }
@@ -98,6 +115,11 @@ export function shouldPreserveUserFacingSessionStateForInputProvenance(value: un
   return sourceTool ? USER_FACING_SESSION_STATE_PRESERVING_SOURCE_TOOLS.has(sourceTool) : false;
 }
 
+/**
+ * Detects user-role transcript messages that are not direct user input. Title,
+ * replay, and memory readers use this to avoid treating inter-session handoffs
+ * as the user's own instruction.
+ */
 export function hasInterSessionUserProvenance(
   message: { role?: unknown; provenance?: unknown } | undefined,
 ): boolean {
@@ -107,6 +129,10 @@ export function hasInterSessionUserProvenance(
   return isInterSessionInputProvenance(message.provenance);
 }
 
+/**
+ * Builds the model-visible envelope that explains inter-session provenance and
+ * carries compact source fields for audit/debugging.
+ */
 export function buildInterSessionPromptPrefix(
   inputProvenance: InputProvenance | undefined,
 ): string {
@@ -161,6 +187,8 @@ export function annotateInterSessionPromptText(
   if (text === prefix || text.startsWith(`${prefix}\n`)) {
     return text;
   }
+  // Keep exactly one generated marker at the front. Prompt decorators may have
+  // already moved or copied text that contains a literal marker.
   const body = removeFirstInterSessionPromptPrefix(text);
   return `${prefix}\n${body}`;
 }

--- a/src/sessions/send-policy.ts
+++ b/src/sessions/send-policy.ts
@@ -9,6 +9,7 @@ import { deriveSessionChatType } from "./session-chat-type.js";
 
 export type SessionSendPolicyDecision = "allow" | "deny";
 
+/** Normalizes stored/configured send-policy strings; invalid values inherit caller fallback. */
 export function normalizeSendPolicy(raw?: string | null): SessionSendPolicyDecision | undefined {
   const value = normalizeOptionalLowercaseString(raw);
   if (value === "allow") {
@@ -71,6 +72,10 @@ function deriveChatTypeFromKey(key?: string): SessionChatType | undefined {
   return undefined;
 }
 
+/**
+ * Resolves whether a session may send replies.
+ * Per-session overrides win, then ordered config rules, then config default, then allow.
+ */
 export function resolveSendPolicy(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
@@ -88,12 +93,14 @@ export function resolveSendPolicy(params: {
     return "allow";
   }
 
+  // Rules may intentionally target either stored agent-scoped keys or their session-key tail.
   const rawSessionKey = params.sessionKey ?? "";
   const strippedSessionKey = stripAgentSessionKeyPrefix(rawSessionKey) ?? "";
   const rawSessionKeyNorm = normalizeLowercaseStringOrEmpty(rawSessionKey);
   const strippedSessionKeyNorm = normalizeLowercaseStringOrEmpty(strippedSessionKey);
   let channel: string | undefined;
   let chatType: SessionChatType | undefined;
+  // Derive channel/chat type lazily so simple key-only rules do not infer extra metadata.
   const getChannel = () => {
     channel ??=
       normalizeMatchValue(params.channel) ??
@@ -138,6 +145,7 @@ export function resolveSendPolicy(params: {
       continue;
     }
     if (action === "deny") {
+      // Deny is fail-closed across matching rules; later allow rules cannot reopen it.
       return "deny";
     }
     allowedMatch = true;

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -69,12 +69,14 @@ function findCasePreservingPeerDescriptor(
   return CASE_PRESERVING_PEERS.find((d) => d.channel === c && d.peerKinds.has(k));
 }
 
+/** True when a folded legacy alias must be proven before merging with the canonical key. */
 export function requiresFoldedSessionKeyAliasProof(sessionKey: string | undefined | null): boolean {
   const ref = parseRawSessionConversationRef(sessionKey);
   const descriptor = findCasePreservingPeerDescriptor(ref?.channel, ref?.kind);
   return descriptor?.span === "tail";
 }
 
+/** Canonicalizes peer IDs unless the owning channel registered them as opaque/case-sensitive. */
 export function normalizeSessionPeerId(params: {
   channel: string | undefined | null;
   peerKind?: string | null;
@@ -202,6 +204,7 @@ export function normalizeSessionKeyPreservingOpaquePeerIds(
     writeNormalizedSessionKeyCache(raw, normalized);
     return normalized;
   }
+  // Preserve opaque peer spans first, then lowercase structural key syntax around them.
   const spans = collectCasePreservedSpans(raw)
     .filter((span) => span.end > span.start)
     .toSorted((a, b) => a.start - b.start);
@@ -250,6 +253,7 @@ export function parseAgentSessionKey(
   return { agentId, rest };
 }
 
+/** Matches cron run keys after agent scoping is stripped and canonicalized. */
 export function isCronRunSessionKey(sessionKey: string | undefined | null): boolean {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
@@ -258,6 +262,7 @@ export function isCronRunSessionKey(sessionKey: string | undefined | null): bool
   return /^cron:[^:]+:run:[^:]+(?::|$)/.test(parsed.rest);
 }
 
+/** Matches any cron-owned session key, scoped or legacy unscoped. */
 export function isCronSessionKey(sessionKey: string | undefined | null): boolean {
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed) {
@@ -266,6 +271,7 @@ export function isCronSessionKey(sessionKey: string | undefined | null): boolean
   return normalizeOptionalLowercaseString(parsed.rest)?.startsWith("cron:") === true;
 }
 
+/** Matches subagent keys in both current agent-scoped and legacy unscoped forms. */
 export function isSubagentSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = normalizeOptionalString(sessionKey);
   if (!raw) {
@@ -278,6 +284,7 @@ export function isSubagentSessionKey(sessionKey: string | undefined | null): boo
   return normalizeOptionalLowercaseString(parsed?.rest)?.startsWith("subagent:") === true;
 }
 
+/** Counts nested subagent ownership markers for depth sorting and display. */
 export function getSubagentDepth(sessionKey: string | undefined | null): number {
   const raw = normalizeOptionalLowercaseString(sessionKey);
   if (!raw) {
@@ -286,6 +293,7 @@ export function getSubagentDepth(sessionKey: string | undefined | null): number 
   return raw.split(":subagent:").length - 1;
 }
 
+/** Matches ACP session keys in both current agent-scoped and legacy unscoped forms. */
 export function isAcpSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = normalizeOptionalString(sessionKey);
   if (!raw) {
@@ -299,6 +307,7 @@ export function isAcpSessionKey(sessionKey: string | undefined | null): boolean 
   return normalizeOptionalLowercaseString(parsed?.rest)?.startsWith("acp:") === true;
 }
 
+/** Splits the last structural `:thread:` suffix without lowercasing opaque IDs. */
 export function parseThreadSessionSuffix(
   sessionKey: string | undefined | null,
 ): ParsedThreadSessionSuffix {
@@ -320,6 +329,7 @@ export function parseThreadSessionSuffix(
   return { baseSessionKey, threadId };
 }
 
+/** Parses channel/group conversation refs while preserving the raw provider-owned id tail. */
 export function parseRawSessionConversationRef(
   sessionKey: string | undefined | null,
 ): RawSessionConversationRef | null {
@@ -351,6 +361,7 @@ export function parseRawSessionConversationRef(
   return { channel, kind, rawId, prefix };
 }
 
+/** Returns the parent key only when the input has a non-empty thread suffix. */
 export function resolveThreadParentSessionKey(
   sessionKey: string | undefined | null,
 ): string | null {

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -1,3 +1,8 @@
+/**
+ * In-process session lifecycle notification consumed by Gateway websocket
+ * fanout. Payloads stay small because listeners reload the session row when
+ * they need a full snapshot.
+ */
 export type SessionLifecycleEvent = {
   sessionKey: string;
   reason: string;
@@ -10,6 +15,10 @@ type SessionLifecycleListener = (event: SessionLifecycleEvent) => void;
 
 const SESSION_LIFECYCLE_LISTENERS = new Set<SessionLifecycleListener>();
 
+/**
+ * Registers a lifecycle listener and returns its unsubscribe function. The bus
+ * is process-local, so callers must unsubscribe during runtime teardown/tests.
+ */
 export function onSessionLifecycleEvent(listener: SessionLifecycleListener): () => void {
   SESSION_LIFECYCLE_LISTENERS.add(listener);
   return () => {
@@ -17,6 +26,11 @@ export function onSessionLifecycleEvent(listener: SessionLifecycleListener): () 
   };
 }
 
+/**
+ * Emits a lifecycle event to all current listeners. Listener failures are
+ * isolated so one broken subscriber cannot prevent Gateway websocket fanout or
+ * other lifecycle consumers from seeing the event.
+ */
 export function emitSessionLifecycleEvent(event: SessionLifecycleEvent): void {
   for (const listener of SESSION_LIFECYCLE_LISTENERS) {
     try {

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -1,6 +1,12 @@
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
+/**
+ * In-process transcript mutation notification consumed by Gateway websocket
+ * fanout, session history, and transcript index refresh paths. `sessionFile` is
+ * required because archive and append events can be resolved from the file path
+ * even when the session key is not provided.
+ */
 export type SessionTranscriptUpdate = {
   sessionFile: string;
   sessionKey?: string;
@@ -14,6 +20,11 @@ type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
 
+/**
+ * Registers a transcript update listener and returns its unsubscribe function.
+ * The bus is process-local; callers that install long-lived listeners should
+ * unregister them during teardown.
+ */
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
   SESSION_TRANSCRIPT_LISTENERS.add(listener);
   return () => {
@@ -21,6 +32,11 @@ export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): 
   };
 }
 
+/**
+ * Emits a normalized transcript update. String inputs are shorthand for a file
+ * path-only mutation, and object inputs preserve optional session/message
+ * metadata for websocket subscribers.
+ */
 export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUpdate): void {
   const normalized =
     typeof update === "string"
@@ -38,6 +54,8 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
     return;
   }
   const messageSeq = asPositiveSafeInteger(normalized.messageSeq);
+  // Normalize before fanout so listeners can treat blank strings and invalid
+  // sequence numbers as absent rather than repeating validation work.
   const nextUpdate: SessionTranscriptUpdate = {
     sessionFile: trimmed,
     ...(normalizeOptionalString(normalized.sessionKey)

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -34,6 +34,7 @@ type PersistedUserTurnMediaFields = {
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }>;
 
+/** Canonical user-turn payload before it is appended to a session transcript. */
 export type UserTurnInput = {
   text?: string | null;
   media?: readonly PersistedUserTurnMediaInput[] | null;
@@ -45,6 +46,7 @@ export type UserTurnInput = {
 
 type UserTurnTranscriptUpdateMode = "inline" | "none";
 
+/** Last-chance transcript hook; returning a non-user message suppresses the persisted turn. */
 export type UserTurnBeforeMessageWrite = (params: {
   message: PersistedUserTurnMessage;
   agentId?: string;
@@ -109,6 +111,10 @@ type UserTurnTranscriptTargetResolver =
 
 type UserTurnInputResolver = () => UserTurnInput | undefined | Promise<UserTurnInput | undefined>;
 
+/**
+ * Coordinates one user turn between runtime-owned persistence and Gateway fallback persistence.
+ * Runtime paths mark ownership as they append; fallback waits when ownership is still pending.
+ */
 export type UserTurnTranscriptRecorder = {
   readonly message: PersistedUserTurnMessage | undefined;
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
@@ -228,6 +234,7 @@ function resolveTranscriptMediaType(params: {
   return params.explicitType ?? mimeTypeFromFilePath(params.mediaPath ?? params.mediaUrl);
 }
 
+/** Rebuilds transcript media inputs from persisted transcript fields for replay/import callers. */
 export function buildPersistedUserTurnMediaInputsFromFields(
   fields: PersistedUserTurnMediaFieldSource | null | undefined,
 ): PersistedUserTurnMediaInput[] {
@@ -334,6 +341,7 @@ export function mergePreparedUserTurnMessageForRuntime(params: {
   ) {
     return params.runtimeMessage;
   }
+  // Prepared metadata carries transcript-only fields; blocked hook markers must stay untouched.
   return {
     ...(params.runtimeMessage as unknown as Record<string, unknown>),
     ...(params.preparedMessage as unknown as Record<string, unknown>),
@@ -364,6 +372,7 @@ function applyBeforeMessageWriteToUserTurn(
   if (nextMessage?.role !== "user") {
     return undefined;
   }
+  // Hooks may redact or replace content, but provenance/idempotency stay attached to this turn.
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
@@ -397,6 +406,7 @@ export async function appendUserTurnTranscriptMessage(
     ...(params.config ? { config: params.config } : {}),
     message: resolvedMessage,
     idempotencyLookup: "scan",
+    // Run the hook only after idempotency lookup so duplicate replays reuse the stored turn.
     prepareMessageAfterIdempotencyCheck: (message) =>
       applyBeforeMessageWriteToUserTurn(message, params),
   });
@@ -407,6 +417,7 @@ export async function appendUserTurnTranscriptMessage(
   switch (params.updateMode ?? "inline") {
     case "inline":
       if (appended.appended) {
+        // Inline mode is the live UI path; idempotent no-op appends should not rebroadcast.
         emitSessionTranscriptUpdate({
           sessionFile: params.transcriptPath,
           ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
@@ -523,6 +534,7 @@ export function createUserTurnTranscriptRecorder(
           );
         } catch (error) {
           handlePersistenceError(error);
+          // Fall back to the admitted text-only message if late media staging fails.
           return message;
         }
       })();
@@ -574,6 +586,7 @@ export function createUserTurnTranscriptRecorder(
       if (!target) {
         return undefined;
       }
+      // The approved path may supply a fresher target after channel/session admission.
       const updateMode = options.updateMode ?? params.updateMode ?? "inline";
       const result = isUserTurnTranscriptFileTarget(target)
         ? await appendUserTurnTranscriptMessage({


### PR DESCRIPTION
## Summary
- Document ACP stateful target resolution, readiness, session creation, and in-place reset handoffs.
- Document the shared Gateway session reset authority and lifecycle helper contracts around target validation, cleanup, store mutation, ACP metadata carry-forward, transcript archival, hooks, shutdown tracking, and lifecycle unbind.
- Document Gateway shutdown session tracking, direct child-session lookup, and transcript archival/stable transcript resolution contracts.
- Document Gateway transcript utility APIs for message metadata, bounded tail reads, indexed async reads, title extraction, usage snapshots, and preview item generation.
- Document Gateway transcript index contracts for oversized records, active tree branches, cache invalidation, and in-flight build sharing.
- Document Gateway transcript-file-to-session-key lookup cache and ambiguity resolution contracts.
- Document Gateway session event broadcast contracts for transcript update serialization, global session fanout, sequence fallback, display-message fallback, and lifecycle events.
- Document the in-process session lifecycle event bus and listener failure isolation contract.
- Document the in-process transcript update event bus and normalization contract.
- Document session input provenance trust-boundary helpers and inter-session prompt envelope behavior.
- Document user-turn transcript persistence, hook, idempotency, runtime ownership, lazy media fallback, and update fanout contracts.
- Document session send-policy normalization, ordered rule resolution, raw-vs-stripped key matching, and deny-wins behavior.
- Document session-key utility contracts for opaque peer-id preservation, folded-alias proof gating, session-kind predicates, and thread suffix parsing.
- Document session-history state contracts for tail reads, cursor pagination, SSE inline append/refresh ownership, projection fallbacks, and transcript rereads.
- Document session-history HTTP endpoint contracts for JSON/SSE projection parity, bounded reads, transcript candidate tracking, serialized SSE writes, per-event reauthorization, and inline-vs-refresh updates.
- Document CLI-session history import and merge contracts for provider gating, local-history authority, comparable text normalization, timestamp-free dedupe, and stable ordering.
- Document Claude CLI history importer contracts for binding lookup, tool block normalization, tool result coalescing, path-safe transcript lookup, and fallback seed windows.
- Document chat transcript injection contracts for rich content preservation, parent-chain ownership, TTS/abort metadata, and transcript update fanout.
- Document chat display projection contracts for display text budgets, tool payload sanitization boundaries, phased assistant filtering, duplicate injected rows, message-tool mirrors, and recent/single-message projections.
- Document chat helper contracts for message sanitization, canvas preview attachment, oversized history trimming, abort partial persistence, pre-registered agent aborts, and stale announce-pair filtering.
- Document session handler contracts for lazy runtime loading, session event fanout, webchat mutation guards, checkpoint fork selection, first-send session creation, transcript ensure, scoped abort/subscription keys, global-agent routing, and active-run interruption.
- Document compaction checkpoint contracts for leaf scan/retention budgets, captured fork identity, reason mapping, newest-checkpoint retention, transcript forking, legacy snapshot cleanup, successor-transcript source requirements, store trimming, and list/get ordering.
- Document subagent reactivation contracts for completed child-session follow-up steering and ended-row-only replacement.
- Document chat state registry contracts for chat-run queues, buffered agent-event metadata, streaming state cleanup, session subscribers, session-message reverse indexes, and tool-event recipient TTL/final grace.
- Document chat abort contracts for abort-controller entries, stop-command detection, expiry bounds, scoped cleanup, in-flight history adoption, abort operation adapters, global delivery, lifecycle emission, provider id updates, and provider-wide aborts.
- Document chat attachment contracts for raw attachment input, inline image blocks, offloaded media refs, upload ceilings, typed errors, MIME precedence, decoded-size validation, media ID namespace guards, data-URL normalization, prompt-order preservation, text-only media placeholders, and all-or-nothing media cleanup.
- Document chat sanitizer contracts for sender-label preservation, user versus assistant/tool envelope grammar, display-safe single-message sanitization, and no-change array identity preservation.
- Document session resolve contracts for canonical key results, spawnedBy visibility, sessionId raw-store matching, public key/sessionId/label resolution, legacy key canonicalization, and label ambiguity detection.
- Document Gateway request-context contracts for shared handler context construction, live runtime references, approval recipient scope filtering, and device invalidation without immediate socket close.
- Document Gateway broadcast contracts for JSON frame fragment reuse, event scope/buffer/sequence enforcement, shared frame construction, and dropped global broadcast sequence gaps.
- Document Gateway runtime state handle contracts for safe default lifecycle handles, inert unref'd interval handles, and live snapshots for hook config, cron state, plugin services, and method lists.
- Document Gateway runtime-service handle contracts for post-ready maintenance handle adoption and shutdown-race cleanup of allocated maintenance intervals.
- Document Gateway lane concurrency contracts for applying config to agent, subagent, cron, and cron-nested process command lanes.
- Document Talk handoff contracts for creation, client replacement events, turn lifecycle, final revoke events, token hashing, and lazy expiry cleanup.
- Document Talk transcription relay contracts for owner-only broadcasts, fixed browser audio format, turn creation, idempotent close, stale-session cleanup, and public relay APIs.
- Document Gateway security path contracts for repeated decode candidates, canonical path selection, fail-closed protected-prefix checks, and plugin route auth prefixes.
- Document plugin HTTP route helper contracts for canonical path candidates, exact-vs-prefix ordering, protected-prefix auth, malformed-path fail-closed auth, route ownership predicates, node-capability route matching, scoped surface normalization, unique surface listing, shortest-TTL lease selection, runtime scope creation, request-dispatch ownership, upgrade dispatch ownership, plugin route runtime-scope inheritance, node-capability auth fallback, scoped URL normalization, token refresh, and lease extension.
- Document MCP loopback protocol contracts for server identity/version negotiation constants and JSON-RPC response builders.
- Document MCP loopback schema contracts for tool schema entries, safe tool-name reads, union schema flattening, and Gateway-scoped tool schema projection.
- Document MCP loopback active-runtime contracts for runtime snapshots, token publication, bearer-token selection, owner-token guarded clearing, and generated config placeholders.
- Document MCP loopback request contracts for HTTP envelope validation, bounded body reads, oversized request teardown, and header-to-tool-scope projection.
- Document MCP loopback handler contracts for JSON-RPC message handling, protocol negotiation, tool visibility validation, hook mediation, and result normalization.
- Document shared Gateway tools.invoke contracts for HTTP/RPC request input, test-only memory gates, legacy action merging, core-tool discovery retry, hook mediation, and protocol-neutral outcomes.
- Document Gateway HTTP helper contracts for shared auth/rate-limit/missing-scope envelopes, bounded JSON bodies, SSE headers, streaming sentinels, and disconnect aborts.
- Document Gateway HTTP auth contracts for header parsing, bearer extraction, origin policy, auth replies, scoped auth, operator-scope resolution, shared-secret trust, and owner resolution.
- Document Gateway HTTP request-context contracts for OpenAI-compatible model ids, model-to-agent routing, x-openclaw-model visibility checks, header precedence, and shared context construction.
- Document Gateway POST JSON endpoint helper contracts for tri-state handling, host-independent path matching, and scope-before-body-read enforcement.
- Document OpenAI-compatible models route contracts for model envelope projection, agent model-id listing, alias preservation, Host-independent path matching, and malformed-vs-missing model-id responses.
- Document OpenAI-compatible embeddings route contracts for request coercion, input grammar, base64 float32 encoding, input bounds, provider selection, override limits, agent-vs-provider model routing, memory-to-generic provider fallback, generic adapter semantics, and per-request dimensions.
- Document session kill route contracts for Host-independent path resolution, admin/requester-owned modes, remote requester versus local admin scopes, latest canonical child-run ownership checks, requester-header trust boundaries, and subagent-control ownership enforcement.
- Document managed outgoing image attachment contracts for storage limits, cleanup retention, transcript index caching, transient-to-history promotion, safe source ingestion, and authenticated HTTP serving.
- Document assistant identity contracts for fallback presentation, Gateway/UI resolver use, and default-agent versus named-agent branding precedence.
- Document channel health policy contracts for monitor/readiness inputs, pure snapshot evaluation, startup grace ordering, and restart reason mapping.
- Document Gateway auth mode policy contracts for shared explicit-mode errors, ambiguous secret detection, inherited secret-default handling, and fail-fast enforcement before auth-sensitive flows.
- Document rate-limit attempt serialization contracts for normalized IP/scope buckets, failure-safe queue chaining, and active-tail cleanup.
- Document agent prompt contracts for OpenAI-compatible conversation rows, internal stream-error filtering, and prompt history/current-message assembly.
- Document auth surface resolution contracts for non-interactive probe credentials, interactive failure reasons, remote fallback recovery, and local token/password precedence.
- Document Gateway agent list contracts for status/local summaries, explicit agent-list authority, disk-discovered agent inclusion, and main-key preservation.
- Document Gateway auth install policy contracts for explicit auth-mode decisions, durable password credential inference, and token creation requirements during service install.
- Document Gateway token source conflict contracts for local env-token precedence warnings, service/remote exclusions, and security/status diagnostic payloads.
- Document known weak Gateway secret contracts for published placeholder lists and startup rejection of example token/password sentinels.
- Document Gateway credential planner flag contracts for implicit token/password precedence and remote credential surface activation.
- Document Gateway connection auth contracts for public connection options, sync raw-config resolution, and async SecretRef-backed credential resolution.
- Document Gateway probe auth contracts for local-probe remote credential stripping, raw probe auth resolution, SecretRef-backed auth, and safe warning-returning helpers.
- Document Gateway auth token resolution contracts for precedence, env fallback modes, explicit token handling, and SecretRef visibility.
- Document configured SecretRef input contracts for fallback metadata, unresolved reason styles, and required SecretRef-only resolution.
- Document Gateway credential SecretRef selection contracts for explicit-auth bypass, active path checks, sentinel probing, and winning ref materialization.
- Document Gateway auth SecretRef helper contracts for configuration detection, active-mode token/password resolution, and cloned runtime materialization.
- Document Gateway auth resolver contracts for mode sources, runtime overrides, SecretRef exclusion, Tailscale allowance, and shared-secret projection.
- Document Gateway HTTP auth request contracts for scope trust fields and scoped authorization config snapshot behavior.
- Document Gateway plugin HTTP route helper contracts, Gateway POST JSON endpoint contracts for host-independent path ownership, per-route body limits, pre-body operator checks, and route-specific scope resolution.
- Document Gateway HTTP response helper contracts for JSON/text writers, method-not-allowed Allow handling, and invalid-request envelopes.
- Document Gateway HTTP routing helper contracts for model override resolution, agent-id selection precedence, and request context inputs.
- Document OpenResponses HTTP contracts for response-session continuity, hashed auth partitioning, shared URL input caps, tool-choice narrowing, and handler ownership.
- Document OpenAI Chat Completions HTTP contracts for configured limits, forced tool-choice routing, streamed tool-call deltas, active-turn image handling, prompt conversion, usage fallback, and handler ownership.
- Document Gateway HTTP listen, Control UI response, OpenResponses output-item, prompt, and file-content helper contracts.
- Document Control UI CSP header, link resolution, and route classification contracts.
- Document shared OpenAI-compatible tool_choice APIs and HTTP tools.invoke contracts, while removing the top-of-file tool_choice comment.
- Keep comments at API/contract points only; no file header or import comments.
- Split this from the already-landed Android comments PR #88554 onto fresh `main`.

## Verification
- `pnpm test packages/gateway-protocol/src/connect-error-details.test.ts src/gateway/server.auth.browser-hardening.test.ts src/gateway/reconnect-gating.test.ts packages/gateway-client/src/client.watchdog.test.ts`
- `pnpm test src/gateway/client-start-readiness.test.ts src/gateway/event-loop-ready.test.ts packages/gateway-client/src/event-loop-ready.test.ts packages/gateway-client/src/timeouts.test.ts`
- `pnpm test src/gateway/boot-echo-guard.test.ts src/gateway/boot.test.ts src/gateway/server-methods/chat-webchat-media.test.ts`
- `pnpm test src/gateway/config-reload.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-reload-handlers.test.ts`
- `pnpm test src/gateway/server-chat.stream-text-merge.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/server-methods/chat-webchat-media.test.ts`
- `pnpm test src/gateway/input-allowlist.test.ts src/gateway/client-bootstrap.test.ts src/gateway/config-reload.test.ts src/acp/server.startup.test.ts`
- `pnpm test src/gateway/control-ui-csp.test.ts src/gateway/control-ui-routing.test.ts src/commands/onboard-helpers.test.ts src/commands/dashboard.links.test.ts`
- `pnpm test src/gateway/server/http-listen.test.ts src/gateway/openresponses-phase.test.ts src/gateway/openresponses-http.test.ts src/gateway/control-ui.http.test.ts`
- `pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`
- `pnpm test src/gateway/openai-http.test.ts src/gateway/openai-http.usage.test.ts src/gateway/openai-http.image-budget.test.ts`
- `pnpm test src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`
- `pnpm test src/gateway/http-utils.model-override.test.ts src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts`
- `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts src/gateway/tools-invoke-http.test.ts`
- `pnpm test src/gateway/http-endpoint-helpers.test.ts src/gateway/openai-http.test.ts src/gateway/embeddings-http.test.ts`
- `pnpm test src/gateway/http-utils.authorize-request.test.ts src/gateway/http-endpoint-helpers.test.ts src/gateway/tools-invoke-http.test.ts`
- `pnpm test src/gateway/auth.test.ts src/gateway/credential-precedence.parity.test.ts src/gateway/startup-auth.test.ts`
- `pnpm test src/gateway/startup-auth.test.ts src/gateway/auth.test.ts src/gateway/credentials.test.ts`
- `pnpm test src/gateway/call.test.ts src/gateway/credentials.test.ts src/gateway/credential-precedence.parity.test.ts`
- `pnpm test src/gateway/resolve-configured-secret-input-string.test.ts src/plugin-sdk/config-runtime.test.ts src/cli/qr-cli.test.ts`
- `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/gateway-install-token.test.ts src/commands/dashboard.links.test.ts`
- `pnpm test src/gateway/probe-auth.test.ts src/gateway/credential-precedence.parity.test.ts`
- `pnpm test src/gateway/connection-auth.test.ts`
- `pnpm test src/gateway/credential-precedence.parity.test.ts src/gateway/credentials.test.ts`
- `pnpm test src/gateway/startup-auth.test.ts`
- `pnpm test src/security/audit-gateway.test.ts`
- `pnpm test src/commands/doctor-gateway-auth-token.test.ts`
- `pnpm test src/gateway/agent-list.test.ts`
- `pnpm test src/gateway/auth-surface-resolution.test.ts`
- `pnpm test src/gateway/agent-prompt.test.ts`
- `pnpm test src/gateway/server/ws-connection/auth-context.test.ts`
- `pnpm test src/gateway/auth-mode-policy.test.ts`
- `pnpm test src/gateway/channel-health-policy.test.ts`
- `pnpm test src/gateway/assistant-identity.test.ts`
- `pnpm test src/gateway/managed-image-attachments.test.ts`
- `git diff --check`
- `pnpm test src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `pnpm test src/gateway/active-sessions-shutdown-tracker.test.ts src/gateway/session-child-sessions.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server.sessions.reset-hooks.test.ts`
- `pnpm test src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-archive.imports.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server.sessions.reset-hooks.test.ts`
- `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/session-utils.test.ts src/gateway/session-utils.search.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts`
- `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/session-utils.test.ts`
- `pnpm test src/gateway/session-transcript-key.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/gateway/session-message-events.test.ts src/gateway/session-transcript-key.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
- `pnpm test src/sessions/session-lifecycle-events.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/sessions/transcript-events.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/sessions/input-provenance.test.ts src/gateway/session-utils.fs.test.ts src/gateway/session-history-state.test.ts`
- `pnpm test src/sessions/user-turn-transcript.test.ts src/sessions/input-provenance.test.ts src/sessions/transcript-events.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/sessions/send-policy.test.ts src/config/schema.help.quality.test.ts`
- `pnpm test src/sessions/session-key-case-preservation.test.ts src/routing/session-key.test.ts src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/explicit-session-key-normalization.test.ts`
- `pnpm test src/gateway/session-history-state.test.ts src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts`
- `pnpm test src/gateway/session-history-state.test.ts`
- `pnpm test src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts src/gateway/session-history-state.test.ts`
- `pnpm test src/gateway/cli-session-history.test.ts src/gateway/session-history-state.test.ts`
- `pnpm test src/gateway/cli-session-history.test.ts src/agents/command/attempt-execution.test.ts`
- `pnpm test src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/session-message-events.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/server-methods/sessions.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server.sessions.reset-hooks.test.ts`
- `pnpm test src/gateway/session-compaction-checkpoints.test.ts src/gateway/server.sessions.compaction.test.ts src/gateway/server.sessions.permissions-hooks.test.ts`
- `pnpm test src/gateway/session-subagent-reactivation.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts`
- `pnpm test src/gateway/server-chat.agent-events.test.ts src/gateway/gateway-misc.test.ts src/gateway/server-close.test.ts src/gateway/server-maintenance.test.ts`
- `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
- `pnpm test src/gateway/chat-attachments.test.ts src/gateway/server-node-events.test.ts`
- `pnpm test src/gateway/chat-sanitize.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts src/agents/tools/embedded-gateway-stub.test.ts`
- `pnpm test src/gateway/server-request-context.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server-maintenance.test.ts`
- `pnpm test src/gateway/server-runtime-state.test.ts src/gateway/server.startup-websocket-race.test.ts`
- `pnpm test src/gateway/server-runtime-services.test.ts`
- `pnpm test src/gateway/server-lanes.test.ts`
- `pnpm test src/gateway/talk-handoff.test.ts`
- `pnpm test src/gateway/talk-transcription-relay.test.ts`
- `pnpm test src/gateway/server/plugin-route-runtime-scopes.test.ts src/gateway/plugin-node-capability.test.ts src/gateway/server.plugin-node-capability-auth.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts`
- `pnpm test src/gateway/server/plugins-http.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts`
- `pnpm test src/gateway/server/plugins-http/route-capability.test.ts src/gateway/server/plugins-http.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts`
- `pnpm test src/gateway/server/plugins-http.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/server/plugins-http/route-capability.test.ts`
- `pnpm test src/gateway/security-path.test.ts`
- `pnpm test src/gateway/mcp-http.test.ts`
- `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`
- `pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts`
- `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts`
- `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.authorize-request.test.ts`
- `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.model-override.test.ts`
- `pnpm test src/gateway/http-endpoint-helpers.test.ts`
- `pnpm test src/gateway/models-http.test.ts`
- `pnpm test src/gateway/embeddings-http.test.ts src/gateway/openai-http.test.ts src/gateway/http-endpoint-helpers.test.ts`
- `pnpm test src/gateway/embeddings-http.test.ts`
- `pnpm test src/gateway/session-kill-http.test.ts src/gateway/server.sessions.reset-hooks.test.ts`
- `pnpm test src/gateway/session-kill-http.test.ts`

Behavior addressed: ACP stateful target, Gateway session reset/lifecycle/transcript/history, Gateway request-context contracts, Gateway broadcast contracts, Gateway runtime state handle contracts, Gateway runtime-service handle contracts, Gateway lane concurrency contracts, Gateway tools.invoke contracts, Gateway HTTP helper/auth/request-context/endpoint-helper/model-route/embeddings-route contracts, session kill route contracts, Talk handoff contracts, Talk transcription relay contracts, Gateway security path contracts, MCP loopback protocol/schema/runtime-state/request/handler contracts, session resolve contracts, session handler contracts, compaction checkpoint contracts, subagent reactivation, chat state registries, chat abort contracts, chat attachment contracts, chat sanitizer contracts, session history HTTP/SSE, CLI-session history imports, Claude CLI history imports, chat transcript injection, chat display projection/helper contracts, session user-turn transcript, send-policy, session-key utility contracts, managed outgoing image attachment contracts, assistant identity contracts, channel health policy contracts, Gateway auth mode policy contracts, rate-limit attempt serialization contracts, agent prompt contracts, auth surface resolution contracts, Gateway agent list contracts, Gateway auth install policy contracts, Gateway token source conflict contracts, known weak Gateway secret contracts, Gateway credential planner flag contracts, Gateway connection auth contracts, Gateway probe auth contracts, Gateway auth token resolution contracts, configured SecretRef input contracts, Gateway credential SecretRef selection contracts, Gateway auth SecretRef helper contracts, Gateway auth resolver contracts, Gateway HTTP auth request contracts, Gateway POST JSON endpoint contracts, Gateway HTTP response helper contracts, Gateway HTTP routing helper contracts, OpenResponses HTTP contracts, OpenAI Chat Completions HTTP contracts, and HTTP tool_choice/tools.invoke contracts are now documented at public/reused API and lifecycle handoff points; no runtime behavior intended.
Real environment tested: local macOS checkout on `codex/acp-stateful-target-comments-20260602` after rebasing on `origin/main`.
Exact steps or command run after this patch: `git diff --check`; `pnpm test packages/gateway-protocol/src/connect-error-details.test.ts src/gateway/server.auth.browser-hardening.test.ts src/gateway/reconnect-gating.test.ts packages/gateway-client/src/client.watchdog.test.ts`; `pnpm test src/gateway/client-start-readiness.test.ts src/gateway/event-loop-ready.test.ts packages/gateway-client/src/event-loop-ready.test.ts packages/gateway-client/src/timeouts.test.ts`; `pnpm test src/gateway/boot-echo-guard.test.ts src/gateway/boot.test.ts src/gateway/server-methods/chat-webchat-media.test.ts`; `pnpm test src/gateway/config-reload.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-reload-handlers.test.ts`; `pnpm test src/gateway/server-chat.stream-text-merge.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/server-methods/chat-webchat-media.test.ts`; `pnpm test src/gateway/input-allowlist.test.ts src/gateway/client-bootstrap.test.ts src/gateway/config-reload.test.ts src/acp/server.startup.test.ts`; `pnpm test src/gateway/control-ui-csp.test.ts src/gateway/control-ui-routing.test.ts src/commands/onboard-helpers.test.ts src/commands/dashboard.links.test.ts`; `pnpm test src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`; `pnpm test src/gateway/active-sessions-shutdown-tracker.test.ts src/gateway/session-child-sessions.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server.sessions.reset-hooks.test.ts`; `pnpm test src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-archive.imports.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server.sessions.reset-hooks.test.ts`; `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/session-utils.test.ts src/gateway/session-utils.search.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts`; `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/session-utils.test.ts`; `pnpm test src/gateway/session-transcript-key.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/gateway/session-message-events.test.ts src/gateway/session-transcript-key.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`; `pnpm test src/sessions/session-lifecycle-events.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/sessions/transcript-events.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/sessions/input-provenance.test.ts src/gateway/session-utils.fs.test.ts src/gateway/session-history-state.test.ts`; `pnpm test src/sessions/user-turn-transcript.test.ts src/sessions/input-provenance.test.ts src/sessions/transcript-events.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/sessions/send-policy.test.ts src/config/schema.help.quality.test.ts`; `pnpm test src/sessions/session-key-case-preservation.test.ts src/routing/session-key.test.ts src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/explicit-session-key-normalization.test.ts`; `pnpm test src/gateway/session-history-state.test.ts src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts`; `pnpm test src/gateway/session-history-state.test.ts`; `pnpm test src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts src/gateway/session-history-state.test.ts`; `pnpm test src/gateway/cli-session-history.test.ts src/gateway/session-history-state.test.ts`; `pnpm test src/gateway/cli-session-history.test.ts src/agents/command/attempt-execution.test.ts`; `pnpm test src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/session-message-events.test.ts src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/server-methods/sessions.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server.sessions.reset-hooks.test.ts`; `pnpm test src/gateway/session-compaction-checkpoints.test.ts src/gateway/server.sessions.compaction.test.ts src/gateway/server.sessions.permissions-hooks.test.ts`; `pnpm test src/gateway/session-subagent-reactivation.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts`; `pnpm test src/gateway/server-chat.agent-events.test.ts src/gateway/gateway-misc.test.ts src/gateway/server-close.test.ts src/gateway/server-maintenance.test.ts`; `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`; `pnpm test src/gateway/chat-attachments.test.ts src/gateway/server-node-events.test.ts`; `pnpm test src/gateway/chat-sanitize.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts src/agents/tools/embedded-gateway-stub.test.ts`; `pnpm test src/gateway/server-request-context.test.ts src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server-maintenance.test.ts`; `pnpm test src/gateway/server-runtime-state.test.ts src/gateway/server.startup-websocket-race.test.ts`; `pnpm test src/gateway/server-runtime-services.test.ts`; `pnpm test src/gateway/server-lanes.test.ts`; `pnpm test src/gateway/talk-handoff.test.ts`; `pnpm test src/gateway/talk-transcription-relay.test.ts`; `pnpm test src/gateway/security-path.test.ts`; `pnpm test src/gateway/server/plugins-http.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/server/plugins-http/route-capability.test.ts`; `pnpm test src/gateway/mcp-http.test.ts`; `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`; `pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts`; `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts`; `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.authorize-request.test.ts`; `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.model-override.test.ts`; `pnpm test src/gateway/http-endpoint-helpers.test.ts`; `pnpm test src/gateway/models-http.test.ts`; `pnpm test src/gateway/embeddings-http.test.ts`; `pnpm test src/gateway/session-kill-http.test.ts`; `pnpm test src/gateway/managed-image-attachments.test.ts`; `pnpm test src/gateway/assistant-identity.test.ts`; `pnpm test src/gateway/channel-health-policy.test.ts`; `pnpm test src/gateway/auth-mode-policy.test.ts`; `pnpm test src/gateway/server/ws-connection/auth-context.test.ts`; `pnpm test src/gateway/agent-prompt.test.ts`; `pnpm test src/gateway/auth-surface-resolution.test.ts`; `pnpm test src/gateway/agent-list.test.ts`; `pnpm test src/commands/doctor-gateway-auth-token.test.ts`; `pnpm test src/security/audit-gateway.test.ts`; `pnpm test src/gateway/startup-auth.test.ts`; `pnpm test src/gateway/credential-precedence.parity.test.ts src/gateway/credentials.test.ts`; `pnpm test src/gateway/connection-auth.test.ts`; `pnpm test src/gateway/probe-auth.test.ts src/gateway/credential-precedence.parity.test.ts`; `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/gateway-install-token.test.ts src/commands/dashboard.links.test.ts`; `pnpm test src/gateway/resolve-configured-secret-input-string.test.ts src/plugin-sdk/config-runtime.test.ts src/cli/qr-cli.test.ts`; `pnpm test src/gateway/call.test.ts src/gateway/credentials.test.ts src/gateway/credential-precedence.parity.test.ts`; `pnpm test src/gateway/startup-auth.test.ts src/gateway/auth.test.ts src/gateway/credentials.test.ts`; `pnpm test src/gateway/auth.test.ts src/gateway/credential-precedence.parity.test.ts src/gateway/startup-auth.test.ts`; `pnpm test src/gateway/http-utils.authorize-request.test.ts src/gateway/http-endpoint-helpers.test.ts src/gateway/tools-invoke-http.test.ts`; `pnpm test src/gateway/http-endpoint-helpers.test.ts src/gateway/openai-http.test.ts src/gateway/embeddings-http.test.ts`; `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts src/gateway/tools-invoke-http.test.ts`; `pnpm test src/gateway/http-utils.model-override.test.ts src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts`; `pnpm test src/gateway/openresponses-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openresponses-phase.test.ts src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`; `pnpm test src/gateway/openai-http.test.ts src/gateway/openai-http.usage.test.ts src/gateway/openai-http.image-budget.test.ts`; `pnpm test src/gateway/server/http-listen.test.ts src/gateway/openresponses-phase.test.ts src/gateway/openresponses-http.test.ts src/gateway/control-ui.http.test.ts`; `pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`
Evidence after fix: latest pushed commit 98c8722c3ff documents connect error detail codes, pairing-required reason/details payloads, auth and device-auth code mapping, recovery advice parsing, pairing request id normalization, pairing message/detail builders, legacy parsers, and protocol-aware message formatting; after confirming the branch was current on origin/main 6c8e065e3b1, `git diff --check origin/main..HEAD` and focused protocol/client auth tests passed locally.
Observed result after fix: PR branch pushed after adding the connect error detail protocol contracts slice.
What was not tested: broad channel suite, full build, full CI.

































