### PR TITLE
refactor: add QMD session artifact identity mapping

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -22,8 +22,10 @@ import {
   buildSessionEntry,
   deriveQmdScopeChannel,
   deriveQmdScopeChatType,
+  isSessionArchiveArtifactName,
   isQmdScopeAllowed,
   listSessionFilesForAgent,
+  parseCanonicalSessionSyncTargetFromPath,
   parseQmdQueryJson,
   resolveCliSpawnInvocation,
   runCliCommand,
@@ -54,12 +56,21 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { formatSessionTranscriptMemoryHitKey } from "openclaw/plugin-sdk/session-transcript-hit";
 import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
   uniqueValues,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asRecord } from "../dreaming-shared.js";
+import {
+  attachQmdSessionArtifactHit,
+  copyQmdSessionArtifactHit,
+  refreshQmdSessionArtifactDocIds,
+  replaceQmdSessionArtifactMappings,
+  resolveQmdSessionArtifactIdentity,
+  type QmdSessionArtifactMapping,
+} from "../qmd-session-artifacts.js";
 import { resolveQmdCollectionPatternFlags, type QmdCollectionPatternFlag } from "./qmd-compat.js";
 import {
   recordMemoryWatchEventPath,
@@ -239,6 +250,14 @@ type CollectionRoot = {
   kind: MemorySource;
 };
 
+type DocLocation = {
+  abs: string;
+  collection: string;
+  collectionRelativePath: string;
+  rel: string;
+  source: MemorySource;
+};
+
 type SessionExporterConfig = {
   dir: string;
   retentionMs?: number;
@@ -345,10 +364,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private readonly managedCollectionNames: string[];
   private readonly collectionRoots = new Map<string, CollectionRoot>();
   private readonly sources = new Set<MemorySource>();
-  private readonly docPathCache = new Map<
-    string,
-    { rel: string; abs: string; source: MemorySource }
-  >();
+  private readonly docPathCache = new Map<string, DocLocation>();
   private readonly exportedSessionState = new Map<
     string,
     {
@@ -1298,14 +1314,27 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (score < minScore) {
         continue;
       }
-      results.push({
+      const result = {
         path: doc.rel,
         startLine: lines.startLine,
         endLine: lines.endLine,
         score,
         snippet,
         source: doc.source,
-      });
+      } satisfies MemorySearchResult;
+      const artifactIdentity =
+        doc.source === "sessions"
+          ? resolveQmdSessionArtifactIdentity({
+              artifactPath: doc.collectionRelativePath,
+              collection: doc.collection,
+              docid: entry.docid?.trim() || undefined,
+              indexPath: this.indexPath,
+              searchPath: doc.rel,
+            })
+          : null;
+      results.push(
+        artifactIdentity ? attachQmdSessionArtifactHit(result, artifactIdentity) : result,
+      );
     }
     opts?.onDebug?.({
       backend: "qmd",
@@ -1543,6 +1572,9 @@ export class QmdMemoryManager implements MemorySearchManager {
           await this.exportSessions();
         }
         await this.runQmdUpdateWithRetry(reason);
+        if (this.sessionExporter) {
+          this.refreshSessionArtifactDocIds();
+        }
         this.dirty = false;
       });
       if (this.closed) {
@@ -2353,6 +2385,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const files = await listSessionFilesForAgent(this.agentId);
     const keep = new Set<string>();
     const tracked = new Set<string>();
+    const artifactMappings: QmdSessionArtifactMapping[] = [];
     const cutoff = this.sessionExporter.retentionMs
       ? Date.now() - this.sessionExporter.retentionMs
       : null;
@@ -2367,6 +2400,10 @@ export class QmdMemoryManager implements MemorySearchManager {
       const targetName = `${path.basename(sessionFile, ".jsonl")}.md`;
       const target = path.join(exportDir, targetName);
       tracked.add(sessionFile);
+      const identity = this.buildSessionArtifactMapping(sessionFile, targetName, target);
+      if (identity) {
+        artifactMappings.push(identity);
+      }
       const state = this.exportedSessionState.get(sessionFile);
       if (!state || state.hash !== entry.hash || state.mtimeMs !== entry.mtimeMs) {
         await exportRoot.write(targetName, this.renderSessionMarkdown(entry), {
@@ -2394,6 +2431,56 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (!tracked.has(sessionFile) || !isPathInside(exportDir, state.target)) {
         this.exportedSessionState.delete(sessionFile);
       }
+    }
+    replaceQmdSessionArtifactMappings({
+      collection: this.sessionExporter.collectionName,
+      indexPath: this.indexPath,
+      mappings: artifactMappings,
+    });
+  }
+
+  private buildSessionArtifactMapping(
+    sessionFile: string,
+    artifactPath: string,
+    target: string,
+  ): QmdSessionArtifactMapping | null {
+    if (!this.sessionExporter) {
+      return null;
+    }
+    const identity = parseCanonicalSessionSyncTargetFromPath(sessionFile);
+    if (!identity?.agentId) {
+      return null;
+    }
+    return {
+      agentId: identity.agentId,
+      archived: isSessionArchiveArtifactName(path.basename(sessionFile)),
+      artifactPath,
+      collection: this.sessionExporter.collectionName,
+      memoryKey: formatSessionTranscriptMemoryHitKey({
+        agentId: identity.agentId,
+        sessionId: identity.sessionId,
+      }),
+      searchPath: this.buildSearchPath(
+        this.sessionExporter.collectionName,
+        artifactPath,
+        path.relative(this.workspaceDir, target),
+        target,
+      ),
+      sessionId: identity.sessionId,
+    };
+  }
+
+  private refreshSessionArtifactDocIds(): void {
+    if (!this.sessionExporter) {
+      return;
+    }
+    try {
+      refreshQmdSessionArtifactDocIds({
+        collection: this.sessionExporter.collectionName,
+        indexPath: this.indexPath,
+      });
+    } catch (err) {
+      log.warn(`failed to refresh qmd session artifact identity docids: ${String(err)}`);
     }
   }
 
@@ -2427,7 +2514,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private async resolveDocLocation(
     docid?: string,
     hints?: { preferredCollection?: string; preferredFile?: string },
-  ): Promise<{ rel: string; abs: string; source: MemorySource } | null> {
+  ): Promise<DocLocation | null> {
     const normalizedHints = this.normalizeDocHints(hints);
     if (!docid) {
       return this.resolveDocLocationFromHints(normalizedHints);
@@ -2473,7 +2560,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private resolveDocLocationFromHints(hints: {
     preferredCollection?: string;
     preferredFile?: string;
-  }): { rel: string; abs: string; source: MemorySource } | null {
+  }): DocLocation | null {
     if (!hints.preferredCollection || !hints.preferredFile) {
       return null;
     }
@@ -2497,7 +2584,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private resolveIndexedDocLocationFromHint(
     collection: string,
     preferredFile: string,
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  ): DocLocation | null {
     const trimmedCollection = collection.trim();
     const trimmedFile = preferredFile.trim();
     if (!trimmedCollection || !trimmedFile) {
@@ -2599,7 +2686,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private pickDocLocation(
     rows: Array<{ collection: string; path: string }>,
     hints?: { preferredCollection?: string; preferredFile?: string },
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  ): DocLocation | null {
     if (hints?.preferredCollection) {
       for (const row of rows) {
         if (row.collection !== hints.preferredCollection) {
@@ -2794,10 +2881,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     return isQmdScopeAllowed(this.qmd.scope, sessionKey);
   }
 
-  private toDocLocation(
-    collection: string,
-    collectionRelativePath: string,
-  ): { rel: string; abs: string; source: MemorySource } | null {
+  private toDocLocation(collection: string, collectionRelativePath: string): DocLocation | null {
     const rootEntry = this.collectionRoots.get(collection);
     if (!rootEntry) {
       return null;
@@ -2811,7 +2895,13 @@ export class QmdMemoryManager implements MemorySearchManager {
       relativeToWorkspace,
       absPath,
     );
-    return { rel: relPath, abs: absPath, source: rootEntry.kind };
+    return {
+      rel: relPath,
+      abs: absPath,
+      collection,
+      collectionRelativePath: normalizedRelative,
+      source: rootEntry.kind,
+    };
   }
 
   private buildSearchPath(
@@ -2950,7 +3040,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         remaining -= snippet.length;
       } else {
         const trimmed = snippet.slice(0, Math.max(0, remaining));
-        clamped.push({ ...entry, snippet: trimmed });
+        clamped.push(copyQmdSessionArtifactHit(entry, { ...entry, snippet: trimmed }));
         break;
       }
     }

--- a/extensions/memory-core/src/qmd-session-artifacts.ts
+++ b/extensions/memory-core/src/qmd-session-artifacts.ts
@@ -1,0 +1,301 @@
+import fsSync from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { requireNodeSqlite } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+
+const QMD_SESSION_ARTIFACT_TABLE = "openclaw_qmd_session_artifacts";
+
+export const QMD_SESSION_ARTIFACT_HIT: unique symbol = Symbol("openclaw.qmdSessionArtifactHit");
+
+export type QmdSessionArtifactMapping = {
+  agentId: string;
+  archived: boolean;
+  artifactPath: string;
+  collection: string;
+  memoryKey: string;
+  searchPath: string;
+  sessionId: string;
+};
+
+export type QmdSessionArtifactLookup = {
+  artifactPath?: string;
+  collection?: string;
+  docid?: string;
+  indexPath: string;
+  searchPath: string;
+};
+
+export type QmdSessionArtifactIdentity = {
+  agentId: string;
+  archived: boolean;
+  memoryKey: string;
+  sessionId: string;
+};
+
+type QmdSessionArtifactHitCarrier = MemorySearchResult & {
+  [QMD_SESSION_ARTIFACT_HIT]?: QmdSessionArtifactIdentity;
+};
+
+type QmdSessionArtifactRow = {
+  agentId: string;
+  artifact_path: string;
+  archived: number;
+  collection: string;
+  docid: string | null;
+  memoryKey: string;
+  search_path: string;
+  sessionId: string;
+};
+
+function ensureQmdSessionArtifactSchema(db: DatabaseSync): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS ${QMD_SESSION_ARTIFACT_TABLE} (
+      collection TEXT NOT NULL,
+      artifact_path TEXT NOT NULL,
+      search_path TEXT NOT NULL,
+      docid TEXT,
+      memory_key TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      archived INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (collection, artifact_path)
+    )`,
+  );
+  try {
+    db.exec(
+      `ALTER TABLE ${QMD_SESSION_ARTIFACT_TABLE}
+       ADD COLUMN archived INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {}
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_openclaw_qmd_session_artifacts_docid
+     ON ${QMD_SESSION_ARTIFACT_TABLE} (docid)`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_openclaw_qmd_session_artifacts_search_path
+     ON ${QMD_SESSION_ARTIFACT_TABLE} (search_path)`,
+  );
+}
+
+function openQmdSessionArtifactDb(indexPath: string, readOnly = false): DatabaseSync {
+  const { DatabaseSync: SqliteDatabase } = requireNodeSqlite();
+  if (!readOnly) {
+    fsSync.mkdirSync(path.dirname(indexPath), { recursive: true });
+  }
+  const db = new SqliteDatabase(indexPath, { readOnly });
+  db.exec("PRAGMA busy_timeout = 1000");
+  return db;
+}
+
+export function attachQmdSessionArtifactHit(
+  hit: MemorySearchResult,
+  identity: QmdSessionArtifactIdentity,
+): MemorySearchResult {
+  Object.defineProperty(hit, QMD_SESSION_ARTIFACT_HIT, {
+    configurable: true,
+    enumerable: false,
+    value: identity,
+  });
+  return hit;
+}
+
+export function copyQmdSessionArtifactHit(
+  source: MemorySearchResult,
+  target: MemorySearchResult,
+): MemorySearchResult {
+  const identity = readQmdSessionArtifactIdentity(source);
+  return identity ? attachQmdSessionArtifactHit(target, identity) : target;
+}
+
+export function readQmdSessionArtifactIdentity(
+  hit: MemorySearchResult,
+): QmdSessionArtifactIdentity | null {
+  return (hit as QmdSessionArtifactHitCarrier)[QMD_SESSION_ARTIFACT_HIT] ?? null;
+}
+
+export function replaceQmdSessionArtifactMappings(params: {
+  collection: string;
+  indexPath: string;
+  mappings: QmdSessionArtifactMapping[];
+}): void {
+  const db = openQmdSessionArtifactDb(params.indexPath);
+  let transactionStarted = false;
+  try {
+    ensureQmdSessionArtifactSchema(db);
+    const deleteCollection = db.prepare(
+      `DELETE FROM ${QMD_SESSION_ARTIFACT_TABLE} WHERE collection = ?`,
+    );
+    const upsert = db.prepare(
+      `INSERT INTO ${QMD_SESSION_ARTIFACT_TABLE}
+       (collection, artifact_path, search_path, docid, memory_key, agent_id, session_id, archived, updated_at)
+       VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?)
+       ON CONFLICT(collection, artifact_path) DO UPDATE SET
+         search_path=excluded.search_path,
+         docid=NULL,
+         memory_key=excluded.memory_key,
+         agent_id=excluded.agent_id,
+         session_id=excluded.session_id,
+         archived=excluded.archived,
+         updated_at=excluded.updated_at`,
+    );
+    db.exec("BEGIN");
+    transactionStarted = true;
+    deleteCollection.run(params.collection);
+    const updatedAt = Date.now();
+    for (const mapping of params.mappings) {
+      upsert.run(
+        mapping.collection,
+        mapping.artifactPath,
+        mapping.searchPath,
+        mapping.memoryKey,
+        mapping.agentId,
+        mapping.sessionId,
+        mapping.archived ? 1 : 0,
+        updatedAt,
+      );
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    if (transactionStarted) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {}
+    }
+    throw err;
+  } finally {
+    db.close();
+  }
+}
+
+export function refreshQmdSessionArtifactDocIds(params: {
+  collection: string;
+  indexPath: string;
+}): void {
+  const db = openQmdSessionArtifactDb(params.indexPath);
+  let transactionStarted = false;
+  try {
+    ensureQmdSessionArtifactSchema(db);
+    const rows = db
+      .prepare(
+        `SELECT d.hash AS docid, m.artifact_path AS artifact_path
+         FROM ${QMD_SESSION_ARTIFACT_TABLE} m
+         JOIN documents d
+           ON d.collection = m.collection
+          AND d.path = m.artifact_path
+          AND d.active = 1
+         WHERE m.collection = ?`,
+      )
+      .all(params.collection) as Array<{ artifact_path: string; docid: string }>;
+    const updateDocId = db.prepare(
+      `UPDATE ${QMD_SESSION_ARTIFACT_TABLE}
+       SET docid = ?, updated_at = ?
+       WHERE collection = ? AND artifact_path = ?`,
+    );
+    db.exec("BEGIN");
+    transactionStarted = true;
+    const updatedAt = Date.now();
+    for (const row of rows) {
+      updateDocId.run(row.docid, updatedAt, params.collection, row.artifact_path);
+    }
+    db.exec("COMMIT");
+  } catch (err) {
+    if (transactionStarted) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {}
+    }
+    throw err;
+  } finally {
+    db.close();
+  }
+}
+
+export function resolveQmdSessionArtifactIdentity(
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactIdentity | null {
+  let db: DatabaseSync;
+  try {
+    db = openQmdSessionArtifactDb(lookup.indexPath, true);
+  } catch {
+    return null;
+  }
+  try {
+    const row =
+      findQmdSessionArtifactByDocId(db, lookup) ?? findQmdSessionArtifactByPath(db, lookup);
+    return row
+      ? {
+          agentId: row.agentId,
+          archived: row.archived === 1,
+          memoryKey: row.memoryKey,
+          sessionId: row.sessionId,
+        }
+      : null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+function findQmdSessionArtifactByDocId(
+  db: DatabaseSync,
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  const docid = lookup.docid?.trim();
+  if (!docid) {
+    return null;
+  }
+  const rows = db
+    .prepare(
+      `SELECT collection, artifact_path, search_path, docid, archived, memory_key AS memoryKey,
+              agent_id AS agentId, session_id AS sessionId
+       FROM ${QMD_SESSION_ARTIFACT_TABLE}
+       WHERE docid = ?`,
+    )
+    .all(docid) as QmdSessionArtifactRow[];
+  return pickQmdSessionArtifactRow(rows, lookup);
+}
+
+function findQmdSessionArtifactByPath(
+  db: DatabaseSync,
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  const rows = db
+    .prepare(
+      `SELECT collection, artifact_path, search_path, docid, archived, memory_key AS memoryKey,
+              agent_id AS agentId, session_id AS sessionId
+       FROM ${QMD_SESSION_ARTIFACT_TABLE}
+       WHERE search_path = ?
+          OR (collection = ? AND artifact_path = ?)`,
+    )
+    .all(
+      lookup.searchPath,
+      lookup.collection ?? "",
+      lookup.artifactPath ?? "",
+    ) as QmdSessionArtifactRow[];
+  return pickQmdSessionArtifactRow(rows, lookup);
+}
+
+function pickQmdSessionArtifactRow(
+  rows: QmdSessionArtifactRow[],
+  lookup: QmdSessionArtifactLookup,
+): QmdSessionArtifactRow | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const exact = rows.find((row) => {
+    if (lookup.collection && row.collection !== lookup.collection) {
+      return false;
+    }
+    if (lookup.artifactPath && row.artifact_path !== lookup.artifactPath) {
+      return false;
+    }
+    return row.search_path === lookup.searchPath;
+  });
+  if (exact) {
+    return exact;
+  }
+  return rows.length === 1 ? (rows[0] ?? null) : null;
+}

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -1,6 +1,15 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachQmdSessionArtifactHit,
+  copyQmdSessionArtifactHit,
+  replaceQmdSessionArtifactMappings,
+  resolveQmdSessionArtifactIdentity,
+} from "./qmd-session-artifacts.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
 
@@ -18,6 +27,7 @@ const crossAgentStore: Record<string, TestSessionEntry> = {
   },
 };
 let combinedSessionStore: Record<string, TestSessionEntry> = crossAgentStore;
+const tempRoots: string[] = [];
 
 vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => {
   const actual =
@@ -32,10 +42,59 @@ vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => 
 });
 
 describe("filterMemorySearchHitsBySessionVisibility", () => {
-  afterEach(() => {
+  afterEach(async () => {
     vi.mocked(sessionTranscriptHit.loadCombinedSessionStoreForGateway).mockClear();
     combinedSessionStore = crossAgentStore;
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    }
   });
+
+  async function createQmdArtifactIndex(params: {
+    agentId: string;
+    archived?: boolean;
+    artifactPath: string;
+    collection: string;
+    searchPath: string;
+    sessionId: string;
+  }): Promise<string> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-session-artifact-"));
+    tempRoots.push(root);
+    const indexPath = path.join(root, "index.sqlite");
+    replaceQmdSessionArtifactMappings({
+      collection: params.collection,
+      indexPath,
+      mappings: [
+        {
+          agentId: params.agentId,
+          archived: params.archived === true,
+          artifactPath: params.artifactPath,
+          collection: params.collection,
+          memoryKey: sessionTranscriptHit.formatSessionTranscriptMemoryHitKey({
+            agentId: params.agentId,
+            sessionId: params.sessionId,
+          }),
+          searchPath: params.searchPath,
+          sessionId: params.sessionId,
+        },
+      ],
+    });
+    return indexPath;
+  }
+
+  function attachMappedQmdHit(
+    hit: MemorySearchResult,
+    lookup: Parameters<typeof resolveQmdSessionArtifactIdentity>[0],
+  ): MemorySearchResult {
+    const identity = resolveQmdSessionArtifactIdentity(lookup);
+    if (!identity) {
+      throw new Error("expected QMD session artifact identity mapping");
+    }
+    return attachQmdSessionArtifactHit(hit, identity);
+  }
 
   it("drops sessions-sourced hits when requester key is missing (fail closed)", async () => {
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
@@ -450,6 +509,189 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg,
       requesterSessionKey: "agent:main:foo_bar",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toStrictEqual([]);
+  });
+
+  it("keeps mapped QMD session hits when the artifact filename no longer matches the session id", async () => {
+    combinedSessionStore = {
+      "agent:main:actual-key": {
+        sessionId: "actual-session-id",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/actual-session-id.jsonl",
+      },
+    };
+    const searchPath = "qmd/sessions-main/lossy-export-name.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      artifactPath: "lossy-export-name.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "actual-session-id",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "lossy-export-name.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const copiedHit = copyQmdSessionArtifactHit(hit, { ...hit, snippet: "trimmed" });
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "self" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:actual-key",
+      sandboxed: false,
+      hits: [copiedHit],
+    });
+
+    expect(filtered).toEqual([copiedHit]);
+  });
+
+  it("denies mapped live QMD session hits when no session-store key remains", async () => {
+    combinedSessionStore = {};
+    const searchPath = "qmd/sessions-main/orphan-live.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      artifactPath: "orphan-live.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "orphan-live",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "orphan-live.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "agent" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toStrictEqual([]);
+  });
+
+  it("keeps mapped archived QMD session hits when no session-store key remains", async () => {
+    combinedSessionStore = {};
+    const searchPath = "qmd/sessions-main/archived-jsonl-deleted-2026-02-16t22-26-33-000z.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      archived: true,
+      artifactPath: "archived-jsonl-deleted-2026-02-16t22-26-33-000z.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "archived",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "archived-jsonl-deleted-2026-02-16t22-26-33-000z.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "all" },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+
+    expect(filtered).toEqual([hit]);
+  });
+
+  it("denies mapped QMD session hits before deprecated filename fallback", async () => {
+    combinedSessionStore = {
+      "agent:main:visible": {
+        sessionId: "visible",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/visible.jsonl",
+      },
+    };
+    const searchPath = "qmd/sessions-main/visible.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "peer",
+      artifactPath: "visible.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "peer-session",
+    });
+    const hit = attachMappedQmdHit(
+      {
+        path: searchPath,
+        source: "sessions",
+        score: 1,
+        snippet: "x",
+        startLine: 1,
+        endLine: 2,
+      },
+      {
+        artifactPath: "visible.md",
+        collection: "sessions-main",
+        indexPath,
+        searchPath,
+      },
+    );
+    const cfg = asOpenClawConfig({
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: true, allow: ["*"] },
+      },
+    });
+
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:visible",
       sandboxed: false,
       hits: [hit],
     });

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -4,6 +4,7 @@ import { resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 import {
   extractTranscriptIdentityFromSessionsMemoryHit,
   loadCombinedSessionStoreForGateway,
+  resolveSessionTranscriptMemoryHitKeyToSessionKeys,
   resolveTranscriptStemToSessionKeys,
 } from "openclaw/plugin-sdk/session-transcript-hit";
 import {
@@ -11,6 +12,7 @@ import {
   createSessionVisibilityGuard,
   resolveEffectiveSessionToolsVisibility,
 } from "openclaw/plugin-sdk/session-visibility";
+import { readQmdSessionArtifactIdentity } from "./qmd-session-artifacts.js";
 
 function normalizeAgentIdForCompare(value: string | undefined): string | undefined {
   return value?.trim().toLowerCase() || undefined;
@@ -83,6 +85,38 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     if (!params.requesterSessionKey || !guard) {
       continue;
     }
+    const artifactIdentity = readQmdSessionArtifactIdentity(hit);
+    if (artifactIdentity) {
+      const normalizedScopedAgentId = normalizeAgentIdForCompare(scopedAgentId);
+      const normalizedOwnerAgentId = normalizeAgentIdForCompare(artifactIdentity.agentId);
+      if (
+        normalizedScopedAgentId &&
+        normalizedOwnerAgentId &&
+        normalizedOwnerAgentId !== normalizedScopedAgentId
+      ) {
+        continue;
+      }
+      const keys = filterSessionKeysByScopedAgent({
+        cfg: params.cfg,
+        scopedAgentId,
+        keys: resolveSessionTranscriptMemoryHitKeyToSessionKeys({
+          store: combinedSessionStore,
+          key: artifactIdentity.memoryKey,
+          includeSyntheticFallback: artifactIdentity.archived,
+        }),
+      });
+      if (keys.length === 0) {
+        continue;
+      }
+      const allowed = keys.some((key) => guard.check(key).allowed);
+      if (!allowed) {
+        continue;
+      }
+      next.push(hit);
+      continue;
+    }
+    // Deprecated migration compatibility for older QMD/session rows that were
+    // indexed before memory-core stored artifact-to-transcript identity.
     const identity = extractTranscriptIdentityFromSessionsMemoryHit(hit.path);
     if (!identity) {
       continue;


### PR DESCRIPTION
## What
Adds an internal QMD session artifact identity mapping so generated QMD Markdown session artifacts resolve back to stable transcript memory/session identity before deprecated filename fallback.

## Why
Path 3 needs QMD search hits to stop treating generated Markdown artifact names as canonical session identity. QMD still needs Markdown files to index transcript content, but those files are search artifacts; identity should come from a storage-neutral transcript memory key/session mapping.

Refs #88838. Builds on #89348.

## Changes
- Add QMD artifact mapping
- Store identity in QMD index
- Prefer mapped session identity
- Preserve archived compatibility
- Guard live orphan hits
- Cover visibility regressions

| File | Change |
|------|--------|
| `extensions/memory-core/src/qmd-session-artifacts.ts` | Adds private artifact mapping helper |
| `extensions/memory-core/src/memory/qmd-manager.ts` | Writes and attaches QMD mappings |
| `extensions/memory-core/src/session-search-visibility.ts` | Prefers mapped session identity |
| `extensions/memory-core/src/session-search-visibility.test.ts` | Covers mapped visibility behavior |

## Testing
- `node scripts/run-vitest.mjs extensions/memory-core/src/session-search-visibility.test.ts extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts`
- `pnpm exec oxfmt --check <touched files>`
- `node scripts/run-oxlint.mjs <touched files>`
- `pnpm tsgo:extensions`
- `pnpm tsgo:test:extensions`
- `git diff --check`
- Autoreview completed with no accepted/actionable findings

This uses memory-core's existing QMD SQLite index/cache only. It does not add a public `SessionCorpusEntry` SDK, 3.2 session/transcript SQLite store modules, production storage flip, runtime dual-read/fallback, JSON sidecar, or doctor migration.
