### PR TITLE
Retry Crestodian startup gateway probe

### DIFF
--- a/src/crestodian/overview.test.ts
+++ b/src/crestodian/overview.test.ts
@@ -49,6 +49,7 @@ describe("loadCrestodianOverview", () => {
           version: command === "codex" ? "codex 1.0.0" : undefined,
         }),
         probeGatewayUrl: async (url) => ({ reachable: false, url, error: "offline" }),
+        delay: async () => undefined,
       },
     });
 
@@ -74,5 +75,69 @@ describe("loadCrestodianOverview", () => {
     expect(startup).not.toContain("Codex:");
     expect(startup).not.toContain("Claude Code:");
     expect(startup).not.toContain("API keys:");
+  });
+
+  it("retries the local startup gateway probe before reporting the gateway unreachable", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.2" } },
+        list: [{ id: "main", default: true }],
+      },
+      gateway: { port: 19001 },
+    };
+    const snapshot: ConfigFileSnapshot = {
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: runtimeConfig,
+      sourceConfig: runtimeConfig,
+      resolved: runtimeConfig,
+      valid: true,
+      runtimeConfig,
+      config: runtimeConfig,
+      hash: "test-hash",
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    };
+    const probeCalls: string[] = [];
+    const retryDelays: number[] = [];
+
+    const overview = await loadCrestodianOverview({
+      env: { OPENCLAW_TEST_FAST: "1" },
+      deps: {
+        readConfigFileSnapshot: async () => snapshot,
+        resolveConfigPath: () => "/tmp/openclaw.json",
+        buildGatewayConnectionDetails: (input) => ({
+          url: `ws://127.0.0.1:${input.config.gateway?.port ?? 8765}`,
+          urlSource: "local loopback",
+        }),
+        probeLocalCommand: async (command) => ({
+          command,
+          found: false,
+        }),
+        probeGatewayUrl: async (url) => {
+          probeCalls.push(url);
+          if (probeCalls.length <= 2) {
+            return { reachable: false, url, error: "timed out after 900ms" };
+          }
+          return { reachable: true, url };
+        },
+        delay: async (ms) => {
+          retryDelays.push(ms);
+        },
+      },
+    });
+
+    expect(probeCalls).toEqual([
+      "ws://127.0.0.1:19001",
+      "ws://127.0.0.1:19001",
+      "ws://127.0.0.1:19001",
+    ]);
+    expect(retryDelays).toEqual([1_000, 2_000]);
+    expect(overview.gateway.reachable).toBe(true);
+    expect(formatCrestodianStartupMessage(overview)).toContain(
+      "Gateway: reachable at ws://127.0.0.1:19001.",
+    );
   });
 });

--- a/src/crestodian/overview.ts
+++ b/src/crestodian/overview.ts
@@ -78,8 +78,13 @@ type CrestodianOverviewDependencies = {
   }) => GatewayConnectionDetails;
   probeLocalCommand?: typeof probeLocalCommand;
   probeGatewayUrl?: typeof probeGatewayUrl;
+  delay?: (ms: number) => Promise<void>;
   resolveOpenClawReferencePaths?: typeof resolveOpenClawReferencePaths;
 };
