### PR TITLE
fix(auto-reply): guard exported session tool schemas

### DIFF
--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -8,7 +8,7 @@ const hoisted = await vi.hoisted(async () => {
     ...createExportCommandSessionMocks(vi),
     resolveCommandsSystemPromptBundleMock: vi.fn(async () => ({
       systemPrompt: "system prompt",
-      tools: [],
+      tools: [] as unknown[],
       skillsPrompt: "",
       bootstrapFiles: [],
       injectedFiles: [],
@@ -163,6 +163,16 @@ function writtenHtml(): string {
   return value;
 }
 
+function decodedSessionData(): { tools?: unknown } {
+  const match = writtenHtml().match(/<script\b[^>]*\bid="session-data"[^>]*>([^<]*)<\/script>/u);
+  if (!match) {
+    throw new Error("Expected encoded session data");
+  }
+  return JSON.parse(Buffer.from(match[1], "base64").toString("utf8")) as {
+    tools?: unknown;
+  };
+}
+
 describe("buildExportSessionReply", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -183,7 +193,7 @@ describe("buildExportSessionReply", () => {
     });
     hoisted.resolveCommandsSystemPromptBundleMock.mockResolvedValue({
       systemPrompt: "system prompt",
-      tools: [],
+      tools: [] as unknown[],
       skillsPrompt: "",
       bootstrapFiles: [],
       injectedFiles: [],
@@ -270,6 +280,60 @@ describe("buildExportSessionReply", () => {
       ).toString("base64"),
     );
     expect(html).toContain('const base64 = document.getElementById("session-data").textContent;');
+  });
+
+  it("skips unexportable tool schemas while preserving healthy siblings", async () => {
+    const unreadableParameters = {
+      name: "fuzzplugin_unreadable_parameters",
+      description: "unreadable parameters",
+    };
+    Object.defineProperty(unreadableParameters, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin export tool parameters getter exploded");
+      },
+    });
+    const cyclicParameters: Record<string, unknown> = { type: "object" };
+    cyclicParameters.self = cyclicParameters;
+    const cyclicTool = {
+      name: "fuzzplugin_cyclic_schema",
+      description: "cyclic parameters",
+      parameters: cyclicParameters,
+    };
+    hoisted.resolveCommandsSystemPromptBundleMock.mockResolvedValue({
+      systemPrompt: "system prompt",
+      tools: [
+        unreadableParameters,
+        cyclicTool,
+        {
+          name: "healthy_reader",
+          description: "Read context",
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+        },
+      ],
+      skillsPrompt: "",
+      bootstrapFiles: [],
+      injectedFiles: [],
+      sandboxRuntime: { sandboxed: false, mode: "off" },
+    });
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).toContain("✅ Session exported!");
+    expect(reply.text).toContain("🔧 Tools: 1");
+    expect(decodedSessionData().tools).toEqual([
+      {
+        name: "healthy_reader",
+        description: "Read context",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+        },
+      },
+    ]);
   });
 
   it("suffixes colliding default export filenames instead of overwriting", async () => {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -9,6 +9,7 @@ import {
   type SessionHeader,
 } from "../../agents/sessions/session-manager.js";
 import { pathExists } from "../../infra/fs-safe.js";
+import { copyArrayEntries, isRecord as isSafeRecord } from "../../shared/safe-record.js";
 import type { ReplyPayload } from "../types.js";
 import {
   isReplyPayload,
@@ -29,6 +30,11 @@ interface SessionData {
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
 }
 
+type ExportSessionTool = NonNullable<SessionData["tools"]>[number];
+
+type ExportToolField = { readable: true; value: unknown } | { readable: false };
+type SerializableExportValue = { serializable: true; value: unknown } | { serializable: false };
+
 type SessionExportJsonlWarning = {
   code: "invalid-session-json" | "invalid-session-row";
   row: number;
@@ -42,6 +48,64 @@ type SessionExportWarningSummary = {
 
 async function loadTemplate(fileName: string): Promise<string> {
   return await fsp.readFile(path.join(EXPORT_HTML_DIR, fileName), "utf-8");
+}
+
+function readExportToolField(tool: unknown, field: string): ExportToolField {
+  if (!isSafeRecord(tool)) {
+    return { readable: false };
+  }
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function cloneSerializableExportValue(value: unknown): SerializableExportValue {
+  let encoded: string | undefined;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    return { serializable: false };
+  }
+  if (encoded === undefined) {
+    return { serializable: false };
+  }
+  return { serializable: true, value: JSON.parse(encoded) as unknown };
+}
+
+function projectExportSessionTool(tool: unknown): ExportSessionTool | undefined {
+  const name = readExportToolField(tool, "name");
+  if (!name.readable || typeof name.value !== "string" || !name.value.trim()) {
+    return undefined;
+  }
+
+  const parameters = readExportToolField(tool, "parameters");
+  if (!parameters.readable) {
+    return undefined;
+  }
+
+  const projected: ExportSessionTool = { name: name.value };
+  const description = readExportToolField(tool, "description");
+  if (description.readable && typeof description.value === "string") {
+    projected.description = description.value;
+  }
+
+  if (parameters.value !== undefined) {
+    const serializableParameters = cloneSerializableExportValue(parameters.value);
+    if (!serializableParameters.serializable) {
+      return undefined;
+    }
+    projected.parameters = serializableParameters.value;
+  }
+  return projected;
+}
+
+function projectExportSessionTools(tools: unknown): ExportSessionTool[] {
+  return copyArrayEntries(tools).flatMap((tool) => {
+    const projected = projectExportSessionTool(tool);
+    return projected ? [projected] : [];
+  });
 }
 
 function replaceHtmlPlaceholder(template: string, name: string, value: string): string {
@@ -280,6 +344,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
     ...params,
     sessionEntry: entry as HandleCommandsParams["sessionEntry"],
   });
+  const exportedTools = projectExportSessionTools(tools);
 
   // 4. Prepare session data
   const sessionData: SessionData = {
@@ -287,11 +352,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
     entries,
     leafId,
     systemPrompt,
-    tools: tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      parameters: t.parameters,
-    })),
+    tools: exportedTools,
   };
 
   // 5. Generate HTML
@@ -330,7 +391,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
       `📊 Entries: ${entries.length}`,
       ...warnings.map(formatSessionExportWarning),
       `🧠 System prompt: ${systemPrompt.length.toLocaleString()} chars`,
-      `🔧 Tools: ${tools.length}`,
+      `🔧 Tools: ${exportedTools.length}`,
     ].join("\n"),
   };
 }


