### PR TITLE
fix: forward isHeartbeat flag to context-engine afterTurn hooks

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2400,6 +2400,7 @@ export async function runCodexAppServerAttempt(
         promptError: Boolean(finalPromptError),
         aborted: finalAborted,
         yieldAborted: Boolean(result.yieldDetected),
+        isHeartbeat: params.bootstrapContextRunKind === "heartbeat",
         sessionIdUsed: activeSessionId,
         sessionKey: contextSessionKey,
         sessionFile: activeSessionFile,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -267,6 +267,7 @@ async function finalizeCliContextEngineTurn(params: {
     promptError: false,
     aborted: runParams.abortSignal?.aborted === true,
     yieldAborted: false,
+    isHeartbeat: runParams.bootstrapContextRunKind === "heartbeat",
     sessionIdUsed: runParams.sessionId,
     sessionKey: runParams.sessionKey,
     sessionFile: runParams.sessionFile,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2385,6 +2385,7 @@ export async function runEmbeddedAttempt(
                   repairAttemptToolUseResultPairing(messages, isOpenAIResponsesApi),
               }
             : {}),
+          isHeartbeat: params.bootstrapContextRunKind === "heartbeat",
           getPrePromptMessageCount: () => prePromptMessageCount,
           onAfterTurnCheckpoint: (messageCount) => {
             contextEngineAfterTurnCheckpoint = messageCount;
@@ -4670,6 +4671,7 @@ export async function runEmbeddedAttempt(
             promptError: Boolean(promptError),
             aborted,
             yieldAborted,
+            isHeartbeat: params.bootstrapContextRunKind === "heartbeat",
             sessionIdUsed,
             sessionKey: params.sessionKey,
             sessionFile: params.sessionFile,

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -578,6 +578,27 @@ describe("installContextEngineLoopHook", () => {
     return { initial, withNew, transformed };
   }
 
+  it("forwards isHeartbeat to afterTurn in the loop hook", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installContextEngineLoopHook({
+      agent,
+      contextEngine: engine,
+      sessionId,
+      sessionKey,
+      sessionFile,
+      tokenBudget,
+      modelId,
+      isHeartbeat: true,
+      getPrePromptMessageCount: () => 0,
+    });
+
+    const messages = [makeUser("ping")];
+    await callTransform(agent, messages);
+
+    expect(engine.afterTurn).toHaveBeenCalledWith(expect.objectContaining({ isHeartbeat: true }));
+  });
+
   it("returns early when the current messages match the pre-prompt baseline", async () => {
     const agent = makeGuardableAgent();
     const engine = makeMockEngine();

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -328,6 +328,7 @@ export function installContextEngineLoopHook(params: {
   tokenBudget?: number;
   modelId: string;
   repairAssembledMessages?: (messages: AgentMessage[]) => AgentMessage[];
+  isHeartbeat?: boolean;
   getPrePromptMessageCount?: () => number;
   onAfterTurnCheckpoint?: (messageCount: number) => void;
   getRuntimeContext?: (params: {
@@ -396,6 +397,7 @@ export function installContextEngineLoopHook(params: {
           messages: transcriptMessages,
           prePromptMessageCount,
           tokenBudget,
+          isHeartbeat: params.isHeartbeat,
           runtimeContext: params.getRuntimeContext?.({
             messages: transcriptMessages,
             prePromptMessageCount,

--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -71,6 +71,28 @@ describe("harness context engine lifecycle", () => {
     expect(assembleParams?.messages).toEqual([visibleUser, visibleAssistant]);
   });
 
+  it("forwards isHeartbeat to afterTurn", async () => {
+    const afterTurn = vi.fn(async () => {});
+
+    await finalizeHarnessContextEngineTurn({
+      contextEngine: createContextEngine({ afterTurn }),
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+      isHeartbeat: true,
+      sessionIdUsed: sessionParams.sessionIdUsed,
+      sessionKey: sessionParams.sessionKey,
+      sessionFile: sessionParams.sessionFile,
+      messagesSnapshot: [textMessage("user", "ping", 1)],
+      prePromptMessageCount: 0,
+      warn: () => {},
+    });
+
+    const calls = (afterTurn as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const params = calls[0]?.[0] as { isHeartbeat?: boolean } | undefined;
+    expect(params?.isHeartbeat).toBe(true);
+  });
+
   it("keeps hidden runtime-context custom messages out of afterTurn hooks", async () => {
     const beforePromptUser = textMessage("user", "old ask", 1);
     const beforePromptRuntimeContext = runtimeContextMessage("old hidden context", 2);

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -136,6 +136,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
   promptError: boolean;
   aborted: boolean;
   yieldAborted: boolean;
+  isHeartbeat?: boolean;
   sessionIdUsed: string;
   sessionKey?: string;
   sessionFile: string;


### PR DESCRIPTION
## Summary

- The context-engine `afterTurn` interface declares `isHeartbeat?: boolean` but the three production call sites (`finalizeHarnessContextEngineTurn` and `installContextEngineLoopHook`) never passed it. Heartbeat runs were indistinguishable from regular user turns to context-engine plugins.
- Threaded `isHeartbeat` through all three paths: CLI runner (`cli-runner.ts`), embedded attempt runner (`attempt.ts`), and Codex app-server runner (`extensions/codex/src/app-server/run-attempt.ts`). Derived from `bootstrapContextRunKind === "heartbeat"` at each call site.

## Verification

- All 25 existing `finalizeHarnessContextEngineTurn` tests pass.
- All 25 existing `installContextEngineLoopHook` tests pass.
- Production function verification via `node --import tsx` confirms `isHeartbeat` is forwarded to `afterTurn`.

## Real behavior proof

**Behavior addressed:** The `isHeartbeat` flag is now forwarded to `contextEngine.afterTurn()` through all three runtime paths (CLI runner, embedded runner, Codex app-server) so context-engine plugins can distinguish heartbeat runs from user-initiated turns.

**Environment tested:** Node 22.x on Linux, `node --import tsx` calling the actual production function.

**Steps run after the patch:** Imported `finalizeHarnessContextEngineTurn` from source, provided a mock context-engine with `afterTurn` that captures `isHeartbeat`, and verified the flag is forwarded correctly for both `true` and `false` values.

**Evidence after fix:**

```text
$ node --import tsx --no-warnings -e "
import { finalizeHarnessContextEngineTurn } from './src/agents/harness/context-engine-lifecycle.js';
let receivedIsHeartbeat;
const mock = { info: { id: 'test' }, afterTurn: (p) => { receivedIsHeartbeat = p.isHeartbeat; } };
await finalizeHarnessContextEngineTurn({ contextEngine: mock, promptError: false, aborted: false,
  yieldAborted: false, isHeartbeat: true, sessionIdUsed: 's1', sessionFile: '/tmp/s1.jsonl',
  messagesSnapshot: [], prePromptMessageCount: 0, warn: () => {} });
console.log('isHeartbeat=true  → afterTurn received:', receivedIsHeartbeat);
await finalizeHarnessContextEngineTurn({ contextEngine: mock, promptError: false, aborted: false,
  yieldAborted: false, isHeartbeat: false, sessionIdUsed: 's2', sessionFile: '/tmp/s2.jsonl',
  messagesSnapshot: [], prePromptMessageCount: 0, warn: () => {} });
console.log('isHeartbeat=false → afterTurn received:', receivedIsHeartbeat);
"
```

```text
isHeartbeat=true  → afterTurn received: true
isHeartbeat=false → afterTurn received: false
```

**Observed result:** The production `finalizeHarnessContextEngineTurn` function forwards `isHeartbeat` to `contextEngine.afterTurn()` for both heartbeat and non-heartbeat runs. All three runtime paths (CLI runner, embedded runner, Codex app-server) now pass the flag.

**Not tested:** Live heartbeat wake with a real context-engine plugin that consumes `isHeartbeat`. The fix threads the flag through the plumbing layer; end-to-end verification requires a context-engine plugin that branches on the flag.