### PR TITLE
fix(agents): persist forked transcript when parent branch has no assistant turn

### DIFF
--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -262,4 +262,65 @@ describe("prepareSessionManagerForRun", () => {
     expect(entries[1]).toEqual(userEntry);
     expect(entries[2]?.message?.role).toBe("assistant");
   });
+
+  it("preserves a forked no-assistant transcript's inherited branch through preparation", async () => {
+    const sessionFile = await makeTempFile();
+    const userEntry = {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-05-27T00:00:01.000Z",
+      message: { role: "user", content: "inherited parent turn" },
+    };
+    const parentSession = "/srv/openclaw/main/sessions/parent.jsonl";
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "fork-session",
+          timestamp: "2026-05-27T00:00:00.000Z",
+          cwd: "/srv/openclaw/main",
+          parentSession,
+        }),
+        JSON.stringify(userEntry),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const sessionManager = {
+      sessionId: "fork-session",
+      cwd: "/srv/openclaw/main",
+      flushed: true,
+      fileEntries: [
+        {
+          type: "session",
+          id: "fork-session",
+          timestamp: "2026-05-27T00:00:00.000Z",
+          cwd: "/srv/openclaw/main",
+          parentSession,
+        },
+        userEntry,
+      ],
+      byId: new Map([["user-1", userEntry]]),
+      labelsById: new Map(),
+      leafId: "user-1",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "child-session",
+      cwd: "/tmp/task-repo",
+    });
+
+    expect(sessionManager.sessionId).toBe("child-session");
+    expect(sessionManager.cwd).toBe("/tmp/task-repo");
+    expect(sessionManager.fileEntries).toHaveLength(2);
+    expect(sessionManager.fileEntries[1]).toBe(userEntry);
+    expect(sessionManager.byId.get("user-1")).toBe(userEntry);
+    expect(sessionManager.leafId).toBe("user-1");
+    expect(sessionManager.flushed).toBe(false);
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
+  });
 });

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import { serializeJsonlLine, writeJsonlLines } from "../../config/sessions/transcript-jsonl.js";
 
-type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
+type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string; parentSession?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -69,6 +69,9 @@ export async function prepareSessionManagerForRun(params: {
     return;
   }
 
+  const isForkedSession =
+    typeof header?.parentSession === "string" && header.parentSession.length > 0;
+
   if (params.hadSessionFile && header && !hasAssistant) {
     if (sm.wasRecoveredFromCorruptHeader?.()) {
       header.id = params.sessionId;
@@ -82,17 +85,22 @@ export async function prepareSessionManagerForRun(params: {
       return;
     }
 
-    // Reset file so the first assistant flush includes header+user+assistant in order.
+    // Truncate so the first assistant flush rewrites header+...+assistant once (no duplicate
+    // header). A forked session keeps its inherited assistant-less branch in memory so the child
+    // run does not lose the parent context the fork copied in; a non-forked half-written session
+    // falls back to the bare header.
     await assertExistingHeaderIsReadable(params.sessionFile);
     await fs.writeFile(params.sessionFile, "", "utf-8");
     header.id = params.sessionId;
     header.cwd = params.cwd;
     sm.sessionId = params.sessionId;
     sm.cwd = params.cwd;
-    sm.fileEntries = [header];
-    sm.byId?.clear?.();
-    sm.labelsById?.clear?.();
-    sm.leafId = null;
+    if (!isForkedSession) {
+      sm.fileEntries = [header];
+      sm.byId?.clear?.();
+      sm.labelsById?.clear?.();
+      sm.leafId = null;
+    }
     sm.flushed = false;
     return;
   }

--- a/src/auto-reply/reply/session-fork.runtime.test.ts
+++ b/src/auto-reply/reply/session-fork.runtime.test.ts
@@ -354,4 +354,59 @@ describe("forkSessionFromParentRuntime", () => {
     expect(header.id).toBe(fork.sessionId);
     expect(header.parentSession).toBe(resolvedParentSessionFile);
   });
+
+  it("persists the forked transcript when the parent branch has no assistant turn", async () => {
+    const root = await makeRoot("openclaw-parent-fork-noassist-");
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir);
+    const cwd = path.join(root, "workspace");
+    await fs.mkdir(cwd);
+    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
+    const parentSessionId = "parent-pending";
+    const lines = [
+      {
+        type: "session",
+        version: 3,
+        id: parentSessionId,
+        timestamp: "2026-05-01T00:00:00.000Z",
+        cwd,
+      },
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-05-01T00:00:01.000Z",
+        message: { role: "user", content: "pending parent question" },
+      },
+    ];
+    await fs.writeFile(
+      parentSessionFile,
+      `${lines.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    const fork = await forkSessionFromParentRuntime({
+      parentEntry: {
+        sessionId: parentSessionId,
+        sessionFile: parentSessionFile,
+        updatedAt: Date.now(),
+      },
+      agentId: "main",
+      sessionsDir,
+    });
+
+    if (!fork) {
+      throw new Error("expected forked session entry");
+    }
+    const raw = await fs.readFile(fork.sessionFile, "utf-8");
+    const forkedEntries = raw
+      .trim()
+      .split(/\r?\n/u)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(forkedEntries.map((entry) => entry.type)).toEqual(["session", "message"]);
+    const forkedHeader = forkedEntries[0];
+    expect(forkedHeader?.id).toBe(fork.sessionId);
+    expect(forkedHeader?.cwd).toBe(cwd);
+    expect(raw).toContain("pending parent question");
+  });
 });

--- a/src/auto-reply/reply/session-fork.runtime.ts
+++ b/src/auto-reply/reply/session-fork.runtime.ts
@@ -264,21 +264,12 @@ async function writeBranchedSession(params: {
     parentSession: params.parentSessionFile,
   } satisfies SessionHeader;
   const entries = [header, ...pathWithoutLabels, ...labelEntries];
-  const hasAssistant = entries.some(
-    (entry) => entry.type === "message" && entry.message.role === "assistant",
-  );
-  if (hasAssistant) {
-    await fs.mkdir(path.dirname(sessionFile), { recursive: true });
-    await fs.writeFile(
-      sessionFile,
-      `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
-      {
-        encoding: "utf-8",
-        mode: 0o600,
-        flag: "wx",
-      },
-    );
-  }
+  await fs.mkdir(path.dirname(sessionFile), { recursive: true });
+  await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+    flag: "wx",
+  });
   return { sessionId, sessionFile };
 }
 


