### PR TITLE
fix(plugins): isolate unreadable plugin tool descriptors

### DIFF
--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -16,6 +16,7 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 
 import {
   buildPluginToolDescriptorCacheKey,
+  capturePluginToolDescriptor,
   createPluginToolDescriptorConfigCacheKeyMemo,
   resetPluginToolDescriptorCache,
 } from "./tool-descriptor-cache.js";
@@ -167,5 +168,85 @@ describe("plugin tool descriptor cache keys", () => {
     });
 
     expect(firstKey).toBe(secondKey);
+  });
+
+  it("skips descriptors whose required tool fields are unreadable", () => {
+    const tool = {
+      name: "fuzzplugin_descriptor",
+      description: "descriptor probe",
+      get parameters() {
+        throw new Error("descriptor parameters getter exploded");
+      },
+      async execute() {
+        return { content: [] };
+      },
+    } as never;
+
+    expect(
+      capturePluginToolDescriptor({
+        pluginId: "fuzzplugin",
+        tool,
+        optional: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("skips descriptors whose required description is unreadable", () => {
+    const tool = {
+      name: "fuzzplugin_descriptor",
+      get description() {
+        throw new Error("descriptor description getter exploded");
+      },
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [] };
+      },
+    } as never;
+
+    expect(
+      capturePluginToolDescriptor({
+        pluginId: "fuzzplugin",
+        tool,
+        optional: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores unreadable optional descriptor metadata", () => {
+    const tool = {
+      name: "fuzzplugin_descriptor",
+      description: "descriptor probe",
+      get displaySummary() {
+        throw new Error("descriptor display getter exploded");
+      },
+      get label() {
+        throw new Error("descriptor label getter exploded");
+      },
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [] };
+      },
+    } as never;
+
+    expect(
+      capturePluginToolDescriptor({
+        pluginId: "fuzzplugin",
+        tool,
+        optional: false,
+      }),
+    ).toEqual({
+      optional: false,
+      descriptor: {
+        name: "fuzzplugin_descriptor",
+        description: "descriptor probe",
+        inputSchema: { type: "object", properties: {} },
+        owner: { kind: "plugin", pluginId: "fuzzplugin" },
+        executor: {
+          kind: "plugin",
+          pluginId: "fuzzplugin",
+          toolName: "fuzzplugin_descriptor",
+        },
+      },
+    });
   });
 });

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -137,27 +137,71 @@ export function buildPluginToolDescriptorCacheKey(params: {
   });
 }
 
-function asJsonObject(value: unknown): JsonObject {
-  return value as JsonObject;
+type ToolDescriptorFieldRead =
+  | {
+      readonly ok: true;
+      readonly value: unknown;
+    }
+  | { readonly ok: false };
+
+function readToolDescriptorField(
+  tool: AnyAgentTool,
+  field: keyof AnyAgentTool | "label" | "displaySummary",
+): ToolDescriptorFieldRead {
+  try {
+    return { ok: true, value: (tool as Record<string, unknown>)[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readOptionalDescriptorString(
+  tool: AnyAgentTool,
+  field: "label" | "displaySummary",
+): string | undefined {
+  const fieldRead = readToolDescriptorField(tool, field);
+  return fieldRead.ok && typeof fieldRead.value === "string" && fieldRead.value.trim()
+    ? fieldRead.value.trim()
+    : undefined;
+}
+
+function asJsonObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonObject)
+    : undefined;
 }
 
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
-}): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
-  const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+}): CachedPluginToolDescriptor | undefined {
+  const nameRead = readToolDescriptorField(params.tool, "name");
+  const parametersRead = readToolDescriptorField(params.tool, "parameters");
+  if (!nameRead.ok || typeof nameRead.value !== "string" || !nameRead.value.trim()) {
+    return undefined;
+  }
+  const inputSchema = parametersRead.ok ? asJsonObject(parametersRead.value) : undefined;
+  if (!inputSchema) {
+    return undefined;
+  }
+  const name = nameRead.value.trim();
+  const descriptionRead = readToolDescriptorField(params.tool, "description");
+  if (!descriptionRead.ok || typeof descriptionRead.value !== "string") {
+    return undefined;
+  }
+  const title = readOptionalDescriptorString(params.tool, "label");
+  const displaySummary = readOptionalDescriptorString(params.tool, "displaySummary");
   return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
+    ...(displaySummary ? { displaySummary } : {}),
     optional: params.optional,
     descriptor: {
-      name: params.tool.name,
+      name,
       ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
+      description: descriptionRead.value,
+      inputSchema,
       owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      executor: { kind: "plugin", pluginId: params.pluginId, toolName: name },
     },
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -163,6 +163,71 @@ function createMalformedTool(name: string) {
   };
 }
 
