### PR TITLE
fix(talk): quarantine invalid realtime consult tools

### DIFF
--- a/src/talk/agent-consult-tool.test.ts
+++ b/src/talk/agent-consult-tool.test.ts
@@ -10,6 +10,7 @@ import {
   resolveRealtimeVoiceAgentConsultTools,
   resolveRealtimeVoiceAgentConsultToolsAllow,
 } from "./agent-consult-tool.js";
+import type { RealtimeVoiceTool } from "./provider-types.js";
 
 describe("realtime voice agent consult tool", () => {
   it("normalizes shared tool arguments for browser chat forwarding", () => {
@@ -113,5 +114,112 @@ describe("realtime voice agent consult tool", () => {
       resolveRealtimeVoiceAgentConsultTools("safe-read-only", [duplicateConsultTool, customTool]),
     ).toStrictEqual([REALTIME_VOICE_AGENT_CONSULT_TOOL, customTool]);
     expect(resolveRealtimeVoiceAgentConsultTools("none", [customTool])).toEqual([customTool]);
+  });
+
+  it("quarantines unreadable custom realtime tools before consult tool exposure", () => {
+    const unreadableName = {
+      type: "function" as const,
+      name: "fuzzplugin_unreadable_name",
+      description: "Bad name",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    Object.defineProperty(unreadableName, "name", {
+      get() {
+        throw new Error("fuzzplugin realtime tool name is unreadable");
+      },
+    });
+    const unreadableDescription = {
+      type: "function" as const,
+      name: "fuzzplugin_unreadable_description",
+      description: "Bad description",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    Object.defineProperty(unreadableDescription, "description", {
+      get() {
+        throw new Error("fuzzplugin realtime tool description is unreadable");
+      },
+    });
+    const invalidParameters = {
+      type: "function" as const,
+      name: "fuzzplugin_invalid_schema",
+      description: "Bad schema",
+      parameters: { type: "array" as const, items: { type: "string" } },
+    };
+    const dynamicParameters = {
+      type: "function" as const,
+      name: "fuzzplugin_dynamic_schema",
+      description: "Dynamic schema",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+      },
+    };
+    const arrayDynamicParameters = {
+      type: "function" as const,
+      name: "fuzzplugin_array_dynamic_schema",
+      description: "Array dynamic schema",
+      parameters: {
+        type: "object" as const,
+        anyOf: [{ $dynamicRef: "#target" }],
+        properties: {},
+      },
+    };
+    let flakyNameReads = 0;
+    const flakyName = {
+      type: "function" as const,
+      name: "fuzzplugin_flaky_name",
+      description: "Safe snapshot",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    Object.defineProperty(flakyName, "name", {
+      get() {
+        flakyNameReads += 1;
+        if (flakyNameReads > 1) {
+          throw new Error("fuzzplugin realtime tool name was reread");
+        }
+        return "fuzzplugin_flaky_name";
+      },
+    });
+
+    const tools = resolveRealtimeVoiceAgentConsultTools("safe-read-only", [
+      unreadableName,
+      unreadableDescription,
+      invalidParameters as unknown as RealtimeVoiceTool,
+      dynamicParameters,
+      arrayDynamicParameters,
+      flakyName,
+    ]);
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+      "fuzzplugin_flaky_name",
+    ]);
+    expect(tools[1]).toEqual({
+      type: "function",
+      name: "fuzzplugin_flaky_name",
+      description: "Safe snapshot",
+      parameters: { type: "object", properties: {} },
+    });
+    expect(flakyNameReads).toBe(1);
+  });
+
+  it("keeps custom realtime tools with dynamic-keyword argument names", () => {
+    const literalDynamicNameTool = {
+      type: "function" as const,
+      name: "fuzzplugin_literal_dynamic_name",
+      description: "Literal dynamic keyword argument name",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          $dynamicRef: { type: "string" },
+        },
+      },
+    };
+
+    expect(resolveRealtimeVoiceAgentConsultTools("none", [literalDynamicNameTool])).toEqual([
+      literalDynamicNameTool,
+    ]);
   });
 });

