### PR TITLE
fix(agents): quarantine normalized runtime tools

### DIFF
--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -132,6 +132,71 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     ]);
   });
 
+  it("quarantines unreadable tools returned by RuntimePlan normalization", () => {
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const unreadable = { ...createParameterFreeTool(), name: "fuzzplugin_unreadable" } as AgentTool;
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin normalized name getter exploded");
+      },
+    });
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    const normalize = vi.fn(() => [unreadable, healthy]);
+    const runtimePlan = {
+      tools: {
+        normalize,
+        logDiagnostics: vi.fn(),
+      },
+    } as unknown as AgentRuntimePlan;
+
+    expect(
+      normalizeAgentRuntimeTools({
+        runtimePlan,
+        tools: [createParameterFreeTool("source") as AgentTool],
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([healthy]);
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0].name is unreadable"],
+        },
+      ],
+    ]);
+  });
+
+  it("quarantines schemas returned by provider normalization before callers read them", () => {
+    const source = createParameterFreeTool("fuzzplugin_provider_shape") as AgentTool;
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const arraySchema = {
+      ...source,
+      parameters: { type: "array", items: { type: "number" } },
+    } as unknown as AgentTool;
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([arraySchema, healthy]);
+
+    expect(
+      normalizeAgentRuntimeTools({
+        tools: [source],
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([healthy]);
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "fuzzplugin_provider_shape",
+          toolIndex: 0,
+          violations: ['fuzzplugin_provider_shape.parameters.type must be "object"'],
+        },
+      ],
+    ]);
+  });
+
   it("accepts legacy optional model fields while normalizing RuntimePlan context", () => {
     const tools = [createParameterFreeTool()] as AgentTool[];
     const normalize = vi.fn(() => tools);

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -11,6 +11,7 @@ import {
 import type { AgentTool } from "../runtime/index.js";
 import {
   filterProviderNormalizableTools,
+  filterRuntimeCompatibleTools,
   type RuntimeToolSchemaDiagnostic,
 } from "../tool-schema-projection.js";
 import type { AgentRuntimePlan } from "./types.js";
@@ -53,6 +54,14 @@ function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   copyChannelAgentToolMeta(source as never, target as never);
 }
 
+function readRuntimeToolName(tool: Pick<AgentTool, "name">): string | undefined {
+  try {
+    return typeof tool.name === "string" && tool.name ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TResult = unknown>(
   sourceTools: AgentTool<TSchemaType, TResult>[],
   normalizedTools: AgentTool<TSchemaType, TResult>[],
@@ -60,7 +69,10 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
   const sourcesByUniqueName = new Map<string, AgentTool<TSchemaType, TResult>>();
   const duplicateNames = new Set<string>();
   for (const source of sourceTools) {
-    const name = source.name;
+    const name = readRuntimeToolName(source);
+    if (!name) {
+      continue;
+    }
     if (sourcesByUniqueName.has(name)) {
       duplicateNames.add(name);
       sourcesByUniqueName.delete(name);
@@ -71,9 +83,14 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
     }
   }
   for (const [index, target] of normalizedTools.entries()) {
+    const targetName = readRuntimeToolName(target);
+    if (!targetName) {
+      continue;
+    }
     const indexedSource = sourceTools[index];
+    const indexedSourceName = indexedSource ? readRuntimeToolName(indexedSource) : undefined;
     const source =
-      indexedSource?.name === target.name ? indexedSource : sourcesByUniqueName.get(target.name);
+      indexedSourceName === targetName ? indexedSource : sourcesByUniqueName.get(targetName);
     if (source) {
       copyRuntimeToolMetadata(source, target);
     }
@@ -112,7 +129,21 @@ export function normalizeAgentRuntimeTools<
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
-  return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const normalizedWithMetadata = preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
+  const runtimeProjection = filterRuntimeCompatibleTools(normalizedWithMetadata);
+  if (runtimeProjection.diagnostics.length > 0) {
+    params.onPreNormalizationSchemaDiagnostics?.(
+      runtimeProjection.diagnostics,
+      normalizedWithMetadata,
+    );
+  }
+  if (
+    runtimeProjection.tools.length === normalizedWithMetadata.length &&
+    runtimeProjection.tools.every((tool, index) => tool === normalizedWithMetadata[index])
+  ) {
+    return normalizedWithMetadata;
+  }
+  return [...runtimeProjection.tools] as AgentTool<TSchemaType, TResult>[];
 }
 
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {


### PR DESCRIPTION
## Summary

- Quarantines tools returned by RuntimePlan/provider schema normalization before later attempt setup reads their names or schemas.
- Preserves plugin/channel metadata without crashing when normalized tool names are unreadable.
- Keeps existing no-op normalization array identity when runtime projection does not filter anything.
- Adds regressions for unreadable normalized tool names and provider-normalized invalid root schemas.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #89384

Was this requested by a maintainer or owner?

Maintainer-directed tool-schema fuzzing follow-up.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a provider/runtime-plan normalization hook can return an unreadable or unsupported tool after pre-normalization quarantine, and downstream attempt setup can read that bad tool before the final runtime projection.
- Real environment tested: AWS Crabbox Linux checkout, local OpenClaw sparse worktree for formatting/lint/autoreview.
- Exact steps or command run after this patch: `CI=1 corepack pnpm test src/agents/runtime-plan/tools.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; AWS Crabbox fresh-PR `check:changed`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): AWS Crabbox focused test `run_327bfebb1e46`, provider `aws`, lease `cbx_277cad24e58b`, slug `quick-lobster`, exit 0, 1 file / 12 tests passed, lease stopped. AWS Crabbox fresh-PR changed gate `run_09ed1a03351a`, provider `aws`, lease `cbx_d96f88092c0c`, slug `swift-prawn`, exit 0, lanes `core` and `coreTests`, lease stopped.
- Observed result after fix: invalid normalized tools are filtered with schema diagnostics and healthy sibling tools remain available.
- What was not tested: full end-to-end assistant turn with a live third-party plugin returning a bad normalized tool.
- Proof limitations or environment constraints: local Vitest hung under severe low-disk pressure; focused Vitest was run remotely. The local sparse checkout could not materialize the wrapper's temporary full checkout for `check:changed`, so broad proof was run from the fresh PR checkout on AWS Crabbox with a remote Node 24 bootstrap.
- Before evidence (optional but encouraged): the initial focused test failed because the first implementation changed no-op array identity; the earlier direct local probe was interrupted after local `tsx`/Vitest spun under low disk.

## Tests and validation

Which commands did you run?

- `CI=1 corepack pnpm test src/agents/runtime-plan/tools.test.ts -- --reporter=dot` on AWS Crabbox: passed, 1 file / 12 tests.
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`: passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/runtime-plan/tools.ts src/agents/runtime-plan/tools.test.ts`: passed.
- `git diff --check origin/main...HEAD`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean; no accepted/actionable findings.
- AWS Crabbox fresh-PR `check:changed`: passed, `run_09ed1a03351a`, lanes `core` and `coreTests`.

What regression coverage was added or updated?

- `normalizeAgentRuntimeTools(...)` quarantines unreadable tools returned by RuntimePlan normalization.
- `normalizeAgentRuntimeTools(...)` quarantines invalid schemas returned by provider normalization before callers read them.

What failed before this fix, if known?

- A normalized tool with an unreadable `name` could escape pre-normalization filtering and crash later attempt setup.
- A provider-normalized tool with an unsupported root schema could be returned before the runtime compatibility filter saw it.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

Tool availability after provider/runtime-plan normalization.

How is that risk mitigated?

The new filter uses the existing runtime schema projection/quarantine path and preserves the original normalized array when no tool is filtered.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known.

Which bot or reviewer comments were addressed?

Local autoreview initially found a stale callback rename. The rename was reverted, the diff narrowed back to runtime-plan files, and the final autoreview was clean.
