### PR TITLE
backport plugin SDK llm-core declaration fix to 2026.6.1

### DIFF
--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -8,7 +8,7 @@
  * aliases before release.
  */
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { publicPluginSdkSubpaths } from "./lib/plugin-sdk-entries.mjs";
@@ -42,6 +42,7 @@ const exportedNames = exportMatch[1]
 const exportSet = new Set(exportedNames);
 
 const requiredRuntimeShimEntries = ["compat.js", "root-alias.cjs"];
+const forbiddenPublicDeclarationSpecifiers = ["@openclaw/llm-core"];
 const requiredSubpathExports = {
   "secret-input-runtime": [
     "coerceSecretRef",
@@ -108,6 +109,24 @@ for (const [entry, names] of Object.entries(requiredSubpathExports)) {
   for (const name of names) {
     if (typeof runtime[name] !== "function") {
       console.error(`MISSING SUBPATH EXPORT: dist/plugin-sdk/${entry}.js#${name}`);
+      missing += 1;
+    }
+  }
+}
+
+for (const entry of readdirSync(resolve(scriptDir, "..", "dist", "plugin-sdk"), {
+  withFileTypes: true,
+})) {
+  if (!entry.isFile() || !entry.name.endsWith(".d.ts")) {
+    continue;
+  }
+  const dtsPath = resolve(scriptDir, "..", "dist", "plugin-sdk", entry.name);
+  const dtsContent = readFileSync(dtsPath, "utf8");
+  for (const specifier of forbiddenPublicDeclarationSpecifiers) {
+    if (dtsContent.includes(`"${specifier}`) || dtsContent.includes(`'${specifier}`)) {
+      console.error(
+        `FORBIDDEN PUBLIC DTS SPECIFIER: dist/plugin-sdk/${entry.name} imports ${specifier}`,
+      );
       missing += 1;
     }
   }

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -138,6 +138,7 @@ export function collectInstalledPackageErrors(params: {
 
   errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot));
   errors.push(...collectInstalledPluginSdkZodArtifactErrors(params.packageRoot));
+  errors.push(...collectInstalledPluginSdkDeclarationErrors(params.packageRoot));
   errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
 
   return errors;
@@ -312,6 +313,34 @@ export function collectInstalledPluginSdkZodArtifactErrors(packageRoot: string):
   }
 
   return [];
+}
+
+export function collectInstalledPluginSdkDeclarationErrors(packageRoot: string): string[] {
+  const pluginSdkDistRoot = join(packageRoot, "dist", "plugin-sdk");
+  const errors: string[] = [];
+  const forbiddenPrivateWorkspaceSpecifiers = ["@openclaw/llm-core"];
+
+  if (!existsSync(pluginSdkDistRoot)) {
+    return [];
+  }
+
+  for (const entry of readdirSync(pluginSdkDistRoot, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".d.ts")) {
+      continue;
+    }
+
+    const relativePath = `dist/plugin-sdk/${entry.name}`;
+    const content = readFileSync(join(pluginSdkDistRoot, entry.name), "utf8");
+    for (const specifier of forbiddenPrivateWorkspaceSpecifiers) {
+      if (content.includes(`"${specifier}`) || content.includes(`'${specifier}`)) {
+        errors.push(
+          `installed package plugin SDK declaration '${relativePath}' references private workspace package ${specifier}.`,
+        );
+      }
+    }
+  }
+
+  return errors;
 }
 
 function listInstalledRootDistJavaScriptFiles(packageRoot: string): string[] {

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -45,6 +45,8 @@ const RUNTIME_SHIMS: Partial<Record<string, string>> = {
 
 function isBareImportSpecifier(id: string): boolean {
   if (
+    id === "@openclaw/llm-core" ||
+    id.startsWith("@openclaw/llm-core/") ||
     id === "@openclaw/model-catalog-core/model-catalog-types" ||
     id.startsWith("@openclaw/normalization-core/") ||
     id.startsWith("@openclaw/media-core/") ||


### PR DESCRIPTION
## Summary
- backport #89336 to the 2026.6.1 release branch
- bundle private @openclaw/llm-core types into flat plugin SDK declaration output
- keep build-time and installed-package guards for public plugin SDK declarations

## Validation
- pnpm build:strict-smoke
- rg -n "@openclaw/llm-core" dist/plugin-sdk/*.d.ts -S (no matches)
- packed openclaw-2026.6.1-beta.2.tgz, installed it into a fresh consumer project, and ran tsc with skipLibCheck=false importing openclaw/plugin-sdk and openclaw/plugin-sdk/llm
- collectInstalledPluginSdkDeclarationErrors(...) against the installed tarball returned []

Cherry-picked from 20e0d068a78aab4c8d9d6ea942b68771f6989942.