### PR TITLE
Add TurnSurfacePolicy v0 for per-turn tool surface gating

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -349,21 +349,11 @@ export function includeForcedCodexDynamicToolAllow(
   toolsAllow: string[] | undefined,
   params: EmbeddedRunAttemptParams,
 ): string[] | undefined {
+  void params;
   if (toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow)) {
     return toolsAllow;
   }
-  const forcedToolNames = shouldForceMessageTool(params) ? ["message"] : [];
-  if (forcedToolNames.length === 0) {
-    return toolsAllow;
-  }
-  if (toolsAllow.length === 0) {
-    return forcedToolNames;
-  }
-  const normalized = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
-  const missingToolNames = forcedToolNames.filter(
-    (toolName) => !normalized.has(normalizeCodexDynamicToolName(toolName)),
-  );
-  return missingToolNames.length === 0 ? toolsAllow : [...toolsAllow, ...missingToolNames];
+  return toolsAllow;
 }
 
 export function shouldEnableCodexAppServerNativeToolSurface(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1303,24 +1303,23 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.assistantTexts).toEqual(["Nested done."]);
   });
 
-  it("keeps forced message dynamic tool when toolsAllow omits it", () => {
+  it("does not widen scoped Codex dynamic toolsAllow with forced message", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.sourceReplyDeliveryMode = "message_tool_only";
-    params.toolsAllow = ["music_generate"];
+    params.toolsAllow = ["finance_research"];
 
     const dynamicToolNames = filterAllowedRuntimeToolNamesForTest(params, [
       createRuntimeDynamicTool("message"),
-      createRuntimeDynamicTool("music_generate"),
+      createRuntimeDynamicTool("finance_research"),
     ]);
 
-    expect(dynamicToolNames).toContain("message");
-    expect(dynamicToolNames).toContain("music_generate");
+    expect(dynamicToolNames).toEqual(["finance_research"]);
   });
 
-  it("keeps forced message dynamic tool when toolsAllow is empty", () => {
+  it("keeps empty Codex dynamic toolsAllow closed when message delivery is forced", () => {
     const tools = [
       createRuntimeDynamicTool("message"),
       createRuntimeDynamicTool("music_generate"),
@@ -1335,7 +1334,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const dynamicToolNames = filterAllowedRuntimeToolNamesForTest(params, tools);
 
-    expect(dynamicToolNames).toEqual(["message"]);
+    expect(dynamicToolNames).toEqual([]);
   });
 
   it("keeps forced heartbeat registration inside narrow toolsAllow policy", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -46,29 +46,26 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
     ).toEqual(["exec", "read"]);
   });
 
-  it("keeps forced message tool through explicit runtime allowlists", () => {
+  it("does not widen explicit runtime allowlists with forced message", () => {
     const tools = [{ name: "music_generate" }, { name: "message" }];
     const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow(["music_generate"], {
       forceMessageTool: true,
     });
 
-    expect(toolsAllow).toEqual(["music_generate", "message"]);
+    expect(toolsAllow).toEqual(["music_generate"]);
     expect(applyEmbeddedAttemptToolsAllow(tools, toolsAllow).map((tool) => tool.name)).toEqual([
       "music_generate",
-      "message",
     ]);
   });
 
-  it("materializes forced message tool through empty runtime allowlists", () => {
+  it("keeps empty runtime allowlists closed even when message delivery is forced", () => {
     const tools = [{ name: "music_generate" }, { name: "message" }];
     const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow([], {
       forceMessageTool: true,
     });
 
-    expect(toolsAllow).toEqual(["message"]);
-    expect(applyEmbeddedAttemptToolsAllow(tools, toolsAllow).map((tool) => tool.name)).toEqual([
-      "message",
-    ]);
+    expect(toolsAllow).toEqual([]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, toolsAllow).map((tool) => tool.name)).toEqual([]);
   });
 
   it("normalizes explicit toolsAllow entries before filtering", () => {
@@ -199,18 +196,17 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
     });
   });
 
-  it("constructs message tool for forced message delivery on explicit no-tools runs", () => {
+  it("does not construct message tool for forced message delivery on explicit no-tools runs", () => {
     expectConstructionPlan(
       resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: [], forceMessageTool: true }),
       {
-        constructTools: true,
-        includeCoreTools: true,
-        runtimeToolAllowlist: ["message"],
+        constructTools: false,
+        includeCoreTools: false,
         coding: {
           includeBaseCodingTools: false,
           includeShellTools: false,
           includeChannelTools: false,
-          includeOpenClawTools: true,
+          includeOpenClawTools: false,
           includePluginTools: false,
         },
       },
@@ -235,7 +231,7 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
     );
   });
 
-  it("materializes OpenClaw tools when a plugin-only allowlist forces message", () => {
+  it("does not widen plugin-only allowlists when message delivery is forced", () => {
     expectConstructionPlan(
       resolveEmbeddedAttemptToolConstructionPlan({
         toolsAllow: ["memory_search"],
@@ -243,13 +239,13 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
       }),
       {
         constructTools: true,
-        includeCoreTools: true,
-        runtimeToolAllowlist: ["memory_search", "message"],
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["memory_search"],
         coding: {
           includeBaseCodingTools: false,
           includeShellTools: false,
           includeChannelTools: true,
-          includeOpenClawTools: true,
+          includeOpenClawTools: false,
           includePluginTools: true,
         },
       },

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -126,10 +126,9 @@ export function mergeForcedEmbeddedAttemptToolsAllow(
     return toolsAllow;
   }
   if (toolsAllow.length === 0) {
-    return ["message"];
+    return toolsAllow;
   }
-  const normalized = new Set(toolsAllow.map((entry) => normalizeToolName(entry)));
-  return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
+  return toolsAllow;
 }
 
 function resolveCodingToolConstructionPlanForAllowlist(

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -213,6 +213,10 @@ import {
   type ToolSearchTargetTranscriptProjection,
 } from "../../tool-search.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
+import {
+  applyTurnSurfacePolicyToTools,
+  compileTurnSurfacePolicy,
+} from "../../turn-surface-policy.js";
 import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
@@ -293,7 +297,6 @@ import { abortable as abortableWithSignal } from "./abortable.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 import {
   applyEmbeddedAttemptToolsAllow,
-  mergeForcedEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
   shouldCreateBundleLspRuntimeForAttempt,
   shouldCreateBundleMcpRuntimeForAttempt,
@@ -1096,14 +1099,14 @@ export async function runEmbeddedAttempt(
       });
     };
     const corePluginToolStages = createEmbeddedRunStageTracker();
-    const toolsAllowWithForcedRuntimeTools = mergeForcedEmbeddedAttemptToolsAllow(
-      params.toolsAllow,
-      {
-        forceMessageTool:
-          params.forceMessageTool === true ||
-          params.sourceReplyDeliveryMode === "message_tool_only",
-      },
-    );
+    const turnSurfacePolicy = compileTurnSurfacePolicy({
+      toolsAllow: params.toolsAllow,
+      forcedRuntimeToolNames:
+        params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only"
+          ? ["message"]
+          : [],
+    });
+    const toolsAllowWithForcedRuntimeTools = turnSurfacePolicy.toolsAllow;
     const toolConstructionPlan = resolveEmbeddedAttemptToolConstructionPlan({
       disableTools: params.disableTools,
       isRawModelRun,
@@ -1245,9 +1248,12 @@ export async function runEmbeddedAttempt(
             },
           });
           corePluginToolStages.mark("attempt:create-openclaw-coding-tools");
-          const filteredTools = applyEmbeddedAttemptToolsAllow(allTools, effectiveToolsAllow, {
-            toolMeta: (tool) => getPluginToolMeta(tool),
-          });
+          const filteredTools = applyTurnSurfacePolicyToTools(
+            applyEmbeddedAttemptToolsAllow(allTools, effectiveToolsAllow, {
+              toolMeta: (tool) => getPluginToolMeta(tool),
+            }),
+            turnSurfacePolicy,
+          );
           corePluginToolStages.mark("attempt:tools-allow");
           return filteredTools;
         })();
@@ -1426,7 +1432,7 @@ export async function runEmbeddedAttempt(
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.disableTools || isRawModelRun,
-      toolsAllow: params.toolsAllow,
+      toolsAllow: toolsAllowWithForcedRuntimeTools,
     });
     const bundleMcpSessionRuntime = bundleMcpEnabled
       ? await getOrCreateSessionMcpRuntime({
@@ -1448,7 +1454,7 @@ export async function runEmbeddedAttempt(
     const bundleLspEnabled = shouldCreateBundleLspRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.disableTools || isRawModelRun,
-      toolsAllow: params.toolsAllow,
+      toolsAllow: toolsAllowWithForcedRuntimeTools,
     });
     bundleLspRuntime = bundleLspEnabled
       ? await createBundleLspToolRuntime({
@@ -1535,7 +1541,10 @@ export async function runEmbeddedAttempt(
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
     });
-    const uncompactedEffectiveTools = [...uncompactedToolSchemaProjection.tools];
+    const uncompactedEffectiveTools = applyTurnSurfacePolicyToTools(
+      [...uncompactedToolSchemaProjection.tools],
+      turnSurfacePolicy,
+    );
     let effectiveTools = uncompactedEffectiveTools;
     const catalogToolHookContext = {
       agentId: sessionAgentId,
@@ -1605,7 +1614,11 @@ export async function runEmbeddedAttempt(
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
     });
-    effectiveTools = [...toolSearchSchemaProjection.tools];
+    toolSearchCatalogApplied = true;
+    effectiveTools = applyTurnSurfacePolicyToTools(
+      [...toolSearchSchemaProjection.tools],
+      turnSurfacePolicy,
+    );
     if (toolSearch.compacted && !toolSearch.catalogReused) {
       prepStages.mark(codeModeControlsEnabledForRun ? "code-mode" : "tool-search");
       log.info(

--- a/src/agents/turn-surface-policy.test.ts
+++ b/src/agents/turn-surface-policy.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTurnSurfacePolicyToTools,
+  compileTurnSurfacePolicy,
+  filterTurnSurfaceRequestedTools,
+  isToolAllowedByTurnSurfacePolicy,
+} from "./turn-surface-policy.js";
+
+describe("compileTurnSurfacePolicy", () => {
+  it("keeps internal finance scope narrowed to finance_research", () => {
+    const policy = compileTurnSurfacePolicy({ toolsAllow: ["finance_research"] });
+    const tools = [
+      { name: "finance_research" },
+      { name: "message" },
+      { name: "web_search" },
+      { name: "memory_search" },
+      { name: "jh_report_memory_search_readonly" },
+    ];
+
+    expect(policy.toolsAllow).toEqual(["finance_research"]);
+    expect(applyTurnSurfacePolicyToTools(tools, policy).map((tool) => tool.name)).toEqual([
+      "finance_research",
+    ]);
+  });
+
+  it("does not allow forced message unless the scoped allowlist includes it", () => {
+    const policy = compileTurnSurfacePolicy({
+      toolsAllow: ["finance_research"],
+      forcedRuntimeToolNames: ["message"],
+    });
+
+    expect(policy.toolsAllow).toEqual(["finance_research"]);
+    expect(isToolAllowedByTurnSurfacePolicy("message", policy)).toBe(false);
+  });
+
+  it("keeps explicit empty allowlists closed", () => {
+    const policy = compileTurnSurfacePolicy({
+      toolsAllow: [],
+      forcedRuntimeToolNames: ["message"],
+    });
+
+    expect(policy.enabled).toBe(true);
+    expect(policy.toolsAllow).toEqual([]);
+    expect(isToolAllowedByTurnSurfacePolicy("message", policy)).toBe(false);
+  });
+
+  it("keeps forced message when send scope already resolved to message", () => {
+    const policy = compileTurnSurfacePolicy({
+      toolsAllow: ["finance_research", "message"],
+      forcedRuntimeToolNames: ["message"],
+    });
+
+    expect(policy.toolsAllow).toEqual(["finance_research", "message"]);
+    expect(isToolAllowedByTurnSurfacePolicy("message", policy)).toBe(true);
+  });
+
+  it("filters gateway requested tools before they widen the surface", () => {
+    const policy = compileTurnSurfacePolicy({ toolsAllow: ["finance_research"] });
+
+    expect(filterTurnSurfaceRequestedTools(["web_search", "message"], policy)).toEqual([]);
+  });
+
+  it("keeps legacy exclude-only policy from enabling default scope deny", () => {
+    const policy = compileTurnSurfacePolicy({ excludeToolNames: ["web_search"] });
+    const tools = [{ name: "message" }, { name: "web_search" }, { name: "exec" }];
+
+    expect(policy.enabled).toBe(true);
+    expect(policy.defaultDenyEnabled).toBe(false);
+    expect(applyTurnSurfacePolicyToTools(tools, policy).map((tool) => tool.name)).toEqual([
+      "message",
+      "exec",
+    ]);
+  });
+
+  it("preserves legacy behavior when no turn surface policy input is present", () => {
+    const policy = compileTurnSurfacePolicy({});
+
+    expect(policy.enabled).toBe(false);
+    expect(policy.defaultDenyEnabled).toBe(false);
+    expect(filterTurnSurfaceRequestedTools(["message"], policy)).toEqual(["message"]);
+  });
+});

--- a/src/agents/turn-surface-policy.ts
+++ b/src/agents/turn-surface-policy.ts
@@ -1,0 +1,157 @@
+import { normalizeToolList, normalizeToolName } from "./tool-policy.js";
+
+export type TurnSurfacePolicy = {
+  enabled: boolean;
+  toolsAllow?: string[];
+  excludeToolNames: string[];
+  defaultDenyEnabled: boolean;
+};
+
+const DEFAULT_SCOPE_DENY_TOOL_NAMES = [
+  "apply_patch",
+  "browser",
+  "canvas",
+  "code_execution",
+  "cron",
+  "edit",
+  "exec",
+  "gateway",
+  "memory_get",
+  "memory_search",
+  "message",
+  "nodes",
+  "process",
+  "sessions_send",
+  "sessions_spawn",
+  "web_fetch",
+  "web_search",
+  "write",
+  "x_search",
+];
+
+function hasWildcardAllow(toolsAllow: string[] | undefined): boolean {
+  return toolsAllow?.some((name) => normalizeToolName(name) === "*") === true;
+}
+
+function normalizeOptionalToolList(list: Iterable<string> | undefined): string[] | undefined {
+  if (!list) {
+    return undefined;
+  }
+  return normalizeToolList(Array.from(list));
+}
+
+function explicitAllowSet(toolsAllow: string[] | undefined): Set<string> | undefined {
+  if (!toolsAllow || hasWildcardAllow(toolsAllow)) {
+    return undefined;
+  }
+  return new Set(normalizeToolList(toolsAllow));
+}
+
+function isSourceSpecificReadonlyTool(normalized: string): boolean {
+  return (
+    /^jh_[a-z0-9_]*_readonly$/u.test(normalized) ||
+    /^openclaw_[a-z0-9_]*_readonly$/u.test(normalized)
+  );
+}
+
+export function isToolAllowedByTurnSurfacePolicy(
+  toolName: string,
+  policy: TurnSurfacePolicy,
+): boolean {
+  if (!policy.enabled) {
+    return true;
+  }
+  const normalized = normalizeToolName(toolName);
+  if (!normalized) {
+    return false;
+  }
+  if (policy.toolsAllow && !hasWildcardAllow(policy.toolsAllow)) {
+    return explicitAllowSet(policy.toolsAllow)?.has(normalized) === true;
+  }
+  return !isToolDeniedByTurnSurfacePolicy(toolName, policy);
+}
+
+export function isToolDeniedByTurnSurfacePolicy(
+  toolName: string,
+  policy: TurnSurfacePolicy,
+): boolean {
+  if (!policy.enabled) {
+    return false;
+  }
+  const normalized = normalizeToolName(toolName);
+  if (!normalized) {
+    return true;
+  }
+  if (explicitAllowSet(policy.toolsAllow)?.has(normalized)) {
+    return false;
+  }
+  if (policy.excludeToolNames.some((name) => normalizeToolName(name) === normalized)) {
+    return true;
+  }
+  return policy.defaultDenyEnabled && isSourceSpecificReadonlyTool(normalized);
+}
+
+export function applyTurnSurfacePolicyToTools<T extends { name: string }>(
+  tools: T[],
+  policy: TurnSurfacePolicy,
+): T[] {
+  if (!policy.enabled) {
+    return tools;
+  }
+  return tools.filter((tool) => isToolAllowedByTurnSurfacePolicy(tool.name, policy));
+}
+
+export function filterTurnSurfaceRequestedTools(
+  requestedTools: string[],
+  policy: TurnSurfacePolicy,
+): string[] {
+  if (!policy.enabled) {
+    return requestedTools;
+  }
+  return requestedTools.filter((toolName) => isToolAllowedByTurnSurfacePolicy(toolName, policy));
+}
+
+export function compileTurnSurfacePolicy(params: {
+  toolsAllow?: string[];
+  excludeToolNames?: Iterable<string>;
+  forcedRuntimeToolNames?: string[];
+}): TurnSurfacePolicy {
+  const normalizedAllow = normalizeOptionalToolList(params.toolsAllow);
+  const explicitAllow = explicitAllowSet(normalizedAllow);
+  const inheritedDeny = normalizeOptionalToolList(params.excludeToolNames) ?? [];
+  const defaultDenyEnabled = params.toolsAllow !== undefined;
+  const enabled = defaultDenyEnabled || inheritedDeny.length > 0;
+  if (!enabled) {
+    return {
+      enabled: false,
+      toolsAllow: params.toolsAllow,
+      excludeToolNames: [],
+      defaultDenyEnabled: false,
+    };
+  }
+
+  const forcedAllowed = filterTurnSurfaceRequestedTools(params.forcedRuntimeToolNames ?? [], {
+    enabled: true,
+    toolsAllow: normalizedAllow,
+    excludeToolNames: inheritedDeny,
+    defaultDenyEnabled,
+  });
+  const toolsAllow =
+    normalizedAllow && forcedAllowed.length > 0 && !hasWildcardAllow(normalizedAllow)
+      ? Array.from(new Set(normalizeToolList([...normalizedAllow, ...forcedAllowed])))
+      : normalizedAllow;
+  const allow = explicitAllowSet(toolsAllow) ?? explicitAllow;
+  const excludeToolNames = normalizeToolList([
+    ...(defaultDenyEnabled
+      ? DEFAULT_SCOPE_DENY_TOOL_NAMES.filter((name) => !allow?.has(normalizeToolName(name)))
+      : []),
+    ...inheritedDeny.filter((name) => !allow?.has(normalizeToolName(name))),
+  ]);
+
+  return {
+    enabled: true,
+    ...(toolsAllow !== undefined ? { toolsAllow } : {}),
+    excludeToolNames,
+    defaultDenyEnabled,
+  };
+}

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -67,4 +67,33 @@ describe("resolveGatewayScopedTools", () => {
 
     expect(result.tools.some((tool) => tool.name === "message")).toBe(false);
   });
+
+  it("does not force message through a scoped internal-finance surface", () => {
+    const result = resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      messageProvider: "telegram",
+      inboundEventKind: "room_event",
+      sourceReplyDeliveryMode: "message_tool_only",
+      surface: "loopback",
+      toolsAllow: ["finance_research"],
+    });
+
+    expect(result.tools.some((tool) => tool.name === "message")).toBe(false);
+  });
+
+  it("does not treat gateway requested tools as scoped surface authority", () => {
+    const result = resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      messageProvider: "telegram",
+      inboundEventKind: "user_request",
+      surface: "loopback",
+      gatewayRequestedTools: ["web_search", "message"],
+      toolsAllow: ["finance_research"],
+    });
+
+    expect(result.tools.some((tool) => tool.name === "web_search")).toBe(false);
+    expect(result.tools.some((tool) => tool.name === "message")).toBe(false);
+  });
 });

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -143,10 +143,6 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolPolicy,
     defaultGatewayDeny.length > 0 ? { deny: defaultGatewayDeny } : undefined,
     Array.isArray(gatewayToolsCfg?.deny) ? { deny: gatewayToolsCfg.deny } : undefined,
