### PR TITLE
fix(agents): guard OpenAI tool schema conversion

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearOpenAIToolSchemaCacheForTest,
+  findOpenAIStrictToolSchemaDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
@@ -90,5 +91,29 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("reports unreadable schemas without aborting strict compatibility checks", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        safe: { type: "string" },
+        get broken() {
+          throw new Error("strict schema child getter exploded");
+        },
+      },
+      required: ["safe", "broken"],
+    };
+    const tool = { name: "fuzzplugin_strict", parameters: schema };
+
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(false);
+    expect(resolveOpenAIStrictToolFlagForInventory([tool], true)).toBe(false);
+    expect(findOpenAIStrictToolSchemaDiagnostics([tool])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "fuzzplugin_strict",
+        violations: ["fuzzplugin_strict.parameters is unreadable"],
+      },
+    ]);
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -12,6 +12,10 @@ type ToolWithParameters = {
   parameters: unknown;
 };
 
+type ToolFieldRead<TField extends keyof ToolWithParameters> =
+  | { readable: true; value: ToolWithParameters[TField] }
+  | { readable: false };
+
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
 
@@ -154,7 +158,11 @@ export function normalizeOpenAIStrictToolParameters<T>(
 }
 
 export function isStrictOpenAIJsonSchemaCompatible(schema: unknown): boolean {
-  return isStrictOpenAIJsonSchemaCompatibleRecursive(normalizeStrictOpenAIJsonSchema(schema));
+  try {
+    return isStrictOpenAIJsonSchemaCompatibleRecursive(normalizeStrictOpenAIJsonSchema(schema));
+  } catch {
+    return false;
+  }
 }
 
 type OpenAIStrictToolSchemaDiagnostic = {
@@ -167,21 +175,59 @@ export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
   return tools.flatMap((tool, toolIndex) => {
-    const violations = findStrictOpenAIJsonSchemaViolations(
-      normalizeStrictOpenAIJsonSchema(tool.parameters),
-      `${typeof tool.name === "string" && tool.name ? tool.name : `tool[${toolIndex}]`}.parameters`,
-    );
+    const nameRead = readToolField(tool, "name");
+    const toolName =
+      nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+        ? nameRead.value
+        : `tool[${toolIndex}]`;
+    const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.readable) {
+      return [
+        {
+          toolIndex,
+          ...(nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+            ? { toolName: nameRead.value }
+            : {}),
+          violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+        },
+      ];
+    }
+
+    let schemaViolations: string[];
+    try {
+      schemaViolations = findStrictOpenAIJsonSchemaViolations(
+        normalizeStrictOpenAIJsonSchema(parametersRead.value),
+        `${toolName}.parameters`,
+      );
+    } catch {
+      schemaViolations = [`${toolName}.parameters is unreadable`];
+    }
+    const violations = [...descriptorViolations, ...schemaViolations];
     if (violations.length === 0) {
       return [];
     }
     return [
       {
         toolIndex,
-        ...(typeof tool.name === "string" && tool.name ? { toolName: tool.name } : {}),
+        ...(nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+          ? { toolName: nameRead.value }
+          : {}),
         violations,
       },
     ];
   });
