### PR TITLE
fix(memory): clean stale short-term temp files

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -246,6 +246,12 @@ function formatRepairSummary(repair: RepairShortTermPromotionArtifactsResult): s
   if (repair.removedStaleLock) {
     actions.push("removed stale lock");
   }
+  const removedStaleTempFiles = repair.removedStaleTempFiles ?? 0;
+  if (removedStaleTempFiles > 0) {
+    actions.push(
+      `removed ${removedStaleTempFiles} stale temp file${removedStaleTempFiles === 1 ? "" : "s"}`,
+    );
+  }
   return actions.length > 0 ? actions.join(" · ") : "no changes";
 }
 

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -135,6 +135,7 @@ function formatRepairSummary(repair: {
   rewroteStore: boolean;
   removedInvalidEntries: number;
   removedOverflowEntries?: number;
+  removedStaleTempFiles?: number;
   removedStaleLock: boolean;
 }): string {
   const actions: string[] = [];
@@ -150,6 +151,12 @@ function formatRepairSummary(repair: {
   }
   if (repair.removedStaleLock) {
     actions.push("removed stale promotion lock");
+  }
+  const removedStaleTempFiles = repair.removedStaleTempFiles ?? 0;
+  if (removedStaleTempFiles > 0) {
+    actions.push(
+      `removed ${removedStaleTempFiles} stale temp file${removedStaleTempFiles === 1 ? "" : "s"}`,
+    );
   }
   return actions.join(", ");
 }

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2969,6 +2969,66 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("removes stale private store temp files for recall and phase signals", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const artifactsDir = path.join(workspaceDir, "memory", ".dreams");
+      const tempNames = [
+        ".short-term-recall.json.abcdef123456.tmp",
+        ".phase-signals.json.abcdef123456.tmp",
+        ".short-term-recall.json.00000000-0000-4000-8000-000000000000.fallback.tmp",
+      ];
+      const staleMtime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      for (const tempName of tempNames) {
+        const tempPath = path.join(artifactsDir, tempName);
+        await fs.writeFile(tempPath, "{}", "utf-8");
+        await fs.utimes(tempPath, staleMtime, staleMtime);
+      }
+
+      const auditBefore = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(auditBefore.issues.map((issue) => issue.code)).toContain("recall-temp-stale");
+
+      const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+
+      expect(repair.changed).toBe(true);
+      expect(repair.removedStaleTempFiles).toBe(3);
+      for (const tempName of tempNames) {
+        await expect(fs.stat(path.join(artifactsDir, tempName))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }
+      const auditAfter = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(auditAfter.issues.map((issue) => issue.code)).not.toContain("recall-temp-stale");
+    });
+  });
+
+  it("preserves fresh and unrelated temp files during repair", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const artifactsDir = path.join(workspaceDir, "memory", ".dreams");
+      const preservedNames = [
+        ".short-term-recall.json.abcdef123456.tmp",
+        ".other.json.abcdef123456.tmp",
+        ".fs-safe-replace.123.uuid.tmp",
+        "random.tmp",
+      ];
+      const staleMtime = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      for (const tempName of preservedNames) {
+        const tempPath = path.join(artifactsDir, tempName);
+        await fs.writeFile(tempPath, "{}", "utf-8");
+        if (tempName !== ".short-term-recall.json.abcdef123456.tmp") {
+          await fs.utimes(tempPath, staleMtime, staleMtime);
+        }
+      }
+
+      const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
+
+      expect(repair.changed).toBe(false);
+      expect(repair.removedStaleTempFiles).toBe(0);
+      for (const tempName of preservedNames) {
+        await expect(fs.stat(path.join(artifactsDir, tempName))).resolves.toBeDefined();
+      }
+    });
+  });
+
   it("uses score tie-breakers when capping stores with invalid timestamps", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -44,6 +44,7 @@ const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join("memory", ".dreams", "ph
 const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-promotion.lock");
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
+const SHORT_TERM_TEMP_STALE_MS = 60 * 60 * 1000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
@@ -163,6 +164,7 @@ type ShortTermAuditIssue = {
     | "recall-store-over-limit"
     | "recall-lock-stale"
     | "recall-lock-unreadable"
+    | "recall-temp-stale"
     | "qmd-index-missing"
     | "qmd-index-empty"
     | "qmd-collections-empty";
@@ -195,6 +197,7 @@ export type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
   removedOverflowEntries: number;
+  removedStaleTempFiles: number;
   rewroteStore: boolean;
   removedStaleLock: boolean;
 };
@@ -743,6 +746,61 @@ function resolveLockPath(workspaceDir: string): string {
 
 function resolveShortTermArtifactsDir(workspaceDir: string): string {
   return path.dirname(resolveLockPath(workspaceDir));
+}
+
+function isShortTermStoreTempFileName(fileName: string): boolean {
+  const storeNames = [
+    path.basename(SHORT_TERM_STORE_RELATIVE_PATH),
+    path.basename(SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH),
+  ];
+  return storeNames.some((storeName) => {
+    if (!fileName.startsWith(`.${storeName}.`)) {
+      return false;
+    }
+    return (
+      /^[a-f0-9]{12}\.tmp$/i.test(fileName.slice(storeName.length + 2)) ||
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.fallback\.tmp$/i.test(
+        fileName.slice(storeName.length + 2),
+      )
+    );
+  });
+}
+
+async function countStaleShortTermStoreTempFiles(workspaceDir: string): Promise<number> {
+  return await removeStaleShortTermStoreTempFiles(workspaceDir, { dryRun: true });
+}
+
+async function removeStaleShortTermStoreTempFiles(
+  workspaceDir: string,
+  opts: { dryRun?: boolean } = {},
+): Promise<number> {
+  const artifactsDir = resolveShortTermArtifactsDir(workspaceDir);
+  let removed = 0;
+  const nowMs = Date.now();
+  for (const dirent of await fs.readdir(artifactsDir, { withFileTypes: true }).catch((err) => {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  })) {
+    if (!dirent.isFile() || !isShortTermStoreTempFileName(dirent.name)) {
+      continue;
+    }
+    const tempPath = path.join(artifactsDir, dirent.name);
+    const stat = await fs.stat(tempPath);
+    if (nowMs - stat.mtimeMs <= SHORT_TERM_TEMP_STALE_MS) {
+      continue;
+    }
+    if (!opts.dryRun) {
+      await fs.unlink(tempPath).catch((err) => {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw err;
+        }
+      });
+    }
+    removed += 1;
+  }
+  return removed;
 }
 
 async function ensureShortTermArtifactsDir(workspaceDir: string): Promise<void> {
@@ -2272,6 +2330,16 @@ export async function auditShortTermPromotionArtifacts(params: {
     }
   }
 
+  const staleTempFileCount = await countStaleShortTermStoreTempFiles(workspaceDir);
+  if (staleTempFileCount > 0) {
+    issues.push({
+      severity: "warn",
+      code: "recall-temp-stale",
+      message: `${staleTempFileCount} stale short-term store temp file${staleTempFileCount === 1 ? "" : "s"} found.`,
+      fixable: true,
+    });
+  }
+
   let qmd: ShortTermAuditSummary["qmd"];
   if (params.qmd) {
     qmd = {
@@ -2340,6 +2408,7 @@ export async function repairShortTermPromotionArtifacts(params: {
   let removedInvalidEntries = 0;
   let removedOverflowEntries = 0;
   let removedStaleLock = false;
+  let removedStaleTempFiles = 0;
 
   try {
     const lockPath = resolveLockPath(workspaceDir);
@@ -2356,6 +2425,7 @@ export async function repairShortTermPromotionArtifacts(params: {
   }
 
   await withShortTermLock(workspaceDir, async () => {
+    removedStaleTempFiles = await removeStaleShortTermStoreTempFiles(workspaceDir);
     const storePath = resolveStorePath(workspaceDir);
     try {
       const raw = await fs.readFile(storePath, "utf-8");
@@ -2408,9 +2478,10 @@ export async function repairShortTermPromotionArtifacts(params: {
   });
 
   return {
-    changed: rewroteStore || removedStaleLock,
+    changed: rewroteStore || removedStaleLock || removedStaleTempFiles > 0,
     removedInvalidEntries,
     removedOverflowEntries,
+    removedStaleTempFiles,
     rewroteStore,
     removedStaleLock,
   };

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -323,6 +323,9 @@ export async function maybeRepairMemoryRecallHealth(params: {
             "Memory recall artifacts repaired:",
             repair.rewroteStore ? `- rewrote recall store${details ? ` (${details})` : ""}` : null,
             repair.removedStaleLock ? "- removed stale promotion lock" : null,
+            repair.removedStaleTempFiles && repair.removedStaleTempFiles > 0
+              ? `- removed ${repair.removedStaleTempFiles} stale temp file${repair.removedStaleTempFiles === 1 ? "" : "s"}`
+              : null,
             `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
           ].filter(Boolean);
           note(lines.join("\n"), "Doctor changes");

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -90,6 +90,7 @@ export type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
   removedOverflowEntries?: number;
+  removedStaleTempFiles?: number;
   rewroteStore: boolean;
   removedStaleLock: boolean;
 };


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes orphaned memory-core short-term store temp files accumulating in `memory/.dreams` after interrupted private atomic writes.

Why does this matter now?

- Issue #77888 reports that temp files left behind by `writeStore` / `writePhaseSignalStore` have no cleanup path.
- The related phase-signal read-error issue #77881 was already fixed by #77924, so this PR is scoped only to stale temp cleanup.

What is the intended outcome?

- `repairShortTermPromotionArtifacts` removes stale private temp files for `short-term-recall.json` and `phase-signals.json`.
- `auditShortTermPromotionArtifacts` reports a real fixable issue when stale temp files are the only problem, so `doctor --fix` can reach the cleanup.
- Memory CLI, dreaming logs, doctor notes, and the SDK facade include the removed temp count.

What is intentionally out of scope?

- No changes to phase-signal read-error behavior, store schema, migration behavior, or generic temp cleanup outside memory-core short-term stores.

What does success look like?

- Stale private temp files with fs-safe private write names are removed.
- Fresh temp files and unrelated temp files are preserved.

What should reviewers focus on?

- The temp filename predicate is intentionally narrow and basename-specific.
- The audit path now emits `recall-temp-stale`, making doctor repair reachable without mocked impossible issue codes.

## Linked context

Which issue does this close?

Closes #77888

Which issues, PRs, or discussions are related?

Related #77881, #77924, #77894

Was this requested by a maintainer or owner?

No maintainer request; this follows up on the remaining open issue after #77924 fixed #77881.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale private temp files for memory-core short-term stores are audited and removed by repair.
- Real environment tested: local OpenClaw source checkout on macOS, branch `fix/77888-memory-stale-temp-cleanup`, head `6562f337379b58be3e5a08139aed516958804fe9`.
- Exact steps or command run after this patch:

```text
pnpm test extensions/memory-core/src/short-term-promotion.test.ts -- --reporter=dot
pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/dreaming.ts extensions/memory-core/src/cli.runtime.ts src/commands/doctor-memory-search.ts src/plugin-sdk/memory-core-engine-runtime.ts
```

- Evidence after fix:

```text
Test Files  1 passed (1)
Tests  79 passed (79)
All matched files use the correct format.
```

- Observed result after fix: the regression test creates stale `.short-term-recall.json.<12hex>.tmp`, `.phase-signals.json.<12hex>.tmp`, and `.short-term-recall.json.<uuid>.fallback.tmp` files; audit reports `recall-temp-stale`, repair removes all 3, and a follow-up audit no longer reports the stale temp issue.
- What was not tested: a crash/kill during a real long-running dreaming sweep.
- Proof limitations or environment constraints: local proof uses filesystem-backed temp workspaces and production memory-core repair APIs rather than a live Gateway dreaming schedule.
- Before evidence: current main has no stale temp audit issue and `repairShortTermPromotionArtifacts` only rewrites recall stores or removes stale locks.

## Tests and validation

Which commands did you run?

```text
pnpm test extensions/memory-core/src/short-term-promotion.test.ts -- --reporter=dot
pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/dreaming.ts extensions/memory-core/src/cli.runtime.ts src/commands/doctor-memory-search.ts src/plugin-sdk/memory-core-engine-runtime.ts
scripts/committer "fix(memory): clean stale short-term temp files" extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/dreaming.ts extensions/memory-core/src/cli.runtime.ts src/commands/doctor-memory-search.ts src/plugin-sdk/memory-core-engine-runtime.ts
```

What regression coverage was added or updated?

- Added coverage that stale private temp files for both short-term stores are removed.
- Added coverage that fresh matching temps and unrelated temp files are preserved.

What failed before this fix, if known?

- There was no repair/audit path for stale short-term store temp files.

If no test was added, why not?

- N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Memory repair/status/doctor can now report and remove stale temp files.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Deleting the wrong file in `memory/.dreams`.

How is that risk mitigated?

- Cleanup only targets files in the short-term artifacts directory whose names match the two known store basenames and private atomic temp suffixes; unrelated `.tmp` and `.fs-safe-*` files are preserved by test.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing known from the author side.

Which bot or reviewer comments were addressed?

- Addresses the remaining #77888 cleanup path after #77894 was closed as superseded by #77924 for #77881.
