### PR TITLE
refactor: add memory session sync identity API

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d522f8860146243ff1e7fd0e4b7b89bce6be0c78ab06c564d25c204bdb93287b  plugin-sdk-api-baseline.json
-62d3c6a2f7bdc01c196a970cc269bb83afac34db27be3d8951edb1bbbbff8eaf  plugin-sdk-api-baseline.jsonl
+944ca9fb6d46b8a3fa5582fc276478adfecdb3125d8854523492a7ac155ee318  plugin-sdk-api-baseline.json
+4b79e9cdc7feadb8bcaa89c31160e445141894556ec03652232c3e6a1948ce50  plugin-sdk-api-baseline.jsonl

--- a/extensions/memory-core/src/memory/manager-session-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-session-reindex.ts
@@ -1,16 +1,17 @@
+import type { MemorySyncParams } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
 export function shouldSyncSessionsForReindex(params: {
   hasSessionSource: boolean;
   sessionsDirty: boolean;
   dirtySessionFileCount: number;
-  sync?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-  };
+  sync?: MemorySyncParams;
   needsFullReindex?: boolean;
 }): boolean {
   if (!params.hasSessionSource) {
     return false;
+  }
+  if (params.sync?.sessions?.some((session) => session.sessionId.trim().length > 0)) {
+    return true;
   }
   if (params.sync?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
     return true;

--- a/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-state.test.ts
@@ -65,6 +65,19 @@ describe("memory session sync state", () => {
     expect(plan.activePaths).toEqual(new Set(["sessions/incremental.jsonl"]));
   });
 
+  it("marks identity-targeted syncs as session work", async () => {
+    const { shouldSyncSessionsForReindex } = await import("./manager-session-reindex.js");
+
+    expect(
+      shouldSyncSessionsForReindex({
+        hasSessionSource: true,
+        sessionsDirty: false,
+        dirtySessionFileCount: 0,
+        sync: { sessions: [{ agentId: "main", sessionId: "targeted" }] },
+      }),
+    ).toBe(true);
+  });
+
   it("marks missing and changed startup session files dirty", () => {
     const dirtyFiles = resolveMemorySessionStartupDirtyFiles({
       files: [

--- a/extensions/memory-core/src/memory/manager-sync-control.ts
+++ b/extensions/memory-core/src/memory/manager-sync-control.ts
@@ -4,7 +4,11 @@ import {
   createSubsystemLogger,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
-import type { MemorySyncProgressUpdate } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemorySessionSyncTarget,
+  MemorySyncParams,
+  MemorySyncProgressUpdate,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
 const log = createSubsystemLogger("memory");
 
@@ -21,6 +25,7 @@ export type MemoryReadonlyRecoveryState = {
   runSync: (params?: {
     reason?: string;
     force?: boolean;
+    sessions?: MemorySessionSyncTarget[];
     sessionFiles?: string[];
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) => Promise<void>;
@@ -82,12 +87,7 @@ export function extractMemoryErrorReason(err: unknown): string {
 
 export async function runMemorySyncWithReadonlyRecovery(
   state: MemoryReadonlyRecoveryState,
-  params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  },
+  params?: MemorySyncParams,
 ): Promise<void> {
   try {
     await state.runSync(params);
@@ -123,25 +123,28 @@ export function enqueueMemoryTargetedSessionSync(
     isClosed: () => boolean;
     getSyncing: () => Promise<void> | null;
     getQueuedSessionFiles: () => Set<string>;
+    getQueuedSessions: () => Map<string, MemorySessionSyncTarget>;
     getQueuedSessionSync: () => Promise<void> | null;
     setQueuedSessionSync: (value: Promise<void> | null) => void;
-    sync: (params?: {
-      reason?: string;
-      force?: boolean;
-      sessionFiles?: string[];
-      progress?: (update: MemorySyncProgressUpdate) => void;
-    }) => Promise<void>;
+    sync: (params?: MemorySyncParams) => Promise<void>;
   },
-  sessionFiles?: string[],
+  targets?: Pick<MemorySyncParams, "sessions" | "sessionFiles">,
 ): Promise<void> {
   const queuedSessionFiles = state.getQueuedSessionFiles();
-  for (const sessionFile of sessionFiles ?? []) {
+  for (const sessionFile of targets?.sessionFiles ?? []) {
     const trimmed = sessionFile.trim();
     if (trimmed) {
       queuedSessionFiles.add(trimmed);
     }
   }
-  if (queuedSessionFiles.size === 0) {
+  const queuedSessions = state.getQueuedSessions();
+  for (const session of targets?.sessions ?? []) {
+    const normalized = normalizeQueuedMemorySessionSyncTarget(session);
+    if (normalized) {
+      queuedSessions.set(memorySessionSyncTargetKey(normalized), normalized);
+    }
+  }
+  if (queuedSessionFiles.size === 0 && queuedSessions.size === 0) {
     return state.getSyncing() ?? Promise.resolve();
   }
   if (!state.getQueuedSessionSync()) {
@@ -149,11 +152,17 @@ export function enqueueMemoryTargetedSessionSync(
       (async () => {
         try {
           await state.getSyncing()?.catch(() => undefined);
-          while (!state.isClosed() && state.getQueuedSessionFiles().size > 0) {
+          while (
+            !state.isClosed() &&
+            (state.getQueuedSessionFiles().size > 0 || state.getQueuedSessions().size > 0)
+          ) {
             const pendingSessionFiles = Array.from(state.getQueuedSessionFiles());
+            const pendingSessions = Array.from(state.getQueuedSessions().values());
             state.getQueuedSessionFiles().clear();
+            state.getQueuedSessions().clear();
             await state.sync({
-              reason: "queued-session-files",
+              reason: "queued-sessions",
+              sessions: pendingSessions,
               sessionFiles: pendingSessionFiles,
             });
           }
@@ -164,6 +173,26 @@ export function enqueueMemoryTargetedSessionSync(
     );
   }
   return state.getQueuedSessionSync() ?? Promise.resolve();
+}
+
+function normalizeQueuedMemorySessionSyncTarget(
+  target: MemorySessionSyncTarget,
+): MemorySessionSyncTarget | null {
+  const sessionId = target.sessionId.trim();
+  if (!sessionId) {
+    return null;
+  }
+  const agentId = target.agentId?.trim();
+  const sessionKey = target.sessionKey?.trim();
+  return {
+    ...(agentId ? { agentId } : {}),
+    sessionId,
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
+function memorySessionSyncTargetKey(target: MemorySessionSyncTarget): string {
+  return [target.agentId ?? "", target.sessionId, target.sessionKey ?? ""].join("\0");
 }
 
 export function createMemorySyncControlConfigForTests(

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type {
   MemorySource,
+  MemorySyncParams,
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,6 +27,7 @@ type MemoryIndexEntry = {
 type SyncParams = {
   reason?: string;
   force?: boolean;
+  sessions?: MemorySyncParams["sessions"];
   sessionFiles?: string[];
   progress?: (update: MemorySyncProgressUpdate) => void;
 };
@@ -37,6 +39,25 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected readonly agentId = "main";
   protected readonly workspaceDir = "/tmp/openclaw-test-workspace";
   protected readonly settings = {
+    chunking: {
+      overlap: 0,
+      tokens: 256,
+    },
+    extraPaths: [],
+    multimodal: {
+      enabled: false,
+      modalities: [],
+      maxFileBytes: 0,
+    },
+    provider: "none",
+    store: {
+      fts: {
+        tokenizer: "unicode61",
+      },
+      vector: {
+        enabled: false,
+      },
+    },
     sync: {
       sessions: {
         deltaBytes: 100_000,
@@ -44,7 +65,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
         postCompactionForce: true,
       },
     },
-  } as ResolvedMemorySearchConfig;
+  } as unknown as ResolvedMemorySearchConfig;
   protected readonly batch = {
     enabled: false,
     wait: false,
@@ -59,6 +80,7 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected db: DatabaseSync;
 
   readonly syncCalls: SyncParams[] = [];
+  readonly indexedPaths: string[] = [];
 
   constructor(sourceRows: SourceStateRow[]) {
     super();
@@ -78,6 +100,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   async markStartupDirtyFiles(): Promise<string[]> {
     return await this.markSessionStartupCatchupDirtyFiles();
+  }
+
+  async runSyncForTest(params?: MemorySyncParams): Promise<void> {
+    await this.runSync(params);
   }
 
   getDirtySessionFiles(): string[] {
@@ -113,9 +139,11 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected resetProviderInitializationForRetry(): void {}
 
   protected async indexFile(
-    _entry: MemoryIndexEntry,
+    entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },
-  ): Promise<void> {}
+  ): Promise<void> {
+    this.indexedPaths.push(entry.path);
+  }
 }
 
 describe("session startup catch-up", () => {
@@ -196,5 +224,29 @@ describe("session startup catch-up", () => {
     expect(harness.getDirtySessionFiles()).toEqual([]);
     expect(harness.isSessionsDirty()).toBe(false);
     expect(harness.syncCalls).toEqual([]);
+  });
+
+  it("does not fall back to full session sync when identity targets normalize away", async () => {
+    await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await harness.runSyncForTest({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "other", sessionId: "thread" }],
+    });
+
+    expect(harness.indexedPaths).toEqual([]);
+  });
+
+  it("does not fall back to full session sync for malformed identity session ids", async () => {
+    await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await harness.runSyncForTest({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "main", sessionId: "bad/nested" }],
+    });
+
+    expect(harness.indexedPaths).toEqual([]);
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -20,6 +20,8 @@ import {
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   listSessionFilesForAgent,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
@@ -31,9 +33,12 @@ import {
   normalizeExtraMemoryPaths,
   runWithConcurrency,
   type MemorySource,
+  type MemorySessionSyncTarget,
+  type MemorySyncParams,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
@@ -232,6 +237,7 @@ export abstract class MemoryManagerSyncOps {
   protected sessionsDirty = false;
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
+  protected sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   protected sessionDeltas = new Map<
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
@@ -242,13 +248,7 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
   protected abstract db: DatabaseSync;
   protected abstract computeProviderKey(): string;
-  protected abstract sync(params?: {
-    reason?: string;
-    force?: boolean;
-    forceSessions?: boolean;
-    sessionFile?: string;
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void>;
+  protected abstract sync(params?: MemorySyncParams): Promise<void>;
   protected abstract withTimeout<T>(
     promise: Promise<T>,
     timeoutMs: number,
@@ -784,6 +784,11 @@ export abstract class MemoryManagerSyncOps {
       if (!this.isSessionFileForAgent(sessionFile)) {
         return;
       }
+      const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
+      if (target) {
+        this.scheduleSessionDirty(target);
+        return;
+      }
       this.scheduleSessionDirty(sessionFile);
     });
   }
@@ -855,8 +860,12 @@ export abstract class MemoryManagerSyncOps {
     return dirtyFiles;
   }
 
-  private scheduleSessionDirty(sessionFile: string) {
-    this.sessionPendingFiles.add(sessionFile);
+  private scheduleSessionDirty(target: string | MemorySessionSyncTarget) {
+    if (typeof target === "string") {
+      this.sessionPendingFiles.add(target);
+    } else {
+      this.sessionPendingTargets.set(this.memorySessionSyncTargetKey(target), target);
+    }
     if (this.sessionWatchTimer) {
       return;
     }
@@ -869,11 +878,14 @@ export abstract class MemoryManagerSyncOps {
   }
 
   private async processSessionDeltaBatch(): Promise<void> {
-    if (this.sessionPendingFiles.size === 0) {
+    if (this.sessionPendingFiles.size === 0 && this.sessionPendingTargets.size === 0) {
       return;
     }
     const pending = Array.from(this.sessionPendingFiles);
+    const pendingTargets = Array.from(this.sessionPendingTargets.values());
     this.sessionPendingFiles.clear();
+    this.sessionPendingTargets.clear();
+    pending.push(...Array.from(this.resolveSessionFilesForSyncTargets(pendingTargets)));
     let shouldSync = false;
     for (const sessionFile of pending) {
       // Usage-counted session archives (`.jsonl.reset.<iso>` and
@@ -1039,6 +1051,27 @@ export abstract class MemoryManagerSyncOps {
     return resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
   }
 
+  private resolveSessionTranscriptUpdateSyncTarget(update: {
+    agentId?: string;
+    sessionFile: string;
+    sessionKey?: string;
+  }): MemorySessionSyncTarget | null {
+    const parsed = parseCanonicalSessionSyncTargetFromPath(update.sessionFile);
+    if (!parsed || isSessionArchiveArtifactName(path.basename(update.sessionFile))) {
+      return null;
+    }
+    const agentId = update.agentId?.trim() || parsed.agentId;
+    if (!agentId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+      return null;
+    }
+    const sessionKey = update.sessionKey?.trim();
+    return {
+      agentId,
+      sessionId: parsed.sessionId,
+      ...(sessionKey ? { sessionKey } : {}),
+    };
+  }
+
   private normalizeTargetSessionFiles(sessionFiles?: string[]): Set<string> | null {
     if (!sessionFiles || sessionFiles.length === 0) {
       return null;
@@ -1050,11 +1083,78 @@ export abstract class MemoryManagerSyncOps {
         continue;
       }
       const resolved = path.resolve(trimmed);
-      if (this.isSessionFileForAgent(resolved)) {
+      if (
+        this.isSessionFileForAgent(resolved) &&
+        parseCanonicalSessionSyncTargetFromPath(resolved)
+      ) {
         normalized.add(resolved);
       }
     }
     return normalized.size > 0 ? normalized : null;
+  }
+
+  private normalizeTargetSessions(
+    sessions?: MemorySessionSyncTarget[],
+  ): Map<string, MemorySessionSyncTarget> | null {
+    if (!sessions || sessions.length === 0) {
+      return null;
+    }
+    const normalized = new Map<string, MemorySessionSyncTarget>();
+    for (const session of sessions) {
+      const sessionId = session.sessionId.trim();
+      const agentId = session.agentId?.trim() || this.agentId;
+      if (!sessionId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+        continue;
+      }
+      const sessionKey = session.sessionKey?.trim();
+      const target = {
+        agentId,
+        sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+      };
+      normalized.set(this.memorySessionSyncTargetKey(target), target);
+    }
+    return normalized.size > 0 ? normalized : null;
+  }
+
+  private resolveSessionFilesForSyncTargets(
+    sessions?: Iterable<MemorySessionSyncTarget> | null,
+  ): Set<string> {
+    const files = new Set<string>();
+    for (const session of sessions ?? []) {
+      const resolved = resolveSessionFileForSyncTarget(session, this.agentId);
+      if (!resolved || normalizeAgentId(resolved.agentId) !== normalizeAgentId(this.agentId)) {
+        continue;
+      }
+      const sessionFile = path.resolve(resolved.sessionFile);
+      if (
+        this.isSessionFileForAgent(sessionFile) &&
+        parseCanonicalSessionSyncTargetFromPath(sessionFile)
+      ) {
+        files.add(sessionFile);
+      }
+    }
+    return files;
+  }
+
+  private combineTargetSessionFiles(params: {
+    sessions?: MemorySessionSyncTarget[];
+    sessionFiles?: string[];
+  }): Set<string> | null {
+    const files = new Set<string>();
+    for (const file of this.normalizeTargetSessionFiles(params.sessionFiles) ?? []) {
+      files.add(file);
+    }
+    for (const file of this.resolveSessionFilesForSyncTargets(
+      this.normalizeTargetSessions(params.sessions)?.values(),
+    )) {
+      files.add(file);
+    }
+    return files.size > 0 ? files : null;
+  }
+
+  private memorySessionSyncTargetKey(target: MemorySessionSyncTarget): string {
+    return [target.agentId ?? "", target.sessionId, target.sessionKey ?? ""].join("\0");
   }
 
   protected ensureIntervalSync() {
@@ -1098,10 +1198,7 @@ export abstract class MemoryManagerSyncOps {
     }, this.settings.sync.watchDebounceMs);
   }
 
-  private shouldSyncSessions(
-    params?: { reason?: string; force?: boolean; sessionFiles?: string[] },
-    needsFullReindex = false,
-  ) {
+  private shouldSyncSessions(params?: MemorySyncParams, needsFullReindex = false) {
     return shouldSyncSessionsForReindex({
       hasSessionSource: this.sources.has("sessions"),
       sessionsDirty: this.sessionsDirty,
@@ -1404,12 +1501,7 @@ export abstract class MemoryManagerSyncOps {
     );
   }
 
-  protected async runSync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  protected async runSync(params?: MemorySyncParams) {
     // Guard: if an embedding provider is configured but currently unavailable,
     // abort sync to prevent silently degrading an existing semantic vector index
     // to fts-only and wiping existing semantic vectors.
@@ -1437,8 +1529,14 @@ export abstract class MemoryManagerSyncOps {
         maxFileBytes: this.settings.multimodal.maxFileBytes,
       },
     });
-    const targetSessionFiles = this.normalizeTargetSessionFiles(params?.sessionFiles);
+    const targetSessionFiles = this.combineTargetSessionFiles({
+      sessions: params?.sessions,
+      sessionFiles: params?.sessionFiles,
+    });
     const hasTargetSessionFiles = targetSessionFiles !== null;
+    if (this.hasRequestedTargetSessionSync(params) && !hasTargetSessionFiles) {
+      return;
+    }
     if (params?.reason === "cli" && !params.force && !hasTargetSessionFiles) {
       await this.markSessionStartupCatchupDirtyFiles();
     }
@@ -1552,6 +1650,13 @@ export abstract class MemoryManagerSyncOps {
 
   protected shouldFallbackOnError(err: unknown): boolean {
     return isMemoryEmbeddingOperationError(err);
+  }
+
+  private hasRequestedTargetSessionSync(params?: MemorySyncParams): boolean {
+    return Boolean(
+      params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+      params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+    );
   }
 
   protected resolveBatchConfig(): {

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -33,6 +33,15 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => {
     isSessionArchiveArtifactName: (fileName: string) => /\.jsonl\.(reset|deleted)\./.test(fileName),
     isUsageCountedSessionTranscriptFileName: (fileName: string) => fileName.endsWith(".jsonl"),
     listSessionFilesForAgent: vi.fn(async () => []),
+    parseCanonicalSessionSyncTargetFromPath: (filePath: string) => ({
+      agentId: "main",
+      sessionId: basename(filePath).replace(/\.jsonl$/, ""),
+    }),
+    resolveSessionFileForSyncTarget: (target: { agentId?: string; sessionId: string }) => ({
+      agentId: target.agentId ?? "main",
+      sessionFile: `/tmp/${target.sessionId}.jsonl`,
+      sessionId: target.sessionId,
+    }),
     sessionPathForFile: (filePath: string) => `sessions/${basename(filePath)}`,
   };
 });

--- a/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
+++ b/extensions/memory-core/src/memory/manager-targeted-sync.test.ts
@@ -1,4 +1,6 @@
+import type { MemorySessionSyncTarget } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
+import { enqueueMemoryTargetedSessionSync } from "./manager-sync-control.js";
 import {
   clearMemorySyncedSessionFiles,
   runMemoryTargetedSessionSync,
@@ -74,5 +76,42 @@ describe("memory targeted session sync", () => {
       progress: undefined,
     });
     expect(runSafeReindex).not.toHaveBeenCalled();
+  });
+
+  it("queues identity session targets while a sync is already running", async () => {
+    let resolveSyncing: (() => void) | undefined;
+    const syncing = new Promise<void>((resolve) => {
+      resolveSyncing = resolve;
+    });
+    const queuedSessionFiles = new Set<string>();
+    const queuedSessions = new Map<string, MemorySessionSyncTarget>();
+    let queuedSessionSync: Promise<void> | null = null;
+    const sync = vi.fn(async () => {});
+
+    const queued = enqueueMemoryTargetedSessionSync(
+      {
+        isClosed: () => false,
+        getSyncing: () => syncing,
+        getQueuedSessionFiles: () => queuedSessionFiles,
+        getQueuedSessions: () => queuedSessions,
+        getQueuedSessionSync: () => queuedSessionSync,
+        setQueuedSessionSync: (value) => {
+          queuedSessionSync = value;
+        },
+        sync,
+      },
+      {
+        sessions: [{ agentId: "main", sessionId: "targeted", sessionKey: "agent:main:targeted" }],
+      },
+    );
+
+    resolveSyncing?.();
+    await queued;
+
+    expect(sync).toHaveBeenCalledWith({
+      reason: "queued-sessions",
+      sessions: [{ agentId: "main", sessionId: "targeted", sessionKey: "agent:main:targeted" }],
+      sessionFiles: [],
+    });
   });
 });

--- a/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
@@ -13,6 +13,7 @@ import {
 type ReadonlyRecoveryHarness = MemoryReadonlyRecoveryState & {
   syncing: Promise<void> | null;
   queuedSessionFiles: Set<string>;
+  queuedSessions: Map<string, unknown>;
   queuedSessionSync: Promise<void> | null;
   vectorDegradedWriteWarningShown: boolean;
   ensureProviderInitialized: ReturnType<typeof vi.fn>;
@@ -31,10 +32,12 @@ describe("memory manager readonly recovery", () => {
 
   function createQueuedSyncHarness(syncing: Promise<void>) {
     const queuedSessionFiles = new Set<string>();
+    const queuedSessions = new Map<string, never>();
     let queuedSessionSync: Promise<void> | null = null;
     const sync = vi.fn(async () => {});
     return {
       queuedSessionFiles,
+      queuedSessions,
       get queuedSessionSync() {
         return queuedSessionSync;
       },
@@ -43,6 +46,7 @@ describe("memory manager readonly recovery", () => {
         isClosed: () => false,
         getSyncing: () => syncing,
         getQueuedSessionFiles: () => queuedSessionFiles,
+        getQueuedSessions: () => queuedSessions,
         getQueuedSessionSync: () => queuedSessionSync,
         setQueuedSessionSync: (value: Promise<void> | null) => {
           queuedSessionSync = value;
@@ -60,6 +64,7 @@ describe("memory manager readonly recovery", () => {
       closed: false,
       syncing: null,
       queuedSessionFiles: new Set<string>(),
+      queuedSessions: new Map<string, never>(),
       queuedSessionSync: null,
       db: initialDb,
       vector: {
@@ -223,11 +228,9 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const queued = enqueueMemoryTargetedSessionSync(harness.state, [
-      "  /tmp/first.jsonl ",
-      "",
-      "/tmp/second.jsonl",
-    ]);
+    const queued = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["  /tmp/first.jsonl ", "", "/tmp/second.jsonl"],
+    });
 
     expect(harness.sync).not.toHaveBeenCalled();
 
@@ -236,7 +239,8 @@ describe("memory manager readonly recovery", () => {
 
     expect(harness.sync).toHaveBeenCalledTimes(1);
     expect(harness.sync).toHaveBeenCalledWith({
-      reason: "queued-session-files",
+      reason: "queued-sessions",
+      sessions: [],
       sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl"],
     });
     expect(harness.queuedSessionSync).toBeNull();
@@ -249,14 +253,12 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const first = enqueueMemoryTargetedSessionSync(harness.state, [
-      "/tmp/first.jsonl",
-      "/tmp/second.jsonl",
-    ]);
-    const second = enqueueMemoryTargetedSessionSync(harness.state, [
-      "/tmp/second.jsonl",
-      "/tmp/third.jsonl",
-    ]);
+    const first = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl"],
+    });
+    const second = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["/tmp/second.jsonl", "/tmp/third.jsonl"],
+    });
 
     expect(first).toBe(second);
 
@@ -265,7 +267,8 @@ describe("memory manager readonly recovery", () => {
 
     expect(harness.sync).toHaveBeenCalledTimes(1);
     expect(harness.sync).toHaveBeenCalledWith({
-      reason: "queued-session-files",
+      reason: "queued-sessions",
+      sessions: [],
       sessionFiles: ["/tmp/first.jsonl", "/tmp/second.jsonl", "/tmp/third.jsonl"],
     });
   });
@@ -277,7 +280,9 @@ describe("memory manager readonly recovery", () => {
     });
     const harness = createQueuedSyncHarness(pendingSync);
 
-    const queued = enqueueMemoryTargetedSessionSync(harness.state, ["", "   "]);
+    const queued = enqueueMemoryTargetedSessionSync(harness.state, {
+      sessionFiles: ["", "   "],
+    });
 
     expect(queued).toBe(pendingSync);
     releaseSync();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -17,8 +17,9 @@ import {
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySearchResult,
+  type MemorySessionSyncTarget,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -171,6 +172,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected override sessionsDirty = false;
   protected override sessionsDirtyFiles = new Set<string>();
   protected override sessionPendingFiles = new Set<string>();
+  protected override sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   protected override sessionDeltas = new Map<
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
@@ -178,6 +180,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private sessionWarm = new Set<string>();
   private syncing: Promise<void> | null = null;
   private queuedSessionFiles = new Set<string>();
+  private queuedSessions = new Map<string, MemorySessionSyncTarget>();
   private queuedSessionSync: Promise<void> | null = null;
   private readonlyRecoveryAttempts = 0;
   private readonlyRecoverySuccesses = 0;
@@ -729,18 +732,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
+  async sync(params?: MemorySyncParams): Promise<void> {
     if (this.closed) {
       return;
     }
     if (this.syncing) {
-      if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-        return this.enqueueTargetedSessionSync(params.sessionFiles);
+      if (hasTargetedSessionSyncParams(params)) {
+        return this.enqueueTargetedSessionSync(params);
       }
       return this.syncing;
     }
@@ -753,28 +751,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return this.syncing ?? Promise.resolve();
   }
 
-  private enqueueTargetedSessionSync(sessionFiles?: string[]): Promise<void> {
+  private enqueueTargetedSessionSync(
+    targets?: Pick<MemorySyncParams, "sessions" | "sessionFiles">,
+  ): Promise<void> {
     return enqueueMemoryTargetedSessionSync(
       {
         isClosed: () => this.closed,
         getSyncing: () => this.syncing,
         getQueuedSessionFiles: () => this.queuedSessionFiles,
+        getQueuedSessions: () => this.queuedSessions,
         getQueuedSessionSync: () => this.queuedSessionSync,
         setQueuedSessionSync: (value) => {
           this.queuedSessionSync = value;
         },
         sync: async (params) => await this.sync(params),
       },
-      sessionFiles,
+      targets,
     );
   }
 
-  private async runSyncWithReadonlyRecovery(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
+  private async runSyncWithReadonlyRecovery(params?: MemorySyncParams): Promise<void> {
     const getClosed = () => this.closed;
     const getDb = () => this.db;
     const setDb = (value: DatabaseSync) => {
@@ -1111,6 +1107,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       throw toLintErrorObject(closeError, "Non-Error thrown");
     }
   }
+}
+
+function hasTargetedSessionSyncParams(params: MemorySyncParams | undefined): boolean {
+  return Boolean(
+    params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+    params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+  );
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -44,7 +44,7 @@ import {
   type MemorySearchRuntimeDebug,
   type MemorySearchResult,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
   type ResolvedMemoryBackendConfig,
   type ResolvedQmdConfig,
   type ResolvedQmdMcporterConfig,
@@ -1321,14 +1321,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     return this.clampResultsByInjectedChars(this.diversifyResultsBySource(ranked, resultLimit));
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void> {
-    if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-      log.debug("qmd sync ignoring targeted sessionFiles hint; running regular update");
+  async sync(params?: MemorySyncParams): Promise<void> {
+    if (
+      params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+      params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)
+    ) {
+      log.debug("qmd sync ignoring targeted session hint; running regular update");
     }
     if (params?.progress) {
       params.progress({ completed: 0, total: 1, label: "Updating QMD index…" });

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -18,7 +18,7 @@ import {
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySource,
-  type MemorySyncProgressUpdate,
+  type MemorySyncParams,
   type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
@@ -360,12 +360,7 @@ class BorrowedMemoryManager implements MemorySearchManager {
     return this.inner.status();
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  async sync(params?: MemorySyncParams) {
     await this.inner.sync?.(params);
   }
 
@@ -519,12 +514,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     };
   }
 
-  async sync(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }) {
+  async sync(params?: MemorySyncParams) {
     this.ensureOpen();
     if (!this.primaryFailed) {
       await this.deps.primary.sync?.(params);

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -7,8 +7,11 @@ export {
   loadDreamingNarrativeTranscriptPathSetForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
   type BuildSessionEntryOptions,
+  type ResolvedMemorySessionSyncTarget,
   type SessionFileEntry,
   type SessionTranscriptClassification,
 } from "./host/session-files.js";

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -35,7 +35,9 @@ export type {
   MemorySearchManager,
   MemorySearchRuntimeDebug,
   MemorySearchResult,
+  MemorySessionSyncTarget,
   MemorySource,
+  MemorySyncParams,
   MemorySyncProgressUpdate,
 } from "./host/types.js";
 export { ensureMemoryIndexSchema } from "./host/memory-schema.js";

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -5,6 +5,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 import {
   buildSessionEntry,
   listSessionFilesForAgent,
+  parseCanonicalSessionSyncTargetFromPath,
+  resolveSessionFileForSyncTarget,
   sessionPathForFile,
   type SessionFileEntry,
 } from "./session-files.js";
@@ -92,6 +94,73 @@ describe("sessionPathForFile", () => {
     expect(sessionPathForFile(path.join(tmpDir, "loose-session.jsonl"))).toBe(
       "sessions/loose-session.jsonl",
     );
+  });
+});
+
+describe("memory session sync targets", () => {
+  it("parses deprecated canonical OpenClaw transcript paths into sync identity", () => {
+    const sessionFile = path.join(tmpDir, "agents", "main", "sessions", "active.jsonl");
+    fsSync.mkdirSync(path.dirname(sessionFile), { recursive: true });
+
+    expect(parseCanonicalSessionSyncTargetFromPath(sessionFile)).toEqual({
+      agentId: "main",
+      sessionId: "active",
+    });
+  });
+
+  it("rejects arbitrary deprecated transcript path hints", () => {
+    expect(parseCanonicalSessionSyncTargetFromPath(path.join(tmpDir, "active.jsonl"))).toBeNull();
+    expect(
+      parseCanonicalSessionSyncTargetFromPath(
+        path.join(tmpDir, "agents", "main", "sessions", "active.trajectory.jsonl"),
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves identity sync targets to the current file-backed transcript", () => {
+    expect(resolveSessionFileForSyncTarget({ sessionId: "active" }, "main")).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(tmpDir, "agents", "main", "sessions", "active.jsonl"),
+    });
+  });
+
+  it("normalizes agent ids before resolving identity sync targets", () => {
+    expect(resolveSessionFileForSyncTarget({ agentId: "MAIN", sessionId: "active" })).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(tmpDir, "agents", "main", "sessions", "active.jsonl"),
+    });
+  });
+
+  it("rejects identity sync targets that would escape the sessions directory", () => {
+    expect(resolveSessionFileForSyncTarget({ sessionId: "../outside" }, "main")).toBeNull();
+  });
+
+  it("resolves identity sync targets through persisted session keys", () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:chat:thread-456": {
+          sessionFile: "active-thread-456.jsonl",
+          sessionId: "active",
+        },
+      }),
+    );
+
+    expect(
+      resolveSessionFileForSyncTarget({
+        agentId: "main",
+        sessionId: "active",
+        sessionKey: "agent:main:chat:thread-456",
+      }),
+    ).toEqual({
+      agentId: "main",
+      sessionId: "active",
+      sessionFile: path.join(sessionsDir, "active-thread-456.jsonl"),
+    });
   });
 });
 

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeAgentId } from "./config-utils.js";
 import { readRegularFile, statRegularFile } from "./fs-utils.js";
 import { hashText } from "./hash.js";
 import { createSubsystemLogger, redactSensitiveText } from "./openclaw-runtime-io.js";
@@ -20,6 +21,7 @@ import {
   stripInboundMetadata,
   stripInternalRuntimeContext,
 } from "./openclaw-runtime-session.js";
+import type { MemorySessionSyncTarget } from "./types.js";
 
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
 // Keep the historical one-line-per-message export shape for normal turns, but
@@ -60,6 +62,12 @@ export type BuildSessionEntryOptions = {
 export type SessionTranscriptClassification = {
   dreamingNarrativeTranscriptPaths: ReadonlySet<string>;
   cronRunTranscriptPaths: ReadonlySet<string>;
+};
+
+export type ResolvedMemorySessionSyncTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
 };
 
 type SessionTranscriptStoreEntry = {
@@ -326,6 +334,91 @@ export function sessionPathForFile(absPath: string): string {
   return path
     .join("sessions", ...(agentId ? [agentId] : []), path.basename(absPath))
     .replace(/\\/g, "/");
+}
+
+/**
+ * Parses a deprecated path-shaped memory sync hint only when it points at an
+ * OpenClaw-owned usage-counted transcript in the canonical agent sessions dir.
+ */
+export function parseCanonicalSessionSyncTargetFromPath(
+  sessionFile: string,
+): MemorySessionSyncTarget | null {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const resolved = path.resolve(trimmed);
+  const fileName = path.basename(resolved);
+  const sessionId = parseUsageCountedSessionIdFromFileName(fileName);
+  if (!sessionId || !isUsageCountedSessionTranscriptFileName(fileName)) {
+    return null;
+  }
+  const agentId = extractAgentIdFromSessionPath(resolved);
+  if (!agentId) {
+    return null;
+  }
+  const canonicalSessionsDir = normalizeComparablePath(
+    resolveSessionTranscriptsDirForAgent(agentId),
+  );
+  if (normalizeComparablePath(path.dirname(resolved)) !== canonicalSessionsDir) {
+    return null;
+  }
+  return { agentId, sessionId };
+}
+
+/**
+ * Resolves a storage-neutral memory sync target to the current file-backed
+ * transcript. The SQLite adapter implements this same identity contract without
+ * deriving a path.
+ */
+export function resolveSessionFileForSyncTarget(
+  target: MemorySessionSyncTarget,
+  defaultAgentId?: string,
+): ResolvedMemorySessionSyncTarget | null {
+  const sessionId = target.sessionId.trim();
+  const rawAgentId = (target.agentId ?? defaultAgentId ?? "").trim();
+  if (!rawAgentId || !sessionId) {
+    return null;
+  }
+  const agentId = normalizeAgentId(rawAgentId);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const sessionKey = target.sessionKey?.trim();
+  if (sessionKey) {
+    const store = readSessionTranscriptClassificationStore(path.join(sessionsDir, "sessions.json"));
+    const persistedPath = resolveSessionStoreTranscriptPath(sessionsDir, store[sessionKey]);
+    const canonicalPath = resolveCanonicalSessionSyncFilePath(agentId, persistedPath);
+    if (canonicalPath) {
+      return {
+        agentId,
+        sessionId,
+        sessionFile: canonicalPath,
+      };
+    }
+  }
+  const sessionFile = resolveCanonicalSessionSyncFilePath(
+    agentId,
+    path.join(sessionsDir, `${sessionId}.jsonl`),
+  );
+  if (!sessionFile) {
+    return null;
+  }
+  return {
+    agentId,
+    sessionId,
+    sessionFile,
+  };
+}
+
+function resolveCanonicalSessionSyncFilePath(
+  agentId: string,
+  sessionFile?: string | null,
+): string | null {
+  if (!sessionFile) {
+    return null;
+  }
+  const resolved = path.resolve(sessionFile);
+  const parsed = parseCanonicalSessionSyncTargetFromPath(resolved);
+  return parsed?.agentId === agentId ? resolved : null;
 }
 
 async function logSessionFileReadFailure(absPath: string, err: unknown): Promise<void> {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -27,6 +27,28 @@ export type MemorySyncProgressUpdate = {
   label?: string;
 };
 
+export type MemorySessionSyncTarget = {
+  /** Owning OpenClaw agent. Omit only when the active manager scope already supplies it. */
+  agentId?: string;
+  /** Storage-neutral transcript/session identity. */
+  sessionId: string;
+  /** Optional visible session-store key for callers that already carry it. */
+  sessionKey?: string;
+};
+
+export type MemorySyncParams = {
+  reason?: string;
+  force?: boolean;
+  /** Storage-neutral session transcript targets to refresh. */
+  sessions?: MemorySessionSyncTarget[];
+  /**
+   * @deprecated Use `sessions` with `{ agentId, sessionId, sessionKey? }`.
+   * During the deprecation window only canonical OpenClaw transcript paths are accepted.
+   */
+  sessionFiles?: string[];
+  progress?: (update: MemorySyncProgressUpdate) => void;
+};
+
 export type MemorySearchRuntimeDebug = {
   backend: "builtin" | "qmd";
   configuredMode?: string;
@@ -96,12 +118,7 @@ export interface MemorySearchManager {
   ): Promise<MemorySearchResult[]>;
   readFile(params: { relPath: string; from?: number; lines?: number }): Promise<MemoryReadResult>;
   status(): MemoryProviderStatus;
-  sync?(params?: {
-    reason?: string;
-    force?: boolean;
-    sessionFiles?: string[];
-    progress?: (update: MemorySyncProgressUpdate) => void;
-  }): Promise<void>;
+  sync?(params?: MemorySyncParams): Promise<void>;
   getCachedEmbeddingAvailability?(): MemoryEmbeddingProbeResult | null;
   probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult>;
   probeVectorStoreAvailability?(): Promise<boolean>;

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -56,6 +56,8 @@ export type {
   MemorySearchManager,
   MemorySearchRuntimeDebug,
   MemorySyncProgressUpdate,
+  MemorySessionSyncTarget,
+  MemorySyncParams,
   ResolvedMemoryBackendConfig,
   ResolvedQmdConfig,
   ResolvedQmdMcporterConfig,


### PR DESCRIPTION
## What
Adds identity-based memory session sync targets so memory-core can sync runtime transcripts by storage-neutral session identity while keeping deprecated `sessionFiles` compatibility for canonical OpenClaw transcript paths.

## Why
Path 3 needs memory sync to stop treating transcript filenames as canonical identity before the SQLite storage flip. The scoped transcript read/write APIs can address known transcript targets, but memory sync also needs an identity-shaped targeted-sync request that can work under either file-backed or SQLite-backed stores.

Refs #88838. Builds on #89262.

## Changes
- Add `sync({ sessions })`
- Deprecate `sessionFiles`
- Resolve identities to files
- Queue identity targets
- Reject unsafe paths
- Update SDK baseline

| File | Change |
|------|--------|
| `packages/memory-host-sdk/src/host/types.ts` | Adds identity sync target params |
| `packages/memory-host-sdk/src/host/session-files.ts` | Resolves canonical session identities |
| `extensions/memory-core/src/memory/manager-sync-ops.ts` | Syncs identity-scoped targets |
| `extensions/memory-core/src/memory/manager-sync-control.ts` | Queues identity sync requests |
| `extensions/memory-core/src/memory/manager.ts` | Passes identity targets through |
| `extensions/memory-core/src/memory/qmd-manager.ts` | Uses normalized target metadata |
| `src/plugin-sdk/memory-core-host-engine-storage.ts` | Mirrors SDK storage API |
| `docs/.generated/plugin-sdk-api-baseline.sha256` | Updates SDK API baseline |

## Testing
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager-session-sync-state.test.ts extensions/memory-core/src/memory/manager.readonly-recovery.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts`
- `pnpm exec oxfmt --check <touched files>`
- `node scripts/run-oxlint.mjs <touched files>`
- `pnpm exec tsx scripts/sync-plugin-sdk-exports.ts --check`
- `pnpm exec tsx scripts/check-plugin-sdk-subpath-exports.ts`
- `pnpm exec tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- Autoreview completed with no actionable findings

Broad `tsgo` proof is still blocked by existing unrelated Copilot/UI type errors outside this branch.