### PR DESCRIPTION
## Summary

A subagent spawned with `context="fork"` (and the realtime voice-consult fork and the reply-session fork) could silently start with an **empty** transcript, dropping the parent conversation it was meant to inherit, with no error surfaced. This happens whenever the parent's leaf branch is a persisted user turn with **no assistant message** in it (a real on-disk state: the gateway transcript writer `appendSessionTranscriptMessage` persists a user message immediately, before the assistant reply exists; `src/agents/command/attempt-execution.test.ts:311` already exercises this "session file has only user message" shape).

The fix spans the two surfaces that share the invariant *"a returned fork file must exist and its inherited branch must survive into the child run"*:

**1. Fork writer (`src/auto-reply/reply/session-fork.runtime.ts`).** `forkSessionFromParentRuntime` (:285) uses `writeBranchedSession` when the parent has entries (`leafId` non-null) and `writeForkHeaderOnly` otherwise. `writeForkHeaderOnly` always writes the new file; `writeBranchedSession` wrote the file **only inside `if (hasAssistant)`** while returning `{ sessionId, sessionFile }` **unconditionally**. So a no-assistant parent branch produced a `sessionFile` path that was never created. Callers register the child with that path and `forkedFromParent: true` (`src/agents/subagent-spawn.ts:515`, `src/talk/agent-consult-runtime.ts:156`, `src/auto-reply/reply/session.ts:744`); the child then opens a non-existent file and starts blank (the result is non-null, so `subagent-spawn.ts:505`'s `if (!fork)` guard never trips). Fix: `writeBranchedSession` now writes unconditionally, matching `writeForkHeaderOnly`.

**2. Child-run preparation (`src/agents/embedded-agent-runner/session-manager-init.ts`).** Writing the file alone is not enough. The child run opens the fork with `hadSessionFile=true` and `prepareSessionManagerForRun` reset *any* no-assistant file to a bare `[header]` (emptying the file and clearing `fileEntries`/`byId`/`leafId`), which dropped the inherited user turn again. That reset exists to avoid a duplicate header on the deferred first-assistant flush (`SessionManager.persist` re-writes all `fileEntries` when the first assistant arrives). A forked session is now detected by its header `parentSession` and keeps its inherited assistant-less branch **in memory** while still truncating the file, so the first assistant flush writes `header + inherited user + child turns + assistant` exactly once. Non-forked half-written sessions are unchanged.

This directly addresses ClawSweeper's `[P1] Preserve the fork through run preparation` finding: the earlier revision proved only that the intermediate fork file existed; this revision proves the inherited context survives a real child run.

**Why this is not one-sided** (sibling surfaces): `writeForkHeaderOnly` (the `leafId === null` path) already writes unconditionally, so part 1 only aligns the divergent branch. In `prepareSessionManagerForRun`, the non-forked no-assistant reset and the has-assistant rewrite paths are unchanged; only the forked case is newly preserved, gated on `parentSession` which both fork writers set. All three fork callers consume the returned `sessionFile` identically. `pnpm tsgo:core` is clean across the change.

## Diff size

```
 src/auto-reply/reply/session-fork.runtime.ts            | 21 +++-----
 src/auto-reply/reply/session-fork.runtime.test.ts       | 55 +++++++++++++
 src/agents/embedded-agent-runner/session-manager-init.ts| 20 ++++---
 src/agents/embedded-agent-runner/session-manager-init.test.ts | 61 +++++++++++++++
 4 files changed, 136 insertions(+), 21 deletions(-)
```

## Verification

Local (Node 22.19.0):

- `node scripts/run-vitest.mjs src/auto-reply/reply/session-fork.runtime.test.ts` — pass (incl. new "persists the forked transcript when the parent branch has no assistant turn").
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/session-manager-init.test.ts` — pass (incl. new "preserves a forked no-assistant transcript's inherited branch through preparation").
- Caller suites green: `src/agents/subagent-spawn.context.test.ts`, `src/talk/agent-consult-runtime.test.ts`.
- `pnpm tsgo:core` — exit 0. `oxfmt --check` and `scripts/run-oxlint.mjs` on all four files — clean.
- Red-proof of part 2: with only the fork-writer fix (reverting `session-manager-init.ts`), the end-to-end check below shows the inherited turn is still dropped (`RETAINS_INHERITED=false`); with both parts it is retained.

## Real behavior proof

- **Behavior addressed:** a forked child session (subagent `context="fork"`, voice consult, or reply-session fork) whose parent's leaf branch has no assistant turn now retains the inherited parent turn all the way through child-run preparation and the first assistant flush, instead of silently starting empty.
- **Real environment tested:** the real production chain in this checkout end to end - `forkSessionFromParentRuntime` (fork writer) then `SessionManager.open` then `prepareSessionManagerForRun` (the real child-run boundary) then real `appendMessage` persistence - reading the actual on-disk transcript the child would run against. The fork is invoked internally (no separate CLI verb), so it is exercised through its real production functions.
- **Exact steps or command run after this patch:** wrote a parent transcript `[session header, user "INHERITED_PARENT_TURN"]`, called `forkSessionFromParentRuntime(...)`, opened the returned file with `SessionManager.open`, ran `prepareSessionManagerForRun({ hadSessionFile:true, ... })`, appended a child user turn + an assistant turn, then read the resulting transcript bytes.
- **Evidence after fix:** copied live console output, before the change (only the fork-writer fix applied, `session-manager-init.ts` at `origin/main`) and after the change (both parts):

```
# only fork-writer fix (child-run prep still resets no-assistant files)
===RETAINS_INHERITED=== false
===RETAINS_CHILD_TASK=== true
===HEADER_COUNT=== 1

# this branch (both parts)
===RETAINS_INHERITED=== true
===RETAINS_CHILD_TASK=== true
===HEADER_COUNT=== 1
```

- **Observed result after fix:** the child's on-disk transcript contains the inherited `INHERITED_PARENT_TURN` and the new `CHILD_TASK` with a single session header (no duplicate); before part 2 the identical chain left `RETAINS_INHERITED=false`, i.e. the parent context was gone after run preparation.
- **What was not tested:** a fully live gateway turn that spawns a `context="fork"` subagent against an in-flight parent over a real model (requires a running Gateway plus model credentials, not available in this environment). The before/after above was exercised through the real production fork writer, the real `prepareSessionManagerForRun` child-run boundary, and the real persistence path.
