### PR TITLE
fix(agents): guard compact reserved tool names

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -165,6 +165,7 @@ import {
 import { applySystemPromptToSession, buildEmbeddedSystemPrompt } from "./system-prompt.js";
 import {
   collectAllowedToolNames,
+  collectReadableToolNames,
   collectRegisteredToolNames,
   toSessionToolAllowlist,
 } from "./tool-name-allowlist.js";
@@ -844,21 +845,22 @@ async function compactEmbeddedAgentSessionDirectOnce(
       [...normalizableToolProjection.tools],
       runtimePlanModelContext,
     );
+    const coreReservedToolNames = collectReadableToolNames(tools);
     const bundleMcpRuntime = toolsEnabled
       ? await createBundleMcpToolRuntime({
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
-          reservedToolNames: tools.map((tool) => tool.name),
+          reservedToolNames: coreReservedToolNames,
         })
       : undefined;
+    const bundleMcpReservedToolNames = bundleMcpRuntime
+      ? collectReadableToolNames(bundleMcpRuntime.tools)
+      : [];
     const bundleLspRuntime = toolsEnabled
       ? await createBundleLspToolRuntime({
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
-          ],
+          reservedToolNames: [...coreReservedToolNames, ...bundleMcpReservedToolNames],
         })
       : undefined;
     const filteredBundledTools = applyFinalEffectiveToolPolicy({

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -10,6 +10,7 @@ import type { ClientToolDefinition } from "./run/params.js";
 import {
   collectAllowedToolNames,
   collectCoreBuiltinToolNames,
+  collectReadableToolNames,
   collectRegisteredToolNames,
   AGENT_RESERVED_TOOL_NAMES,
   toSessionToolAllowlist,
@@ -51,6 +52,23 @@ describe("tool name allowlists", () => {
     );
 
     expect(allowlist).toEqual(["exec", "image_generate", "read"]);
+  });
+
+  it("collects readable tool names without aborting on a poisoned sibling", () => {
+    const unreadableTool = {
+      get name(): string {
+        throw new Error("tool name getter exploded");
+      },
+    };
+
+    expect(
+      collectReadableToolNames([
+        { name: "exec" },
+        unreadableTool,
+        { name: "read" },
+        { name: undefined },
+      ]),
+    ).toEqual(["exec", "read"]);
   });
 
   it("keeps hidden core names available for client conflict admission", () => {

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.ts
@@ -17,6 +17,20 @@ function addName(names: Set<string>, value: unknown): void {
   }
 }
 
+export function collectReadableToolNames(tools: readonly { readonly name?: unknown }[]): string[] {
+  const names: string[] = [];
+  for (const tool of tools) {
+    try {
+      if (typeof tool.name === "string") {
+        names.push(tool.name);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return names;
+}
+
 export function collectAllowedToolNames(params: {
   tools: AgentTool[];
   clientTools?: ClientToolDefinition[];


### PR DESCRIPTION
## Summary
- collect compact bundled-runtime reserved tool names through a guarded helper so unreadable tool-name accessors cannot abort setup
- keep readable sibling names reserved for MCP/LSP collision avoidance while leaving malformed descriptors for the existing schema quarantine path

## Verification
Behavior addressed: compact runs no longer crash while collecting core or MCP reserved tool names if a provider-normalized or bundled tool descriptor has an unreadable `name` getter.
Real environment tested: AWS Crabbox Linux changed gate plus focused local Vitest in the Codex worktree.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-name-allowlist.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 1 file / 9 tests after the final rebase; oxfmt, targeted oxlint, and diff-check passed; AWS Crabbox `pnpm check:changed` passed on provider `aws`, run `run_4291c5845c1a`, lease `cbx_0e359131c866`, lanes `core` and `coreTests`, exit 0.
Observed result after fix: `collectReadableToolNames` preserves readable siblings and skips a poisoned name getter, and compact now uses that collector for MCP/LSP reserved-name inputs.
What was not tested: no live provider run; the full compact harness selected tests stalled locally, including a neighboring existing quarantine test, so the regression proof uses the lightweight helper test plus changed gate rather than a full compact integration test.
