### PR TITLE
fix(backup): resolve legacy hardlink targets by link subtree (follow-up to #89328)

### DIFF
--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildBackupArchiveRoot } from "./backup-shared.js";
+import { buildBackupArchivePath, buildBackupArchiveRoot } from "./backup-shared.js";
 import { backupVerifyCommand } from "./backup-verify.js";
 
 const TEST_ARCHIVE_ROOT = "2026-03-09T00-00-00.000Z-openclaw-backup";
@@ -386,6 +386,150 @@ describe("backupVerifyCommand", () => {
       await expect(backupVerifyCommand(runtime, { archive: archivePath })).resolves.toMatchObject({
         ok: true,
       });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts internal hardlink targets stored as pre-remap relative paths", async () => {
+    // Archives created before the hardlink dereference fix store the link
+    // target as the node-tar cwd-relative path (e.g. ".openclaw/state/a.bin"),
+    // not the remapped "<root>/payload/posix/..." entry path. Verify must keep
+    // accepting these as long as the linked file is present in the archive.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-legacy-linkpath-"));
+    const archivePath = path.join(tempDir, "legacy.tar.gz");
+    const payloadArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/home/gonto/.openclaw/state/a.bin`;
+    const hardlinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/home/gonto/.openclaw/state/logs/b.bin`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(payloadArchivePath), null, 2)}\n`,
+          }),
+          encodeTarEntry({ path: payloadArchivePath, contents: "payload\n" }),
+          encodeTarEntry({
+            path: hardlinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/state/a.bin",
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      const result = await backupVerifyCommand(runtime, { archive: archivePath });
+      expect(result.ok).toBe(true);
+      expect(result.entryCount).toBe(3);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies a real archive containing a deduplicated hardlink", async () => {
+    // Build a genuine archive the way pre-dereference backups did: real
+    // hardlinked files plus an `onWriteEntry` remap into the archive payload
+    // namespace. node-tar records the link target as the cwd-relative source
+    // path, exactly the shape reported in #89257, so this guards the actual
+    // verifier path rather than a hand-encoded approximation.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-real-hardlink-"));
+    const home = path.join(tempDir, "home", "gonto");
+    const stateDir = path.join(home, ".openclaw", "state");
+    const logsDir = path.join(stateDir, "logs");
+    await fs.mkdir(logsDir, { recursive: true });
+    const targetSource = path.join(stateDir, "a.bin");
+    const linkSource = path.join(logsDir, "b.bin");
+    await fs.writeFile(targetSource, "shared backup content\n");
+    await fs.link(targetSource, linkSource);
+
+    const manifestPath = path.join(tempDir, "manifest.json");
+    const targetArchivePath = buildBackupArchivePath(TEST_ARCHIVE_ROOT, targetSource);
+    await fs.writeFile(
+      manifestPath,
+      `${JSON.stringify(createBackupManifest(targetArchivePath), null, 2)}\n`,
+    );
+
+    const archivePath = path.join(tempDir, "backup.tar.gz");
+    try {
+      await tar.c(
+        {
+          file: archivePath,
+          gzip: true,
+          portable: true,
+          preservePaths: true,
+          // cwd ancestry makes node-tar dedupe the hardlink, producing the
+          // cwd-relative linkpath that older backups carried. Reuse the real
+          // archive-path encoder so the fixture mirrors production remapping.
+          cwd: home,
+          onWriteEntry: (entry) => {
+            const absolute = path.resolve(home, entry.path);
+            entry.path =
+              absolute === manifestPath
+                ? `${TEST_ARCHIVE_ROOT}/manifest.json`
+                : buildBackupArchivePath(TEST_ARCHIVE_ROOT, absolute);
+          },
+        },
+        [manifestPath, ".openclaw/state"],
+      );
+
+      // Guard the fixture itself: if dedup ever stops producing a Link entry
+      // with a cwd-relative target, this test would silently stop exercising
+      // the legacy hardlink path instead of failing.
+      const linkTargets: Array<string | undefined> = [];
+      await tar.t({
+        file: archivePath,
+        gzip: true,
+        onentry: (entry) => {
+          if (entry.type === "Link") {
+            linkTargets.push(entry.linkpath);
+          }
+          entry.resume();
+        },
+      });
+      expect(linkTargets).toStrictEqual([".openclaw/state/a.bin"]);
+
+      const runtime = createBackupVerifyRuntime();
+      const result = await backupVerifyCommand(runtime, { archive: archivePath });
+      expect(result.ok).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a dropped hardlink target even when an unrelated entry shares its tail", async () => {
+    // Integrity guard: a legacy cwd-relative linkpath must resolve to a target
+    // in the link's own source subtree. A same-named file in a different
+    // directory must not mask a dropped/corrupt target, or verify would report
+    // OK for an archive whose hardlink dangles on restore.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-tail-collision-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const unrelatedArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/home/gonto/old-backup/.openclaw/state/a.bin`;
+    const hardlinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/home/gonto/.openclaw/state/logs/b.bin`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(unrelatedArchivePath), null, 2)}\n`,
+          }),
+          // Unrelated file in a different subtree; the link's real target
+          // (.../.openclaw/state/a.bin next to the link) is absent.
+          encodeTarEntry({ path: unrelatedArchivePath, contents: "payload\n" }),
+          encodeTarEntry({
+            path: hardlinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/state/a.bin",
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /hardlink target is missing from archive entries/i,
+      );
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -535,6 +535,81 @@ describe("backupVerifyCommand", () => {
     }
   });
 
