### PR TITLE
fix(sessions): guard agent tool definition mirroring

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2488,7 +2488,7 @@ export class AgentSession {
       ? Object.fromEntries(
           Object.entries(this.baseToolsOverride).map(([name, tool]) => [
             name,
-            createToolDefinitionFromAgentTool(tool),
+            createToolDefinitionFromAgentTool(tool, name),
           ]),
         )
       : createAllToolDefinitions(this.cwd, {

--- a/src/agents/sessions/tools/tool-definition-wrapper.test.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.test.ts
@@ -1,0 +1,62 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AgentTool } from "../../runtime/index.js";
+import { createToolDefinitionFromAgentTool } from "./tool-definition-wrapper.js";
+
+describe("createToolDefinitionFromAgentTool", () => {
+  it("falls back to registry metadata when agent tool descriptor fields are unreadable", async () => {
+    const tool = {
+      get name() {
+        throw new Error("session tool name getter exploded");
+      },
+      get label() {
+        throw new Error("session tool label getter exploded");
+      },
+      get description() {
+        throw new Error("session tool description getter exploded");
+      },
+      get parameters() {
+        throw new Error("session tool parameters getter exploded");
+      },
+      execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+    } as unknown as AgentTool;
+
+    const definition = createToolDefinitionFromAgentTool(tool, "base_read");
+
+    expect(definition.name).toBe("base_read");
+    expect(definition.label).toBe("base_read");
+    expect(definition.description).toBe("");
+    expect(definition.parameters).toMatchObject({ type: "object", properties: {} });
+    await expect(
+      definition.execute("call-1", {}, undefined, undefined, {} as never),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+    });
+  });
+
+  it("preserves readable agent tool metadata", () => {
+    const parameters = Type.Object({ query: Type.String() });
+    const prepareArguments = (args: unknown) => args as { query: string };
+    const tool = {
+      name: "custom_lookup",
+      label: "Custom Lookup",
+      description: "Looks up a test value.",
+      parameters,
+      prepareArguments,
+      executionMode: "sequential",
+      execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+    } satisfies AgentTool<typeof parameters>;
+
+    const definition = createToolDefinitionFromAgentTool(tool, "fallback_lookup");
+
+    expect(definition).toMatchObject({
+      name: "custom_lookup",
+      label: "Custom Lookup",
+      description: "Looks up a test value.",
+      parameters,
+      prepareArguments,
+      executionMode: "sequential",
+    });
+  });
+});

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -1,6 +1,23 @@
-import type { TSchema } from "typebox";
+import { Type, type TSchema } from "typebox";
 import type { AgentTool } from "../../runtime/index.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
+
+function createFallbackToolParameters(): TSchema {
+  return Type.Object({});
+}
+
+function readAgentToolField(tool: AgentTool, key: keyof AgentTool): unknown {
+  try {
+    return tool[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readAgentToolString(tool: AgentTool, key: keyof AgentTool): string | undefined {
+  const value = readAgentToolField(tool, key);
+  return typeof value === "string" && value ? value : undefined;
+}
 
 /** Wrap a ToolDefinition into an AgentTool for the core runtime. */
 export function wrapToolDefinition<
@@ -37,14 +54,32 @@ export function wrapToolDefinitions(
  * This keeps AgentSession's internal registry definition-first even when a caller
  * provides plain AgentTool overrides that do not include prompt metadata or renderers.
  */
-export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefinition {
+export function createToolDefinitionFromAgentTool(
+  tool: AgentTool,
+  fallbackName?: string,
+): ToolDefinition {
+  const name = readAgentToolString(tool, "name") ?? fallbackName ?? "tool";
+  const label = readAgentToolString(tool, "label") ?? name;
+  const description = readAgentToolString(tool, "description") ?? "";
+  const parametersValue = readAgentToolField(tool, "parameters");
+  const parameters =
+    parametersValue && typeof parametersValue === "object"
+      ? (parametersValue as TSchema)
+      : createFallbackToolParameters();
+  const prepareArguments = readAgentToolField(tool, "prepareArguments") as
+    | AgentTool["prepareArguments"]
+    | undefined;
+  const executionMode = readAgentToolField(tool, "executionMode") as
+    | AgentTool["executionMode"]
+    | undefined;
+
   return {
-    name: tool.name,
-    label: tool.label,
-    description: tool.description,
-    parameters: tool.parameters,
-    prepareArguments: tool.prepareArguments,
-    executionMode: tool.executionMode,
+    name,
+    label,
+    description,
+    parameters,
+    prepareArguments,
+    executionMode,
     execute: async (toolCallId, params, signal, onUpdate) =>
       tool.execute(toolCallId, params, signal, onUpdate),
   };


### PR DESCRIPTION
Summary:
- Guard `createToolDefinitionFromAgentTool()` against unreadable AgentTool descriptor fields.
- Use the base-tool registry key as the fallback name when mirroring base tool overrides.
- Preserve readable metadata and fall back to an empty object parameter schema when parameters are unreadable or invalid.

Verification:
- Red probe before the fix:
  `node --import tsx -e '<probe>'` failed with `Error: session tool name getter exploded` from `createToolDefinitionFromAgentTool`.
- Direct source probe after the fix:
  `node --import tsx -e '<probe>'` returned `{"name":"base_read","label":"base_read","description":"","parameters":{"type":"object","properties":{}}}`.
- `CI=1 node scripts/run-vitest.mjs src/agents/sessions/tools/tool-definition-wrapper.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts src/agents/sessions/agent-session.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts src/agents/sessions/agent-session.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox changed gate passed:
  `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`
  Provider: `aws`; run: `run_41e59c5b009d`; lease: `cbx_644164ab2aa2`; exit: 0; lanes: `core`, `coreTests`; lease stopped: true.
- `origin/main` moved before the broad gate; the branch rebased cleanly first. `origin/main` did not move after the green gate.

Behavior addressed: session base-tool override mirroring no longer lets one unreadable AgentTool descriptor abort runtime tool-definition construction.

Real environment tested: focused local Codex worktree proof plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: direct source probe, focused Vitest, oxfmt, touched-file oxlint, diff-check, local autoreview, and AWS Crabbox `pnpm check:changed`.

Evidence after fix: hostile name/description/parameters getters fall back to registry metadata and an empty object schema, focused test passed 2/2, and AWS changed gate exited 0.

Observed result after fix: readable AgentTool metadata is preserved, while unreadable descriptor fields no longer poison session tool-definition mirroring.

What was not tested: no live agent session was driven end to end; coverage is the pure wrapper behavior plus changed-gate type/lint/import-cycle checks.
