### PR TITLE
fix(providers): use native reasoning mode for Gemini instead of tagged

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -353,7 +353,7 @@ API key auth, and dynamic model resolution.
     | --- | --- | --- |
     | `openai-compatible` | Shared OpenAI-style replay policy for OpenAI-compatible transports, including tool-call-id sanitation, assistant-first ordering fixes, and generic Gemini-turn validation where the transport needs it | `moonshot`, `ollama`, `xai`, `zai` |
     | `anthropic-by-model` | Claude-aware replay policy chosen by `modelId`, so Anthropic-message transports only get Claude-specific thinking-block cleanup when the resolved model is actually a Claude id | `amazon-bedrock`, `anthropic-vertex` |
-    | `google-gemini` | Native Gemini replay policy plus bootstrap replay sanitation and tagged reasoning-output mode | `google`, `google-gemini-cli` |
+    | `google-gemini` | Native Gemini replay policy plus bootstrap replay sanitation. The shared family keeps the text-output Gemini CLI on tagged reasoning; the direct `google` provider overrides `resolveReasoningOutputMode` to `native` because Gemini API thinking arrives as native thought parts. | `google`, `google-gemini-cli` |
     | `passthrough-gemini` | Gemini thought-signature sanitation for Gemini models running through OpenAI-compatible proxy transports; does not enable native Gemini replay validation or bootstrap rewrites | `openrouter`, `kilocode`, `opencode`, `opencode-go` |
     | `hybrid-anthropic-openai` | Hybrid policy for providers that mix Anthropic-message and OpenAI-compatible model surfaces in one plugin; optional Claude-only thinking-block dropping stays scoped to the Anthropic side | `minimax` |
 
@@ -375,6 +375,13 @@ API key auth, and dynamic model resolution.
       - `openclaw/plugin-sdk/provider-model-shared` - `ProviderReplayFamily`, `buildProviderReplayFamilyHooks(...)`, and the raw replay builders (`buildOpenAICompatibleReplayPolicy`, `buildAnthropicReplayPolicyForModel`, `buildGoogleGeminiReplayPolicy`, `buildHybridAnthropicOrOpenAIReplayPolicy`). Also exports Gemini replay helpers (`sanitizeGoogleGeminiReplayHistory`, `resolveTaggedReasoningOutputMode`) and endpoint/model helpers (`resolveProviderEndpoint`, `normalizeProviderId`, `normalizeGooglePreviewModelId`).
       - `openclaw/plugin-sdk/provider-stream` - `ProviderStreamFamily`, `buildProviderStreamFamilyHooks(...)`, `composeProviderStreamWrappers(...)`, plus the shared OpenAI/Codex wrappers (`createOpenAIAttributionHeadersWrapper`, `createOpenAIFastModeWrapper`, `createOpenAIServiceTierWrapper`, `createOpenAIResponsesContextManagementWrapper`, `createCodexNativeWebSearchWrapper`), DeepSeek V4 OpenAI-compatible wrapper (`createDeepSeekV4OpenAICompatibleThinkingWrapper`), Anthropic Messages thinking prefill cleanup (`createAnthropicThinkingPrefillPayloadWrapper`), plain-text tool-call compat (`createPlainTextToolCallCompatWrapper`), and shared proxy/provider wrappers (`createOpenRouterWrapper`, `createToolStreamWrapper`, `createMinimaxFastModeWrapper`).
       - `openclaw/plugin-sdk/provider-tools` - `ProviderToolCompatFamily`, `buildProviderToolCompatFamilyHooks("deepseek" | "gemini" | "openai")`, and underlying provider schema helpers.
+
+      For Gemini-family providers, keep the reasoning-output mode aligned with
+      the transport. Direct Google Gemini API providers should use `native`
+      reasoning output so OpenClaw consumes native thought parts without adding
+      `<think>` / `<final>` prompt directives. Text-only Gemini CLI-style
+      backends that parse a final JSON/text response can keep the shared
+      `google-gemini` tagged contract.
 
       Some stream helpers stay provider-local on purpose. `@openclaw/anthropic-provider` keeps `wrapAnthropicProviderStream`, `resolveAnthropicBetas`, `resolveAnthropicFastMode`, `resolveAnthropicServiceTier`, and the lower-level Anthropic wrapper builders in its own public `api.ts` / `contract-api.ts` seam because they encode Claude OAuth beta handling and `context1m` gating. The xAI plugin similarly keeps native xAI Responses shaping in its own `wrapStreamFn` (`/fast` aliases, default `tool_stream`, unsupported strict-tool cleanup, xAI-specific reasoning-payload removal).
 

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -66,6 +66,12 @@ describe("google provider plugin hooks", () => {
         modelId: "gemini-3.1-pro-preview",
       } as never),
     ).toBe("native");