+}
+
+function readToolField<TField extends keyof ToolWithParameters>(
+  tool: ToolWithParameters,
+  field: TField,
+): ToolFieldRead<TField> {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 function isStrictOpenAIJsonSchemaCompatibleRecursive(schema: unknown): boolean {
@@ -304,5 +350,8 @@ export function resolveOpenAIStrictToolFlagForInventory(
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
-  return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
+  return tools.every((tool) => {
+    const parametersRead = readToolField(tool, "parameters");
+    return parametersRead.readable && isStrictOpenAIJsonSchemaCompatible(parametersRead.value);
+  });
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4647,6 +4647,256 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("skips unreadable responses tool schemas while preserving healthy siblings", () => {
+    const unreadableSchema = {
+      type: "object",
+      properties: {
+        safe: { type: "string" },
+        get broken() {
+          throw new Error("responses schema child getter exploded");
+        },
+      },
+      required: ["safe", "broken"],
+    };
+
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "fuzzplugin_strict",
+            description: "Broken tool",
+            parameters: unreadableSchema,
+          },
+          {
+            name: "read",
+            description: "Read file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as {
+      tools?: Array<{ name?: string; parameters?: Record<string, unknown>; strict?: boolean }>;
+      tool_choice?: unknown;
+    };
+
+    expect(params.tools?.map((tool) => tool.name)).toEqual(["read"]);
+    expect(params.tools?.[0]?.strict).toBe(true);
+    expect(params).not.toHaveProperty("tool_choice");
+    expectRecordFields(params.tools?.[0]?.parameters, {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    });
+
+    expect(() =>
+      buildOpenAIResponsesParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-responses">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+            {
+              name: "read",
+              description: "Read file",
+              parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+                required: ["path"],
+              },
+            },
+          ],
+        } as never,
+        {
+          toolChoice: { type: "function", name: "fuzzplugin_strict" },
+        } as never,
+      ),
+    ).toThrow(/tool_choice selected skipped tool "fuzzplugin_strict"/);
+
+    const filteredAllowedTools = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "fuzzplugin_strict",
+            description: "Broken tool",
+            parameters: unreadableSchema,
+          },
+          {
+            name: "read",
+            description: "Read file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      {
+        toolChoice: {
+          type: "allowed_tools",
+          mode: "required",
+          tools: [
+            { type: "function", name: "fuzzplugin_strict" },
+            { type: "function", name: "read" },
+          ],
+        },
+      } as never,
+    ) as {
+      tool_choice?: { tools?: Array<{ name?: string }> };
+      tools?: Array<{ name?: string }>;
+    };
+
+    expect(filteredAllowedTools.tools?.map((tool) => tool.name)).toEqual(["read"]);
+    expect(filteredAllowedTools.tool_choice?.tools?.map((tool) => tool.name)).toEqual(["read"]);
+
+    const customChoice = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "fuzzplugin_strict",
+            description: "Broken tool",
+            parameters: unreadableSchema,
+          },
+        ],
+      } as never,
+      {
+        toolChoice: { type: "custom", name: "native_custom" },
+      } as never,
+    ) as { tools?: unknown; tool_choice?: unknown };
+
+    expect(customChoice).not.toHaveProperty("tools");
+    expect(customChoice.tool_choice).toEqual({ type: "custom", name: "native_custom" });
+
+    expect(() =>
+      buildOpenAIResponsesParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-responses">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+          ],
+        } as never,
+        {
+          toolChoice: "required",
+        } as never,
+      ),
+    ).toThrow(/tool_choice requires a tool/);
+
+    expect(() =>
+      buildOpenAIResponsesParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-responses">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+          ],
+        } as never,
+        {
+          toolChoice: {
+            type: "allowed_tools",
+            mode: "required",
+            tools: [{ type: "function", name: "fuzzplugin_strict" }],
+          },
+        } as never,
+      ),
+    ).toThrow(/tool_choice allowed_tools selected only skipped tools/);
+  });
+
   it("adds native OpenAI turn metadata on direct Responses routes", () => {
     const params = buildOpenAIResponsesParams(
       {
@@ -6235,6 +6485,232 @@ describe("openai transport stream", () => {
       type: "array",
       items: { type: "string" },
     });
+  });
+
+  it("skips unreadable completions tool schemas while preserving healthy siblings", () => {
+    const unreadableSchema = {
+      type: "object",
+      properties: {
+        safe: { type: "string" },
+        get broken() {
+          throw new Error("completions schema child getter exploded");
+        },
+      },
+      required: ["safe", "broken"],
+    };
+
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "fuzzplugin_strict",
+            description: "Broken tool",
+            parameters: unreadableSchema,
+          },
+          {
+            name: "read",
+            description: "Read file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      undefined,
+    ) as {
+      tools?: Array<{
+        function?: { name?: string; parameters?: Record<string, unknown>; strict?: boolean };
+      }>;
+      tool_choice?: unknown;
+    };
+
+    expect(params.tools?.map((tool) => tool.function?.name)).toEqual(["read"]);
+    expect(params.tools?.[0]?.function?.strict).toBe(true);
+    expect(params).not.toHaveProperty("tool_choice");
+    expectRecordFields(params.tools?.[0]?.function?.parameters, {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    });
+
+    expect(() =>
+      buildOpenAICompletionsParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+            {
+              name: "read",
+              description: "Read file",
+              parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+                required: ["path"],
+              },
+            },
+          ],
+        } as never,
+        {
+          toolChoice: { type: "function", function: { name: "fuzzplugin_strict" } },
+        } as never,
+      ),
+    ).toThrow(/tool_choice selected skipped tool "fuzzplugin_strict"/);
+
+    const filteredAllowedTools = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "fuzzplugin_strict",
+            description: "Broken tool",
+            parameters: unreadableSchema,
+          },
+          {
+            name: "read",
+            description: "Read file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      {
+        toolChoice: {
+          type: "allowed_tools",
+          allowed_tools: {
+            mode: "required",
+            tools: [
+              { type: "function", name: "fuzzplugin_strict" },
+              { type: "function", name: "read" },
+            ],
+          },
+        },
+      } as never,
+    ) as {
+      tool_choice?: { allowed_tools?: { tools?: Array<{ name?: string }> } };
+      tools?: Array<{ function?: { name?: string } }>;
+    };
+
+    expect(filteredAllowedTools.tools?.map((tool) => tool.function?.name)).toEqual(["read"]);
+    expect(
+      filteredAllowedTools.tool_choice?.allowed_tools?.tools?.map((tool) => tool.name),
+    ).toEqual(["read"]);
+
+    expect(() =>
+      buildOpenAICompletionsParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+          ],
+        } as never,
+        {
+          toolChoice: "required",
+        } as never,
+      ),
+    ).toThrow(/tool_choice requires a tool/);
+
+    expect(() =>
+      buildOpenAICompletionsParams(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [],
+          tools: [
+            {
+              name: "fuzzplugin_strict",
+              description: "Broken tool",
+              parameters: unreadableSchema,
+            },
+          ],
+        } as never,
+        {
+          toolChoice: {
+            type: "allowed_tools",
+            allowed_tools: {
+              mode: "required",
+              tools: [{ type: "function", name: "fuzzplugin_strict" }],
+            },
+          },
+        } as never,
+      ),
+    ).toThrow(/tool_choice allowed_tools selected only skipped tools/);
   });
 
   it("omits tools from completions payload when model compat sets supportsTools to false", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -98,6 +98,13 @@ const log = createSubsystemLogger("openai-transport");
 const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
+type ConvertedToolChoice<TToolChoice> = { toolChoice?: TToolChoice };
+type OpenAIAllowedToolsChoice = {
+  record: Record<string, unknown>;
+  mode?: unknown;
+  tools: unknown[];
+  withTools: (tools: unknown[]) => unknown;
+};
 type OpenAIResponsesReasoningReplayMetadata = {
   v: 1;
   source: "openai-responses";
@@ -1273,26 +1280,220 @@ function convertResponsesTools(
   model: OpenAIModeModel,
   options?: { strict?: boolean | null },
 ): FunctionTool[] {
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(tools, options?.strict, {
+  const normalizableTools = sortTransportToolsByName(tools).filter((tool) =>
+    canNormalizeOpenAIToolParametersForTransport(tool, model, { transport: "responses" }),
+  );
+  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(normalizableTools, options?.strict, {
     transport: "responses",
     model,
   });
-  return sortTransportToolsByName(tools).map((tool): FunctionTool => {
+  return normalizableTools.flatMap((tool): FunctionTool[] => {
+    const parameters = normalizeOpenAIToolParametersForTransport(tool, strict === true, model, {
+      transport: "responses",
+    });
+    if (!parameters) {
+      return [];
+    }
     const result = {
       type: "function" as const,
       name: tool.name,
       description: tool.description,
-      parameters: normalizeOpenAIStrictToolParameters(
-        tool.parameters,
-        strict === true,
-        model.compat,
-      ) as Record<string, unknown>,
+      parameters: parameters as Record<string, unknown>,
     } as FunctionTool;
     if (strict !== undefined) {
       result.strict = strict;
     }
-    return result;
+    return [result];
   });
+}
+
+function canNormalizeOpenAIToolParametersForTransport(
+  tool: { name?: string; parameters: unknown },
+  model: OpenAIModeModel,
+  context: { transport: "responses" | "completions" },
+): boolean {
+  return normalizeOpenAIToolParametersForTransport(tool, false, model, context) !== undefined;
+}
+
+function normalizeOpenAIToolParametersForTransport(
+  tool: { name?: string; parameters: unknown },
+  strict: boolean,
+  model: OpenAIModeModel,
+  context: { transport: "responses" | "completions" },
+): unknown {
+  try {
+    return normalizeOpenAIStrictToolParameters(tool.parameters, strict, model.compat);
+  } catch (error) {
+    log.warn(
+      `OpenAI ${context.transport} skipped unreadable tool schema for ` +
+        `${model.provider ?? "unknown"}/${model.id ?? "unknown"}`,
+      {
+        transport: context.transport,
+        provider: model.provider,
+        model: model.id,
+        toolName: tool.name,
+        strict,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return undefined;
+  }
+}
+
+function resolveOpenAIToolChoiceForConvertedTools<TToolChoice>(
+  toolChoice: TToolChoice | undefined,
+  toolNames: readonly string[],
+  model: OpenAIModeModel,
+  context: { transport: "responses" | "completions" },
+): ConvertedToolChoice<TToolChoice> {
+  if (!toolChoice) {
+    return {};
+  }
+  const allowedToolsChoice = readOpenAIAllowedToolsChoice(toolChoice);
+  if (allowedToolsChoice) {
+    return resolveOpenAIAllowedToolsChoiceForConvertedTools(
+      toolChoice,
+      allowedToolsChoice,
+      toolNames,
+      model,
+      context,
+    );
+  }
+  const explicitToolName = readOpenAIToolChoiceName(toolChoice);
+  if (toolNames.length === 0) {
+    if (isRequiredOpenAIToolChoice(toolChoice, explicitToolName)) {
+      throwUnsatisfiedOpenAIToolChoice({ explicitToolName, model, context });
+    }
+    if (isObjectToolChoice(toolChoice)) {
+      return { toolChoice };
+    }
+    return {};
+  }
+  if (!explicitToolName || toolNames.includes(explicitToolName)) {
+    return { toolChoice };
+  }
+  return throwUnsatisfiedOpenAIToolChoice({
+    explicitToolName,
+    model,
+    context,
+    availableTools: toolNames,
+  });
+}
+
+function resolveOpenAIAllowedToolsChoiceForConvertedTools<TToolChoice>(
+  toolChoice: TToolChoice,
+  allowedToolsChoice: OpenAIAllowedToolsChoice,
+  toolNames: readonly string[],
+  model: OpenAIModeModel,
+  context: { transport: "responses" | "completions" },
+): ConvertedToolChoice<TToolChoice> {
+  const filteredTools = allowedToolsChoice.tools.filter((tool) => {
+    const toolName = readOpenAIToolChoiceName(tool);
+    return !toolName || toolNames.includes(toolName);
+  });
+  if (filteredTools.length === 0) {
+    return throwUnsatisfiedOpenAIToolChoice({
+      explicitToolName: undefined,
+      reason: "allowed_tools selected only skipped tools",
+      model,
+      context,
+      availableTools: toolNames,
+    });
+  }
+  if (filteredTools.length === allowedToolsChoice.tools.length) {
+    return { toolChoice };
+  }
+  return {
+    toolChoice: allowedToolsChoice.withTools(filteredTools) as TToolChoice,
+  };
+}
+
+function readOpenAIToolChoiceName(toolChoice: unknown): string | undefined {
+  if (!toolChoice || typeof toolChoice !== "object") {
+    return undefined;
+  }
+  const record = toolChoice as Record<string, unknown>;
+  if (record.type === "function" && typeof record.name === "string") {
+    return record.name;
+  }
+  const functionChoice = record.function;
+  if (
+    functionChoice &&
+    typeof functionChoice === "object" &&
+    typeof (functionChoice as Record<string, unknown>).name === "string"
+  ) {
+    return (functionChoice as Record<string, string>).name;
+  }
+  return undefined;
+}
+
+function isObjectToolChoice(toolChoice: unknown): boolean {
+  return Boolean(toolChoice && typeof toolChoice === "object");
+}
+
+function readOpenAIAllowedToolsChoice(toolChoice: unknown): OpenAIAllowedToolsChoice | undefined {
+  if (!toolChoice || typeof toolChoice !== "object") {
+    return undefined;
+  }
+  const record = toolChoice as Record<string, unknown>;
+  if (record.type !== "allowed_tools") {
+    return undefined;
+  }
+  if (Array.isArray(record.tools)) {
+    return {
+      record,
+      mode: record.mode,
+      tools: record.tools,
+      withTools: (tools) => ({ ...record, tools }),
+    };
+  }
+  const nested = record.allowed_tools;
+  if (!nested || typeof nested !== "object") {
+    return undefined;
+  }
+  const nestedRecord = nested as Record<string, unknown>;
+  if (!Array.isArray(nestedRecord.tools)) {
+    return undefined;
+  }
+  return {
+    record,
+    mode: nestedRecord.mode,
+    tools: nestedRecord.tools,
+    withTools: (tools) => ({
+      ...record,
+      allowed_tools: { ...nestedRecord, tools },
+    }),
+  };
+}
+
+function isRequiredOpenAIToolChoice(toolChoice: unknown, explicitToolName: string | undefined) {
+  return (
+    explicitToolName !== undefined ||
+    toolChoice === "required" ||
+    readOpenAIAllowedToolsChoice(toolChoice)?.mode === "required"
+  );
+}
+
+function throwUnsatisfiedOpenAIToolChoice(params: {
+  explicitToolName: string | undefined;
+  reason?: string;
+  model: OpenAIModeModel;
+  context: { transport: "responses" | "completions" };
+  availableTools?: readonly string[];
+}): never {
+  const selected =
+    params.reason ??
+    (params.explicitToolName
+      ? `selected skipped tool "${params.explicitToolName}"`
+      : "requires a tool");
+  const available =
+    params.availableTools && params.availableTools.length > 0
+      ? `; available tools after filtering: ${params.availableTools.join(", ")}`
+      : "";
+  throw new Error(
+    `OpenAI ${params.context.transport} tool_choice ${selected}, but unreadable tool schemas ` +
+      `were skipped for ${params.model.provider ?? "unknown"}/${params.model.id ?? "unknown"}${available}`,
+  );
 }
 
 function resolveOpenAIStrictToolFlagWithDiagnostics(
@@ -2244,13 +2445,22 @@ export function buildOpenAIResponsesParams(
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
-    params.tools = convertResponsesTools(context.tools, model as OpenAIModeModel, {
+    const convertedTools = convertResponsesTools(context.tools, model as OpenAIModeModel, {
       strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
         transport: "stream",
       }),
     });
-    if (options?.toolChoice) {
-      params.tool_choice = options.toolChoice;
+    const toolChoice = resolveOpenAIToolChoiceForConvertedTools(
+      options?.toolChoice,
+      convertedTools.map((tool) => tool.name),
+      model as OpenAIModeModel,
+      { transport: "responses" },
+    );
+    if (convertedTools.length > 0 || context.tools.length === 0) {
+      params.tools = convertedTools;
+    }
+    if (toolChoice.toolChoice) {
+      params.tool_choice = toolChoice.toolChoice;
     }
   }
   if (model.reasoning) {
@@ -3607,39 +3817,52 @@ function convertTools(
   compat: ReturnType<typeof getCompat>,
   model: OpenAIModeModel,
 ) {
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(
-    tools,
-    resolveOpenAIStrictToolSetting(model, {
-      transport: "stream",
-      supportsStrictMode: compat?.supportsStrictMode,
-    }),
+  const requestedStrict = resolveOpenAIStrictToolSetting(model, {
+    transport: "stream",
+    supportsStrictMode: compat?.supportsStrictMode,
+  });
+  const normalizableTools = sortTransportToolsByName(tools).filter((tool) =>
+    canNormalizeOpenAIToolParametersForTransport(tool, model, { transport: "completions" }),
+  );
+  const filteredStrict = resolveOpenAIStrictToolFlagWithDiagnostics(
+    normalizableTools,
+    requestedStrict,
     {
       transport: "completions",
       model,
     },
   );
-  return sortTransportToolsByName(tools).map((tool) => {
+  return normalizableTools.flatMap((tool) => {
+    const parameters = normalizeOpenAIToolParametersForTransport(
+      tool,
+      filteredStrict === true,
+      model,
+      {
+        transport: "completions",
+      },
+    );
+    if (!parameters) {
+      return [];
+    }
     const functionTool: {
       name: string;
       description: string | undefined;
-      parameters: ReturnType<typeof normalizeOpenAIStrictToolParameters>;
+      parameters: unknown;
       strict?: boolean;
     } = {
       name: tool.name,
       description: tool.description,
-      parameters: normalizeOpenAIStrictToolParameters(
-        tool.parameters,
-        strict === true,
-        model.compat,
-      ),
+      parameters,
     };
-    if (strict !== undefined) {
-      functionTool.strict = strict;
+    if (filteredStrict !== undefined) {
+      functionTool.strict = filteredStrict;
     }
-    return {
-      type: "function",
-      function: functionTool,
-    };
+    return [
+      {
+        type: "function",
+        function: functionTool,
+      },
+    ];
   });
 }
 
@@ -4041,10 +4264,22 @@ export function buildOpenAICompletionsParams(
   }
   if (supportsModelTools(model)) {
     if (context.tools) {
-      params.tools = convertTools(context.tools, compat, model);
-      if (options?.toolChoice) {
-        params.tool_choice = options.toolChoice;
+      const convertedTools = convertTools(context.tools, compat, model);
+      const toolChoice = resolveOpenAIToolChoiceForConvertedTools(
+        options?.toolChoice,
+        convertedTools.flatMap((tool) =>
+          typeof tool.function.name === "string" ? [tool.function.name] : [],
+        ),
+        model,
+        { transport: "completions" },
+      );
+      if (convertedTools.length > 0 || context.tools.length === 0) {
+        params.tools = convertedTools;
+      }
+      if (toolChoice.toolChoice) {
+        params.tool_choice = toolChoice.toolChoice;
       } else if (
+        !options?.toolChoice &&
         compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
         Array.isArray(params.tools) &&
         params.tools.length > 0


### PR DESCRIPTION
## Summary

- Hardens OpenAI strict-tool schema diagnostics so unreadable tool schemas return incompatibility diagnostics instead of throwing.
- Filters unreadable function-tool schemas out of Responses and Chat Completions payload conversion while preserving healthy sibling tools.
- Reconciles `tool_choice` after filtering: pinned/required skipped function choices fail locally, `allowed_tools` is filtered to remaining tools, and non-function Responses choices pass through unchanged.
- Out of scope: changing runtime tool discovery, provider auth, or live provider behavior.

## Linked context

Which issue does this close?

N/A

Which issues, PRs, or discussions are related?

Related to the ongoing tool-schema fuzzing/hardening pass.

Was this requested by a maintainer or owner?

Maintainer fuzzing/hardening pass on tool-schema ingress surfaces.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unreadable OpenAI function-tool schemas no longer crash strict compatibility diagnostics or final Responses/Chat Completions payload conversion; healthy sibling tools still ship, hard `tool_choice` constraints do not silently broaden, and non-function Responses choices are preserved.
- Real environment tested: focused local Vitest/direct probes in the local worktree plus AWS Crabbox Linux changed gate.
- Exact steps or command run after this patch: `node --import tsx -e '...'` direct red/green probes for `findOpenAIStrictToolSchemaDiagnostics` and `buildOpenAIResponsesParams`; `CI=1 node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.test.ts --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): direct diagnostics probe returns `fuzzplugin_strict.parameters is unreadable`; direct Responses payload probe skips `fuzzplugin_strict`, keeps `read`, and throws a clear local error for pinned skipped `tool_choice`; focused Vitest passed 2 files / 240 tests after final rebase; oxfmt, targeted oxlint, and diff-check passed; AWS Crabbox `pnpm check:changed` passed on provider `aws`, run `run_7808c8ad534f`, lease `cbx_eff01b9db45a`, lanes `core, coreTests`, exit 0.
- Observed result after fix: unreadable schemas are treated as non-normalizable, healthy sibling tools remain available with strict mode preserved, and hard tool-choice constraints fail locally instead of producing inconsistent provider payloads.
- What was not tested: no live OpenAI provider call.
- Proof limitations or environment constraints: local disk was low, so broad changed-gate validation ran remotely through Crabbox.
- Before evidence (optional but encouraged): the same direct strict diagnostics probe threw `Error: strict schema child getter exploded` from schema normalization before the patch.

## Tests and validation

Which commands did you run?

- `node --import tsx -e '...'` red/green probes for strict diagnostics and Responses payload conversion
- `CI=1 node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --target linux --idle-timeout 30m --ttl 90m --timing-json --shell -- "pnpm check:changed"`

What regression coverage was added or updated?

OpenAI strict schema diagnostics, Responses payload conversion, Chat Completions payload conversion, pinned choices, required choices, flat and nested `allowed_tools`, and non-function Responses choices.

What failed before this fix, if known?

Direct strict diagnostics threw before returning a diagnostic when a nested schema getter threw.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

OpenAI tool payload construction and `tool_choice` semantics.

How is that risk mitigated?

The filtering is scoped to schemas that throw during parameter normalization, strict compatibility is recomputed after filtering, and hard choice constraints throw locally rather than silently widening access.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed until the final autoreview pass returned no accepted/actionable findings.
