### PR TITLE
fix(agents): dedupe transcript rewrite suffix replay

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -295,6 +295,179 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
     }
     expect(replayedAssistant.content).toEqual([{ type: "text", text: "summarized" }]);
   });
+
+  it("dedupes byte-identical replayed messages so suffix replay does not clone user entries", () => {
+    const sessionManager = SessionManager.inMemory();
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "anchor", timestamp: 1 }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: createTextContent("x".repeat(8_000)),
+        isError: false,
+        timestamp: 2,
+      }),
+      asAppendMessage({ role: "user", content: "duplicate user message", timestamp: 3 }),
+      asAppendMessage({ role: "user", content: "duplicate user message", timestamp: 3 }),
+      asAppendMessage({ role: "assistant", content: createTextContent("tail"), timestamp: 4 }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: entryIds[1],
+          message: createToolResultReplacement("read", "[externalized file_123]", 2),
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const duplicateCount = getBranchMessages(sessionManager).filter(
+      (message) => message.role === "user" && message.content === "duplicate user message",
+    ).length;
+    expect(duplicateCount).toBe(1);
+  });
+
+  it("keeps distinct compactions with identical summaries but different kept boundaries", () => {
+    const sessionManager = SessionManager.inMemory();
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: createTextContent("x".repeat(8_000)),
+        isError: false,
+        timestamp: 1,
+      }),
+      asAppendMessage({ role: "assistant", content: createTextContent("kept one"), timestamp: 2 }),
+      asAppendMessage({ role: "assistant", content: createTextContent("kept two"), timestamp: 3 }),
+    ]);
+    const keptOneId = entryIds[1];
+    const keptTwoId = entryIds[2];
+    // Two compactions sharing summary/tokens/details/fromHook but pointing at
+    // different kept boundaries must not collapse during replay.
+    sessionManager.appendCompaction("summary", keptOneId, 100);
+    sessionManager.appendCompaction("summary", keptTwoId, 100);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: entryIds[0],
+          message: createToolResultReplacement("read", "[externalized file_123]", 1),
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const compactions = sessionManager
+      .getBranch()
+      .filter((entry) => entry.type === "compaction");
+    expect(compactions).toHaveLength(2);
+    const keptBoundaries = new Set(
+      compactions.map((entry) => (entry.type === "compaction" ? entry.firstKeptEntryId : null)),
+    );
+    expect(keptBoundaries.size).toBe(2);
+  });
+
+  it("preserves legitimate repeated user messages that differ only by timestamp", () => {
+    const sessionManager = SessionManager.inMemory();
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "anchor", timestamp: 1 }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: createTextContent("x".repeat(8_000)),
+        isError: false,
+        timestamp: 2,
+      }),
+      asAppendMessage({ role: "user", content: "same question", timestamp: 3 }),
+      asAppendMessage({ role: "user", content: "same question", timestamp: 4 }),
+      asAppendMessage({ role: "assistant", content: createTextContent("tail"), timestamp: 5 }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: entryIds[1],
+          message: createToolResultReplacement("read", "[externalized file_123]", 2),
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    // Two genuine repeats (distinct timestamps) must both survive — only the
+    // byte-identical recovery clone is collapsed.
+    const repeated = getBranchMessages(sessionManager).filter(
+      (message) => message.role === "user" && message.content === "same question",
+    );
+    expect(repeated).toHaveLength(2);
+  });
+
+  it("preserves byte-identical repeated assistant and tool-result entries during replay", () => {
+    const sessionManager = SessionManager.inMemory();
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "anchor", timestamp: 1 }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: createTextContent("x".repeat(8_000)),
+        isError: false,
+        timestamp: 2,
+      }),
+      asAppendMessage({ role: "assistant", content: createTextContent("repeat"), timestamp: 3 }),
+      asAppendMessage({ role: "assistant", content: createTextContent("repeat"), timestamp: 3 }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_2",
+        toolName: "exec",
+        content: createTextContent("same output"),
+        isError: false,
+        timestamp: 4,
+      }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_2",
+        toolName: "exec",
+        content: createTextContent("same output"),
+        isError: false,
+        timestamp: 4,
+      }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: entryIds[1],
+          message: createToolResultReplacement("read", "[externalized file_123]", 2),
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const branchMessages = getBranchMessages(sessionManager);
+    const assistantRepeats = branchMessages.filter(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some((part) => part.type === "text" && part.text === "repeat"),
+    );
+    const toolRepeats = branchMessages.filter(
+      (message) =>
+        message.role === "toolResult" &&
+        Array.isArray(message.content) &&
+        message.content.some((part) => part.type === "text" && part.text === "same output"),
+    );
+    // Identical assistant/tool payloads can be legitimate history; never deduped.
+    expect(assistantRepeats).toHaveLength(2);
+    expect(toolRepeats).toHaveLength(2);
+  });
 });
 
 describe("rewriteTranscriptEntriesInSessionFile", () => {

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   TranscriptRewriteReplacement,
   TranscriptRewriteRequest,
@@ -35,6 +36,45 @@ function remapEntryId(
     return null;
   }
   return rewrittenEntryIds.get(entryId) ?? entryId;
+}
+
+function hashJson(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value ?? null)).digest("hex");
+}
+
+// Replay identity that collapses ONLY the proven context-overflow clone pattern
+// during suffix replay, preserving exact suffix history for everything else.
+// Recovery duplicated byte-identical role=user rows in the persisted transcript
+// (issue #66443). A legitimately repeated user message carries a distinct
+// timestamp, so hashing the full payload keeps it while collapsing the identical
+// recovery clone. Compaction identity folds in the remapped firstKeptEntryId so
+// two genuinely distinct compactions (different kept boundary) are not merged —
+// buildSessionContext() uses that boundary to pick surviving pre-compaction
+// messages. Assistant, tool-result, and custom entries are never deduped:
+// identical payloads there can be legitimate history, so they always replay.
+function computeBranchEntryReplayIdentity(
+  entry: SessionBranchEntry,
+  rewrittenEntryIds: ReadonlyMap<string, string>,
+): string | null {
+  if (entry.type === "message") {
+    return computeMessageReplayIdentity(entry.message);
+  }
+  if (entry.type === "compaction") {
+    const keptId = remapEntryId(entry.firstKeptEntryId, rewrittenEntryIds) ?? entry.firstKeptEntryId;
+    return `compaction:${entry.tokensBefore}:${hashJson({
+      keptId,
+      summary: entry.summary,
+      details: entry.details,
+      fromHook: entry.fromHook,
+    })}`;
+  }
+  return null;
+}
+
+// Only role=user messages are clone-deduped; the message timestamp separates a
+// recovery clone (byte-identical) from a legitimate repeat (distinct timestamp).
+function computeMessageReplayIdentity(message: AgentMessage): string | null {
+  return message.role === "user" ? `user:${hashJson(message)}` : null;
 }
 
 function appendBranchEntry(params: {
@@ -227,19 +267,41 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
   // re-running persistence hooks or size truncation on replayed messages.
   const appendMessage = getRawSessionAppendMessage(params.sessionManager);
   const rewrittenEntryIds = new Map<string, string>();
+  const emittedReplayIdentities = new Map<string, string>();
   for (let index = matchedIndices[0]; index < branch.length; index++) {
     const entry = branch[index];
     const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
-    const newEntryId =
-      replacement === undefined
-        ? appendBranchEntry({
-            sessionManager: params.sessionManager,
-            entry,
-            rewrittenEntryIds,
-            appendMessage,
-          })
-        : appendMessage(replacement as Parameters<typeof params.sessionManager.appendMessage>[0]);
+    if (replacement === undefined) {
+      const replayIdentity = computeBranchEntryReplayIdentity(entry, rewrittenEntryIds);
+      const existingEntryId =
+        replayIdentity === null ? undefined : emittedReplayIdentities.get(replayIdentity);
+      if (existingEntryId !== undefined) {
+        // Identical entry already replayed in this pass; collapse the clone and
+        // point its id at the survivor so repeated overflow recovery cannot keep
+        // re-appending duplicate suffix entries.
+        rewrittenEntryIds.set(entry.id, existingEntryId);
+        continue;
+      }
+      const newEntryId = appendBranchEntry({
+        sessionManager: params.sessionManager,
+        entry,
+        rewrittenEntryIds,
+        appendMessage,
+      });
+      rewrittenEntryIds.set(entry.id, newEntryId);
+      if (replayIdentity !== null) {
+        emittedReplayIdentities.set(replayIdentity, newEntryId);
+      }
+      continue;
+    }
+    const newEntryId = appendMessage(
+      replacement as Parameters<typeof params.sessionManager.appendMessage>[0],
+    );
     rewrittenEntryIds.set(entry.id, newEntryId);
+    const replacementReplayIdentity = computeMessageReplayIdentity(replacement);
+    if (replacementReplayIdentity !== null) {
+      emittedReplayIdentities.set(replacementReplayIdentity, newEntryId);
+    }
   }
 
   return {
@@ -345,19 +407,38 @@ export function rewriteTranscriptEntriesInState(params: {
 
   const appendedEntries: SessionBranchEntry[] = [];
   const rewrittenEntryIds = new Map<string, string>();
+  const emittedReplayIdentities = new Map<string, string>();
   for (let index = matchedIndices[0]; index < branch.length; index++) {
     const entry = branch[index];
     const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
-    const newEntry =
-      replacement === undefined
-        ? appendTranscriptStateBranchEntry({
-            state: params.state,
-            entry,
-            rewrittenEntryIds,
-          })
-        : params.state.appendMessage(replacement);
+    if (replacement === undefined) {
+      const replayIdentity = computeBranchEntryReplayIdentity(entry, rewrittenEntryIds);
+      const existingEntryId =
+        replayIdentity === null ? undefined : emittedReplayIdentities.get(replayIdentity);
+      if (existingEntryId !== undefined) {
+        // Collapse the replay clone (see rewriteTranscriptEntriesInSessionManager).
+        rewrittenEntryIds.set(entry.id, existingEntryId);
+        continue;
+      }
+      const newEntry = appendTranscriptStateBranchEntry({
+        state: params.state,
+        entry,
+        rewrittenEntryIds,
+      });
+      rewrittenEntryIds.set(entry.id, newEntry.id);
+      appendedEntries.push(newEntry);
+      if (replayIdentity !== null) {
+        emittedReplayIdentities.set(replayIdentity, newEntry.id);
+      }
+      continue;
+    }
+    const newEntry = params.state.appendMessage(replacement);
     rewrittenEntryIds.set(entry.id, newEntry.id);
     appendedEntries.push(newEntry);
+    const replacementReplayIdentity = computeMessageReplayIdentity(replacement);
+    if (replacementReplayIdentity !== null) {
+      emittedReplayIdentities.set(replacementReplayIdentity, newEntry.id);
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Context-overflow recovery re-runs transcript suffix replay without a replay-identity guard, so byte-identical `role=user` entries are re-appended on every recovery pass and the persisted session JSONL accumulates duplicate messages (issue #66443).

- Collapses **only the proven overflow-clone pattern** during replay: byte-identical `role=user` messages and byte-identical compactions. Exact suffix history is preserved for assistant, tool-result, and custom entries.
- A legitimately repeated user message carries a **distinct timestamp**, so the full-payload hash keeps it while collapsing the identical recovery clone; compaction identity folds in the remapped `firstKeptEntryId` so two distinct compactions are not merged.
- Intended outcome: overflow recovery becomes idempotent for the clone pattern without violating the rewrite's "preserve exact suffix history" contract for legitimate entries.
- Intentionally out of scope: the broader duplicate-transcript umbrella, and repeated-bootstrap-custom dedup (custom entries are deliberately left untouched to avoid dropping legitimate history).
- Reviewers should focus on the user/compaction scoping and the timestamp-based clone-vs-repeat distinction.

## Linked context

Closes #66443

Related #79150 — superseded prior attempt; this PR addresses its "include the kept boundary in compaction identity" review note.

Not maintainer-requested; selected from the `clawsweeper:queueable-fix` backlog.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Overflow recovery duplicated `role=user` entries in the persisted session JSONL (issue #66443 captured one unique message stored as three byte-identical copies).
- Real environment tested: Linux / Node 24, exercising the actual production functions `rewriteTranscriptEntriesInSessionManager` and `rewriteTranscriptEntriesInState` against a real in-memory `SessionManager` and persisted transcript-file-state — these functions are run for real, not mocked.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-rewrite.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output. The regression reproduces the bug on unfixed `main` and passes after the fix, and added tests prove legitimate repeats survive:

```
unfixed main: × dedupes byte-identical replayed messages ...
              AssertionError: expected 2 to be 1   (the clone is re-appended)

with the fix: Test Files  1 passed (1)
              Tests       10 passed (10)           (clone collapsed; legitimate repeats kept)
```

- Observed result after fix: after the overflow-style suffix replay, a byte-identical `role=user` clone is collapsed to one entry, while (a) two user messages with distinct timestamps, (b) byte-identical repeated assistant/tool-result entries, and (c) two distinct compactions are all preserved.
- What was not tested: a live gateway context-overflow on a running OpenClaw deployment (see limitations).
- Proof limitations or environment constraints: this is unit/integration-level proof against the real production functions, which CONTRIBUTING.md treats as supplemental rather than a live-setup behavior capture. I could not drive a live gateway into context overflow in this environment (it needs a full running OpenClaw + provider + a forced overflow, and the sandbox network blocked both a clean install and the `crabbox check:changed` gate). A maintainer with a live setup can confirm end-to-end behavior, or apply `proof: override` for this logic-only dedup fix; I am happy to add a live capture if someone can reproduce an overflow.
- Before evidence (optional but encouraged): the failing assertion above (`expected 2 to be 1`) is the before-state captured from unfixed `main`.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-rewrite.test.ts` -> 10 passed (4 new).
- Sibling callers: `tool-result-truncation`, `context-engine-maintenance`, `compact.hooks`, `cli-runner.context-engine` -> 126 passed.
- `tsgo -p tsconfig.core.json` and core test types: no errors in the changed files (two unrelated pre-existing errors in `src/config/io.ts` and `src/secrets/config-io.ts` are present on `main`).
- Regression coverage added in `transcript-rewrite.test.ts`: clone collapse (fails first with `expected 2 to be 1`, passes after); distinct compactions preserved; legitimate repeated user messages (distinct timestamps) preserved; byte-identical repeated assistant/tool-result entries preserved.

## Risk checklist

- Did user-visible behavior change? No — internal transcript maintenance that removes only byte-identical recovery clones.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: collapsing genuinely distinct entries during replay (the `merge-risk: session-state` concern).
- How is that risk mitigated? Dedup is constrained to `role=user` messages and compactions only; the full-payload hash (including timestamp) distinguishes a recovery clone from a legitimate repeat; compaction identity includes the remapped `firstKeptEntryId`; assistant/tool-result/custom entries are never deduped. Covered by the four regression tests above.

## Current review state

- Next action: maintainer review / ClawSweeper re-review (auto-triggered by this push).
- Addressed ClawSweeper P1 "Preserve distinct replayed transcript entries": constrained the replay dedup to the proven user-message + compaction clone pattern (per the recommended "Constrain Replay Dedupe" option), restored exact-history for assistant/tool/custom entries, and added regression coverage proving legitimate repeated messages/tool entries survive. The dedup helper is shared by both the SessionManager and TranscriptFileState rewrite paths.
- Still open: real behavior proof is unit-level only; a live-overflow capture needs a real setup or a maintainer `proof: override`.