+    expect(
+      provider.resolveReasoningOutputMode?.({
+        provider: "google",
+        modelId: "gemini-3.1-pro-preview",
+      } as never),
+    ).toBe("native");
 
     const sanitized = await Promise.resolve(
       provider.sanitizeReplayHistory?.({
@@ -145,6 +151,12 @@ describe("google provider plugin hooks", () => {
       provider.resolveReasoningOutputMode?.({
         provider: "google-vertex",
         modelApi: "google-vertex",
+        modelId: "gemini-3.1-pro-preview",
+      } as never),
+    ).toBe("native");
+    expect(
+      provider.resolveReasoningOutputMode?.({
+        provider: "google-vertex",
         modelId: "gemini-3.1-pro-preview",
       } as never),
     ).toBe("native");

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -65,7 +65,7 @@ describe("google provider plugin hooks", () => {
         modelApi: "google-generative-ai",
         modelId: "gemini-3.1-pro-preview",
       } as never),
-    ).toBe("tagged");
+    ).toBe("native");
 
     const sanitized = await Promise.resolve(
       provider.sanitizeReplayHistory?.({
@@ -100,6 +100,22 @@ describe("google provider plugin hooks", () => {
     });
     expect(customEntries).toHaveLength(1);
     expect(customEntries[0]?.customType).toBe("google-turn-ordering-bootstrap");
+  });
+
+  it("keeps google-gemini-cli on tagged reasoning mode", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: googleProviderPlugin,
+      id: "google",
+      name: "Google Provider",
+    });
+    const cliProvider = requireRegisteredProvider(providers, "google-gemini-cli");
+    expect(
+      cliProvider.resolveReasoningOutputMode?.({
+        provider: "google-gemini-cli",
+        modelApi: "google-gemini-cli",
+        modelId: "gemini-2.5-pro",
+      } as never),
+    ).toBe("tagged");
   });
 
   it("owns Gemini tool schema normalization for direct and CLI providers", async () => {

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -118,6 +118,38 @@ describe("google provider plugin hooks", () => {
     ).toBe("tagged");
   });
 
+  it("keeps google-antigravity hook aliases on tagged reasoning mode", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: googleProviderPlugin,
+      id: "google",
+      name: "Google Provider",
+    });
+    const provider = requireRegisteredProvider(providers, "google-antigravity");
+    expect(
+      provider.resolveReasoningOutputMode?.({
+        provider: "google-antigravity",
+        modelApi: "openai-completions",
+        modelId: "gemini-3-pro-low",
+      } as never),
+    ).toBe("tagged");
+  });
+
+  it("keeps google-vertex hook aliases on native reasoning mode", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: googleProviderPlugin,
+      id: "google",
+      name: "Google Provider",
+    });
+    const provider = requireRegisteredProvider(providers, "google-vertex");
+    expect(
+      provider.resolveReasoningOutputMode?.({
+        provider: "google-vertex",
+        modelApi: "google-vertex",
+        modelId: "gemini-3.1-pro-preview",
+      } as never),
+    ).toBe("native");
+  });
+
   it("owns Gemini tool schema normalization for direct and CLI providers", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: googleProviderPlugin,

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -1,9 +1,9 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import type {
-  ProviderPlugin,
+  OpenClawPluginApi,
   ProviderReasoningOutputModeContext,
-} from "openclaw/plugin-sdk/provider-model-shared";
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeGoogleModelId } from "./model-id.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL, applyGoogleGeminiModelDefault } from "./onboard.js";
 import {

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -25,9 +25,10 @@ function resolveGoogleReasoningOutputMode(
   ctx: ProviderReasoningOutputModeContext,
 ): "native" | "tagged" {
   if (ctx.provider === "google" || ctx.provider === "google-vertex") {
-    return ctx.modelApi === "google-generative-ai" || ctx.modelApi === "google-vertex"
-      ? "native"
-      : "tagged";
+    const api = ctx.model?.api ?? ctx.modelApi;
+    if (!api || api === "google-generative-ai" || api === "google-vertex") {
+      return "native";
+    }
   }
   return "tagged";
 }

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -76,6 +76,11 @@ export function buildGoogleProvider(): ProviderPlugin {
       return undefined;
     },
     ...GOOGLE_GEMINI_PROVIDER_HOOKS,
+    // Gemini 2.5+ delivers reasoning via native thinkingParts (thinkingConfig.includeThoughts).
+    // Tagged mode simultaneously injects <think>/<final> which the model opens before a tool
+    // call, never closes, leaving the post-tool turn empty (payloads=0). The CLI backend keeps
+    // tagged mode because it emits JSON text, not native thought parts.
+    resolveReasoningOutputMode: () => "native" as const,
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
   };
 }

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -1,6 +1,9 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
-import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ProviderPlugin,
+  ProviderReasoningOutputModeContext,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeGoogleModelId } from "./model-id.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL, applyGoogleGeminiModelDefault } from "./onboard.js";
 import {
@@ -17,6 +20,17 @@ import {
   createGoogleGenerativeAiTransportStreamFn,
   createGoogleVertexTransportStreamFn,
 } from "./transport-stream.js";
+
+function resolveGoogleReasoningOutputMode(
+  ctx: ProviderReasoningOutputModeContext,
+): "native" | "tagged" {
+  if (ctx.provider === "google" || ctx.provider === "google-vertex") {
+    return ctx.modelApi === "google-generative-ai" || ctx.modelApi === "google-vertex"
+      ? "native"
+      : "tagged";
+  }
+  return "tagged";
+}
 
 export function buildGoogleProvider(): ProviderPlugin {
   return {
@@ -80,7 +94,7 @@ export function buildGoogleProvider(): ProviderPlugin {
     // Tagged mode simultaneously injects <think>/<final> which the model opens before a tool
     // call, never closes, leaving the post-tool turn empty (payloads=0). The CLI backend keeps
     // tagged mode because it emits JSON text, not native thought parts.
-    resolveReasoningOutputMode: () => "native" as const,
+    resolveReasoningOutputMode: resolveGoogleReasoningOutputMode,
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
   };
 }

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -22,8 +22,8 @@ describe("resolveReasoningOutputMode", () => {
     resolveProviderReasoningOutputModeWithPluginMock.mockReturnValue(undefined);
   });
 
-  it.each([["google-generative-ai", "tagged"]] as const)(
-    "falls back to the built-in map for %s",
+  it.each([["google-generative-ai", "native"]] as const)(
+    "falls back to native for %s when no plugin override is present",
     (provider, expected) => {
       expect(resolveReasoningOutputMode({ provider, workspaceDir: process.cwd() })).toBe(expected);
       expect(resolveProviderReasoningOutputModeWithPluginMock).toHaveBeenCalledTimes(1);
@@ -73,7 +73,7 @@ describe("isReasoningTagProvider", () => {
   });
 
   it.each([
-    ["google-generative-ai", true],
+    ["google-generative-ai", false],
     [null, false],
     [undefined, false],
     ["", false],

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -1,15 +1,8 @@
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderReasoningOutputModeWithPlugin } from "../plugins/provider-runtime.js";
-
-const BUILTIN_REASONING_OUTPUT_MODES = {
-  "google-generative-ai": "tagged",
-} as const;
 
 /**
  * Utility functions for provider-specific logic and capabilities.
@@ -30,7 +23,6 @@ export function resolveReasoningOutputMode(params: {
     return "native";
   }
 
-  const normalized = normalizeOptionalLowercaseString(provider) ?? "";
   const pluginMode = resolveProviderReasoningOutputModeWithPlugin({
     provider,
     config: params.config,
@@ -51,13 +43,6 @@ export function resolveReasoningOutputMode(params: {
     return pluginMode;
   }
 
-  const builtInMode =
-    BUILTIN_REASONING_OUTPUT_MODES[normalized as keyof typeof BUILTIN_REASONING_OUTPUT_MODES];
-  if (builtInMode) {
-    return builtInMode;
-  }
-
-  // Keep a tiny built-in fallback for non-plugin Google surfaces.
   return "native";
 }
 


### PR DESCRIPTION
## Summary

Gemini 2.5 Pro/Flash exposes reasoning via native `thinkingParts` through `thinkingConfig.includeThoughts`. The shared `google-gemini` family hook was selecting tagged reasoning output, which injected a `<think>...</think>/<final>...</final>` directive into the system prompt at the same time as the native thinking config was active.

The model then:
1. Emits a native `thought:true` part
2. Opens a `<think>` text block per the injected directive
3. Pivots to a tool call before closing `</think>`
4. Returns an empty post-tool assistant turn (`content: []`)

Gateway logs: `incomplete turn detected: stopReason=stop payloads=0` - surfacing a spurious error to the user, while burning about 140K input tokens.

### Changes

- **`extensions/google/provider-registration.ts`** - override `resolveReasoningOutputMode` in the direct `google` provider to return `"native"`, superseding the shared `google-gemini` family default of `"tagged"`
- **`src/utils/provider-utils.ts`** - remove the now-dead `BUILTIN_REASONING_OUTPUT_MODES` entry keyed on `"google-generative-ai"`: production callers pass the plugin id `"google"`, not the transport API string, so the map entry was unreachable
- **`docs/plugins/sdk-provider-plugins.md`** - document that direct Google uses native reasoning output while Gemini CLI keeps the tagged contract
- Tests updated in both `provider-utils.test.ts` and `extensions/google/index.test.ts`

## Real behavior proof

- Behavior or issue addressed: Gemini 2.5 Pro/Flash with `thinkingDefault: medium` producing `payloads=0` errors and spurious user-facing error messages on turns that include a tool call, as reported in #69220.
- Real environment tested: macOS arm64, Node v24.15.0, local source checkout on commit `2ed7ec9c3d`; direct Google provider using auth profile `google:default`; model `google/gemini-2.5-flash`; embedded OpenClaw run with `--thinking medium`.
- Exact steps or command run after this patch: `pnpm openclaw agent --agent main --session-key pr-89379-gemini-proof --local --model google/gemini-2.5-flash --thinking medium --message 'Use an available local tool to run a harmless command that prints exactly OPENCLAW_GEMINI_PROOF, then reply with a one-sentence final answer that includes the command output. Do not search the web.' --json`; `node scripts/run-vitest.mjs src/utils/provider-utils.test.ts`; `node scripts/run-vitest.mjs extensions/google/index.test.ts`; `node ./node_modules/.bin/oxfmt --check docs/plugins/sdk-provider-plugins.md extensions/google/provider-registration.ts extensions/google/index.test.ts src/utils/provider-utils.ts src/utils/provider-utils.test.ts`; `pnpm docs:list`; `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live output and redacted runtime log from the patched direct Gemini run:

```json
{
  "payloads": [
    {
      "text": "The command output is OPENCLAW_GEMINI_PROOF.",
      "mediaUrl": null
    }
  ],
  "meta": {
    "provider": "google",
    "model": "gemini-2.5-flash",
    "requestShaping": { "authMode": "auth-profile", "thinking": "medium" },
    "toolSummary": { "calls": 1, "tools": ["exec"], "failures": 0 },
    "completion": { "stopReason": "stop", "finishReason": "stop" },
    "executionTrace": {
      "winnerProvider": "google",
      "winnerModel": "gemini-2.5-flash",
      "result": "success",
      "runner": "embedded",
      "fallbackUsed": false
    }
  },
  "sessionScan": {
    "events": [
      { "type": "model_change", "provider": "google", "modelId": "gemini-2.5-flash" },
      { "type": "assistant", "contentTypes": ["thinking", "toolCall"], "toolNames": ["exec"], "stopReason": "toolUse" },
      { "type": "toolResult", "ok": true },
      { "type": "assistant", "contentTypes": ["text"], "stopReason": "stop" }
    ],
    "hasThinkTag": false,
    "hasFinalTag": false
  }
}
```

- Observed result after fix: the live Gemini turn used one `exec` tool call, returned a post-tool assistant final text payload, and did not hit `payloads=0`; the session scan found no injected `<think>` or `<final>` tags. Focused tests passed: `provider-utils.test.ts` 25/25, `extensions/google/index.test.ts` 11/11. Formatting/docs/diff checks passed.
- What was not tested: Gemini 2.5 Pro live API path was tested with `gemini-2.5-flash`; Gemini 2.5 Pro specifically and Gemini 3 were not tested in this local credential profile. Older Gemini models without native thinking are expected unaffected because native mode only prevents OpenClaw from injecting text-tag reasoning directives.
- Proof limitations or environment constraints: proof uses local auth-profile credentials and a local embedded OpenClaw run, not Crabbox, so no secret-bearing remote run was needed.

## Tests and validation

- `pnpm openclaw agent --agent main --session-key pr-89379-gemini-proof --local --model google/gemini-2.5-flash --thinking medium --message 'Use an available local tool to run a harmless command that prints exactly OPENCLAW_GEMINI_PROOF, then reply with a one-sentence final answer that includes the command output. Do not search the web.' --json`
- `node scripts/run-vitest.mjs src/utils/provider-utils.test.ts` - 25/25 passed
- `node scripts/run-vitest.mjs extensions/google/index.test.ts` - 11/11 passed
- `node ./node_modules/.bin/oxfmt --check docs/plugins/sdk-provider-plugins.md extensions/google/provider-registration.ts extensions/google/index.test.ts src/utils/provider-utils.ts src/utils/provider-utils.test.ts` - clean
- `pnpm docs:list` - completed
- `git diff --check` - clean

Fixes #69220


