### PR TITLE
fix: redact trajectory exports consistently

### DIFF
--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -283,6 +283,7 @@ describe("exportTrajectoryBundle", () => {
       "xoxb-1234567890-abcdefghijkl",
       "ya29.exported-access-token-with-enough-length",
       "ADMIN_PASSWORD=plain-text-password",
+      "sk-top-level-export-secret",
     ];
     const header = {
       type: "session",
@@ -351,6 +352,7 @@ describe("exportTrajectoryBundle", () => {
           seq: 1,
           sourceSeq: 1,
           sessionId: "session-1",
+          apiKey: rawSecrets[5],
           data: {
             systemPrompt: `system includes ${rawSecrets[1]}`,
             tools: [{ name: "danger", description: `tool mentions ${rawSecrets[2]}` }],
@@ -396,6 +398,7 @@ describe("exportTrajectoryBundle", () => {
           seq: 4,
           sourceSeq: 4,
           sessionId: "session-1",
+          runId: rawSecrets[5],
           data: {
             assistantTexts: [`assistant ${rawSecrets[2]}`],
             finalPromptText: `final ${rawSecrets[3]}`,
@@ -411,6 +414,7 @@ describe("exportTrajectoryBundle", () => {
       outputDir,
       sessionFile,
       sessionId: "session-1",
+      sessionKey: rawSecrets[5],
       workspaceDir: tmpDir,
       runtimeFile,
     });

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -417,7 +417,7 @@ describe("exportTrajectoryBundle", () => {
       "utf8",
     );
 
-    await exportTrajectoryBundle({
+    const bundle = await exportTrajectoryBundle({
       outputDir,
       sessionFile,
       sessionId: "session-1",
@@ -434,6 +434,8 @@ describe("exportTrajectoryBundle", () => {
     for (const secret of rawSecrets) {
       expect(exportedBundleText).not.toContain(secret);
     }
+    expect(JSON.stringify(bundle.events)).not.toContain(rawSecrets[5]);
+    expect(JSON.stringify(bundle.manifest)).not.toContain(rawSecrets[5]);
   });
 
   it("rejects oversized runtime trajectory files", async () => {

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -309,7 +309,10 @@ describe("exportTrajectoryBundle", () => {
           type: "toolCall",
           id: "call_1",
           name: "read",
-          arguments: { command: `curl -H 'Authorization: Bearer ${rawSecrets[1]}'` },
+          arguments: {
+            [rawSecrets[5]]: "secret-looking tool argument key",
+            command: `curl -H 'Authorization: Bearer ${rawSecrets[1]}'`,
+          },
         },
       ]),
     };
@@ -370,6 +373,10 @@ describe("exportTrajectoryBundle", () => {
           sessionId: "session-1",
           data: {
             harness: { type: "openclaw", token: rawSecrets[3] },
+            metadata: {
+              [`https://example.test/callback?token=${rawSecrets[1]}`]:
+                "secret-looking metadata key",
+            },
             prompting: {
               skillsPrompt: `skills ${rawSecrets[4]}`,
               userPromptPrefixText: `prefix ${rawSecrets[0]}`,

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -272,6 +272,159 @@ describe("exportTrajectoryBundle", () => {
     );
   });
 
+  it("redacts broad secret patterns from every exported bundle file", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const runtimeFile = path.join(tmpDir, "session.trajectory.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    const rawSecrets = [
+      "sk-exported-session-secret",
+      "ghp_123456789012345678901234",
+      "xoxb-1234567890-abcdefghijkl",
+      "ya29.exported-access-token-with-enough-length",
+      "ADMIN_PASSWORD=plain-text-password",
+    ];
+    const header = {
+      type: "session",
+      version: 3,
+      id: "session-1",
+      timestamp: "2026-04-01T05:46:39.000Z",
+      cwd: tmpDir,
+    };
+    const userEntry = {
+      type: "message",
+      id: "entry-user",
+      parentId: null,
+      timestamp: "2026-04-01T05:46:40.000Z",
+      message: userMessage(`user pasted ${rawSecrets[0]} keep-visible-marker`),
+    };
+    const assistantEntry = {
+      type: "message",
+      id: "entry-assistant",
+      parentId: "entry-user",
+      timestamp: "2026-04-01T05:46:41.000Z",
+      message: assistantMessage([
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "read",
+          arguments: { command: `curl -H 'Authorization: Bearer ${rawSecrets[1]}'` },
+        },
+      ]),
+    };
+    const compactionEntry = {
+      type: "compaction",
+      id: "entry-compaction",
+      parentId: "entry-assistant",
+      timestamp: "2026-04-01T05:46:42.000Z",
+      summary: `compaction summary saw ${rawSecrets[2]}`,
+      firstKeptEntryId: "entry-assistant",
+      tokensBefore: 1024,
+      details: { note: rawSecrets[3] },
+    };
+    const branchSummaryEntry = {
+      type: "branch_summary",
+      id: "entry-branch-summary",
+      parentId: "entry-compaction",
+      timestamp: "2026-04-01T05:46:43.000Z",
+      fromId: "entry-assistant",
+      summary: `branch summary saw ${rawSecrets[4]}`,
+      details: { token: rawSecrets[0] },
+    };
+    fs.writeFileSync(
+      sessionFile,
+      `${[header, userEntry, assistantEntry, compactionEntry, branchSummaryEntry]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n")}\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      runtimeFile,
+      [
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "session-1",
+          source: "runtime",
+          type: "context.compiled",
+          ts: "2026-04-22T08:00:00.000Z",
+          seq: 1,
+          sourceSeq: 1,
+          sessionId: "session-1",
+          data: {
+            systemPrompt: `system includes ${rawSecrets[1]}`,
+            tools: [{ name: "danger", description: `tool mentions ${rawSecrets[2]}` }],
+          },
+        },
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "session-1",
+          source: "runtime",
+          type: "trace.metadata",
+          ts: "2026-04-22T08:00:01.000Z",
+          seq: 2,
+          sourceSeq: 2,
+          sessionId: "session-1",
+          data: {
+            harness: { type: "openclaw", token: rawSecrets[3] },
+            prompting: {
+              skillsPrompt: `skills ${rawSecrets[4]}`,
+              userPromptPrefixText: `prefix ${rawSecrets[0]}`,
+            },
+          },
+        },
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "session-1",
+          source: "runtime",
+          type: "prompt.submitted",
+          ts: "2026-04-22T08:00:02.000Z",
+          seq: 3,
+          sourceSeq: 3,
+          sessionId: "session-1",
+          data: { prompt: `submitted ${rawSecrets[1]}` },
+        },
+        {
+          traceSchema: "openclaw-trajectory",
+          schemaVersion: 1,
+          traceId: "session-1",
+          source: "runtime",
+          type: "trace.artifacts",
+          ts: "2026-04-22T08:00:03.000Z",
+          seq: 4,
+          sourceSeq: 4,
+          sessionId: "session-1",
+          data: {
+            assistantTexts: [`assistant ${rawSecrets[2]}`],
+            finalPromptText: `final ${rawSecrets[3]}`,
+          },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+      "utf8",
+    );
+
+    await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+      runtimeFile,
+    });
+
+    const exportedBundleText = fs
+      .readdirSync(outputDir)
+      .map((file) => fs.readFileSync(path.join(outputDir, file), "utf8"))
+      .join("\n");
+    expect(exportedBundleText).toContain("keep-visible-marker");
+    for (const secret of rawSecrets) {
+      expect(exportedBundleText).not.toContain(secret);
+    }
+  });
+
   it("rejects oversized runtime trajectory files", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -601,15 +601,7 @@ function redactEventForExport(
   event: TrajectoryEvent,
   redaction: TrajectoryExportRedaction,
 ): TrajectoryEvent {
-  return {
-    ...event,
-    workspaceDir: event.workspaceDir
-      ? maybeRedactPathString(event.workspaceDir, redaction)
-      : undefined,
-    data: event.data
-      ? (redactTrajectoryExportValue(event.data, redaction) as Record<string, unknown>)
-      : undefined,
-  };
+  return redactTrajectoryExportValue(event, redaction) as TrajectoryEvent;
 }
 
 function resolveRuntimeContext(runtimeEvents: TrajectoryEvent[]): RuntimeTrajectoryContext {
@@ -1038,14 +1030,18 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
 
   const contents: DiagnosticSupportBundleContent[] = [...supportBundleContents(files)];
   manifest.contents = contents;
+  const redactedManifest = redactTrajectoryExportValue(
+    manifest,
+    redaction,
+  ) as TrajectoryBundleManifest;
 
   await writeSupportBundleDirectory({
     outputDir: params.outputDir,
-    files: [jsonSupportBundleFile("manifest.json", manifest), ...files],
+    files: [jsonSupportBundleFile("manifest.json", redactedManifest), ...files],
   });
 
   return {
-    manifest,
+    manifest: redactedManifest,
     outputDir: params.outputDir,
     events,
     header,

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -599,11 +599,48 @@ function redactLocalPathValues(value: unknown, redaction: TrajectoryExportRedact
   return next;
 }
 
+function uniqueRedactedObjectKey(key: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(key)) {
+    usedKeys.add(key);
+    return key;
+  }
+  let index = 2;
+  while (usedKeys.has(`${key}#${index}`)) {
+    index += 1;
+  }
+  const unique = `${key}#${index}`;
+  usedKeys.add(unique);
+  return unique;
+}
+
+function redactTrajectoryExportObjectKeys(
+  value: unknown,
+  redaction: TrajectoryExportRedaction,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactTrajectoryExportObjectKeys(entry, redaction));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const usedKeys = new Set<string>();
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const redactedKey = redactToolPayloadText(maybeRedactPathString(key, redaction));
+    next[uniqueRedactedObjectKey(redactedKey, usedKeys)] = redactTrajectoryExportObjectKeys(
+      entry,
+      redaction,
+    );
+  }
+  return next;
+}
+
 function redactTrajectoryExportValue(
   value: unknown,
   redaction: TrajectoryExportRedaction,
 ): unknown {
-  return sanitizeTrajectoryExportValue(redactLocalPathValues(value, redaction));
+  const redactedValue = sanitizeTrajectoryExportValue(redactLocalPathValues(value, redaction));
+  return redactTrajectoryExportObjectKeys(redactedValue, redaction);
 }
 
 function redactEventForExport(

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -18,7 +18,7 @@ import {
   redactSupportString,
   type SupportRedactionContext,
 } from "../logging/diagnostic-support-redaction.js";
-import { redactSecrets } from "../logging/redact.js";
+import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import { TRAJECTORY_RUNTIME_FILE_MAX_BYTES, safeTrajectorySessionFileName } from "./paths.js";
 import { isRegularNonSymlinkFile, resolveTrajectoryRuntimeFile } from "./runtime-file.js";
@@ -530,6 +530,15 @@ function trajectoryJsonlFile(
   return jsonlSupportBundleFile(pathName, lines);
 }
 
+function redactTrajectoryBundleFileContent(
+  file: DiagnosticSupportBundleFile,
+): DiagnosticSupportBundleFile {
+  return {
+    ...file,
+    content: redactToolPayloadText(file.content),
+  };
+}
+
 function buildTrajectoryExportRedaction(params: {
   workspaceDir: string;
 }): TrajectoryExportRedaction {
@@ -1028,16 +1037,20 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
     );
   }
 
-  const contents: DiagnosticSupportBundleContent[] = [...supportBundleContents(files)];
+  const redactedFiles = files.map(redactTrajectoryBundleFileContent);
+  const contents: DiagnosticSupportBundleContent[] = [...supportBundleContents(redactedFiles)];
   manifest.contents = contents;
   const redactedManifest = redactTrajectoryExportValue(
     manifest,
     redaction,
   ) as TrajectoryBundleManifest;
+  const manifestFile = redactTrajectoryBundleFileContent(
+    jsonSupportBundleFile("manifest.json", redactedManifest),
+  );
 
   await writeSupportBundleDirectory({
     outputDir: params.outputDir,
-    files: [jsonSupportBundleFile("manifest.json", redactedManifest), ...files],
+    files: [manifestFile, ...redactedFiles],
   });
 
   return {

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -18,6 +18,7 @@ import {
   redactSupportString,
   type SupportRedactionContext,
 } from "../logging/diagnostic-support-redaction.js";
+import { redactSecrets } from "../logging/redact.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
 import { TRAJECTORY_RUNTIME_FILE_MAX_BYTES, safeTrajectorySessionFileName } from "./paths.js";
 import { isRegularNonSymlinkFile, resolveTrajectoryRuntimeFile } from "./runtime-file.js";
@@ -389,6 +390,10 @@ function extractAssistantToolCalls(
   });
 }
 
+function sanitizeTrajectoryExportValue<T>(value: T): T {
+  return redactSecrets(sanitizeDiagnosticPayload(value)) as T;
+}
+
 function buildTranscriptEvents(params: {
   entries: SessionEntry[];
   sessionId: string;
@@ -585,6 +590,13 @@ function redactLocalPathValues(value: unknown, redaction: TrajectoryExportRedact
   return next;
 }
 
+function redactTrajectoryExportValue(
+  value: unknown,
+  redaction: TrajectoryExportRedaction,
+): unknown {
+  return sanitizeTrajectoryExportValue(redactLocalPathValues(value, redaction));
+}
+
 function redactEventForExport(
   event: TrajectoryEvent,
   redaction: TrajectoryExportRedaction,
@@ -595,7 +607,7 @@ function redactEventForExport(
       ? maybeRedactPathString(event.workspaceDir, redaction)
       : undefined,
     data: event.data
-      ? (redactLocalPathValues(event.data, redaction) as Record<string, unknown>)
+      ? (redactTrajectoryExportValue(event.data, redaction) as Record<string, unknown>)
       : undefined,
   };
 }
@@ -967,19 +979,25 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
   });
   if (metadataCapture) {
     files.push(
-      jsonSupportBundleFile("metadata.json", redactLocalPathValues(metadataCapture, redaction)),
+      jsonSupportBundleFile(
+        "metadata.json",
+        redactTrajectoryExportValue(metadataCapture, redaction),
+      ),
     );
     supplementalFiles.push("metadata.json");
   }
   if (artifactsCapture) {
     files.push(
-      jsonSupportBundleFile("artifacts.json", redactLocalPathValues(artifactsCapture, redaction)),
+      jsonSupportBundleFile(
+        "artifacts.json",
+        redactTrajectoryExportValue(artifactsCapture, redaction),
+      ),
     );
     supplementalFiles.push("artifacts.json");
   }
   if (promptsCapture) {
     files.push(
-      jsonSupportBundleFile("prompts.json", redactLocalPathValues(promptsCapture, redaction)),
+      jsonSupportBundleFile("prompts.json", redactTrajectoryExportValue(promptsCapture, redaction)),
     );
     supplementalFiles.push("prompts.json");
   }
@@ -991,12 +1009,12 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
   files.push(
     jsonSupportBundleFile(
       "session-branch.json",
-      redactLocalPathValues(
-        sanitizeDiagnosticPayload({
+      redactTrajectoryExportValue(
+        {
           header,
           leafId,
           entries: branchEntries,
-        }),
+        },
         redaction,
       ),
     ),
@@ -1005,7 +1023,7 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
     files.push(
       textSupportBundleFile(
         "system-prompt.txt",
-        redactLocalPathValues(bundleRuntimeContext.systemPrompt, redaction) as string,
+        redactTrajectoryExportValue(bundleRuntimeContext.systemPrompt, redaction) as string,
       ),
     );
   }
@@ -1013,7 +1031,7 @@ export async function exportTrajectoryBundle(params: BuildTrajectoryBundleParams
     files.push(
       jsonSupportBundleFile(
         "tools.json",
-        redactLocalPathValues(bundleRuntimeContext.tools, redaction),
+        redactTrajectoryExportValue(bundleRuntimeContext.tools, redaction),
       ),
     );
   }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Aligns trajectory bundle export redaction with the broader secret redaction used by runtime trajectory capture.
- Applies export redaction to event data, session branch data, supplemental metadata/artifact/prompt files, system prompt text, and exported tool definitions.
- Preserves existing workspace/home path compaction by applying path redaction before broad secret redaction.
- Adds regression coverage that exports mixed transcript/runtime data and verifies raw token-looking values do not appear in any generated bundle file.

Why does this matter now?

Trajectory bundles are shareable diagnostics, so export output needs the same secret-safety guarantees as runtime trajectory persistence.

What is the intended outcome?

Exported trajectory bundles should keep useful diagnostics while removing credential-looking strings across all generated files.

What is intentionally out of scope?

No changes to trajectory capture semantics, bundle structure, config, migrations, or logging redaction settings.

What does success look like?

A trajectory export containing token-like values produces bundle files without the raw token strings while retaining benign diagnostic text and path compaction behavior.

What should reviewers focus on?

The redaction order in `src/trajectory/export.ts` and the breadth of the export regression in `src/trajectory/export.test.ts`.

AI-assisted: yes.

## Linked context

Which issue does this close?

None in this public PR body.

Which issues, PRs, or discussions are related?

None in this public PR body.

Was this requested by a maintainer or owner?

Maintainer-triaged security hardening work.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Trajectory export bundle redaction now covers broad credential-looking strings across generated bundle files.
- Real environment tested: Local OpenClaw source checkout on Node/Vitest through the repo test wrapper.
- Exact steps or command run after this patch: `pnpm format src/trajectory/export.ts src/trajectory/export.test.ts`; `node scripts/run-vitest.mjs run src/trajectory/export.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Focused test run passed 18 tests in `src/trajectory/export.test.ts`.
- Observed result after fix: The new regression exported a bundle and verified none of the raw token-looking values appeared in the generated files.
- What was not tested: Full test suite and live UI-driven export flow.
- Proof limitations or environment constraints: Local focused validation only so far; CI is pending.
- Before evidence (optional but encouraged): The previous export path only applied diagnostic payload sanitization to event/session data and path-only redaction to supplemental bundle files.

## Tests and validation

Which commands did you run?

- `pnpm format src/trajectory/export.ts src/trajectory/export.test.ts`
- `node scripts/run-vitest.mjs run src/trajectory/export.test.ts`

What regression coverage was added or updated?

- Added `redacts broad secret patterns from every exported bundle file` in `src/trajectory/export.test.ts`.

What failed before this fix, if known?

- The new regression would expose raw token-looking strings in exported bundle files before this change.

If no test was added, why not?

- Regression coverage was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Exported trajectory diagnostics redact more credential-looking strings.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. Secret redaction coverage for trajectory exports changed.

What is the highest-risk area?

Over-redacting useful diagnostic text in trajectory bundles.

How is that risk mitigated?

The redaction order keeps existing path compaction behavior, and the regression asserts benign marker text survives while raw token-looking values do not.

## Current review state

What is the next action?

Run the required post-PR gates and CI monitoring.

What is still waiting on author, maintainer, CI, or external proof?

Post-PR review gates and CI are pending.

Which bot or reviewer comments were addressed?

None yet.
