### PR TITLE
fix(xai): skip unreadable tool payload entries

### DIFF
--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -253,6 +253,53 @@ describe("xai stream wrappers", () => {
     expect(payload.tools[0]?.function).not.toHaveProperty("strict");
   });
 
+  it("skips unreadable tool payload entries while preserving healthy siblings", () => {
+    const payload = {
+      tools: [
+        {
+          type: "function",
+          get function() {
+            throw new Error("xai tool function getter exploded");
+          },
+        },
+        {
+          type: "function",
+          function: {
+            name: "broken_strict",
+            parameters: { type: "object", properties: {} },
+            get strict() {
+              throw new Error("xai tool strict getter exploded");
+            },
+          },
+        },
+        {
+          type: "function",
+          function: {
+            name: "read_context",
+            parameters: { type: "object", properties: {} },
+            strict: true,
+          },
+        },
+      ],
+    };
+
+    runXaiToolPayloadWrapper({
+      payload,
+      api: "openai-completions",
+      modelId: "grok-4-fast-non-reasoning",
+    });
+
+    expect(payload.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read_context",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
+
   it("strips unsupported reasoning controls from non-reasoning xai payloads", () => {
     const payload: Record<string, unknown> = {
       reasoning: { effort: "high" },

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -22,6 +22,8 @@ interface MutableAssistantMessageEventStream extends AsyncIterable<AssistantMess
   result: () => Promise<AssistantMessage>;
 }
 
+const OMIT_XAI_TOOL = Symbol("omit-xai-tool");
+
 function resolveXaiFastModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
@@ -29,22 +31,37 @@ function resolveXaiFastModelId(modelId: unknown): string | undefined {
   return XAI_FAST_MODEL_IDS.get(modelId.trim());
 }
 
-function stripUnsupportedStrictFlag(tool: unknown): unknown {
+function stripUnsupportedStrictFlag(tool: unknown) {
   if (!tool || typeof tool !== "object") {
     return tool;
   }
   const toolObj = tool as Record<string, unknown>;
-  const fn = toolObj.function;
+  let fn: unknown;
+  try {
+    fn = toolObj.function;
+  } catch {
+    return OMIT_XAI_TOOL;
+  }
   if (!fn || typeof fn !== "object") {
     return tool;
   }
   const fnObj = fn as Record<string, unknown>;
-  if (typeof fnObj.strict !== "boolean") {
+  let strict: unknown;
+  try {
+    strict = fnObj.strict;
+  } catch {
+    return OMIT_XAI_TOOL;
+  }
+  if (typeof strict !== "boolean") {
     return tool;
   }
-  const nextFunction = { ...fnObj };
-  delete nextFunction.strict;
-  return { ...toolObj, function: nextFunction };
+  try {
+    const nextFunction = { ...fnObj };
+    delete nextFunction.strict;
+    return { ...toolObj, function: nextFunction };
+  } catch {
+    return OMIT_XAI_TOOL;
+  }
 }
 
 function supportsExplicitImageInput(model: { input?: unknown }): boolean {
@@ -258,7 +275,14 @@ export function createXaiToolPayloadCompatibilityWrapper(
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
           if (Array.isArray(payloadObj.tools)) {
-            payloadObj.tools = payloadObj.tools.map((tool) => stripUnsupportedStrictFlag(tool));
+            const tools: unknown[] = [];
+            for (const tool of payloadObj.tools) {
+              const projectedTool = stripUnsupportedStrictFlag(tool);
+              if (projectedTool !== OMIT_XAI_TOOL) {
+                tools.push(projectedTool);
+              }
+            }
+            payloadObj.tools = tools;
           }
           normalizeXaiResponsesToolResultPayload(payloadObj, model);
           if (!supportsReasoningControls(model)) {


### PR DESCRIPTION
Summary:
- Guard xAI tool payload compatibility against unreadable tool/function/strict accessors.
- Drop only unreadable tool payload entries while preserving healthy siblings.
- Keep existing xAI `strict` stripping behavior for readable function tools.

Verification:
- Red probe before the fix:
  `node --import tsx -e '<probe>'` failed with `Error: xai tool function getter exploded` from `stripUnsupportedStrictFlag`.
- Direct source probe after the fix:
  `node --import tsx -e '<probe>'` returned `{"tools":[{"type":"function","function":{"name":"read_context","parameters":{"type":"object","properties":{}}}}]}`.
- `CI=1 node scripts/run-vitest.mjs extensions/xai/stream.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/xai/stream.ts extensions/xai/stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate passed:
  `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`
  Provider: `aws`; run: `run_dce1ffb5f533`; lease: `cbx_bd6e0de6afc4`; exit: 0; lanes: `extensions`, `extensionTests`; lease stopped: true.
- `origin/main` moved by 2 commits after the green Crabbox gate; a clean rebase was followed by focused direct source probe, format, diff-check, and Vitest sanity. Per repo rule, the full remote gate was not repeated.
- Local touched-file oxlint in the sparse Codex worktree reported SDK type-resolution false positives where `StreamFn` was treated as an error type; the AWS changed gate covered extension lint and passed with 0 warnings / 0 errors.

Behavior addressed: xAI payload compatibility no longer lets one unreadable tool payload entry abort strict-flag cleanup for healthy siblings.

Real environment tested: focused local Codex worktree proof plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: direct source probe, focused Vitest for `extensions/xai/stream.test.ts`, oxfmt, diff-check, local autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: unreadable `function` and `strict` getter entries were omitted, healthy `read_context` remained, `strict` was removed from that healthy function payload, focused xAI stream tests passed 14/14, and AWS changed gate exited 0.

Observed result after fix: the wrapper preserves readable tool payload siblings and no longer throws from unreadable xAI tool payload accessors.

What was not tested: no live xAI API request was made; this patch is confined to provider payload projection before dispatch.
