### PR TITLE
fix(agents): guard prompt cache tool names

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -17,6 +17,18 @@ describe("prompt cache observability", () => {
     ).toEqual(["read", "write"]);
   });
 
+  it("collects prompt-cache tool names without aborting on unreadable descriptors", () => {
+    const unreadableTool = {
+      get name(): string {
+        throw new Error("tool name getter exploded");
+      },
+    };
+
+    expect(
+      collectPromptCacheToolNames([{ name: " read " }, unreadableTool, { name: "write" }]),
+    ).toEqual(["read", "write"]);
+  });
+
   it("tracks cache-relevant changes and reports a real cache-read drop", () => {
     const first = beginPromptCacheObservation({
       sessionId: "session-1",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -137,8 +137,19 @@ function diffSnapshots(
   return changes.length > 0 ? changes : null;
 }
 
-export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): string[] {
-  return tools.map((tool) => tool.name?.trim()).filter((name): name is string => Boolean(name));
+export function collectPromptCacheToolNames(tools: readonly { name?: string }[]): string[] {
+  const names: string[] = [];
+  for (const tool of tools) {
+    try {
+      const name = tool.name?.trim();
+      if (name) {
+        names.push(name);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return names;
 }
 
 export function beginPromptCacheObservation(params: {


### PR DESCRIPTION
## Summary
- make prompt-cache observability collect tool names through guarded descriptor reads
- preserve healthy trimmed tool names while skipping descriptors whose `name` getter throws
- keep this scoped to diagnostics/cache tracking so schema projection and quarantine behavior stay unchanged

## Verification
Behavior addressed: prompt-cache debug/cache-trace observability can no longer abort an assistant turn while collecting tool names from a malformed custom tool descriptor.
Real environment tested: AWS Crabbox Linux changed gate plus focused local Vitest and a direct red/green collector probe in the Codex worktree.
Exact steps or command run after this patch: `node --import tsx -e 'import { collectPromptCacheToolNames } from "./src/agents/embedded-agent-runner/prompt-cache-observability.ts"; const bad = { get name() { throw new Error("tool name getter exploded"); } }; console.log(JSON.stringify(collectPromptCacheToolNames([{ name: " read " }, bad, { name: "write" }])));'`; `CI=1 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.
Evidence after fix: direct probe returned `["read","write"]`; focused Vitest passed 1 file / 8 tests after the final rebase; oxfmt, targeted oxlint, and diff-check passed; AWS Crabbox `pnpm check:changed` passed on provider `aws`, run `run_4b331aec4b83`, lease `cbx_926ab35c15db`, lanes `core` and `coreTests`, exit 0.
Observed result after fix: `collectPromptCacheToolNames` skips an unreadable descriptor and still reports healthy `read` and `write` siblings for prompt-cache diagnostics.
What was not tested: no live provider run; the first AWS Crabbox attempt (`run_e2993ab21f87`, lease `cbx_b5c72e52989e`) failed during rsync before executing tests because the temporary sync checkout disappeared, then the retry passed.
