### PR TITLE
fix(agents): guard bootstrap tool name lookup

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1167,6 +1167,75 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     ]);
   });
 
+  it("keeps bootstrap file access when a sibling raw tool name is unreadable", async () => {
+    hoisted.isWorkspaceBootstrapPendingMock.mockResolvedValueOnce(true);
+    hoisted.createOpenClawCodingToolsMock.mockImplementationOnce(() => [
+      {
+        get name() {
+          throw new Error("bootstrap tool name getter exploded");
+        },
+        label: "Broken",
+        description: "Broken descriptor.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ text: "bad" }),
+      },
+      {
+        name: "read",
+        label: "Read",
+        description: "Read files.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ text: "ok" }),
+      },
+    ]);
+    hoisted.resolveBootstrapContextForRunMock.mockResolvedValueOnce({
+      bootstrapFiles: [
+        {
+          name: "BOOTSTRAP.md",
+          path: "/tmp/openclaw-bootstrap-workspace/BOOTSTRAP.md",
+          content: "Ask who I am.",
+          missing: false,
+        },
+      ],
+      contextFiles: [
+        {
+          path: "/tmp/openclaw-bootstrap-workspace/BOOTSTRAP.md",
+          content: "Ask who I am.",
+        },
+      ],
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        disableTools: false,
+        prompt: "visible ask",
+        transcriptPrompt: "visible ask",
+        trigger: "user",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    const promptInput = hoisted.embeddedSystemPromptInputs.at(-1) as {
+      bootstrapMode?: string;
+      contextFiles?: Array<{ path: string; content: string }>;
+    };
+
+    expect(promptInput.bootstrapMode).toBe("full");
+    expect(promptInput.contextFiles).toEqual([
+      {
+        path: "/tmp/openclaw-bootstrap-workspace/BOOTSTRAP.md",
+        content: "Ask who I am.",
+      },
+    ]);
+  });
+
   it("skips bootstrap preload on completed continuation-skip turns", async () => {
     hoisted.resolveContextInjectionModeMock.mockReturnValue("continuation-skip");
     hoisted.hasCompletedBootstrapTurnMock.mockResolvedValue(true);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -628,6 +628,19 @@ function hasVisiblePendingToolMediaReply(
   );
 }
 
+function hasToolNamed(tools: readonly { name?: unknown }[], expectedName: string): boolean {
+  for (const tool of tools) {
+    try {
+      if (tool.name === expectedName) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boolean {
   if (!message || message.role !== "assistant") {
     return false;
@@ -1253,7 +1266,7 @@ export async function runEmbeddedAttempt(
         })();
     prepStages.mark("core-plugin-tools");
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
-    const bootstrapHasFileAccess = toolsEnabled && toolsRaw.some((tool) => tool.name === "read");
+    const bootstrapHasFileAccess = toolsEnabled && hasToolNamed(toolsRaw, "read");
     const bootstrapWarn = makeBootstrapWarn({
       sessionLabel,
       workspaceDir: resolvedWorkspace,


### PR DESCRIPTION
## Summary
- guard embedded-attempt workspace-bootstrap file-access detection against unreadable raw tool names
- keep bootstrap routing able to see a healthy `read` sibling after a malformed descriptor is skipped later by schema projection

## Verification
Behavior addressed: embedded attempts no longer abort workspace bootstrap routing when a malformed pre-projection tool descriptor has an unreadable `name` getter before a healthy `read` tool.
Real environment tested: AWS Crabbox Linux changed gate plus focused local Vitest in the Codex worktree.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 1 file / 57 tests after the final rebase; oxfmt, targeted oxlint, and diff-check passed; AWS Crabbox `pnpm check:changed` passed on provider `aws`, run `run_579e88fedf97`, lease `cbx_7b13637323fe`, lanes `core` and `coreTests`, exit 0.
Observed result after fix: the new regression preserves full bootstrap context when an unreadable raw tool-name getter precedes a healthy `read` tool.
What was not tested: no live provider run; the source-only selected red repro stalled in the heavy context-engine harness after temporarily restoring the raw lookup, so the proof relies on the focused regression plus changed gate.
