### PR TITLE
docs: document gateway client API contracts

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -355,11 +355,15 @@ const DEFAULT_GATEWAY_CLIENT_URL = "ws://127.0.0.1:18789";
 const DEFAULT_CLIENT_VERSION = "0.0.0";
 
 export type GatewayReconnectPausedInfo = {
+  /** WebSocket close code that paused reconnect attempts. */
   code: number;
+  /** Raw close reason, kept for diagnostics before detail-code normalization. */
   reason: string;
+  /** Structured connect-error detail when the pause came from a gateway policy close. */
   detailCode: string | null;
 };
 
+/** Error wrapper for failed gateway requests and connect handshakes. */
 export class GatewayClientRequestError extends Error {
   readonly gatewayCode: string;
   readonly details?: unknown;
@@ -450,6 +454,7 @@ export const GATEWAY_CLOSE_CODE_HINTS: Readonly<Record<number, string>> = {
   1013: "try again later",
 };
 
+/** Returns a stable operator-facing hint for common WebSocket close codes. */
 export function describeGatewayCloseCode(code: number): string | undefined {
   return GATEWAY_CLOSE_CODE_HINTS[code];
 }
@@ -490,6 +495,8 @@ export function resolveGatewayClientConnectChallengeTimeoutMs(
     "connectChallengeTimeoutMs" | "connectDelayMs" | "preauthHandshakeTimeoutMs"
   >,
 ): number {
+  // Keep the client watchdog at or below the gateway's pre-auth budget so the
+  // caller sees a client-side timeout before the server closes the socket.
   return resolveConnectChallengeTimeoutMs(readConnectChallengeTimeoutOverride(opts), {
     configuredTimeoutMs: opts.preauthHandshakeTimeoutMs,
   });

--- a/packages/gateway-client/src/device-auth.ts
+++ b/packages/gateway-client/src/device-auth.ts
@@ -1,14 +1,3 @@
-export function normalizeDeviceMetadataForAuth(value?: string | null): string {
-  if (typeof value !== "string") {
-    return "";
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "";
-  }
-  return trimmed.replace(/[A-Z]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 32));
-}
-
 type DeviceAuthPayloadParams = {
   deviceId: string;
   clientId: string;
@@ -25,6 +14,19 @@ type DeviceAuthPayloadV3Params = DeviceAuthPayloadParams & {
   deviceFamily?: string | null;
 };
 
+/** Normalizes optional device metadata for byte-stable auth payload signatures. */
+export function normalizeDeviceMetadataForAuth(value?: string | null): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.replace(/[A-Z]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 32));
+}
+
+/** Builds the legacy v2 device-auth signing payload accepted by older gateways. */
 export function buildDeviceAuthPayload(params: DeviceAuthPayloadParams): string {
   const scopes = params.scopes.join(",");
   const token = params.token ?? "";
@@ -41,6 +43,7 @@ export function buildDeviceAuthPayload(params: DeviceAuthPayloadParams): string 
   ].join("|");
 }
 
