### PR TITLE
Fix ControlUI session picker chat switching

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -699,11 +699,14 @@ function renderChatSessionPickerPopover(
                 aria-selected=${selected ? "true" : "false"}
                 title=${label}
                 type="button"
-                @click=${() => {
-                  closeChatSessionPicker(state);
-                  if (row.key !== state.sessionKey) {
-                    onSwitchSession(state, row.key);
+                @click=${(event: MouseEvent) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const nextSessionKey = row.key;
+                  if (nextSessionKey !== state.sessionKey) {
+                    onSwitchSession(state, nextSessionKey);
                   }
+                  closeChatSessionPicker(state);
                 }}
               >
                 <span class="chat-session-picker__option-main">

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1936,6 +1936,41 @@ describe("chat session controls", () => {
     expect(onSwitchSession).toHaveBeenCalledWith(state, targetSessionKey);
   });
 
+  it("switches sessions from the desktop picker option before closing the picker", () => {
+    const { state } = createChatHeaderState();
+    const onSwitchSession = vi.fn((callbackState: AppViewState, nextSessionKey: string) => {
+      expect(callbackState).toBe(state);
+      expect(callbackState.chatSessionPickerOpen).toBe(true);
+      expect(nextSessionKey).toBe("agent:main:work");
+    });
+    state.sessionKey = "agent:main:main";
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "desktop";
+    const sessions = createSessionsResultFromRows([
+      { key: "agent:main:main", kind: "direct", label: "Main", updatedAt: 2 },
+      { key: "agent:main:work", kind: "direct", label: "Work", updatedAt: 1 },
+    ]);
+    state.sessionsResult = sessions;
+    state.chatSessionPickerResult = sessions;
+    const container = document.createElement("div");
+    render(
+      renderChatSessionSelect(state, onSwitchSession, {
+        surface: "desktop",
+      }),
+      container,
+    );
+
+    container
+      .querySelector<HTMLButtonElement>(
+        'button[data-chat-session-picker-option="true"][data-session-key="agent:main:work"]',
+      )!
+      .click();
+
+    expect(onSwitchSession).toHaveBeenCalledTimes(1);
+    expect(state.chatSessionPickerOpen).toBe(false);
+    expect(state.chatSessionPickerSurface).toBeNull();
+  });
+
   it("clears applied chat session picker search when the input is cleared", async () => {
     const { state } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The ControlUI desktop/right-side chat session picker could close before the selected session switch ran, leaving users unable to switch chats from that picker even though the sidebar recent list worked.

Why does this matter now?

Issue #87984 reports a visible ControlUI navigation bug in OpenClaw 5.27 where the top/right session selector is not usable for switching active conversations.

What is the intended outcome?

Selecting a non-current session from the desktop session picker invokes the same session switch path as other session navigation controls, then closes the picker.

What should reviewers focus on?

- The click handler ordering in `ui/src/ui/chat/session-controls.ts`.
- The focused desktop picker regression in `ui/src/ui/views/chat.test.ts`.

## Linked context

Which issue does this close?

Closes #87984.

Was this requested by a maintainer or owner?

No direct maintainer request beyond the open issue classification.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ControlUI desktop/right-side session picker option clicks now switch the active chat before the picker closes.
- Real environment tested: local OpenClaw contributor checkout `/Users/andy/openclaw-87984-controlui` on branch `codex/87984-chat-session-picker`, rendering the actual `renderChatSessionSelect` ControlUI module in a local DOM and dispatching a desktop picker option click.
- Exact steps or command run after this patch: `node --import tsx --input-type=module - <<'NODE' ... NODE`, with jsdom initialized before dynamically importing `./ui/src/ui/chat/session-controls.ts`, rendering `renderChatSessionSelect(..., { surface: "desktop", sessionSwitcherOnly: true })`, and dispatching a click on `button[data-chat-session-picker-option="true"][data-session-key="agent:main:work"]`.
- Evidence after fix (copied terminal output):

```json
{
  "clickedOptionFound": true,
  "switchCalls": [
    {
      "sameState": true,
      "nextSessionKey": "agent:main:work",
      "openAtCallback": true,
      "surfaceAtCallback": "desktop"
    }
  ],
  "afterClick": {
    "pickerOpen": false,
    "pickerSurface": null
  }
}
```

- Observed result after fix: the desktop picker found the target option, invoked the switch callback once with `agent:main:work` while the picker was still open on the `desktop` surface, then closed the picker afterward.
- What was not tested: a full running gateway plus manual browser click was not performed in this worker.
- Proof limitations or environment constraints: the direct smoke uses the real ControlUI module and DOM event dispatch locally, but not a connected live gateway session list.
- Before evidence (optional but encouraged): before this patch, the click handler closed the picker before invoking `onSwitchSession`, matching the reported symptom that picker selection failed while other navigation paths worked.

## Tests and validation

Which commands did you run?

- `pnpm vitest run ui/src/ui/views/chat.test.ts -t "chat session controls"`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts`
- `pnpm tsgo:test:ui`
- `git diff --check`

What regression coverage was added or updated?

Added desktop session picker coverage proving a non-current option switches sessions before picker close state is applied.

What failed before this fix, if known?

The old handler closed picker state first, then attempted to switch sessions.

If no test was added, why not?

A focused regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Session picker click event ordering.

How is that risk mitigated?

The change is scoped to picker option clicks, keeps the existing current-session no-op behavior, and adds focused UI regression coverage.

## Current review state

What is the next action?

Ready for maintainer and ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI, Real behavior proof re-check, and ClawSweeper.

@clawsweeper please re-review.
