### PR TITLE
fix(ui): allow short tweakcn built-in theme names (claude, zinc, slate)

### DIFF
--- a/ui/src/ui/custom-theme.test.ts
+++ b/ui/src/ui/custom-theme.test.ts
@@ -113,6 +113,24 @@ describe("custom theme import helpers", () => {
     });
   });
 
+  it("accepts short built-in tweakcn theme names (claude, zinc, slate)", () => {
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/themes/claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
+    expect(normalizeTweakcnThemeUrl("zinc")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/zinc",
+      fetchUrl: "https://tweakcn.com/r/themes/zinc",
+      themeId: "zinc",
+    });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/slate")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/slate",
+      fetchUrl: "https://tweakcn.com/r/themes/slate",
+      themeId: "slate",
+    });
+  });
+
   it("maps a tweakcn payload into a normalized imported theme record", () => {
     const imported = createImportedTheme();
 

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{1,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
The tweakcn theme ID validator pattern required a minimum of 8 characters, blocking valid built-in tweakcn theme names like claude (6 chars), zinc (4 chars), slate (5 chars).

Lower the minimum repetition from {7,127} to {1,127} (minimum 2 total characters) to accept all valid tweakcn theme IDs while keeping the upper safety bound.

## Verification
- Existing tests pass (custom-theme: 13/13)
- Added focused regression test for short built-in theme names (claude, zinc, slate)
- Lint clean

Closes #88987

@clawsweeper re-review