### PR TITLE
Fix backup verifier for root-relative hardlink targets

### DIFF
--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -358,6 +358,39 @@ describe("backupVerifyCommand", () => {
     }
   });
 
+  it("accepts root-relative internal hardlink targets from older backups", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-rootless-linkpath-"));
+    const archivePath = path.join(tempDir, "backup.tar.gz");
+    const rootRelativeTargetPath = "payload/posix/tmp/.openclaw/target.txt";
+    const payloadArchivePath = `${TEST_ARCHIVE_ROOT}/${rootRelativeTargetPath}`;
+    const hardlinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/hardlink.txt`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(payloadArchivePath), null, 2)}\n`,
+          }),
+          encodeTarEntry({ path: payloadArchivePath, contents: "payload\n" }),
+          encodeTarEntry({
+            path: hardlinkArchivePath,
+            type: "Link",
+            linkpath: rootRelativeTargetPath,
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject({
+        ok: true,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects hardlink targets missing from archive entries", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-missing-linkpath-"));
     const archivePath = path.join(tempDir, "broken.tar.gz");

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -301,14 +301,20 @@ function verifyHardlinkTargetsAgainstArchiveRoot(
 ): void {
   const normalizedRoot = normalizeArchiveRoot(archiveRoot);
   for (const target of hardlinkTargets) {
-    if (!isArchivePathWithin(target.normalized, normalizedRoot)) {
+    // Older backup archives may store hardlink linkpath values relative to the
+    // archive root instead of including the root segment. Accept that form only
+    // when it resolves to a real entry inside this archive.
+    const normalizedTarget = isArchivePathWithin(target.normalized, normalizedRoot)
+      ? target.normalized
+      : path.posix.join(normalizedRoot, target.normalized);
+    if (!isArchivePathWithin(normalizedTarget, normalizedRoot)) {
       throw new Error(
-        `Archive hardlink target is outside the declared archive root: ${target.entryPath} -> ${target.normalized}`,
+        `Archive hardlink target is outside the declared archive root: ${target.entryPath} -> ${normalizedTarget}`,
       );
     }
-    if (!entries.has(target.normalized)) {
+    if (!entries.has(normalizedTarget)) {
       throw new Error(
-        `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${target.normalized}`,
+        `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${normalizedTarget}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Accept older backup hardlink targets that are stored relative to the archive root when they resolve to an existing entry inside the archive.
- Keep absolute, backslash, and traversal hardlink validation intact before the compatibility path.
- Add regression coverage for the older internal hardlink shape reported in #89257.

Refs #89257

AI-assisted: yes, prepared with Codex and checked with `codex review` before submission.

## Verification
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts src/infra/backup-create.test.ts src/commands/backup.create-verify.test.ts src/commands/backup.atomic.test.ts src/cli/program/register.backup.test.ts`
- `git diff --check -- src/commands/backup-verify.ts src/commands/backup-verify.test.ts`
- `pnpm build`
- `codex review --base origin/main`

## Real behavior proof
Behavior addressed: `backup verify` now accepts older backup archives whose internal hardlink targets are recorded relative to the archive payload/root, while preserving rejection for unsafe or missing hardlink targets.

Real environment tested: Source checkout on the PR branch, using a synthetic backup archive that matches the reported older internal hardlink shape. Release-branch reproduction of the verifier failure was confirmed separately before the fix.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts src/infra/backup-create.test.ts src/commands/backup.create-verify.test.ts src/commands/backup.atomic.test.ts src/cli/program/register.backup.test.ts`
- `git diff --check -- src/commands/backup-verify.ts src/commands/backup-verify.test.ts`
- `pnpm build`
- `codex review --base origin/main`
- Disposable state smoke:
  ```sh
  TMP_ROOT=$(mktemp -d)
  mkdir -p "$TMP_ROOT/home" "$TMP_ROOT/state" "$TMP_ROOT/backups" "$TMP_ROOT/state/node_modules/a" "$TMP_ROOT/state/node_modules/b"
  printf '{}\n' > "$TMP_ROOT/state/openclaw.json"
  printf 'shared\n' > "$TMP_ROOT/state/node_modules/a/file.txt"
  ln "$TMP_ROOT/state/node_modules/a/file.txt" "$TMP_ROOT/state/node_modules/b/file.txt"
  HOME="$TMP_ROOT/home" OPENCLAW_HOME="$TMP_ROOT/home" OPENCLAW_STATE_DIR="$TMP_ROOT/state" OPENCLAW_CONFIG_PATH="$TMP_ROOT/state/openclaw.json" node openclaw.mjs backup create --output "$TMP_ROOT/backups" --verify --no-include-workspace
  find "$TMP_ROOT/backups" -maxdepth 1 -name '*.tmp' -print
  rm -rf "$TMP_ROOT"
  ```

Evidence after fix: Focused backup tests passed, build passed, Codex review reported no actionable regressions, and the disposable create/verify smoke printed `Archive verification: passed` with no `.tmp` files listed.

Observed result after fix: The new verifier regression accepts the older internal hardlink target shape, while existing unsafe and missing hardlink target tests continue to pass.

What was not tested: Full `pnpm check && pnpm test`; the reporter's actual archive; the reported `backup create --verify` exit-13 temp archive failure; applying this fix to `release/2026.5.28`.
