### PR TITLE
fix(plugin-sdk): guard provider tool schema traversal

### DIFF
--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -11,6 +11,28 @@ import {
 } from "./provider-tools.js";
 
 describe("buildProviderToolCompatFamilyHooks", () => {
+  function createUnreadablePropertiesParameters(): Record<string, unknown> {
+    const parameters: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(parameters, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("provider properties getter exploded");
+      },
+    });
+    return parameters;
+  }
+
+  function createUnreadableSchemaArray(): unknown[] {
+    return new Proxy([{ type: "string" }], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("provider schema array getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+  }
+
   function normalizeOpenAIParameters(parameters: unknown): unknown {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [{ name: "demo", description: "", parameters }] as never;
@@ -228,6 +250,158 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("keeps deepseek provider hooks from throwing on unreadable tool schemas", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const broken = {
+      name: "fuzzplugin_provider",
+      description: "",
+      parameters: createUnreadablePropertiesParameters(),
+    };
+    const healthy = {
+      name: "healthy",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          mode: {
+            anyOf: [
+              { const: "fast", type: "string" },
+              { const: "safe", type: "string" },
+            ],
+          },
+        },
+      },
+    };
+    const ctx = {
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [broken, healthy],
+    } as never;
+
+    const normalized = hooks.normalizeToolSchemas(ctx);
+
+    expect(normalized[0]).toBe(broken);
+    expect(normalized[1]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["fast", "safe"],
+        },
+      },
+    });
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: {
+          provider: "deepseek",
+          api: "openai-completions",
+          id: "deepseek-v4-pro",
+        } as never,
+        tools: normalized,
+      } as never),
+    ).toEqual([
+      {
+        toolName: "fuzzplugin_provider",
+        toolIndex: 0,
+        violations: ["fuzzplugin_provider.parameters is unreadable"],
+      },
+    ]);
+  });
+
+  it("reports unreadable provider schema arrays without throwing", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        tools: [
+          {
+            name: "fuzzplugin_array",
+            description: "",
+            parameters: {
+              type: "object",
+              anyOf: createUnreadableSchemaArray(),
+            },
+          },
+        ],
+      } as never),
+    ).toEqual([
+      {
+        toolName: "fuzzplugin_array",
+        toolIndex: 0,
+        violations: [
+          "fuzzplugin_array.parameters.anyOf",
+          "fuzzplugin_array.parameters.anyOf[0] is unreadable",
+        ],
+      },
+    ]);
+  });
+
+  it("keeps gemini provider hooks from throwing on unreadable tool schemas", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("gemini");
+    const broken = {
+      name: "fuzzplugin_provider",
+      description: "",
+      parameters: createUnreadablePropertiesParameters(),
+    };
+    const healthy = {
+      name: "healthy",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", minLength: 3 },
+        },
+        required: ["query"],
+      },
+    };
+    const ctx = {
+      provider: "gemini",
+      modelId: "gemini-3-pro",
+      modelApi: "google-gemini",
+      model: {
+        provider: "gemini",
+        api: "google-gemini",
+        id: "gemini-3-pro",
+      } as never,
+      tools: [broken, healthy],
+    } as never;
+
+    const normalized = hooks.normalizeToolSchemas(ctx);
+
+    expect(normalized[0]).toBe(broken);
+    expect(normalized[1]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
+    expect(hooks.inspectToolSchemas(ctx)).toEqual([
+      {
+        toolName: "fuzzplugin_provider",
+        toolIndex: 0,
+        violations: ["fuzzplugin_provider.parameters is unreadable"],
+      },
+      {
+        toolName: "healthy",
+        toolIndex: 1,
+        violations: ["healthy.parameters.properties.query.minLength"],
+      },
+    ]);
+  });
+
   it("normalizes parameter-free and typed-object schemas for the openai family", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [
@@ -395,6 +569,62 @@ describe("buildProviderToolCompatFamilyHooks", () => {
         tools: [permissiveTool],
       }),
     ).toStrictEqual([]);
+  });
+
+  it("keeps openai provider normalization from throwing on unreadable tool schemas", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("openai");
+    const broken = {
+      name: "fuzzplugin_provider",
+      description: "",
+      parameters: createUnreadablePropertiesParameters(),
+    };
+    const healthy = { name: "healthy", description: "", parameters: {} };
+    const ctx = {
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      model: {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        id: "gpt-5.4",
+      } as never,
+      tools: [broken, healthy],
+    } as never;
+
+    const normalized = hooks.normalizeToolSchemas(ctx);
+
+    expect(normalized[0]).toBe(broken);
+    expect(normalized[1]?.parameters).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    expect(hooks.inspectToolSchemas(ctx)).toStrictEqual([]);
+  });
+
+  it("reports unreadable schemas from strict openai schema inspection", () => {
+    expect(
+      findOpenAIStrictSchemaViolations(createUnreadablePropertiesParameters(), "tool.params"),
+    ).toEqual(["tool.params is unreadable"]);
+  });
+
+  it("reports unreadable arrays from strict openai schema inspection", () => {
+    expect(
+      findOpenAIStrictSchemaViolations(
+        {
+          type: "object",
+          anyOf: createUnreadableSchemaArray(),
+        },
+        "tool.params",
+      ),
+    ).toEqual([
+      "tool.params.anyOf",
+      "tool.params.additionalProperties",
+      "tool.params.required",
+      "tool.params.anyOf[0] is unreadable",
+    ]);
   });
 
   it("skips openai strict-tool normalization on non-native routes", () => {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -13,6 +13,109 @@ import type {
 // Shared provider-tool helpers for plugin-owned schema compatibility rewrites.
 export { cleanSchemaForGemini, GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS, stripUnsupportedSchemaKeywords };
 
+type ToolFieldRead<TField extends "name" | "parameters"> =
+  | {
+      readonly ok: true;
+      readonly value: AnyAgentTool[TField];
+    }
+  | { readonly ok: false };
+
+function readToolField<TField extends "name" | "parameters">(
+  tool: AnyAgentTool,
+  field: TField,
+): ToolFieldRead<TField> {
+  try {
+    return { ok: true, value: tool[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readToolName(
+  tool: AnyAgentTool,
+  toolIndex: number,
+): {
+  readonly toolName: string;
+  readonly violations: string[];
+} {
+  const nameRead = readToolField(tool, "name");
+  const toolName =
+    nameRead.ok && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : `tool[${toolIndex}]`;
+  return {
+    toolName,
+    violations: nameRead.ok ? [] : [`${toolName}.name is unreadable`],
+  };
+}
+
+function readObjectEntries(
+  value: object,
+  path: string,
+):
+  | { readonly ok: true; readonly entries: [string, unknown][] }
+  | {
+      readonly ok: false;
+      readonly violations: string[];
+    } {
+  try {
+    return { ok: true, entries: Object.entries(value) };
+  } catch {
+    return { ok: false, violations: [`${path} is unreadable`] };
+  }
+}
+
+function inspectSchemaArray(
+  schema: readonly unknown[],
+  path: string,
+  inspect: (entry: unknown, path: string) => string[],
+): string[] {
+  let length: number;
+  try {
+    length = schema.length;
+  } catch {
+    return [`${path} is unreadable`];
+  }
+  const violations: string[] = [];
+  for (let index = 0; index < length; index += 1) {
+    let entry: unknown;
+    try {
+      entry = schema[index];
+    } catch {
+      violations.push(`${path}[${index}] is unreadable`);
+      continue;
+    }
+    violations.push(...inspect(entry, `${path}[${index}]`));
+  }
+  return violations;
+}
+
+function findEntry(entries: readonly [string, unknown][], key: string): unknown {
+  return entries.find(([entryKey]) => entryKey === key)?.[1];
+}
+
+function normalizeToolParameters(
+  tool: AnyAgentTool,
+  normalize: (parameters: unknown) => unknown,
+): AnyAgentTool {
+  const parametersRead = readToolField(tool, "parameters");
+  if (!parametersRead.ok || !parametersRead.value || typeof parametersRead.value !== "object") {
+    return tool;
+  }
+  let parameters: unknown;
+  try {
+    parameters = normalize(parametersRead.value);
+  } catch {
+    return tool;
+  }
+  return parameters === parametersRead.value
+    ? tool
+    : {
+        ...tool,
+        parameters: parameters as AnyAgentTool["parameters"],
+      };
+}
+
 export function findUnsupportedSchemaKeywords(
   schema: unknown,
   path: string,
@@ -22,24 +125,33 @@ export function findUnsupportedSchemaKeywords(
     return [];
   }
   if (Array.isArray(schema)) {
-    return schema.flatMap((item, index) =>
-      findUnsupportedSchemaKeywords(item, `${path}[${index}]`, unsupportedKeywords),
+    return inspectSchemaArray(schema, path, (item, itemPath) =>
+      findUnsupportedSchemaKeywords(item, itemPath, unsupportedKeywords),
     );
   }
-  const record = schema as Record<string, unknown>;
+  const entriesRead = readObjectEntries(schema, path);
+  if (!entriesRead.ok) {
+    return entriesRead.violations;
+  }
   const violations: string[] = [];
+  const propertiesValue = findEntry(entriesRead.entries, "properties");
   const properties =
-    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
-      ? (record.properties as Record<string, unknown>)
+    propertiesValue && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)
+      ? propertiesValue
       : undefined;
   if (properties) {
-    for (const [key, value] of Object.entries(properties)) {
-      violations.push(
-        ...findUnsupportedSchemaKeywords(value, `${path}.properties.${key}`, unsupportedKeywords),
-      );
+    const propertyEntriesRead = readObjectEntries(properties, `${path}.properties`);
+    if (!propertyEntriesRead.ok) {
+      violations.push(...propertyEntriesRead.violations);
+    } else {
+      for (const [key, value] of propertyEntriesRead.entries) {
+        violations.push(
+          ...findUnsupportedSchemaKeywords(value, `${path}.properties.${key}`, unsupportedKeywords),
+        );
+      }
     }
   }
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entriesRead.entries) {
     if (key === "properties") {
       continue;
     }
@@ -58,30 +170,34 @@ export function findUnsupportedSchemaKeywords(
 export function normalizeGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
-    }
-    return {
-      ...tool,
-      parameters: cleanSchemaForGemini(tool.parameters),
-    };
-  });
+  return ctx.tools.map((tool) => normalizeToolParameters(tool, cleanSchemaForGemini));
 }
 
 export function inspectGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
   return ctx.tools.flatMap((tool, toolIndex) => {
+    const { toolName, violations: descriptorViolations } = readToolName(tool, toolIndex);
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      return [
+        {
+          toolName,
+          toolIndex,
+          violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+        },
+      ];
+    }
     const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
+      parametersRead.value,
+      `${toolName}.parameters`,
       GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
     );
-    if (violations.length === 0) {
+    const allViolations = [...descriptorViolations, ...violations];
+    if (allViolations.length === 0) {
       return [];
     }
-    return [{ toolName: tool.name, toolIndex, violations }];
+    return [{ toolName, toolIndex, violations: allViolations }];
   });
 }
 
@@ -92,19 +208,20 @@ export function normalizeOpenAIToolSchemas(
     return ctx.tools;
   }
   return ctx.tools.map((tool) => {
-    if (tool.parameters == null) {
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      return tool;
+    }
+    if (parametersRead.value == null) {
       return {
         ...tool,
         parameters: normalizeOpenAIStrictCompatSchema({}),
       };
     }
-    if (typeof tool.parameters !== "object") {
+    if (typeof parametersRead.value !== "object") {
       return tool;
     }
-    return {
-      ...tool,
-      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
-    };
+    return normalizeToolParameters(tool, normalizeOpenAIStrictCompatSchema);
   });
 }
 
@@ -284,8 +401,8 @@ export function findOpenAIStrictSchemaViolations(
     if (options?.requireObjectRoot) {
       return [`${path}.type`];
     }
-    return schema.flatMap((item, index) =>
-      findOpenAIStrictSchemaViolations(item, `${path}[${index}]`),
+    return inspectSchemaArray(schema, path, (item, itemPath) =>
+      findOpenAIStrictSchemaViolations(item, itemPath),
     );
   }
   if (!schema || typeof schema !== "object") {
@@ -295,48 +412,68 @@ export function findOpenAIStrictSchemaViolations(
     return [];
   }
 
-  const record = schema as Record<string, unknown>;
+  const entriesRead = readObjectEntries(schema, path);
+  if (!entriesRead.ok) {
+    return entriesRead.violations;
+  }
   const violations: string[] = [];
+  const anyOf = findEntry(entriesRead.entries, "anyOf");
+  const oneOf = findEntry(entriesRead.entries, "oneOf");
+  const allOf = findEntry(entriesRead.entries, "allOf");
   for (const key of ["anyOf", "oneOf", "allOf"] as const) {
-    if (Array.isArray(record[key])) {
+    const value = key === "anyOf" ? anyOf : key === "oneOf" ? oneOf : allOf;
+    if (Array.isArray(value)) {
       violations.push(`${path}.${key}`);
     }
   }
-  if (Array.isArray(record.type)) {
+  const typeValue = findEntry(entriesRead.entries, "type");
+  if (Array.isArray(typeValue)) {
     violations.push(`${path}.type`);
   }
 
+  const propertiesValue = findEntry(entriesRead.entries, "properties");
   const properties =
-    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
-      ? (record.properties as Record<string, unknown>)
+    propertiesValue && typeof propertiesValue === "object" && !Array.isArray(propertiesValue)
+      ? propertiesValue
       : undefined;
 
-  if (record.type === "object") {
-    if (record.additionalProperties !== false) {
+  if (typeValue === "object") {
+    if (findEntry(entriesRead.entries, "additionalProperties") !== false) {
       violations.push(`${path}.additionalProperties`);
     }
-    const required = Array.isArray(record.required)
-      ? record.required.filter((entry): entry is string => typeof entry === "string")
+    const requiredValue = findEntry(entriesRead.entries, "required");
+    const required = Array.isArray(requiredValue)
+      ? requiredValue.filter((entry): entry is string => typeof entry === "string")
       : undefined;
     if (!required) {
       violations.push(`${path}.required`);
     } else if (properties) {
       const requiredSet = new Set(required);
-      for (const key of Object.keys(properties)) {
-        if (!requiredSet.has(key)) {
-          violations.push(`${path}.required.${key}`);
+      const propertyEntriesRead = readObjectEntries(properties, `${path}.properties`);
+      if (!propertyEntriesRead.ok) {
+        violations.push(...propertyEntriesRead.violations);
+      } else {
+        for (const [key] of propertyEntriesRead.entries) {
+          if (!requiredSet.has(key)) {
+            violations.push(`${path}.required.${key}`);
+          }
         }
       }
     }
   }
 
   if (properties) {
-    for (const [key, value] of Object.entries(properties)) {
-      violations.push(...findOpenAIStrictSchemaViolations(value, `${path}.properties.${key}`));
+    const propertyEntriesRead = readObjectEntries(properties, `${path}.properties`);
+    if (!propertyEntriesRead.ok) {
+      violations.push(...propertyEntriesRead.violations);
+    } else {
+      for (const [key, value] of propertyEntriesRead.entries) {
+        violations.push(...findOpenAIStrictSchemaViolations(value, `${path}.properties.${key}`));
+      }
     }
   }
 
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entriesRead.entries) {
     if (key === "properties") {
       continue;
     }
@@ -353,6 +490,21 @@ export function inspectOpenAIToolSchemas(
 ): ProviderToolSchemaDiagnostic[] {
   if (!shouldApplyOpenAIToolCompat(ctx)) {
     return [];
+  }
+  const diagnostics: ProviderToolSchemaDiagnostic[] = [];
+  for (const [toolIndex, tool] of ctx.tools.entries()) {
+    const { toolName, violations } = readToolName(tool, toolIndex);
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations: [...violations, `${toolName}.parameters is unreadable`],
+      });
+    }
+  }
+  if (diagnostics.length > 0) {
+    return diagnostics;
   }
   // Native OpenAI transports fall back to `strict: false` when any tool schema is not
   // strict-compatible, so these findings are expected for optional-heavy tool schemas.
@@ -465,33 +617,34 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
 export function normalizeDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
-    }
-    const parameters = normalizeDeepSeekSchema(tool.parameters);
-    return parameters === tool.parameters
-      ? tool
-      : {
-          ...tool,
-          parameters: parameters as TSchema,
-        };
-  });
+  return ctx.tools.map((tool) => normalizeToolParameters(tool, normalizeDeepSeekSchema));
 }
 
 export function inspectDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
   return ctx.tools.flatMap((tool, toolIndex) => {
+    const { toolName, violations: descriptorViolations } = readToolName(tool, toolIndex);
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      return [
+        {
+          toolName,
+          toolIndex,
+          violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+        },
+      ];
+    }
     const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
+      parametersRead.value,
+      `${toolName}.parameters`,
       DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
     );
-    if (violations.length === 0) {
+    const allViolations = [...descriptorViolations, ...violations];
+    if (allViolations.length === 0) {
       return [];
     }
-    return [{ toolName: tool.name, toolIndex, violations }];
+    return [{ toolName, toolIndex, violations: allViolations }];
   });
 }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Provider tool-schema compatibility hooks could throw while walking plugin-provided schemas with hostile accessors or proxy arrays.
- A single malformed schema could abort provider normalization/inspection before diagnostics were returned.

Why does this matter now?

- This continues the active tool-schema hardening work from the reported bad-plugin crash path.
- `provider-tools` is a public plugin SDK boundary used by OpenAI-family, DeepSeek, and Gemini provider plugins.

What is the intended outcome?

- Provider normalization leaves unreadable malformed tools unchanged instead of throwing.
- Provider inspection reports unreadable schema paths where diagnostics are expected.
- Healthy sibling tools still normalize/inspect normally.

What is intentionally out of scope?

- No provider policy changes for normal readable schemas.
- No change to OpenAI strict-schema warning policy; strict-incompatible readable schemas still rely on transport strict:false handling.

What does success look like?

- Hostile getter/proxy schemas return diagnostics or are skipped by normalization without crashing the hook call.
- Existing provider schema rewrite behavior stays intact.

What should reviewers focus on?

- The guarded read/traversal helpers in `src/plugin-sdk/provider-tools.ts`.
- Whether the fallback behavior is bounded enough for a public SDK helper.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #89378

Was this requested by a maintainer or owner?

- Maintainer fuzzing sweep for active tool-schema/plugin SDK crash surfaces.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: provider tool-schema normalization/inspection should not crash when a plugin exposes unreadable schema fields or proxy schema arrays.
- Real environment tested: local focused Node/Vitest proof plus Linux AWS Crabbox changed gate.
- Exact steps or command run after this patch:
  - `node --import tsx -e '...'` direct DeepSeek proxy-array inspection probe.
  - `CI=1 node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts --reporter=dot`
  - `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 30m --ttl 90m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): direct probe returned a diagnostic for `fuzzplugin_array.parameters.anyOf[0] is unreadable`; AWS Crabbox run `run_368c6ae99ea2`, lease `cbx_f5b477048c16`, slug `harbor-krill`, provider `aws`, exit 0.
- Observed result after fix: focused Vitest passed 1 file / 16 tests; formatting, targeted oxlint, branch autoreview, and remote changed gate passed.
- What was not tested: full local `pnpm check`/`pnpm test`; this Codex worktree uses linked pnpm state, so broad pnpm gates were run remotely.
- Proof limitations or environment constraints: Blacksmith Testbox was unavailable locally because `blacksmith` was not authenticated; the broad gate was run through direct AWS Crabbox instead.
- Before evidence (optional but encouraged): direct pre-fix probes threw `provider properties getter exploded` from `findUnsupportedSchemaKeywords(...)` and `provider array getter exploded` from proxy-array traversal.

## Tests and validation

Which commands did you run?

- `CI=1 node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox changed gate: `run_368c6ae99ea2`, `cbx_f5b477048c16`, exit 0.

What regression coverage was added or updated?

- DeepSeek hooks preserve healthy sibling normalization and report unreadable schemas.
- Gemini hooks preserve healthy sibling normalization and report unreadable schemas plus normal unsupported keyword diagnostics.
- OpenAI-family normalization no longer throws on unreadable schema objects.
- Strict OpenAI schema inspection reports unreadable object and array traversal paths.

What failed before this fix, if known?

- Direct provider hook probes crashed before returning diagnostics.
- First AWS changed-gate attempt `run_fa96954b0ca3` caught a TypeScript test typing issue; fixed before the passing rerun.

If no test was added, why not?

- Tests were added in `src/plugin-sdk/provider-tools.test.ts`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Public plugin SDK provider helper behavior for malformed schemas.

How is that risk mitigated?

- Normal readable schema behavior is preserved by existing tests.
- New tests cover each provider family hook touched by the guard.
- Remote `check:changed` included core, coreTests, extensions, and extensionTests lanes.

## Current review state

What is the next action?

- Draft PR ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- GitHub CI has not been observed yet after PR creation.
- Optional redacted local transcript was not included because it requires explicit approval.

Which bot or reviewer comments were addressed?

- Local branch autoreview reported no accepted/actionable findings.