+
+type GatewayProbeResult = Awaited<ReturnType<typeof probeGatewayUrl>>;
+
+const CRESTODIAN_GATEWAY_STARTUP_RETRY_DELAYS_MS = [1_000, 2_000] as const;
 
 function issueMessages(snapshot: ConfigFileSnapshot): string[] {
   return snapshot.issues.map((issue) => {
@@ -138,6 +143,41 @@ function resolveFastTestReferences(env: NodeJS.ProcessEnv): OpenClawReferencePat
   };
 }
 
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isLocalLoopbackGatewayUrl(url: string): boolean {
+  try {
+    const httpUrl = url.replace(/^ws:/, "http:").replace(/^wss:/, "https:");
+    const hostname = new URL(httpUrl).hostname;
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+async function probeStartupGatewayUrl(
+  url: string,
+  deps: CrestodianOverviewDependencies,
+): Promise<GatewayProbeResult> {
+  const probe = deps.probeGatewayUrl ?? probeGatewayUrl;
+  let result = await probe(url);
+  if (result.reachable || !isLocalLoopbackGatewayUrl(url)) {
+    return result;
+  }
+  for (const retryDelayMs of CRESTODIAN_GATEWAY_STARTUP_RETRY_DELAYS_MS) {
+    await (deps.delay ?? delay)(retryDelayMs);
+    result = await probe(url);
+    if (result.reachable) {
+      return result;
+    }
+  }
+  return result;
+}
+
 export async function loadCrestodianOverview(
   opts: { env?: NodeJS.ProcessEnv; deps?: CrestodianOverviewDependencies } = {},
 ): Promise<CrestodianOverview> {
@@ -170,7 +210,7 @@ export async function loadCrestodianOverview(
   const [codex, claude, gateway, references] = await Promise.all([
     commandProbe("codex"),
     commandProbe("claude"),
-    (deps.probeGatewayUrl ?? probeGatewayUrl)(gatewayUrl),
+    probeStartupGatewayUrl(gatewayUrl, deps),
     resolveFastTestReferences(env) ??
       resolveReferences({
         argv1: process.argv[1],


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Crestodian could report a local gateway as unreachable during bare `openclaw` startup if the first health probe raced gateway route readiness.

Why does this matter now?

Issue #88254 reports a confusing first-launch/SSH-login false negative: the startup banner says the gateway is not reachable even though chat works shortly afterward.

What is the intended outcome?

For local loopback gateway URLs, Crestodian retries the startup probe over a short bounded window before reporting the gateway unreachable.

What should reviewers focus on?

- The local-loopback-only retry in `src/crestodian/overview.ts`.
- The focused no-live-gateway regression in `src/crestodian/overview.test.ts`.

## Linked context

Which issue does this close?

Closes #88254.

Was this requested by a maintainer or owner?

No direct maintainer request beyond the open issue classification.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Crestodian startup avoids a false unreachable banner when a local gateway becomes reachable shortly after the first startup probe misses.
- Real environment tested: local OpenClaw contributor checkout `/Users/andy/openclaw` on branch `codex/88254-crestodian-probe-timeout`, isolated temp state/config under `/tmp/openclaw-crestodian-proof-52EfBV`, foreground dev gateway with `OPENCLAW_SKIP_CHANNELS=1`, and one-shot `openclaw --dev crestodian --json`.
- Exact steps or command run after this patch: warmed the local runtime with `pnpm openclaw --dev --version`, then started `pnpm openclaw --dev crestodian --json` first while a delayed background launcher started `pnpm openclaw --dev gateway run --dev --allow-unconfigured --auth token --token proof-token --port 19001` 450ms later. The wrapper captured Crestodian JSON, gateway logs, and killed the foreground gateway afterward.
- Evidence after fix (copied terminal output):

```text
proof_tmp=/tmp/openclaw-crestodian-proof-52EfBV
crestodian_exit=0
crestodian_gateway={"url":"ws://127.0.0.1:19001","source":"local loopback","reachable":true}
gateway_ready_lines=2:2026-06-02T00:20:17.324-07:00 Dev config ready: /tmp/openclaw-crestodian-proof-52EfBV/openclaw.json
3:2026-06-02T00:20:17.328-07:00 Dev workspace ready: ~/.openclaw/workspace-dev
9:2026-06-02T00:20:17.897-07:00 [gateway] starting HTTP server...
10:2026-06-02T00:20:17.922-07:00 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
14:2026-06-02T00:20:18.119-07:00 [gateway] ready
crestodian_stderr=$ node scripts/run-node.mjs --dev crestodian --json
gateway_log_head=$ node scripts/run-node.mjs --dev gateway run --dev --allow-unconfigured --auth token --token proof-token --port 19001
2026-06-02T00:20:17.330-07:00 [gateway] loading configuration...
2026-06-02T00:20:17.352-07:00 [gateway] resolving authentication...
2026-06-02T00:20:17.358-07:00 [gateway] starting...
2026-06-02T00:20:17.897-07:00 [gateway] starting HTTP server...
2026-06-02T00:20:18.118-07:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 0.8s)
2026-06-02T00:20:18.119-07:00 [gateway] ready
```

- Observed result after fix: Crestodian started before the foreground gateway was ready, the delayed real gateway reached `/healthz`, and Crestodian returned `reachable:true` for `ws://127.0.0.1:19001` instead of the false unreachable result seen with only one retry.
- What was not tested: the reporter's exact SSH/systemd user-service login environment was not reproduced.
- Proof limitations or environment constraints: this proof uses an isolated local dev foreground gateway rather than systemd, but it exercises the actual CLI, Gateway HTTP listener, and Crestodian network probe path without injected probe responses.
- Before evidence (optional but encouraged): before widening the retry window, the same delayed foreground gateway proof returned `reachable:false` / `fetch failed` because the single 1000ms retry still missed real gateway readiness.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/crestodian/overview.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/crestodian/probes.test.ts`
- `pnpm exec oxlint src/crestodian/overview.ts src/crestodian/overview.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/crestodian/overview.ts src/crestodian/overview.test.ts`
- `git diff --check`
- `pnpm openclaw --dev --version`
- isolated delayed foreground gateway proof shown above

What regression coverage was added or updated?

Added overview coverage where the first two local gateway probes return 900ms timeouts and the third probe succeeds after retry delays of 1000ms and 2000ms.

What failed before this fix, if known?

The overview path performed only one gateway probe, so one transient startup miss became a user-visible unreachable banner. A narrower single-retry version also missed an actual delayed foreground dev gateway in local proof.

If no test was added, why not?

A focused regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Startup latency when the local gateway is genuinely down.

How is that risk mitigated?

The retry is only for local loopback gateway URLs, uses two bounded delays of 1000ms and 2000ms, and does not affect remote gateway URLs.

## Current review state

What is the next action?

Ready for maintainer and ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI rerun and ClawSweeper re-review for the amended retry budget and real delayed-gateway proof.

@clawsweeper please re-review.
