### PR TITLE
fix(update): detect npm shrinkwrap installs

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -29,6 +29,18 @@ describe("detectPackageManager", () => {
     );
   });
 
+  it("uses npm shrinkwrap as published npm package evidence", async () => {
+    await withPackageManagerRoot(
+      [
+        { path: "package.json", content: JSON.stringify({ packageManager: "pnpm@11.2.2" }) },
+        { path: "npm-shrinkwrap.json", content: "{}" },
+      ],
+      async (root) => {
+        await expect(detectPackageManager(root)).resolves.toBe("npm");
+      },
+    );
+  });
+
   it.each([
     {
       name: "uses bun.lock",
@@ -45,6 +57,14 @@ describe("detectPackageManager", () => {
       files: [
         { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
         { path: "package-lock.json", content: "" },
+      ],
+      expected: "npm",
+    },
+    {
+      name: "falls back to npm shrinkwrap for unsupported packageManager values",
+      files: [
+        { path: "package.json", content: JSON.stringify({ packageManager: "yarn@4.0.0" }) },
+        { path: "npm-shrinkwrap.json", content: "{}" },
       ],
       expected: "npm",
     },

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -4,12 +4,16 @@ import { readPackageManagerSpec } from "./package-json.js";
 type DetectedPackageManager = "pnpm" | "bun" | "npm";
 
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
+  const files = await fs.readdir(root).catch((): string[] => []);
+  if (files.includes("npm-shrinkwrap.json")) {
+    return "npm";
+  }
+
   const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
   if (pm === "pnpm" || pm === "bun" || pm === "npm") {
     return pm;
   }
 
-  const files = await fs.readdir(root).catch((): string[] => []);
   if (files.includes("pnpm-lock.yaml")) {
     return "pnpm";
   }

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -230,6 +230,23 @@ describe("checkDepsStatus", () => {
       expect(okDeps.status).toBe("ok");
     });
   });
+
+  it("uses npm shrinkwrap as the npm package lock marker", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-" }, async (root) => {
+      const lockfilePath = path.join(root, "npm-shrinkwrap.json");
+      await fs.writeFile(lockfilePath, "{}", "utf8");
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const deps = await checkDepsStatus({ root, manager: "npm" });
+
+      expect(deps).toMatchObject({
+        manager: "npm",
+        status: "ok",
+        lockfilePath,
+        markerPath: path.join(root, "node_modules"),
+      });
+    });
+  });
 });
 
 describe("checkUpdateStatus", () => {
@@ -266,6 +283,33 @@ describe("checkUpdateStatus", () => {
       expect(status.git).toBeUndefined();
       expect(status.registry).toBeUndefined();
       expect(status.deps?.manager).toBe("npm");
+    });
+  });
+
+  it("detects npm package installs from shrinkwrap before packageManager metadata", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-" }, async (root) => {
+      const shrinkwrapPath = path.join(root, "npm-shrinkwrap.json");
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ packageManager: "pnpm@11.2.2" }),
+        "utf8",
+      );
+      await fs.writeFile(shrinkwrapPath, "{}", "utf8");
+      await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+
+      expect(status.root).toBe(root);
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("npm");
+      expect(status.deps?.manager).toBe("npm");
+      expect(status.deps?.lockfilePath).toBe(shrinkwrapPath);
+      expect(status.deps?.status).toBe("ok");
     });
   });
 

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -219,7 +220,12 @@ function resolveDepsMarker(params: { root: string; manager: PackageManager }): {
   }
   if (params.manager === "npm") {
     return {
-      lockfilePath: path.join(root, "package-lock.json"),
+      lockfilePath: path.join(
+        root,
+        existsSync(path.join(root, "npm-shrinkwrap.json"))
+          ? "npm-shrinkwrap.json"
+          : "package-lock.json",
+      ),
       markerPath: path.join(root, "node_modules"),
     };
   }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes update/status package-manager detection for npm-installed OpenClaw packages that include `npm-shrinkwrap.json` while retaining the repo build-time `packageManager: pnpm@...` metadata.

Why does this matter now?

- Issue #87732 shows a global npm install reporting `packageManager: pnpm` and checking for missing `pnpm-lock.yaml`, even though the package root contains `npm-shrinkwrap.json` and no pnpm lockfile.

What is the intended outcome?

- `npm-shrinkwrap.json` is treated as npm install evidence before package.json `packageManager` metadata.
- npm dependency status uses `npm-shrinkwrap.json` as the npm lock marker when present.

What is intentionally out of scope?

- No change to git install detection, update execution mode, registry resolution, or package-manager config.

What does success look like?

- A published npm package root with `packageManager: pnpm@...` plus `npm-shrinkwrap.json` reports npm and checks the shrinkwrap instead of `pnpm-lock.yaml`.

What should reviewers focus on?

- The precedence change in `detectPackageManager` and the npm deps marker selection in `checkDepsStatus`.

## Linked context

Which issue does this close?

Closes #87732

Which issues, PRs, or discussions are related?

Related #87732

Was this requested by a maintainer or owner?

No maintainer request; this is a small external issue fix from the open issue queue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: npm-installed OpenClaw package roots with shrinkwrap no longer report as pnpm because of build-time packageManager metadata.
- Real environment tested: local OpenClaw source checkout on macOS, branch `fix/87732-npm-install-package-manager`, head `b7c084be680bb2fa480845a1e5c266bff5d824fe`.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --reporter=dot
pnpm exec oxfmt --check --threads=1 src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts src/infra/update-check.ts src/infra/update-check.test.ts
```

- Evidence after fix:

```text
Both focused Vitest files exited successfully.
All matched files use the correct format.
```

- Observed result after fix: the new fixture with `package.json` declaring `pnpm@11.2.2` and a root `npm-shrinkwrap.json` resolves package manager `npm`; update status reports `deps.manager: npm`, uses `npm-shrinkwrap.json`, and returns dependency status `ok` when `node_modules` exists.
- What was not tested: a real Raspberry Pi global npm install or live systemd service status.
- Proof limitations or environment constraints: local proof uses source fixtures that model the reporter's package root evidence instead of installing a published package globally.
- Before evidence: current main read `package.json.packageManager` first and selected pnpm before considering npm install markers; npm deps status only checked `package-lock.json`.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/infra/detect-package-manager.test.ts src/infra/update-check.test.ts --reporter=dot
pnpm exec oxfmt --check --threads=1 src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts src/infra/update-check.ts src/infra/update-check.test.ts
scripts/committer "fix(update): detect npm shrinkwrap installs" src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts src/infra/update-check.ts src/infra/update-check.test.ts
```

What regression coverage was added or updated?

- Added detector coverage for `npm-shrinkwrap.json` overriding build-time pnpm metadata.
- Added dependency status coverage for npm shrinkwrap as the lock marker.
- Added update status coverage for the published npm package-root shape from #87732.

What failed before this fix, if known?

- The package-manager detector returned pnpm for roots with `packageManager: pnpm@...` even when the package install evidence was npm shrinkwrap.

If no test was added, why not?

- N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Update/status output for npm-installed packages with shrinkwrap reports npm instead of pnpm.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Package-manager detection precedence for unusual roots that contain both shrinkwrap and another manager marker.

How is that risk mitigated?

- `npm-shrinkwrap.json` is publishable npm package lock evidence and matches the official OpenClaw npm package shape; git install detection still happens before package manager detection in update status.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- Nothing known from the author side.

Which bot or reviewer comments were addressed?

- Addresses ClawSweeper's source-repro/fix-shape-clear guidance on #87732.