+  it("rejects a legacy hardlink whose target resolves only to itself", async () => {
+    // A self-referential link has no real payload behind it; the ancestor walk
+    // must not satisfy the target by matching the link entry's own path.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-self-linkpath-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const payloadArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/target.txt`;
+    const selfLinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/self.txt`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(payloadArchivePath), null, 2)}\n`,
+          }),
+          encodeTarEntry({ path: payloadArchivePath, contents: "payload\n" }),
+          encodeTarEntry({
+            path: selfLinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/self.txt",
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /hardlink target is missing from archive entries/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a legacy hardlink whose target is another link entry", async () => {
+    // A hardlink target must be a real payload file, not another Link entry,
+    // otherwise verify would pass an archive with no backing data for the chain.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-link-to-link-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const payloadArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/target.txt`;
+    const firstLinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/a.txt`;
+    const secondLinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/b.txt`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(payloadArchivePath), null, 2)}\n`,
+          }),
+          encodeTarEntry({ path: payloadArchivePath, contents: "payload\n" }),
+          encodeTarEntry({
+            path: firstLinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/target.txt",
+          }),
+          // Points at the other Link entry rather than the real file.
+          encodeTarEntry({
+            path: secondLinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/a.txt",
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /hardlink target is missing from archive entries/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects hardlink targets missing from archive entries", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-missing-linkpath-"));
     const archivePath = path.join(tempDir, "broken.tar.gz");

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -36,14 +36,15 @@ function createBackupManifest(assetArchivePath: string, archiveRoot = TEST_ARCHI
 function encodeTarEntry(params: {
   path: string;
   contents?: string;
-  type?: "File" | "Link";
+  type?: "File" | "Link" | "Directory";
   linkpath?: string;
 }): Buffer {
   const body = Buffer.from(params.contents ?? "", "utf8");
+  const bodyless = params.type === "Link" || params.type === "Directory";
   const header = new tar.Header({
     path: params.path,
     type: params.type ?? "File",
-    size: params.type === "Link" ? 0 : body.length,
+    size: bodyless ? 0 : body.length,
     mode: 0o600,
     uid: 0,
     gid: 0,
@@ -52,7 +53,7 @@ function encodeTarEntry(params: {
   });
   const headerBlock = Buffer.alloc(512);
   header.encode(headerBlock);
-  if (params.type === "Link") {
+  if (bodyless) {
     return headerBlock;
   }
   const padding = Buffer.alloc((512 - (body.length % 512)) % 512);
@@ -595,6 +596,42 @@ describe("backupVerifyCommand", () => {
             path: secondLinkArchivePath,
             type: "Link",
             linkpath: ".openclaw/a.txt",
+          }),
+          Buffer.alloc(1024),
+        ]),
+      );
+      await fs.writeFile(archivePath, archive);
+
+      const runtime = createBackupVerifyRuntime();
+      await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+        /hardlink target is missing from archive entries/i,
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a legacy hardlink whose target resolves to a non-file entry", async () => {
+    // Hardlinks must be backed by file contents; a target that resolves to a
+    // directory (or any non-file) entry is not a valid restore source.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-dir-linkpath-"));
+    const archivePath = path.join(tempDir, "broken.tar.gz");
+    const payloadArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/target.txt`;
+    const dirArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/state`;
+    const hardlinkArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/logs/b.bin`;
+    try {
+      const archive = gzipSync(
+        Buffer.concat([
+          encodeTarEntry({
+            path: `${TEST_ARCHIVE_ROOT}/manifest.json`,
+            contents: `${JSON.stringify(createBackupManifest(payloadArchivePath), null, 2)}\n`,
+          }),
+          encodeTarEntry({ path: payloadArchivePath, contents: "payload\n" }),
+          encodeTarEntry({ path: `${dirArchivePath}/`, type: "Directory" }),
+          encodeTarEntry({
+            path: hardlinkArchivePath,
+            type: "Link",
+            linkpath: ".openclaw/state",
           }),
           Buffer.alloc(1024),
         ]),

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -377,6 +377,7 @@ export async function backupVerifyCommand(
   const entries = rawEntries.map((entry) => ({
     raw: entry.path,
     normalized: normalizeArchivePath(entry.path, "Archive entry"),
+    isLink: entry.type === "Link",
   }));
   const hardlinkTargets = rawEntries
     .filter((entry) => entry.type === "Link" && entry.linkpath)
@@ -389,6 +390,13 @@ export async function backupVerifyCommand(
       ),
     }));
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
+  // Hardlink targets must resolve to a real archived file. Excluding Link
+  // entries keeps a corrupt/malicious self-referential or link-to-link hardlink
+  // from satisfying the integrity check by pointing at another link rather than
+  // a payload file.
+  const payloadEntrySet = new Set(
+    entries.filter((entry) => !entry.isLink).map((entry) => entry.normalized),
+  );
 
   const manifestMatches = entries.filter((entry) => isRootManifestEntry(entry.normalized));
   if (manifestMatches.length !== 1) {
@@ -406,7 +414,7 @@ export async function backupVerifyCommand(
   const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
   const manifest = parseManifest(manifestRaw);
   verifyManifestAgainstEntries(manifest, normalizedEntrySet);
-  verifyHardlinkTargetsAgainstArchiveEntries(hardlinkTargets, normalizedEntrySet);
+  verifyHardlinkTargetsAgainstArchiveEntries(hardlinkTargets, payloadEntrySet);
 
   const result: BackupVerifyResult = {
     ok: true,

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -294,27 +294,47 @@ function verifyManifestAgainstEntries(manifest: BackupManifest, entries: Set<str
   }
 }
 
-function verifyHardlinkTargetsAgainstArchiveRoot(
-  hardlinkTargets: Array<{ entryPath: string; normalized: string }>,
-  archiveRoot: string,
+function archiveHasHardlinkTarget(
+  linkEntry: string,
+  normalizedTarget: string,
+  entries: Set<string>,
+): boolean {
+  if (entries.has(normalizedTarget)) {
+    return true;
+  }
+  // Archives created before the hardlink dereference fix store the link target
+  // as node-tar's cwd-relative source path (e.g. ".openclaw/state/db"), not the
+  // remapped "<root>/payload/posix/..." entry path. node-tar only dedupes files
+  // under a shared cwd, so the real target is `<ancestor-of-link>/<linkpath>`.
+  // Walk the link entry's ancestor dirs and require an exact entry match rather
+  // than a loose suffix scan, so a dropped target cannot be masked by an
+  // unrelated same-named file elsewhere in the archive.
+  let dir = path.posix.dirname(linkEntry);
+  while (dir && dir !== "." && dir !== "/") {
+    if (entries.has(path.posix.join(dir, normalizedTarget))) {
+      return true;
+    }
+    const parent = path.posix.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return false;
+}
+
+function verifyHardlinkTargetsAgainstArchiveEntries(
+  hardlinkTargets: Array<{ entryPath: string; entryNormalized: string; normalized: string }>,
   entries: Set<string>,
 ): void {
-  const normalizedRoot = normalizeArchiveRoot(archiveRoot);
+  // normalizeArchivePath already rejected absolute paths, backslashes, and ".."
+  // traversal, so each normalized target is a clean relative path that cannot
+  // escape the extraction root. The remaining concern is integrity: the linked
+  // file must actually exist in the archive.
   for (const target of hardlinkTargets) {
-    // Older backup archives may store hardlink linkpath values relative to the
-    // archive root instead of including the root segment. Accept that form only
-    // when it resolves to a real entry inside this archive.
-    const normalizedTarget = isArchivePathWithin(target.normalized, normalizedRoot)
-      ? target.normalized
-      : path.posix.join(normalizedRoot, target.normalized);
-    if (!isArchivePathWithin(normalizedTarget, normalizedRoot)) {
+    if (!archiveHasHardlinkTarget(target.entryNormalized, target.normalized, entries)) {
       throw new Error(
-        `Archive hardlink target is outside the declared archive root: ${target.entryPath} -> ${normalizedTarget}`,
-      );
-    }
-    if (!entries.has(normalizedTarget)) {
-      throw new Error(
-        `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${normalizedTarget}`,
+        `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${target.normalized}`,
       );
     }
   }
@@ -362,6 +382,7 @@ export async function backupVerifyCommand(
     .filter((entry) => entry.type === "Link" && entry.linkpath)
     .map((entry) => ({
       entryPath: entry.path,
+      entryNormalized: normalizeArchivePath(entry.path, "Archive entry"),
       normalized: normalizeArchivePath(
         entry.linkpath ?? "",
         `Archive hardlink target for ${entry.path}`,
@@ -385,11 +406,7 @@ export async function backupVerifyCommand(
   const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
   const manifest = parseManifest(manifestRaw);
   verifyManifestAgainstEntries(manifest, normalizedEntrySet);
-  verifyHardlinkTargetsAgainstArchiveRoot(
-    hardlinkTargets,
-    manifest.archiveRoot,
-    normalizedEntrySet,
-  );
+  verifyHardlinkTargetsAgainstArchiveEntries(hardlinkTargets, normalizedEntrySet);
 
   const result: BackupVerifyResult = {
     ok: true,

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -377,7 +377,7 @@ export async function backupVerifyCommand(
   const entries = rawEntries.map((entry) => ({
     raw: entry.path,
     normalized: normalizeArchivePath(entry.path, "Archive entry"),
-    isLink: entry.type === "Link",
+    isFile: entry.type === "File",
   }));
   const hardlinkTargets = rawEntries
     .filter((entry) => entry.type === "Link" && entry.linkpath)
@@ -390,12 +390,12 @@ export async function backupVerifyCommand(
       ),
     }));
   const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
-  // Hardlink targets must resolve to a real archived file. Excluding Link
-  // entries keeps a corrupt/malicious self-referential or link-to-link hardlink
-  // from satisfying the integrity check by pointing at another link rather than
-  // a payload file.
+  // Hardlink targets must resolve to a regular archived file. Restricting to
+  // File entries (not just non-Link) keeps a corrupt/malicious hardlink that
+  // points at a directory, another link, or itself from satisfying the
+  // integrity check without backing file contents.
   const payloadEntrySet = new Set(
-    entries.filter((entry) => !entry.isLink).map((entry) => entry.normalized),
+    entries.filter((entry) => entry.isFile).map((entry) => entry.normalized),
   );
 
   const manifestMatches = entries.filter((entry) => isRootManifestEntry(entry.normalized));


### PR DESCRIPTION
## Summary
Follow-up to #89328 (merged as 5be282e459), which still leaves the originally reported failure in place.

`backup verify` rejected previously valid backups containing internal hardlinks with `Archive hardlink target is outside the declared archive root` (#89257). Root cause: node-tar records a deduplicated hardlink's `linkpath` as the **cwd-relative source path** (e.g. `.openclaw/state/db`), while `onWriteEntry` only remaps the entry's own `path` into the `<root>/payload/posix/...` namespace.

#89328 reconstructs the target as `path.posix.join(archiveRoot, linkpath)` — that only re-adds the root segment, producing `<root>/.openclaw/state/db`. The real entry is `<root>/payload/posix/<abs-path>/.openclaw/state/db`, so a genuine `openclaw backup create` archive (linkpath `.openclaw/state/...`) **still fails verify on current `main`**.

This change resolves the target correctly. node-tar only dedupes files under a shared `cwd`, so the target is `<ancestor-of-link>/<linkpath>`: walk the link entry's own ancestor dirs and require an **exact regular-file** entry match.

- Fixes the real cwd-relative linkpath shape that `main` still rejects.
- Still accepts the root-relative shape #89328 targeted (its test is kept and passes — the ancestor walk reaches the archive-root segment).
- Anchoring to the link's ancestor chain (instead of a global `endsWith` scan) and restricting matches to regular `File` entries keep the missing-target integrity check meaningful: a dropped target, a self-referential link, a link-to-link, or a directory target can no longer satisfy verification.
- Absolute/backslash/`..` traversal rejection is unchanged (`normalizeArchivePath`); `verifyManifestAgainstEntries` still enforces every entry is under the archive root.

Out of scope (per the issue triage): the `backup create --verify` exit-13 / truncated `.tmp` half is a separate failure (Node unsettled top-level await abandoning the tar write) that needs live user state to reproduce. Not addressed here.

Refs #89257, #89328

## Real behavior proof
Behavior addressed: `backup verify` accepts older archives whose internal hardlink targets are node-tar cwd-relative paths, while still rejecting absolute, backslash, traversal, missing, self-link, link-to-link, and non-file targets.

Real environment tested: Local source checkout on this branch (`OPENCLAW_FORCE_BUILD=1 pnpm openclaw ...`, Node 24, macOS). Built a genuine archive with real `fs.link` + `tar.c` (default linkCache, so dedup is on and the `Link` entry carries the actual cwd-relative `linkpath` `.openclaw/state/a.bin`), then ran the real CLI `openclaw backup verify` against it before and after the fix.

Exact steps or command run after this patch: `OPENCLAW_FORCE_BUILD=1 pnpm openclaw backup verify /tmp/legacy-backup.tar.gz` (archive built by a script that hardlinks two files under a state dir and remaps entries via the production archive-path encoder; the produced `Link` entry's `linkpath` is `.openclaw/state/a.bin`).

Evidence after fix: real CLI console output, same archive, before vs after this change:

```console
# BEFORE — current main (#89328) rejects the genuine cwd-relative hardlink
$ pnpm openclaw backup verify /tmp/legacy-backup.tar.gz
Error: Archive hardlink target is missing from archive entries:
  2026-05-04T00-00-00.000Z-openclaw-backup/payload/posix/.../home/gonto/.openclaw/state/logs/b.bin
  -> 2026-05-04T00-00-00.000Z-openclaw-backup/.openclaw/state/a.bin

# AFTER — this PR
$ OPENCLAW_FORCE_BUILD=1 pnpm openclaw backup verify /tmp/legacy-backup.tar.gz
Backup archive OK: /tmp/legacy-backup.tar.gz
Archive root: 2026-05-04T00-00-00.000Z-openclaw-backup
Created at: 2026-05-04T00:00:00.000Z
Assets verified: 1
Archive entries scanned: 5
```

Observed result after fix: the real `openclaw backup verify` CLI prints `Backup archive OK` (`Assets verified: 1`, `Archive entries scanned: 5`) for the legacy internal-hardlink archive; corrupt shapes (dropped/tail-collision/self-link/link-to-link/non-file target) still error with `Archive hardlink target is missing from archive entries`.

What was not tested: the reporter's actual archive; the separate `backup create --verify` exit-13 / truncated `.tmp` failure (still tracked in #89257); applying to `release/2026.5.28`.

## Verification (supplemental)
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts src/infra/backup-create.test.ts src/commands/backup.create-verify.test.ts src/commands/backup.atomic.test.ts src/cli/program/register.backup.test.ts` → 21 passed
- `pnpm format:check` / `oxlint` / `pnpm tsgo:core` / `pnpm check:test-types` — clean
