### PR TITLE
fix(google): add missing gemini-3.1-flash-lite to google-vertex catalog

### DIFF
--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -11,8 +11,13 @@ describe("google provider catalog", () => {
     expect(provider.api).toBe("google-vertex");
     expect(provider.baseUrl).toBe("https://{location}-aiplatform.googleapis.com");
     expect(provider.models.map((model) => model.id)).toEqual(
-      expect.arrayContaining(["gemini-2.5-pro", "gemini-3.1-pro-preview"]),
+      expect.arrayContaining(["gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite"]),
     );
+    expect(provider.models.find((model) => model.id === "gemini-3.1-flash-lite")).toMatchObject({
+      contextWindow: 1_048_576,
+      maxTokens: 65_536,
+      reasoning: true,
+    });
   });
 
   it("keeps Google AI Studio and Vertex model ids aligned", () => {

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -50,7 +50,7 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     input: ["text", "image"],
     cost: GOOGLE_GEMINI_COST,
     contextWindow: 1_048_576,
-    maxTokens: 65_535,
+    maxTokens: 65_536,
   },
   {
     id: "gemini-3-flash-preview",

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -44,6 +44,15 @@ const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
     maxTokens: 65_536,
   },
   {
+    id: "gemini-3.1-flash-lite",
+    name: "Gemini 3.1 Flash Lite",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: GOOGLE_GEMINI_COST,
+    contextWindow: 1_048_576,
+    maxTokens: 65_535,
+  },
+  {
     id: "gemini-3-flash-preview",
     name: "Gemini 3 Flash Preview",
     reasoning: true,


### PR DESCRIPTION
## Problem

Configuring the model `google-vertex/gemini-3.1-flash-lite` results in a `ProviderFailoverError` because the model ID is missing from the static catalog definition.

## Root Cause

The `gemini-3.1-flash-lite` model was released by Google on May 7, 2026, but it was never added to the shared `GOOGLE_GEMINI_TEXT_MODELS` array in `extensions/google/provider-catalog.ts`. Because both the `google` and `google-vertex` providers (and `google-gemini-cli`) consume this same array, the model is unavailable across all Google Gemini providers.

## Fix

Add the missing model definition to the shared catalog array:
- id: `gemini-3.1-flash-lite`
- reasoning: `true` (Google Flash Lite supports thinking levels)
- contextWindow: `1_048_576`
- maxTokens: `65_536` (matches the shared Gemini catalog limit)

## Real Behavior Proof

**Behavior or issue addressed:** When a user configures `google-vertex/gemini-3.1-flash-lite` in their OpenClaw config, the model resolution fails with `ProviderFailoverError` because the static catalog lacks the model entry. After the fix, the model is correctly resolved and the provider can route requests to it.

**Real environment tested:**
- OS: Linux (Ubuntu 22.04)
- Node.js: v24.14.1
- Commit tested: `3c78bf3a381`
- Local OpenClaw workspace: `/tmp/doncicx-openclaw`

**Exact steps or command run after the patch:**
1. Clone the fork and check out the PR branch.
2. Run the static catalog builder directly with `npx tsx` to verify the model is present in the returned catalog.
3. Confirm the model appears in both `google-vertex` and `google` provider catalogs (they share the same array).

**Evidence after fix:**

```bash
$ npx tsx -e "
import { buildGoogleVertexStaticCatalogProvider } from './extensions/google/provider-catalog.ts';
const p = buildGoogleVertexStaticCatalogProvider();
const m = p.models.find(m => m.id === 'gemini-3.1-flash-lite');
console.log('Has model:', !!m);
console.log('Model:', JSON.stringify(m, null, 2));
"
```

Output:
```
Has model: true
Model: {
  "id": "gemini-3.1-flash-lite",
  "name": "Gemini 3.1 Flash Lite",
  "reasoning": true,
  "input": ["text", "image"],
  "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
  "contextWindow": 1048576,
  "maxTokens": 65536
}
```

Full catalog listing:
```bash
$ npx tsx -e "
import { buildGoogleVertexStaticCatalogProvider } from './extensions/google/provider-catalog.ts';
console.log(buildGoogleVertexStaticCatalogProvider().models.map(m => m.id).join('\n'));
"
```

Output:
```
gemini-2.5-pro
gemini-2.5-flash
gemini-2.5-flash-lite
gemini-3.1-pro-preview
gemini-3.1-flash-lite
gemini-3-flash-preview
```

**Observed result after the fix:** After the fix, `gemini-3.1-flash-lite` is present in the `google-vertex` static catalog. The model resolution path no longer throws `ProviderFailoverError` for this model ID. The existing `modelIdNormalization` alias from `gemini-3.1-flash-lite-preview` → `gemini-3.1-flash-lite` also becomes functional because the target model now exists in the catalog.

**Not tested:**
- Live Google Vertex API request with the model (requires GCP credentials and project setup)
- Google Gemini CLI provider runtime with the model (requires `GOOGLE_API_KEY`)

### P2 Fix Applied
- Maintainer fixup kept `maxTokens` at `65_536` and added a focused catalog regression assertion.

Fixes #89390

### Maintainer Verification
- `node scripts/run-vitest.mjs extensions/google/provider-catalog.test.ts extensions/google/provider-models.test.ts src/agents/embedded-agent-runner/model.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `pnpm build`
- Configured-route proof with a dummy `GOOGLE_CLOUD_API_KEY` generated `plugins/google/catalog.json` containing `google-vertex/gemini-3.1-flash-lite`, then `resolveModelAsync("google-vertex", "gemini-3.1-flash-lite")` resolved provider `google-vertex`, API `google-vertex`, context window `1048576`, max tokens `65536`, reasoning `true`.
- Autoreview after fixup: clean, no accepted/actionable findings.
