### PR TITLE
fix(codex): quarantine unreadable dynamic tool descriptors

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -371,6 +371,90 @@ describe("createCodexDynamicToolBridge", () => {
     expect(badExecute).not.toHaveBeenCalled();
   });
 
+  it("quarantines unreadable dynamic tool descriptors before bridge registration", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const unreadableName = createTool({ name: "fuzzplugin_unreadable_name" });
+    Object.defineProperty(unreadableName, "name", {
+      get() {
+        throw new Error("fuzzplugin dynamic tool name is unreadable");
+      },
+    });
+    const unreadableParameters = createTool({ name: "fuzzplugin_unreadable_parameters" });
+    Object.defineProperty(unreadableParameters, "parameters", {
+      get() {
+        throw new Error("fuzzplugin dynamic tool schema is unreadable");
+      },
+    });
+    const unreadableDescription = createTool({ name: "fuzzplugin_unreadable_description" });
+    Object.defineProperty(unreadableDescription, "description", {
+      get() {
+        throw new Error("fuzzplugin dynamic tool description is unreadable");
+      },
+    });
+    let flakyNameReads = 0;
+    const flakyName = createTool({ name: "fuzzplugin_flaky_name" });
+    Object.defineProperty(flakyName, "name", {
+      get() {
+        flakyNameReads += 1;
+        if (flakyNameReads > 1) {
+          throw new Error("fuzzplugin dynamic tool name was reread");
+        }
+        return "fuzzplugin_flaky_name";
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools: [unreadableName, createTool({ name: "message" }), unreadableParameters],
+      registeredTools: [
+        unreadableName,
+        createTool({ name: "message" }),
+        unreadableParameters,
+        unreadableDescription,
+        flakyName,
+      ],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message", "fuzzplugin_flaky_name"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "tool[0]",
+        violations: ["tool[0].name is unreadable"],
+      },
+      {
+        tool: "fuzzplugin_unreadable_parameters",
+        violations: ["fuzzplugin_unreadable_parameters.inputSchema is unreadable"],
+      },
+      {
+        tool: "fuzzplugin_unreadable_description",
+        violations: ["fuzzplugin_unreadable_description.description is unreadable"],
+      },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "tool[0], fuzzplugin_unreadable_parameters, fuzzplugin_unreadable_description",
+      ),
+      expect.objectContaining({
+        tools: [
+          {
+            tool: "tool[0]",
+            violations: ["tool[0].name is unreadable"],
+          },
+          {
+            tool: "fuzzplugin_unreadable_parameters",
+            violations: ["fuzzplugin_unreadable_parameters.inputSchema is unreadable"],
+          },
+          {
+            tool: "fuzzplugin_unreadable_description",
+            violations: ["fuzzplugin_unreadable_description.description is unreadable"],
+          },
+        ],
+      }),
+    );
+    expect(flakyNameReads).toBe(1);
+  });
+
   it("can expose all dynamic tools directly for compatibility", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "web_search" }), createTool({ name: "message" })],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -51,7 +51,11 @@ type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