-    turnSurfacePolicy.excludeToolNames.length > 0
-      ? { deny: turnSurfacePolicy.excludeToolNames }
-      : undefined,
-    excludedToolNames.length > 0 ? { deny: excludedToolNames } : undefined,
   ]);
   const inheritedToolDenylist = [...explicitDenylist];
   // Passed by reference to sessions_spawn and populated after the final policy

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -23,6 +23,11 @@ import {
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import {
+  applyTurnSurfacePolicyToTools,
+  compileTurnSurfacePolicy,
+  filterTurnSurfaceRequestedTools,
+} from "../agents/turn-surface-policy.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -51,6 +56,7 @@ export function resolveGatewayScopedTools(params: {
   excludeToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
+  toolsAllow?: string[];
 }) {
   const {
     agentId,
@@ -66,21 +72,32 @@ export function resolveGatewayScopedTools(params: {
   const profilePolicy = resolveToolProfilePolicy(profile);
   const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
   const gatewayRequestedTools = params.gatewayRequestedTools ?? [];
+  const turnSurfacePolicy = compileTurnSurfacePolicy({
+    toolsAllow: params.toolsAllow,
+    excludeToolNames: params.excludeToolNames,
+  });
+  const policyFilteredGatewayRequestedTools = filterTurnSurfaceRequestedTools(
+    gatewayRequestedTools,
+    turnSurfacePolicy,
+  );
   const messageProvider = params.messageProvider?.trim().toLowerCase();
   const sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined =
     params.sourceReplyDeliveryMode ??
     (params.inboundEventKind === "room_event" && messageProvider !== "webchat"
       ? "message_tool_only"
       : undefined);
-  const runtimeAlsoAllow = sourceReplyDeliveryMode === "message_tool_only" ? ["message"] : [];
+  const runtimeAlsoAllow =
+    sourceReplyDeliveryMode === "message_tool_only"
+      ? filterTurnSurfaceRequestedTools(["message"], turnSurfacePolicy)
+      : [];
   const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, [
     ...(profileAlsoAllow ?? []),
-    ...gatewayRequestedTools,
+    ...policyFilteredGatewayRequestedTools,
     ...runtimeAlsoAllow,
   ]);
   const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(providerProfilePolicy, [
     ...(providerProfileAlsoAllow ?? []),
-    ...gatewayRequestedTools,
+    ...policyFilteredGatewayRequestedTools,
     ...runtimeAlsoAllow,
   ]);
   const groupPolicy = resolveGroupToolPolicy({
@@ -126,6 +143,10 @@ export function resolveGatewayScopedTools(params: {
     inheritedToolPolicy,
     defaultGatewayDeny.length > 0 ? { deny: defaultGatewayDeny } : undefined,
     Array.isArray(gatewayToolsCfg?.deny) ? { deny: gatewayToolsCfg.deny } : undefined,
+    turnSurfacePolicy.excludeToolNames.length > 0
+      ? { deny: turnSurfacePolicy.excludeToolNames }
+      : undefined,
+    excludedToolNames.length > 0 ? { deny: excludedToolNames } : undefined,
   ]);
   const inheritedToolDenylist = [...explicitDenylist];
   // Passed by reference to sessions_spawn and populated after the final policy
@@ -141,7 +162,9 @@ export function resolveGatewayScopedTools(params: {
     groupPolicy,
     subagentPolicy,
     inheritedToolPolicy,
-    gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
+    policyFilteredGatewayRequestedTools.length > 0
+      ? { allow: policyFilteredGatewayRequestedTools }
+      : undefined,
   ].some(hasRestrictiveAllowPolicy);
 
   const allTools = createOpenClawTools({
@@ -172,7 +195,9 @@ export function resolveGatewayScopedTools(params: {
       groupPolicy,
       subagentPolicy,
       inheritedToolPolicy,
-      gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
+      policyFilteredGatewayRequestedTools.length > 0
+        ? { allow: policyFilteredGatewayRequestedTools }
+        : undefined,
     ]),
     pluginToolDenylist: explicitDenylist,
     inheritedToolAllowlist,
@@ -206,9 +231,13 @@ export function resolveGatewayScopedTools(params: {
   const gatewayDenySet = new Set([
     ...defaultGatewayDeny,
     ...(Array.isArray(gatewayToolsCfg?.deny) ? gatewayToolsCfg.deny : []),
+    ...turnSurfacePolicy.excludeToolNames,
     ...excludedToolNames,
   ]);
-  const tools = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
+  const tools = applyTurnSurfacePolicyToTools(
+    policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name)),
+    turnSurfacePolicy,
+  );
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, tools);
   }


### PR DESCRIPTION
## Summary

- add `TurnSurfacePolicy` to compile per-turn `toolsAllow` / `excludeToolNames` into an effective model-facing tool surface
- filter gateway requested tools and forced `message` before they widen scoped surfaces
- apply the same surface policy across embedded runtime tool construction, bundled/effective tools, tool-search catalog results, and Codex app-server forced dynamic tool handling

## Boundary

This change keeps the gate on the OpenClaw runtime/chief side. It does not modify `finance_research` and does not make `finance_research` the owner of web/browser/provider/memory/write surface gating.

## Real behavior proof

- Behavior or issue addressed: Turn-scoped `toolsAllow: ["finance_research"]` must not expose web/browser/memory/message/send/write/source-readonly tools to the model-facing surface, and forced `message` delivery must not widen that scoped surface.

- Real environment tested: Local OpenClaw source checkout for PR #89365 at head `7adc4f8a7e` on macOS, using the repository's production TypeScript modules through `node --import tsx`. No provider, web, browser, memory, write, send, or publish tool was executed.

- Exact steps or command run after the patch:

```sh
node --import tsx .artifacts/turn-surface-policy-real-proof.ts
```

- Evidence after fix: Terminal output from the local OpenClaw source checkout command above:

```text
OpenClaw TurnSurfacePolicy v0 real behavior proof
head: "7adc4f8a7e"
branch: "codex/turn-surface-policy-v0-main"
policy.toolsAllow: ["finance_research"]
policy.defaultDenyEnabled: true
policy.excludeToolNames.includes.message: true
policy.filteredCandidateTools: ["finance_research"]
policy.forbiddenRemaining: []
embedded.constructTools: true
embedded.includeCoreTools: false
embedded.runtimeToolAllowlist: ["finance_research"]
embedded.filteredTools: ["finance_research"]
No provider, web, browser, memory, write, send, or publish tool was executed.
```

- Observed result after fix: The production `TurnSurfacePolicy` compiler/filter left `policy.filteredCandidateTools` as `["finance_research"]`, reported `policy.forbiddenRemaining` as `[]`, included `message` in the default deny set, and the embedded tool-construction path kept `embedded.includeCoreTools` as `false` while filtering to `["finance_research"]`.

- What was not tested: I did not run a live provider, web search, browser action, OpenClaw memory action, message send, write, publish, Telegram delivery, or production/resident smoke. This proof is limited to the local OpenClaw runtime tool-surface construction paths touched by this PR.

## Tests

- `node scripts/run-vitest.mjs run src/agents/turn-surface-policy.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/gateway/tool-resolution.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
  - unit-fast: 2 files / 28 tests passed
  - gateway: 1 file / 6 tests passed
  - extension-codex: 1 file / 86 tests passed
- `git diff --check HEAD^ HEAD` passed
- `env CI=true corepack pnpm exec oxfmt --check extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/turn-surface-policy.test.ts src/agents/turn-surface-policy.ts src/gateway/tool-resolution.test.ts src/gateway/tool-resolution.ts` passed
