### PR TITLE
fix(daemon): default Windows tasks to hidden launcher

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -211,7 +211,7 @@ describe("installScheduledTask", () => {
     });
   });
 
-  it("creates hidden launcher Windows tasks when requested", async () => {
+  it("creates hidden launcher Windows tasks by default", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
 
@@ -219,7 +219,6 @@ describe("installScheduledTask", () => {
         ...env,
         USERDOMAIN: "WORKSTATION",
         USERNAME: "alice",
-        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
       });
       const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
       const launcher = await fs.readFile(launcherPath, "utf8");
@@ -326,7 +325,7 @@ describe("installScheduledTask", () => {
     });
   });
 
-  it("updates existing tasks to use the hidden launcher when requested", async () => {
+  it("updates existing tasks to use the hidden launcher by default", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       // /Query, /Query /TN, /Change (TR-only), /Create /XML (upgrade re-apply), /Run.
       schtasksResponses.push(
@@ -341,7 +340,6 @@ describe("installScheduledTask", () => {
         ...env,
         USERDOMAIN: "WORKSTATION",
         USERNAME: "alice",
-        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "true",
       });
       const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -73,7 +73,7 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 
-function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
+function resolveStartupEntryPath(env: Record<string, string>, extension = "vbs") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
   return path.join(
     env.APPDATA,
@@ -86,8 +86,11 @@ function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd")
   );
 }
 
-async function writeStartupFallbackEntry(env: Record<string, string>) {
-  const startupEntryPath = resolveStartupEntryPath(env);
+async function writeStartupFallbackEntry(
+  env: Record<string, string>,
+  extension: "cmd" | "vbs" = "vbs",
+) {
+  const startupEntryPath = resolveStartupEntryPath(env, extension);
   await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
   await fs.writeFile(startupEntryPath, "@echo off\r\n", "utf8");
   return startupEntryPath;
@@ -292,24 +295,22 @@ describe("Windows startup fallback", () => {
       const startupEntryPath = resolveStartupEntryPath(env);
       const startupScript = await fs.readFile(startupEntryPath, "utf8");
       expect(result.scriptPath).toBe(resolveTaskScriptPath(env));
-      expect(startupScript).toContain('start "" /min cmd.exe /d /c');
+      expect(startupScript).toContain("WScript.Shell");
       expect(startupScript).toContain("gateway.cmd");
+      expect(startupScript).toContain(`Run """${result.scriptPath}""", 0, False`);
       expectStartupFallbackSpawn();
       expect(childUnref).toHaveBeenCalled();
       expect(printed).toContain("Installed Windows login item");
     });
   });
 
-  it("uses a hidden Startup-folder launcher when requested", async () => {
+  it("uses a hidden Startup-folder launcher by default", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses([
         { code: 5, stdout: "", stderr: "ERROR: Access is denied." },
       ]);
 
-      const result = await installGatewayScheduledTask({
-        ...env,
-        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
-      });
+      const result = await installGatewayScheduledTask(env);
 
       const startupEntryPath = resolveStartupEntryPath(env, "vbs");
       const startupScript = await fs.readFile(startupEntryPath, "utf8");
@@ -637,7 +638,7 @@ describe("Windows startup fallback", () => {
   it("keeps legacy Startup-folder cmd entries visible after hidden launcher opt-in", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(env);
+      await writeStartupFallbackEntry(env, "cmd");
 
       await expect(
         isScheduledTaskInstalled({
@@ -650,16 +651,50 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("keeps legacy Startup-folder vbs entries visible after hidden launcher opt-out", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      addStartupFallbackMissingResponses();
+      await writeStartupFallbackEntry(env, "vbs");
+
+      await expect(
+        isScheduledTaskInstalled({
+          env: {
+            ...env,
+            OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "0",
+          },
+        }),
+      ).resolves.toBe(true);
+    });
+  });
+
   it("removes legacy Startup-folder cmd entries after hidden launcher opt-in", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       schtasksResponses.push({ code: 0, stdout: "", stderr: "" });
-      const startupEntryPath = await writeStartupFallbackEntry(env);
+      const startupEntryPath = await writeStartupFallbackEntry(env, "cmd");
       const stdout = new PassThrough();
 
       await uninstallScheduledTask({
         env: {
           ...env,
           OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
+        },
+        stdout,
+      });
+
+      await expect(fs.access(startupEntryPath)).rejects.toThrow();
+    });
+  });
+
+  it("removes legacy Startup-folder vbs entries after hidden launcher opt-out", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      schtasksResponses.push({ code: 0, stdout: "", stderr: "" });
+      const startupEntryPath = await writeStartupFallbackEntry(env, "vbs");
+      const stdout = new PassThrough();
+
+      await uninstallScheduledTask({
+        env: {
+          ...env,
+          OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "0",
         },
         stdout,
       });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -96,9 +96,10 @@ function resolveStartupEntryPath(env: GatewayServiceEnv, extension?: "cmd" | "vb
 function resolveStartupEntryPaths(env: GatewayServiceEnv): string[] {
   const primaryPath = resolveStartupEntryPath(env);
   const legacyCmdPath = resolveStartupEntryPath(env, "cmd");
-  // Hidden VBS launchers supersede cmd launchers, but uninstall must remove the
-  // legacy cmd path from older installs too.
-  return uniqueStrings([primaryPath, legacyCmdPath]);
+  const legacyVbsPath = resolveStartupEntryPath(env, "vbs");
+  // Hidden VBS launchers supersede cmd launchers, but cleanup must remove both
+  // launcher variants left by older installs or changed settings.
+  return uniqueStrings([primaryPath, legacyCmdPath, legacyVbsPath]);
 }
 
 // `/TR` is parsed by schtasks itself, while the generated `gateway.cmd` line is parsed by cmd.exe.
@@ -227,7 +228,7 @@ function resolveSchtasksCreateUser(env: GatewayServiceEnv, taskUser: string | nu
 
 function shouldUseHiddenWindowsTaskLauncher(env: GatewayServiceEnv): boolean {
   const value = normalizeLowercaseStringOrEmpty(env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER);
-  return value === "1" || value === "true" || value === "yes";
+  return value !== "0" && value !== "false" && value !== "no";
 }
 
 function resolveTaskLauncherScriptPath(env: GatewayServiceEnv, scriptPath: string): string {


### PR DESCRIPTION
## Summary
- Default Windows Scheduled Task installs and upgrades to the existing `gateway.vbs` hidden launcher instead of running `gateway.cmd` directly.
- Keep the existing internal escape hatch for explicit falsey `OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER` values.
- Update daemon install coverage so fresh and existing tasks prove the default action points at the hidden launcher.

Fixes #89231.

## Verification
- `node scripts/run-vitest.mjs src/daemon/schtasks.install.test.ts`
- `node scripts/run-vitest.mjs src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.test.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks-exec.test.ts`
- `node scripts/run-oxlint.mjs src/daemon/schtasks.ts src/daemon/schtasks.install.test.ts`
- `git diff --check`

`pnpm tsgo:core` was attempted after installing/linking dependencies, but this checkout reports existing unrelated type errors in `src/agents/sessions/auth-storage.ts`, `src/agents/utils/image-resize.ts`, `src/gateway/managed-image-attachments.ts`, `src/media/image-ops.ts`, and `src/media/web-media.ts`.

## Duplicate check
- `gh pr list --repo openclaw/openclaw --state open --search '89231 Windows scheduled task visible console gateway.cmd windowless launcher gateway.vbs' --json number,title,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo openclaw/openclaw --state open --head leno23:leno23/fix-windows-task-hidden-launcher-89231 --json number,title,url --limit 10` -> `[]`

## Real behavior proof

Behavior addressed: Windows Scheduled Task creation/update now defaults the task action to the existing hidden `.vbs` launcher instead of `gateway.cmd`, preventing the cmd console from being the default launch target.

Real environment tested: macOS 26.3.2 local checkout running the real OpenClaw daemon installer code path with a local `schtasks` command shim to capture the Scheduled Task action arguments.

Exact steps or command run after this patch: `node --import tsx /tmp/openclaw-hidden-launcher-proof.mjs`

Evidence after fix: terminal output from the after-patch OpenClaw daemon installer run:

```text
scriptPath=/var/folders/hy/bphml7v52zxdq_8_273nn9ph0000gn/T/openclaw-hidden-launcher-proof-bucDks/.openclaw/gateway.cmd
launcherPath=/var/folders/hy/bphml7v52zxdq_8_273nn9ph0000gn/T/openclaw-hidden-launcher-proof-bucDks/.openclaw/gateway.vbs
launcherContainsWScript=true
launcherRunsCmd=true
taskActionUsesVbs=true
schtasksArgs=
/Query
/Query /TN OpenClaw Gateway
/Change /TN OpenClaw Gateway /TR /var/folders/hy/bphml7v52zxdq_8_273nn9ph0000gn/T/openclaw-hidden-launcher-proof-bucDks/.openclaw/gateway.vbs
/Create /F /TN OpenClaw Gateway /XML /var/folders/hy/bphml7v52zxdq_8_273nn9ph0000gn/T/openclaw-task-xml-qLNiCK/task.xml
/Run /TN OpenClaw Gateway
/Query
/Query /TN OpenClaw Gateway /V /FO LIST
```

Observed result after fix: The generated launcher file is `gateway.vbs`, it contains `WScript.Shell`, it runs the generated `gateway.cmd`, and the captured Scheduled Task `/TR` action uses `gateway.vbs` by default.

What was not tested: A live Windows 11 desktop Scheduled Task launch with visual confirmation that no `cmd.exe` window appears.