### PR TITLE
fix(ollama): skip unreadable tool descriptors

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -8,7 +8,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-import { buildAssistantMessage, createOllamaStreamFn } from "./stream.js";
+import { buildAssistantMessage, createOllamaStreamFn, testing } from "./stream.js";
 
 function makeOllamaResponse(params: {
   content?: string;
@@ -251,6 +251,35 @@ describe("createOllamaStreamFn thinking events", () => {
       timeoutMs: 2500,
       auditContext: "ollama-stream.chat",
     });
+  });
+
+  it("skips unreadable tool descriptors while preserving healthy siblings", () => {
+    const brokenTool = {
+      get name() {
+        throw new Error("ollama tool name getter exploded");
+      },
+      description: "broken",
+      parameters: { type: "object", properties: {} },
+    };
+    const healthyTool = {
+      name: "read_context",
+      description: "Read context",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+    };
+
+    expect(testing.buildOllamaToolNameSet([brokenTool, healthyTool] as never)).toEqual(
+      new Set(["read_context"]),
+    );
+    expect(testing.extractOllamaTools([brokenTool, healthyTool] as never)).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read_context",
+          description: "Read context",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ]);
   });
 
   it("promotes standalone bracketed local-model tool text to a structured tool call", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -912,11 +912,21 @@ function buildOllamaToolNameSet(tools: Tool[] | undefined): ReadonlySet<string> 
   }
   const names = new Set<string>();
   for (const tool of tools) {
-    if (typeof tool.name === "string" && tool.name.trim()) {
-      names.add(tool.name.trim());
+    const name = readOllamaToolName(tool);
+    if (name) {
+      names.add(name);
     }
   }
   return names.size > 0 ? names : undefined;
+}
+
+function readOllamaToolName(tool: Tool): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" && name.trim() ? name.trim() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeOllamaToolCallName(
@@ -1004,19 +1014,34 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
   }
   const result: OllamaTool[] = [];
   for (const tool of tools) {
-    if (typeof tool.name !== "string" || !tool.name) {
+    const projected = readOllamaTool(tool);
+    if (!projected) {
       continue;
     }
-    result.push({
-      type: "function",
-      function: {
-        name: tool.name,
-        description: typeof tool.description === "string" ? tool.description : "",
-        parameters: normalizeOllamaToolSchema(tool.parameters, true),
-      },
-    });
+    result.push(projected);
   }
   return result;
+}
+
+function readOllamaTool(tool: Tool): OllamaTool | undefined {
+  try {
+    const name = readOllamaToolName(tool);
+    if (!name) {
+      return undefined;
+    }
+    const description = typeof tool.description === "string" ? tool.description : "";
+    const parameters = normalizeOllamaToolSchema(tool.parameters, true);
+    return {
+      type: "function",
+      function: {
+        name,
+        description,
+        parameters,
+      },
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 export function buildAssistantMessage(
@@ -1494,3 +1519,8 @@ export function createConfiguredOllamaStreamFn(params: {
     resolveOllamaModelHeaders(params.model),
   );
 }
+
+export const testing = {
+  buildOllamaToolNameSet,
+  extractOllamaTools,
+};


### PR DESCRIPTION
Summary
- Guard Ollama tool name collection and tools payload projection against unreadable tool descriptors.
- Preserve healthy sibling tools when a malformed descriptor is skipped.
- Add focused regression coverage for unreadable descriptors in the Ollama projection helpers.

Verification
- Direct red/green source probe for buildOllamaToolNameSet/extractOllamaTools with an unreadable tool name getter and a healthy sibling.
- ./node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts
- git diff --check origin/main...HEAD
- Local autoreview: clean, no accepted/actionable findings
- AWS Crabbox: provider aws, lease cbx_cfe637cc6f49, run run_d706ad8f6be1, command pnpm check:changed, exit 0

Behavior addressed
Ollama provider tool projection no longer aborts when one tool descriptor has an unreadable name, while healthy sibling tools remain available for prompt/tool-call normalization and the Ollama tools payload.

Real environment tested
Local focused source probe on macOS, plus AWS Crabbox linux changed gate.

Exact steps or command run after this patch
pnpm check:changed via AWS Crabbox run run_d706ad8f6be1.

Evidence after fix
Direct source probe returns only the healthy read_context descriptor. AWS Crabbox changed gate exits 0 across extensions and extensionTests lanes.

Observed result after fix
Unreadable Ollama tool descriptors are skipped instead of crashing name collection or payload projection.

What was not tested
Live Ollama server call. Focused local Vitest for this file hung in the sparse worktree, so the broad proof is the AWS Crabbox changed gate.
