### PR TITLE
fix(plugin-sdk): guard provider schema inspection

### DIFF
--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -144,6 +144,38 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("reports unreadable schema children without aborting provider inspection", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("gemini");
+    const tool = {
+      name: "fuzzplugin_unreadable_child",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          safe: { type: "string" },
+          get broken(): unknown {
+            throw new Error("schema child getter exploded");
+          },
+        },
+      },
+    } as never;
+
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "google",
+        modelId: "gemini-2.5-pro",
+        modelApi: "google-gemini",
+        tools: [tool],
+      }),
+    ).toEqual([
+      {
+        toolName: "fuzzplugin_unreadable_child",
+        toolIndex: 0,
+        violations: ["fuzzplugin_unreadable_child.parameters.properties.broken is unreadable"],
+      },
+    ]);
+  });
+
   it("preserves string-const unions as a flat enum for the deepseek family", () => {
     // Regression for https://github.com/openclaw/openclaw/issues/86468 —
     // Typebox `Type.Union([Type.Literal(...)])` collapses to anyOf of consts;

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -28,31 +28,64 @@ export function findUnsupportedSchemaKeywords(
   }
   const record = schema as Record<string, unknown>;
   const violations: string[] = [];
+  const propertiesRead = readSchemaProperty(record, "properties", `${path}.properties`);
+  if (!propertiesRead.ok) {
+    violations.push(propertiesRead.violation);
+  }
   const properties =
-    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
-      ? (record.properties as Record<string, unknown>)
+    propertiesRead.ok &&
+    propertiesRead.value &&
+    typeof propertiesRead.value === "object" &&
+    !Array.isArray(propertiesRead.value)
+      ? (propertiesRead.value as Record<string, unknown>)
       : undefined;
   if (properties) {
-    for (const [key, value] of Object.entries(properties)) {
+    for (const key of Object.keys(properties)) {
+      const value = readSchemaProperty(properties, key, `${path}.properties.${key}`);
+      if (!value.ok) {
+        violations.push(value.violation);
+        continue;
+      }
       violations.push(
-        ...findUnsupportedSchemaKeywords(value, `${path}.properties.${key}`, unsupportedKeywords),
+        ...findUnsupportedSchemaKeywords(
+          value.value,
+          `${path}.properties.${key}`,
+          unsupportedKeywords,
+        ),
       );
     }
   }
-  for (const [key, value] of Object.entries(record)) {
+  for (const key of Object.keys(record)) {
     if (key === "properties") {
       continue;
     }
     if (unsupportedKeywords.has(key)) {
       violations.push(`${path}.${key}`);
     }
-    if (value && typeof value === "object") {
+    const value = readSchemaProperty(record, key, `${path}.${key}`);
+    if (!value.ok) {
+      violations.push(value.violation);
+      continue;
+    }
+    if (value.value && typeof value.value === "object") {
       violations.push(
-        ...findUnsupportedSchemaKeywords(value, `${path}.${key}`, unsupportedKeywords),
+        ...findUnsupportedSchemaKeywords(value.value, `${path}.${key}`, unsupportedKeywords),
       );
     }
   }
   return violations;
+}
+
+function readSchemaProperty(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): { ok: true; value: unknown } | { ok: false; violation: string } {
+  try {
+    return { ok: true, value: record[key] };
+  } catch {
+    return { ok: false, violation: `${path} is unreadable` };
+  }
 }
 
 export function normalizeGeminiToolSchemas(


### PR DESCRIPTION
## Summary

- Fixes a provider schema inspection crash when a nested tool-parameter schema property is unreadable.
- Converts throwing child schema getters into stable unsupported-schema diagnostics.
- Keeps sibling schema traversal intact for Gemini/DeepSeek provider compatibility checks.
- Out of scope: changing provider payload normalization or live provider execution.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner?

Maintainer fuzzing/hardening pass on plugin SDK tool-schema ingress.

## Real behavior proof (required for external PRs)

Behavior addressed: provider `inspectToolSchemas` helpers no longer crash when a tool parameter schema contains a nested property getter that throws; the unreadable child is reported as an unsupported-schema diagnostic.

Real environment tested: AWS Crabbox Linux changed gate plus focused local Vitest and direct red/green provider-inspection probes in the local worktree.

Exact steps or command run after this patch: `node --import tsx -e 'import { inspectGeminiToolSchemas } from "./src/plugin-sdk/provider-tools.ts"; const tool = { name: "fuzzplugin_unreadable_child", description: "", parameters: { type: "object", properties: { safe: { type: "string" }, get broken() { throw new Error("schema child getter exploded"); } } } }; console.log(JSON.stringify(inspectGeminiToolSchemas({ provider: "google", modelId: "gemini-2.5-pro", modelApi: "google-gemini", tools: [tool] })));'`; `CI=1 node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: direct provider-inspection probe returned the unreadable-child diagnostic; focused Vitest passed 1 file / 11 tests after final rebase; oxfmt, targeted oxlint, and diff-check passed; AWS Crabbox `pnpm check:changed` passed on provider `aws`, run `run_9d59793d8e9c`, lease `cbx_db235e3796a8`, lanes `core, coreTests, extensions, extensionTests`, exit 0.

Observed result after fix: `inspectGeminiToolSchemas` reports `fuzzplugin_unreadable_child.parameters.properties.broken is unreadable` and continues without throwing.

What was not tested: no live provider run; selected Vitest filter for this single test wedged locally, so proof uses the direct red/green probe, full focused provider-tools test file, and changed gate.

Proof limitations or environment constraints: local disk was low, so broad changed-gate validation ran remotely through Crabbox instead of local `pnpm check:changed`.

Before evidence (optional but encouraged): with the test-only red probe and the production guard removed, the same direct provider-inspection probe threw `Error: schema child getter exploded` from `Object.entries` in provider schema traversal.

## Tests and validation

Commands run:

- `node --import tsx -e '...'` red/green probe for `inspectGeminiToolSchemas`
- `CI=1 node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`

Regression coverage added: provider SDK inspection now covers a nested schema property getter that throws and asserts an unreadable-child diagnostic.

What failed before this fix: direct provider inspection threw from nested schema traversal instead of returning diagnostics.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, provider schema diagnostics become more robust for malformed/unreadable plugin tool schemas.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Provider compatibility diagnostics for plugin tool schemas.

How is that risk mitigated?

The guard is scoped to schema inspection property reads, preserves existing unsupported-keyword traversal, keeps sibling traversal, and is covered by focused unit proof plus changed-gate validation.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review.

Which bot or reviewer comments were addressed?

Local autoreview had no accepted/actionable findings.
