### PR TITLE
fix(android): improve companion-first shell UX

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.ui.design.ClawDesignTheme
+import ai.openclaw.app.ui.design.ClawErrorState
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
@@ -473,6 +474,14 @@ private fun GatewaySetupScreen(
             onClick = { advancedOpen = true },
           )
         }
+        error?.let { message ->
+          item {
+            ClawErrorState(
+              title = "Setup code issue",
+              body = message,
+            )
+          }
+        }
         item {
           Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Surface(
@@ -505,9 +514,6 @@ private fun GatewaySetupScreen(
               }
               ClawTextField(value = token, onValueChange = onTokenChange, placeholder = "Token optional")
               ClawTextField(value = password, onValueChange = onPasswordChange, placeholder = "Password optional")
-              error?.let {
-                Text(text = it, style = ClawTheme.type.caption, color = ClawTheme.colors.warning)
-              }
             }
           }
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -18,11 +18,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -78,9 +82,16 @@ internal fun ProvidersModelsScreen(
     }
   }
 
-  ClawScaffold(contentPadding = PaddingValues(start = 20.dp, top = 13.dp, end = 20.dp, bottom = 13.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 20.dp, top = 13.dp, end = 20.dp, bottom = 6.dp),
+    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+  ) {
     Box(modifier = Modifier.fillMaxSize()) {
-      LazyColumn(verticalArrangement = Arrangement.spacedBy(7.dp), contentPadding = PaddingValues(bottom = 112.dp)) {
+      LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(7.dp),
+        contentPadding = PaddingValues(bottom = 4.dp),
+      ) {
         item {
           Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -88,8 +91,15 @@ internal fun SessionsScreen(
     }
   }
 
-  ClawScaffold(contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 20.dp)) {
-    LazyColumn(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+  ) {
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(7.dp),
+      contentPadding = PaddingValues(bottom = 4.dp),
+    ) {
       item {
         Row(
           modifier = Modifier.fillMaxWidth(),
@@ -133,11 +143,16 @@ internal fun SessionsScreen(
 
       if (visibleSessions.isEmpty()) {
         item {
-          ClawEmptyState(
-            title = emptySessionTitle(filter),
-            body = emptySessionBody(filter),
-            action = { ClawPrimaryButton(text = "Start Chat", onClick = onOpenChat) },
-          )
+          Box(
+            modifier = Modifier.fillParentMaxHeight(0.56f).fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+          ) {
+            ClawEmptyState(
+              title = emptySessionTitle(filter),
+              body = emptySessionBody(filter),
+              action = { ClawPrimaryButton(text = "Start Chat", onClick = onOpenChat) },
+            )
+          }
         }
       } else {
         items(visibleSessions, key = { it.key }) { session ->
@@ -154,10 +169,6 @@ internal fun SessionsScreen(
             },
           )
         }
-      }
-
-      item {
-        Spacer(modifier = Modifier.height(16.dp))
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -44,11 +44,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
@@ -1028,8 +1032,11 @@ internal fun SettingsDetailFrame(
   onBack: () -> Unit,
   content: @Composable () -> Unit,
 ) {
-  ClawScaffold(contentPadding = PaddingValues(start = ClawTheme.spacing.lg, top = 14.dp, end = ClawTheme.spacing.lg, bottom = 20.dp)) {
-    LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = ClawTheme.spacing.lg, top = 14.dp, end = ClawTheme.spacing.lg, bottom = 6.dp),
+    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+  ) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(10.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
       item {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(9.dp)) {
           SettingsBackButton(onClick = onBack)
@@ -1044,9 +1051,6 @@ internal fun SettingsDetailFrame(
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
           content()
         }
-      }
-      item {
-        Spacer(modifier = Modifier.height(12.dp))
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -793,10 +793,8 @@ private fun ChatShellScreen(
   ) {
     ChatScreen(
       viewModel = viewModel,
-      onBack = {},
       onVoice = onVoice,
       onOpenSessions = onOpenSessions,
-      showBackButton = false,
     )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -9,11 +9,14 @@ import ai.openclaw.app.HomeDestination
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.ui.chat.ChatScreen
+import ai.openclaw.app.ui.design.ClawBottomNav
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawEmptyState
+import ai.openclaw.app.ui.design.ClawNavItem
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawScaffold
+import ai.openclaw.app.ui.design.ClawSecondaryButton
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
@@ -24,20 +27,26 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Notifications
@@ -54,6 +63,7 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -69,22 +79,29 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-private enum class Tab(
+internal enum class Tab(
   val key: String,
   val label: String,
+  val icon: ImageVector,
 ) {
-  Overview(key = "overview", label = "Home"),
-  Chat(key = "chat", label = "Chat"),
-  Voice(key = "voice", label = "Voice"),
-  Sessions(key = "sessions", label = "Sessions"),
-  Settings(key = "settings", label = "Settings"),
-  ProvidersModels(key = "providers-models", label = "Providers"),
+  Overview(key = "overview", label = "Home", icon = Icons.Default.Home),
+  Chat(key = "chat", label = "Chat", icon = Icons.Outlined.ChatBubbleOutline),
+  Voice(key = "voice", label = "Voice", icon = Icons.Outlined.MicNone),
+  Sessions(key = "sessions", label = "Sessions", icon = Icons.Outlined.AccessTime),
+  Settings(key = "settings", label = "Settings", icon = Icons.Outlined.Settings),
+  ProvidersModels(key = "providers-models", label = "Providers", icon = Icons.Outlined.Inventory2),
 }
+
+private val shellNavTabs = listOf(Tab.Overview, Tab.Chat, Tab.Voice, Tab.Settings)
+
+private val shellContentInsets: WindowInsets
+  @Composable get() = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
 
 /** Main post-onboarding shell that owns top-level Android navigation state. */
 @Composable
@@ -131,117 +148,143 @@ fun ShellScreen(
       commandOpen = false
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-      when (activeTab) {
-        Tab.Overview ->
-          OverviewScreen(
-            viewModel = viewModel,
-            onSelectTab = { activeTab = it },
-            onOpenSettingsRoute = {
-              settingsRoute = it
-              returnToOverviewFromSettings = true
-              activeTab = Tab.Settings
-            },
-            onOpenCommand = { commandOpen = true },
-          )
-        Tab.Chat ->
-          ChatShellScreen(
-            viewModel = viewModel,
-            onBack = { activeTab = Tab.Overview },
-            onVoice = { activeTab = Tab.Voice },
-          )
-        Tab.Voice ->
-          VoiceShellScreen(
-            viewModel = viewModel,
-            onOpenCommand = { commandOpen = true },
-            onOpenGatewaySettings = {
-              settingsRoute = SettingsRoute.Gateway
-              returnToOverviewFromSettings = false
-              activeTab = Tab.Settings
-            },
-            onOpenVoiceSettings = {
-              settingsRoute = SettingsRoute.Voice
-              returnToOverviewFromSettings = false
-              activeTab = Tab.Settings
-            },
-          )
-        Tab.ProvidersModels ->
-          ProvidersModelsScreen(
-            viewModel = viewModel,
-            onBack = { activeTab = Tab.Overview },
-            onAddProvider = {
-              settingsRoute = SettingsRoute.Gateway
-              returnToOverviewFromSettings = false
-              activeTab = Tab.Settings
-            },
-          )
-        Tab.Sessions ->
-          SessionsScreen(
-            viewModel = viewModel,
-            onOpenCommand = { commandOpen = true },
-            onOpenChat = { activeTab = Tab.Chat },
-          )
-        Tab.Settings ->
-          SettingsShellScreen(
-            viewModel = viewModel,
-            route = settingsRoute,
-            onRouteChange = {
-              settingsRoute = it
-              returnToOverviewFromSettings = false
-            },
-            onRouteBack = {
-              settingsRoute = SettingsRoute.Home
-              if (returnToOverviewFromSettings) {
+    val density = LocalDensity.current
+    val keyboardVisible = WindowInsets.ime.getBottom(density) > 0
+
+    Scaffold(
+      modifier = modifier.fillMaxSize(),
+      containerColor = ClawTheme.colors.canvas,
+      contentWindowInsets = WindowInsets(0, 0, 0, 0),
+      bottomBar = {
+        if (!keyboardVisible) {
+          ClawBottomNav(
+            items = shellNavTabs.map { ClawNavItem(key = it.key, label = it.label, icon = it.icon) },
+            selectedKey = if (activeTab in shellNavTabs) activeTab.key else Tab.Overview.key,
+            onSelect = { key ->
+              val next = shellNavTabs.firstOrNull { it.key == key } ?: Tab.Overview
+              if (next == Tab.Settings) {
+                settingsRoute = SettingsRoute.Home
                 returnToOverviewFromSettings = false
-                activeTab = Tab.Overview
               }
+              activeTab = next
             },
-            onOpenCommand = { commandOpen = true },
           )
-      }
+        }
+      },
+    ) { shellPadding ->
+      Box(modifier = Modifier.fillMaxSize().padding(shellPadding)) {
+        when (activeTab) {
+          Tab.Overview ->
+            OverviewScreen(
+              viewModel = viewModel,
+              onSelectTab = { activeTab = it },
+              onOpenSettingsRoute = {
+                settingsRoute = it
+                returnToOverviewFromSettings = true
+                activeTab = Tab.Settings
+              },
+              onOpenCommand = { commandOpen = true },
+            )
+          Tab.Chat ->
+            ChatShellScreen(
+              viewModel = viewModel,
+              onVoice = { activeTab = Tab.Voice },
+              onOpenSessions = { activeTab = Tab.Sessions },
+            )
+          Tab.Voice ->
+            VoiceShellScreen(
+              viewModel = viewModel,
+              onOpenCommand = { commandOpen = true },
+              onOpenGatewaySettings = {
+                settingsRoute = SettingsRoute.Gateway
+                returnToOverviewFromSettings = false
+                activeTab = Tab.Settings
+              },
+              onOpenVoiceSettings = {
+                settingsRoute = SettingsRoute.Voice
+                returnToOverviewFromSettings = false
+                activeTab = Tab.Settings
+              },
+            )
+          Tab.ProvidersModels ->
+            ProvidersModelsScreen(
+              viewModel = viewModel,
+              onBack = { activeTab = Tab.Overview },
+              onAddProvider = {
+                settingsRoute = SettingsRoute.Gateway
+                returnToOverviewFromSettings = false
+                activeTab = Tab.Settings
+              },
+            )
+          Tab.Sessions ->
+            SessionsScreen(
+              viewModel = viewModel,
+              onOpenCommand = { commandOpen = true },
+              onOpenChat = { activeTab = Tab.Chat },
+            )
+          Tab.Settings ->
+            SettingsShellScreen(
+              viewModel = viewModel,
+              route = settingsRoute,
+              onRouteChange = {
+                settingsRoute = it
+                returnToOverviewFromSettings = false
+              },
+              onRouteBack = {
+                settingsRoute = SettingsRoute.Home
+                if (returnToOverviewFromSettings) {
+                  returnToOverviewFromSettings = false
+                  activeTab = Tab.Overview
+                }
+              },
+              onBackHome = { activeTab = Tab.Overview },
+              onOpenCommand = { commandOpen = true },
+            )
+        }
 
-      if (commandOpen) {
-        CommandPalette(
-          viewModel = viewModel,
-          onDismiss = { commandOpen = false },
-          onOpenChat = {
-            activeTab = Tab.Chat
-            commandOpen = false
-          },
-          onOpenVoice = {
-            activeTab = Tab.Voice
-            commandOpen = false
-          },
-          onOpenSessions = {
-            activeTab = Tab.Sessions
-            commandOpen = false
-          },
-          onOpenProviders = {
-            activeTab = Tab.ProvidersModels
-            commandOpen = false
-          },
-          onOpenSettings = {
-            settingsRoute = SettingsRoute.Home
-            returnToOverviewFromSettings = false
-            activeTab = Tab.Settings
-            commandOpen = false
-          },
-          onOpenSession = { sessionKey ->
-            viewModel.switchChatSession(sessionKey)
-            activeTab = Tab.Chat
-            commandOpen = false
-          },
-        )
-      }
+        if (commandOpen) {
+          CommandPalette(
+            viewModel = viewModel,
+            onDismiss = { commandOpen = false },
+            onOpenChat = {
+              activeTab = Tab.Chat
+              commandOpen = false
+            },
+            onOpenVoice = {
+              activeTab = Tab.Voice
+              commandOpen = false
+            },
+            onOpenSessions = {
+              activeTab = Tab.Sessions
+              commandOpen = false
+            },
+            onOpenProviders = {
+              activeTab = Tab.ProvidersModels
+              commandOpen = false
+            },
+            onOpenSettings = {
+              settingsRoute = SettingsRoute.Home
+              returnToOverviewFromSettings = false
+              activeTab = Tab.Settings
+              commandOpen = false
+            },
+            onOpenSession = { sessionKey ->
+              viewModel.switchChatSession(sessionKey)
+              activeTab = Tab.Chat
+              commandOpen = false
+            },
+          )
+        }
 
-      pendingTrust?.let { prompt ->
-        // Gateway certificate trust is modal across the shell so navigation
-        // cannot hide a changed TLS identity prompt.
-        GatewayTrustDialog(
-          prompt = prompt,
-          onAccept = viewModel::acceptGatewayTrustPrompt,
-          onDecline = viewModel::declineGatewayTrustPrompt,
-        )
+        pendingTrust?.let { prompt ->
+          // Gateway certificate trust is modal across the shell so navigation
+          // cannot hide a changed TLS identity prompt.
+          GatewayTrustDialog(
+            prompt = prompt,
+            onAccept = viewModel::acceptGatewayTrustPrompt,
+            onDecline = viewModel::declineGatewayTrustPrompt,
+          )
+        }
       }
     }
   }
@@ -289,33 +332,39 @@ private fun OverviewScreen(
   val isConnected by viewModel.isConnected.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
+  val statusText by viewModel.statusText.collectAsState()
   val models by viewModel.modelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
-  val agents by viewModel.gatewayAgents.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val cronStatus by viewModel.cronStatus.collectAsState()
-  val usageSummary by viewModel.usageSummary.collectAsState()
-  val skillsSummary by viewModel.skillsSummary.collectAsState()
   val nodesDevicesSummary by viewModel.nodesDevicesSummary.collectAsState()
   val channelsSummary by viewModel.channelsSummary.collectAsState()
   val readyProviderCount = providers.count { modelProviderReady(it.status) }
+  val attentionRows =
+    homeAttentionRows(
+      isConnected = isConnected,
+      pendingApprovals = pendingToolCalls.size,
+      channelsSummary = channelsSummary,
+      nodesDevicesSummary = nodesDevicesSummary,
+      readyProviderCount = readyProviderCount,
+    )
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
       viewModel.refreshChatSessions(limit = 20)
       viewModel.refreshModelCatalog()
-      viewModel.refreshAgents()
       viewModel.refreshCronJobs()
-      viewModel.refreshUsage()
-      viewModel.refreshSkills()
       viewModel.refreshNodesDevices()
       viewModel.refreshChannels()
     }
   }
 
-  ClawScaffold(contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 20.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentWindowInsets = shellContentInsets,
+  ) {
     Box(modifier = Modifier.fillMaxSize()) {
-      LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp), contentPadding = PaddingValues(bottom = 104.dp)) {
+      LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(12.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
         item {
           Row(
             modifier = Modifier.fillMaxWidth(),
@@ -334,41 +383,20 @@ private fun OverviewScreen(
         }
 
         item {
-          SectionLabel(title = "MODULES")
+          CompanionHeroPanel(
+            statusText = gatewaySummary(statusText, isConnected),
+            isConnected = isConnected,
+            pendingRunCount = pendingRunCount,
+            onOpenChat = { onSelectTab(Tab.Chat) },
+            onOpenVoice = { onSelectTab(Tab.Voice) },
+            onOpenGateway = { onOpenSettingsRoute(SettingsRoute.Gateway) },
+          )
         }
 
-        item {
-          ModuleList(
-            rows =
-              listOf(
-                ModuleRow("Chat", null, null, Icons.Outlined.ChatBubbleOutline, Tab.Chat),
-                ModuleRow("Sessions", null, if (sessions.isEmpty()) "Empty" else "${sessions.size} recent", Icons.Outlined.AccessTime, Tab.Sessions),
-                ModuleRow("Voice", null, if (isConnected) "Ready" else "Offline", Icons.Outlined.MicNone, Tab.Voice),
-                ModuleRow(
-                  title = "Providers & Models",
-                  subtitle = null,
-                  metadata =
-                    when {
-                      !isConnected -> "Offline"
-                      readyProviderCount > 0 -> "$readyProviderCount ready"
-                      models.isNotEmpty() -> "${models.size} models"
-                      else -> "Setup"
-                    },
-                  icon = Icons.Outlined.Inventory2,
-                  tab = Tab.ProvidersModels,
-                ),
-                ModuleRow("Channels", null, channelsSummaryText(channelsSummary), Icons.Default.Notifications, Tab.Settings, SettingsRoute.Channels),
-                ModuleRow("Agents", null, if (agents.isEmpty()) "Load" else "${agents.size} ready", Icons.Default.Person, Tab.Settings, SettingsRoute.Agents),
-                ModuleRow("Approvals", null, approvalsSummary(pendingToolCalls.size), Icons.Default.Lock, Tab.Settings, SettingsRoute.Approvals),
-                ModuleRow("Cron Jobs", null, cronJobsSummary(cronStatus.jobs), Icons.Outlined.AccessTime, Tab.Settings, SettingsRoute.CronJobs),
-                ModuleRow("Skills", null, skillsSummaryText(skillsSummary.skills), Icons.Default.Settings, Tab.Settings, SettingsRoute.Skills),
-                ModuleRow("Nodes & Devices", null, nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, Tab.Settings, SettingsRoute.NodesDevices),
-                ModuleRow("Usage", null, usageSummaryText(usageSummary.providers.size), Icons.Default.Storage, Tab.Settings, SettingsRoute.Usage),
-                ModuleRow("Settings", null, null, Icons.Outlined.Settings, Tab.Settings, SettingsRoute.Home),
-              ),
-            onSelectTab = onSelectTab,
-            onOpenSettingsRoute = onOpenSettingsRoute,
-          )
+        if (attentionRows.isNotEmpty()) {
+          item {
+            HomeAttentionPanel(rows = attentionRows, onSelectTab = onSelectTab, onOpenSettingsRoute = onOpenSettingsRoute)
+          }
         }
 
         item {
@@ -397,7 +425,7 @@ private fun OverviewScreen(
           item {
             RecentSessionList(
               rows =
-                sessions.take(7).map { session ->
+                sessions.take(5).map { session ->
                   RecentSessionListItem(
                     key = session.key,
                     title = displaySessionTitle(session.displayName),
@@ -412,8 +440,39 @@ private fun OverviewScreen(
             )
           }
         }
+
+        item {
+          SectionLabel(title = "Control center")
+        }
+
+        item {
+          ModuleList(
+            rows =
+              listOf(
+                ModuleRow("Sessions", "Conversation history", if (sessions.isEmpty()) "Empty" else "${sessions.size} recent", Icons.Outlined.AccessTime, Tab.Sessions),
+                ModuleRow(
+                  title = "Providers & Models",
+                  subtitle = "Model setup",
+                  metadata =
+                    when {
+                      !isConnected -> "Offline"
+                      readyProviderCount > 0 -> "$readyProviderCount ready"
+                      models.isNotEmpty() -> "${models.size} models"
+                      else -> "Setup"
+                    },
+                  icon = Icons.Outlined.Inventory2,
+                  tab = Tab.ProvidersModels,
+                ),
+                ModuleRow("Channels", "Connected messengers", channelsSummaryText(channelsSummary), Icons.Default.Notifications, Tab.Settings, SettingsRoute.Channels),
+                ModuleRow("Nodes & Devices", "Phone and node health", nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, Tab.Settings, SettingsRoute.NodesDevices),
+                ModuleRow("Approvals", "Tool decisions", approvalsSummary(pendingToolCalls.size), Icons.Default.Lock, Tab.Settings, SettingsRoute.Approvals),
+                ModuleRow("Settings", "More runtime controls", null, Icons.Outlined.Settings, Tab.Settings, SettingsRoute.Home),
+              ),
+            onSelectTab = onSelectTab,
+            onOpenSettingsRoute = onOpenSettingsRoute,
+          )
+        }
       }
-      OverviewChatButton(onClick = { onSelectTab(Tab.Chat) }, modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 20.dp))
     }
   }
 }
@@ -427,26 +486,109 @@ private data class ModuleRow(
   val settingsRoute: SettingsRoute? = null,
 )
 
-/** Floating overview shortcut that keeps chat one tap away from module lists. */
 @Composable
-private fun OverviewChatButton(
-  onClick: () -> Unit,
-  modifier: Modifier = Modifier,
+private fun CompanionHeroPanel(
+  statusText: String,
+  isConnected: Boolean,
+  pendingRunCount: Int,
+  onOpenChat: () -> Unit,
+  onOpenVoice: () -> Unit,
+  onOpenGateway: () -> Unit,
 ) {
-  Surface(
-    onClick = onClick,
-    modifier = modifier.height(ClawTheme.spacing.touchTarget),
-    shape = RoundedCornerShape(ClawTheme.radii.button),
-    color = ClawTheme.colors.primary,
-    contentColor = ClawTheme.colors.primaryText,
-  ) {
-    Row(
-      modifier = Modifier.padding(horizontal = 16.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-      Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(18.dp))
-      Text(text = "Chat", style = ClawTheme.type.label.copy(fontSize = 16.sp, lineHeight = 20.sp))
+  ClawPanel(contentPadding = PaddingValues(16.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Surface(
+          modifier = Modifier.size(38.dp),
+          shape = CircleShape,
+          color = if (isConnected) ClawTheme.colors.successSoft else ClawTheme.colors.surfacePressed,
+          border = BorderStroke(1.dp, if (isConnected) ClawTheme.colors.success else ClawTheme.colors.border),
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(19.dp), tint = if (isConnected) ClawTheme.colors.success else ClawTheme.colors.text)
+          }
+        }
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+          Text(text = if (pendingRunCount > 0) "OpenClaw is working" else "Ready when you are", style = ClawTheme.type.title.copy(fontSize = 20.sp, lineHeight = 24.sp), color = ClawTheme.colors.text)
+          Text(text = statusText, style = ClawTheme.type.body, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+      }
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+        ClawPrimaryButton(text = "Start chat", icon = Icons.Outlined.ChatBubbleOutline, onClick = onOpenChat, modifier = Modifier.weight(1f))
+        ClawSecondaryButton(text = "Voice", icon = Icons.Outlined.MicNone, onClick = onOpenVoice, modifier = Modifier.weight(1f))
+      }
+      if (!isConnected) {
+        ClawSecondaryButton(text = "Reconnect gateway", icon = Icons.Default.Cloud, onClick = onOpenGateway, modifier = Modifier.fillMaxWidth())
+      }
+    }
+  }
+}
+
+internal data class HomeAttentionRow(
+  val title: String,
+  val subtitle: String,
+  val icon: ImageVector,
+  val tab: Tab,
+  val settingsRoute: SettingsRoute? = null,
+)
+
+internal fun homeAttentionRows(
+  isConnected: Boolean,
+  pendingApprovals: Int,
+  channelsSummary: GatewayChannelsSummary,
+  nodesDevicesSummary: GatewayNodesDevicesSummary,
+  readyProviderCount: Int,
+): List<HomeAttentionRow> =
+  listOfNotNull(
+    if (!isConnected) {
+      HomeAttentionRow("Gateway", "Connect before chat, voice, and live status.", Icons.Default.Cloud, Tab.Settings, SettingsRoute.Gateway)
+    } else {
+      null
+    },
+    if (pendingApprovals > 0) {
+      HomeAttentionRow("Approvals", approvalsSummary(pendingApprovals), Icons.Default.Lock, Tab.Settings, SettingsRoute.Approvals)
+    } else {
+      null
+    },
+    if (channelsSummary.channels.any { it.error != null }) {
+      HomeAttentionRow("Channels", channelsSummaryText(channelsSummary), Icons.Default.Notifications, Tab.Settings, SettingsRoute.Channels)
+    } else {
+      null
+    },
+    if (nodesDevicesSummary.pendingDevices.isNotEmpty()) {
+      HomeAttentionRow("Nodes & Devices", nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, Tab.Settings, SettingsRoute.NodesDevices)
+    } else {
+      null
+    },
+    if (isConnected && readyProviderCount == 0) {
+      HomeAttentionRow("Providers", "No ready providers", Icons.Outlined.Inventory2, Tab.ProvidersModels)
+    } else {
+      null
+    },
+  )
+
+@Composable
+private fun HomeAttentionPanel(
+  rows: List<HomeAttentionRow>,
+  onSelectTab: (Tab) -> Unit,
+  onOpenSettingsRoute: (SettingsRoute) -> Unit,
+) {
+  ClawPanel(contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      Text(text = "Needs attention", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.warning)
+      rows.forEach { row ->
+        ModuleListRow(
+          row = ModuleRow(row.title, row.subtitle, null, row.icon, row.tab, row.settingsRoute),
+          onClick = {
+            val route = row.settingsRoute
+            if (route == null) {
+              onSelectTab(row.tab)
+            } else {
+              onOpenSettingsRoute(route)
+            }
+          },
+        )
+      }
     }
   }
 }
@@ -527,14 +669,18 @@ private fun ModuleListRow(
       horizontalArrangement = Arrangement.spacedBy(9.dp),
     ) {
       Icon(imageVector = row.icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = ClawTheme.colors.text)
-      Text(
-        text = row.title,
-        style = ClawTheme.type.body,
-        color = ClawTheme.colors.text,
-        modifier = Modifier.weight(1f),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-      )
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(
+          text = row.title,
+          style = ClawTheme.type.body,
+          color = ClawTheme.colors.text,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        row.subtitle?.let {
+          Text(text = it, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textSubtle, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+      }
       row.metadata?.let {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
           Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(statusDotColor(it)))
@@ -638,11 +784,20 @@ private fun RecentSessionRowContent(
 @Composable
 private fun ChatShellScreen(
   viewModel: MainViewModel,
-  onBack: () -> Unit,
   onVoice: () -> Unit,
+  onOpenSessions: () -> Unit,
 ) {
-  ClawScaffold(contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = 8.dp)) {
-    ChatScreen(viewModel = viewModel, onBack = onBack, onVoice = onVoice)
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = 0.dp),
+    contentWindowInsets = shellContentInsets,
+  ) {
+    ChatScreen(
+      viewModel = viewModel,
+      onBack = {},
+      onVoice = onVoice,
+      onOpenSessions = onOpenSessions,
+      showBackButton = false,
+    )
   }
 }
 
@@ -653,7 +808,10 @@ private fun VoiceShellScreen(
   onOpenGatewaySettings: () -> Unit,
   onOpenVoiceSettings: () -> Unit,
 ) {
-  ClawScaffold(contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = 8.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 0.dp, top = 8.dp, end = 0.dp, bottom = 0.dp),
+    contentWindowInsets = shellContentInsets,
+  ) {
     VoiceScreen(
       viewModel = viewModel,
       onOpenCommand = onOpenCommand,
@@ -669,6 +827,7 @@ private fun SettingsShellScreen(
   route: SettingsRoute,
   onRouteChange: (SettingsRoute) -> Unit,
   onRouteBack: () -> Unit,
+  onBackHome: () -> Unit,
   onOpenCommand: () -> Unit,
 ) {
   val displayName by viewModel.displayName.collectAsState()
@@ -707,14 +866,18 @@ private fun SettingsShellScreen(
     return
   }
 
-  ClawScaffold(contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 20.dp)) {
-    LazyColumn(verticalArrangement = Arrangement.spacedBy(13.dp)) {
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 6.dp),
+    contentWindowInsets = shellContentInsets,
+  ) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(13.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
       item {
         Row(
           modifier = Modifier.fillMaxWidth(),
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(9.dp),
         ) {
+          PlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back to home", onClick = onBackHome)
           Text(text = "Settings", style = ClawTheme.type.title.copy(fontSize = 16.sp, lineHeight = 20.sp), color = ClawTheme.colors.text, modifier = Modifier.weight(1f))
           SettingsSearchButton(onClick = onOpenCommand)
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -103,6 +103,8 @@ private val shellNavTabs = listOf(Tab.Overview, Tab.Chat, Tab.Voice, Tab.Setting
 private val shellContentInsets: WindowInsets
   @Composable get() = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
 
+internal fun shellBottomNavVisible(keyboardVisible: Boolean, commandOpen: Boolean): Boolean = !keyboardVisible && !commandOpen
+
 /** Main post-onboarding shell that owns top-level Android navigation state. */
 @Composable
 fun ShellScreen(
@@ -150,13 +152,14 @@ fun ShellScreen(
 
     val density = LocalDensity.current
     val keyboardVisible = WindowInsets.ime.getBottom(density) > 0
+    val showBottomNav = shellBottomNavVisible(keyboardVisible = keyboardVisible, commandOpen = commandOpen)
 
     Scaffold(
       modifier = modifier.fillMaxSize(),
       containerColor = ClawTheme.colors.canvas,
       contentWindowInsets = WindowInsets(0, 0, 0, 0),
       bottomBar = {
-        if (!keyboardVisible) {
+        if (showBottomNav) {
           ClawBottomNav(
             items = shellNavTabs.map { ClawNavItem(key = it.key, label = it.label, icon = it.icon) },
             selectedKey = if (activeTab in shellNavTabs) activeTab.key else Tab.Overview.key,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
@@ -80,10 +79,8 @@ import java.util.Locale
 @Composable
 fun ChatScreen(
   viewModel: MainViewModel,
-  onBack: () -> Unit,
   onVoice: () -> Unit,
-  onOpenSessions: (() -> Unit)? = null,
-  showBackButton: Boolean = true,
+  onOpenSessions: () -> Unit,
 ) {
   val messages by viewModel.chatMessages.collectAsState()
   val historyLoading by viewModel.chatHistoryLoading.collectAsState()
@@ -162,12 +159,10 @@ fun ChatScreen(
       thinkingLevel = thinkingLevel,
       healthOk = healthOk,
       pendingRunCount = pendingRunCount,
-      onBack = onBack,
       onMore = {
         viewModel.refreshChat()
         viewModel.refreshChatSessions(limit = 100)
       },
-      showBackButton = showBackButton,
     )
 
     ChatSessionSwitcher(
@@ -236,7 +231,7 @@ private fun ChatSessionSwitcher(
   sessions: List<ChatSessionEntry>,
   mainSessionKey: String,
   onSelectSession: (String) -> Unit,
-  onOpenSessions: (() -> Unit)?,
+  onOpenSessions: () -> Unit,
 ) {
   val choices =
     remember(sessionKey, sessions, mainSessionKey) {
@@ -260,7 +255,7 @@ private fun ChatSessionSwitcher(
         onClick = { onSelectSession(entry.key) },
       )
     }
-    if (onOpenSessions != null && sessions.size > choices.size) {
+    if (sessions.size > choices.size) {
       Surface(
         onClick = onOpenSessions,
         modifier = Modifier.heightIn(min = 36.dp),
@@ -312,20 +307,14 @@ private fun ChatHeader(
   thinkingLevel: String,
   healthOk: Boolean,
   pendingRunCount: Int,
-  onBack: () -> Unit,
   onMore: () -> Unit,
-  showBackButton: Boolean,
 ) {
   Row(
     modifier = Modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(6.dp),
   ) {
-    if (showBackButton) {
-      HeaderIcon(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
-    } else {
-      Box(modifier = Modifier.size(ClawTheme.spacing.touchTarget))
-    }
+    Box(modifier = Modifier.size(ClawTheme.spacing.touchTarget))
 
     Column(
       modifier = Modifier.weight(1f),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawLoadingState
@@ -42,6 +43,7 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -80,6 +82,8 @@ fun ChatScreen(
   viewModel: MainViewModel,
   onBack: () -> Unit,
   onVoice: () -> Unit,
+  onOpenSessions: (() -> Unit)? = null,
+  showBackButton: Boolean = true,
 ) {
   val messages by viewModel.chatMessages.collectAsState()
   val historyLoading by viewModel.chatHistoryLoading.collectAsState()
@@ -163,6 +167,18 @@ fun ChatScreen(
         viewModel.refreshChat()
         viewModel.refreshChatSessions(limit = 100)
       },
+      showBackButton = showBackButton,
+    )
+
+    ChatSessionSwitcher(
+      sessionKey = sessionKey,
+      sessions = sessions,
+      mainSessionKey = mainSessionKey,
+      onSelectSession = { key ->
+        viewModel.switchChatSession(key)
+        viewModel.refreshChatSessions(limit = 100)
+      },
+      onOpenSessions = onOpenSessions,
     )
 
     errorText?.takeIf { it.isNotBlank() }?.let { error ->
@@ -215,6 +231,82 @@ fun ChatScreen(
 }
 
 @Composable
+private fun ChatSessionSwitcher(
+  sessionKey: String,
+  sessions: List<ChatSessionEntry>,
+  mainSessionKey: String,
+  onSelectSession: (String) -> Unit,
+  onOpenSessions: (() -> Unit)?,
+) {
+  val choices =
+    remember(sessionKey, sessions, mainSessionKey) {
+      resolveCompactSessionChoices(
+        currentSessionKey = sessionKey,
+        sessions = sessions,
+        mainSessionKey = mainSessionKey,
+      )
+    }
+  if (choices.size <= 1 && sessions.size <= 1) return
+
+  Row(
+    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    choices.forEach { entry ->
+      ChatSessionChip(
+        text = chatSessionChipText(entry = entry, mainSessionKey = mainSessionKey),
+        active = isActiveSessionChoice(entry.key, sessionKey, mainSessionKey),
+        onClick = { onSelectSession(entry.key) },
+      )
+    }
+    if (onOpenSessions != null && sessions.size > choices.size) {
+      Surface(
+        onClick = onOpenSessions,
+        modifier = Modifier.heightIn(min = 36.dp),
+        shape = RoundedCornerShape(ClawTheme.radii.pill),
+        color = ClawTheme.colors.canvas,
+        contentColor = ClawTheme.colors.textMuted,
+        border = BorderStroke(1.dp, ClawTheme.colors.border),
+      ) {
+        Row(
+          modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+          Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null, modifier = Modifier.size(16.dp))
+          Text(text = "All", style = ClawTheme.type.caption, maxLines = 1)
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ChatSessionChip(
+  text: String,
+  active: Boolean,
+  onClick: () -> Unit,
+) {
+  Surface(
+    onClick = onClick,
+    modifier = Modifier.heightIn(min = 36.dp),
+    shape = RoundedCornerShape(ClawTheme.radii.pill),
+    color = if (active) ClawTheme.colors.primary else ClawTheme.colors.surfaceRaised,
+    contentColor = if (active) ClawTheme.colors.primaryText else ClawTheme.colors.text,
+    border = BorderStroke(1.dp, if (active) ClawTheme.colors.primary else ClawTheme.colors.border),
+  ) {
+    Text(
+      text = text,
+      modifier = Modifier.padding(horizontal = 11.dp, vertical = 7.dp),
+      style = ClawTheme.type.caption,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}
+
+@Composable
 private fun ChatHeader(
   sessionTitle: String,
   thinkingLevel: String,
@@ -222,13 +314,18 @@ private fun ChatHeader(
   pendingRunCount: Int,
   onBack: () -> Unit,
   onMore: () -> Unit,
+  showBackButton: Boolean,
 ) {
   Row(
     modifier = Modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(6.dp),
   ) {
-    HeaderIcon(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
+    if (showBackButton) {
+      HeaderIcon(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
+    } else {
+      Box(modifier = Modifier.size(ClawTheme.spacing.touchTarget))
+    }
 
     Column(
       modifier = Modifier.weight(1f),
@@ -786,11 +883,31 @@ private fun AttachmentChip(
 
 private fun currentSessionTitle(
   sessionKey: String,
-  sessions: List<ai.openclaw.app.chat.ChatSessionEntry>,
+  sessions: List<ChatSessionEntry>,
 ): String {
   val entry = sessions.firstOrNull { it.key == sessionKey }
   val name = entry?.displayName?.takeIf { it.isNotBlank() } ?: return "New chat"
   return friendlySessionName(name)
+}
+
+private fun chatSessionChipText(
+  entry: ChatSessionEntry,
+  mainSessionKey: String,
+): String {
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  if (entry.key == mainKey || (entry.key == "main" && mainKey == "main")) return "Main"
+  val name = entry.displayName?.takeIf { it.isNotBlank() } ?: entry.key.takeIf { entry.updatedAtMs != null } ?: "Current"
+  return friendlySessionName(name)
+}
+
+private fun isActiveSessionChoice(
+  choiceKey: String,
+  sessionKey: String,
+  mainSessionKey: String,
+): Boolean {
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  val current = sessionKey.trim().let { if (it == "main" && mainKey != "main") mainKey else it }
+  return choiceKey == current
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -4,22 +4,9 @@ import ai.openclaw.app.chat.ChatSessionEntry
 
 private const val RECENT_WINDOW_MS = 24 * 60 * 60 * 1000L
 
-/**
- * Derive a human-friendly label from a raw session key.
- * Examples:
- *   "telegram:g-agent-main-main" -> "Main"
- *   "agent:main:main" -> "Main"
- *   "discord:g-server-channel" -> "Server Channel"
- *   "my-custom-session" -> "My Custom Session"
- */
 fun friendlySessionName(key: String): String {
-  // Strip common prefixes like "telegram:", "agent:", "discord:" etc.
   val stripped = key.substringAfterLast(":")
-
-  // Remove leading "g-" prefix (gateway artifact)
   val cleaned = if (stripped.startsWith("g-")) stripped.removePrefix("g-") else stripped
-
-  // Split on hyphens/underscores, title-case each word, collapse "main main" -> "Main"
   val words =
     cleaned
       .split('-', '_')
@@ -79,7 +66,6 @@ fun resolveSessionChoices(
   return result
 }
 
-/** Builds the compact top-of-chat session switcher without dropping main or the active session. */
 fun resolveCompactSessionChoices(
   currentSessionKey: String,
   sessions: List<ChatSessionEntry>,
@@ -94,24 +80,14 @@ fun resolveCompactSessionChoices(
       mainSessionKey = mainSessionKey,
       nowMs = nowMs,
     )
-  if (allChoices.size <= maxOptions) return allChoices
-
   val mainKey = mainSessionKey.trim().ifEmpty { "main" }
   val current = currentSessionKey.trim().let { if (it == "main" && mainKey != "main") mainKey else it }
-  val pinnedKeys = listOf(mainKey, current).filter { it.isNotBlank() }
-  val result = mutableListOf<ChatSessionEntry>()
-  val seen = mutableSetOf<String>()
+  val pinnedRank = listOf(mainKey, current).filter { it.isNotBlank() }.distinct().withIndex().associate { it.value to it.index }
+  val unpinnedRank = pinnedRank.size
 
-  pinnedKeys.forEach { key ->
-    allChoices.firstOrNull { it.key == key }?.let { entry ->
-      if (seen.add(entry.key)) result.add(entry)
-    }
-  }
-
-  allChoices.forEach { entry ->
-    if (result.size >= maxOptions) return@forEach
-    if (seen.add(entry.key)) result.add(entry)
-  }
-
-  return result
+  return allChoices
+    .withIndex()
+    .sortedWith(compareBy({ pinnedRank[it.value.key] ?: unpinnedRank }, { it.index }))
+    .take(maxOptions)
+    .map { it.value }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/SessionFilters.kt
@@ -78,3 +78,40 @@ fun resolveSessionChoices(
 
   return result
 }
+
+/** Builds the compact top-of-chat session switcher without dropping main or the active session. */
+fun resolveCompactSessionChoices(
+  currentSessionKey: String,
+  sessions: List<ChatSessionEntry>,
+  mainSessionKey: String,
+  nowMs: Long = System.currentTimeMillis(),
+  maxOptions: Int = 5,
+): List<ChatSessionEntry> {
+  val allChoices =
+    resolveSessionChoices(
+      currentSessionKey = currentSessionKey,
+      sessions = sessions,
+      mainSessionKey = mainSessionKey,
+      nowMs = nowMs,
+    )
+  if (allChoices.size <= maxOptions) return allChoices
+
+  val mainKey = mainSessionKey.trim().ifEmpty { "main" }
+  val current = currentSessionKey.trim().let { if (it == "main" && mainKey != "main") mainKey else it }
+  val pinnedKeys = listOf(mainKey, current).filter { it.isNotBlank() }
+  val result = mutableListOf<ChatSessionEntry>()
+  val seen = mutableSetOf<String>()
+
+  pinnedKeys.forEach { key ->
+    allChoices.firstOrNull { it.key == key }?.let { entry ->
+      if (seen.add(entry.key)) result.add(entry)
+    }
+  }
+
+  allChoices.forEach { entry ->
+    if (result.size >= maxOptions) return@forEach
+    if (seen.add(entry.key)) result.add(entry)
+  }
+
+  return result
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
@@ -61,6 +61,7 @@ internal enum class ClawStatus {
 internal fun ClawScaffold(
   modifier: Modifier = Modifier,
   contentPadding: PaddingValues = PaddingValues(horizontal = ClawTheme.spacing.lg, vertical = ClawTheme.spacing.lg),
+  contentWindowInsets: WindowInsets = WindowInsets.safeDrawing,
   content: @Composable () -> Unit,
 ) {
   Box(
@@ -68,7 +69,7 @@ internal fun ClawScaffold(
       modifier
         .fillMaxSize()
         .background(ClawTheme.colors.canvas)
-        .windowInsetsPadding(WindowInsets.safeDrawing)
+        .windowInsetsPadding(contentWindowInsets)
         .padding(contentPadding),
   ) {
     content()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.design
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -91,27 +92,29 @@ internal fun ClawBottomNav(
 ) {
   val safeInsets = WindowInsets.navigationBars.only(androidx.compose.foundation.layout.WindowInsetsSides.Bottom)
 
-  Surface(
-    modifier = modifier.fillMaxWidth(),
-    color = ClawTheme.colors.surface.copy(alpha = 0.96f),
-    border = BorderStroke(1.dp, ClawTheme.colors.border),
-    shape = RoundedCornerShape(topStart = ClawTheme.radii.sheet, topEnd = ClawTheme.radii.sheet),
-  ) {
-    Row(
-      modifier =
-        Modifier
-          .windowInsetsPadding(safeInsets)
-          .padding(horizontal = 8.dp, vertical = 8.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(4.dp),
+  Box(modifier = modifier.fillMaxWidth().background(ClawTheme.colors.canvas)) {
+    Surface(
+      modifier = Modifier.fillMaxWidth(),
+      color = ClawTheme.colors.surface.copy(alpha = 0.96f),
+      border = BorderStroke(1.dp, ClawTheme.colors.border),
+      shape = RoundedCornerShape(topStart = ClawTheme.radii.sheet, topEnd = ClawTheme.radii.sheet),
     ) {
-      items.forEach { item ->
-        ClawBottomNavItem(
-          item = item,
-          selected = item.key == selectedKey,
-          onClick = { onSelect(item.key) },
-          modifier = Modifier.weight(1f),
-        )
+      Row(
+        modifier =
+          Modifier
+            .windowInsetsPadding(safeInsets)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+      ) {
+        items.forEach { item ->
+          ClawBottomNavItem(
+            item = item,
+            selected = item.key == selectedKey,
+            onClick = { onSelect(item.key) },
+            modifier = Modifier.weight(1f),
+          )
+        }
       }
     }
   }
@@ -129,7 +132,7 @@ private fun ClawBottomNavItem(
     modifier = modifier.heightIn(min = 48.dp),
     shape = RoundedCornerShape(ClawTheme.radii.control),
     color = if (selected) ClawTheme.colors.primary else Color.Transparent,
-    contentColor = if (selected) ClawTheme.colors.primaryText else ClawTheme.colors.textSubtle,
+    contentColor = if (selected) ClawTheme.colors.primaryText else ClawTheme.colors.textMuted,
   ) {
     Column(
       modifier = Modifier.padding(horizontal = 5.dp, vertical = 6.dp),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -1,0 +1,89 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.GatewayChannelSummary
+import ai.openclaw.app.GatewayChannelsSummary
+import ai.openclaw.app.GatewayNodesDevicesSummary
+import ai.openclaw.app.GatewayPendingDeviceSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ShellScreenLogicTest {
+  @Test
+  fun homeAttentionRowsSurfaceGatewayWhenDisconnected() {
+    val rows =
+      homeAttentionRows(
+        isConnected = false,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary = emptyNodesDevices(),
+        readyProviderCount = 0,
+      )
+
+    assertEquals(listOf("Gateway"), rows.map { it.title })
+  }
+
+  @Test
+  fun homeAttentionRowsSurfaceOnlyActionableConnectedIssues() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 2,
+        channelsSummary =
+          GatewayChannelsSummary(
+            channels =
+              listOf(
+                GatewayChannelSummary(
+                  id = "telegram",
+                  label = "Telegram",
+                  accountCount = 1,
+                  enabled = true,
+                  configured = true,
+                  linked = true,
+                  running = false,
+                  connected = false,
+                  error = "offline",
+                ),
+              ),
+          ),
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes = emptyList(),
+            pendingDevices =
+              listOf(
+                GatewayPendingDeviceSummary(
+                  requestId = "request-1",
+                  deviceId = "device-1",
+                  displayName = "Phone",
+                  remoteIp = null,
+                  roles = emptyList(),
+                  scopes = emptyList(),
+                  requestedAtMs = null,
+                  repair = false,
+                ),
+              ),
+            pairedDevices = emptyList(),
+          ),
+        readyProviderCount = 0,
+      )
+
+    assertEquals(listOf("Approvals", "Channels", "Nodes & Devices", "Providers"), rows.map { it.title })
+  }
+
+  @Test
+  fun homeAttentionRowsStayQuietWhenConnectedAndHealthy() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary = emptyNodesDevices(),
+        readyProviderCount = 1,
+      )
+
+    assertEquals(emptyList<String>(), rows.map { it.title })
+  }
+
+  private fun emptyChannels(): GatewayChannelsSummary = GatewayChannelsSummary(channels = emptyList())
+
+  private fun emptyNodesDevices(): GatewayNodesDevicesSummary = GatewayNodesDevicesSummary(nodes = emptyList(), pendingDevices = emptyList(), pairedDevices = emptyList())
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -5,9 +5,18 @@ import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.GatewayNodesDevicesSummary
 import ai.openclaw.app.GatewayPendingDeviceSummary
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ShellScreenLogicTest {
+  @Test
+  fun bottomNavHidesForKeyboardAndCommandPalette() {
+    assertTrue(shellBottomNavVisible(keyboardVisible = false, commandOpen = false))
+    assertFalse(shellBottomNavVisible(keyboardVisible = true, commandOpen = false))
+    assertFalse(shellBottomNavVisible(keyboardVisible = false, commandOpen = true))
+  }
+
   @Test
   fun homeAttentionRowsSurfaceGatewayWhenDisconnected() {
     val rows =

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/SessionFiltersTest.kt
@@ -32,4 +32,29 @@ class SessionFiltersTest {
     val result = resolveSessionChoices("custom", sessions, mainSessionKey = "main", nowMs = now).map { it.key }
     assertEquals(listOf("main", "custom"), result)
   }
+
+  @Test
+  fun compactChoicesKeepMainAndCurrentWhileCappingRecentSessions() {
+    val now = 1_700_000_000_000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "recent-1", updatedAtMs = now - 1),
+        ChatSessionEntry(key = "recent-2", updatedAtMs = now - 2),
+        ChatSessionEntry(key = "recent-3", updatedAtMs = now - 3),
+        ChatSessionEntry(key = "recent-4", updatedAtMs = now - 4),
+        ChatSessionEntry(key = "main", updatedAtMs = now - 5),
+        ChatSessionEntry(key = "active-old", updatedAtMs = now - 30 * 60 * 60 * 1000L),
+      )
+
+    val result =
+      resolveCompactSessionChoices(
+        currentSessionKey = "active-old",
+        sessions = sessions,
+        mainSessionKey = "main",
+        nowMs = now,
+        maxOptions = 4,
+      ).map { it.key }
+
+    assertEquals(listOf("main", "active-old", "recent-1", "recent-2"), result)
+  }
 }


### PR DESCRIPTION
## Summary

- Reworks the Android shell so the app opens as a companion-first experience instead of a module console: Home now leads with chat/voice actions, gateway attention, recent sessions, then runtime controls.
- Makes Chat, Voice, Home, and Settings top-level bottom navigation destinations, with top-level Chat no longer showing a nested back affordance.
- Shows setup-code / QR-scanner errors directly on the onboarding Gateway Setup screen instead of hiding them behind Advanced.
- Adds compact in-chat session switching and tightens bottom-navigation / keyboard / scroll spacing across Home, Chat, Sessions, Providers & Models, and Settings without changing the existing Claw visual language.
- Intentionally out of scope: connected-gateway feature behavior, Play/release permission policy, and non-Android app parity.

AI-assisted: implemented and validated with Codex, then manually inspected and tested in a local Android emulator setup.

## Linked context

Which issue does this close?

N/A. This does not close a tracked issue.

Which issues, PRs, or discussions are related?

Related: none. This is a focused Android UX polish PR for the current rebuilt Android shell/onboarding surfaces.

Was this requested by a maintainer or owner?

No direct maintainer request. The change is limited to Android UI/onboarding behavior and keeps the existing design system.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  - Android Home now prioritizes companion actions before runtime/admin surfaces.
  - Onboarding scan/setup errors are visible before Advanced.
  - Sessions and Providers & Models no longer reserve an extra bottom safe-area gap above the bottom nav.
  - Chat hides the bottom nav while the keyboard is open so the composer sits directly above the keyboard.
  - Top-level Chat does not show a back arrow, and session switching is exposed as compact chips when sessions are available.
- Real environment tested: local Android emulator, third-party debug APK built from commit `51046d159816bad8ded0f9e8da88a1c7e2a945d2`.
- Exact steps or command run after this patch:
  - Built and installed `:app:assembleThirdPartyDebug`.
  - Fresh onboarding smoke: cleared app data, opened Gateway Setup, tapped Scan setup code on the emulator, and captured the visible scanner error state.
  - Shell smoke: marked onboarding complete in the local emulator profile, launched Home, opened Sessions, opened Chat, focused the composer, and captured the keyboard-open state.
  - Layout matrix: repeated Home/Sessions screenshots at narrow, standard, and large emulator viewport sizes.
- Evidence after fix:

  Contact sheet:

  ![Android emulator proof contact sheet](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/pr-proof-contact-sheet.png)

  Individual screenshots:

  - [Onboarding scan error is visible before Advanced](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/onboarding-scan-error-visible.png)
  - [Home, narrow viewport](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/home-small.png)
  - [Home, standard viewport](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/home-standard.png)
  - [Home, large viewport](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/home-large.png)
  - [Sessions bottom spacing, standard viewport](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/sessions-standard.png)
  - [Chat keyboard-open state](https://raw.githubusercontent.com/Tosko4/openclaw/a867e2a69ebed1b9e3c15b2ac262cca928ce5c7a/proof/android-companion-first-ux/51046d1598/chat-keyboard-standard.png)

- Observed result after fix:
  - Setup-code scanner failure renders as `Setup code issue` in the main Gateway Setup flow before Advanced.
  - Home remains companion-first and the bottom nav stays visually attached to the app canvas across the tested viewport sizes.
  - Sessions empty state is vertically balanced instead of ending high above the nav.
  - Keyboard-open Chat no longer shows the bottom nav, and the composer remains immediately above the keyboard.
- What was not tested:
  - Physical Android hardware.
  - Connected-gateway multi-session switching with real gateway session data.
  - Play/release builds.
  - End-to-end pairing against a real gateway after this UI-only patch.
- Proof limitations or environment constraints:
  - The emulator proof uses offline/local UI states to avoid exposing private gateway/session data. Multi-session choice behavior is covered by unit tests, while real connected multi-session UI proof is left for a maintainer or author setup with safe public session data.
- Before evidence (optional but encouraged): not included because the original problem reports were private feedback screenshots. The after-fix screenshots above show the corrected public-safe states.

## Tests and validation

Which commands did you run?

```bash
git fetch upstream --prune
git fetch origin --prune
git rebase upstream/main
ANDROID_HOME=/home/nabu/Android/Sdk ./gradlew :app:compileThirdPartyDebugKotlin :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest --tests ai.openclaw.app.ui.ShellScreenLogicTest --tests ai.openclaw.app.ui.chat.SessionFiltersTest
ANDROID_HOME=/home/nabu/Android/Sdk ./gradlew :app:assembleThirdPartyDebug
git diff --check
ANDROID_HOME=/home/nabu/Android/Sdk ./gradlew :app:ktlintCheck
codex review --base upstream/main
```

What regression coverage was added or updated?

- Added `ShellScreenLogicTest` coverage for Home attention-row logic.
- Added compact session-choice coverage in `SessionFiltersTest` for pinning main/current sessions while capping compact choices.
- Existing `OnboardingFlowLogicTest` stayed green after the visible error-state change.

What failed before this fix, if known?

- Manual UI proof before this patch showed setup/scan errors hidden behind Advanced, Home reading as runtime/module-first, top-level Chat looking nested, bottom nav / content spacing gaps, and keyboard-open Chat reserving bottom-nav space.

If no test was added, why not?

- Tests were added for the non-visual shell/session-selection logic. The remaining layout work is covered by emulator screenshots because Compose visual spacing/insets are behavior-proofed better through real UI capture than pure unit tests.

Validation notes:

- `:app:compileThirdPartyDebugKotlin` + focused unit tests: passed.
- `:app:assembleThirdPartyDebug`: passed.
- `git diff --check`: passed.
- `:app:ktlintCheck`: still fails on untouched files outside this PR: `DeviceHandler.kt`, `ChatController.kt`, `GatewayDiscovery.kt`, `PermissionRequester.kt`, `MicCaptureManager.kt`, and `TalkModeManager.kt`.
- `codex review --base upstream/main`: attempted, but local Codex auth failed with `401 Unauthorized`; no local Codex review result is claimed for this PR.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This changes Android UI presentation and local shell navigation only; setup-code parsing, gateway auth, token storage, TLS behavior, permissions, network policy, and node execution behavior are unchanged.

What is the highest-risk area?

Android UX/layout regression across viewport sizes, keyboard insets, and users with multiple sessions.

How is that risk mitigated?

- Bottom insets are owned by the shell/bottom nav instead of duplicated inside child screens.
- Keyboard-open Chat hides the bottom nav using IME visibility rather than hard-coded device dimensions.
- Session choice logic is extracted and covered with focused unit tests.
- Emulator proof covers onboarding, Home, Sessions, and keyboard-open Chat, including multiple viewport sizes for Home/Sessions.

## Current review state

What is the next action?

Draft PR for maintainer/ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

- CI and ClawSweeper review are pending.
- Real connected-gateway multi-session proof is not included because the local session data would expose private context; the unit tests cover selection behavior and the PR includes offline UI proof.
- Repo-wide Android ktlint remains blocked by existing untouched files noted above.

Which bot or reviewer comments were addressed?

No bot or reviewer comments yet.