+/** Builds the v3 device-auth signing payload with normalized platform metadata. */
 export function buildDeviceAuthPayloadV3(params: DeviceAuthPayloadV3Params): string {
   const scopes = params.scopes.join(",");
   const token = params.token ?? "";

--- a/src/gateway/active-sessions-shutdown-tracker.ts
+++ b/src/gateway/active-sessions-shutdown-tracker.ts
@@ -24,6 +24,7 @@ export type ActiveSessionForShutdown = {
 
 const trackedSessions = new Map<string, ActiveSessionForShutdown>();
 
+/** Records a started session so shutdown/restart can emit a matching `session_end`. */
 export function noteActiveSessionForShutdown(entry: ActiveSessionForShutdown): void {
   if (!entry.sessionId) {
     return;
@@ -31,6 +32,7 @@ export function noteActiveSessionForShutdown(entry: ActiveSessionForShutdown): v
   trackedSessions.set(entry.sessionId, entry);
 }
 
+/** Removes sessions already finalized by reset/delete/compaction from shutdown drain. */
 export function forgetActiveSessionForShutdown(sessionId: string | undefined): void {
   if (!sessionId) {
     return;
@@ -38,10 +40,12 @@ export function forgetActiveSessionForShutdown(sessionId: string | undefined): v
   trackedSessions.delete(sessionId);
 }
 
+/** Returns the current shutdown-finalization snapshot without mutating tracker state. */
 export function listActiveSessionsForShutdown(): ActiveSessionForShutdown[] {
   return Array.from(trackedSessions.values());
 }
 
+/** Clears process-local tracker state for isolated tests. */
 export function clearActiveSessionsForShutdownTracker(): void {
   trackedSessions.clear();
 }

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -1,5 +1,6 @@
 import type { AgentEventPayload } from "../infra/agent-events.js";
 
+/** Extracts streamable assistant text, preferring incremental deltas over full snapshots. */
 export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string {
   const delta = evt.data.delta;
   const text = evt.data.text;

--- a/src/gateway/auth-config-utils.ts
+++ b/src/gateway/auth-config-utils.ts
@@ -132,6 +132,8 @@ async function resolveGatewayAuthSecretRef(params: {
   if (!value) {
     return params.cfg;
   }
+  // Materialization is caller-local: pairing/setup/startup need resolved values for
+  // auth decisions, but the canonical config must keep its SecretRef shape.
   const nextConfig = structuredClone(params.cfg);
   nextConfig.gateway ??= {};
   nextConfig.gateway.auth ??= {};
@@ -162,6 +164,8 @@ async function resolveGatewayPasswordSecretRef(params: {
 export async function materializeGatewayAuthSecretRefs(
   params: GatewayAuthSecretRefResolutionParams,
 ): Promise<OpenClawConfig> {
+  // Resolve token first so implicit-mode password refs are skipped when a token
+  // ref already satisfies Gateway auth; this avoids loading unrelated secret providers.
   const cfgWithToken = await resolveGatewayAuthSecretRef({
     cfg: params.cfg,
     env: params.env,

--- a/src/gateway/auth-install-policy.ts
+++ b/src/gateway/auth-install-policy.ts
@@ -5,6 +5,7 @@ import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 
 type GatewayInstallAuthMode = NonNullable<NonNullable<OpenClawConfig["gateway"]>["auth"]>["mode"];
 
+/** Maps explicit gateway auth modes to whether service install must provide a token. */
 function hasExplicitGatewayInstallAuthMode(
   mode: GatewayInstallAuthMode | undefined,
 ): boolean | undefined {
@@ -21,6 +22,7 @@ function hasConfiguredGatewayPasswordForInstall(cfg: OpenClawConfig): boolean {
   return hasConfiguredSecretInput(cfg.gateway?.auth?.password, cfg.secrets?.defaults);
 }
 
+/** Checks only env values persisted into the managed service runtime. */
 function hasDurableGatewayPasswordEnvForInstall(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
@@ -32,6 +34,7 @@ function hasDurableGatewayPasswordEnvForInstall(
   );
 }
 
+/** Decides whether install-time service setup needs a Gateway token available. */
 export function shouldRequireGatewayTokenForInstall(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,

--- a/src/gateway/auth-mode-policy.ts
+++ b/src/gateway/auth-mode-policy.ts
@@ -1,9 +1,11 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 
+/** Shared operator-facing error when token and password auth need an explicit mode. */
 export const EXPLICIT_GATEWAY_AUTH_MODE_REQUIRED_ERROR =
   "Invalid config: gateway.auth.token and gateway.auth.password are both configured, but gateway.auth.mode is unset. Set gateway.auth.mode to token or password.";
 
+/** Detects the dual-credential config state where auth mode inference is unsafe. */
 export function hasAmbiguousGatewayAuthModeConfig(cfg: OpenClawConfig): boolean {
   const auth = cfg.gateway?.auth;
   if (!auth) {
@@ -13,11 +15,14 @@ export function hasAmbiguousGatewayAuthModeConfig(cfg: OpenClawConfig): boolean 
     return false;
   }
   const defaults = cfg.secrets?.defaults;
+  // SecretRefs count as configured here because startup/install must not guess
+  // which credential owner intended before resolving provider-backed values.
   const tokenConfigured = hasConfiguredSecretInput(auth.token, defaults);
   const passwordConfigured = hasConfiguredSecretInput(auth.password, defaults);
   return tokenConfigured && passwordConfigured;
 }
 
+/** Enforces explicit auth mode before startup materializes Gateway auth secrets. */
 export function assertExplicitGatewayAuthModeWhenBothConfigured(cfg: OpenClawConfig): void {
   if (!hasAmbiguousGatewayAuthModeConfig(cfg)) {
     return;

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -1,27 +1,5 @@
-/**
- * In-memory sliding-window rate limiter for gateway authentication attempts.
- *
- * Tracks failed auth attempts by {scope, clientIp}. A scope lets callers keep
- * independent counters for different credential classes (for example, shared
- * gateway token/password vs device-token auth) while still sharing one
- * limiter instance.
- *
- * Design decisions:
- * - Pure in-memory Map – no external dependencies; suitable for a single
- *   gateway process.  The Map is periodically pruned to avoid unbounded
- *   growth.
- * - Loopback addresses (127.0.0.1 / ::1) are exempt by default so that local
- *   CLI sessions are never locked out.
- * - The module is side-effect-free: callers create an instance via
- *   {@link createAuthRateLimiter} and pass it where needed.
- */
-
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isLoopbackAddress, resolveClientIp } from "./net.js";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface RateLimitConfig {
   /** Maximum failed attempts before blocking.  @default 10 */
@@ -80,18 +58,10 @@ export interface AuthRateLimiter {
   dispose(): void;
 }
 
-// ---------------------------------------------------------------------------
-// Defaults
-// ---------------------------------------------------------------------------
-
 const DEFAULT_MAX_ATTEMPTS = 10;
 const DEFAULT_WINDOW_MS = 60_000; // 1 minute
 const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
-
-// ---------------------------------------------------------------------------
-// Implementation
-// ---------------------------------------------------------------------------
 
 /**
  * Canonicalize client IPs used for auth throttling so all call sites
@@ -99,6 +69,8 @@ const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
  */
 export function normalizeRateLimitClientIp(ip: string | undefined): string {
   if (typeof ip === "string" && ip.startsWith(BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX)) {
+    // Browser-origin probes are synthetic buckets, not network addresses; keep
+    // them out of IP normalization so localhost origins remain distinguishable.
     return ip;
   }
   return resolveClientIp({ remoteAddr: ip }) ?? "unknown";
@@ -147,6 +119,8 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
   } {
     const ip = normalizeIp(rawIp);
     const scope = normalizeScope(rawScope);
+    // Scope is part of the key so device-token, shared-secret, hook, and
+    // bootstrap failures do not lock each other out for the same client.
     return { key: `${scope}:${ip}`, ip };
   }
 
@@ -182,8 +156,9 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
       };
     }
 
-    // Lockout expired – clear it.
     if (entry.lockedUntil && now >= entry.lockedUntil) {
+      // Expired lockouts start with a clean window so stale failures do not
+      // immediately relock the client on the first post-lockout check.
       entry.lockedUntil = undefined;
       entry.attempts = [];
     }
@@ -207,8 +182,9 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
       entries.set(key, entry);
     }
 
-    // If currently locked, do nothing (already blocked).
     if (entry.lockedUntil && now < entry.lockedUntil) {
+      // Do not extend lockouts from extra attempts while already blocked; this
+      // keeps retry-after bounded and predictable for clients.
       return;
     }
 
@@ -228,8 +204,9 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
   function prune(): void {
     const now = Date.now();
     for (const [key, entry] of entries) {
-      // If locked out, keep the entry until the lockout expires.
       if (entry.lockedUntil && now < entry.lockedUntil) {
+        // Keep active lockout entries even after their sliding-window attempts
+        // age out; the lockout deadline is the active state.
         continue;
       }
       slideWindow(entry, now);

--- a/src/gateway/auth-surface-resolution.ts
+++ b/src/gateway/auth-surface-resolution.ts
@@ -34,6 +34,7 @@ async function resolveGatewayCredential(params: {
   return resolved;
 }
 
+/** Attaches unresolved SecretRef diagnostics only when a caller can surface them. */
 function withDiagnostics<T extends object>(params: {
   diagnostics: string[];
   result: T;
@@ -43,6 +44,7 @@ function withDiagnostics<T extends object>(params: {
     : params.result;
 }
 
+/** Resolves credentials for non-interactive probe flows without forcing fallback failures. */
 export async function resolveGatewayProbeSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -60,6 +62,8 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
       path: "gateway.remote.token",
       value: params.config.gateway?.remote?.token,
     });
+    // Remote probes prefer token auth; only resolve password if no token is
+    // available so unresolved password refs do not mask a valid token.
     const remotePassword = remoteToken.value
       ? { value: undefined }
       : await resolveGatewayCredential({
@@ -76,6 +80,8 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
   }
 
   if (authMode === "none" || authMode === "trusted-proxy") {
+    // Local probes do not synthesize credentials for modes where shared-secret
+    // auth is not the active authorization boundary.
     return {};
   }
 
@@ -126,6 +132,8 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
     return { token: envToken };
   }
   if (envPassword) {
+    // Auto mode allows env password as a compatibility fallback only after
+    // config/env token resolution has failed.
     return withDiagnostics({ diagnostics, result: { password: envPassword } });
   }
   const password = await resolveGatewayCredential({
@@ -141,6 +149,7 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
   });
 }
 
+/** Resolves credentials for interactive/local client flows with actionable failure text. */
 export async function resolveGatewayInteractiveSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -185,6 +194,8 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
           });
     const token = explicitToken ?? remoteToken.value ?? envToken;
     const password = explicitPassword ?? envPassword ?? remotePassword.value;
+    // Interactive remote mode can report why SecretRefs failed when no explicit,
+    // remote, or env fallback credential remains.
     return token || password
       ? { token, password }
       : {
@@ -197,6 +208,8 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
 
   const authMode = params.config.gateway?.auth?.mode;
   if (authMode === "none" || authMode === "trusted-proxy") {
+    // These modes do not require shared-secret auth, but explicit/env values are
+    // still returned so manual client overrides can target mixed deployments.
     return {
       token: explicitToken ?? envToken,
       password: explicitPassword ?? envPassword,
@@ -272,6 +285,8 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
   const shouldUsePassword =
     Boolean(explicitPassword ?? envPassword) || (hasConfiguredPassword && !hasConfiguredToken);
   if (shouldUsePassword) {
+    // In auto mode, an explicit/env password or password-only config means the
+    // client should prompt/report password errors instead of token errors.
     const password = await resolvePassword();
     return {
       token: explicitToken ?? envToken,

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -9,6 +9,7 @@ import {
 type GatewayAuthTokenResolutionSource = "explicit" | "config" | "secretRef" | "env";
 type GatewayAuthTokenEnvFallback = "never" | "no-secret-ref" | "always";
 
+/** Resolves the token used by non-request Gateway clients without mutating config. */
 export async function resolveGatewayAuthToken(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -57,6 +58,8 @@ export async function resolveGatewayAuthToken(params: {
     return { secretRefConfigured: false };
   }
 
+  // SecretRef-backed config is authoritative for service/doctor paths; callers opt into
+  // OPENCLAW_GATEWAY_TOKEN fallback only where an unresolved ref should not block probing.
   const resolved = await resolveConfiguredSecretInputString({
     config: params.cfg,
     env: params.env,

--- a/src/gateway/auth-token-source-conflict.ts
+++ b/src/gateway/auth-token-source-conflict.ts
@@ -14,6 +14,7 @@ export type GatewayAuthTokenSourceConflict = {
   diagnostic: string;
 };
 
+/** Builds the audit/status warning for ambient env tokens that can shadow local config tokens. */
 export function resolveGatewayAuthTokenSourceConflict(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -23,6 +24,8 @@ export function resolveGatewayAuthTokenSourceConflict(params: {
     return null;
   }
 
+  // The managed gateway service intentionally prefers persisted config, so its own
+  // process env is not treated as a shell/client shadowing risk.
   if (params.env.OPENCLAW_SERVICE_KIND?.trim() === GATEWAY_SERVICE_KIND) {
     return null;
   }

--- a/src/gateway/auth-token-source-conflict.ts
+++ b/src/gateway/auth-token-source-conflict.ts
@@ -6,11 +6,17 @@ const GATEWAY_ENV_TOKEN = "OPENCLAW_GATEWAY_TOKEN";
 const GATEWAY_SERVICE_KIND = "gateway";
 
 export type GatewayAuthTokenSourceConflict = {
+  /** Stable id shared by doctor, status, and security audit findings. */
   checkId: "gateway.env_token_overrides_config";
+  /** Short human-readable warning title. */
   title: string;
+  /** Explanation of how local clients and the managed service can diverge. */
   detail: string;
+  /** Operator action that makes the env/config token source canonical again. */
   remediation: string;
+  /** Preformatted doctor warning block. */
   warningLines: string[];
+  /** Single-line status/config diagnostic. */
   diagnostic: string;
 };
 
@@ -30,6 +36,8 @@ export function resolveGatewayAuthTokenSourceConflict(params: {
     return null;
   }
 
+  // Remote gateways do not compare the local config token against a locally
+  // managed service, so an ambient token cannot shadow the running service.
   if (params.cfg.gateway?.mode === "remote") {
     return null;
   }
@@ -44,6 +52,8 @@ export function resolveGatewayAuthTokenSourceConflict(params: {
     value: tokenInput,
     defaults: params.cfg.secrets?.defaults,
   });
+  // Config that explicitly points at OPENCLAW_GATEWAY_TOKEN has made the env
+  // var canonical, so matching by source is enough even before resolving it.
   if (ref?.source === "env" && ref.id === GATEWAY_ENV_TOKEN) {
     return null;
   }

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -316,6 +316,8 @@ function authorizeTrustedProxy(params: {
   }
   const remoteIsLoopback = isLoopbackAddress(remoteAddr);
   if (remoteIsLoopback && trustedProxyConfig.allowLoopback !== true) {
+    // Loopback proxies are common in tests and dev tools, so require explicit
+    // opt-in before trusting identity headers from local processes.
     return { reason: "trusted_proxy_loopback_source" };
   }
   if (!remoteIsLoopback) {
@@ -324,6 +326,8 @@ function authorizeTrustedProxy(params: {
       return { reason: "trusted_proxy_local_interface_check_failed" };
     }
     if (localInterfaceMatch) {
+      // A non-loopback local interface is still same-machine traffic, not an
+      // external reverse proxy boundary.
       return { reason: "trusted_proxy_local_interface_source" };
     }
   }
@@ -370,6 +374,8 @@ function authorizeTrustedProxyBrowserOrigin(params: {
     return null;
   }
 
+  // Trusted-proxy identity can satisfy HTTP auth, but browser-origin checks
+  // still prevent a third-party site from riding that proxy-authenticated user.
   const originCheck = checkBrowserOrigin({
     requestHost: params.browserOriginPolicy?.requestHost,
     origin,
@@ -394,9 +400,8 @@ function authorizeTokenAuth(params: {
     return { ok: false, reason: "token_missing_config" };
   }
   if (!params.connectToken) {
-    // Don't burn rate-limit slots for missing credentials — the client
-    // simply hasn't provided a token yet (e.g. bare browser open).
-    // Only actual *wrong* credentials should count as failures.
+    // Missing credentials often come from a bare browser open; only wrong
+    // credentials are treated as brute-force attempts.
     return { ok: false, reason: "token_missing" };
   }
   if (!safeEqualSecret(params.connectToken, params.authToken)) {
@@ -418,7 +423,7 @@ function authorizePasswordAuth(params: {
     return { ok: false, reason: "password_missing_config" };
   }
   if (!params.connectPassword) {
-    // Same as token_missing — don't penalize absent credentials.
+    // Same as token_missing: absent credentials are not a failed secret guess.
     return { ok: false, reason: "password_missing" };
   }
   if (!safeEqualSecret(params.connectPassword, params.authPassword)) {
@@ -542,6 +547,8 @@ async function authorizeGatewayConnectCore(
     !localDirect &&
     !hasExplicitSharedSecretAuth(connectAuth)
   ) {
+    // Tailscale forwarded identity is only a tokenless fallback for the Control
+    // UI websocket surface; explicit shared secrets always take precedence.
     const tailscaleCheck = await resolveVerifiedTailscaleUser({
       req,
       tailscaleWhois,

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -27,11 +27,13 @@ type ChannelHealthEvaluationReason =
   | "disconnected"
   | "stale-socket";
 
+/** Result shared by health commands, readiness probes, and restart monitor logic. */
 export type ChannelHealthEvaluation = {
   healthy: boolean;
   reason: ChannelHealthEvaluationReason;
 };
 
+/** Time-window policy used to evaluate one channel status snapshot. */
 export type ChannelHealthPolicy = {
   channelId: ChannelId;
   now: number;
@@ -51,6 +53,7 @@ const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
 export const DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
 export const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
 
+/** Evaluates whether a channel snapshot is healthy enough to keep running. */
 export function evaluateChannelHealth(
   snapshot: ChannelHealthSnapshot,
   policy: ChannelHealthPolicy,
@@ -112,6 +115,9 @@ export function evaluateChannelHealth(
   // go idle while their upstream clients maintain heartbeats internally.
   const shouldCheckStaleSocket = snapshot.connected === true && lastTransportActivityAt != null;
   if (shouldCheckStaleSocket) {
+    // Patch-merged status can carry the previous lifecycle's transport timestamp;
+    // give the new lifecycle one stale window before treating that inherited value
+    // as proof that the socket is no longer alive.
     if (lastStartAt != null && lastTransportActivityAt < lastStartAt) {
       const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
       if (lifecycleEventGap <= policy.staleEventThresholdMs) {
@@ -127,6 +133,7 @@ export function evaluateChannelHealth(
   return { healthy: true, reason: "healthy" };
 }
 
+/** Converts an unhealthy evaluation into the restart reason reported to channels. */
 export function resolveChannelRestartReason(
   snapshot: ChannelHealthSnapshot,
   evaluation: ChannelHealthEvaluation,

--- a/src/gateway/channel-status-patches.ts
+++ b/src/gateway/channel-status-patches.ts
@@ -1,13 +1,16 @@
+/** Channel status fields set when a transport establishes a fresh connection. */
 export type ConnectedChannelStatusPatch = {
   connected: true;
   lastConnectedAt: number;
   lastEventAt: number;
 };
 
+/** Channel status fields set by heartbeat/activity without implying reconnect. */
 export type TransportActivityChannelStatusPatch = {
   lastTransportActivityAt: number;
 };
 
+/** Builds the canonical connection-liveness patch with one shared timestamp. */
 export function createConnectedChannelStatusPatch(
   at: number = Date.now(),
 ): ConnectedChannelStatusPatch {
@@ -18,6 +21,7 @@ export function createConnectedChannelStatusPatch(
   };
 }
 
+/** Builds the transport-activity patch used by heartbeat-only status updates. */
 export function createTransportActivityStatusPatch(
   at: number = Date.now(),
 ): TransportActivityChannelStatusPatch {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -51,6 +51,7 @@ type RegisteredChatAbortController = {
   cleanup: () => void;
 };
 
+/** Checks whether user text should be treated as a request to stop the active chat run. */
 export function isChatStopCommandText(text: string): boolean {
   return isAbortRequestText(text);
 }
@@ -64,6 +65,7 @@ function createChatAbortSignalReason(stopReason: string | undefined): Error | un
   return reason;
 }
 
+/** Computes the cleanup deadline for a tracked chat run after model timeout plus grace. */
 export function resolveChatRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -93,6 +95,7 @@ export function resolveChatRunExpiresAtMs(params: {
   return Math.min(max, Math.max(min, target));
 }
 
+/** Computes the cleanup deadline for backend agent runs that share chat abort state. */
 export function resolveAgentRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -108,6 +111,7 @@ export function resolveAgentRunExpiresAtMs(params: {
   });
 }
 
+/** Registers an abort controller entry for an active chat or agent run. */
 export function registerChatAbortController(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   runId: string;
@@ -280,6 +284,7 @@ export function boundInFlightRunSnapshotForChatHistory(params: {
   return { runId: params.snapshot.runId, text: "" };
 }
 
+/** Runtime hooks needed to abort a chat run and publish lifecycle state. */
 export type ChatAbortOps = {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   chatRunBuffers: Map<string, string>;
@@ -296,6 +301,7 @@ export type ChatAbortOps = {
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
 };
 
+/** Narrow abort adapter used by callers that expose chat run state under different names. */
 export type TrackedChatRunAbortOps = {
   chatAbortControllers: ChatAbortOps["chatAbortControllers"];
   chatRunBuffers: ChatAbortOps["chatRunBuffers"];
@@ -309,6 +315,7 @@ export type TrackedChatRunAbortOps = {
   nodeSendToSession: ChatAbortOps["nodeSendToSession"];
 };
 
+/** Aborts a run through a tracked-state adapter without duplicating abort logic. */
 export function abortTrackedChatRunById(
   ops: TrackedChatRunAbortOps,
   params: Parameters<typeof abortChatRunById>[1],
@@ -396,6 +403,7 @@ function resolveDefaultGlobalAgentId(ops: ChatAbortOps): string | undefined {
   return cfg ? resolveDefaultAgentId(cfg) : undefined;
 }
 
+/** Aborts one active chat run, clears tracking state, and emits terminal events. */
 export function abortChatRunById(
   ops: ChatAbortOps,
   params: {
@@ -453,6 +461,7 @@ export function abortChatRunById(
   return { aborted: true };
 }
 
+/** Updates provider metadata once a run has selected its effective provider. */
 export function updateChatRunProvider(
   chatAbortControllers: Map<string, ChatAbortControllerEntry>,
   params: {
@@ -470,6 +479,7 @@ export function updateChatRunProvider(
   return true;
 }
 
+/** Aborts all active runs associated with a provider or auth-provider id. */
 export function abortChatRunsForProvider(
   ops: ChatAbortOps,
   params: {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -8,6 +8,7 @@ import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { deleteMediaBuffer, saveMediaBuffer } from "../media/store.js";
 
+/** Raw Gateway chat attachment accepted from RPC callers. */
 export type ChatAttachment = {
   type?: string;
   mimeType?: string;
@@ -15,12 +16,14 @@ export type ChatAttachment = {
   content?: unknown;
 };
 
+/** Inline image payload passed directly to image-capable agent providers. */
 export type ChatImageContent = {
   type: "image";
   data: string;
   mimeType: string;
 };
 
+/** Media-store reference for attachments staged outside inline model input. */
 export type OffloadedRef = {
   mediaRef: string;
   id: string;
@@ -58,6 +61,7 @@ const TEXT_ONLY_OFFLOAD_LIMIT = 10;
 
 export const DEFAULT_CHAT_ATTACHMENT_MAX_MB = 20;
 
+/** Resolves the configured per-agent attachment limit in bytes. */
 export function resolveChatAttachmentMaxBytes(cfg: OpenClawConfig): number {
   const configured = cfg.agents?.defaults?.mediaMaxMb;
   const mb =
@@ -73,6 +77,7 @@ type UnsupportedAttachmentReason =
   | "unsupported-non-image"
   | "non-image-too-large-for-sandbox";
 
+/** Typed attachment rejection that callers can convert into client-facing errors. */
 export class UnsupportedAttachmentError extends Error {
   readonly reason: UnsupportedAttachmentReason;
   constructor(reason: UnsupportedAttachmentReason, message: string) {
@@ -82,6 +87,7 @@ export class UnsupportedAttachmentError extends Error {
   }
 }
 
+/** Wraps media-store failures after an attachment must be offloaded. */
 export class MediaOffloadError extends Error {
   override readonly cause: unknown;
   constructor(message: string, options?: ErrorOptions) {
@@ -235,6 +241,7 @@ function validateAttachmentBase64OrThrow(
   return sizeBytes;
 }
 
+/** Normalizes, validates, and routes chat attachments into inline images or media refs. */
 export async function parseMessageWithAttachments(
   message: string,
   attachments: ChatAttachment[] | undefined,
@@ -428,6 +435,7 @@ export async function parseMessageWithAttachments(
   };
 }
 
+/** Sniffs the same MIME signals as parsing to preflight image-only attachment paths. */
 export async function resolveChatAttachmentLooksLikeImage(
   attachment: ChatAttachment,
   index = 0,
@@ -447,7 +455,7 @@ export async function resolveChatAttachmentLooksLikeImage(
 
 /**
  * @deprecated Use parseMessageWithAttachments instead.
- * This function converts images to markdown data URLs which Claude API cannot process as images.
+ * This legacy helper converts images to markdown data URLs instead of provider-native image blocks.
  */
 export function buildMessageWithAttachments(
   message: string,

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -17,6 +17,7 @@ import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
 import { isSuppressedControlReplyText } from "./control-reply-text.js";
 
+/** Default per-field text budget for display-safe chat history projection. */
 export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 8_000;
 
 type RoleContentMessage = {
@@ -32,6 +33,7 @@ type PendingMessageToolVisibleReply = {
   succeeded: boolean;
 };
 
+/** Resolves the caller override used by chat history sanitizers and display projections. */
 export function resolveEffectiveChatHistoryMaxChars(_cfg: unknown, maxChars?: number): number {
   if (typeof maxChars === "number") {
     return maxChars;
@@ -52,6 +54,7 @@ function truncateChatHistoryText(
   };
 }
 
+/** Detects provider spellings for tool call/result content blocks that need payload fidelity. */
 export function isToolHistoryBlockType(type: unknown): boolean {
   if (typeof type !== "string") {
     return false;
@@ -192,6 +195,8 @@ function projectAssistantTextFromMixedToolContent(
     return null;
   }
 
+  // Mixed tool/text assistant entries are commentary transport artifacts; display keeps only
+  // the text blocks users saw while exact tool payloads stay available in raw transcripts.
   const textBlocks: unknown[] = [];
   for (const block of content) {
     if (!block || typeof block !== "object") {
@@ -840,6 +845,7 @@ function shouldDropAssistantHistoryMessage(message: unknown): boolean {
   return !hasAssistantNonTextContent(message);
 }
 
+/** Produces display-safe history without mutating already-clean message arrays. */
 export function sanitizeChatHistoryMessages(
   messages: unknown[],
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
@@ -1191,6 +1197,7 @@ function filterVisibleProjectedHistoryMessages(
   return changed ? visible : messages;
 }
 
+/** Projects raw transcript messages into the canonical Gateway chat-display shape. */
 export function projectChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; stripEnvelope?: boolean },
@@ -1220,6 +1227,7 @@ function limitChatDisplayMessages<T>(messages: T[], maxMessages?: number): T[] {
   return messages.slice(-Math.floor(maxMessages));
 }
 
+/** Projects chat-display messages, then keeps only the most recent display entries. */
 export function projectRecentChatDisplayMessages(
   messages: unknown[],
   options?: { maxChars?: number; maxMessages?: number; stripEnvelope?: boolean },
@@ -1230,6 +1238,7 @@ export function projectRecentChatDisplayMessages(
   );
 }
 
+/** Projects a single raw transcript message, returning undefined when it is display-hidden. */
 export function projectChatDisplayMessage(
   message: unknown,
   options?: { maxChars?: number; stripEnvelope?: boolean },

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -64,6 +64,7 @@ function stripEnvelopeFromContentWithRole(
   return { content: next, changed };
 }
 
+/** Removes display-only chat envelopes from one gateway chat message. */
 export function stripEnvelopeFromMessage(message: unknown): unknown {
   if (!message || typeof message !== "object") {
     return message;
@@ -75,6 +76,8 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   let changed = false;
   const next: Record<string, unknown> = { ...entry };
   const senderLabel = stripUserEnvelope ? extractMessageSenderLabel(entry) : null;
+  // Preserve the parsed human/channel label before removing the user envelope
+  // text that carried it, so display callers keep attribution without markup.
   if (senderLabel && entry.senderLabel !== senderLabel) {
     next.senderLabel = senderLabel;
     changed = true;
@@ -107,6 +110,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   return changed ? next : message;
 }
 
+/** Removes display-only chat envelopes from a message list without needless cloning. */
 export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;

--- a/src/gateway/client-bootstrap.ts
+++ b/src/gateway/client-bootstrap.ts
@@ -3,6 +3,7 @@ import { resolveGatewayConnectionAuth } from "./connection-auth.js";
 import { buildGatewayConnectionDetailsWithResolvers } from "./connection-details.js";
 import type { ExplicitGatewayAuth } from "./credentials.js";
 
+/** Maps connection-detail provenance into auth resolver override provenance. */
 export function resolveGatewayUrlOverrideSource(urlSource: string): "cli" | "env" | undefined {
   if (urlSource === "cli --url") {
     return "cli";
@@ -13,6 +14,7 @@ export function resolveGatewayUrlOverrideSource(urlSource: string): "cli" | "env
   return undefined;
 }
 
+/** Builds the resolved URL, auth, and preauth settings for GatewayClient callers. */
 export async function resolveGatewayClientBootstrap(params: {
   config: OpenClawConfig;
   gatewayUrl?: string;
@@ -32,6 +34,8 @@ export async function resolveGatewayClientBootstrap(params: {
     url: params.gatewayUrl,
   });
   const urlOverrideSource = resolveGatewayUrlOverrideSource(connection.urlSource);
+  // Only explicit CLI/env URLs should alter auth source selection. Config and
+  // local defaults keep normal config/env credential precedence.
   const auth = await resolveGatewayConnectionAuth({
     config: params.config,
     explicitAuth: params.explicitAuth,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -73,8 +73,11 @@ export type GatewayClientRequestOptions = {
 };
 
 export type GatewayReconnectPausedInfo = {
+  /** WebSocket close code that paused reconnect attempts. */
   code: number;
+  /** Raw close reason, kept for diagnostics before detail-code normalization. */
   reason: string;
+  /** Structured connect-error detail when the pause came from a gateway policy close. */
   detailCode: string | null;
 };
 
@@ -89,6 +92,7 @@ type GatewayClientErrorShape = {
 export const GATEWAY_CLOSE_CODE_HINTS: Readonly<Record<number, string>> =
   BASE_GATEWAY_CLOSE_CODE_HINTS;
 
+/** Error wrapper for failed gateway requests and connect handshakes. */
 export const GatewayClientRequestError = BaseGatewayClientRequestError as unknown as {
   new (error: GatewayClientErrorShape): Error & {
     readonly gatewayCode: string;
@@ -100,6 +104,7 @@ export const GatewayClientRequestError = BaseGatewayClientRequestError as unknow
 
 export type GatewayClientRequestError = InstanceType<typeof GatewayClientRequestError>;
 
+/** Returns a stable operator-facing hint for common WebSocket close codes. */
 export function describeGatewayCloseCode(code: number): string | undefined {
   return baseDescribeGatewayCloseCode(code);
 }
@@ -184,6 +189,8 @@ export function resolveGatewayClientConnectChallengeTimeoutMs(
     "connectChallengeTimeoutMs" | "connectDelayMs" | "preauthHandshakeTimeoutMs"
   >,
 ): number {
+  // Mirror the package resolver exactly; core callers pass gateway-derived
+  // budgets through this wrapper so package code stays OpenClaw-runtime free.
   return baseResolveGatewayClientConnectChallengeTimeoutMs(opts);
 }
 

--- a/src/gateway/config-reload-settings.ts
+++ b/src/gateway/config-reload-settings.ts
@@ -1,6 +1,7 @@
 import type { GatewayReloadMode } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Normalized Gateway config-reload mode and debounce window used by reload paths. */
 export type GatewayReloadSettings = {
   mode: GatewayReloadMode;
   debounceMs: number;
@@ -11,6 +12,7 @@ const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
   debounceMs: 300,
 };
 
+/** Resolves reload settings from config while clamping invalid debounce values. */
 export function resolveGatewayReloadSettings(cfg: OpenClawConfig): GatewayReloadSettings {
   const rawMode = cfg.gateway?.reload?.mode;
   const mode =

--- a/src/gateway/connection-auth.ts
+++ b/src/gateway/connection-auth.ts
@@ -24,6 +24,7 @@ export type GatewayConnectionAuthOptions = {
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
 
+/** Converts connection-auth options into the shared credential resolver shape. */
 function toGatewayCredentialOptions(
   params: Omit<GatewayConnectionAuthOptions, "config"> & { cfg: OpenClawConfig },
 ) {
@@ -43,6 +44,7 @@ function toGatewayCredentialOptions(
   };
 }
 
+/** Resolves gateway connection credentials, including async SecretRef materialization. */
 export async function resolveGatewayConnectionAuth(
   params: GatewayConnectionAuthOptions,
 ): Promise<{ token?: string; password?: string }> {
@@ -52,6 +54,7 @@ export async function resolveGatewayConnectionAuth(
   });
 }
 
+/** Resolves gateway connection credentials from already-materialized config values only. */
 export function resolveGatewayConnectionAuthFromConfig(
   params: Omit<GatewayConnectionAuthOptions, "config"> & { cfg: OpenClawConfig },
 ): { token?: string; password?: string } {

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -4,6 +4,7 @@ import { resolveConfigPath, resolveGatewayPort } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isSecureWebSocketUrl } from "./net.js";
 
+/** Resolved Gateway target plus the operator-facing explanation of how it was chosen. */
 export type GatewayConnectionDetails = {
   url: string;
   urlSource: string;
@@ -18,6 +19,7 @@ type GatewayConnectionDetailResolvers = {
   resolveGatewayPort?: (cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => number;
 };
 
+/** Builds CLI/status Gateway connection details with injectable resolvers for tests. */
 export function buildGatewayConnectionDetailsWithResolvers(
   options: {
     config?: OpenClawConfig;

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -1,7 +1,9 @@
 export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/__openclaw/control-ui-config.json";
 
+/** Sandbox strength for embedded Control UI surfaces. */
 export type ControlUiEmbedSandboxMode = "strict" | "scripts" | "trusted";
 
+/** JSON bootstrap payload consumed by the browser Control UI before app startup. */
 export type ControlUiBootstrapConfig = {
   basePath: string;
   assistantName: string;

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -27,11 +27,14 @@ export function computeInlineScriptHashes(html: string): string[] {
 }
 
 function hasScriptSrcAttribute(openTag: string): boolean {
+  // Parse only attribute names so src/data-src-like values in quoted text cannot
+  // make an external script look inline or vice versa.
   return Array.from(openTag.matchAll(SCRIPT_ATTRIBUTE_NAME_RE)).some(
     (match) => normalizeLowercaseStringOrEmpty(match[1]) === "src",
   );
 }
 
+/** Builds the restrictive Control UI CSP header, optionally allowing hashed inline scripts. */
 export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }): string {
   const hashes = opts?.inlineScriptHashes;
   const scriptSrc = hashes?.length

--- a/src/gateway/control-ui-http-utils.ts
+++ b/src/gateway/control-ui-http-utils.ts
@@ -1,15 +1,18 @@
 import type { ServerResponse } from "node:http";
 
+/** Returns whether a Control UI route may serve a read-only HTTP request. */
 export function isReadHttpMethod(method: string | undefined): boolean {
   return method === "GET" || method === "HEAD";
 }
 
+/** Sends a UTF-8 plain-text Control UI response with the provided status code. */
 export function respondPlainText(res: ServerResponse, statusCode: number, body: string): void {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.end(body);
 }
 
+/** Sends the shared Control UI 404 response used by route and media handlers. */
 export function respondNotFound(res: ServerResponse): void {
   respondPlainText(res, 404, "Not Found");
 }

--- a/src/gateway/control-ui-links.ts
+++ b/src/gateway/control-ui-links.ts
@@ -5,6 +5,7 @@ import {
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { isValidIPv4 } from "./net.js";
 
+/** Resolves operator-facing Control UI HTTP and WebSocket URLs for a Gateway bind mode. */
 export function resolveControlUiLinks(params: {
   port: number;
   bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -8,6 +8,7 @@ type ControlUiRequestClassification =
 
 const ROOT_MOUNTED_GATEWAY_PROBE_PATHS = new Set(["/health", "/healthz", "/ready", "/readyz"]);
 
+/** Classifies an HTTP request before the Control UI static handler claims it. */
 export function classifyControlUiRequest(params: {
   basePath: string;
   pathname: string;

--- a/src/gateway/control-ui-shared.ts
+++ b/src/gateway/control-ui-shared.ts
@@ -6,6 +6,7 @@ import {
 
 const CONTROL_UI_AVATAR_PREFIX = "/avatar";
 
+/** Normalizes the configured Control UI mount path into router-ready form. */
 export function normalizeControlUiBasePath(basePath?: string): string {
   if (!basePath) {
     return "";
@@ -26,12 +27,14 @@ export function normalizeControlUiBasePath(basePath?: string): string {
   return normalized;
 }
 
+/** Builds the Control UI avatar endpoint URL for an agent id. */
 export function buildControlUiAvatarUrl(basePath: string, agentId: string): string {
   return basePath
     ? `${basePath}${CONTROL_UI_AVATAR_PREFIX}/${agentId}`
     : `${CONTROL_UI_AVATAR_PREFIX}/${agentId}`;
 }
 
+/** Resolves configured assistant avatar values against the mounted Control UI path. */
 export function resolveAssistantAvatarUrl(params: {
   avatar?: string | null;
   agentId?: string | null;
@@ -49,6 +52,8 @@ export function resolveAssistantAvatarUrl(params: {
   const baseAvatarPrefix = basePath
     ? `${basePath}${CONTROL_UI_AVATAR_PREFIX}/`
     : `${CONTROL_UI_AVATAR_PREFIX}/`;
+  // Preserve already-mounted avatar URLs, but remount legacy root-relative
+  // `/avatar/...` values when the Control UI is served below a base path.
   if (basePath && avatar.startsWith(`${CONTROL_UI_AVATAR_PREFIX}/`)) {
     return `${basePath}${avatar}`;
   }

--- a/src/gateway/device-metadata-normalization.ts
+++ b/src/gateway/device-metadata-normalization.ts
@@ -10,6 +10,7 @@ function toLowerAscii(input: string): string {
   return input.replace(/[A-Z]/g, (char) => String.fromCharCode(char.charCodeAt(0) + 32));
 }
 
+/** Normalizes metadata exactly as device-auth payload verification expects it. */
 export function normalizeDeviceMetadataForAuth(value?: string | null): string {
   const trimmed = normalizeTrimmedMetadata(value);
   if (!trimmed) {
@@ -20,6 +21,7 @@ export function normalizeDeviceMetadataForAuth(value?: string | null): string {
   return toLowerAscii(trimmed);
 }
 
+/** Normalizes metadata for policy matching, where Unicode accents should collapse. */
 export function normalizeDeviceMetadataForPolicy(value?: string | null): string {
   const trimmed = normalizeTrimmedMetadata(value);
   if (!trimmed) {

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -60,6 +60,7 @@ export type ExecApprovalIdLookupResult =
 export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
   private pending = new Map<string, PendingEntry<TPayload>>();
 
+  /** Builds an approval record without registering it, so callers can publish first. */
   create(request: TPayload, timeoutMs: number, id?: string | null): ExecApprovalRecord<TPayload> {
     const now = Date.now();
     const resolvedTimeoutMs = resolveApprovalTimeoutMs(timeoutMs);
@@ -101,7 +102,8 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       resolvePromise = resolve;
       rejectPromise = reject;
     });
-    // Create entry first so we can capture it in the closure (not re-fetch from map)
+    // Capture the entry object in timeout/cleanup closures; map lookups can see
+    // a newer record with the same id during the resolved-entry grace window.
     const entry: PendingEntry<TPayload> = {
       record,
       resolve: resolvePromise!,
@@ -132,16 +134,17 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     if (!pending) {
       return false;
     }
-    // Prevent double-resolve (e.g., if called after timeout already resolved)
     if (pending.record.resolvedAtMs !== undefined) {
+      // Timeout and operator resolution can race; only the first transition is
+      // allowed to publish a decision.
       return false;
     }
     clearTimeout(pending.timer);
     pending.record.resolvedAtMs = Date.now();
     pending.record.decision = decision;
     pending.record.resolvedBy = resolvedBy ?? null;
-    // Resolve the promise first, then delete after a grace period.
-    // This allows in-flight awaitDecision calls to find the resolved entry.
+    // Resolve first, then keep the record briefly so late awaitDecision calls
+    // and replay guards can still inspect the authoritative decision.
     pending.resolve(decision);
     scheduleResolvedEntryCleanup(() => {
       // Only delete if the entry hasn't been replaced
@@ -178,6 +181,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     return entry?.record ?? null;
   }
 
+  /** Returns unresolved records that should still be visible to operators. */
   listPendingRecords(): ExecApprovalRecord<TPayload>[] {
     return Array.from(this.pending.values())
       .map((entry) => entry.record)
@@ -200,10 +204,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     return true;
   }
 
-  /**
-   * Wait for decision on an already-registered approval.
-   * Returns the decision promise if the ID is pending, null otherwise.
-   */
+  /** Returns the decision promise for an already-registered approval id. */
   awaitDecision(recordId: string): Promise<ExecApprovalDecision | null> | null {
     const entry = this.pending.get(recordId);
     return entry?.promise ?? null;
@@ -239,6 +240,8 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
         continue;
       }
       if (normalizeLowercaseStringOrEmpty(id).startsWith(lowerPrefix)) {
+        // Prefix lookup is operator-facing convenience only; ambiguity is
+        // surfaced instead of picking a record.
         matches.push(id);
       }
     }

--- a/src/gateway/explicit-connection-policy.ts
+++ b/src/gateway/explicit-connection-policy.ts
@@ -5,6 +5,7 @@ function hasExplicitGatewayConnectionAuth(auth?: ExplicitGatewayAuth): boolean {
   return Boolean(trimToUndefined(auth?.token) || trimToUndefined(auth?.password));
 }
 
+/** Returns true only when a direct Gateway URL has enough inline auth to avoid reading config. */
 export function canSkipGatewayConfigLoad(params: {
   config?: OpenClawConfig;
   urlOverride?: string;
@@ -17,6 +18,9 @@ export function canSkipGatewayConfigLoad(params: {
   );
 }
 
+/** Identifies CLI command paths whose Gateway calls must work before config is readable. */
 export function isGatewayConfigBypassCommandPath(commandPath: readonly string[]): boolean {
+  // Cron can run from unattended schedulers, so explicit connection flags/env are allowed
+  // to bypass the startup config guard before the normal config path is available.
   return commandPath[0] === "cron";
 }

--- a/src/gateway/hooks-policy.ts
+++ b/src/gateway/hooks-policy.ts
@@ -1,5 +1,6 @@
 import { normalizeAgentId } from "../routing/session-key.js";
 
+/** Resolves hook agent routing allowlist; undefined means unrestricted routing. */
 export function resolveAllowedAgentIds(raw: string[] | undefined): Set<string> | undefined {
   if (!Array.isArray(raw)) {
     return undefined;
@@ -12,6 +13,8 @@ export function resolveAllowedAgentIds(raw: string[] | undefined): Set<string> |
       continue;
     }
     if (trimmed === "*") {
+      // Wildcard is intentionally represented as undefined, matching the
+      // unconfigured policy path used by runtime hooks and security audits.
       hasWildcard = true;
       break;
     }

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -15,6 +15,7 @@ import { sendGatewayAuthFailure, sendMissingScopeForbidden } from "./http-common
 import { ADMIN_SCOPE, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
+/** Reads the first HTTP header value after normalizing caller-provided header names. */
 export function getHeader(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[normalizeLowercaseStringOrEmpty(name)];
   if (typeof raw === "string") {
@@ -26,6 +27,7 @@ export function getHeader(req: IncomingMessage, name: string): string | undefine
   return undefined;
 }
 
+/** Extracts a non-empty Bearer token from the Authorization header. */
 export function getBearerToken(req: IncomingMessage): string | undefined {
   const raw = normalizeOptionalString(getHeader(req, "authorization")) ?? "";
   if (!normalizeLowercaseStringOrEmpty(raw).startsWith("bearer ")) {
@@ -35,6 +37,7 @@ export function getBearerToken(req: IncomingMessage): string | undefined {
 }
 
 type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
+/** Auth metadata HTTP endpoints pass forward into scope and owner resolution. */
 export type AuthorizedGatewayHttpRequest = {
   authMethod?: GatewayAuthResult["method"];
   trustDeclaredOperatorScopes: boolean;
@@ -50,6 +53,7 @@ export type GatewayHttpRequestAuthCheckResult =
       authResult: GatewayAuthResult;
     };
 
+/** Builds the browser-origin policy used by HTTP auth checks from request/config state. */
 export function resolveHttpBrowserOriginPolicy(
   req: IncomingMessage,
   cfg = getRuntimeConfig(),
@@ -138,6 +142,7 @@ export async function checkGatewayHttpRequestAuth(params: {
   };
 }
 
+/** Authenticates an HTTP request, resolves operator scopes, and sends authz failures. */
 export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   req: IncomingMessage;
   res: ServerResponse;
@@ -178,6 +183,7 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   return { cfg, requestAuth, operatorScopes };
 }
 
+/** Returns true for shared-secret token/password auth carried through Bearer headers. */
 export function isGatewayBearerHttpRequest(
   req: IncomingMessage,
   auth?: SharedSecretGatewayAuth,
@@ -213,6 +219,7 @@ export function resolveTrustedHttpOperatorScopes(
     .filter((scope) => scope.length > 0);
 }
 
+/** Resolves scopes for OpenAI-compatible routes that opt into shared-secret defaults. */
 export function resolveOpenAiCompatibleHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
@@ -220,6 +227,7 @@ export function resolveOpenAiCompatibleHttpOperatorScopes(
   return resolveSharedSecretHttpOperatorScopes(req, requestAuth);
 }
 
+/** Resolves scopes for direct HTTP routes where shared-secret auth is full operator auth. */
 export function resolveSharedSecretHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -31,6 +31,7 @@ export function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+/** Sends plain-text diagnostics for protocol errors that should not mimic OpenAI JSON. */
 export function sendText(res: ServerResponse, status: number, body: string) {
   res.statusCode = status;
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
@@ -88,6 +89,7 @@ export function sendMissingScopeForbidden(res: ServerResponse, missingScope: str
   sendJson(res, 403, buildMissingScopeForbiddenBody(missingScope));
 }
 
+/** Reads a bounded JSON request body and writes the matching HTTP error on failure. */
 export async function readJsonBodyOrError(
   req: IncomingMessage,
   res: ServerResponse,
@@ -124,6 +126,7 @@ export function writeDone(res: ServerResponse) {
   res.write("data: [DONE]\n\n");
 }
 
+/** Sets the common Server-Sent Events envelope used by OpenAI-compatible streams. */
 export function setSseHeaders(res: ServerResponse) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
@@ -138,6 +141,8 @@ export function watchClientDisconnect(
   abortController: AbortController,
   onDisconnect?: () => void,
 ) {
+  // HTTP upgrades and streamed responses may expose either request or response
+  // sockets. De-duplicate so one TCP close only aborts the upstream model once.
   const sockets = Array.from(
     new Set(
       [req.socket, res.socket].filter(

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -13,6 +13,7 @@ import {
 } from "./http-utils.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
+/** Handles shared POST+JSON Gateway HTTP plumbing; false means the path belongs elsewhere. */
 export async function handleGatewayPostJsonEndpoint(
   req: IncomingMessage,
   res: ServerResponse,
@@ -66,6 +67,8 @@ export async function handleGatewayPostJsonEndpoint(
     }
   }
 
+  // Read the body only after auth and scope checks so rejected callers cannot
+  // force endpoint-specific JSON work or large-body diagnostics.
   const body = await readJsonBodyOrError(req, res, opts.maxBodyBytes);
   if (body === undefined) {
     return undefined;

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -22,6 +22,8 @@ function cronUnavailable(): never {
   throw new Error("Cron is unavailable in local embedded agent gateway context.");
 }
 
+// Embedded local dispatch shares Gateway method code but not daemon services;
+// keep unavailable subsystems fail-closed instead of silently no-oping writes.
 const unavailableCron: CronServiceContract = {
   start: async () => {
     cronUnavailable();
@@ -54,6 +56,8 @@ export function createLocalGatewayRequestContext(
   const agentDeltaSentAt: GatewayRequestContext["agentDeltaSentAt"] = new Map();
   const bufferedAgentEvents: GatewayRequestContext["bufferedAgentEvents"] = new Map();
   const clearChatRunState = (runId: string) => {
+    // Mirror daemon cleanup keys so in-process chat tests exercise the same
+    // assistant/thinking buffer lifecycle without needing a websocket server.
     chatRunBuffers.delete(runId);
     chatDeltaSentAt.delete(runId);
     chatDeltaLastBroadcastLen.delete(runId);
@@ -147,6 +151,8 @@ export function createLocalGatewayRequestContext(
 export function withLocalGatewayRequestScope<T>(params: LocalGatewayScopeParams, run: () => T): T {
   const existing = getPluginRuntimeGatewayRequestScope();
   if (existing?.context) {
+    // Nested plugin calls should inherit the outer request context; replacing it
+    // would lose auth/session metadata captured by the caller's gateway scope.
     return run();
   }
   const context = createLocalGatewayRequestContext(params);

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -6,14 +6,17 @@ type McpLoopbackRuntime = {
 
 let activeRuntime: McpLoopbackRuntime | undefined;
 
+/** Returns a snapshot of the active MCP loopback runtime, if the Gateway owns one. */
 export function getActiveMcpLoopbackRuntime(): McpLoopbackRuntime | undefined {
   return activeRuntime ? { ...activeRuntime } : undefined;
 }
 
+/** Publishes the current MCP loopback runtime for agent CLI preparation. */
 export function setActiveMcpLoopbackRuntime(runtime: McpLoopbackRuntime): void {
   activeRuntime = { ...runtime };
 }
 
+/** Selects the bearer token that matches whether the spawned CLI owns the session. */
 export function resolveMcpLoopbackBearerToken(
   runtime: McpLoopbackRuntime,
   senderIsOwner: boolean,
@@ -21,12 +24,14 @@ export function resolveMcpLoopbackBearerToken(
   return senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken;
 }
 
+/** Clears the active runtime only when the closing server still owns the token. */
 export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): void {
   if (activeRuntime?.ownerToken === ownerToken) {
     activeRuntime = undefined;
   }
 }
 
+/** Builds the CLI MCP server config with env placeholders expanded by the spawned process. */
 export function createMcpLoopbackServerConfig(port: number) {
   return {
     mcpServers: {

--- a/src/gateway/mcp-http.protocol.ts
+++ b/src/gateway/mcp-http.protocol.ts
@@ -1,9 +1,13 @@
-export const MCP_LOOPBACK_SERVER_NAME = "openclaw";
-export const MCP_LOOPBACK_SERVER_VERSION = "0.1.0";
-export const MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
-
 type JsonRpcId = string | number | null | undefined;
 
+/** MCP server identity advertised during the loopback initialize handshake. */
+export const MCP_LOOPBACK_SERVER_NAME = "openclaw";
+/** MCP server version advertised to local loopback clients. */
+export const MCP_LOOPBACK_SERVER_VERSION = "0.1.0";
+/** Protocol versions accepted from local MCP clients, newest first. */
+export const MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS = ["2025-03-26", "2024-11-05"] as const;
+
+/** Minimal JSON-RPC request shape accepted by the MCP loopback HTTP server. */
 export type JsonRpcRequest = {
   jsonrpc: "2.0";
   id?: JsonRpcId;
@@ -11,10 +15,12 @@ export type JsonRpcRequest = {
   params?: Record<string, unknown>;
 };
 
+/** Builds a JSON-RPC success frame, preserving null ids for notifications/errors. */
 export function jsonRpcResult(id: JsonRpcId, result: unknown) {
   return { jsonrpc: "2.0" as const, id: id ?? null, result };
 }
 
+/** Builds a JSON-RPC error frame with the caller-selected MCP error code. */
 export function jsonRpcError(id: JsonRpcId, code: number, message: string) {
   return { jsonrpc: "2.0" as const, id: id ?? null, error: { code, message } };
 }

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -19,6 +19,7 @@ function readLoopbackToolField(tool: McpLoopbackTool, key: "name" | "description
   }
 }
 
+/** Reads a usable MCP tool name without trusting provider/tool getters. */
 export function readMcpLoopbackToolName(tool: McpLoopbackTool): string | undefined {
   const value = readLoopbackToolField(tool, "name");
   if (typeof value !== "string") {
@@ -146,6 +147,8 @@ export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry
     if (!raw) {
       return [];
     }
+    // MCP clients expect one object schema per tool. Flatten local unions into a
+    // conservative object shape instead of exposing provider-specific anyOf/oneOf.
     if (raw.anyOf || raw.oneOf) {
       raw = flattenUnionSchema(raw);
     }

--- a/src/gateway/model-pricing-config.ts
+++ b/src/gateway/model-pricing-config.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Returns whether optional Gateway model-pricing refreshes should run; enabled by default. */
 export function isGatewayModelPricingEnabled(config: OpenClawConfig): boolean {
   return config.models?.pricing?.enabled !== false;
 }

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -93,6 +93,7 @@ function canBridgeNoDeviceApprovalFromBackend(params: {
   );
 }
 
+/** Returns whether an approval is bound to channel turn metadata for replay checks. */
 function hasChatApprovalReplayBinding(request: ExecApprovalRecord["request"]): boolean {
   return (
     normalizeComparableString(request.turnSourceChannel, { lowercase: true }) !== null ||
@@ -155,6 +156,8 @@ function canBridgeNoDeviceChatApprovalFromBackend(params: {
 
   const request = params.snapshot.request;
   const plan = request.systemRunPlan ?? null;
+  // Backend chat replays are allowed only when the replay carries the same
+  // channel/session/agent binding as the original approval request.
   return (
     matchesRequiredString({
       expected: request.turnSourceChannel,
@@ -356,6 +359,8 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
     };
   }
   if (runtimeContext.plan) {
+    // Rehydrate forwarded params from the approved plan so caller-supplied
+    // command/cwd/session fields cannot drift after approval.
     next.command = [...runtimeContext.plan.argv];
     next.systemRunPlan = runtimeContext.plan;
     if (runtimeContext.commandText) {
@@ -394,11 +399,12 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
     return toSystemRunApprovalMismatchError({ runId, match: approvalMatch });
   }
 
-  // Normal path: enforce the decision recorded by the gateway.
   if (snapshot.decision === "allow-once") {
     if (typeof manager.consumeAllowOnce !== "function" || !manager.consumeAllowOnce(runId)) {
       return systemRunApprovalRequired(runId);
     }
+    // allow-once is consumed before forwarding so the same approval cannot be
+    // replayed through the manager's resolved-entry grace period.
     next.approved = true;
     next.approvalDecision = "allow-once";
     return { ok: true, params: next };
@@ -411,7 +417,7 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
   }
 
   // If the approval request timed out (decision=null), allow askFallback-driven
-  // "allow-once" ONLY for clients that are allowed to use exec approvals.
+  // "allow-once" only for clients that can use exec approvals.
   const timedOut =
     snapshot.resolvedAtMs !== undefined &&
     snapshot.decision === undefined &&

--- a/src/gateway/node-pairing-auto-approve.ts
+++ b/src/gateway/node-pairing-auto-approve.ts
@@ -1,5 +1,6 @@
 import { isTrustedProxyAddress } from "./net.js";
 
+/** Reasons a node pairing request can require approval or re-approval. */
 export type NodePairingAutoApproveReason =
   | "not-paired"
   | "role-upgrade"
@@ -12,6 +13,7 @@ type NodePairingAutoApproveClientIpSource =
   | "loopback-trusted-proxy"
   | "none";
 
+/** Classifies whether a reported client IP is direct or came through trusted proxy headers. */
 export function resolveNodePairingClientIpSource(params: {
   reportedClientIp?: string;
   hasProxyHeaders: boolean;
@@ -27,6 +29,7 @@ export function resolveNodePairingClientIpSource(params: {
   return params.remoteIsLoopback ? "loopback-trusted-proxy" : "trusted-proxy";
 }
 
+/** Allows only first-time node pairing from configured CIDRs, never browser/control clients. */
 export function shouldAutoApproveNodePairingFromTrustedCidrs(params: {
   existingPairedDevice: boolean;
   role: string;
@@ -39,6 +42,8 @@ export function shouldAutoApproveNodePairingFromTrustedCidrs(params: {
   reportedClientIp?: string;
   autoApproveCidrs?: readonly string[];
 }): boolean {
+  // Auto-approval is intentionally narrower than normal pairing: it cannot
+  // grant role/scope/metadata upgrades or approve browser-originated clients.
   if (params.existingPairedDevice) {
     return false;
   }

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -69,6 +69,8 @@ function pruneExpired(state: NodePendingWorkState, nowMs: number): boolean {
     return false;
   }
   let changed = false;
+  // Expiry changes the visible revision because nodes poll by revision and need
+  // to observe disappearing work even when no explicit ack happened.
   for (const [id, item] of state.itemsById) {
     if (
       item.expiresAtMs !== null &&
@@ -92,6 +94,8 @@ function pruneStateIfEmpty(nodeId: string, state: NodePendingWorkState) {
 
 function sortedItems(state: NodePendingWorkState): NodePendingWorkItem[] {
   return [...state.itemsById.values()].toSorted((a, b) => {
+    // Keep ordering deterministic for reconnecting nodes: urgent work first,
+    // FIFO within a priority, then id for same-timestamp inserts.
     const priorityDelta = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
     if (priorityDelta !== 0) {
       return priorityDelta;
@@ -104,6 +108,8 @@ function sortedItems(state: NodePendingWorkState): NodePendingWorkItem[] {
 }
 
 function makeBaselineStatusItem(nowMs: number): NodePendingWorkItem {
+  // A synthetic status request gives reconnecting nodes a cheap default action
+  // without persisting queue state for every paired-but-idle node.
   return {
     id: DEFAULT_STATUS_ITEM_ID,
     type: "status.request",
@@ -137,6 +143,8 @@ export function enqueueNodePendingWork(params: {
   pruneExpired(state, nowMs);
   const existing = [...state.itemsById.values()].find((item) => item.type === params.type);
   if (existing) {
+    // Pending work is keyed by type, not caller request id, so repeated nudges
+    // refresh wake behavior without duplicating the same node-side action.
     return { revision: state.revision, item: existing, deduped: true };
   }
   const item: NodePendingWorkItem = {
@@ -177,6 +185,8 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   return {
     revision,
     items,
+    // hasMore accounts for the synthetic baseline too; a full page with no room
+    // for baseline should prompt the node to drain again.
     hasMore: explicitItems.length > explicitReturnedCount || (includeBaseline && !baselineIncluded),
   };
 }
@@ -197,6 +207,7 @@ export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: st
   for (const itemId of params.itemIds) {
     const trimmedId = itemId.trim();
     if (!trimmedId || trimmedId === DEFAULT_STATUS_ITEM_ID) {
+      // The baseline item is virtual and must never advance revision on ack.
       continue;
     }
     if (state.itemsById.delete(trimmedId)) {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -87,6 +87,7 @@ export type SerializedEventPayload = {
   readonly [SERIALIZED_EVENT_PAYLOAD]: true;
 };
 
+/** Serializes a node event payload once so fanout paths can reuse identical JSON bytes. */
 export function serializeEventPayload(payload: unknown): SerializedEventPayload | null {
   if (payload === undefined) {
     return null;
@@ -153,15 +154,19 @@ function withSystemRunEventRunId(params: { command: string; params?: unknown }):
   if (normalizeString(obj.runId)) {
     return params.params;
   }
+  // Gateway-originated system.run calls need a stable run id so later node
+  // system-run events can be tied back to the invoke authorization.
   return { ...obj, runId: randomUUID() };
 }
 
+/** Tracks connected node sessions, pending invokes, and authorized system.run events. */
 export class NodeRegistry {
   private nodesById = new Map<string, NodeSession>();
   private nodesByConn = new Map<string, string>();
   private pendingInvokes = new Map<string, PendingInvoke>();
   private authorizedSystemRunEvents = new Map<string, AuthorizedSystemRunEvent>();
 
+  /** Registers or replaces a node connection and snapshots its declared/effective surface. */
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
     const nodeId = connect.device?.id ?? connect.client.id;
@@ -229,6 +234,8 @@ export class NodeRegistry {
     if (unregistersCurrentNode) {
       this.nodesById.delete(nodeId);
     }
+    // Reject only invokes tied to the closing websocket; a newer reconnect with
+    // the same node id remains registered and can continue receiving commands.
     for (const [id, pending] of this.pendingInvokes.entries()) {
       if (pending.connId !== connId) {
         continue;
@@ -253,6 +260,7 @@ export class NodeRegistry {
     return this.nodesById.get(nodeId);
   }
 
+  /** Probes a node websocket with ping/pong when the socket implementation supports it. */
   async checkConnectivity(nodeId: string, timeoutMs = 2_000): Promise<NodeConnectivityResult> {
     const node = this.nodesById.get(nodeId);
     if (!node) {
@@ -344,6 +352,7 @@ export class NodeRegistry {
     return this.updateSurface(nodeId, { commands });
   }
 
+  /** Narrows a node's live capabilities/commands/permissions to its declared surface. */
   updateSurface(
     nodeId: string,
     surface: {
@@ -378,6 +387,8 @@ export class NodeRegistry {
       const declared = node.declaredPermissions ?? {};
       const nextEntries: Array<[string, boolean]> = [];
       for (const [key, declaredValue] of Object.entries(declared)) {
+        // A denied declared permission stays visible as false so clients can
+        // explain why it cannot be elevated at runtime.
         if (!declaredValue) {
           nextEntries.push([key, false]);
           continue;
@@ -400,6 +411,7 @@ export class NodeRegistry {
     return node;
   }
 
+  /** Sends a command invoke to a connected node and resolves when the node reports a result. */
   async invoke(params: {
     nodeId: string;
     command: string;
@@ -440,6 +452,8 @@ export class NodeRegistry {
       params: invokeParams,
     });
     if (systemRunEvent) {
+      // system.run may emit asynchronous agent events before/after the invoke
+      // result; remember this connection/run so those events can be authorized.
       this.rememberAuthorizedSystemRunEvent({
         nodeId: params.nodeId,
         connId: node.connId,
@@ -467,6 +481,7 @@ export class NodeRegistry {
     });
   }
 
+  /** Verifies that a node-emitted system.run event belongs to a Gateway-issued invoke. */
   authorizeSystemRunEvent(params: {
     nodeId: string;
     connId?: string;
@@ -488,6 +503,8 @@ export class NodeRegistry {
         sessionKey: params.sessionKey,
       });
       if (!match && this.allowsLegacyMacRunIdFallback({ nodeId: params.nodeId, connId })) {
+        // Older macOS nodes generated their own runtime run id; allow the
+        // fallback only when exactly one matching pending authorization exists.
         match = this.matchSingleAuthorizedSystemRunEvent({
           nodeId: params.nodeId,
           connId,
@@ -534,6 +551,8 @@ export class NodeRegistry {
     if (typeof timeoutMs !== "number") {
       return null;
     }
+    // Keep authorization alive slightly longer than the command timeout so a
+    // terminal event racing the invoke timeout can still be accepted.
     const durationMs = addTimerTimeoutGraceMs(timeoutMs, AUTHORIZED_SYSTEM_RUN_EVENT_GRACE_MS);
     return resolveExpiresAtMsFromDurationMs(durationMs) ?? 0;
   }
@@ -572,6 +591,7 @@ export class NodeRegistry {
         continue;
       }
       if (match) {
+        // Ambiguous legacy events must not be attributed to the wrong run.
         return null;
       }
       match = { key, event };
@@ -634,6 +654,7 @@ export class NodeRegistry {
     clearTimeout(pending.timer);
     this.pendingInvokes.delete(params.id);
     if (!params.ok && pending.systemRunEvent) {
+      // Failed invokes never legitimately own follow-up system.run events.
       this.forgetAuthorizedSystemRunEvent({
         nodeId: pending.nodeId,
         connId: pending.connId,
@@ -657,6 +678,7 @@ export class NodeRegistry {
     return this.sendEventToSession(node, event, payload);
   }
 
+  /** Sends a pre-serialized event payload to one node without rebuilding JSON. */
   sendEventRaw(
     nodeId: string,
     event: string,
@@ -703,6 +725,8 @@ export class NodeRegistry {
       return false;
     }
     try {
+      // SerializedEventPayload is branded, so this string concatenation can
+      // embed JSON safely without accepting arbitrary caller-provided fragments.
       const payloadFragment = payloadJSON ? `,"payload":${payloadJSON.json}` : "";
       node.client.socket.send(
         `{"type":"event","event":${JSON.stringify(event)}${payloadFragment}}`,
@@ -728,6 +752,8 @@ export class NodeRegistry {
       reason: "ws_send_buffer_close",
     });
     try {
+      // Close slow consumers before queuing more outbound work; dropping only
+      // this frame would leave the gateway repeatedly serializing doomed sends.
       node.client.socket.close(SLOW_CONSUMER_CLOSE_CODE, "slow consumer");
     } catch {
       /* ignore */

--- a/src/gateway/operator-approval-runtime-token.ts
+++ b/src/gateway/operator-approval-runtime-token.ts
@@ -2,11 +2,13 @@ import { randomBytes, timingSafeEqual } from "node:crypto";
 
 let approvalRuntimeToken: string | null = null;
 
+/** Returns the process-local token used by trusted local approval runtimes. */
 export function getOperatorApprovalRuntimeToken(): string {
   approvalRuntimeToken ??= randomBytes(32).toString("base64url");
   return approvalRuntimeToken;
 }
 
+/** Validates a presented approval runtime token without leaking token bytes via timing. */
 export function isOperatorApprovalRuntimeToken(value: string | null | undefined): boolean {
   const token = value?.trim();
   if (!token) {
@@ -15,5 +17,7 @@ export function isOperatorApprovalRuntimeToken(value: string | null | undefined)
   const expected = getOperatorApprovalRuntimeToken();
   const tokenBytes = Buffer.from(token);
   const expectedBytes = Buffer.from(expected);
+  // timingSafeEqual requires equal-length buffers; keep the length check outside
+  // the comparison so invalid tokens fail without throwing.
   return tokenBytes.length === expectedBytes.length && timingSafeEqual(tokenBytes, expectedBytes);
 }

--- a/src/gateway/operator-scopes.ts
+++ b/src/gateway/operator-scopes.ts
@@ -1,8 +1,13 @@
-export const ADMIN_SCOPE = "operator.admin" as const;
+export const ADMIN_SCOPE = "operator.admin" as const; // Full control-plane access; satisfies every operator scope.
+/** Read-only control-plane access for status, catalogs, logs, and session reads. */
 export const READ_SCOPE = "operator.read" as const;
+/** Mutating operator access; also satisfies read-scoped gateway methods. */
 export const WRITE_SCOPE = "operator.write" as const;
+/** Approval APIs for exec and plugin approval decisions. */
 export const APPROVALS_SCOPE = "operator.approvals" as const;
+/** Pairing lifecycle APIs for devices, nodes, and issued operator tokens. */
 export const PAIRING_SCOPE = "operator.pairing" as const;
+/** Narrow access to Talk configuration payloads that include secrets. */
 export const TALK_SECRETS_SCOPE = "operator.talk.secrets" as const;
 
 /** Operator privileges advertised by gateway auth and checked by method policy. */
@@ -23,6 +28,8 @@ const KNOWN_OPERATOR_SCOPE_VALUES: readonly OperatorScope[] = [
   TALK_SECRETS_SCOPE,
 ];
 
+// Keep the runtime allowlist tied to OperatorScope so untrusted scope strings cannot
+// drift from the public type exported to plugins and gateway clients.
 const KNOWN_OPERATOR_SCOPES: ReadonlySet<OperatorScope> = new Set(KNOWN_OPERATOR_SCOPE_VALUES);
 
 /** Narrows untrusted auth-token scope entries to the gateway's closed scope set. */

--- a/src/gateway/plugin-channel-reload-targets.ts
+++ b/src/gateway/plugin-channel-reload-targets.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/index.js";
 
+/** Channel/plugin identifiers whose config changes should trigger a channel reload. */
 export type ChannelPluginReloadTarget = {
   channelId: ChannelId;
   pluginId?: string | null;
@@ -14,6 +15,7 @@ function addNormalizedTarget(targets: Set<string>, value: string | null | undefi
   }
 }
 
+/** Returns every config id that may represent the same channel plugin entry. */
 export function listChannelPluginConfigTargetIds(
   target: ChannelPluginReloadTarget,
 ): ReadonlySet<string> {
@@ -26,6 +28,7 @@ export function listChannelPluginConfigTargetIds(
   return targets;
 }
 
+/** Checks whether changed config paths touch any plugin entry/install target or child path. */
 export function pluginConfigTargetsChanged(
   targetIds: Iterable<string>,
   changedPaths: readonly string[],

--- a/src/gateway/probe-target.ts
+++ b/src/gateway/probe-target.ts
@@ -1,12 +1,17 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Describes whether probe commands should contact the local gateway or a configured remote. */
 export type GatewayProbeTargetResolution = {
+  /** Configured gateway mode before remote URL validation. */
   gatewayMode: "local" | "remote";
+  /** Effective probe target after falling back from incomplete remote config. */
   mode: "local" | "remote";
+  /** True when remote mode is configured but no usable remote URL is available. */
   remoteUrlMissing: boolean;
 };
 
+/** Resolves the effective gateway probe target without letting partial remote config fail closed. */
 export function resolveGatewayProbeTarget(cfg: OpenClawConfig): GatewayProbeTargetResolution {
   const gatewayMode = cfg.gateway?.mode === "remote" ? "remote" : "local";
   const remoteUrlRaw = normalizeOptionalString(cfg.gateway?.remote?.url) ?? "";

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -20,6 +20,7 @@ export type ChatRunRegistry = {
   clear: () => void;
 };
 
+/** Maintains FIFO client-run ownership for agent sessions that can overlap by sessionId. */
 export function createChatRunRegistry(): ChatRunRegistry {
   const chatRunSessions = new Map<string, ChatRunEntry[]>();
 
@@ -102,6 +103,8 @@ export function createChatRunState(): ChatRunState {
   const abortedRuns = new Map<string, number>();
 
   const clearRun = (runId: string) => {
+    // Agent streaming keeps separate visible/raw/thinking buffers keyed from
+    // the run id; clear all derived keys when the run ends or aborts.
     rawBuffers.delete(runId);
     buffers.delete(runId);
     bufferUpdatedAt.delete(runId);
@@ -173,6 +176,7 @@ type ToolRecipientEntry = {
 const TOOL_EVENT_RECIPIENT_TTL_MS = 10 * 60 * 1000;
 const TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS = 30 * 1000;
 
+/** Tracks control connections that want coarse sessions.changed broadcasts. */
 export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRegistry {
   const connIds = new Set<string>();
   const empty = new Set<string>();
@@ -199,6 +203,7 @@ export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRe
   };
 }
 
+/** Tracks per-session message subscribers with reverse lookup for connection cleanup. */
 export function createSessionMessageSubscriberRegistry(): SessionMessageSubscriberRegistry {
   const sessionToConnIds = new Map<string, Set<string>>();
   const connToSessionKeys = new Map<string, Set<string>>();
@@ -217,6 +222,8 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
       connIds.add(normalizedConnId);
       sessionToConnIds.set(normalizedSessionKey, connIds);
 
+      // The reverse map lets disconnect cleanup remove a connection from every
+      // session bucket without scanning all sessions.
       const sessionKeys = connToSessionKeys.get(normalizedConnId) ?? new Set<string>();
       sessionKeys.add(normalizedSessionKey);
       connToSessionKeys.set(normalizedConnId, sessionKeys);
@@ -251,6 +258,8 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
       if (!sessionKeys) {
         return;
       }
+      // Walk the reverse index first, then drop it, to keep both maps symmetric
+      // when a websocket closes without individual unsubscribe calls.
       for (const sessionKey of sessionKeys) {
         const connIds = sessionToConnIds.get(sessionKey);
         if (!connIds) {
@@ -277,6 +286,7 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
   };
 }
 
+/** Remembers which websocket connections should receive late tool events for a run. */
 export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
   const recipients = new Map<string, ToolRecipientEntry>();
 
@@ -289,6 +299,8 @@ export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
       const cutoff = entry.finalizedAt
         ? entry.finalizedAt + TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS
         : entry.updatedAt + TOOL_EVENT_RECIPIENT_TTL_MS;
+      // Finalized runs keep a short grace period for trailing tool events; live
+      // runs use a longer idle TTL refreshed by add/get.
       if (now >= cutoff) {
         recipients.delete(runId);
       }

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -138,6 +138,7 @@ async function postCronWebhook(params: {
   }
 }
 
+/** Sends the configured immediate failure alert for a cron job through webhook or announce. */
 export async function sendGatewayCronFailureAlert(params: {
   deps: CliDeps;
   logger: CronLogger;
@@ -206,6 +207,7 @@ export async function sendGatewayCronFailureAlert(params: {
   });
 }
 
+/** Dispatches completion webhooks and best-effort failure notifications for a finished run. */
 export function dispatchGatewayCronFinishedNotifications(params: {
   evt: CronEvent;
   job?: CronJob;
@@ -255,6 +257,8 @@ export function dispatchGatewayCronFinishedNotifications(params: {
 
   if (params.evt.summary) {
     for (const webhookTarget of webhookTargets) {
+      // Completion notifications must not block the cron scheduler loop; failures are
+      // contained in postCronWebhook logging so the job finish path can continue.
       void (async () => {
         await postCronWebhook({
           webhookUrl: webhookTarget.url,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -191,6 +191,8 @@ function getCachedPluginGatewayAuthBypassPaths(
   if (cached) {
     return cached;
   }
+  // Runtime config objects are immutable snapshots in normal operation, so the
+  // WeakMap avoids recomputing bundled callback bypasses without stale global state.
   const resolved = resolvePluginGatewayAuthBypassPaths(configSnapshot).catch((error: unknown) => {
     pluginGatewayAuthBypassPathsCache.delete(configSnapshot);
     throw error;
@@ -306,6 +308,8 @@ async function handleGatewayProbeRequest(
     try {
       const result = getReadiness();
       statusCode = result.ready ? 200 : 503;
+      // Remote unauthenticated probes get only the boolean; subsystem names are
+      // operator diagnostics and require local/direct or authenticated access.
       body = JSON.stringify(includeDetails ? result : { ready: result.ready });
     } catch {
       statusCode = 503;
@@ -381,6 +385,8 @@ export async function runGatewayHttpRequestStages(
 ): Promise<boolean> {
   for (const stage of stages) {
     try {
+      // Stages claim by returning true; false keeps walking the ordered router
+      // so plugin, compat, Control UI, and fallback routes can share one server.
       if (await stage.run()) {
         return true;
       }
@@ -465,6 +471,8 @@ function buildPluginRequestStages(params: {
       run: () => {
         const pathContext =
           params.pluginPathContext ?? resolvePluginRoutePathContext(params.requestPath);
+        // Reuse the auth-stage context so plugin handlers see the exact gateway
+        // auth result that authorized the overlapping protected path.
         return (
           params.handlePluginRequest?.(params.req, params.res, pathContext, {
             gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
@@ -553,6 +561,8 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (GATEWAY_PROBE_STATUS_BY_PATH.get(requestPath) === "live") {
+        // Liveness probes stay shallow and unauthenticated so orchestration can
+        // check process health before config, plugin, or auth state is loaded.
         await handleGatewayProbeRequest(
           req,
           res,

--- a/src/gateway/server-live-state.ts
+++ b/src/gateway/server-live-state.ts
@@ -7,6 +7,7 @@ import {
 } from "./server-runtime-handles.js";
 import type { HookClientIpConfig } from "./server/hooks-request-handler.js";
 
+/** Runtime state assembled after gateway startup and shared by request handlers. */
 export type GatewayServerLiveState = GatewayServerMutableState & {
   hooksConfig: HooksConfigResolved | null;
   hookClientIpConfig: HookClientIpConfig;
@@ -15,6 +16,7 @@ export type GatewayServerLiveState = GatewayServerMutableState & {
   gatewayMethods: string[];
 };
 
+/** Creates a fresh live-state bundle with mutable handles reset for a new server run. */
 export function createGatewayServerLiveState(params: {
   hooksConfig: HooksConfigResolved | null;
   hookClientIpConfig: HookClientIpConfig;

--- a/src/gateway/server-methods/nodes-pending.ts
+++ b/src/gateway/server-methods/nodes-pending.ts
@@ -23,6 +23,8 @@ import type { GatewayRequestHandlers } from "./types.js";
 function resolveClientNodeId(
   client: { connect?: { device?: { id?: string }; client?: { id?: string } } } | null,
 ): string | null {
+  // Connected nodes may identify through the newer device field or older client
+  // field; pending drain accepts either but never a caller-supplied node id.
   const nodeId = client?.connect?.device?.id ?? client?.connect?.client?.id ?? "";
   const trimmed = nodeId.trim();
   return trimmed.length > 0 ? trimmed : null;
@@ -83,6 +85,8 @@ export const nodePendingHandlers: GatewayRequestHandlers = {
       });
       let wakeTriggered = false;
       if (p.wake !== false && !queued.deduped && !context.nodeRegistry.get(p.nodeId)) {
+        // Only the first enqueue for a work type triggers APNs wake. Duplicate
+        // callers share the queued item and should not amplify push traffic.
         const wakeReqId = queued.item.id;
         context.logGateway.info(
           `node pending wake start node=${p.nodeId} req=${wakeReqId} type=${queued.item.type}`,
@@ -139,6 +143,8 @@ export const nodePendingHandlers: GatewayRequestHandlers = {
           }
         }
         if (!context.nodeRegistry.get(p.nodeId)) {
+          // The nudge is a last-mile user-visible alert after background wakes
+          // failed to reconnect the node within both wait windows.
           const nudge = await maybeSendNodeWakeNudge(p.nodeId, { cfg });
           context.logGateway.info(
             `node pending wake nudge node=${p.nodeId} req=${wakeReqId} sent=${nudge.sent} ` +

--- a/src/gateway/server-methods/nodes.handlers.invoke-result.ts
+++ b/src/gateway/server-methods/nodes.handlers.invoke-result.ts
@@ -12,6 +12,8 @@ function normalizeNodeInvokeResultParams(params: unknown): unknown {
   }
   const raw = params as Record<string, unknown>;
   const normalized: Record<string, unknown> = { ...raw };
+  // Older nodes sometimes send structured payloads in payloadJSON. Promote
+  // those values before validation so the registry handles one result shape.
   if (normalized.payloadJSON === null) {
     delete normalized.payloadJSON;
   } else if (normalized.payloadJSON !== undefined && typeof normalized.payloadJSON !== "string") {
@@ -51,6 +53,8 @@ export const handleNodeInvokeResult: GatewayRequestHandler = async ({
   };
   const callerNodeId = client?.connect?.device?.id ?? client?.connect?.client?.id;
   if (callerNodeId && callerNodeId !== p.nodeId) {
+    // Invoke results are authority-bearing: a connected node may only settle
+    // its own pending invocation, even if it guesses another invoke id.
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId mismatch"));
     return;
   }

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -13,6 +13,8 @@ type ValidatorFn = ((value: unknown) => boolean) & {
   errors?: ValidationError[] | null;
 };
 
+// Protocol validators keep their last error set on the function object; read it
+// immediately so concurrent handlers cannot accidentally report another method.
 export function respondInvalidParams(params: {
   respond: RespondFn;
   method: string;
@@ -32,6 +34,8 @@ export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Pr
   try {
     await fn();
   } catch (err) {
+    // Node-method handlers expose operational failures as UNAVAILABLE so callers
+    // can distinguish transient runtime errors from invalid request shapes.
     respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
   }
 }
@@ -50,6 +54,8 @@ export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; err
   const nodeCode = normalizeOptionalString(nodeError?.code) ?? "";
   const nodeMessage = normalizeOptionalString(nodeError?.message) ?? "node invoke failed";
   const message = nodeCode ? `${nodeCode}: ${nodeMessage}` : nodeMessage;
+  // Preserve the original node error in details for UI diagnostics while keeping
+  // the top-level RPC error in Gateway protocol shape.
   respond(
     false,
     undefined,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -275,6 +275,8 @@ function shouldQueueAsPendingForegroundAction(params: {
 function prunePendingNodeActions(nodeId: string, nowMs: number): PendingNodeAction[] {
   const queue = pendingNodeActionsById.get(nodeId) ?? [];
   const minTimestampMs = nowMs - NODE_PENDING_ACTION_TTL_MS;
+  // Pending actions are only a reconnect bridge for foreground-only commands;
+  // stale entries must not survive long enough to replay old user intent.
   const live = queue.filter((entry) => entry.enqueuedAtMs >= minTimestampMs);
   if (live.length === 0) {
     pendingNodeActionsById.delete(nodeId);
@@ -403,6 +405,8 @@ function toPendingParamsJSON(params: unknown): string | undefined {
     return undefined;
   }
   try {
+    // Persist the original params as JSON because pending actions may outlive
+    // the request object and are later exposed through node.pending.list.
     return JSON.stringify(params);
   } catch {
     return undefined;
@@ -426,6 +430,8 @@ function emitTalkPttNodeEvent(params: {
   const sessionId = `node:${params.nodeId}:talk:${captureId}`;
   const seq = (talkPttEventSeqBySessionId.get(sessionId) ?? 0) + 1;
   talkPttEventSeqBySessionId.set(sessionId, seq);
+  // Talk events need stable monotonic ids per capture for UI ordering, but this
+  // is only live presence state; bound the map by old capture ids.
   while (talkPttEventSeqBySessionId.size > 2048) {
     const oldest = talkPttEventSeqBySessionId.keys().next().value;
     if (oldest === undefined) {

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -6,6 +6,7 @@ type TrackedActiveSessionRun = {
   agentId?: string;
 };
 
+/** Extracts visible in-flight runs from the abort-controller registry. */
 function collectTrackedActiveSessionRuns(
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
 ): TrackedActiveSessionRun[] {
@@ -41,6 +42,8 @@ function isTrackedActiveSessionRunForKey(
   if (key !== "global") {
     return true;
   }
+  // The global session key is shared across agent stores; compare agent ids so
+  // one agent's active run does not block another agent's global session row.
   const requestedAgentId = agentId ?? defaultAgentId;
   if (!requestedAgentId) {
     return true;
@@ -51,6 +54,7 @@ function isTrackedActiveSessionRunForKey(
     : false;
 }
 
+/** Checks whether a requested/canonical session key currently has a visible active run. */
 export function hasTrackedActiveSessionRun(params: {
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
   requestedKey: string;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -161,6 +161,7 @@ function filterSessionStoreToConfiguredAgents(
   );
 }
 
+/** Copies runtime/model choices from a parent session into a newly spawned child session. */
 function inheritSessionRuntimeSelection(
   parentEntry: SessionEntry | undefined,
 ): Partial<SessionEntry> {
@@ -205,6 +206,7 @@ function loadSessionsRuntimeModule(): Promise<SessionsRuntimeModule> {
   return sessionsRuntimeModulePromise;
 }
 
+/** Normalizes loose RPC keys while preserving the Gateway error shape for missing keys. */
 function requireSessionKey(key: unknown, respond: RespondFn): string | null {
   const raw =
     typeof key === "string"
@@ -272,6 +274,7 @@ function resolveOptionalInitialSessionMessage(params: {
   return undefined;
 }
 
+/** Detects fresh chat-send acknowledgements where clients can optimistically place the row. */
 function shouldAttachPendingMessageSeq(params: { payload: unknown; cached?: boolean }): boolean {
   if (params.cached) {
     return false;
@@ -306,6 +309,8 @@ function emitSessionsChanged(
       )
     : null;
   const omitUnscopedGlobalGoal = payload.sessionKey === "global" && !payload.agentId;
+  // A bare global notification fans out to multiple agent views, so omit goal
+  // text unless the caller already selected the exact global-agent store.
   const defaultAgentId = resolveDefaultAgentId(context.getRuntimeConfig());
   context.broadcastToConnIds(
     "sessions.changed",
@@ -399,6 +404,7 @@ function emitSessionOperation(
   );
 }
 
+/** Blocks WebChat clients from mutating sessions outside the chat.send command path. */
 function rejectWebchatSessionMutation(params: {
   action: "patch" | "delete" | "compact" | "restore";
   client: GatewayClient | null;
@@ -467,6 +473,7 @@ function cloneCheckpointSessionEntry(params: {
   };
 }
 
+/** Chooses the checkpoint transcript and token baseline for branch/restore operations. */
 function resolveCheckpointForkSource(
   checkpoint: NonNullable<ReturnType<typeof getSessionCompactionCheckpoint>>,
 ): { sourceFile: string; sourceLeafId?: string; totalTokens?: number } | null {
@@ -575,6 +582,7 @@ async function createAgentMainSessionForSend(params: {
   };
 }
 
+/** Ensures a newly-created store row has a JSONL transcript before clients can use it. */
 function ensureSessionTranscriptFile(params: {
   sessionId: string;
   storePath: string;
@@ -624,6 +632,8 @@ function resolveAbortSessionKey(params: {
     return params.activeRunSessionKey;
   }
   const candidates = [params.canonicalKey, params.requestedKey, ...(params.aliasKeys ?? [])];
+  // Active runs may still be keyed by a pre-canonical alias, so prefer the
+  // visible controller key over the resolved store key when aborting.
   for (const active of params.context.chatAbortControllers.values()) {
     if (active.controlUiVisible === false) {
       continue;
@@ -687,6 +697,7 @@ function resolveScopedAbortKey(params: {
   if (ownerAgentId && ownerAgentId !== scopedAgentId) {
     return undefined;
   }
+  // Return the store-local key only after proving the requested agent owns it.
   return resolveStoredSessionKeyForAgentStore({
     cfg: params.cfg,
     agentId: scopedAgentId,
@@ -749,6 +760,8 @@ function resolveRequestedGlobalAgentId(
     }
     return { ok: true, agentId };
   }
+  // Agent-prefixed global aliases select an agent store; ordinary keys keep the
+  // legacy no-agent behavior so existing global callers are not retargeted.
   if (!parsed?.agentId) {
     return { ok: true };
   }
@@ -950,6 +963,8 @@ async function handleSessionSend(params: {
     typeof rawIdempotencyKey === "string" && rawIdempotencyKey.trim()
       ? rawIdempotencyKey.trim()
       : randomUUID();
+  // sessions.send/steer delegate to chat.send so transcript persistence,
+  // dedupe, and provider routing stay in one command path.
   await chatHandlers["chat.send"]({
     req: params.req,
     params: {
@@ -1260,6 +1275,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     for (const key of keys) {
       try {
+        // Batch previews can point at the same per-agent store, so reuse loaded
+        // stores while still resolving each key through the canonical target path.
         const cachedStoreTarget = resolveGatewaySessionStoreTargetWithStore({
           cfg,
           key,
@@ -1488,6 +1505,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       !resolveOptionalInitialSessionMessage(p) &&
       cfg.session?.dmScope === "main"
     ) {
+      // In main-DM scope, "new chat" from a main session is a reset of that
+      // session rather than a child dashboard session.
       const parentAgentId = normalizeAgentId(
         parentSelectedAgentId ??
           resolveAgentIdFromSessionKey(canonicalParentSessionKey) ??
@@ -1528,6 +1547,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
     }
     if (canonicalParentSessionKey && p.emitCommandHooks === true) {
+      // Plugin and command hooks observe the parent before child creation so
+      // integrations can snapshot the outgoing session state.
       const { entry: parentEntry } = loadSessionEntry(
         canonicalParentSessionKey,
         parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
@@ -1596,6 +1617,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       const inheritedSelection = normalizeOptionalString(p.model)
         ? {}
         : inheritSessionRuntimeSelection(parentSessionEntry);
+      // Explicit model selection wins; otherwise child sessions inherit runtime
+      // choices so sub-sessions do not silently fall back to defaults.
       const nextEntry: SessionEntry = {
         ...patched.entry,
         ...inheritedSelection,
@@ -1661,6 +1684,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       : undefined;
 
     if (initialMessage) {
+      // Create can optionally start the first run through chat.send; the session
+      // row is already durable before provider work begins.
       await chatHandlers["chat.send"]({
         req,
         params: {
@@ -1717,6 +1742,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       });
     }
     if (canonicalParentSessionKey && p.emitCommandHooks === true) {
+      // Emit lifecycle hooks after the new row exists so listeners can link the
+      // previous and next transcript identities.
       const { entry: parentEntry } = loadSessionEntry(
         canonicalParentSessionKey,
         parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
@@ -1820,6 +1847,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     const nextKey = buildDashboardSessionKey(target.agentId);
     const label = entry.label?.trim() ? `${entry.label.trim()} (checkpoint)` : "Checkpoint branch";
+    // Branching creates a new dashboard session and points back to the source
+    // session; restore below replaces the source row in-place.
     const nextEntry = cloneCheckpointSessionEntry({
       currentEntry: entry,
       nextSessionId: branchedSession.sessionId,

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -70,6 +70,7 @@ import { assertValidParams } from "./validation.js";
 
 type ManagedRoomTalkSession = Extract<UnifiedTalkSessionRecord, { kind: "managed-room" }>;
 
+/** Resolves Talk mode from old transport-first callers and newer mode-first callers. */
 function normalizeTalkSessionMode(params: { mode?: string; transport?: string }): TalkMode {
   const mode = normalizeOptionalLowercaseString(params.mode) as TalkMode | undefined;
   if (mode) {
@@ -80,6 +81,7 @@ function normalizeTalkSessionMode(params: { mode?: string; transport?: string })
     : "realtime";
 }
 
+/** Maps Talk mode to the Gateway-owned transport used by unified session handlers. */
 function normalizeTalkSessionTransport(params: {
   mode: TalkMode;
   transport?: string;
@@ -91,6 +93,7 @@ function normalizeTalkSessionTransport(params: {
   return params.mode === "stt-tts" ? "managed-room" : "gateway-relay";
 }
 
+/** Selects whether Talk drives an agent, direct tools, or transcription-only behavior. */
 function normalizeTalkSessionBrain(params: { mode: TalkMode; brain?: string }): TalkBrain {
   const brain = normalizeOptionalLowercaseString(params.brain) as TalkBrain | undefined;
   if (brain) {
@@ -143,6 +146,7 @@ function respondOk(respond: RespondFn, payload: unknown = { ok: true }) {
   respond(true, payload, undefined);
 }
 
+/** Runs a managed-room turn mutation only for the active room client and broadcasts room deltas. */
 function respondManagedRoomTurn(params: {
   session: UnifiedTalkSessionRecord;
   connId?: string;
@@ -211,6 +215,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           return;
         }
         const spawnedBy = normalizeOptionalString(params.spawnedBy);
+        // Unscoped managed rooms can steer existing sessions, so only spawned
+        // rooms or admin-scoped Gateway callers may bind an arbitrary key.
         if (
           normalizeOptionalString(params.sessionKey) &&
           !spawnedBy &&
@@ -275,6 +281,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
       }
 
       if (mode === "realtime") {
+        // Gateway relay owns the provider socket and forwards only the current
+        // browser connection's audio/control messages into the realtime session.
         if (transport !== "gateway-relay" || brain !== "agent-consult") {
           respondInvalidRequest(
             respond,
@@ -325,6 +333,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
       }
 
       if (mode === "transcription") {
+        // Transcription sessions are intentionally brainless; agent steering is
+        // exposed through realtime or managed-room sessions instead.
         if (transport !== "gateway-relay" || brain !== "none") {
           respondInvalidRequest(
             respond,
@@ -394,6 +404,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         roomId: result.record.roomId,
         events: result.replacementEvents,
       });
+      // The replaced client receives removal events, then the joining client
+      // receives the active room view keyed to its connection id.
       broadcastTalkRoomEvents(context, client?.connId, {
         handoffId: result.record.id,
         roomId: result.record.roomId,
@@ -642,6 +654,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         return;
       }
       const requestedSessionKey = normalizeOptionalString(params.sessionKey);
+      // Managed rooms carry their bound session key in the handoff record; a
+      // caller-supplied different key would steer a room the caller did not join.
       if (requestedSessionKey && requestedSessionKey !== sessionKey) {
         respondInvalidRequest(
           respond,

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -1,5 +1,6 @@
 import { getRuntimeConfig } from "../config/io.js";
 
+/** Gateway-facing model entries shared by the HTTP/TUI catalog endpoints. */
 export type GatewayModelChoice = import("../agents/model-catalog.js").ModelCatalogEntry;
 
 type GatewayModelCatalogConfig = ReturnType<typeof getRuntimeConfig>;
@@ -73,6 +74,8 @@ function startGatewayModelCatalogRefresh(
   const refresh = resolveLoadModelCatalog(params)
     .then((loadModelCatalog) => loadModelCatalog({ config, readOnly }))
     .then((catalog) => {
+      // Only the refresh that belongs to the current stale generation may publish
+      // results; a newer reload invalidation should keep serving the previous cache.
       if ((readOnly || catalog.length > 0) && refreshGeneration === cache.staleGeneration) {
         cache.lastSuccessfulCatalog = catalog;
         cache.appliedGeneration = cache.staleGeneration;
@@ -88,6 +91,7 @@ function startGatewayModelCatalogRefresh(
   return refresh;
 }
 
+/** Invalidates both model-catalog cache views after provider/plugin reloads. */
 export function markGatewayModelCatalogStaleForReload(): void {
   readOnlyModelCatalogCache.staleGeneration += 1;
   fullModelCatalogCache.staleGeneration += 1;
@@ -103,6 +107,7 @@ export async function resetModelCatalogCacheForTest(): Promise<void> {
   resetModelCatalogCacheForTestLocal();
 }
 
+/** Loads the Gateway model catalog, serving the last good value during stale refreshes. */
 export async function loadGatewayModelCatalog(
   params?: LoadGatewayModelCatalogParams,
 ): Promise<GatewayModelChoice[]> {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -66,6 +66,8 @@ export type NodeEventHandleResult = {
   reason?: string;
 };
 
+// Node event payloads arrive from several app versions; accept the strongest
+// stable identifier first so retries dedupe without collapsing distinct text.
 function normalizeFiniteInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
 }
@@ -118,6 +120,8 @@ function shouldDropDuplicateVoiceTranscript(params: {
     ts: params.now,
   });
 
+  // The map is process-local dedupe, not history. Prune by age first, then
+  // insertion order, so one noisy session cannot grow gateway memory forever.
   if (recentVoiceTranscripts.size > MAX_RECENT_VOICE_TRANSCRIPTS) {
     const cutoff = params.now - VOICE_TRANSCRIPT_DEDUPE_WINDOW_MS * 2;
     for (const [key, value] of recentVoiceTranscripts) {
@@ -252,6 +256,8 @@ async function touchSessionStore(params: {
     return;
   }
   await updateSessionStore(storePath, (store) => {
+    // Session rows may be addressed by legacy or canonical keys. Migrate before
+    // touching so voice/node activity preserves the row visible to chat APIs.
     const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
       cfg: params.cfg,
       key: params.sessionKey,
@@ -285,6 +291,8 @@ function queueSessionStoreTouch(params: {
   sessionId: string;
   now: number;
 }) {
+  // Voice transcripts should not block on a best-effort store timestamp update;
+  // the agent run can proceed even if persistence is temporarily unavailable.
   void touchSessionStore({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
@@ -393,6 +401,8 @@ export const handleNodeEvent = async (
       if (shouldDropDuplicateVoiceTranscript({ sessionKey: canonicalKey, fingerprint, now })) {
         return undefined;
       }
+      // Reuse the stored session id when present so node-originated voice turns
+      // append to the visible chat thread instead of creating detached runs.
       const sessionId = entry?.sessionId ?? randomUUID();
       queueSessionStoreTouch({
         ctx,
@@ -545,6 +555,8 @@ export const handleNodeEvent = async (
       await touchSessionStore({ cfg, sessionKey, storePath, canonicalKey, entry, sessionId, now });
 
       if (deliverRequested && (!channel || !to)) {
+        // Share-sheet requests often omit an explicit reply route. Fall back to
+        // the last durable channel only when delivery was explicitly requested.
         const entryChannel =
           typeof entry?.lastChannel === "string"
             ? normalizeChannelId(entry.lastChannel)
@@ -756,6 +768,8 @@ export const handleNodeEvent = async (
         if (!shouldNotify) {
           return undefined;
         }
+        // Nodes can retry terminal exec events after reconnect. Deduping by
+        // runId keeps system notifications idempotent while preserving failures.
         if (
           runId &&
           shouldDropDuplicateExecFinished({
@@ -862,6 +876,8 @@ export const handleNodeEvent = async (
 
       const lastSeenReason = normalizeNodePresenceAliveReason(obj.trigger);
       try {
+        // Persist node and device presence together because pairing can be
+        // repaired through either record; success on either side is meaningful.
         const [nodeUpdated, deviceUpdated] = await Promise.all([
           updatePairedNodeMetadata(nodeId, {
             lastSeenAtMs: now,

--- a/src/gateway/server-node-session-runtime.ts
+++ b/src/gateway/server-node-session-runtime.ts
@@ -6,6 +6,7 @@ import {
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
 import { hasConnectedTalkNode } from "./server-talk-nodes.js";
 
+/** Creates the node/session registries shared by Gateway RPC, node events, and Talk presence. */
 export function createGatewayNodeSessionRuntime(params: {
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
 }) {
@@ -21,6 +22,8 @@ export function createGatewayNodeSessionRuntime(params: {
   }) => {
     nodeRegistry.sendEventRaw(opts.nodeId, opts.event, opts.payloadJSON ?? null);
   };
+  // Session subscriptions route by session key but deliver over node ids; keep
+  // the raw node send adapter local so subscription code never owns registry IO.
   const nodeSendToSession = (sessionKey: string, event: string, payload: unknown) =>
     nodeSubscriptions.sendToSession(sessionKey, event, payload, nodeSendEvent);
   const nodeSendToAllSubscribed = (event: string, payload: unknown) =>
@@ -28,6 +31,8 @@ export function createGatewayNodeSessionRuntime(params: {
   const broadcastVoiceWakeChanged = (triggers: string[]) => {
     params.broadcast("voicewake.changed", { triggers }, { dropIfSlow: true });
   };
+  // Talk only needs a boolean presence snapshot; the node registry keeps the
+  // richer session metadata for targeted node RPC delivery.
   const hasTalkNodeConnected = () => hasConnectedTalkNode(nodeRegistry);
 
   return {

--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -32,6 +32,7 @@ type NodeSubscriptionManager = {
   clear: () => void;
 };
 
+/** Tracks node subscriptions by both node id and session key for targeted Gateway fanout. */
 export function createNodeSubscriptionManager(): NodeSubscriptionManager {
   const nodeSubscriptions = new Map<string, Set<string>>();
   const sessionSubscribers = new Map<string, Set<string>>();
@@ -55,6 +56,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     }
     nodeSet.add(normalizedSessionKey);
 
+    // Keep the reverse index in lockstep so sendToSession can avoid scanning
+    // every connected node on hot transcript/tool-event paths.
     let sessionSet = sessionSubscribers.get(normalizedSessionKey);
     if (!sessionSet) {
       sessionSet = new Set<string>();
@@ -76,6 +79,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
       nodeSubscriptions.delete(normalizedNodeId);
     }
 
+    // Mirror node removal into the reverse index; stale node ids here would
+    // cause future session fanout to target disconnected or unsubscribed nodes.
     const sessionSet = sessionSubscribers.get(normalizedSessionKey);
     sessionSet?.delete(normalizedNodeId);
     if (sessionSet?.size === 0) {
@@ -89,6 +94,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     if (!nodeSet) {
       return;
     }
+    // Copy cleanup through each subscribed session key before deleting the node
+    // side so both maps remain symmetric after disconnect.
     for (const sessionKey of nodeSet) {
       const sessionSet = sessionSubscribers.get(sessionKey);
       sessionSet?.delete(normalizedNodeId);
@@ -115,6 +122,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     }
 
     const payloadJSON = toPayloadJSON(payload);
+    // Serialize once per broadcast; node-registry accepts the already-serialized
+    // payload so each subscriber gets identical bytes without repeated work.
     for (const nodeId of subs) {
       sendEvent({ nodeId, event, payloadJSON });
     }
@@ -129,6 +138,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
       return;
     }
     const payloadJSON = toPayloadJSON(payload);
+    // Broadcast only to nodes that explicitly subscribed to at least one
+    // session, not every connected node.
     for (const nodeId of nodeSubscriptions.keys()) {
       sendEvent({ nodeId, event, payloadJSON });
     }
@@ -144,6 +155,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
       return;
     }
     const payloadJSON = toPayloadJSON(payload);
+    // This path intentionally bypasses session subscriptions for node-level
+    // events such as capability or presence updates.
     for (const node of listConnected()) {
       sendEvent({ nodeId: node.nodeId, event, payloadJSON });
     }

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -10,6 +10,8 @@ type GatewayRequestContextClient = GatewayClient & {
   invalidatedReason?: string;
 };
 
+// Server startup owns the concrete state containers; handlers receive this
+// narrow façade so hot-reloaded services can be swapped without rebuilding RPCs.
 export type GatewayRequestContextParams = {
   deps: GatewayRequestContext["deps"];
   runtimeState: Pick<GatewayServerLiveState, "cronState">;
@@ -118,6 +120,8 @@ export function createGatewayRequestContext(
     getApprovalClientConnIds: (opts = {}) => {
       const connIds = new Set<string>();
       for (const gatewayClient of params.clients) {
+        // Approval fanout must use the live client set because browser clients
+        // can connect/disconnect while a tool approval request is being routed.
         if (!gatewayClient.connId) {
           continue;
         }
@@ -143,6 +147,8 @@ export function createGatewayRequestContext(
         if (opts?.role && gatewayClient.connect.role !== opts.role) {
           continue;
         }
+        // Mark-only invalidation lets already-open sockets finish the close path
+        // naturally while per-request dispatch rejects any later pipelined RPCs.
         gatewayClient.invalidated = true;
         gatewayClient.invalidatedReason = reason;
       }

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -23,12 +23,15 @@ import {
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
 
+/** Returns all subscription keys that should see a transcript update for one session. */
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   const normalizedAgentId = normalizeOptionalString(agentId);
   if (sessionKey === "global") {
     const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(getRuntimeConfig()));
     if (normalizedAgentId) {
       const scopedKey = `agent:${normalizeAgentId(normalizedAgentId)}:global`;
+      // The default agent keeps backward compatibility with bare "global"
+      // subscribers while non-default global stores stay agent-scoped.
       return normalizeAgentId(normalizedAgentId) === defaultAgentId
         ? [scopedKey, sessionKey]
         : [scopedKey];
@@ -38,6 +41,7 @@ function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string
   return [sessionKey];
 }
 
+/** Builds the session fields attached to transcript/lifecycle broadcasts. */
 function buildGatewaySessionSnapshot(params: {
   sessionRow: GatewaySessionRow | null | undefined;
   agentId?: string;
@@ -53,6 +57,8 @@ function buildGatewaySessionSnapshot(params: {
   const omitUnscopedGlobalGoal = sessionRow.key === "global" && !params.agentId;
   const session = params.includeSession ? { ...sessionRow } : undefined;
   if (session && omitUnscopedGlobalGoal) {
+    // A bare global event can be observed by multiple agent views; hide the
+    // selected agent's goal unless the event itself is agent-scoped.
     delete session.goal;
   }
   return {
@@ -111,6 +117,7 @@ function buildGatewaySessionSnapshot(params: {
   };
 }
 
+/** Creates the serialized transcript-update broadcaster used by Gateway startup wiring. */
 export function createTranscriptUpdateBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;
@@ -118,6 +125,8 @@ export function createTranscriptUpdateBroadcastHandler(params: {
 }) {
   let broadcastQueue = Promise.resolve();
   return (update: SessionTranscriptUpdate): void => {
+    // Preserve transcript event order even when message-count reads or session
+    // snapshots are async; failed broadcasts should not poison future updates.
     broadcastQueue = broadcastQueue
       .then(() => handleTranscriptUpdateBroadcast(params, update))
       .catch(() => undefined);
@@ -158,6 +167,8 @@ async function handleTranscriptUpdateBroadcast(
   }
   let messageSeq = asPositiveSafeInteger(update.messageSeq);
   if (messageSeq === undefined) {
+    // Some transcript writers emit only the file/update; derive the sequence
+    // from the current row so UI subscribers can still order streamed messages.
     const { entry, storePath } = loadSessionEntry(sessionKey, { agentId: visibleAgentId });
     messageSeq = entry?.sessionId
       ? asPositiveSafeInteger(
@@ -179,6 +190,8 @@ async function handleTranscriptUpdateBroadcast(
   });
   const message = projectChatDisplayMessage(rawMessage);
   if (message) {
+    // Message subscribers get the display-safe message plus the same session
+    // snapshot fields as sessions.changed so lists and transcripts stay in sync.
     params.broadcastToConnIds(
       "session.message",
       {
@@ -199,6 +212,8 @@ async function handleTranscriptUpdateBroadcast(
   if (sessionEventConnIds.size === 0) {
     return;
   }
+  // Non-displayable transcript entries still update session lists with the
+  // message phase so clients can refresh usage, title, or lifecycle metadata.
   params.broadcastToConnIds(
     "sessions.changed",
     {
@@ -215,6 +230,7 @@ async function handleTranscriptUpdateBroadcast(
   );
 }
 
+/** Creates the lifecycle-event broadcaster used for session start/end/reset projections. */
 export function createLifecycleEventBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;

--- a/src/gateway/server-session-key.ts
+++ b/src/gateway/server-session-key.ts
@@ -50,6 +50,8 @@ function setResolvedSessionKeyCache(
   }
   let expiresAt: number | null = null;
   if (sessionKey === null) {
+    // Misses are short-lived so late agent events can still bind a run to a
+    // session soon after the first lookup races ahead of session persistence.
     const missExpiresAt = resolveExpiresAtMsFromDurationMs(RUN_LOOKUP_MISS_TTL_MS);
     if (missExpiresAt === undefined) {
       return;
@@ -69,6 +71,8 @@ function sessionKeyMatchesAgent(sessionKey: string, agentId: string, cfg: OpenCl
   const normalizedAgentId = normalizeAgentId(agentId);
   const parsed = parseAgentSessionKey(sessionKey);
   if (!parsed && sessionKey.trim().toLowerCase().startsWith("agent:")) {
+    // Malformed agent-prefixed keys should not be treated as legacy bare keys
+    // for another agent store.
     return false;
   }
   const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey, storeAgentId: agentId });
@@ -79,6 +83,7 @@ function resolveRunSessionKeyForCaller(storeKey: string) {
   return toAgentRequestSessionKey(storeKey) ?? storeKey;
 }
 
+/** Resolves an agent run id to the session key visible to gateway callers. */
 export function resolveSessionKeyForRun(runId: string, opts: { agentId?: string } = {}) {
   const cfg = getRuntimeConfig();
   const explicitAgentId =
@@ -124,6 +129,7 @@ export function resolveSessionKeyForRun(runId: string, opts: { agentId?: string 
   return undefined;
 }
 
+/** Clears run-id lookup cache for tests that mutate active run context or stores. */
 export function resetResolvedSessionKeyForRunCacheForTest(): void {
   resolvedSessionKeyByRunId.clear();
 }

--- a/src/gateway/server-talk-nodes.ts
+++ b/src/gateway/server-talk-nodes.ts
@@ -4,11 +4,14 @@ import type { NodeRegistry, NodeSession } from "./node-registry.js";
 const TALK_CAPABILITY = "talk";
 const TALK_COMMAND_PREFIX = "talk.";
 
+/** Returns true when any connected node advertises Talk capability or Talk commands. */
 export function hasConnectedTalkNode(registry: NodeRegistry): boolean {
   return registry.listConnected().some(isTalkCapableNode);
 }
 
 function isTalkCapableNode(node: NodeSession): boolean {
+  // Some nodes expose a broad capability while older/custom nodes expose only
+  // talk.* commands, so accept either advertisement.
   return (
     node.caps.some(
       (capability) => normalizeOptionalLowercaseString(capability) === TALK_CAPABILITY,

--- a/src/gateway/server-utils.ts
+++ b/src/gateway/server-utils.ts
@@ -1,13 +1,17 @@
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { defaultVoiceWakeTriggers } from "../infra/voicewake.js";
 
+/** Normalizes configured voice wake phrases while preserving safe defaults when empty. */
 export function normalizeVoiceWakeTriggers(input: unknown): string[] {
+  // Voicewake config is user-editable; cap count and phrase length before the
+  // values reach runtime matching so config mistakes cannot create huge scans.
   const cleaned = normalizeTrimmedStringList(input)
     .slice(0, 32)
     .map((value) => value.slice(0, 64));
   return cleaned.length > 0 ? cleaned : defaultVoiceWakeTriggers();
 }
 
+/** Formats unknown gateway errors into compact operator-facing diagnostics. */
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
     return err.message;

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -11,6 +11,7 @@ type GatewayWsRuntimeParams = Omit<
   context: GatewayRequestContext;
 };
 
+/** Wires websocket connection handling to the already-built live Gateway request context. */
 export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
   attachGatewayWsConnectionHandler({
     wss: params.wss,
@@ -36,6 +37,8 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     extraHandlers: params.extraHandlers,
     getMethodRegistry: params.getMethodRegistry,
     broadcast: params.broadcast,
+    // Keep a single context object per server runtime; hot-reloaded fields inside
+    // the context stay live without rebuilding websocket handler closures.
     buildRequestContext: () => params.context,
   });
 }

--- a/src/gateway/server/close-reason.ts
+++ b/src/gateway/server/close-reason.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 
 const CLOSE_REASON_MAX_BYTES = 120;
 
+/** Truncates websocket close reasons to fit protocol byte limits. */
 export function truncateCloseReason(reason: string, maxBytes = CLOSE_REASON_MAX_BYTES): string {
   if (!reason) {
     return "invalid handshake";
@@ -10,5 +11,7 @@ export function truncateCloseReason(reason: string, maxBytes = CLOSE_REASON_MAX_
   if (buf.length <= maxBytes) {
     return reason;
   }
+  // Decode the byte slice back to UTF-8 so callers never send raw partial bytes
+  // in close frames; invalid trailing code units are replaced by Buffer.
   return buf.subarray(0, maxBytes).toString();
 }

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -73,6 +73,8 @@ export function classifyGatewayEventLoopHealthReasons(
     return reasons;
   }
 
+  // Utilization and CPU counters are noisy over tiny windows; require delay
+  // co-evidence so frequent async wakeups do not make readiness flap.
   const hasDelayCoEvidence =
     metrics.delayP99Ms >= LOAD_DEGRADATION_DELAY_COEVIDENCE_MS ||
     metrics.delayMaxMs >= LOAD_DEGRADATION_DELAY_COEVIDENCE_MS;
@@ -127,6 +129,8 @@ export function createGatewayEventLoopHealthMonitor(
       const hasDelayWarning =
         delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS || delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS;
 
+      // Keep rate baselines stable until a full sample exists, except for hard
+      // delay spikes which are already a direct blocking signal.
       if (!hasDelayWarning && intervalMs < SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS) {
         return lastSnapshot;
       }
@@ -156,6 +160,8 @@ export function createGatewayEventLoopHealthMonitor(
         cpuCoreRatio,
       };
 
+      // Reset only after the snapshot is classified so the next interval starts
+      // from the same wall/cpu/ELU boundary used for this published result.
       monitor.reset();
       lastWallAt = now;
       lastCpuUsage = readCpuUsage();

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -52,19 +52,23 @@ export function buildGatewaySnapshot(opts?: { includeSensitive?: boolean }): Sna
   return snapshot;
 }
 
+/** Returns the last public health snapshot published to gateway clients. */
 export function getHealthCache(): HealthSummary | null {
   return healthCache;
 }
 
+/** Monotonic health version used by clients to detect snapshot changes. */
 export function getHealthVersion(): number {
   return healthVersion;
 }
 
+/** Advances the presence version without coupling presence changes to health refreshes. */
 export function incrementPresenceVersion(): number {
   presenceVersion += 1;
   return presenceVersion;
 }
 
+/** Monotonic presence version included in gateway protocol snapshots. */
 export function getPresenceVersion(): number {
   return presenceVersion;
 }
@@ -82,6 +86,8 @@ export async function refreshGatewayHealthSnapshot(opts?: {
   const includeSensitive = opts?.includeSensitive === true;
   let refresh = includeSensitive ? sensitiveHealthRefresh : healthRefresh;
   if (!refresh) {
+    // Public and sensitive refreshes are deduped separately so an admin probe
+    // cannot poison the client cache with path/auth metadata.
     refresh = (async () => {
       let runtimeSnapshot: ChannelRuntimeSnapshot | undefined;
       try {

--- a/src/gateway/server/hook-client-ip-config.ts
+++ b/src/gateway/server/hook-client-ip-config.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { HookClientIpConfig } from "./hooks-request-handler.js";
 
+/** Extracts only the proxy trust fields the hook HTTP handler needs for client identity. */
 export function resolveHookClientIpConfig(cfg: OpenClawConfig): HookClientIpConfig {
   return {
     trustedProxies: cfg.gateway?.trustedProxies,

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -103,6 +103,8 @@ export function createHooksRequestHandler(
 
   const resolveHookClientKey = (req: IncomingMessage): string => {
     const clientIpConfig = getClientIpConfig?.();
+    // Hook auth is internet-facing, so rate-limit on the same proxy-aware client
+    // identity used by gateway auth instead of trusting raw remoteAddress alone.
     const clientIp =
       resolveRequestClientIp(
         req,
@@ -146,6 +148,8 @@ export function createHooksRequestHandler(
         "utf8",
       )
       .digest("hex");
+    // Scope the idempotency key by token and normalized dispatch input so the
+    // same upstream key cannot replay a different hook target or payload.
     return `${tokenFingerprint}:${scopeFingerprint}:${idempotencyFingerprint}`;
   };
 
@@ -254,6 +258,8 @@ export function createHooksRequestHandler(
       sessionKeyValue: string,
       targetAgentId: string,
     ): string | null => {
+      // Session policy is enforced after agent fallback resolution so prefix
+      // checks match the actual per-agent session that will receive the run.
       const dispatchSessionKey = normalizeHookDispatchSessionKey({
         sessionKey: sessionKeyValue,
         targetAgentId,
@@ -354,6 +360,8 @@ export function createHooksRequestHandler(
           path: subPath,
         });
         if (mapped) {
+          // A mapping returning null intentionally consumes the request without
+          // dispatching; callers use this for filters and allowlist misses.
           if (!mapped.ok) {
             sendJson(res, 400, { ok: false, error: mapped.error });
             return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -36,6 +36,8 @@ function shouldAnnounceHookRunResult(params: {
   if (params.result.status !== "ok") {
     return true;
   }
+  // Successful hooks stay quiet when delivery is disabled or the channel
+  // already attempted delivery; non-ok results still surface as system events.
   return (
     params.deliver && params.result.delivered !== true && params.result.deliveryAttempted !== true
   );
@@ -143,6 +145,8 @@ export function createGatewayHooksRequestHandler(params: {
     let hookEventSessionKey: string | undefined;
     void (async () => {
       try {
+        // Resolve config inside the async turn so hooks use the live gateway
+        // state at dispatch time without blocking the HTTP acknowledgement.
         const cfg = getRuntimeConfig();
         hookEventSessionKey = resolveHookEventSessionKey({
           cfg,
@@ -162,6 +166,8 @@ export function createGatewayHooksRequestHandler(params: {
           result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
         const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
         if (result.status !== "ok") {
+          // Console-facing logs are sanitized separately from structured fields
+          // so diagnostics remain useful without leaking control characters.
           logHooks.warn("hook agent run returned non-ok status", {
             sourcePath: value.sourcePath,
             name: safeName,

--- a/src/gateway/server/http-listen.ts
+++ b/src/gateway/server/http-listen.ts
@@ -8,6 +8,8 @@ const EADDRINUSE_RETRY_INTERVAL_MS = 500;
 async function closeServerQuietly(httpServer: HttpServer): Promise<void> {
   await new Promise<void>((resolve) => {
     try {
+      // Retrying listen() after EADDRINUSE needs a clean server state even if
+      // Node reports the previous bind failure before a listening callback.
       httpServer.close(() => resolve());
     } catch {
       resolve();
@@ -26,10 +28,14 @@ export async function listenGatewayHttpServer(params: {
     try {
       await new Promise<void>((resolve, reject) => {
         const onError = (err: NodeJS.ErrnoException) => {
+          // Remove the paired listener so a late "listening" event from a failed
+          // attempt cannot resolve the next retry's promise.
           httpServer.off("listening", onListening);
           reject(err);
         };
         const onListening = () => {
+          // Symmetric cleanup keeps repeated listen attempts from accumulating
+          // stale error handlers on the shared server instance.
           httpServer.off("error", onError);
           resolve();
         };

--- a/src/gateway/server/plugin-node-capability-auth.ts
+++ b/src/gateway/server/plugin-node-capability-auth.ts
@@ -41,6 +41,8 @@ export async function authorizePluginNodeCapabilityRequest(params: {
   let lastAuthFailure: GatewayAuthResult | null = null;
   const token = getBearerToken(req);
   if (token) {
+    // Explicit bearer auth wins when valid, but failures are preserved so a
+    // missing live node capability can return the concrete auth failure.
     const authResult = await authorizeHttpGatewayConnect({
       auth: { ...auth, allowTailscale: false },
       connectAuth: { token, password: token },
@@ -64,6 +66,8 @@ export async function authorizePluginNodeCapabilityRequest(params: {
       capability,
     })
   ) {
+    // Node capability auth is a live websocket grant; it only authorizes the
+    // requested capability and never broadens the caller's operator scopes.
     return { ok: true };
   }
 

--- a/src/gateway/server/plugin-route-runtime-scopes.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.ts
@@ -8,6 +8,7 @@ import { CLI_DEFAULT_OPERATOR_SCOPES, WRITE_SCOPE } from "../method-scopes.js";
 
 export type PluginRouteRuntimeScopeSurface = "write-default" | "trusted-operator";
 
+/** Resolves the operator scopes exposed to plugin HTTP route runtime helpers. */
 export function resolvePluginRouteRuntimeOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
@@ -15,11 +16,15 @@ export function resolvePluginRouteRuntimeOperatorScopes(
 ): string[] {
   if (surface === "trusted-operator") {
     if (!requestAuth.trustDeclaredOperatorScopes) {
+      // Shared-secret routes opting into trusted operator runtime get the CLI
+      // default scopes, not caller-declared headers from an untrusted request.
       return [...CLI_DEFAULT_OPERATOR_SCOPES];
     }
     return resolveTrustedHttpOperatorScopes(req, requestAuth);
   }
   if (requestAuth.authMethod !== "trusted-proxy") {
+    // Default plugin routes get write-only helpers even when bearer auth has
+    // broader gateway authority; admin scopes require an explicit route opt-in.
     return [WRITE_SCOPE];
   }
   if (getHeader(req, "x-openclaw-scopes") === undefined) {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -37,6 +37,8 @@ function resolvePluginRoutePathContextForRequest(
   providedPathContext: PluginRoutePathContext | undefined,
 ): PluginRoutePathContext {
   if (providedPathContext) {
+    // Upstream auth probes pass the exact path context they checked; reuse it so
+    // dispatch cannot canonicalize a subtly different encoded path.
     return providedPathContext;
   }
   const url = new URL(req.url ?? "/", "http://localhost");
@@ -46,6 +48,8 @@ function resolvePluginRoutePathContextForRequest(
 function createPluginRouteRuntimeClient(
   scopes: readonly string[],
 ): GatewayRequestOptions["client"] {
+  // Plugin HTTP handlers call gateway methods through the same runtime scope
+  // shape as websocket clients, but with a fixed internal backend identity.
   return {
     connect: {
       minProtocol: PROTOCOL_VERSION,
@@ -85,6 +89,7 @@ function getMissingPluginRouteRuntimeContext(
   return context.gatewayRequestOperatorScopes === undefined ? "caller scope context" : undefined;
 }
 
+/** Builds the gateway runtime scope visible while a plugin HTTP route handler runs. */
 function createPluginRouteRuntimeScope(params: {
   route: PluginHttpRouteRegistration;
   req: IncomingMessage;
@@ -121,6 +126,7 @@ export type PluginRouteDispatchContext = {
   gatewayRequestOperatorScopes?: readonly string[];
 };
 
+/** Dispatches registered plugin HTTP routes and returns whether the request was claimed. */
 export type PluginHttpRequestHandler = (
   req: IncomingMessage,
   res: ServerResponse,
@@ -128,6 +134,7 @@ export type PluginHttpRequestHandler = (
   dispatchContext?: PluginRouteDispatchContext,
 ) => Promise<boolean>;
 
+/** Dispatches registered plugin HTTP upgrade routes and returns whether the socket was claimed. */
 export type PluginHttpUpgradeHandler = (
   req: IncomingMessage,
   socket: Duplex,
@@ -144,6 +151,8 @@ export function createGatewayPluginRequestHandler(params: {
 }): PluginHttpRequestHandler {
   const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
+    // Prefer the server-local route registry when available; plugins can
+    // register routes after startup while older handler closures still exist.
     const registry = params.getRouteRegistry?.() ?? params.registry;
     const gatewayRequestContext = params.getGatewayRequestContext?.();
     const routes = registry.httpRoutes ?? [];
@@ -158,6 +167,8 @@ export function createGatewayPluginRequestHandler(params: {
     }
     const requiresGatewayAuth = matchedPluginRoutesRequireGatewayAuth(matchedRoutes);
     if (requiresGatewayAuth && dispatchContext?.gatewayAuthSatisfied !== true) {
+      // Do not run plugin-auth exact routes when an overlapping gateway-auth
+      // prefix also matched; the preauth layer must satisfy the whole set first.
       log.warn(`plugin http route blocked without gateway auth (${pathContext.canonicalPath})`);
       return false;
     }
@@ -181,6 +192,8 @@ export function createGatewayPluginRequestHandler(params: {
 
     for (const route of matchedRoutes) {
       try {
+        // Handlers may return false to delegate to the next matching route; any
+        // other result claims the request, including void handlers that wrote.
         const handled = await withPluginRuntimeGatewayRequestScope(
           createPluginRouteRuntimeScope({
             route,
@@ -216,6 +229,8 @@ export function createGatewayPluginUpgradeHandler(params: {
 }): PluginHttpUpgradeHandler {
   const { log } = params;
   return async (req, socket, head, providedPathContext, dispatchContext) => {
+    // Upgrade dispatch follows the same route registry and path context rules as
+    // normal HTTP requests, but must write/destroy the socket itself on failure.
     const registry = params.getRouteRegistry?.() ?? params.registry;
     const gatewayRequestContext = params.getGatewayRequestContext?.();
     const routes = registry.httpRoutes ?? [];
@@ -232,6 +247,8 @@ export function createGatewayPluginUpgradeHandler(params: {
     }
     const requiresGatewayAuth = matchedPluginRoutesRequireGatewayAuth(matchedRoutes);
     if (requiresGatewayAuth && dispatchContext?.gatewayAuthSatisfied !== true) {
+      // Matched upgrades are claimed before rejection so the caller does not
+      // hand an unauthenticated socket to another route family.
       log.warn(`plugin http upgrade blocked without gateway auth (${pathContext.canonicalPath})`);
       writeUpgradeUnauthorized(socket);
       return true;

--- a/src/gateway/server/plugins-http/path-context.ts
+++ b/src/gateway/server/plugins-http/path-context.ts
@@ -13,6 +13,7 @@ export type PluginRoutePathContext = {
   rawNormalizedPath: string;
 };
 
+/** Normalizes protected path prefixes once for encoded-path security checks. */
 function normalizeProtectedPrefix(prefix: string): string {
   const collapsed = normalizeLowercaseStringOrEmpty(prefix).replace(/\/{2,}/g, "/");
   if (collapsed.length <= 1) {
@@ -22,6 +23,8 @@ function normalizeProtectedPrefix(prefix: string): string {
 }
 
 export function prefixMatchPath(pathname: string, prefix: string): boolean {
+  // `%` keeps partially encoded slash variants in the protected prefix match
+  // until canonicalization can prove they decode to a safe plugin route.
   return (
     pathname === prefix || pathname.startsWith(`${prefix}/`) || pathname.startsWith(`${prefix}%`)
   );
@@ -43,6 +46,8 @@ export function isProtectedPluginRoutePathFromContext(context: PluginRoutePathCo
   if (!context.malformedEncoding) {
     return false;
   }
+  // Malformed encodings cannot produce a full candidate list; fall back to the
+  // raw normalized path so protected prefixes still fail closed.
   return NORMALIZED_PROTECTED_PLUGIN_ROUTE_PREFIXES.some((prefix) =>
     prefixMatchPath(context.rawNormalizedPath, prefix),
   );

--- a/src/gateway/server/plugins-http/route-auth.ts
+++ b/src/gateway/server/plugins-http/route-auth.ts
@@ -12,6 +12,7 @@ export function matchedPluginRoutesRequireGatewayAuth(
   return routes.some((route) => route.auth === "gateway");
 }
 
+/** Decides whether a plugin HTTP path must pass gateway auth before route dispatch. */
 export function shouldEnforceGatewayAuthForPluginPath(
   registry: PluginRegistry,
   pathnameOrContext: string | PluginRoutePathContext,
@@ -21,6 +22,8 @@ export function shouldEnforceGatewayAuthForPluginPath(
       ? resolvePluginRoutePathContext(pathnameOrContext)
       : pathnameOrContext;
   if (pathContext.malformedEncoding || pathContext.decodePassLimitReached) {
+    // Ambiguous paths fail closed so encoded protected prefixes cannot bypass
+    // gateway auth through a plugin route match.
     return true;
   }
   if (isProtectedPluginRoutePathFromContext(pathContext)) {

--- a/src/gateway/server/plugins-http/route-capability.ts
+++ b/src/gateway/server/plugins-http/route-capability.ts
@@ -21,6 +21,8 @@ function resolvePluginNodeCapabilityRouteSurface(
 ): PluginNodeCapabilitySurface {
   const surface = route.nodeCapability.surface.trim();
   const owner = route.pluginId?.trim() || route.source?.trim();
+  // Scope keys include the owning plugin so two plugins can expose the same
+  // surface string without sharing node capability grants.
   return {
     ...route.nodeCapability,
     surface,
@@ -62,6 +64,8 @@ export function listPluginNodeCapabilities(
       const next = resolvePluginNodeCapabilityRouteSurface(route as PluginNodeCapabilityRoute);
       const existing = surfaces.get(surface);
       if (!existing || resolveTtlMs(next) < resolveTtlMs(existing)) {
+        // Advertise the shortest TTL for duplicate surfaces so callers refresh
+        // before any matching route's grant can expire.
         surfaces.set(surface, next);
       }
     }

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -19,6 +19,7 @@ export function doesPluginRouteMatchPath(
   return context.candidates.some((candidate) => candidate === routeCanonicalPath);
 }
 
+/** Returns deterministic route precedence: longest exact routes, then longest prefixes. */
 export function findMatchingPluginHttpRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
@@ -44,6 +45,7 @@ export function findMatchingPluginHttpRoutes(
   return [...exactMatches, ...prefixMatches];
 }
 
+/** Finds the first registered plugin HTTP route after canonical path normalization. */
 export function findRegisteredPluginHttpRoute(
   registry: PluginRegistry,
   pathname: string,

--- a/src/gateway/server/preauth-connection-budget.ts
+++ b/src/gateway/server/preauth-connection-budget.ts
@@ -20,6 +20,7 @@ function getMaxPreauthConnectionsPerIpFromEnv(env: NodeJS.ProcessEnv = process.e
   return parsed;
 }
 
+/** Per-IP cap for websocket upgrades that have not completed authentication yet. */
 export type PreauthConnectionBudget = {
   acquire(clientIp: string | undefined): boolean;
   release(clientIp: string | undefined): void;
@@ -45,6 +46,8 @@ export function createPreauthConnectionBudget(
       const ip = normalizeBudgetKey(clientIp);
       const next = (counts.get(ip) ?? 0) + 1;
       if (next > maxConnectionsPerIp) {
+        // Failed acquires do not mutate counts; the caller may reject the socket
+        // without needing to release a budget slot it never owned.
         return false;
       }
       counts.set(ip, next);

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -16,6 +16,7 @@ export type ReadinessResult = {
   eventLoop?: GatewayEventLoopHealth;
 };
 
+/** Synchronous readiness probe used by HTTP health endpoints and Kubernetes-style checks. */
 export type ReadinessChecker = () => ReadinessResult;
 
 const DEFAULT_READINESS_CACHE_TTL_MS = 1_000;
@@ -52,12 +53,16 @@ export function createReadinessChecker(deps: {
     const uptimeMs = now - startedAt;
     if (deps.getStartupPending?.()) {
       const reason = deps.getStartupPendingReason?.() ?? "startup-sidecars";
+      // Startup readiness is intentionally uncached so sidecar completion flips
+      // the probe green on the first request after startup settles.
       return withEventLoopHealth(
         { ready: false, failing: [reason], uptimeMs },
         deps.getEventLoopHealth,
       );
     }
     if (deps.shouldSkipChannelReadiness?.()) {
+      // Some deployments use the gateway without managed channels; skip only
+      // channel failures while still attaching event-loop health below.
       return withEventLoopHealth({ ready: true, failing: [], uptimeMs }, deps.getEventLoopHealth);
     }
     if (cachedState && now - cachedAt < cacheTtlMs) {
@@ -83,6 +88,8 @@ export function createReadinessChecker(deps: {
         };
         const health = evaluateChannelHealth(accountSnapshot, policy);
         if (!health.healthy && !shouldIgnoreReadinessFailure(accountSnapshot, health)) {
+          // Report the channel once even if several accounts are failing; the
+          // detailed account diagnostics live in the health snapshot.
           failing.push(channelId);
           break;
         }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -178,6 +178,8 @@ function attachGatewayWsMessageHandlerOnDemand(params: GatewayWsMessageHandlerPa
   const queued: RawData[] = [];
   const queueMessage = (data: RawData) => {
     if (queued.length >= MAX_QUEUED_MESSAGE_HANDLER_FRAMES) {
+      // Bound pre-handshake buffering while the heavy message handler module is
+      // loading; unbounded frames here would bypass normal parsed-frame limits.
       params.setCloseCause("message-handler-loading-overflow", {
         queuedFrames: queued.length,
       });
@@ -194,6 +196,8 @@ function attachGatewayWsMessageHandlerOnDemand(params: GatewayWsMessageHandlerPa
         return;
       }
       attachGatewayWsMessageHandler(params);
+      // Replay through the socket emitter so the real handler observes the same
+      // message event shape as live websocket frames.
       for (const data of queued) {
         params.socket.emit("message", data);
       }
@@ -302,6 +306,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         return;
       }
       holdsPreauthBudget = false;
+      // The claimed key is set during upgrade acceptance; release it exactly
+      // once whether the socket authenticates, times out, or closes early.
       preauthConnectionBudget.release(preauthBudgetKey);
     };
 
@@ -446,6 +452,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         client?.presenceKey &&
         (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
       ) {
+        // Node presence is cleared only for the currently registered connection;
+        // stale sockets that lose a reconnect race must not mark the node offline.
         upsertPresence(client.presenceKey, { reason: "disconnect" });
         broadcastPresenceSnapshot({ broadcast, incrementPresenceVersion, getHealthVersion });
       }
@@ -523,6 +531,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         if (closed) {
           return false;
         }
+        // Authentication succeeded; from here normal frame limits apply and the
+        // preauth budget slot must be freed before long-lived pings start.
         releasePreauthBudget();
         client = next;
         clients.add(next);

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -118,6 +118,8 @@ function resolveDeviceTokenCandidate(connectAuth: HandshakeConnectAuth | null | 
   if (!fallbackToken) {
     return {};
   }
+  // Older clients sent the device token in auth.token. Keep it as a fallback
+  // candidate but remember the source so failures can guide a device-token retry.
   return { token: fallbackToken, source: "shared-token-fallback" };
 }
 
@@ -281,6 +283,8 @@ async function resolveConnectAuthDecisionCore(
 
   let deviceTokenRateLimited = false;
   if (params.rateLimiter) {
+    // Device-token checks have their own bucket because shared-secret failures
+    // can legitimately fall through into this legacy-token retry path.
     const deviceRateCheck = params.rateLimiter.check(
       params.clientIp,
       AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
@@ -306,6 +310,8 @@ async function resolveConnectAuthDecisionCore(
       authOk = true;
       authMethod = "device-token";
       if (tokenCheck.issuer?.kind === "shared-gateway-auth") {
+        // Shared-gateway-auth issued device tokens carry the generation they
+        // belong to; the websocket layer closes stale generation clients later.
         deviceTokenSharedGatewaySessionGeneration = tokenCheck.issuer.generation;
       }
       params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -7,6 +7,8 @@ import type { ResolvedGatewayAuth } from "../../auth.js";
 
 export type AuthProvidedKind = "token" | "bootstrap-token" | "device-token" | "password" | "none";
 
+// Keep user-facing auth hints client-aware: CLI users need config keys, while
+// browser clients need Control UI instructions rather than daemon config text.
 export function formatGatewayAuthFailureMessage(params: {
   authMode: ResolvedGatewayAuth["mode"];
   authProvided: AuthProvidedKind;
@@ -61,6 +63,8 @@ export function formatGatewayAuthFailureMessage(params: {
       break;
   }
 
+  // Fall back from explicit reason codes to mode/auth-shape combinations so
+  // older auth failures still produce actionable retry guidance.
   if (authMode === "token" && authProvided === "none") {
     return `unauthorized: gateway token missing (${tokenHint})`;
   }

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -47,6 +47,8 @@ function resolveBrowserOriginRateLimitKey(requestOrigin?: string): string {
     return BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP;
   }
   try {
+    // Browser-origin loopback clients otherwise all share 127.0.0.1; key by
+    // normalized origin so one web app cannot exhaust another app's bucket.
     return `${BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX}${normalizeLowercaseStringOrEmpty(new URL(trimmedOrigin).origin)}`;
   } catch {
     return BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP;
@@ -129,6 +131,8 @@ function isCliContainerLocalEquivalent(params: {
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
     params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI;
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // Docker-published CLI traffic can arrive from loopback to a private host.
+  // Treat it as local only when shared-secret auth and no browser/proxy headers agree.
   return (
     isCliClient &&
     params.sharedAuthOk &&
@@ -185,6 +189,8 @@ function isControlUiBrowserContainerLocalEquivalent(params: {
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI &&
     params.connectParams.client.mode === GATEWAY_CLIENT_MODES.WEBCHAT;
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  // Browser container locality requires both Host and Origin to stay loopback;
+  // a private remote address alone is not enough to auto-pair a web client.
   return (
     isControlUiBrowser &&
     params.sharedAuthOk &&
@@ -339,6 +345,8 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     return "v3";
   }
 
+  // V2 signatures predate platform/device-family pinning. Accept them for
+  // existing clients, but callers can use the returned version to decide refresh policy.
   const payloadV2 = buildDeviceAuthPayload(basePayload);
   if (verifyDeviceSignature(params.device.publicKey, payloadV2, params.device.signature)) {
     return "v2";

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
@@ -32,6 +32,8 @@ export class HandshakeAuthLogLimiter {
     }
 
     if (nowMs - entry.lastLoggedAtMs < this.intervalMs) {
+      // Suppression is per fingerprint so startup retries from one client do
+      // not hide different clients, methods, or auth reasons.
       entry.suppressedSinceLastLog += 1;
       return { shouldLog: false, suppressedSinceLastLog: 0 };
     }
@@ -46,6 +48,8 @@ export class HandshakeAuthLogLimiter {
     if (this.entries.size < this.maxEntries) {
       return;
     }
+    // Map insertion order gives a simple FIFO cap; limiter freshness is best
+    // effort and only controls log volume, not authorization decisions.
     const oldestKey = this.entries.keys().next().value;
     if (oldestKey !== undefined) {
       this.entries.delete(oldestKey);
@@ -60,6 +64,8 @@ export function buildHandshakeAuthLogKey(params: {
   mode?: string;
   authProvided?: string;
 }): string {
+  // Include enough request shape to separate benign dashboard retries from
+  // security-relevant mismatches without logging raw credential material.
   return [
     params.reason ?? "unknown",
     params.remoteAddr ?? "?",

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1041,6 +1041,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         const sessionSharedGatewaySessionGeneration =
           sharedGatewaySessionGeneration ?? deviceTokenSharedGatewaySessionGeneration;
         if (sessionUsesSharedGatewayAuth) {
+          // Shared-auth sessions are tied to the current secret/proxy generation;
+          // reject stale handshakes before they become long-lived websocket clients.
           const requiredSharedGatewaySessionGeneration =
             getRequiredSharedGatewaySessionGeneration?.();
           if (
@@ -1067,6 +1069,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           authMethod,
         });
         if (trustedProxyAuthOk) {
+          // Trusted proxies can narrow requested scopes through a header, but
+          // they cannot grant scopes the client did not already request.
           scopes = resolveTrustedProxyControlUiScopes({
             requestedScopes: scopes,
             upgradeReq,
@@ -1238,6 +1242,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             let resolvedByConcurrentApproval = false;
             let recoveryRequestId: string | undefined;
             const resolveLivePendingRequestId = async (): Promise<string | undefined> => {
+              // Pairing requests are supersedable; use the live request id for
+              // the response so reconnecting clients wait on the active approval.
               const pendingList = await listDevicePairing();
               const exactPending = pendingList.pending.find(
                 (pending) => pending.requestId === pairing.request.requestId,
@@ -1281,6 +1287,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                   { dropIfSlow: true },
                 );
               } else {
+                // A failed silent approval can still be okay if another socket
+                // approved the same device between request creation and approval.
                 resolvedByConcurrentApproval = pairingStateAllowsRequestedAccess(
                   await getPairedDevice(device.id),
                 );

--- a/src/gateway/server/ws-connection/unauthorized-flood-guard.ts
+++ b/src/gateway/server/ws-connection/unauthorized-flood-guard.ts
@@ -33,6 +33,8 @@ export class UnauthorizedFloodGuard {
     const shouldLog = this.count === 1 || this.count % this.logEvery === 0 || shouldClose;
 
     if (!shouldLog) {
+      // Suppressed counts are reported only on the next emitted log entry; the
+      // immediate decision stays zero so callers do not double-count hidden attempts.
       this.suppressedSinceLastLog += 1;
       return {
         shouldClose,
@@ -62,6 +64,8 @@ export function isUnauthorizedRoleError(error?: ErrorShape): boolean {
   if (!error) {
     return false;
   }
+  // Role failures are protocol-level invalid requests, not auth credential
+  // failures; websocket handling uses this to apply flood protection narrowly.
   return (
     error.code === ErrorCodes.INVALID_REQUEST &&
     typeof error.message === "string" &&

--- a/src/gateway/server/ws-shared-generation.ts
+++ b/src/gateway/server/ws-shared-generation.ts
@@ -27,23 +27,30 @@ function normalizeTrustedProxyConfig(trustedProxy: GatewayTrustedProxyConfig | u
 } {
   return {
     userHeader: trustedProxy?.userHeader,
+    // Sort unordered policy arrays so equivalent config files do not force a
+    // shared-gateway-auth generation rollover.
     requiredHeaders: [...(trustedProxy?.requiredHeaders ?? [])].toSorted(),
     allowUsers: [...(trustedProxy?.allowUsers ?? [])].toSorted(),
     allowLoopback: trustedProxy?.allowLoopback,
   };
 }
 
+/** Returns the stable generation key used to invalidate shared-auth websocket sessions. */
 export function resolveSharedGatewaySessionGeneration(
   auth: ResolvedGatewayAuth,
   trustedProxies?: readonly string[],
 ): string | undefined {
   const shared = resolveSharedSecret(auth);
   if (shared) {
+    // Include the mode separator so identical token/password bytes cannot share
+    // a generation across different auth modes.
     return createHash("sha256")
       .update(`${shared.mode}\u0000${shared.secret}`, "utf8")
       .digest("base64url");
   }
   if (auth.mode === "trusted-proxy") {
+    // Trusted-proxy sessions depend on proxy policy rather than a secret value;
+    // include both header rules and trusted CIDRs so policy changes eject clients.
     return createHash("sha256")
       .update(
         JSON.stringify({

--- a/src/gateway/session-child-sessions.ts
+++ b/src/gateway/session-child-sessions.ts
@@ -3,11 +3,13 @@ import { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
+/** Stored child session paired with its canonical store key. */
 export type DirectChildSessionEntry = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
+/** Identifies one stored session that directly descends from a parent session. */
 export function isDirectChildSessionEntry(params: {
   sessionKey: string;
   entry: SessionEntry | undefined;
@@ -23,6 +25,7 @@ export function isDirectChildSessionEntry(params: {
   );
 }
 
+/** Lists direct child sessions from the combined Gateway store without recursive traversal. */
 export function findDirectChildSessionsForParent(params: {
   cfg: OpenClawConfig;
   parentKey: string;

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -21,9 +21,12 @@ import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
 
 const log = createSubsystemLogger("gateway/session-compaction-checkpoints");
 const MAX_COMPACTION_CHECKPOINTS_PER_SESSION = 25;
+/** Maximum transcript tail bytes scanned to recover the pre-compaction leaf entry. */
 export const MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES = 64 * 1024 * 1024;
+/** Maximum retained snapshot bytes for checkpoint artifacts attached to one session. */
 export const MAX_COMPACTION_CHECKPOINT_RETAINED_BYTES_PER_SESSION = 128 * 1024 * 1024;
 
+/** Stable pre-compaction transcript identity captured before the compaction rewrite. */
 export type CapturedCompactionCheckpointSnapshot = {
   sessionId: string;
   sessionFile?: string;
@@ -117,6 +120,7 @@ async function statCheckpointSnapshotBytes(
   return bytesByPath;
 }
 
+/** Maps compaction trigger metadata into the persisted checkpoint reason enum. */
 export function resolveSessionCompactionCheckpointReason(params: {
   trigger?: "budget" | "overflow" | "manual";
   timedOut?: boolean;
@@ -268,6 +272,7 @@ function trimTranscriptEntriesThroughLeaf(
   return entries.slice(0, leafIndex + 1);
 }
 
+/** Reads the latest transcript entry id using a bounded tail scan. */
 export async function readSessionLeafIdFromTranscriptAsync(
   sessionFile: string,
   maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
@@ -327,6 +332,7 @@ export async function readSessionLeafIdFromTranscriptAsync(
   return null;
 }
 
+/** Forks a checkpoint transcript, optionally truncating it at the stored source leaf. */
 export async function forkCompactionCheckpointTranscriptAsync(params: {
   sourceFile: string;
   sourceLeafId?: string;
@@ -423,6 +429,7 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
   };
 }
 
+/** Removes legacy copied checkpoint snapshots when a caller abandons the checkpoint. */
 export async function cleanupCompactionCheckpointSnapshot(
   snapshot: CapturedCompactionCheckpointSnapshot | null | undefined,
 ): Promise<void> {
@@ -470,6 +477,7 @@ async function cleanupTrimmedCompactionCheckpointFiles(params: {
   }
 }
 
+/** Persists one compaction checkpoint and trims older checkpoint metadata/artifacts. */
 export async function persistSessionCompactionCheckpoint(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -566,12 +574,14 @@ export async function persistSessionCompactionCheckpoint(params: {
   return checkpoint;
 }
 
+/** Lists persisted checkpoints newest-first for session restore/branch APIs. */
 export function listSessionCompactionCheckpoints(
   entry: Pick<SessionEntry, "compactionCheckpoints"> | undefined,
 ): SessionCompactionCheckpoint[] {
   return sessionStoreCheckpoints(entry).toSorted((a, b) => b.createdAt - a.createdAt);
 }
 
+/** Finds one persisted checkpoint by id after normalizing the requested id. */
 export function getSessionCompactionCheckpoint(params: {
   entry: Pick<SessionEntry, "compactionCheckpoints"> | undefined;
   checkpointId: string;

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -65,6 +65,8 @@ function resolveCursorSeq(cursor: string | undefined): number | undefined {
     return undefined;
   }
   const normalized = cursor.startsWith("seq:") ? cursor.slice(4) : cursor;
+  // Cursor values are exact transcript sequence numbers; reject partial parses
+  // so "seq:2next" cannot accidentally page from message 2.
   if (!/^\d+$/.test(normalized)) {
     return undefined;
   }
@@ -108,6 +110,8 @@ function paginateSessionMessages(
   const cursorSeq = resolveCursorSeq(cursor);
   let endExclusive = messages.length;
   if (typeof cursorSeq === "number") {
+    // Page backward from the first message at or after the cursor sequence.
+    // Messages without OpenClaw seq metadata fall back to their 1-based index.
     endExclusive = messages.findIndex((message, index) => {
       const seq = resolveMessageSeq(message);
       if (typeof seq === "number") {
@@ -150,6 +154,8 @@ export function buildSessionHistorySnapshot(params: {
     params.totalRawMessages > params.rawMessages.length &&
     history.messages.length > 0
   ) {
+    // Recent-tail reads may omit older raw messages before projection. Mark the
+    // display page as partial even when every loaded visible message was used.
     const firstSeq = resolveMessageSeq(history.messages[0]);
     history.hasMore = true;
     if (typeof firstSeq === "number") {
@@ -238,6 +244,8 @@ export class SessionHistorySseState {
     }
     const carriedSeq = asPositiveSafeInteger(update.messageSeq);
     if (carriedSeq !== undefined) {
+      // Duplicate or out-of-order live appends mean the SSE client has missed a
+      // state transition; force a disk refresh instead of appending stale data.
       if (carriedSeq <= this.rawTranscriptSeq) {
         return { shouldRefresh: true };
       }
@@ -265,6 +273,8 @@ export class SessionHistorySseState {
       }
       const projectedMessage = addedMessages[0];
       if (projectedMessage !== undefined) {
+        // message-tool mirrors can be synthesized from a later silent control
+        // reply, so attach the current raw seq when projection did not carry one.
         const emittedMessage: SessionHistoryMessage =
           isMessageToolMirrorMessage(projectedMessage) ||
           resolveMessageSeq(projectedMessage) === undefined
@@ -288,6 +298,8 @@ export class SessionHistorySseState {
     );
     if (!sanitizedMessage) {
       if (projectedMessages.length < this.sentHistory.messages.length) {
+        // A hidden control message can collapse previously buffered projection
+        // state; ask the client to reload the current display page.
         this.sentHistory = buildPaginatedSessionHistory({
           messages: projectedMessages,
           hasMore: false,
@@ -341,6 +353,8 @@ export class SessionHistorySseState {
 
   private async readRawSnapshotAsync(): Promise<SessionHistoryRawSnapshot> {
     if (this.cursor === undefined && typeof this.limit === "number") {
+      // Non-cursor history streams only need a raw tail wide enough for display
+      // projection filters; cursor mode below needs the full transcript.
       const snapshot = await readRecentSessionMessagesWithStatsAsync(
         this.target.sessionId,
         this.target.storePath,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -47,6 +47,7 @@ type SessionHistoryRawSnapshot = {
   totalRawMessages?: number;
 };
 
+/** Expands a visible history limit into the raw tail window needed before projection filters. */
 export function resolveSessionHistoryTailReadOptions(limit: number): {
   maxMessages: number;
   maxLines: number;
@@ -128,6 +129,7 @@ function paginateSessionMessages(
   });
 }
 
+/** Builds one paginated, display-safe history page while preserving raw transcript progress. */
 export function buildSessionHistorySnapshot(params: {
   rawMessages: unknown[];
   maxChars?: number;
@@ -164,6 +166,7 @@ export function buildSessionHistorySnapshot(params: {
   };
 }
 
+/** Maintains chat.history SSE pagination state between full refreshes and inline appends. */
 export class SessionHistorySseState {
   private readonly target: SessionHistoryTranscriptTarget;
   private readonly maxChars: number;
@@ -172,6 +175,7 @@ export class SessionHistorySseState {
   private sentHistory: PaginatedSessionHistory;
   private rawTranscriptSeq: number;
 
+  /** Seeds SSE state from the same raw messages used for the initial history response. */
   static fromRawSnapshot(params: {
     target: SessionHistoryTranscriptTarget;
     rawMessages: unknown[];
@@ -218,10 +222,12 @@ export class SessionHistorySseState {
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
   }
 
+  /** Returns the last display page sent to the SSE client. */
   snapshot(): PaginatedSessionHistory {
     return this.sentHistory;
   }
 
+  /** Attempts to project one live transcript append, or asks the caller to refresh. */
   appendInlineMessage(update: {
     message: unknown;
     messageId?: string;
@@ -309,6 +315,7 @@ export class SessionHistorySseState {
     };
   }
 
+  /** Reloads transcript history from disk and replaces the tracked display page. */
   async refreshAsync(): Promise<PaginatedSessionHistory> {
     const rawSnapshot = await this.readRawSnapshotAsync();
     const snapshot = this.buildSnapshot(rawSnapshot);

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -29,6 +29,7 @@ type SessionKeyPathResolution =
   | { matched: true; sessionKey: string }
   | { error: "invalid-session-key"; matched: true };
 
+/** Parses `/sessions/:key/kill` without claiming unrelated Gateway paths. */
 function resolveSessionKeyFromPath(pathname: string): SessionKeyPathResolution {
   const match = pathname.match(/^\/sessions\/([^/]+)\/kill$/);
   if (!match) {
@@ -45,6 +46,7 @@ function resolveSessionKeyFromPath(pathname: string): SessionKeyPathResolution {
   }
 }
 
+/** Handles subagent kill requests for local admins or the owning requester session. */
 export async function handleSessionKillHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -103,6 +105,8 @@ export async function handleSessionKillHttpRequest(
     return true;
   }
 
+  // Requester-scoped kills abort only runs controlled by that requester; local
+  // admin kills use the stronger delete scope and can terminate by child key.
   const requiredOperatorMethod =
     requesterSessionKey && !allowLocalAdminKill ? "sessions.abort" : "sessions.delete";
   const scopeAuth = authorizeOperatorScopesForMethod(requiredOperatorMethod, requestedScopes);

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -118,6 +118,7 @@ function resolveRuntimeMs(params: {
   return undefined;
 }
 
+/** Projects an agent lifecycle event into the in-memory Gateway session row fields. */
 export function deriveGatewaySessionLifecycleSnapshot(params: {
   session?: Partial<LifecycleSessionShape> | null;
   event: LifecycleEventLike;
@@ -158,6 +159,7 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
   };
 }
 
+/** Converts a lifecycle event into the session-store patch shape, dropping invalid timestamps. */
 export function derivePersistedSessionLifecyclePatch(params: {
   entry?: Partial<PersistedLifecycleSessionShape> | null;
   event: LifecycleEventLike;
@@ -188,6 +190,7 @@ export function isStaleLifecycleEventForSession(params: {
   );
 }
 
+/** Persists a lifecycle event for one session key while guarding reset-rotated rows. */
 export async function persistGatewaySessionLifecycleEvent(params: {
   sessionKey: string;
   agentId?: string;

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -47,6 +47,8 @@ function resolveLifecyclePhase(event: LifecycleEventLike): LifecyclePhase | null
 function mapAgentRunTerminalOutcomeToSessionStatus(
   outcome: AgentRunTerminalOutcome,
 ): SessionRunStatus {
+  // Keep Gateway session status names stable while sharing terminal-outcome
+  // classification with agent-run tracking.
   switch (outcome.reason) {
     case "completed":
       return "done";
@@ -66,6 +68,8 @@ function mapAgentRunTerminalOutcomeToSessionStatus(
 
 function resolveTerminalStatus(event: LifecycleEventLike): SessionRunStatus {
   const phase = resolveLifecyclePhase(event);
+  // Lifecycle events do not carry a ready-made terminal outcome; rebuild the
+  // same normalized outcome used by run tracking before projecting session rows.
   const terminal = buildAgentRunTerminalOutcome({
     status: phase === "error" ? "error" : event.data?.aborted === true ? "timeout" : "ok",
     error: event.data?.error,
@@ -83,6 +87,8 @@ function resolveLifecycleStartedAt(
   existingStartedAt: number | undefined,
   event: LifecycleEventLike,
 ): number | undefined {
+  // Prefer the provider/run timestamp, then the existing row, then event time so
+  // late terminal events do not erase an earlier real start.
   if (isFiniteTimestamp(event.data?.startedAt)) {
     return event.data.startedAt;
   }
@@ -108,6 +114,8 @@ function resolveRuntimeMs(params: {
   if (isFiniteTimestamp(startedAt) && isFiniteTimestamp(endedAt)) {
     return Math.max(0, endedAt - startedAt);
   }
+  // Preserve existing duration when a partial event lacks enough timing data;
+  // lifecycle projection should not make a previously measured run look unknown.
   if (
     typeof existingRuntimeMs === "number" &&
     Number.isFinite(existingRuntimeMs) &&
@@ -145,9 +153,10 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
   const startedAt = resolveLifecycleStartedAt(existing?.startedAt, params.event);
   const endedAt = resolveLifecycleEndedAt(params.event);
   const updatedAt = endedAt ?? existing?.updatedAt;
+  const status = resolveTerminalStatus(params.event);
   return {
     updatedAt,
-    status: resolveTerminalStatus(params.event),
+    status,
     startedAt,
     endedAt,
     runtimeMs: resolveRuntimeMs({
@@ -155,7 +164,7 @@ export function deriveGatewaySessionLifecycleSnapshot(params: {
       endedAt,
       existingRuntimeMs: existing?.runtimeMs,
     }),
-    abortedLastRun: resolveTerminalStatus(params.event) === "killed",
+    abortedLastRun: status === "killed",
   };
 }
 

--- a/src/gateway/session-patch-hooks.ts
+++ b/src/gateway/session-patch-hooks.ts
@@ -8,6 +8,7 @@ import {
   type SessionPatchHookEvent,
 } from "../hooks/internal-hooks.js";
 
+/** Emits cloned session patch context to internal hooks after persisted session updates. */
 export function triggerSessionPatchHook(params: {
   cfg: OpenClawConfig;
   sessionEntry: SessionEntry;
@@ -18,6 +19,8 @@ export function triggerSessionPatchHook(params: {
     return;
   }
 
+  // Clone mutable session/patch data before async hook delivery so listeners see
+  // the persisted patch snapshot, not later in-process mutations of the entry.
   const hookContext: SessionPatchHookContext = structuredClone({
     sessionEntry: params.sessionEntry,
     patch: params.patch,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -116,6 +116,7 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
   };
 }
 
+/** Archives transcripts for reset/delete callers that only need destination paths. */
 export function archiveSessionTranscriptsForSession(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -127,6 +128,7 @@ export function archiveSessionTranscriptsForSession(params: {
   return archiveSessionTranscriptsForSessionDetailed(params).map((entry) => entry.archivedPath);
 }
 
+/** Archives the stable transcript set and preserves source/destination metadata for hooks. */
 export function archiveSessionTranscriptsForSessionDetailed(params: {
   sessionId: string | undefined;
   storePath: string;
@@ -148,6 +150,7 @@ export function archiveSessionTranscriptsForSessionDetailed(params: {
   });
 }
 
+/** Emits best-effort `session_end` plugin hooks and forgets the shutdown drain entry. */
 export function emitGatewaySessionEndPluginHook(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -202,6 +205,7 @@ export function emitGatewaySessionEndPluginHook(params: {
   });
 }
 
+/** Emits best-effort `session_start` hooks and registers the session for shutdown finalization. */
 export function emitGatewaySessionStartPluginHook(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -333,6 +337,7 @@ export async function drainActiveSessionsForShutdown(params: {
   }
 }
 
+/** Unbinds a session target and optionally emits the matching child-session lifecycle hook. */
 export async function emitSessionUnboundLifecycleEvent(params: {
   targetSessionKey: string;
   reason: "session-reset" | "session-delete";
@@ -645,6 +650,7 @@ async function closeChildAcpRuntimesForParent(params: {
   );
 }
 
+/** Clears runtime resources that must be stopped before a reset/delete mutates persisted state. */
 export async function cleanupSessionBeforeMutation(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -691,6 +697,7 @@ export async function cleanupSessionBeforeMutation(params: {
   return parentAcpError;
 }
 
+/** Fires the legacy before-reset plugin hook with a best-effort full transcript snapshot. */
 export async function emitGatewayBeforeResetPluginHook(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -742,6 +749,7 @@ export async function emitGatewayBeforeResetPluginHook(params: {
     });
 }
 
+/** Resolves, cleans, rotates, and announces a Gateway session reset/new-session mutation. */
 export async function performGatewaySessionReset(params: {
   key: string;
   agentId?: string;
@@ -755,6 +763,8 @@ export async function performGatewaySessionReset(params: {
     const cfg = getRuntimeConfig();
     const explicitAgentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
     const parsedKey = parseAgentSessionKey(params.key);
+    // Global stores can still receive agent-prefixed session keys; infer the
+    // agent from the key only when the caller did not already pin `agentId`.
     const inferredGlobalAgentId =
       !explicitAgentId &&
       parsedKey &&
@@ -946,6 +956,8 @@ export async function performGatewaySessionReset(params: {
     return nextEntry;
   });
   if (pendingAcpResetMeta) {
+    // ACP reset creates fresh pending metadata for the logical session key; move
+    // it under the newly rotated session id before hooks observe the new entry.
     writeAcpSessionMetaForMigration({
       sessionKey: pendingAcpResetMeta.sessionKey,
       sessionId: next.sessionId,
@@ -968,6 +980,8 @@ export async function performGatewaySessionReset(params: {
     agentId: target.agentId,
     reason: "reset",
   });
+  // Create the replacement transcript before start/end hooks so plugin payloads
+  // can reference both the archived old transcript and the fresh destination.
   fs.mkdirSync(path.dirname(next.sessionFile as string), { recursive: true });
   if (!fs.existsSync(next.sessionFile as string)) {
     const header = {

--- a/src/gateway/session-store-key.ts
+++ b/src/gateway/session-store-key.ts
@@ -17,6 +17,7 @@ import {
 } from "../routing/session-key.js";
 import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
 
+/** Prefixes a bare session key with the owning agent while preserving global sentinels. */
 export function canonicalizeSessionKeyForAgent(agentId: string, key: string): string {
   const lowered = normalizeLowercaseStringOrEmpty(key);
   if (lowered === "global" || lowered === "unknown") {
@@ -38,6 +39,9 @@ function shouldRemapLegacyDefaultMainAlias(
   parsed: ParsedAgentSessionKey,
   options?: { storeAgentId?: string },
 ): boolean {
+  // Older stores used agent:main:main for the default agent. When the configured
+  // default moved away from "main", remap only the legacy main alias, not every
+  // agent:main:* key that may represent a deleted agent's real session.
   const agentId = normalizeAgentId(parsed.agentId);
   if (agentId !== DEFAULT_AGENT_ID || listAgentIds(cfg).includes(DEFAULT_AGENT_ID)) {
     return false;
@@ -68,6 +72,7 @@ function resolveParsedSessionStoreKey(
   return { agentId, sessionKey: `agent:${agentId}:${rest}` };
 }
 
+/** Resolves any user-facing session key into the canonical persisted store key. */
 export function resolveSessionStoreKey(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -107,6 +112,7 @@ export function resolveSessionStoreKey(params: {
   return canonicalizeSessionKeyForAgent(agentId, raw);
 }
 
+/** Returns the owning agent id for a canonical store key, defaulting sentinels to the store owner. */
 export function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): string {
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     return resolveDefaultStoreAgentId(cfg);
@@ -118,6 +124,7 @@ export function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: st
   return resolveDefaultStoreAgentId(cfg);
 }
 
+/** Resolves a session key as viewed from a specific agent-scoped store. */
 export function resolveStoredSessionKeyForAgentStore(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -139,6 +146,7 @@ export function resolveStoredSessionKeyForAgentStore(params: {
   });
 }
 
+/** Resolves the stored session owner, returning null for global/unknown sentinels. */
 export function resolveStoredSessionOwnerAgentId(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -151,6 +159,7 @@ export function resolveStoredSessionOwnerAgentId(params: {
   return resolveSessionStoreAgentId(params.cfg, canonicalKey);
 }
 
+/** Canonicalizes a spawned-by lineage key relative to the spawning agent. */
 export function canonicalizeSpawnedByForAgent(
   cfg: OpenClawConfig,
   agentId: string,

--- a/src/gateway/session-subagent-reactivation.ts
+++ b/src/gateway/session-subagent-reactivation.ts
@@ -1,9 +1,12 @@
 import { getLatestSubagentRunByChildSessionKey } from "../agents/subagent-registry-read.js";
 
 async function loadSessionSubagentReactivationRuntime() {
+  // Keep the writer/runtime module lazy so read-only session paths do not pull
+  // in subagent mutation dependencies unless a completed run is actually reused.
   return import("./session-subagent-reactivation.runtime.js");
 }
 
+/** Replaces the latest completed subagent run after a follow-up steer creates a new run id. */
 export async function reactivateCompletedSubagentSession(params: {
   sessionKey: string;
   runId?: string;

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -16,6 +16,7 @@ import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 
 type ArchiveFileReason = SessionArchiveReason;
+/** Archive move result that preserves both the original transcript and archive path. */
 export type ArchivedSessionTranscript = {
   sourcePath: string;
   archivedPath: string;
@@ -69,6 +70,7 @@ function canonicalizePathForComparison(filePath: string): string {
   }
 }
 
+/** Returns transcript path candidates ordered from most-specific current path to fallbacks. */
 export function resolveSessionTranscriptCandidates(
   sessionId: string,
   storePath: string | undefined,
@@ -125,6 +127,7 @@ export function resolveSessionTranscriptCandidates(
   return uniqueStrings(candidates);
 }
 
+/** Renames one transcript file into an archive suffix and emits the transcript mutation event. */
 export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): string {
   const ts = formatSessionArchiveTimestamp();
   const archived = `${filePath}.${reason}.${ts}`;
@@ -142,6 +145,7 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
   return archived;
 }
 
+/** Archives matching transcript candidates and returns only the archived file paths. */
 export function archiveSessionTranscripts(opts: {
   sessionId: string;
   storePath: string | undefined;
@@ -158,6 +162,7 @@ export function archiveSessionTranscripts(opts: {
   return archiveSessionTranscriptsDetailed(opts).map((entry) => entry.archivedPath);
 }
 
+/** Archives matching transcript candidates while preserving source-to-archive mapping. */
 export function archiveSessionTranscriptsDetailed(opts: {
   sessionId: string;
   storePath: string | undefined;
@@ -208,6 +213,7 @@ export function archiveSessionTranscriptsDetailed(opts: {
   return archived;
 }
 
+/** Chooses the transcript path a completed/deleted session should report to downstream code. */
 export function resolveStableSessionEndTranscript(params: {
   sessionId: string;
   storePath: string | undefined;
@@ -247,6 +253,7 @@ export function resolveStableSessionEndTranscript(params: {
   return {};
 }
 
+/** Removes old archive files for one archive reason and reports scan/removal counts. */
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   olderThanMs: number;

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -9,6 +9,7 @@ const TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER = "[chat.history omitted: message
 
 type ParsedTranscriptRecord = Record<string, unknown>;
 
+/** One visible transcript record with byte offsets for targeted indexed reads. */
 export type IndexedTranscriptEntry = {
   seq: number;
   id?: string;
@@ -119,6 +120,7 @@ function setCachedIndex(filePath: string, entry: CacheEntry): void {
   }
 }
 
+/** Clears transcript index caches for tests that rewrite transcript files in place. */
 export function clearSessionTranscriptIndexCache(): void {
   transcriptIndexCache.clear();
   transcriptIndexBuilds.clear();
@@ -141,6 +143,9 @@ function buildOversizedIndexedRawEntry(params: {
   offset: number;
   byteLength: number;
 }): IndexedRawEntry | null {
+  // Oversized transcript lines cannot be fully parsed without risking large
+  // allocations, but history pagination still needs id/parent metadata and a
+  // visible placeholder so the sequence remains stable.
   const prefix = params.line.slice(0, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS);
   const messageMatch = /"message"\s*:/.exec(prefix);
   const recordPrefix = messageMatch ? prefix.slice(0, messageMatch.index) : prefix;
@@ -218,6 +223,9 @@ function buildActiveTreeEntries(params: {
   byId: Map<string, IndexedRawEntry>;
   leafId?: string;
 }): IndexedRawEntry[] {
+  // Tree-style transcripts keep many branches; history views should follow only
+  // the active leaf chain. Cycles indicate corrupt metadata, so fall back to an
+  // empty active path instead of looping forever.
   const out: IndexedRawEntry[] = [];
   const seen = new Set<string>();
   let currentId = params.leafId;
@@ -323,6 +331,7 @@ async function buildSessionTranscriptIndex(
   };
 }
 
+/** Builds or reuses the transcript index for full/history/message-id reads. */
 export async function readSessionTranscriptIndex(
   filePath: string,
   opts: ReadSessionTranscriptIndexOptions = {},
@@ -347,6 +356,8 @@ export async function readSessionTranscriptIndex(
   }
   const inFlight = transcriptIndexBuilds.get(filePath);
   if (inFlight && inFlight.mtimeMs === stat.mtimeMs && inFlight.size === stat.size) {
+    // Share concurrent index builds for the same file snapshot; repeated history
+    // requests can otherwise fan out identical chunk scans.
     return await inFlight.promise;
   }
   const promise = buildSessionTranscriptIndex(filePath, stat);

--- a/src/gateway/session-transcript-key.ts
+++ b/src/gateway/session-transcript-key.ts
@@ -38,10 +38,12 @@ function sessionKeyMatchesTranscriptPath(params: {
   ).some((candidate) => resolveTranscriptPathForComparison(candidate) === params.targetPath);
 }
 
+/** Clears transcript-file lookup cache between tests that mutate runtime session stores. */
 export function clearSessionTranscriptKeyCacheForTests(): void {
   TRANSCRIPT_SESSION_KEY_CACHE.clear();
 }
 
+/** Resolves a transcript file path back to the freshest unambiguous gateway session key. */
 export function resolveSessionKeyForTranscriptFile(sessionFile: string): string | undefined {
   const targetPath = resolveTranscriptPathForComparison(sessionFile);
   if (!targetPath) {
@@ -81,6 +83,9 @@ export function resolveSessionKeyForTranscriptFile(sessionFile: string): string 
   }
 
   if (matchingEntries.length > 0) {
+    // Multiple store keys can point at the same transcript during migrations or
+    // agent-key aliases. Resolve each sessionId group first, then require one
+    // newest winner so callers do not attach artifacts to an ambiguous session.
     const matchesBySessionId = new Map<string, Array<[string, SessionEntry]>>();
     for (const entry of matchingEntries) {
       const sessionId = entry[1].sessionId;

--- a/src/gateway/session-transcript-path.ts
+++ b/src/gateway/session-transcript-path.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
+/** Resolves transcript paths to a stable comparable form, tolerating files not yet created. */
 export function resolveTranscriptPathForComparison(value: string | undefined): string | undefined {
   const trimmed = normalizeOptionalString(value);
   if (!trimmed) {
@@ -11,6 +12,8 @@ export function resolveTranscriptPathForComparison(value: string | undefined): s
   try {
     return fs.realpathSync(resolved);
   } catch {
+    // New transcripts may be compared before the file exists; path.resolve still
+    // canonicalizes relative input enough for candidate/update matching.
     return resolved;
   }
 }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -121,6 +121,7 @@ async function yieldTranscriptScan(): Promise<void> {
   });
 }
 
+/** Adds OpenClaw-only metadata to object messages without mutating the original value. */
 export function attachOpenClawTranscriptMeta(
   message: unknown,
   meta: Record<string, unknown>,
@@ -144,6 +145,7 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
+/** Reads all parsed transcript messages from the first matching session transcript. */
 export function readSessionMessages(
   sessionId: string,
   storePath: string | undefined,
@@ -159,12 +161,14 @@ export function readSessionMessages(
   return transcriptRecordsToMessages(readSelectedTranscriptRecords(filePath));
 }
 
+/** Bounds tail transcript reads by message count plus optional byte/line caps. */
 export type ReadRecentSessionMessagesOptions = {
   maxMessages: number;
   maxBytes?: number;
   maxLines?: number;
 };
 
+/** Selects between full indexed transcript reads and bounded recent tail reads. */
 export type ReadSessionMessagesAsyncOptions =
   | {
       mode: "full";
@@ -198,6 +202,7 @@ function normalizeRecentSessionReadOptions(opts?: Partial<ReadRecentSessionMessa
   return { maxMessages, maxBytes, maxLines };
 }
 
+/** Reads a bounded tail window of transcript messages without parsing the whole file. */
 export function readRecentSessionMessages(
   sessionId: string,
   storePath: string | undefined,
@@ -528,6 +533,7 @@ async function visitTranscriptLinesAsync(
   }
 }
 
+/** Visits all parsed transcript messages in sequence order and returns the count. */
 export function visitSessionMessages(
   sessionId: string,
   storePath: string | undefined,
@@ -546,6 +552,7 @@ export function visitSessionMessages(
   return messages.length;
 }
 
+/** Counts transcript messages, using file-stat cache when available. */
 export function readSessionMessageCount(
   sessionId: string,
   storePath: string | undefined,
@@ -572,6 +579,7 @@ export function readSessionMessageCount(
   return count;
 }
 
+/** Async transcript reader backed by the transcript index for full reads. */
 export async function readSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -590,6 +598,7 @@ export async function readSessionMessagesAsync(
   return index?.entries.flatMap((entry) => indexedTranscriptEntryToMessages(entry)) ?? [];
 }
 
+/** Looks up one indexed transcript message by id without parsing oversized lines. */
 export async function readSessionMessageByIdAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -615,6 +624,7 @@ export async function readSessionMessageByIdAsync(
   return { message, seq: entry.seq, oversized: false, found: true };
 }
 
+/** Async indexed message visitor with optional index-cache control. */
 export async function visitSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -639,6 +649,7 @@ export async function visitSessionMessagesAsync(
   return index.entries.length;
 }
 
+/** Async message count reader that reuses transcript-index metadata when possible. */
 export async function readSessionMessageCountAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -666,6 +677,7 @@ export async function readSessionMessageCountAsync(
   return count;
 }
 
+/** Reads recent messages and annotates each object message with its transcript sequence. */
 export function readRecentSessionMessagesWithStats(
   sessionId: string,
   storePath: string | undefined,
@@ -681,6 +693,7 @@ export function readRecentSessionMessagesWithStats(
   return { messages: messagesWithSeq, totalMessages };
 }
 
+/** Async bounded tail reader for recent transcript messages. */
 export async function readRecentSessionMessagesAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -713,6 +726,7 @@ export async function readRecentSessionMessagesAsync(
   return parseRecentTranscriptTailMessages(lines, maxMessages);
 }
 
+/** Async recent-message reader that also returns total transcript message count. */
 export async function readRecentSessionMessagesWithStatsAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -728,6 +742,7 @@ export async function readRecentSessionMessagesWithStatsAsync(
   return { messages: messagesWithSeq, totalMessages };
 }
 
+/** Reads the last transcript lines and reports total line count for diagnostics/previews. */
 export function readRecentSessionTranscriptLines(params: {
   sessionId: string;
   storePath: string | undefined;
@@ -818,6 +833,7 @@ export {
   resolveSessionTranscriptCandidates,
 } from "./session-transcript-files.fs.js";
 
+/** Keeps the newest array items that fit within a JSON byte budget. */
 export function capArrayByJsonBytes<T>(
   items: T[],
   maxBytes: number,
@@ -844,6 +860,7 @@ type TranscriptMessage = {
   provenance?: unknown;
 };
 
+/** Extracts title/source fields from transcript content without loading session store rows. */
 export function readSessionTitleFieldsFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -916,6 +933,7 @@ export function readSessionTitleFieldsFromTranscript(
   }
 }
 
+/** Async title/source extractor for indexed transcript scans. */
 export async function readSessionTitleFieldsFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1079,6 +1097,7 @@ function withOpenTranscriptFd<T>(filePath: string, read: (fd: number) => T | nul
   return null;
 }
 
+/** Returns the first user-visible transcript message for derived session titles. */
 export function readFirstUserMessageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1477,6 +1496,7 @@ function extractAggregateUsageFromTranscriptChunk(
   );
 }
 
+/** Reads aggregate usage from the full transcript for the latest list row snapshot. */
 export function readLatestSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1498,6 +1518,7 @@ export function readLatestSessionUsageFromTranscript(
   });
 }
 
+/** Async full-transcript usage reader for callers already on async paths. */
 export async function readLatestSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1526,6 +1547,7 @@ export async function readLatestSessionUsageFromTranscriptAsync(
   }
 }
 
+/** Async tail usage reader that aggregates usage from a bounded byte window. */
 export async function readRecentSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1554,6 +1576,7 @@ export async function readRecentSessionUsageFromTranscriptAsync(
   }
 }
 
+/** Async tail usage reader that returns the latest usage record in the bounded window. */
 export async function readLatestRecentSessionUsageFromTranscriptAsync(
   sessionId: string,
   storePath: string | undefined,
@@ -1582,6 +1605,7 @@ export async function readLatestRecentSessionUsageFromTranscriptAsync(
   }
 }
 
+/** Sync tail usage reader used by lightweight session listing. */
 export function readRecentSessionUsageFromTranscript(
   sessionId: string,
   storePath: string | undefined,
@@ -1806,6 +1830,7 @@ function readRecentMessagesFromTranscript(
   }
 }
 
+/** Builds redacted preview items from recent transcript messages for sessions.preview. */
 export function readSessionPreviewItemsFromTranscript(
   sessionId: string,
   storePath: string | undefined,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -927,6 +927,7 @@ export function resolveDeletedAgentIdFromSessionKey(
   return agentId;
 }
 
+/** Loads a session entry and its canonical/legacy keys from the resolved agent store. */
 export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; clone?: boolean }) {
   const cfg = getRuntimeConfig();
   const key = normalizeOptionalString(sessionKey) ?? "";
@@ -950,6 +951,7 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
   };
 }
 
+/** Chooses the newest entry among canonical and legacy store keys. */
 export function resolveFreshestSessionStoreMatchFromStoreKeys(
   store: Record<string, SessionEntry>,
   storeKeys: string[],
@@ -968,6 +970,7 @@ export function resolveFreshestSessionStoreMatchFromStoreKeys(
   return freshest;
 }
 
+/** Returns the newest entry among candidate store keys without exposing the matched key. */
 export function resolveFreshestSessionEntryFromStoreKeys(
   store: Record<string, SessionEntry>,
   storeKeys: string[],
@@ -1055,6 +1058,7 @@ export function pruneLegacyStoreKeys(params: {
   }
 }
 
+/** Promotes the freshest legacy entry to the canonical key and removes old aliases. */
 export function migrateAndPruneGatewaySessionStoreKey(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -1086,6 +1090,7 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
   return { target, primaryKey, entry: params.store[primaryKey] };
 }
 
+/** Classifies a stored session key for Control UI/session list grouping. */
 export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySessionRow["kind"] {
   if (key === "global") {
     return "global";
@@ -1102,6 +1107,7 @@ export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySe
   return "direct";
 }
 
+/** Parses channel/group session keys, including agent-prefixed keys. */
 export function parseGroupKey(
   key: string,
 ): { channel?: string; kind?: "group" | "channel"; id?: string } | null {
@@ -1467,6 +1473,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   };
 }
 
+/** Resolves canonical key, candidate aliases, owner agent, store path, and loaded store. */
 export function resolveGatewaySessionStoreTargetWithStore(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -1538,6 +1545,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   };
 }
 
+/** Resolves the session store target metadata without returning the loaded store object. */
 export function resolveGatewaySessionStoreTarget(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -1552,6 +1560,7 @@ export function resolveGatewaySessionStoreTarget(params: {
 
 export { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
 
+/** Resolves the effective thinking-level default for one session model/agent pair. */
 export function resolveGatewaySessionThinkingDefault(params: {
   cfg: OpenClawConfig;
   provider: string;
@@ -1573,6 +1582,7 @@ export function resolveGatewaySessionThinkingDefault(params: {
   );
 }
 
+/** Builds default model/thinking metadata included with Gateway sessions.list. */
 export function getSessionDefaults(
   cfg: OpenClawConfig,
   modelCatalog?: ModelCatalogEntry[],
@@ -1604,6 +1614,7 @@ export function getSessionDefaults(
   };
 }
 
+/** Resolves the runtime provider/model pair for a session entry or agent default. */
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -1657,6 +1668,7 @@ export function resolveSessionModelRef(
   return resolved;
 }
 
+/** Checks catalog-backed image support for the model selected by a Gateway session. */
 export async function resolveGatewayModelSupportsImages(params: {
   loadGatewayModelCatalog: (params?: { readOnly?: boolean }) => Promise<ModelCatalogEntry[]>;
   provider?: string;
@@ -1730,6 +1742,7 @@ export async function resolveGatewayModelSupportsImages(params: {
   }
 }
 
+/** Resolves the displayable model identity while preserving provider when it is known. */
 export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
@@ -1810,6 +1823,7 @@ function resolveSessionDisplayModelIdentityRefCached(params: {
   return value;
 }
 
+/** Converts CLI-provider display rows back to the underlying configured model identity. */
 export function resolveSessionDisplayModelIdentityRef(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -1849,6 +1863,7 @@ export function resolveSessionDisplayModelIdentityRef(params: {
   };
 }
 
+/** Builds the normalized Gateway session row used by list/info/Control UI callers. */
 export function buildGatewaySessionRow(params: {
   cfg: OpenClawConfig;
   storePath: string;

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -14,6 +14,7 @@ import type {
 } from "../shared/session-types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
+/** Default session model/thinking values returned with Gateway session lists. */
 export type GatewaySessionsDefaults = {
   modelProvider: string | null;
   model: string | null;
@@ -27,11 +28,13 @@ export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeo
 
 type SubagentRunState = "active" | "interrupted" | "historical";
 
+/** Lightweight checkpoint metadata shown in session rows without transcript payloads. */
 export type SessionCompactionCheckpointPreview = Pick<
   SessionCompactionCheckpoint,
   "checkpointId" | "createdAt" | "reason"
 >;
 
+/** Normalized session row shape returned by Gateway session list/info APIs. */
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
@@ -99,17 +102,20 @@ export type GatewaySessionRow = {
 
 export type GatewayAgentRow = SharedGatewayAgentRow;
 
+/** Redacted single-message preview item for session preview responses. */
 export type SessionPreviewItem = {
   role: "user" | "assistant" | "tool" | "system" | "other";
   text: string;
 };
 
+/** Preview status and items for one requested session key. */
 export type SessionsPreviewEntry = {
   key: string;
   status: "ok" | "empty" | "missing" | "error";
   items: SessionPreviewItem[];
 };
 
+/** Batched preview payload returned by Gateway sessions.preview. */
 export type SessionsPreviewResult = {
   ts: number;
   previews: SessionsPreviewEntry[];
@@ -117,6 +123,7 @@ export type SessionsPreviewResult = {
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
 
+/** Result shape for sessions.patch, including resolved runtime model fields. */
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;
   resolved?: {

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -41,6 +41,7 @@ const log = createSubsystemLogger("gateway/sessions-history-sse");
 
 const MAX_SESSION_HISTORY_LIMIT = 1000;
 
+/** Returns the decoded session key for `/sessions/:key/history`, or null for other paths. */
 function resolveSessionHistoryPath(req: IncomingMessage): string | null {
   const url = new URL(req.url ?? "/", "http://localhost");
   const match = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
@@ -63,6 +64,7 @@ function getRequestUrl(req: IncomingMessage): URL {
   return new URL(req.url ?? "/", "http://localhost");
 }
 
+/** Resolves a client-requested history limit while bounding transcript work. */
 function resolveLimit(req: IncomingMessage): number | undefined {
   const raw = getRequestUrl(req).searchParams.get("limit");
   if (raw == null || raw.trim() === "") {
@@ -81,6 +83,7 @@ function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
   res.write(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
+/** Handles JSON and SSE session history reads for the Gateway HTTP surface. */
 export async function handleSessionHistoryHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -139,6 +142,8 @@ export async function handleSessionHistoryHttpRequest(
   const limit = resolveLimit(req);
   const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
   const effectiveMaxChars = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  // First-page reads can use the transcript tail directly; cursor pagination
+  // still needs the full transcript so offsets remain stable across pages.
   const boundedSnapshot =
     cursor === undefined && typeof limit === "number"
       ? await readRecentSessionMessagesWithStatsAsync(
@@ -252,6 +257,8 @@ export async function handleSessionHistoryHttpRequest(
   };
 
   const isStreamStillAuthorized = async (): Promise<boolean> => {
+    // SSE streams are long-lived, so each heartbeat/update rechecks current auth
+    // and closes the stream if the token or scopes were revoked after connect.
     const cfgLocal = getRuntimeConfig();
     const currentRequestAuth = await checkGatewayHttpRequestAuth({
       req,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -129,6 +129,7 @@ function normalizeSubagentControlScope(raw: string): "children" | "none" | undef
   return undefined;
 }
 
+/** Applies a validated sessions.patch payload to one store entry without writing the store. */
 export async function applySessionsPatchToStore(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -18,6 +18,7 @@ import {
   resolveGatewaySessionStoreTarget,
 } from "./session-utils.js";
 
+/** Canonical session-key resolution result shared by Gateway methods and agent tools. */
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
 
 function resolveSessionVisibilityFilterOptions(p: SessionsResolveParams) {
@@ -90,6 +91,7 @@ function findVisibleSessionIdMatches(params: {
   );
 }
 
+/** Resolves key/sessionId/label selectors to one visible canonical session key. */
 export async function resolveSessionKeyFromResolveParams(params: {
   cfg: OpenClawConfig;
   p: SessionsResolveParams;


### PR DESCRIPTION
## Summary
- Document gateway client reconnect-pause metadata, request-error wrapper, and close-code hint contracts.
- Document timeout resolver behavior in both the reusable gateway-client package and OpenClaw runtime wrapper.
- Document device-auth signing payload builders and the auth-vs-policy metadata normalization split.
- Document MCP loopback protocol constants, JSON-RPC builders, safe tool-name reads, and tool-schema union flattening.
- Document node pairing auto-approval reasons, client-IP source classification, and first-time-node-only CIDR policy.
- Document gateway server utility contracts for voice-wake trigger normalization and compact error formatting.
- Document gateway probe target resolution and remote-mode fallback reporting.
- Document transcript-file to session-key lookup cache and ambiguity handling.
- Document run-id to session-key lookup cache, agent-scope filtering, and miss-race behavior.
- Document session-store key canonicalization, default-agent alias remapping, and lineage key handling.
- Document process-local approval runtime token generation and timing-safe validation.
- Document hook agent allowlist wildcard and unrestricted-routing policy.
- Document explicit Gateway config-bypass policy for direct URL/auth calls and cron command paths.
- Document public operator scope vocabulary and runtime scope allowlist invariants.
- Document Gateway auth-token resolution precedence and env/config conflict diagnostics.
- Document Gateway auth SecretRef materialization clone boundary and active-ref ordering.
- Document shared HTTP response/body/SSE/disconnect helper contracts.
- Document Gateway HTTP auth helper APIs and scope-resolution variants.
- Document shared Gateway POST+JSON endpoint dispatch helper contract.
- Document Gateway live-state and Control UI bootstrap contracts.
- Document channel plugin reload target matching contracts.
- Document Gateway cron failure/completion notification dispatch contracts.
- Document Gateway model-catalog cache refresh and invalidation contracts.
- Document channel status patch helpers and assistant stream text extraction.
- Document channel health policy evaluation and restart-reason contracts.
- Document Gateway connection detail resolution contracts.
- Document Gateway config reload settings normalization.
- Document Gateway model-pricing enablement default.
- Document MCP loopback runtime publication and token-selection helpers.
- Document Control UI CSP hash/header helpers.
- Document Control UI HTTP method/response helpers.
- Document Control UI link resolution for operator output.
- Document Control UI routing and shared avatar/base-path helper contracts.
- Document Gateway auth-mode ambiguity policy contracts.
- Document Gateway install auth-token requirement policy contracts.
- Document Gateway auth-token source conflict diagnostic contracts.
- Document Gateway client bootstrap URL/auth provenance contracts.
- Document Gateway chat envelope sanitizer contracts.
- Document Gateway chat attachment parsing/offload contracts.
- Document Gateway chat abort lifecycle contracts.
- Document Gateway chat display projection and history sanitizer contracts.
- Document Gateway direct child-session helper contracts.
- Document Gateway session history snapshot and SSE state contracts.
- Document Gateway session lifecycle projection and persistence contracts.
- Document Gateway session transcript archive/path helper contracts.
- Document Gateway compaction checkpoint helper contracts.
- Document Gateway session resolver result and selector contracts.
- Document Gateway session patch helper contract.
- Document Gateway session reset lifecycle helper contracts.
- Document Gateway session HTTP, patch-hook, and reactivation helper contracts.
- Document Gateway session runtime tracker and transcript path helper contracts.
- Document Gateway session utility row/default/store/model contracts.
- Document Gateway transcript reader, usage, and preview helper contracts.
- Document Gateway transcript index cache and active-tree contracts.
- Document Gateway session method and Talk session mode/ownership contracts.
- Document Gateway node/session event runtime fanout contracts.
- Document Gateway session history/lifecycle state projection contracts.
- Document Gateway node subscription, chat-run, subscriber, and Talk-node registry contracts.
- Document Gateway node registry invoke/event authorization contracts.
- Document Gateway node event dedupe/persistence, pending-action, Talk PTT, and invoke-result compatibility contracts.
- Document Gateway request-context, embedded local context, and shared node-method error helper contracts.
- Document Gateway node pending-work queue, drain, ack, and wake-staging contracts.
- Document Gateway websocket auth fallback, locality, rate-limit, and signature-version helper contracts.
- Document Gateway websocket auth failure-message, log-limiter, and unauthorized-flood contracts.
- Document Gateway websocket shared-generation, preauth-budget, close-reason, and runtime adapter contracts.
- Document Gateway websocket lazy handler loading, budget release, stale-node disconnect, and client registration contracts.
- Document Gateway websocket shared-auth generation, trusted-proxy scope, and pairing recovery contracts.
- Document Gateway server helper event-loop/readiness, hook dispatch/auth, plugin route auth, and plugin node-capability contracts.
- Document Gateway plugin HTTP dispatch registry, route fallthrough, runtime-scope injection, and upgrade rejection contracts.
- Document Gateway auth rate-limit, connection credential, and interactive/probe auth-surface resolution contracts while removing stale file-header commentary.
- Document Gateway shared-secret, trusted-proxy, browser-origin, and Tailscale auth branch contracts.
- Document Gateway HTTP pipeline probe redaction, plugin auth/dispatch context, stage routing, and liveness contracts.
- Document Gateway exec approval lifecycle, id lookup, and system.run replay guard contracts.

## Verification
- `git diff --check`
- `pnpm test packages/gateway-client/src/client.watchdog.test.ts packages/gateway-client/src/timeouts.test.ts src/gateway/client.test.ts src/tui/gateway-chat.test.ts`
- `pnpm test src/gateway/device-auth.test.ts src/gateway/node-command-policy.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`
- `pnpm test src/gateway/node-pairing-auto-approve.test.ts src/gateway/server.node-pairing-auto-approve.test.ts src/gateway/server.node-pairing-authz.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/probe-auth.test.ts`
- `pnpm test src/gateway/session-transcript-key.test.ts`
- `pnpm test src/gateway/server-session-key.test.ts src/gateway/server-methods/artifacts.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
- `pnpm test src/gateway/session-utils.test.ts`
- `pnpm test src/gateway/operator-approvals-client.test.ts src/agents/tools/gateway.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts`
- `pnpm test src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts src/security/audit-hooks-routing.test.ts`
- `pnpm test src/gateway/call.test.ts src/cli/command-path-policy.test.ts`
- `pnpm test src/gateway/method-scopes.test.ts src/agents/tools/gateway.test.ts`
- `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/status.scan.config-shared.test.ts src/security/audit-gateway.test.ts src/commands/doctor-security.test.ts`
- `pnpm test src/gateway/startup-auth.test.ts src/pairing/setup-code.test.ts src/gateway/call.test.ts`
- `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts`
- `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.authorize-request.test.ts src/gateway/http-endpoint-helpers.test.ts`
- `pnpm test src/gateway/http-endpoint-helpers.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts`
- `pnpm test src/gateway/server-request-context.test.ts src/gateway/control-ui.http.test.ts`
- `pnpm test src/gateway/plugin-channel-reload-targets.test.ts src/gateway/server-aux-handlers.test.ts`
- `pnpm test src/gateway/server-cron-notifications.test.ts src/gateway/server.cron.test.ts`
- `pnpm test src/gateway/server-model-catalog.test.ts`
- `pnpm test src/gateway/channel-status-patches.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`
- `pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/server.health.test.ts src/gateway/server-methods/channels.status.test.ts`
- `pnpm test src/gateway/call.test.ts src/gateway/client-bootstrap.test.ts src/commands/status.scan.shared.test.ts src/cli/capability-cli.test.ts`
- `pnpm test src/gateway/config-reload.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts`
- `pnpm test src/gateway/model-pricing-cache.test.ts src/gateway/server-runtime-services.test.ts src/commands/health.test.ts`
- `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts src/agents/cli-runner/prepare.test.ts`
- `pnpm test src/gateway/control-ui-csp.test.ts src/gateway/control-ui.http.test.ts`
- `pnpm test src/gateway/control-ui-routing.test.ts src/gateway/control-ui.http.test.ts`
- `pnpm test src/commands/onboard-helpers.test.ts src/commands/dashboard.test.ts src/cli/daemon-cli/status.print.test.ts`
- `pnpm test src/gateway/control-ui-routing.test.ts src/gateway/control-ui.http.test.ts src/commands/onboard-helpers.test.ts src/commands/status.scan.shared.test.ts`
- `pnpm test src/gateway/auth-mode-policy.test.ts src/gateway/startup-auth.test.ts src/commands/gateway-install-token.test.ts`
- `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/gateway-install-token.test.ts`
- `pnpm test src/commands/status.scan.config-shared.test.ts src/commands/doctor-security.test.ts src/security/audit-gateway.test.ts`
- `pnpm test src/gateway/client-bootstrap.test.ts src/gateway/call.test.ts src/gateway/operator-approvals-client.test.ts`
- `pnpm test src/gateway/chat-sanitize.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm test src/gateway/chat-attachments.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts`
- `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/models-auth-status.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/session-child-sessions.test.ts`
- `pnpm test src/gateway/session-history-state.test.ts`
- `pnpm test src/gateway/session-lifecycle-state.test.ts`
- `pnpm test src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-utils.fs.test.ts`
- `pnpm test src/gateway/session-compaction-checkpoints.test.ts`
- `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts src/agents/tools/embedded-gateway-stub.test.ts`
- `pnpm test src/gateway/sessions-patch.test.ts src/tui/embedded-backend.test.ts`
- `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server-close.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts`
- `pnpm test src/gateway/session-kill-http.test.ts src/gateway/sessions-history-http.revocation.test.ts src/gateway/session-subagent-reactivation.test.ts`
- `pnpm test src/gateway/active-sessions-shutdown-tracker.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server-methods/agent.create-event.test.ts src/gateway/sessions-history-http.revocation.test.ts`
- `pnpm test src/gateway/session-utils.test.ts src/gateway/session-utils.plugin-runtime.test.ts src/gateway/session-utils.subagent.test.ts`
- `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts`
- `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm test src/gateway/server.sessions.list-changed.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/gateway/server-methods/sessions.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/talk.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/session-message-events.test.ts`
- `pnpm test src/gateway/session-history-state.test.ts src/gateway/session-lifecycle-state.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server-talk-nodes.test.ts src/gateway/server-chat.agent-events.test.ts`
- `pnpm test src/gateway/node-registry.test.ts src/gateway/server-node-events.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts`
- `pnpm test src/gateway/server-node-events.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/server-request-context.test.ts src/gateway/local-request-context.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/push.test.ts src/gateway/server-methods/environments.test.ts`
- `pnpm test src/gateway/node-pending-work.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts`
- `pnpm test src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server/ws-connection/auth-context.state.test.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- `pnpm test src/gateway/server/ws-connection/auth-messages.test.ts src/gateway/server/ws-connection/unauthorized-flood-guard.test.ts src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts`
- `pnpm test src/gateway/server/ws-shared-generation.test.ts src/gateway/server/preauth-connection-budget.test.ts src/gateway/server/ws-connection.test.ts`
- `pnpm test src/gateway/server/ws-connection.test.ts src/gateway/server/ws-connection.startup.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts`
- `pnpm test src/gateway/server/ws-connection.test.ts src/gateway/server/ws-connection.startup.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`
- `pnpm test src/gateway/server-node-events.test.ts src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/server/event-loop-health.test.ts src/gateway/server/readiness.test.ts src/gateway/server/http-listen.test.ts src/gateway/server/hooks.agent-trust.test.ts src/gateway/server/plugin-route-runtime-scopes.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/server/plugins-http/route-capability.test.ts src/gateway/server/plugins-http.test.ts`
- `pnpm test src/gateway/server/plugins-http.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/server/plugin-route-runtime-scopes.test.ts src/gateway/server/plugins-http/route-capability.test.ts`
- `pnpm test src/gateway/auth-rate-limit.test.ts src/gateway/auth-surface-resolution.test.ts src/gateway/connection-auth.test.ts src/gateway/auth.test.ts`
- `pnpm test src/gateway/auth.test.ts src/gateway/auth-rate-limit.test.ts src/gateway/origin-check.test.ts src/gateway/net.test.ts`
- `pnpm test src/gateway/server-http.stages.test.ts src/gateway/server-http.probe.test.ts src/gateway/server-http.request-trace.test.ts src/gateway/server.plugin-http-auth.test.ts`
- `pnpm test src/gateway/exec-approval-manager.test.ts src/gateway/node-invoke-system-run-approval.test.ts src/gateway/node-invoke-system-run-approval-match.test.ts src/gateway/system-run-approval-binding.test.ts src/gateway/system-run-approval-binding.contract.test.ts`

## Real behavior proof
Behavior addressed: exported gateway client API contracts are now documented for reconnect pause callbacks, request error handling, close-code hints, connect challenge timeout resolution, device-auth signing payloads, metadata normalization, MCP loopback JSON-RPC/tool-schema handling, node pairing auto-approval policy, voice-wake trigger normalization, gateway error formatting, probe target resolution, transcript-file session lookup, run-id session-key lookup, session-store key canonicalization, approval runtime token validation, hook agent allowlist routing, explicit Gateway config-bypass policy, operator scope vocabulary, Gateway auth-token precedence diagnostics, Gateway auth SecretRef materialization, shared HTTP helpers, HTTP auth helper APIs, the POST+JSON endpoint dispatch helper, Gateway live state, Control UI bootstrap payloads, channel plugin reload target matching, cron notification dispatch, model-catalog cache refresh/invalidation, channel status patches, assistant stream text extraction, channel health policy evaluation, Gateway connection detail resolution, Gateway config reload settings normalization, model-pricing enablement, MCP loopback runtime publication/token selection, Control UI CSP hashing/header construction, Control UI HTTP method/response helpers, Control UI link resolution, Control UI routing/shared avatar/base-path helper contracts, Gateway auth-mode ambiguity policy contracts, Gateway install auth-token requirement policy contracts, Gateway auth-token source conflict diagnostic contracts, Gateway client bootstrap URL/auth provenance contracts, Gateway chat envelope sanitizer contracts, Gateway chat attachment parsing/offload contracts, Gateway chat abort lifecycle contracts, Gateway chat display projection contracts, Gateway direct child-session helper contracts, Gateway session history snapshot/SSE state contracts, Gateway session lifecycle projection/persistence contracts, Gateway transcript archive/path helper contracts, Gateway compaction checkpoint helper contracts, Gateway session resolver selector contracts, Gateway session patch helper contract, Gateway session reset lifecycle helper contracts, Gateway session HTTP/reactivation helper contracts, Gateway session runtime tracker/path helper contracts, Gateway session utility row/default/store/model contracts, Gateway transcript reader/usage/preview helper contracts, Gateway transcript index cache/active-tree contracts, Gateway session method/Talk session mode and ownership contracts, Gateway node/session event runtime fanout contracts, Gateway session history/lifecycle state projection contracts, Gateway node subscription/chat-run/subscriber registry contracts, Gateway node registry invoke/event authorization contracts, Gateway server helper event-loop/readiness, hook dispatch/auth, plugin route auth, and plugin node-capability contracts, Gateway plugin HTTP dispatch registry, route fallthrough, runtime-scope injection, and upgrade rejection contracts, Gateway auth rate-limit/credential/surface resolution contracts, Gateway shared-secret/trusted-proxy/browser-origin/Tailscale auth branch contracts, Gateway HTTP pipeline probe redaction/plugin-stage/routing contracts, and Gateway exec approval lifecycle/replay guard contracts.
Real environment tested: local OpenClaw checkout on `codex/protocol-schema-comments-20260602`, rebased on `origin/main`.
Exact steps or command run after this patch: `git diff --check`; `pnpm test packages/gateway-client/src/client.watchdog.test.ts packages/gateway-client/src/timeouts.test.ts src/gateway/client.test.ts src/tui/gateway-chat.test.ts`; `pnpm test src/gateway/device-auth.test.ts src/gateway/node-command-policy.test.ts src/gateway/gateway-misc.test.ts`; `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts`; `pnpm test src/gateway/node-pairing-auto-approve.test.ts src/gateway/server.node-pairing-auto-approve.test.ts src/gateway/server.node-pairing-authz.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts`; `pnpm test src/gateway/probe-auth.test.ts`; `pnpm test src/gateway/session-transcript-key.test.ts`; `pnpm test src/gateway/server-session-key.test.ts src/gateway/server-methods/artifacts.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`; `pnpm test src/gateway/session-utils.test.ts`; `pnpm test src/gateway/operator-approvals-client.test.ts src/agents/tools/gateway.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts`; `pnpm test src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts src/security/audit-hooks-routing.test.ts`; `pnpm test src/gateway/call.test.ts src/cli/command-path-policy.test.ts`; `pnpm test src/gateway/method-scopes.test.ts src/agents/tools/gateway.test.ts`; `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/status.scan.config-shared.test.ts src/security/audit-gateway.test.ts src/commands/doctor-security.test.ts`; `pnpm test src/gateway/startup-auth.test.ts src/pairing/setup-code.test.ts src/gateway/call.test.ts`; `pnpm test src/gateway/http-common.test.ts src/gateway/http-common.fuzz.test.ts`; `pnpm test src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.authorize-request.test.ts src/gateway/http-endpoint-helpers.test.ts`; `pnpm test src/gateway/http-endpoint-helpers.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/embeddings-http.test.ts`; `pnpm test src/gateway/server-request-context.test.ts src/gateway/control-ui.http.test.ts`; `pnpm test src/gateway/plugin-channel-reload-targets.test.ts src/gateway/server-aux-handlers.test.ts`; `pnpm test src/gateway/server-cron-notifications.test.ts src/gateway/server.cron.test.ts`; `pnpm test src/gateway/server-model-catalog.test.ts`; `pnpm test src/gateway/channel-status-patches.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`; `pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/server.health.test.ts src/gateway/server-methods/channels.status.test.ts`; `pnpm test src/gateway/call.test.ts src/gateway/client-bootstrap.test.ts src/commands/status.scan.shared.test.ts src/cli/capability-cli.test.ts`; `pnpm test src/gateway/config-reload.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts`; `pnpm test src/gateway/model-pricing-cache.test.ts src/gateway/server-runtime-services.test.ts src/commands/health.test.ts`; `pnpm test src/gateway/mcp-http.test.ts src/gateway/gateway-cli-backend.live-probe-helpers.test.ts src/agents/cli-runner/prepare.test.ts`; `pnpm test src/gateway/control-ui-csp.test.ts src/gateway/control-ui.http.test.ts`; `pnpm test src/gateway/control-ui-routing.test.ts src/gateway/control-ui.http.test.ts`; `pnpm test src/commands/onboard-helpers.test.ts src/commands/dashboard.test.ts src/cli/daemon-cli/status.print.test.ts`; `pnpm test src/gateway/control-ui-routing.test.ts src/gateway/control-ui.http.test.ts src/commands/onboard-helpers.test.ts src/commands/status.scan.shared.test.ts`; `pnpm test src/gateway/auth-mode-policy.test.ts src/gateway/startup-auth.test.ts src/commands/gateway-install-token.test.ts`; `pnpm test src/commands/doctor-gateway-auth-token.test.ts src/commands/gateway-install-token.test.ts`; `pnpm test src/commands/status.scan.config-shared.test.ts src/commands/doctor-security.test.ts src/security/audit-gateway.test.ts`; `pnpm test src/gateway/client-bootstrap.test.ts src/gateway/call.test.ts src/gateway/operator-approvals-client.test.ts`; `pnpm test src/gateway/chat-sanitize.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`; `pnpm test src/gateway/chat-attachments.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts`; `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/models-auth-status.test.ts`; `pnpm test src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/session-child-sessions.test.ts`; `pnpm test src/gateway/session-history-state.test.ts`; `pnpm test src/gateway/session-lifecycle-state.test.ts`; `pnpm test src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/session-utils.fs.test.ts`; `pnpm test src/gateway/session-compaction-checkpoints.test.ts`; `pnpm test src/gateway/sessions-resolve.test.ts src/gateway/sessions-resolve-store.test.ts src/agents/tools/embedded-gateway-stub.test.ts`; `pnpm test src/gateway/sessions-patch.test.ts src/tui/embedded-backend.test.ts`; `pnpm test src/gateway/server.sessions.reset-hooks.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server-close.test.ts src/channels/plugins/acp-stateful-target-driver.test.ts`; `pnpm test src/gateway/session-kill-http.test.ts src/gateway/sessions-history-http.revocation.test.ts src/gateway/session-subagent-reactivation.test.ts`; `pnpm test src/gateway/active-sessions-shutdown-tracker.test.ts src/gateway/drain-active-sessions-for-shutdown.test.ts src/gateway/server-methods/agent.create-event.test.ts src/gateway/sessions-history-http.revocation.test.ts`; `pnpm test src/gateway/session-utils.test.ts src/gateway/session-utils.plugin-runtime.test.ts src/gateway/session-utils.subagent.test.ts`; `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts`; `pnpm test src/gateway/session-utils.fs.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`; `pnpm test src/gateway/server.sessions.list-changed.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/gateway/server-methods/sessions.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/talk.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts src/gateway/session-message-events.test.ts`; `pnpm test src/gateway/session-history-state.test.ts src/gateway/session-lifecycle-state.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server-talk-nodes.test.ts src/gateway/server-chat.agent-events.test.ts`; `pnpm test src/gateway/node-registry.test.ts src/gateway/server-node-events.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts`.
Evidence after fix: focused package/client, core wrapper, TUI gateway-chat, device-auth, node-command policy, gateway misc, MCP loopback HTTP, MCP live-probe helper, node pairing auto-approve/authz, probe auth, session transcript-key, server-session-key, artifacts, session abort-agent-scope, session-utils, operator approvals client, gateway tool, websocket post-connect health, hooks, server hooks, audit hooks routing, gateway call, CLI command-path, method-scope, doctor token, status scan config, audit gateway, doctor security, startup auth, pairing setup-code, HTTP common, HTTP request-context, HTTP authorize-request, HTTP endpoint helper, OpenAI HTTP, OpenResponses HTTP, embeddings HTTP, server request-context, Control UI HTTP, plugin channel reload-target, server aux-handler, cron notification, gateway cron, model-catalog, channel status/HTTP stream, channel health policy, connection details, client bootstrap, status scan, capability CLI, config reload, config write/shared-auth, model-pricing cache, runtime services, health, MCP HTTP, MCP live-probe helper, CLI prepare, Control UI CSP, Control UI routing, Control UI HTTP, onboard helper, dashboard, daemon status, auth-mode policy, startup auth, doctor gateway-token, gateway install-token, status scan config, doctor security, audit gateway, client bootstrap, gateway call, operator approvals client, chat sanitizer, chat directive-tag, chat attachments, gateway agent attachment, chat abort, chat abort authorization, model auth-status, server-methods display projection, session child helper, session history state, session lifecycle state, transcript archive events, session fs, compaction checkpoint, session resolver, embedded gateway stub, session patch, TUI embedded backend, reset-hook, shutdown-drain, server-close, ACP stateful target driver, session kill HTTP, session history revocation, subagent reactivation, active session shutdown tracker, session active-run projection, transcript path matching, session utility, plugin-runtime row, subagent session utility, transcript reader, transcript archive, usage, preview, transcript index, directive-tag reader, sessions list/change, session abort/send, Talk handler, gateway misc, session message-event, session history/lifecycle state, Talk-node, server chat agent-event, node-registry, server node-event, and node invoke/wake tests passed after the branch was rebased on current `origin/main`.
Observed result after fix: API comments are present on the shared package and core wrapper without adding file-header or import-area comments; device-auth metadata comments describe the reusable signing and policy contracts; MCP comments describe protocol negotiation and schema projection contracts; node pairing comments document the narrow auto-approval policy; server utility comments document bounded trigger normalization and diagnostic formatting; probe target comments document remote-mode fallback semantics; transcript lookup comments document cache reset and ambiguous-session handling; run-session lookup comments document miss caching and agent-scope filtering; session-store comments document persisted-key canonicalization and legacy default-agent alias handling; approval runtime comments document token generation and timing-safe validation; hook policy comments document wildcard/unrestricted routing semantics; explicit connection policy comments document when config loading and config guard bypasses are intentional; operator-scope comments document public scope meanings and the runtime allowlist invariant; auth-token comments document precedence and when env fallback/conflict warnings are intentional; auth-config comments document local materialization of active SecretRefs without mutating canonical config; HTTP helper comments document shared response, body-limit, SSE, and disconnect semantics; HTTP auth comments document reusable header parsing, auth metadata, scoped authorization, and shared-secret scope resolver variants; endpoint helper comments document path-delegation and auth-before-body ordering; live-state comments document startup-assembled runtime state and Control UI bootstrap contracts; reload-target comments document channel/plugin alias matching and exact/subpath config detection; cron notification comments document failure/completion dispatch contracts and non-blocking completion webhooks; model-catalog comments document cache invalidation and stale refresh publishing semantics; channel status and assistant stream comments document liveness patch semantics and delta-over-snapshot extraction; channel health comments document policy/result contracts and inherited transport timestamp handling; connection details comments document the resolved target/explanation shape and resolver-injected builder contract; reload-settings comments document normalized reload mode/debounce semantics; model-pricing config comments document default-enabled optional pricing refresh behavior; MCP loopback runtime comments document active runtime snapshots, owner/non-owner token selection, owner-token guarded cleanup, and env-placeholder server config; Control UI CSP comments document inline-script hash handling, attribute parsing, and restrictive header construction; Control UI HTTP comments document read-method routing and shared plain-text/not-found response helpers; Control UI link comments document operator-facing HTTP/WebSocket URL resolution across bind modes; auth-mode policy comments document the dual-credential ambiguity guard and SecretRef ownership invariant; install auth-policy comments document explicit mode decisions and durable service-env password inference; token-source conflict comments document shared audit/status fields and warning suppression invariants; client-bootstrap comments document URL provenance mapping and explicit override auth precedence; chat sanitizer comments document envelope stripping and sender-label attribution preservation; chat attachment comments document raw attachment, inline image, offloaded media-ref, parser, preflight, and legacy builder contracts; chat abort comments document stop matching, run expiry, registration, tracked adapters, provider metadata, and abort fanout contracts; chat display projection comments document history text limits, tool block detection, display sanitization, recent-message projection, and single-message projection contracts; child-session comments document direct lineage matching and non-recursive listing contracts; session-history comments document tail-window sizing, display-safe snapshots, SSE page state, inline append refresh behavior, and disk refresh contracts; lifecycle comments document event-to-row projection, persisted patch normalization, and reset-rotated row protection; transcript archive comments document candidate ordering, archive event emission, source-to-archive mapping, stable end-transcript selection, and archive cleanup counts; compaction checkpoint comments document retained-byte limits, reason mapping, tail leaf scans, checkpoint forks/capture/persist, cleanup, and lookup/list contracts; session resolver comments document the canonical key/error union and key/sessionId/label selector resolution contract; session patch comments document validated sessions.patch mutation without direct store writes; session reset comments document archive helper variants, start/end/unbind hook emission, cleanup-before-mutation, global-store agent inference, ACP reset metadata migration, and replacement transcript creation before lifecycle hooks; session HTTP comments document kill path handling, requester-vs-admin kill scopes, history path/limit handling, SSE auth rechecks, patch-hook cloning, and lazy completed-subagent reactivation; session runtime comments document shutdown finalization tracker APIs, global-session active-run agent matching, and transcript path comparison for not-yet-created files; session utility comments document public row/result types, canonical/legacy store lookup, default thinking/model resolution, image capability checks, and normalized Gateway session row construction; transcript reader comments document OpenClaw metadata attachment, full/recent/indexed reads, count caching, message id lookup, recent sequence annotations, usage snapshots, capped arrays, title extraction, and preview item construction; transcript index comments document visible indexed entries, cache clearing, oversized-line placeholders, active tree-chain selection, and shared in-flight index builds; session method comments document parent runtime inheritance, global-agent notifications, WebChat mutation blocking, checkpoint branch/restore selection, transcript creation, abort alias resolution, scoped abort ownership, send/steer delegation, preview store caching, main-DM reset semantics, child creation hooks, and Talk mode/transport/brain ownership checks; session event comments document node/session registry wiring, node delivery adapters, Talk presence snapshots, global message subscription fanout, session snapshot goal redaction, serialized transcript broadcasts, sequence fallback reads, display-safe message broadcasts, and sessions.changed fallback events; session state comments document exact cursor parsing, raw-tail pagination, duplicate live append refreshes, message-tool mirror seq attachment, hidden control-message refreshes, terminal outcome status mapping, lifecycle timestamp preference, and runtime preservation for partial lifecycle events; subscription comments document bidirectional node/session indexes, single-serialization fanout, node-level bypass broadcasts, chat-run FIFO ownership, run buffer cleanup, websocket subscriber reverse cleanup, tool-event recipient TTLs, and Talk-node capability detection; node-registry comments document serialized payload branding, reconnect-safe unregister, declared-surface narrowing, system.run authorization, legacy macOS fallback ambiguity, failed-invoke cleanup, raw event JSON embedding, and slow-consumer closure.
Latest slice proof: commit 896def06ad3 documents approval record publication, resolved-entry grace, one-shot consumption, prefix lookup ambiguity, backend chat replay binding, approved-plan rehydration, and allow-once replay protection on current origin/main.
What was not tested: no full suite or live gateway session; this is documentation-only code commentary.
