### PR TITLE
fix: report gateway health auth diagnostics

### DIFF
--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -1,14 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+  GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
+} from "./gateway-health-auth-diagnostic.js";
 
 const callGateway = vi.hoisted(() => vi.fn());
+const isGatewayCredentialsRequiredError = vi.hoisted(() => vi.fn(() => false));
+const probeGatewayStatus = vi.hoisted(() => vi.fn());
 const note = vi.hoisted(() => vi.fn());
+const TEST_GATEWAY_URL = "ws://127.0.0.1:18789";
+const TEST_AUTH_CLOSE_ERROR = "gateway closed (1008):";
+const TEST_TLS_FINGERPRINT = "sha256:test-doctor-gateway-fingerprint";
 
 vi.mock("../gateway/call.js", () => ({
   buildGatewayConnectionDetails: vi.fn(() => ({
-    message: "Gateway target: ws://127.0.0.1:18789",
+    message: `Gateway target: ${TEST_GATEWAY_URL}`,
+    url: TEST_GATEWAY_URL,
+  })),
+  buildGatewayProbeConnectionDetails: vi.fn(() => ({
+    preauthHandshakeTimeoutMs: 4321,
+    tlsFingerprint: TEST_TLS_FINGERPRINT,
+    url: TEST_GATEWAY_URL,
   })),
   callGateway,
+  isGatewayCredentialsRequiredError,
+}));
+
+vi.mock("../cli/daemon-cli/probe.js", () => ({
+  probeGatewayStatus,
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
@@ -26,6 +46,9 @@ describe("checkGatewayHealth", () => {
 
   beforeEach(() => {
     callGateway.mockReset();
+    isGatewayCredentialsRequiredError.mockReset();
+    isGatewayCredentialsRequiredError.mockReturnValue(false);
+    probeGatewayStatus.mockReset();
     note.mockReset();
   });
 
@@ -35,7 +58,7 @@ describe("checkGatewayHealth", () => {
 
     await expect(
       checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
-    ).resolves.toEqual({ healthOk: true, status: { ok: true } });
+    ).resolves.toEqual({ authenticated: true, healthOk: true, status: { ok: true } });
 
     expect(callGateway).toHaveBeenNthCalledWith(1, {
       method: "status",
@@ -58,7 +81,11 @@ describe("checkGatewayHealth", () => {
 
     await expect(
       checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
-    ).resolves.toEqual({ healthOk: true, status: { runtimeVersion: "2026.4.23" } });
+    ).resolves.toEqual({
+      authenticated: true,
+      healthOk: true,
+      status: { runtimeVersion: "2026.4.23" },
+    });
 
     const mismatchNotes = note.mock.calls
       .filter(([, title]) => title === "OpenClaw version mismatch")
@@ -78,12 +105,42 @@ describe("checkGatewayHealth", () => {
 
     await expect(
       checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
-    ).resolves.toEqual({ healthOk: false });
+    ).resolves.toEqual({ authenticated: false, healthOk: false, status: undefined });
 
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(runtime.error).toHaveBeenCalledWith(
       expect.stringContaining("gateway timeout after 3000ms"),
     );
+  });
+
+  it("reports credentials-required when status RPC auth blocks a reachable gateway", async () => {
+    callGateway.mockRejectedValueOnce(new Error());
+    isGatewayCredentialsRequiredError.mockReturnValueOnce(true);
+    probeGatewayStatus.mockResolvedValueOnce({
+      ok: false,
+      kind: "connect",
+      error: TEST_AUTH_CLOSE_ERROR,
+    });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await expect(
+      checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
+    ).resolves.toEqual({ authenticated: false, healthOk: true });
+
+    expect(probeGatewayStatus).toHaveBeenCalledWith({
+      url: TEST_GATEWAY_URL,
+      timeoutMs: 3000,
+      tlsFingerprint: TEST_TLS_FINGERPRINT,
+      preauthHandshakeTimeoutMs: 4321,
+      config: cfg,
+      json: true,
+    });
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+      GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
+    );
+    expect(callGateway).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -116,7 +173,7 @@ describe("probeGatewayMemoryStatus", () => {
     // A transport timeout must NOT be treated as a skipped probe. It is a real
     // diagnostic signal and the renderer should warn for key-optional providers.
     callGateway.mockRejectedValue(
-      new Error("gateway timeout after 8000ms\nGateway target: ws://127.0.0.1:18789"),
+      new Error(`gateway timeout after 8000ms\nGateway target: ${TEST_GATEWAY_URL}`),
     );
 
     const result = await probeGatewayMemoryStatus({ cfg });

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -1,11 +1,22 @@
 import { note } from "../../packages/terminal-core/src/note.js";
+import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  buildGatewayProbeConnectionDetails,
+  callGateway,
+  isGatewayCredentialsRequiredError,
+} from "../gateway/call.js";
 import type { DoctorMemoryStatusPayload } from "../gateway/server-methods/doctor.js";
 import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { VERSION } from "../version.js";
+import {
+  GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+  GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
+  gatewayProbeResultSawGateway,
+} from "./gateway-health-auth-diagnostic.js";
 import { formatHealthCheckFailure } from "./health-format.js";
 import type { StatusSummary } from "./status.types.js";
 
@@ -45,8 +56,7 @@ export async function checkGatewayHealth(params: {
   runtime: RuntimeEnv;
   cfg: OpenClawConfig;
   timeoutMs?: number;
-}): Promise<{ healthOk: boolean; status?: StatusSummary }> {
-  const gatewayDetails = buildGatewayConnectionDetails({ config: params.cfg });
+}): Promise<{ healthOk: boolean; authenticated: boolean; status?: StatusSummary }> {
   const timeoutMs =
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 10_000;
   let healthOk = false;
@@ -60,17 +70,6 @@ export async function checkGatewayHealth(params: {
     });
     healthOk = true;
     noteCliGatewayVersionSkew(status);
-  } catch (err) {
-    const message = String(err);
-    if (message.includes("gateway closed")) {
-      note("Gateway not running.", "Gateway");
-      note(gatewayDetails.message, "Gateway connection");
-    } else {
-      params.runtime.error(formatHealthCheckFailure(err));
-    }
-  }
-
-  if (healthOk) {
     try {
       const statusLocal = await callGateway({
         method: "channels.status",
@@ -94,9 +93,38 @@ export async function checkGatewayHealth(params: {
     } catch {
       // ignore: doctor already reported gateway health
     }
+    return { healthOk, authenticated: true, status };
+  } catch (err) {
+    if (isGatewayCredentialsRequiredError(err)) {
+      const probeDetails = await buildGatewayProbeConnectionDetails({ config: params.cfg });
+      const probe = await probeGatewayStatus({
+        url: probeDetails.url,
+        timeoutMs,
+        tlsFingerprint: probeDetails.tlsFingerprint,
+        preauthHandshakeTimeoutMs: probeDetails.preauthHandshakeTimeoutMs,
+        config: params.cfg,
+        json: true,
+      });
+      if (gatewayProbeResultSawGateway(probe)) {
+        note(
+          GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+          GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
+        );
+        healthOk = true;
+        return { healthOk, authenticated: false };
+      }
+    }
+    const message = String(err);
+    if (message.includes("gateway closed")) {
+      const gatewayDetails = buildGatewayConnectionDetails({ config: params.cfg });
+      note("Gateway not running.", "Gateway");
+      note(gatewayDetails.message, "Gateway connection");
+    } else {
+      params.runtime.error(formatHealthCheckFailure(err));
+    }
   }
 
-  return { healthOk, status };
+  return { healthOk, authenticated: false, status };
 }
 
 export async function probeGatewayMemoryStatus(params: {

--- a/src/commands/gateway-health-auth-diagnostic.ts
+++ b/src/commands/gateway-health-auth-diagnostic.ts
@@ -1,0 +1,41 @@
+import type { DaemonStatus } from "../cli/daemon-cli/status.gather.js";
+
+type GatewayProbeReachabilityEvidence = NonNullable<DaemonStatus["rpc"]>;
+
+export const GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE =
+  "Gateway is reachable, but this CLI has no token/password or paired device token for read-scope health RPCs.";
+export const GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE = "Gateway credentials required";
+export const GATEWAY_HEALTH_REACHABLE_LINE = "Gateway: reachable";
+
+export function gatewayProbeResultSawGateway(status: GatewayProbeReachabilityEvidence): boolean {
+  if (status.ok) {
+    return true;
+  }
+  const auth = status.auth;
+  if (auth?.capability && auth.capability !== "unknown") {
+    return true;
+  }
+  if (auth?.role || (auth?.scopes?.length ?? 0) > 0) {
+    return true;
+  }
+  const server = status.server;
+  if (server?.version || server?.connId) {
+    return true;
+  }
+  return /\bgateway closed \(\d+\):|\bpairing required\b|\bdevice identity required\b/i.test(
+    status.error ?? "",
+  );
+}
+
+export function buildCredentialsRequiredHealthDiagnostic() {
+  return {
+    ok: false,
+    error: {
+      type: "gateway_credentials_required",
+      message: GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+    },
+    gateway: {
+      reachable: true,
+    },
+  };
+}

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -2,6 +2,7 @@ import type { DaemonStatus } from "../cli/daemon-cli/status.gather.js";
 import { promptYesNo } from "../cli/prompt.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { gatewayProbeResultSawGateway } from "./gateway-health-auth-diagnostic.js";
 
 const daemonStatusModuleLoader = createLazyImportLoader(
   () => import("../cli/daemon-cli/status.gather.js"),
@@ -80,25 +81,7 @@ function gatewayIsRunning(status: DaemonStatus): boolean {
 }
 
 function gatewayProbeSawGateway(status: DaemonStatus): boolean {
-  const rpc = status.rpc;
-  if (!rpc) {
-    return false;
-  }
-  if (rpc.ok) {
-    return true;
-  }
-  if (rpc.auth?.capability && rpc.auth.capability !== "unknown") {
-    return true;
-  }
-  if (rpc.auth?.role || (rpc.auth?.scopes?.length ?? 0) > 0) {
-    return true;
-  }
-  if (rpc.server?.version || rpc.server?.connId) {
-    return true;
-  }
-  return /\bgateway closed \(\d+\):|\bpairing required\b|\bdevice identity required\b/i.test(
-    rpc.error ?? "",
-  );
+  return Boolean(status.rpc && gatewayProbeResultSawGateway(status.rpc));
 }
 
 function gatewayLooksReachable(status: DaemonStatus): boolean {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import {
+  buildCredentialsRequiredHealthDiagnostic,
+  GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+  GATEWAY_HEALTH_REACHABLE_LINE,
+} from "./gateway-health-auth-diagnostic.js";
 import { formatHealthCheckFailure } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
@@ -57,19 +62,37 @@ const createHealthSummary = (params: {
 };
 
 const callGatewayMock = vi.fn();
+const isGatewayCredentialsRequiredErrorMock = vi.fn((_value: unknown) => false);
+const TEST_GATEWAY_URL = "ws://127.0.0.1:18789";
+const TEST_GATEWAY_MESSAGE = `Gateway mode: local\nGateway target: ${TEST_GATEWAY_URL}`;
+const TEST_AUTH_CLOSE_ERROR = "gateway closed (1008):";
+const TEST_TLS_FINGERPRINT = "sha256:test-health-gateway-fingerprint";
 const buildGatewayConnectionDetailsMock = vi.fn(() => ({
-  message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
+  message: TEST_GATEWAY_MESSAGE,
+  url: TEST_GATEWAY_URL,
+}));
+const buildGatewayProbeConnectionDetailsMock = vi.fn(() => ({
+  message: TEST_GATEWAY_MESSAGE,
+  preauthHandshakeTimeoutMs: 4321,
+  tlsFingerprint: TEST_TLS_FINGERPRINT,
+  url: TEST_GATEWAY_URL,
 }));
 const formatGatewayTransportErrorJsonMock = vi.fn();
-const isGatewayCredentialsRequiredErrorMock = vi.fn(() => false);
+const probeGatewayStatusMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
     Reflect.apply(buildGatewayConnectionDetailsMock, undefined, args),
+  buildGatewayProbeConnectionDetails: (...args: [unknown, ...unknown[]]) =>
+    Reflect.apply(buildGatewayProbeConnectionDetailsMock, undefined, args),
   formatGatewayTransportErrorJson: (...args: unknown[]) =>
     formatGatewayTransportErrorJsonMock(...args),
-  isGatewayCredentialsRequiredError: (...args: unknown[]) =>
-    isGatewayCredentialsRequiredErrorMock(...args),
+  isGatewayCredentialsRequiredError: (value: unknown) =>
+    isGatewayCredentialsRequiredErrorMock(value),
+}));
+
+vi.mock("../cli/daemon-cli/probe.js", () => ({
+  probeGatewayStatus: (...args: unknown[]) => probeGatewayStatusMock(...args),
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
@@ -104,10 +127,18 @@ describe("healthCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     buildGatewayConnectionDetailsMock.mockReturnValue({
-      message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
+      message: TEST_GATEWAY_MESSAGE,
+      url: TEST_GATEWAY_URL,
+    });
+    buildGatewayProbeConnectionDetailsMock.mockReturnValue({
+      message: TEST_GATEWAY_MESSAGE,
+      preauthHandshakeTimeoutMs: 4321,
+      tlsFingerprint: TEST_TLS_FINGERPRINT,
+      url: TEST_GATEWAY_URL,
     });
     formatGatewayTransportErrorJsonMock.mockReturnValue(null);
     isGatewayCredentialsRequiredErrorMock.mockReturnValue(false);
+    probeGatewayStatusMock.mockReset();
   });
 
   it("outputs JSON from gateway", async () => {
@@ -190,7 +221,7 @@ describe("healthCommand", () => {
     expect(runtime.log.mock.calls.slice(0, 3)).toEqual([
       ["Gateway connection:"],
       ["  Gateway mode: local"],
-      ["  Gateway target: ws://127.0.0.1:18789"],
+      [`  Gateway target: ${TEST_GATEWAY_URL}`],
     ]);
     expect(buildGatewayConnectionDetailsMock).toHaveBeenCalled();
   });
@@ -233,7 +264,7 @@ describe("healthCommand", () => {
         reason: "no close reason",
       },
       gateway: {
-        url: "ws://127.0.0.1:18789",
+        url: TEST_GATEWAY_URL,
         urlSource: "local loopback",
         bindDetail: "Bind: loopback",
       },
@@ -247,6 +278,47 @@ describe("healthCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(JSON.parse(requireFirstRuntimeLog())).toEqual(payload);
   });
+
+  it.each([
+    { json: true, expectedLogs: 1 },
+    { json: undefined, expectedLogs: 2 },
+  ])(
+    "reports reachable gateway diagnostics when health RPC credentials are missing",
+    async ({ json, expectedLogs }) => {
+      callGatewayMock.mockRejectedValueOnce(new Error());
+      isGatewayCredentialsRequiredErrorMock.mockReturnValueOnce(true);
+      probeGatewayStatusMock.mockResolvedValueOnce({
+        ok: false,
+        kind: "connect",
+        error: TEST_AUTH_CLOSE_ERROR,
+      });
+
+      await healthCommand({ json, timeoutMs: 5000, config: {} }, runtime as never);
+
+      expect(probeGatewayStatusMock).toHaveBeenCalledWith({
+        url: TEST_GATEWAY_URL,
+        token: undefined,
+        password: undefined,
+        tlsFingerprint: TEST_TLS_FINGERPRINT,
+        preauthHandshakeTimeoutMs: 4321,
+        timeoutMs: 5000,
+        config: {},
+        json,
+      });
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.log).toHaveBeenCalledTimes(expectedLogs);
+      if (json) {
+        expect(JSON.parse(requireFirstRuntimeLog())).toEqual(
+          buildCredentialsRequiredHealthDiagnostic(),
+        );
+      } else {
+        expect(runtime.log.mock.calls).toEqual([
+          [GATEWAY_HEALTH_REACHABLE_LINE],
+          [GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE],
+        ]);
+      }
+    },
+  );
 
   it("formats degraded model-pricing health as a warning", () => {
     const snapshot = createHealthSummary({

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -61,12 +61,15 @@ const buildGatewayConnectionDetailsMock = vi.fn(() => ({
   message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
 }));
 const formatGatewayTransportErrorJsonMock = vi.fn();
+const isGatewayCredentialsRequiredErrorMock = vi.fn(() => false);
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
     Reflect.apply(buildGatewayConnectionDetailsMock, undefined, args),
   formatGatewayTransportErrorJson: (...args: unknown[]) =>
     formatGatewayTransportErrorJsonMock(...args),
+  isGatewayCredentialsRequiredError: (...args: unknown[]) =>
+    isGatewayCredentialsRequiredErrorMock(...args),
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
@@ -104,6 +107,7 @@ describe("healthCommand", () => {
       message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
     });
     formatGatewayTransportErrorJsonMock.mockReturnValue(null);
+    isGatewayCredentialsRequiredErrorMock.mockReturnValue(false);
   });
 
   it("outputs JSON from gateway", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -21,6 +21,7 @@ import {
   buildGatewayConnectionDetails,
   callGateway,
   formatGatewayTransportErrorJson,
+  isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -647,6 +648,19 @@ export async function healthCommand(
         }),
     );
   } catch (error) {
+    if (isGatewayCredentialsRequiredError(error)) {
+      const message = formatErrorMessage(error);
+      if (opts.json) {
+        writeRuntimeJson(runtime, {
+          ok: false,
+          error: { type: "gateway_credentials_required", message },
+        });
+      } else {
+        runtime.error(message);
+      }
+      runtime.exit(1);
+      return;
+    }
     if (opts.json) {
       const payload = formatGatewayTransportErrorJson(error);
       if (payload) {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,12 +13,14 @@ import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-on
 import { buildChannelAccountSnapshotFromAccount } from "../channels/plugins/status.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
+import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import { withProgress } from "../cli/progress.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listContextEngineQuarantines } from "../context-engine/registry.js";
 import {
   buildGatewayConnectionDetails,
+  buildGatewayProbeConnectionDetails,
   callGateway,
   formatGatewayTransportErrorJson,
   isGatewayCredentialsRequiredError,
@@ -39,6 +41,11 @@ import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import {
+  buildCredentialsRequiredHealthDiagnostic,
+  GATEWAY_HEALTH_REACHABLE_LINE,
+  gatewayProbeResultSawGateway,
+} from "./gateway-health-auth-diagnostic.js";
 import { formatHealthChannelLines } from "./health-format.js";
 import type {
   AgentHealthSummary,
@@ -649,17 +656,34 @@ export async function healthCommand(
     );
   } catch (error) {
     if (isGatewayCredentialsRequiredError(error)) {
-      const message = formatErrorMessage(error);
-      if (opts.json) {
-        writeRuntimeJson(runtime, {
-          ok: false,
-          error: { type: "gateway_credentials_required", message },
-        });
-      } else {
-        runtime.error(message);
+      const details = await buildGatewayProbeConnectionDetails({
+        config: cfg,
+        token: opts.token,
+        password: opts.password,
+      });
+      const probe = await probeGatewayStatus({
+        url: details.url,
+        token: opts.token,
+        password: opts.password,
+        tlsFingerprint: details.tlsFingerprint,
+        preauthHandshakeTimeoutMs: details.preauthHandshakeTimeoutMs,
+        timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        config: cfg,
+        json: opts.json,
+      });
+      if (gatewayProbeResultSawGateway(probe)) {
+        const diagnostic = buildCredentialsRequiredHealthDiagnostic();
+        if (opts.json) {
+          writeRuntimeJson(runtime, diagnostic);
+          runtime.exit(1);
+          return;
+        }
+        runtime.log(GATEWAY_HEALTH_REACHABLE_LINE);
+        runtime.log(diagnostic.error.message);
+        runtime.exit(1);
+        return;
       }
-      runtime.exit(1);
-      return;
+      throw error;
     }
     if (opts.json) {
       const payload = formatGatewayTransportErrorJson(error);

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -27,11 +27,19 @@ const mocks = vi.hoisted(() => ({
     config: {},
     issues: [],
   }),
+  checkGatewayHealth: vi.fn(),
+  probeGatewayMemoryStatus: vi.fn(),
   applyWizardMetadata: vi.fn((cfg: unknown) => cfg),
   logConfigUpdated: vi.fn(),
+  isRecord: vi.fn(
+    (value: unknown): value is Record<string, unknown> =>
+      typeof value === "object" && value !== null && !Array.isArray(value),
+  ),
   shortenHomePath: vi.fn((p: string) => p),
   formatCliCommand: vi.fn((cmd: string) => cmd),
 }));
+
+const DOCTOR_GATEWAY_HEALTH_ID = "doctor:gateway-health";
 
 vi.mock("../commands/doctor/shared/release-configured-plugin-installs.js", () => ({
   maybeRunConfiguredPluginInstallReleaseStep: mocks.maybeRunConfiguredPluginInstallReleaseStep,
@@ -83,6 +91,11 @@ vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: mocks.readConfigFileSnapshot,
 }));
 
+vi.mock("../commands/doctor-gateway-health.js", () => ({
+  checkGatewayHealth: mocks.checkGatewayHealth,
+  probeGatewayMemoryStatus: mocks.probeGatewayMemoryStatus,
+}));
+
 vi.mock("../commands/onboard-helpers.js", () => ({
   applyWizardMetadata: mocks.applyWizardMetadata,
 }));
@@ -92,6 +105,7 @@ vi.mock("../config/logging.js", () => ({
 }));
 
 vi.mock("../utils.js", () => ({
+  isRecord: mocks.isRecord,
   shortenHomePath: mocks.shortenHomePath,
 }));
 
@@ -176,6 +190,8 @@ describe("doctor health contributions", () => {
       config: {},
       issues: [],
     });
+    mocks.checkGatewayHealth.mockReset();
+    mocks.probeGatewayMemoryStatus.mockReset();
   });
 
   afterEach(() => {
@@ -191,6 +207,32 @@ describe("doctor health contributions", () => {
       ids.indexOf("doctor:plugin-registry"),
     );
     expect(ids.indexOf("doctor:plugin-registry")).toBeLessThan(ids.indexOf("doctor:write-config"));
+  });
+
+  it("skips read-scope gateway probes when gateway health only proved reachability", async () => {
+    mocks.checkGatewayHealth.mockResolvedValue({
+      authenticated: false,
+      healthOk: true,
+    });
+    const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
+    const ctx = {
+      cfg: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(ctx.healthOk).toBe(true);
+    expect(ctx.gatewayHealthAuthenticated).toBe(false);
+    expect(ctx.gatewayMemoryProbe).toEqual({ checked: false, ready: false, skipped: true });
+    expect(mocks.probeGatewayMemoryStatus).not.toHaveBeenCalled();
   });
 
   it("keeps release configured plugin installs repair-only", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -40,6 +40,7 @@ type DoctorHealthFlowContext = {
   env?: NodeJS.ProcessEnv;
   gatewayDetails?: ReturnType<typeof buildGatewayConnectionDetails>;
   healthOk?: boolean;
+  gatewayHealthAuthenticated?: boolean;
   gatewayHealthSkipped?: boolean;
   gatewayStatus?: import("../commands/status.types.js").StatusSummary;
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
@@ -792,20 +793,21 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   }
   const { checkGatewayHealth, probeGatewayMemoryStatus } =
     await import("../commands/doctor-gateway-health.js");
-  const { healthOk, status } = await checkGatewayHealth({
+  const { healthOk, authenticated, status } = await checkGatewayHealth({
     runtime: ctx.runtime,
     cfg: ctx.cfg,
     timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
   });
   ctx.gatewayHealthSkipped = false;
   ctx.healthOk = healthOk;
+  ctx.gatewayHealthAuthenticated = authenticated;
   ctx.gatewayStatus = status;
-  ctx.gatewayMemoryProbe = healthOk
+  ctx.gatewayMemoryProbe = authenticated
     ? await probeGatewayMemoryStatus({
         cfg: ctx.cfg,
         timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
       })
-    : { checked: false, ready: false, skipped: false };
+    : { checked: false, ready: false, skipped: healthOk };
 }
 
 async function runWhatsappResponsivenessHealth(ctx: DoctorHealthFlowContext): Promise<void> {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -168,6 +168,7 @@ vi.mock("./event-loop-ready.js", () => ({
 const {
   testing,
   buildGatewayConnectionDetails,
+  buildGatewayProbeConnectionDetails,
   callGateway,
   callGatewayCli,
   callGatewayScoped,
@@ -867,6 +868,33 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.remoteFallbackNote).toBeUndefined();
     expect(details.message).toContain("Gateway target: wss://example.com/ws");
     expect(details.message).toContain("Source: cli --url");
+  });
+
+  it("reuses gateway call TLS resolution for local probe connection details", async () => {
+    const config = {
+      gateway: {
+        mode: "local",
+        bind: "loopback",
+        tls: { enabled: true },
+        handshakeTimeoutMs: 4321,
+      },
+    } satisfies OpenClawConfig;
+    resolveGatewayPort.mockReturnValue(18800);
+    testing.setDepsForTests({
+      getRuntimeConfig: () => config,
+      resolveGatewayPort: () => 18800,
+      loadGatewayTlsRuntime: async () => ({
+        enabled: true,
+        fingerprintSha256: "sha256:test-local-gateway-fingerprint",
+        required: true,
+      }),
+    });
+
+    const details = await buildGatewayProbeConnectionDetails({ config });
+
+    expect(details.url).toBe("wss://127.0.0.1:18800");
+    expect(details.tlsFingerprint).toBe("sha256:test-local-gateway-fingerprint");
+    expect(details.preauthHandshakeTimeoutMs).toBe(4321);
   });
 
   it("redacts credential-bearing target URLs from connection messages", () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -180,6 +180,11 @@ export type GatewayTransportErrorJson = {
   };
 };
 
+export type GatewayProbeConnectionDetails = GatewayConnectionDetails & {
+  tlsFingerprint?: string;
+  preauthHandshakeTimeoutMs?: number;
+};
+
 function firstGatewayErrorLine(message: string): string {
   return message.split("\n", 1)[0]?.trim() || message;
 }
@@ -1044,6 +1049,38 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     connectionDetails,
     deviceIdentity,
   });
+}
+
+export async function buildGatewayProbeConnectionDetails(
+  opts: Pick<
+    CallGatewayBaseOptions,
+    "config" | "configPath" | "password" | "tlsFingerprint" | "token" | "url"
+  > = {},
+): Promise<GatewayProbeConnectionDetails> {
+  const callOpts = {
+    ...opts,
+    method: "status",
+  } satisfies CallGatewayBaseOptions;
+  const context = await resolveGatewayCallContext(callOpts);
+  ensureRemoteModeUrlConfigured(context);
+  const connectionDetails = buildGatewayConnectionDetails({
+    config: context.config,
+    url: context.urlOverride,
+    urlSource: context.urlOverrideSource,
+    ...(opts.configPath ? { configPath: opts.configPath } : {}),
+  });
+  const tlsFingerprint = await resolveGatewayTlsFingerprint({
+    opts: callOpts,
+    context,
+    url: connectionDetails.url,
+  });
+  return {
+    ...connectionDetails,
+    ...(tlsFingerprint ? { tlsFingerprint } : {}),
+    ...(context.config.gateway?.handshakeTimeoutMs
+      ? { preauthHandshakeTimeoutMs: context.config.gateway.handshakeTimeoutMs }
+      : {}),
+  };
 }
 
 export async function callGatewayScoped<T = Record<string, unknown>>(


### PR DESCRIPTION
## Issue

Fixes #89711. Health and doctor diagnostics can surface a raw Gateway credentials error when the Gateway is reachable but the CLI cannot authenticate the health/status RPC:

```text
Health check failed: GatewayCredentialsRequiredError: gateway status requires credentials before opening a websocket
```

The user-visible problem is that the Gateway can be running and reachable, but `openclaw health` / doctor report the raw credentials guard error before they can explain that credentials or pairing are required.

## Summary

- Keep the `callGateway` credential guard intact for real health/status RPCs, but recover the diagnostic path when that guard blocks `openclaw health` or doctor gateway health.
- Add a shared gateway probe reachability classifier that treats auth-close probe results like `gateway closed (1008): device identity required` as evidence that the Gateway is reachable.
- Reuse the Gateway call connection resolver for credential-diagnostic probes so local TLS and pinned remote Gateway fingerprints are preserved.
- Keep doctor liveness distinct from authenticated Gateway RPC access, so doctor can avoid daemon restart churn while skipping read-scope follow-up probes when only reachability was proven.

## Commit Layout

- `b859c97796` is the minimal backportable fix: `openclaw health` catches the credentials-required guard and returns a normal failed health result instead of leaking the raw exception.
- `c22ea31d24` is the fuller fix: shared diagnostic wording, reachability probe handling, doctor behavior, and focused regression coverage.

Relevant history:

- `4252f07ff0f1b8a80eaadf77e96afa5aa65d2f90` added the pre-websocket credential guard that real RPCs should keep using.
- `7be08d03769f44e3beb68a2d75a9516a21db3cc7` changed that missing-credentials failure to surface as `GatewayCredentialsRequiredError`.
- This PR keeps those safety changes and adjusts only the health/doctor diagnostic path so users see a reachability-aware credentials message instead of a raw guard error.

## Verification

- `node scripts/run-vitest.mjs src/gateway/call.test.ts src/commands/health.test.ts src/commands/doctor-gateway-health.test.ts src/commands/gateway-readiness.test.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm check:test-types`
- `node scripts/run-oxlint.mjs src/gateway/call.ts src/gateway/call.test.ts src/commands/health.ts src/commands/doctor-gateway-health.ts src/commands/gateway-health-auth-diagnostic.ts src/commands/gateway-readiness.ts src/commands/health.test.ts src/commands/doctor-gateway-health.test.ts src/commands/gateway-readiness.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxfmt --check src/gateway/call.ts src/gateway/call.test.ts src/commands/health.ts src/commands/doctor-gateway-health.ts src/commands/gateway-health-auth-diagnostic.ts src/commands/gateway-readiness.ts src/commands/health.test.ts src/commands/doctor-gateway-health.test.ts src/commands/gateway-readiness.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts && git diff --check && pnpm deadcode:unused-files`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings reported