+  sourceTool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
+  beforeToolCallWrapped: boolean;
 };
 
 type CodexDynamicToolSchemaQuarantine = {
@@ -101,19 +105,20 @@ export function createCodexDynamicToolBridge(params: {
   const registeredProjection = params.registeredTools
     ? projectCodexDynamicTools(params.registeredTools)
     : availableProjection;
-  const availableTools = availableProjection.tools.map(({ tool, inputSchema }) => {
-    if (isToolWrappedWithBeforeToolCallHook(tool)) {
-      setBeforeToolCallDiagnosticsEnabled(tool, false);
-      return { tool, inputSchema };
+  const availableTools = availableProjection.tools.map((projectedTool) => {
+    if (projectedTool.beforeToolCallWrapped) {
+      setBeforeToolCallDiagnosticsEnabled(projectedTool.sourceTool, false);
+      return projectedTool;
     }
     return {
-      tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
-      inputSchema,
+      ...projectedTool,
+      tool: wrapToolWithBeforeToolCallHook(projectedTool.tool, params.hookContext, {
+        emitDiagnostics: false,
+      }),
     };
   });
-  const toolMap = new Map(availableTools.map(({ tool }) => [tool.name, tool]));
-  const registeredTools = registeredProjection.tools.map(({ tool }) => tool);
-  const registeredToolNames = new Set(registeredTools.map((tool) => tool.name));
+  const toolMap = new Map(availableTools.map(({ name, tool }) => [name, tool]));
+  const registeredToolNames = new Set(registeredProjection.tools.map((tool) => tool.name));
   const quarantinedTools = dedupeQuarantinedDynamicTools([
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
@@ -142,17 +147,19 @@ export function createCodexDynamicToolBridge(params: {
   ]);
 
   return {
-    availableSpecs: availableTools.map(({ tool, inputSchema }) =>
+    availableSpecs: availableTools.map(({ name, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        name,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
       }),
     ),
-    specs: registeredProjection.tools.map(({ tool, inputSchema }) =>
+    specs: registeredProjection.tools.map(({ name, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        name,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
@@ -286,17 +293,18 @@ export function createCodexDynamicToolBridge(params: {
 }
 
 function createCodexDynamicToolSpec(params: {
-  tool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
   loading: CodexDynamicToolsLoading;
   directToolNames: ReadonlySet<string>;
 }): CodexDynamicToolSpec {
   const base = {
-    name: params.tool.name,
-    description: params.tool.description,
+    name: params.name,
+    description: params.description,
     inputSchema: params.inputSchema,
   };
-  if (params.loading === "direct" || params.directToolNames.has(params.tool.name)) {
+  if (params.loading === "direct" || params.directToolNames.has(params.name)) {
     return base;
   }
   return {
@@ -312,15 +320,128 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
 } {
   const projectedTools: ProjectedCodexDynamicTool[] = [];
   const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
-  for (const tool of tools) {
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${tool.name}.inputSchema`);
-    if (projection.violations.length > 0) {
-      quarantinedTools.push({ tool: tool.name, violations: projection.violations });
+  let toolCount: number;
+  try {
+    toolCount = tools.length;
+  } catch {
+    return {
+      tools: projectedTools,
+      quarantinedTools: [{ tool: "tool[0]", violations: ["tool[0] is unreadable"] }],
+    };
+  }
+  for (let toolIndex = 0; toolIndex < toolCount; toolIndex += 1) {
+    let tool: AnyAgentTool;
+    try {
+      const candidate = tools[toolIndex];
+      if (!candidate) {
+        throw new Error("missing dynamic tool entry");
+      }
+      tool = candidate;
+    } catch {
+      const toolName = `tool[${toolIndex}]`;
+      quarantinedTools.push({ tool: toolName, violations: [`${toolName} is unreadable`] });
       continue;
     }
-    projectedTools.push({ tool, inputSchema: projection.schema as JsonValue });
+
+    const nameRead = readDynamicToolDescriptorField(tool, "name");
+    const toolName =
+      nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+        ? nameRead.value
+        : `tool[${toolIndex}]`;
+    const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+    const parametersRead = readDynamicToolDescriptorField(tool, "parameters");
+    if (!parametersRead.readable) {
+      quarantinedTools.push({
+        tool: toolName,
+        violations: [...descriptorViolations, `${toolName}.inputSchema is unreadable`],
+      });
+      continue;
+    }
+    if (descriptorViolations.length > 0) {
+      quarantinedTools.push({ tool: toolName, violations: descriptorViolations });
+      continue;
+    }
+    const descriptionRead = readDynamicToolDescriptorField(tool, "description");
+    if (!descriptionRead.readable) {
+      quarantinedTools.push({
+        tool: toolName,
+        violations: [`${toolName}.description is unreadable`],
+      });
+      continue;
+    }
+    if (typeof descriptionRead.value !== "string") {
+      quarantinedTools.push({
+        tool: toolName,
+        violations: [`${toolName}.description must be a string`],
+      });
+      continue;
+    }
+
+    const projection = projectRuntimeToolInputSchema(
+      parametersRead.value,
+      `${toolName}.inputSchema`,
+    );
+    if (projection.violations.length > 0) {
+      quarantinedTools.push({
+        tool: toolName,
+        violations: [...descriptorViolations, ...projection.violations],
+      });
+      continue;
+    }
+    const executeRead = readDynamicToolDescriptorField(tool, "execute");
+    if (!executeRead.readable || typeof executeRead.value !== "function") {
+      quarantinedTools.push({ tool: toolName, violations: [`${toolName}.execute is unreadable`] });
+      continue;
+    }
+    const prepareArgumentsRead = readDynamicToolDescriptorField(tool, "prepareArguments");
+    if (!prepareArgumentsRead.readable) {
+      quarantinedTools.push({
+        tool: toolName,
+        violations: [`${toolName}.prepareArguments is unreadable`],
+      });
+      continue;
+    }
+    const labelRead = readDynamicToolDescriptorField(tool, "label");
+    const displaySummaryRead = readDynamicToolDescriptorField(tool, "displaySummary");
+    const executionModeRead = readDynamicToolDescriptorField(tool, "executionMode");
+    const snapshotTool: AnyAgentTool = {
+      name: toolName,
+      label: labelRead.readable && typeof labelRead.value === "string" ? labelRead.value : toolName,
+      description: descriptionRead.value,
+      parameters: parametersRead.value,
+      execute: executeRead.value,
+      ...(prepareArgumentsRead.readable && typeof prepareArgumentsRead.value === "function"
+        ? { prepareArguments: prepareArgumentsRead.value }
+        : {}),
+      ...(executionModeRead.readable &&
+      (executionModeRead.value === "parallel" || executionModeRead.value === "sequential")
+        ? { executionMode: executionModeRead.value }
+        : {}),
+      ...(displaySummaryRead.readable && typeof displaySummaryRead.value === "string"
+        ? { displaySummary: displaySummaryRead.value }
+        : {}),
+    } as AnyAgentTool;
+    projectedTools.push({
+      tool: snapshotTool,
+      sourceTool: tool,
+      name: toolName,
+      description: descriptionRead.value,
+      inputSchema: projection.schema as JsonValue,
+      beforeToolCallWrapped: isToolWrappedWithBeforeToolCallHook(tool),
+    });
   }
   return { tools: projectedTools, quarantinedTools };
+}
+
+function readDynamicToolDescriptorField<TField extends keyof AnyAgentTool>(
+  tool: AnyAgentTool,
+  field: TField,
+): { readable: true; value: AnyAgentTool[TField] } | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 function warnQuarantinedDynamicTools(tools: readonly CodexDynamicToolSchemaQuarantine[]): void {


### PR DESCRIPTION
## Summary

- Quarantines unreadable Codex app-server dynamic tool descriptors before bridge registration builds specs, maps, or wrappers.
- Snapshots readable descriptor fields once so a plugin getter cannot pass schema projection and crash later during Codex tool spec construction.
- Preserves healthy sibling tools and existing dynamic-tool quarantine warnings/diagnostics.
- Out of scope: changing plugin SDK registration contracts or provider-side schema normalization.

## Linked context

Related to the active runtime tool-schema fuzzing sweep for unsupported plugin tool schemas crashing turns before assistant content.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A malformed Codex dynamic tool descriptor can no longer crash bridge registration before the assistant turn reaches content.
- Real environment tested: Local OpenClaw Codex extension Vitest harness in a Codex worktree.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=dot`; AWS Crabbox fresh-PR `pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `extensions/codex/src/app-server/dynamic-tools.test.ts` passed, 37 tests.
- Observed result after fix: unreadable dynamic tool `name`, `parameters`, and `description` descriptors are quarantined; a one-shot readable name is captured once and reused without a later getter crash; healthy `message` remains registered.
- What was not tested: live Telegram/Codex app-server turn with an installed hostile plugin.
- Proof limitations or environment constraints: local disk is very low, so broad changed proof ran remotely instead of in the local Codex worktree.
- Before evidence (optional but encouraged): autoreview confirmed the earlier guarded projection still crashed when downstream registration reread raw descriptors.

## Tests and validation

- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts`
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=dot`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh-PR changed gate:
  `/opt/homebrew/bin/crabbox run --provider aws --fresh-pr openclaw/openclaw#89397 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` passed. Provider: `aws`; run: `run_b533b3b7e58c`; lease: `cbx_8180c941abce`; slug: `brisk-krill`; exit 0; lanes: `extensions`, `extensionTests`; command 4m26.143s; total 4m42.141s; lease stopped.

Regression coverage added:

- `createCodexDynamicToolBridge(...)` quarantines unreadable dynamic tool descriptor fields before bridge registration.
- The same regression verifies a one-shot dynamic tool name is not reread during spec construction.

Known validation note:

- Targeted local extension oxlint currently reports pre-existing sparse/type-resolution errors in `extensions/codex/src/app-server/dynamic-tools.ts`, so lint/typecheck proof is being routed through remote changed validation.

## Risk checklist

- Did user-visible behavior change? (`Yes/No`) Yes.
- Did config, environment, or migration behavior change? (`Yes/No`) No.
- Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes, tool registration now quarantines malformed dynamic descriptors earlier.
- What is the highest-risk area? Accidentally changing Codex dynamic tool registration/wrapping semantics.
- How is that risk mitigated? Existing dynamic-tool tests still pass, including direct/searchable registration and wrapped-tool behavior; the fix snapshots only registration descriptors and keeps execution dispatch tied to the captured name.

## Current review state

- Next action: maintainer review.
- Still waiting on: nothing known from author.
- Bot or reviewer comments addressed: local autoreview first found the raw-descriptor reread issue; the patch now snapshots descriptor fields and final autoreview is clean.
