### PR TITLE
fix(ui): accept short tweakcn theme ids

### DIFF
--- a/ui/src/ui/custom-theme.test.ts
+++ b/ui/src/ui/custom-theme.test.ts
@@ -82,6 +82,16 @@ describe("custom theme import helpers", () => {
       fetchUrl: "https://tweakcn.com/r/themes/cmlhfpjhw000004l4f4ax3m7z",
       themeId: "cmlhfpjhw000004l4f4ax3m7z",
     });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
+    expect(normalizeTweakcnThemeUrl("claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
   });
 
   it("extracts theme ids from copied tweakcn editor URLs and pasted text", () => {
@@ -110,6 +120,11 @@ describe("custom theme import helpers", () => {
       sourceUrl: "https://tweakcn.com/themes/amethyst-haze",
       fetchUrl: "https://tweakcn.com/r/themes/amethyst-haze",
       themeId: "amethyst-haze",
+    });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/editor/theme?theme=claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
     });
   });
 

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes the Control UI custom theme importer rejecting valid short tweakcn theme IDs such as `claude` before it can fetch the registry payload.

Why does this matter now?

- Issue #88987 reports that built-in tweakcn registry URLs like `https://tweakcn.com/r/themes/claude` return valid JSON but OpenClaw rejects them as unsupported links.

What is the intended outcome?

- Short valid tweakcn IDs are normalized into the existing canonical source URL and registry fetch URL.
- Existing host, path, query, fetch, payload-size, and CSS token safety checks remain unchanged.

What is intentionally out of scope?

- No new theme UI, storage changes, docs changes, or broader tweakcn compatibility behavior.

What does success look like?

- `claude`, `https://tweakcn.com/r/themes/claude`, and `https://tweakcn.com/editor/theme?theme=claude` normalize successfully.

What should reviewers focus on?

- The validator length relaxation and the focused regression coverage in `ui/src/ui/custom-theme.test.ts`.

## Linked context

Which issue does this close?

Closes #88987

Which issues, PRs, or discussions are related?

Related #88987

Was this requested by a maintainer or owner?

No maintainer request; this is a small external issue fix from the open issue queue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: tweakcn short built-in theme IDs no longer fail validation before fetch.
- Real environment tested: local OpenClaw source checkout on macOS, branch `fix/88987-tweakcn-short-theme`, head `f108e9c045019ce551c0f9c57d9090e3588f5091`.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs ui/src/ui/custom-theme.test.ts --reporter=dot
```

- Evidence after fix:

```text
Command exited successfully.
Added coverage normalizes:
- https://tweakcn.com/r/themes/claude
- claude
- https://tweakcn.com/editor/theme?theme=claude
```

- Observed result after fix: the short `claude` ID maps to `https://tweakcn.com/themes/claude` and fetches from `https://tweakcn.com/r/themes/claude` instead of throwing `Unsupported tweakcn link`.
- What was not tested: a full browser Control UI import click and a live network fetch to tweakcn from the UI.
- Proof limitations or environment constraints: this proof exercises the production URL normalization and import helper tests locally; the issue already includes live registry evidence for the `claude` endpoint.
- Before evidence: current main required at least 8 theme-id characters via `THEME_ID_PATTERN`, so `claude` failed before fetch.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs ui/src/ui/custom-theme.test.ts --reporter=dot
scripts/committer "fix(ui): accept short tweakcn theme ids" ui/src/ui/custom-theme.ts ui/src/ui/custom-theme.test.ts
```

What regression coverage was added or updated?

- Added short theme ID normalization coverage for raw IDs, registry URLs, and editor query URLs.

What failed before this fix, if known?

- `normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/claude")` threw `Unsupported tweakcn link. Expected a theme share URL.` because the theme ID was shorter than 8 characters.

If no test was added, why not?

- N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Valid short tweakcn IDs are now accepted.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Accepting a broader set of tweakcn theme ID strings.

How is that risk mitigated?

- The accepted character set and 128-character maximum remain unchanged, and the importer still requires tweakcn hosts/paths plus bounded no-redirect JSON fetch and CSS token validation.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing known from the author side.

Which bot or reviewer comments were addressed?

- Addresses ClawSweeper's source-repro/fix-shape-clear guidance on #88987.