--- a/src/talk/agent-consult-tool.ts
+++ b/src/talk/agent-consult-tool.ts
@@ -94,11 +94,127 @@ export function resolveRealtimeVoiceAgentConsultTools(
     tools.set(REALTIME_VOICE_AGENT_CONSULT_TOOL.name, REALTIME_VOICE_AGENT_CONSULT_TOOL);
   }
   for (const tool of customTools) {
-    if (!tools.has(tool.name)) {
-      tools.set(tool.name, tool);
+    const projectedTool = projectRealtimeVoiceTool(tool);
+    if (projectedTool && !tools.has(projectedTool.name)) {
+      tools.set(projectedTool.name, projectedTool);
     }
   }
   return [...tools.values()];
+}
+
+function projectRealtimeVoiceTool(tool: RealtimeVoiceTool): RealtimeVoiceTool | undefined {
+  const nameRead = readRealtimeVoiceToolField(tool, "name");
+  if (!nameRead.readable || typeof nameRead.value !== "string" || !nameRead.value) {
+    return undefined;
+  }
+  const descriptionRead = readRealtimeVoiceToolField(tool, "description");
+  if (!descriptionRead.readable || typeof descriptionRead.value !== "string") {
+    return undefined;
+  }
+  const parametersRead = readRealtimeVoiceToolField(tool, "parameters");
+  if (!parametersRead.readable) {
+    return undefined;
+  }
+  const parameters = projectRealtimeVoiceToolParameters(parametersRead.value);
+  if (!parameters) {
+    return undefined;
+  }
+  return {
+    type: "function",
+    name: nameRead.value,
+    description: descriptionRead.value,
+    parameters,
+  };
+}
+
+function projectRealtimeVoiceToolParameters(
+  value: unknown,
+): RealtimeVoiceTool["parameters"] | undefined {
+  let text: string | undefined;
+  try {
+    text = JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+  if (!text) {
+    return undefined;
+  }
+  const parsed = JSON.parse(text) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const schema = parsed as Record<string, unknown>;
+  if (schema.type !== undefined && schema.type !== "object") {
+    return undefined;
+  }
+  if (
+    schema.properties !== undefined &&
+    (!schema.properties ||
+      typeof schema.properties !== "object" ||
+      Array.isArray(schema.properties))
+  ) {
+    return undefined;
+  }
+  if (hasRealtimeVoiceDynamicSchemaKeyword(schema)) {
+    return undefined;
+  }
+  return {
+    ...schema,
+    type: "object",
+    properties: (schema.properties ?? {}) as Record<string, unknown>,
+  } as RealtimeVoiceTool["parameters"];
+}
+
+const REALTIME_VOICE_SCHEMA_MAP_KEYWORDS = new Set([
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+function hasRealtimeVoiceDynamicSchemaKeyword(value: unknown, inspectCurrent = true): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasRealtimeVoiceDynamicSchemaKeyword(entry));
+  }
+  const record = value as Record<string, unknown>;
+  if (inspectCurrent && ("$dynamicRef" in record || "$dynamicAnchor" in record)) {
+    return true;
+  }
+  for (const [key, child] of Object.entries(record)) {
+    if (!child || typeof child !== "object") {
+      continue;
+    }
+    if (REALTIME_VOICE_SCHEMA_MAP_KEYWORDS.has(key) && !Array.isArray(child)) {
+      if (
+        Object.values(child as Record<string, unknown>).some((entry) =>
+          hasRealtimeVoiceDynamicSchemaKeyword(entry),
+        )
+      ) {
+        return true;
+      }
+      continue;
+    }
+    if (hasRealtimeVoiceDynamicSchemaKeyword(child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function readRealtimeVoiceToolField<TField extends keyof RealtimeVoiceTool>(
+  tool: RealtimeVoiceTool,
+  field: TField,
+): { readable: true; value: RealtimeVoiceTool[TField] } | { readable: false } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 export function resolveRealtimeVoiceAgentConsultToolsAllow(


### PR DESCRIPTION
## Summary

- Quarantines malformed custom realtime voice tools before consult-tool exposure builds the provider tool list.
- Snapshots readable custom realtime tool descriptors once, so hostile getters cannot pass filtering and crash later provider/session setup.
- Rejects unsupported realtime custom tool schemas, including non-object roots and `$dynamicRef` / `$dynamicAnchor` schema keywords, while preserving legal argument names that happen to match those strings.
- Out of scope: changing the built-in `openclaw_agent_consult` tool or realtime provider transport behavior.

## Linked context

Related to the active runtime tool-schema fuzzing sweep for unsupported plugin tool schemas crashing assistant turns before content.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A malformed custom realtime voice tool can no longer prevent the built-in agent consult tool from being exposed.
- Real environment tested: Local OpenClaw unit-fast Vitest harness in a Codex worktree.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/talk/agent-consult-tool.test.ts -- --reporter=dot`; AWS Crabbox fresh-PR `pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `src/talk/agent-consult-tool.test.ts` passed, 9 tests.
- Observed result after fix: unreadable custom realtime `name` / `description`, invalid root schema, and dynamic-schema-keyword tools are skipped; healthy sibling tools and the built-in consult tool remain exposed.
- What was not tested: live Discord/Meet realtime voice session with an installed hostile provider/plugin custom tool.
- Proof limitations or environment constraints: broad changed proof ran remotely instead of in the local Codex worktree.
- Before evidence (optional but encouraged): autoreview found the initial dynamic-keyword traversal false-positive and array-callback false-negative; both were fixed and covered.

## Tests and validation

- `./node_modules/.bin/oxfmt --check --threads=1 src/talk/agent-consult-tool.ts src/talk/agent-consult-tool.test.ts`
- `git diff --check origin/main...HEAD`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/talk/agent-consult-tool.ts src/talk/agent-consult-tool.test.ts`
- `node scripts/run-vitest.mjs src/talk/agent-consult-tool.test.ts -- --reporter=dot`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh-PR changed gate:
  `/opt/homebrew/bin/crabbox run --provider aws --fresh-pr openclaw/openclaw#89402 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` passed. Provider: `aws`; run: `run_5a0028615d1a`; lease: `cbx_837653a9b790`; slug: `violet-barnacle`; exit 0; lanes: `core`, `coreTests`; command 3m45.567s; total 4m3.09s; lease stopped.

Regression coverage added:

- malformed custom realtime tool descriptors are skipped before consult tool exposure;
- a one-shot readable custom tool name is snapshotted and not reread;
- schemas with `$dynamicRef` / `$dynamicAnchor` are rejected;
- a legal argument property named `$dynamicRef` remains accepted.

## Risk checklist

- Did user-visible behavior change? (`Yes/No`) Yes.
- Did config, environment, or migration behavior change? (`Yes/No`) No.
- Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes, malformed realtime custom tools are no longer exposed to providers.
- What is the highest-risk area? Accidentally dropping valid custom realtime voice tools.
- How is that risk mitigated? The regression preserves healthy tools, keeps consult ordering/deduplication behavior, and covers the schema-map keyword edge that review found.

## Current review state

- Next action: maintainer review.
- Still waiting on: nothing known from author.
- Bot or reviewer comments addressed: local autoreview found and then cleared dynamic-keyword traversal issues.
