### PR TITLE
fix(doctor): warn about unrecognized hooks.internal.entries keys

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -154,8 +154,12 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     );
   }
   const hookTransformsDirWarnings = collectInvalidHookTransformsDirWarnings(cfg, snapshot.path);
-  if (hookTransformsDirWarnings.length > 0) {
-    note(sanitizeDoctorNote(hookTransformsDirWarnings.join("\n")), "Doctor warnings");
+  const unknownHookEntryKeyWarnings = (
+    await import("./doctor/shared/hook-entry-keys-warnings.js")
+  ).collectUnknownHookEntryKeysWarnings(cfg);
+  const allHookWarnings = [...hookTransformsDirWarnings, ...unknownHookEntryKeyWarnings];
+  if (allHookWarnings.length > 0) {
+    note(sanitizeDoctorNote(allHookWarnings.join("\n")), "Doctor warnings");
   }
 
   const normalized = normalizeCompatibilityConfigValues(candidate);

--- a/src/commands/doctor/shared/hook-entry-keys-warnings.test.ts
+++ b/src/commands/doctor/shared/hook-entry-keys-warnings.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { collectUnknownHookEntryKeysWarnings } from "./hook-entry-keys-warnings.js";
+
+function makeConfig(overrides: Partial<OpenClawConfig>): OpenClawConfig {
+  return {
+    hooks: { internal: {} },
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("collectUnknownHookEntryKeysWarnings", () => {
+  it("returns empty when no entries are configured", () => {
+    expect(collectUnknownHookEntryKeysWarnings(makeConfig({ hooks: { internal: {} } }))).toEqual(
+      [],
+    );
+  });
+
+  it("returns empty for entries that only use known keys (enabled, env)", () => {
+    const cfg = makeConfig({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            "bootstrap-extra-files": {
+              enabled: true,
+              env: { FOO: "bar" },
+            },
+          },
+        },
+      },
+    });
+    expect(collectUnknownHookEntryKeysWarnings(cfg)).toEqual([]);
+  });
+
+  it("warns when entry contains unknown 'handler' key", () => {
+    const cfg = makeConfig({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            "self-improve": {
+              enabled: true,
+              handler: "./hooks/self-improve.ts",
+            },
+          },
+        },
+      },
+    });
+    const warnings = collectUnknownHookEntryKeysWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('hooks.internal.entries["self-improve"]');
+    expect(warnings[0]).toContain('"handler"');
+  });
+
+  it("warns when entry contains unknown 'extraDirs' key directly under entry", () => {
+    const cfg = makeConfig({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            "my-hook": {
+              enabled: true,
+              extraDirs: ["./extra-hooks"],
+            },
+          },
+        },
+      },
+    });
+    const warnings = collectUnknownHookEntryKeysWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"extraDirs"');
+  });
+
+  it("warns when entry contains multiple unknown keys", () => {
+    const cfg = makeConfig({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            "my-hook": {
+              enabled: true,
+              handler: "./handler.ts",
+              extraDirs: ["./dir"],
+              installs: { someId: { id: "someId", hooks: ["my-hook"] } },
+            },
+          },
+        },
+      },
+    });
+    const warnings = collectUnknownHookEntryKeysWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"handler"');
+    expect(warnings[0]).toContain('"extraDirs"');
+    expect(warnings[0]).toContain('"installs"');
+  });
+
+  it("handles multiple entries independently", () => {
+    const cfg = makeConfig({
+      hooks: {
+        internal: {
+          enabled: true,
+          entries: {
+            hook1: { enabled: true, handler: "./h1.ts" },
+            hook2: { enabled: true, env: { KEY: "val" } },
+            hook3: { enabled: true, extraDirs: ["./d"] },
+          },
+        },
+      },
+    });
+    const warnings = collectUnknownHookEntryKeysWarnings(cfg);
+    expect(warnings).toHaveLength(2); // hook1 and hook3 warn
+    expect(warnings[0]).toContain("hook1");
+    expect(warnings[1]).toContain("hook3");
+  });
+
+  it("returns empty when entries is undefined", () => {
+    const cfg = makeConfig({ hooks: { internal: { enabled: true } } });
+    expect(collectUnknownHookEntryKeysWarnings(cfg)).toEqual([]);
+  });
+
+  it("returns empty when hooks.internal is undefined", () => {
+    const cfg = makeConfig({});
+    expect(collectUnknownHookEntryKeysWarnings(cfg)).toEqual([]);
+  });
+});

