### PR TITLE
fix(tools): guard planner descriptor reads

### DIFF
--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,4 +1,7 @@
-export type ToolPlanContractErrorCode = "duplicate-tool-name" | "missing-executor";
+export type ToolPlanContractErrorCode =
+  | "duplicate-tool-name"
+  | "invalid-descriptor"
+  | "missing-executor";
 
 export class ToolPlanContractError extends Error {
   readonly code: ToolPlanContractErrorCode;

--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -79,6 +79,61 @@ describe("buildToolPlan", () => {
     expect(contractError.toolName).toBe("read");
   });
 
+  it("fails with a contract error when descriptor names are unreadable", () => {
+    const unreadable = descriptor("unreadable");
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("planner descriptor name getter exploded");
+      },
+    });
+
+    let error: unknown;
+    try {
+      buildToolPlan({
+        descriptors: [unreadable, descriptor("healthy")],
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(ToolPlanContractError);
+    const contractError = error as ToolPlanContractError;
+    expect(contractError.code).toBe("invalid-descriptor");
+    expect(contractError.toolName).toBe("tool[0]");
+    expect(contractError.message).toBe("Tool descriptor name is unreadable: tool[0]");
+  });
+
+  it("does not re-read descriptor names while reporting missing executors", () => {
+    const stateful = descriptor("stateful", { executor: undefined });
+    let nameReads = 0;
+    Object.defineProperty(stateful, "name", {
+      enumerable: true,
+      get() {
+        nameReads += 1;
+        if (nameReads > 1) {
+          throw new Error("planner descriptor name was read twice");
+        }
+        return "stateful";
+      },
+    });
+
+    let error: unknown;
+    try {
+      buildToolPlan({
+        descriptors: [stateful],
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(nameReads).toBe(1);
+    expect(error).toBeInstanceOf(ToolPlanContractError);
+    const contractError = error as ToolPlanContractError;
+    expect(contractError.code).toBe("missing-executor");
+    expect(contractError.toolName).toBe("stateful");
+  });
+
   it("does not require an executor for unavailable descriptors", () => {
     const plan = buildToolPlan({
       descriptors: [

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -3,19 +3,70 @@ import { ToolPlanContractError } from "./diagnostics.js";
 import type {
   BuildToolPlanOptions,
   HiddenToolPlanEntry,
+  ToolExecutorRef,
   ToolDescriptor,
   ToolPlan,
   ToolPlanEntry,
 } from "./types.js";
 
-function compareDescriptors(left: ToolDescriptor, right: ToolDescriptor): number {
+type PlanningDescriptor = {
+  descriptor: ToolDescriptor;
+  executor: ToolExecutorRef | undefined;
+  index: number;
+  name: string;
+  sortKey: string;
+};
+
+function invalidDescriptor(index: number, message: string): never {
+  const toolName = `tool[${index}]`;
+  throw new ToolPlanContractError({
+    code: "invalid-descriptor",
+    toolName,
+    message: `${message}: ${toolName}`,
+  });
+}
+
+function readDescriptorField(
+  descriptor: ToolDescriptor,
+  field: keyof ToolDescriptor,
+  index: number,
+): unknown {
+  try {
+    return descriptor[field];
+  } catch {
+    return invalidDescriptor(index, `Tool descriptor ${field} is unreadable`);
+  }
+}
+
+function prepareDescriptor(descriptor: ToolDescriptor, index: number): PlanningDescriptor {
+  const name = readDescriptorField(descriptor, "name", index);
+  if (typeof name !== "string") {
+    invalidDescriptor(index, "Tool descriptor name must be a string");
+  }
+
+  const sortKey = readDescriptorField(descriptor, "sortKey", index);
+  if (sortKey !== undefined && typeof sortKey !== "string") {
+    invalidDescriptor(index, "Tool descriptor sortKey must be a string when present");
+  }
+
+  return {
+    descriptor,
+    executor: readDescriptorField(descriptor, "executor", index) as ToolExecutorRef | undefined,
+    index,
+    name,
+    sortKey: sortKey ?? name,
+  };
+}
+
+function compareDescriptors(left: PlanningDescriptor, right: PlanningDescriptor): number {
   return (
-    (left.sortKey ?? left.name).localeCompare(right.sortKey ?? right.name) ||
-    left.name.localeCompare(right.name)
+    left.sortKey.localeCompare(right.sortKey) ||
+    left.name.localeCompare(right.name) ||
+    left.index - right.index
   );
 }
 
-function assertUniqueNames(descriptors: readonly ToolDescriptor[]): void {
+function assertUniqueNames(descriptors: readonly PlanningDescriptor[]): void {
   const seen = new Set<string>();
   for (const descriptor of descriptors) {
     if (seen.has(descriptor.name)) {
@@ -30,13 +81,14 @@ function assertUniqueNames(descriptors: readonly ToolDescriptor[]): void {
 }
 
 export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
-  const descriptors = options.descriptors.toSorted(compareDescriptors);
+  const descriptors = options.descriptors.map(prepareDescriptor).toSorted(compareDescriptors);
   assertUniqueNames(descriptors);
 
   const visible: ToolPlanEntry[] = [];
   const hidden: HiddenToolPlanEntry[] = [];
 
-  for (const descriptor of descriptors) {
+  for (const planned of descriptors) {
+    const descriptor = planned.descriptor;
     const diagnostics = [
       ...evaluateToolAvailability({ descriptor, context: options.availability }),
     ];
@@ -44,14 +96,14 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
       hidden.push({ descriptor, diagnostics });
       continue;
     }
-    if (!descriptor.executor) {
+    if (!planned.executor) {
       throw new ToolPlanContractError({
         code: "missing-executor",
-        toolName: descriptor.name,
-        message: `Visible tool descriptor has no executor ref: ${descriptor.name}`,
+        toolName: planned.name,
+        message: `Visible tool descriptor has no executor ref: ${planned.name}`,
       });
     }
-    visible.push({ descriptor, executor: descriptor.executor });
+    visible.push({ descriptor, executor: planned.executor });
   }
 
   return { visible, hidden };


### PR DESCRIPTION
## Summary
- Snapshot tool descriptor planning fields once before sorting, duplicate checks, and missing-executor reporting.
- Convert unreadable or invalid descriptor names/sort keys into `ToolPlanContractError` instead of leaking arbitrary getter errors.
- Keep missing-executor errors stable when descriptor names are stateful or hostile.

## Verification
- Red proof: temporarily reverted `src/tools/planner.ts` and `src/tools/diagnostics.ts` while keeping the new tests; `CI=1 node scripts/run-vitest.mjs src/tools/planner.test.ts --reporter=dot` failed because the raw getter error escaped and stateful names were read twice.
- `CI=1 node scripts/run-vitest.mjs src/tools/planner.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/tools/planner.ts src/tools/planner.test.ts src/tools/diagnostics.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/tools/planner.ts src/tools/planner.test.ts src/tools/diagnostics.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean.
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"` -> `run_d02fc033b476`, lease `cbx_57f43360e2f5`, exit 0.
- Post-rebase sanity: `CI=1 node scripts/run-vitest.mjs src/tools/planner.test.ts --reporter=dot`

## Real behavior proof
Behavior addressed: tool planning no longer leaks raw descriptor getter failures or re-reads hostile descriptor names while sorting and reporting contract errors.

Real environment tested: AWS Crabbox Linux c7a.8xlarge via `run_d02fc033b476` / `cbx_57f43360e2f5`, plus focused local Vitest in the Codex worktree.

Exact steps or command run after this patch: `pnpm check:changed` through `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: Crabbox `run_d02fc033b476` completed with exit 0; focused local Vitest passed 8 tests after the final rebase.

Observed result after fix: `check:changed` selected `core, coreTests` and completed successfully; the planner regression reports `invalid-descriptor` for unreadable names and keeps missing-executor errors stable after a single name read.

What was not tested: End-to-end runtime use of the experimental `src/tools` planner beyond the focused planner contract tests.