+function createUnreadableParametersTool(name: string) {
+  return {
+    name,
+    description: `${name} tool`,
+    get parameters() {
+      throw new Error("plugin parameters getter exploded");
+    },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }] };
+    },
+  };
+}
+
+function createUnreadableDescriptionTool(name: string) {
+  return {
+    name,
+    get description() {
+      throw new Error("plugin description getter exploded");
+    },
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }] };
+    },
+  };
+}
+
+function createUnreadableExecuteTool(name: string) {
+  return {
+    name,
+    description: `${name} tool`,
+    get execute() {
+      throw new Error("plugin execute getter exploded");
+    },
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createUnreadableLabelTool(name: string) {
+  return {
+    name,
+    description: `${name} tool`,
+    get label() {
+      throw new Error("plugin label getter exploded");
+    },
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }] };
+    },
+  };
+}
+
+function createUnreadableDisplaySummaryTool(name: string) {
+  return {
+    name,
+    description: `${name} tool`,
+    get displaySummary() {
+      throw new Error("plugin display summary getter exploded");
+    },
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }] };
+    },
+  };
+}
+
 function installConsoleMethodSpy(method: "log" | "warn") {
   const spy = vi.fn();
   loggingState.rawConsole = {
@@ -1936,6 +2001,70 @@ describe("resolvePluginTools optional tools", () => {
       registry.diagnostics,
       "plugin tool is malformed (schema-bug): broken_tool missing parameters object",
     );
+  });
+
+  it("skips plugin tools with unreadable schema fields while keeping valid sibling tools", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["fuzzplugin_descriptor", "valid_tool"],
+        factory: () => [
+          createUnreadableParametersTool("fuzzplugin_descriptor"),
+          makeTool("valid_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-bug): fuzzplugin_descriptor missing parameters object",
+    );
+  });
+
+  it.each([
+    {
+      name: "execute",
+      tool: createUnreadableExecuteTool("fuzzplugin_descriptor"),
+      expected:
+        "plugin tool is malformed (schema-bug): fuzzplugin_descriptor missing execute function",
+    },
+    {
+      name: "description",
+      tool: createUnreadableDescriptionTool("fuzzplugin_descriptor"),
+      expected:
+        "plugin tool is malformed (schema-bug): fuzzplugin_descriptor missing description string",
+    },
+    {
+      name: "label",
+      tool: createUnreadableLabelTool("fuzzplugin_descriptor"),
+      expected: "plugin tool is malformed (schema-bug): fuzzplugin_descriptor has unreadable label",
+    },
+    {
+      name: "display summary",
+      tool: createUnreadableDisplaySummaryTool("fuzzplugin_descriptor"),
+      expected:
+        "plugin tool is malformed (schema-bug): fuzzplugin_descriptor has unreadable displaySummary",
+    },
+  ])("skips plugin tools with unreadable $name while keeping valid sibling tools", (testCase) => {
+    const registry = setRegistry([
+      {
+        pluginId: "schema-bug",
+        optional: false,
+        source: "/tmp/schema-bug.js",
+        names: ["fuzzplugin_descriptor", "valid_tool"],
+        factory: () => [testCase.tool, makeTool("valid_tool")],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(registry.diagnostics, testCase.expected);
   });
 
   it("warns with plugin factory timing details when a factory is slow", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -107,12 +107,14 @@ function runWithPluginToolScope<T>(entry: PluginToolRegistration, run: () => T):
 }
 
 function isAgentTool(value: unknown): value is AnyAgentTool {
-  return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof (value as { execute?: unknown }).execute === "function"
-  );
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  try {
+    return typeof (value as { execute?: unknown }).execute === "function";
+  } catch {
+    return false;
+  }
 }
 
 function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTool): AnyAgentTool {
@@ -316,7 +318,11 @@ function readPluginToolName(tool: unknown): string {
     return "";
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  try {
+    return typeof tool.name === "string" ? tool.name.trim() : "";
+  } catch {
+    return "";
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -452,11 +458,39 @@ function describeMalformedPluginTool(tool: unknown): string | undefined {
   if (!name) {
     return "missing non-empty name";
   }
-  if (typeof tool.execute !== "function") {
+  let execute: unknown;
+  try {
+    execute = tool.execute;
+  } catch {
     return `${name} missing execute function`;
   }
-  if (!isRecord(tool.parameters)) {
+  if (typeof execute !== "function") {
+    return `${name} missing execute function`;
+  }
+  let description: unknown;
+  try {
+    description = tool.description;
+  } catch {
+    return `${name} missing description string`;
+  }
+  if (typeof description !== "string") {
+    return `${name} missing description string`;
+  }
+  let parameters: unknown;
+  try {
+    parameters = tool.parameters;
+  } catch {
     return `${name} missing parameters object`;
+  }
+  if (!isRecord(parameters)) {
+    return `${name} missing parameters object`;
+  }
+  for (const optionalField of ["label", "displaySummary"] as const) {
+    try {
+      void tool[optionalField];
+    } catch {
+      return `${name} has unreadable ${optionalField}`;
+    }
   }
   return undefined;
 }
@@ -1333,14 +1367,15 @@ export function resolvePluginTools(params: {
       });
       if (manifestPlugin) {
         const capturedDescriptors = capturedDescriptorsByPluginId.get(entry.pluginId) ?? [];
-        capturedDescriptors.push(
-          capturePluginToolDescriptor({
-            pluginId: entry.pluginId,
-            tool,
-            optional,
-          }),
-        );
-        capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        const capturedDescriptor = capturePluginToolDescriptor({
+          pluginId: entry.pluginId,
+          tool,
+          optional,
+        });
+        if (capturedDescriptor) {
+          capturedDescriptors.push(capturedDescriptor);
+          capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        }
       }
       tools.push(tool);
     }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Plugin tool descriptor capture and callback wrapping could read plugin-owned tool fields before malformed-tool isolation ran.
- A tool with a throwing `parameters`, `description`, `execute`, `label`, or `displaySummary` getter could crash descriptor capture or drop valid sibling tools.

Why does this matter now?

- This is another active ingress in the tool-schema crash class: a broken plugin tool should be quarantined, not poison the whole assistant/tool startup path.

What is the intended outcome?

- Required unreadable tool fields are reported as malformed plugin tools.
- Valid sibling plugin tools keep loading.
- Descriptor cache capture fails closed when required descriptor fields cannot be read.

What is intentionally out of scope?

- No plugin manifest/config behavior changes.
- No compatibility shim for malformed plugin tools.

What does success look like?

- Hostile plugin tool getters produce diagnostics or skipped descriptors instead of pre-content crashes.

What should reviewers focus on?

- `describeMalformedPluginTool(...)` and `isAgentTool(...)` in `src/plugins/tools.ts`.
- `capturePluginToolDescriptor(...)` fail-closed behavior in `src/plugins/tool-descriptor-cache.ts`.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #89381

Was this requested by a maintainer or owner?

- Maintainer fuzzing sweep for active tool-schema/plugin SDK crash surfaces.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unreadable plugin-owned tool fields should not crash descriptor capture or factory wrapping before malformed-tool isolation can report the offending tool.
- Real environment tested: local focused Node/Vitest proof plus Linux AWS Crabbox changed gate.
- Exact steps or command run after this patch:
  - `node --import tsx -e '...'` direct descriptor-capture probe with a throwing `parameters` getter.
  - `CI=1 node scripts/run-vitest.mjs src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts --reporter=dot`
  - `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tool-descriptor-cache.ts src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.ts src/plugins/tools.optional.test.ts`
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/tool-descriptor-cache.ts src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.ts src/plugins/tools.optional.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 30m --ttl 90m --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): direct descriptor-capture probe returned `true` for skipped descriptor instead of throwing; AWS Crabbox run `run_adaaa99b9b62`, lease `cbx_e033116251c2`, slug `jade-krill`, provider `aws`, exit 0.
- Observed result after fix: focused Vitest passed 2 files / 79 tests; formatting, targeted oxlint, branch autoreview, and remote changed gate passed.
- What was not tested: full local `pnpm check`/`pnpm test`; this Codex worktree uses linked pnpm state, so broad pnpm gates were run remotely.
- Proof limitations or environment constraints: direct AWS Crabbox was used for the changed gate; Blacksmith Testbox auth is unavailable in this local environment.
- Before evidence (optional but encouraged): direct pre-fix descriptor-capture probe threw `descriptor parameters getter exploded`; autoreview also found the pre-validation `execute` getter path.

## Tests and validation

Which commands did you run?

- `CI=1 node scripts/run-vitest.mjs src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tool-descriptor-cache.ts src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/tool-descriptor-cache.ts src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox changed gate: `run_adaaa99b9b62`, `cbx_e033116251c2`, exit 0.

What regression coverage was added or updated?

- Descriptor capture skips unreadable required fields.
- Descriptor capture ignores unreadable optional descriptor metadata.
- Plugin resolver skips unreadable `parameters`, `execute`, `description`, `label`, and `displaySummary` while keeping a valid sibling.

What failed before this fix, if known?

- Direct descriptor-capture probe crashed on a throwing `parameters` getter.
- Autoreview found `isAgentTool(...)` could read a throwing `execute` getter before malformed-tool validation.

If no test was added, why not?

- Tests were added in `src/plugins/tool-descriptor-cache.test.ts` and `src/plugins/tools.optional.test.ts`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Plugin tool loading and descriptor-cache behavior for malformed tools.

How is that risk mitigated?

- The change is fail-closed only for unreadable/malformed plugin tool fields.
- Existing valid sibling behavior is covered by resolver tests.
- AWS `check:changed` covered `core` and `coreTests`.

## Current review state

What is the next action?

- Draft PR ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- GitHub CI has not been observed yet after PR creation.
- Optional redacted local transcript was not included because it requires explicit approval.

Which bot or reviewer comments were addressed?

- Local autoreview findings were addressed and final branch autoreview was clean.