--- a/src/commands/doctor/shared/hook-entry-keys-warnings.ts
+++ b/src/commands/doctor/shared/hook-entry-keys-warnings.ts
@@ -1,0 +1,51 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+/**
+ * Collect warnings for hook entries that use keys that are not recognized
+ * by the hook discovery/loading system.
+ *
+ * Currently the only entry types that actually load handlers are those defined
+ * by a discovered hook directory (bundled, managed, or workspace). The only
+ * recognized config key for entries is `enabled` + `env`.
+ *
+ * Configured keys such as `handler`, `extraDirs`, or `installs` directly under
+ * an entry are silently ignored — the entry is treated as enabled but no handler
+ * is ever loaded, because the hook name doesn't match any discovered hook.
+ */
+export function collectUnknownHookEntryKeysWarnings(cfg: OpenClawConfig): string[] {
+  const entries = cfg.hooks?.internal?.entries;
+  if (!entries || typeof entries !== "object") {
+    return [];
+  }
+
+  // Known keys that have runtime effect when placed under an entry
+  const KNOWN_ENTRY_KEYS = new Set(["enabled", "env"]);
+
+  const warnings: string[] = [];
+
+  for (const [entryName, entryValue] of Object.entries(entries)) {
+    if (!entryValue || typeof entryValue !== "object") {
+      continue;
+    }
+
+    // Only check top-level entry keys (not nested properties)
+    // The passthrough on HookConfigSchema means Zod doesn't reject extra keys,
+    // and the loader only looks at hook name + enabled flag from the discovered hook registry.
+    const extraKeys = Object.keys(entryValue as object).filter((key) => !KNOWN_ENTRY_KEYS.has(key));
+
+    if (extraKeys.length === 0) {
+      continue;
+    }
+
+    warnings.push(
+      `- hooks.internal.entries["${entryName}"]: contains unrecognized key(s) [${extraKeys.map((k) => `"${k}"`).join(", ")}]. ` +
+        'Only the hook name (matching a discovered hook directory) and the "enabled" flag are used; ' +
+        'keys such as "handler", "extraDirs", "installs" have no effect here. ' +
+        "To configure a hook, add the hook name to hooks.internal.entries and ensure the hook " +
+        "is discoverable (bundled, managed, or workspace hook directory with HOOK.md). " +
+        "See https://docs.openclaw.ai/automation/hooks for the supported configuration shape.",
+    );
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Fix Summary

When configuring  with keys like , , or  directly under the entry, the gateway **silently ignores them** — no error is logged, no warning is emitted by ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██
██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██
██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
                       OPENCLAW                       
 
┌  OpenClaw doctor
│
◇  Startup optimization ────────────────────────────────────────────────╮
│                                                                       │
│  - NODE_COMPILE_CACHE is not set; repeated CLI runs can be slower on  │
│    small hosts (Pi/VM).                                               │
│  - OPENCLAW_NO_RESPAWN is not set to 1; set it when you want routine  │
│    gateway restarts to stay in-process instead of handing off to a    │
│    managed supervisor.                                                │
│  - Suggested env for low-power hosts:                                 │
│    export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache          │
│    mkdir -p /var/tmp/openclaw-compile-cache                           │
│    export OPENCLAW_NO_RESPAWN=1                                       │
│                                                                       │
├───────────────────────────────────────────────────────────────────────╯
│
◇  Doctor warnings ───────────────────────────────────────────────────────╮
│                                                                         │
│  - Agent "main" is routed from channel "discord", but the message tool  │
│    is unavailable for that agent; explicit channel actions such as      │
│    sendAttachment, upload-file, thread-reply, or reply can fail. Add    │
│    "message" to the agent tool allowlist, add "group:messaging", or     │
│    switch the agent to a profile that includes messaging tools.         │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  Command owner ─────────────────────────────────────────────────────────╮
│                                                                         │
│  No command owner is configured.                                        │
│  A command owner is the human operator account allowed to run           │
│  owner-only commands and approve dangerous actions, including           │
│  /diagnostics, /export-trajectory, /config, and exec approvals.         │
│  DM pairing only lets someone talk to the bot; it does not make that    │
│  sender the owner for privileged commands.                              │
│  Fix: set commands.ownerAllowFrom to your channel user id, for example  │
│  openclaw config set commands.ownerAllowFrom '["telegram:123456789"]'   │
│  Restart the gateway after changing this if it is already running.      │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  State integrity ────────────────────────────────────────────────────────╮
│                                                                          │
│  - OAuth dir not present (~/.openclaw/credentials). Skipping create      │
│    because no WhatsApp/pairing channel config is active.                 │
│  - Found 3 orphan transcript files in ~/.openclaw/agents/main/sessions.  │
│    These .jsonl files are no longer referenced by sessions.json, so      │
│    they are not part of any active session history.                      │
│    Doctor can archive them safely by renaming each file to               │
│    *.deleted.<timestamp>.                                                │
│    Examples: 7ba42784-d08e-490d-b8b0-122d0668b5e9.jsonl,                 │
│    d008cdab-195d-402a-8a4c-a130299cccc5.jsonl,                           │
│    f6771aa2-90f9-49cc-8ab9-2088fdbc0ca9.jsonl                            │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Cron ───────────────────────────────────────────────────────────────────╮
│                                                                          │
│  Cron model overrides detected at ~/.openclaw/cron/jobs.json.            │
│  - 1 job set `payload.model` and will not inherit                        │
│    `agents.defaults.model` (minimax/MiniMax-M2.7)                        │
│  - Provider namespaces: minimax=1                                        │
│  Review with openclaw cron list and openclaw cron show <job-id>; remove  │
│  `payload.model` from jobs that should inherit the default.              │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Security ──────────────────────────────────────────────────────────────╮
│                                                                         │
│  - Discord DMs: locked (channels.discord.dmPolicy="pairing") with no    │
│    allowlist; unknown senders will be blocked / get a pairing code.     │
│    Approve via: openclaw pairing list discord / openclaw pairing        │
│    approve discord <code>                                               │
│  - Discord guilds: groupPolicy="open" with no guild/channel allowlist;  │
│    any channel can trigger (mention-gated). Set                         │
│    channels.discord.groupPolicy="allowlist" and configure               │
│    channels.discord.guilds.<id>.channels.                               │
│  - Run: openclaw security audit --deep                                  │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  Skills status ───────────╮
│                           │
│  Eligible: 23             │
│  Missing requirements: 0  │
│  Blocked by allowlist: 0  │
│                           │
├───────────────────────────╯
│
◇  Plugins ──────╮
│                │
│  Loaded: 66    │
│  Imported: 0   │
│  Disabled: 25  │
│  Errors: 0     │
│                │
├────────────────╯
Run "openclaw doctor --fix" to apply changes.
│
└  Doctor complete., and  accepts it without complaint.

This is because the hook loader only acts on hook *names* that match discovered hook directories (bundled, managed, or workspace). Keys placed directly under an entry (other than  and OPENCLAW_SERVICE_KIND=gateway
QT_ACCESSIBILITY=1
XDG_MENU_PREFIX=xfce-
SSH_AUTH_SOCK=/home/ubuntu/.ssh/agent/s.i8eS4hqUqe.agent.cs6yG7U1Xc
MEMORY_PRESSURE_WRITE=c29tZSAyMDAwMDAgMjAwMDAwMAA=
DESKTOP_SESSION=xfce
PWD=/tmp/openclaw-src
LOGNAME=ubuntu
XDG_SESSION_TYPE=x11
GPG_AGENT_INFO=/run/user/1000/gnupg/S.gpg-agent:0:1
SYSTEMD_EXEC_PID=78955
OPENCLAW_SHELL=exec
HOME=/home/ubuntu
LANG=C.UTF-8
XDG_CURRENT_DESKTOP=XFCE
MEMORY_PRESSURE_WATCH=/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/openclaw-gateway.service/memory.pressure
TMPDIR=/tmp
INVOCATION_ID=f8122b3a2e6a4ec1a3a880697fa0c9c0
MANAGERPID=1504
XDG_CACHE_HOME=/home/ubuntu/.cache
XDG_SESSION_CLASS=user
OPENCLAW_GATEWAY_PORT=18789
XAUTHLOCALHOSTNAME=
USER=ubuntu
OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service
DISPLAY=:0
SHLVL=0
OPENCLAW_SERVICE_MARKER=openclaw
OPENCLAW_PATH_BOOTSTRAPPED=1
OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Gateway
MANAGERPIDFDID=4884
XDG_RUNTIME_DIR=/tmp/runtime-ubuntu
OPENCLAW_CLI=1
OPENCLAW_SERVICE_VERSION=2026.5.12
JOURNAL_STREAM=10:653959
XDG_DATA_DIRS=/usr/share/xfce4:/usr/local/share:/usr/share:/var/lib/snapd/desktop:/usr/share
PATH=/home/ubuntu/.local/bin:/usr/bin:/home/ubuntu/.npm-global/bin:/bin:/home/ubuntu/bin:/home/ubuntu/.nix-profile/bin:/usr/local/bin:/snap/bin
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
OLDPWD=/home/ubuntu/.openclaw/workspace
_=/usr/bin/env) have no runtime effect.

## What Changed

- **New warning function**  in  that scans  for keys other than  and OPENCLAW_SERVICE_KIND=gateway
QT_ACCESSIBILITY=1
XDG_MENU_PREFIX=xfce-
SSH_AUTH_SOCK=/home/ubuntu/.ssh/agent/s.i8eS4hqUqe.agent.cs6yG7U1Xc
MEMORY_PRESSURE_WRITE=c29tZSAyMDAwMDAgMjAwMDAwMAA=
DESKTOP_SESSION=xfce
PWD=/tmp/openclaw-src
LOGNAME=ubuntu
XDG_SESSION_TYPE=x11
GPG_AGENT_INFO=/run/user/1000/gnupg/S.gpg-agent:0:1
SYSTEMD_EXEC_PID=78955
OPENCLAW_SHELL=exec
HOME=/home/ubuntu
LANG=C.UTF-8
XDG_CURRENT_DESKTOP=XFCE
MEMORY_PRESSURE_WATCH=/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/openclaw-gateway.service/memory.pressure
TMPDIR=/tmp
INVOCATION_ID=f8122b3a2e6a4ec1a3a880697fa0c9c0
MANAGERPID=1504
XDG_CACHE_HOME=/home/ubuntu/.cache
XDG_SESSION_CLASS=user
OPENCLAW_GATEWAY_PORT=18789
XAUTHLOCALHOSTNAME=
USER=ubuntu
OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service
DISPLAY=:0
SHLVL=0
OPENCLAW_SERVICE_MARKER=openclaw
OPENCLAW_PATH_BOOTSTRAPPED=1
OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Gateway
MANAGERPIDFDID=4884
XDG_RUNTIME_DIR=/tmp/runtime-ubuntu
OPENCLAW_CLI=1
OPENCLAW_SERVICE_VERSION=2026.5.12
JOURNAL_STREAM=10:653959
XDG_DATA_DIRS=/usr/share/xfce4:/usr/local/share:/usr/share:/var/lib/snapd/desktop:/usr/share
PATH=/home/ubuntu/.local/bin:/usr/bin:/home/ubuntu/.npm-global/bin:/bin:/home/ubuntu/bin:/home/ubuntu/.nix-profile/bin:/usr/local/bin:/snap/bin
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
OLDPWD=/home/ubuntu/.openclaw/workspace
_=/usr/bin/env.
- **Integrated** into the doctor config flow, emitting a clear warning message that explains which keys are unrecognized and points to the docs.
- **Added tests** covering: valid entries (no warning), unknown keys (handler, extraDirs, installs), multiple entries, edge cases (undefined entries/internal).

## Example Warning

When a user has this config:



▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██
██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██
██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
                       OPENCLAW                       
 
┌  OpenClaw doctor
│
◇  Startup optimization ────────────────────────────────────────────────╮
│                                                                       │
│  - NODE_COMPILE_CACHE is not set; repeated CLI runs can be slower on  │
│    small hosts (Pi/VM).                                               │
│  - OPENCLAW_NO_RESPAWN is not set to 1; set it when you want routine  │
│    gateway restarts to stay in-process instead of handing off to a    │
│    managed supervisor.                                                │
│  - Suggested env for low-power hosts:                                 │
│    export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache          │
│    mkdir -p /var/tmp/openclaw-compile-cache                           │
│    export OPENCLAW_NO_RESPAWN=1                                       │
│                                                                       │
├───────────────────────────────────────────────────────────────────────╯
│
◇  Doctor warnings ───────────────────────────────────────────────────────╮
│                                                                         │
│  - Agent "main" is routed from channel "discord", but the message tool  │
│    is unavailable for that agent; explicit channel actions such as      │
│    sendAttachment, upload-file, thread-reply, or reply can fail. Add    │
│    "message" to the agent tool allowlist, add "group:messaging", or     │
│    switch the agent to a profile that includes messaging tools.         │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  Command owner ─────────────────────────────────────────────────────────╮
│                                                                         │
│  No command owner is configured.                                        │
│  A command owner is the human operator account allowed to run           │
│  owner-only commands and approve dangerous actions, including           │
│  /diagnostics, /export-trajectory, /config, and exec approvals.         │
│  DM pairing only lets someone talk to the bot; it does not make that    │
│  sender the owner for privileged commands.                              │
│  Fix: set commands.ownerAllowFrom to your channel user id, for example  │
│  openclaw config set commands.ownerAllowFrom '["telegram:123456789"]'   │
│  Restart the gateway after changing this if it is already running.      │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  State integrity ────────────────────────────────────────────────────────╮
│                                                                          │
│  - OAuth dir not present (~/.openclaw/credentials). Skipping create      │
│    because no WhatsApp/pairing channel config is active.                 │
│  - Found 3 orphan transcript files in ~/.openclaw/agents/main/sessions.  │
│    These .jsonl files are no longer referenced by sessions.json, so      │
│    they are not part of any active session history.                      │
│    Doctor can archive them safely by renaming each file to               │
│    *.deleted.<timestamp>.                                                │
│    Examples: 7ba42784-d08e-490d-b8b0-122d0668b5e9.jsonl,                 │
│    d008cdab-195d-402a-8a4c-a130299cccc5.jsonl,                           │
│    f6771aa2-90f9-49cc-8ab9-2088fdbc0ca9.jsonl                            │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Cron ───────────────────────────────────────────────────────────────────╮
│                                                                          │
│  Cron model overrides detected at ~/.openclaw/cron/jobs.json.            │
│  - 1 job set `payload.model` and will not inherit                        │
│    `agents.defaults.model` (minimax/MiniMax-M2.7)                        │
│  - Provider namespaces: minimax=1                                        │
│  Review with openclaw cron list and openclaw cron show <job-id>; remove  │
│  `payload.model` from jobs that should inherit the default.              │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
│
◇  Security ──────────────────────────────────────────────────────────────╮
│                                                                         │
│  - Discord DMs: locked (channels.discord.dmPolicy="pairing") with no    │
│    allowlist; unknown senders will be blocked / get a pairing code.     │
│    Approve via: openclaw pairing list discord / openclaw pairing        │
│    approve discord <code>                                               │
│  - Discord guilds: groupPolicy="open" with no guild/channel allowlist;  │
│    any channel can trigger (mention-gated). Set                         │
│    channels.discord.groupPolicy="allowlist" and configure               │
│    channels.discord.guilds.<id>.channels.                               │
│  - Run: openclaw security audit --deep                                  │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
│
◇  Skills status ───────────╮
│                           │
│  Eligible: 23             │
│  Missing requirements: 0  │
│  Blocked by allowlist: 0  │
│                           │
├───────────────────────────╯
│
◇  Plugins ──────╮
│                │
│  Loaded: 66    │
│  Imported: 0   │
│  Disabled: 25  │
│  Errors: 0     │
│                │
├────────────────╯
Run "openclaw doctor --fix" to apply changes.
│
└  Doctor complete. will emit:



## Tests

All 8 unit tests pass:


Existing doctor-config-flow tests (34 tests) continue to pass.

Fixes #89309