### PR TITLE
docs: note active memory timeout circuit breaker

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -797,6 +797,7 @@ If active memory is too slow:
 
 - lower `queryMode`
 - lower `timeoutMs`
+- keep the circuit breaker enabled so repeated timeouts skip recall briefly
 - reduce recent turn counts
 - reduce per-turn char caps
 
@@ -845,6 +846,19 @@ confirm `config.toolsAllow` names the tools that plugin actually registers.
 
     See [Cold-start grace](#cold-start-grace) under Recommended setup for the
     recommended `setupGraceTimeoutMs` value.
+
+  </Accordion>
+
+  <Accordion title="Every reply feels delayed after repeated Active Memory timeouts">
+    Active Memory keeps a small per-agent/model circuit breaker. After
+    consecutive `status=timeout` results, it skips recall for a short cooldown
+    instead of blocking every reply on the same failing path. The defaults are
+    `circuitBreakerMaxTimeouts: 3` and `circuitBreakerCooldownMs: 60000`.
+
+    If you already tuned `timeoutMs` and `setupGraceTimeoutMs` but still see
+    bursts of repeated timeouts, lower `circuitBreakerMaxTimeouts` to trip
+    sooner or raise `circuitBreakerCooldownMs` to give the memory backend more
+    time to recover.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -797,7 +797,7 @@ If active memory is too slow:
 
 - lower `queryMode`
 - lower `timeoutMs`
-- keep the circuit breaker enabled so repeated timeouts skip recall briefly
+- tune `circuitBreakerMaxTimeouts` and `circuitBreakerCooldownMs` so repeated timeouts skip recall briefly
 - reduce recent turn counts
 - reduce per-turn char caps
 


### PR DESCRIPTION
## Summary
- note that repeated Active Memory timeouts are handled by the existing automatic circuit breaker
- add a troubleshooting entry for repeated Active Memory timeout delays
- document and point operators at the real `circuitBreakerMaxTimeouts` and `circuitBreakerCooldownMs` knobs

## Real behavior proof
- **Behavior or issue addressed:** The slow Active Memory troubleshooting guidance no longer implies a separate circuit-breaker enable/disable setting. It now points operators at the actual timeout-count and cooldown knobs exposed by the Active Memory config.
- **Real environment tested:** Local OpenClaw checkout on macOS, branch `docs/active-memory-timeout-circuit-breaker`, OpenClaw CLI `OpenClaw 2026.5.20 (e510042)`, PR head `83fcdad0a1328ff8a8a105de98d71e0fccbd8d16`.
- **Exact steps or command run after this patch:** Ran `openclaw --version`; inspected the changed docs and runtime config with `rg`; ran `git diff --check`; ran `git diff --check origin/main...HEAD`; ran `node scripts/check-docs-mdx.mjs docs/concepts/active-memory.md`; ran `node scripts/format-docs.mjs --check`.
- **Evidence after fix:** Terminal output from the local checkout:

  ```text
  $ openclaw --version
  OpenClaw 2026.5.20 (e510042)

  $ rg -n 'tune `circuitBreakerMaxTimeouts`|circuitBreakerMaxTimeouts\?:|circuitBreakerCooldownMs\?:' docs/concepts/active-memory.md extensions/active-memory/index.ts
  docs/concepts/active-memory.md:800:- tune `circuitBreakerMaxTimeouts` and `circuitBreakerCooldownMs` so repeated timeouts skip recall briefly
  extensions/active-memory/index.ts:161:  circuitBreakerMaxTimeouts?: number;
  extensions/active-memory/index.ts:162:  circuitBreakerCooldownMs?: number;

  $ node scripts/check-docs-mdx.mjs docs/concepts/active-memory.md
  Docs MDX check passed (1 files, 49ms).

  $ node scripts/format-docs.mjs --check
  Docs formatting clean (661 files).
  ```

- **Observed result after fix:** The documentation points to the real `circuitBreakerMaxTimeouts` and `circuitBreakerCooldownMs` settings, and the docs MDX/formatting gates pass on the updated branch.
- **What was not tested:** No additional gaps

## Checks
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `node scripts/check-docs-mdx.mjs docs/concepts/active-memory.md`
- `node scripts/format-docs.mjs --check`