### PR DESCRIPTION
## Summary
- Guard `/export-session` tool metadata projection so unreadable or non-JSON-serializable parameter schemas are skipped instead of crashing HTML generation.
- Preserve serializable sibling tool descriptors in the exported session data and report the exported-safe tool count.

## Verification
- Red proof: temporarily reverted `src/auto-reply/reply/commands-export-session.ts` while keeping the new test; `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-export-session.test.ts --reporter=dot` failed on `fuzzplugin export tool parameters getter exploded`.
- `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-export-session.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/commands-export-session.ts src/auto-reply/reply/commands-export-session.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/commands-export-session.ts src/auto-reply/reply/commands-export-session.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after the production/test changes and again after the test typing fix.
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"` -> `run_e0751261df5b`, lease `cbx_47a53a4a6505`, exit 0.
- Post-rebase sanity: `CI=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-export-session.test.ts --reporter=dot`

## Real behavior proof
Behavior addressed: `/export-session` no longer crashes while embedding resolved tool descriptors when a tool has an unreadable or non-JSON-serializable parameter schema; healthy sibling tool descriptors still appear in the exported HTML session data.

Real environment tested: AWS Crabbox Linux c7a.8xlarge via `run_e0751261df5b` / `cbx_47a53a4a6505`, plus focused local Vitest in the Codex worktree.

Exact steps or command run after this patch: `pnpm check:changed` through `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: Crabbox `run_e0751261df5b` completed with exit 0; focused local Vitest passed 8 tests after the final rebase.

Observed result after fix: `check:changed` selected `core, coreTests` and completed successfully; the focused regression preserved only the healthy exported tool descriptor.

What was not tested: Manual browser inspection of the generated HTML. Resolver-level unreadable tool-name handling is separate from this export-schema boundary and is already tracked by https://github.com/openclaw/openclaw/pull/89292.
