### PR TITLE
fix(feishu): use resolved runtime config for gateway sends

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -266,6 +266,48 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
   });
 
+  it("uses resolved runtime account credentials when creating the media upload client", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      configured: true,
+      accountId: "main",
+      config: {},
+      appId: "cli_resolved",
+      appSecret: "resolved-feishu-app-secret", // pragma: allowlist secret
+      domain: "feishu",
+    });
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-image"),
+      fileName: "photo.png",
+      kind: "image",
+      contentType: "image/png",
+    });
+
+    await sendMediaFeishu({
+      cfg: {
+        channels: {
+          feishu: {
+            appId: "cli_resolved",
+            appSecret: {
+              source: "env",
+              provider: "default",
+              id: "FEISHU_SECRET_REF_NOT_FOR_CLIENT",
+            },
+          },
+        },
+      } as never,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/photo.png",
+      accountId: "main",
+    });
+
+    const clientConfig = mockCallArg<{ appSecret?: string }>(createFeishuClientMock, 0, 0);
+    expect(clientConfig.appSecret).toBe("resolved-feishu-app-secret");
+    expect(JSON.stringify(createFeishuClientMock.mock.calls)).not.toContain(
+      "FEISHU_SECRET_REF_NOT_FOR_CLIENT",
+    );
+    expect(JSON.stringify(loadWebMediaMock.mock.calls)).toContain("https://example.com/photo.png");
+  });
+
   it("falls back to generic file for unsupported audio formats", async () => {
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("remote-mp3"),

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -379,6 +379,64 @@ describe("gateway send mirroring", () => {
     expect(response?.[0]).toBe(true);
   });
 
+  it("uses the resolved runtime config for gateway sends when Feishu appSecret is SecretRef-backed", async () => {
+    const sourceConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_source",
+          appSecret: {
+            source: "env",
+            provider: "default",
+            id: "FEISHU_APP_SECRET",
+          },
+        },
+      },
+    };
+    const runtimeConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_source",
+          appSecret: "resolved-feishu-secret",
+        },
+      },
+    };
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({
+      config,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(runtimeConfig);
+    mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(sourceConfig);
+    mocks.deliverOutboundPayloads.mockResolvedValue([
+      { messageId: "feishu-media", channel: "feishu" },
+    ]);
+
+    const context = {
+      ...makeContext(),
+      getRuntimeConfig: () => sourceConfig,
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn();
+    await sendHandlers.send({
+      params: {
+        channel: "feishu",
+        to: "chat:oc_target",
+        mediaUrl: "https://example.com/image.png",
+        idempotencyKey: "idem-feishu-runtime-config",
+      } as never,
+      respond,
+      context,
+      req: { type: "req", id: "1", method: "send" },
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(deliveryCall()?.cfg).toBe(runtimeConfig);
+    expect(JSON.stringify(deliveryCall()?.cfg)).toContain("resolved-feishu-secret");
+    expect(JSON.stringify(deliveryCall()?.cfg)).not.toContain("FEISHU_APP_SECRET");
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(true);
+  });
+
   it("matches message.action runtime config against the canonical pre-auto-enable source config", async () => {
     const sourceConfig = {
       channels: {
@@ -549,18 +607,19 @@ describe("gateway send mirroring", () => {
     expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(autoEnabledRequestConfig);
   });
 
-  it("does not read the runtime config snapshot for send requests", async () => {
-    mockDeliverySuccess("m-no-runtime-config-read");
+  it("checks the runtime config snapshot for send requests", async () => {
+    mockDeliverySuccess("m-runtime-config-checked");
 
     await runSend({
       to: "channel:C1",
       message: "hi",
       channel: "slack",
-      idempotencyKey: "idem-send-no-runtime-config-read",
+      idempotencyKey: "idem-send-runtime-config-checked",
     });
 
-    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
-    expect(mocks.getRuntimeConfigSourceSnapshot).not.toHaveBeenCalled();
+    expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.getRuntimeConfigSourceSnapshot).toHaveBeenCalledTimes(1);
+    expect(deliveryCall()?.cfg).toEqual({});
   });
 
   it("dedupes concurrent message.action requests while inflight", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -261,7 +261,7 @@ function resolveGatewayOutboundTarget(params: {
   return { ok: true, to: resolved.to };
 }
 
-function resolveMessageActionRuntimeConfig(params: {
+function resolveCurrentMessageRuntimeConfig(params: {
   cfg: OpenClawConfig;
   sourceCfg: OpenClawConfig;
 }): OpenClawConfig {
@@ -275,7 +275,7 @@ function resolveMessageActionRuntimeConfig(params: {
     runtimeConfig,
     runtimeSourceConfig,
   });
-  // Message actions must use the hot runtime snapshot when it matches the caller's source config.
+  // Message sends/actions must use the hot runtime snapshot when it matches the caller's source config.
   if (selected === runtimeConfig && selected !== params.cfg) {
     return resolveGatewayPluginConfig({ config: selected });
   }
@@ -492,7 +492,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         return { ok: false, error: resolvedChannel.error };
       }
       const { cfg: selectedCfg, sourceCfg, channel } = resolvedChannel;
-      const cfg = resolveMessageActionRuntimeConfig({ cfg: selectedCfg, sourceCfg });
+      const cfg = resolveCurrentMessageRuntimeConfig({ cfg: selectedCfg, sourceCfg });
       const plugin = resolveOutboundChannelPlugin({ channel, cfg });
       if (!plugin?.actions?.handleAction) {
         return {
@@ -630,7 +630,8 @@ export const sendHandlers: GatewayRequestHandlers = {
       if (resolvedChannel.kind !== "ready") {
         return resolvedChannel.result;
       }
-      const { cfg, channel } = resolvedChannel;
+      const { cfg: selectedCfg, sourceCfg, channel } = resolvedChannel;
+      const cfg = resolveCurrentMessageRuntimeConfig({ cfg: selectedCfg, sourceCfg });
       const outboundChannel = channel;
       const plugin = resolveOutboundChannelPlugin({ channel, cfg });
       if (!plugin) {


### PR DESCRIPTION
## Summary
- use the hot runtime config snapshot for gateway send requests when it matches the caller source config, so resolved Feishu SecretRef credentials reach delivery
- keep Feishu mediaUrl as a plain payload input instead of resolving media URLs through SecretRef
- add regression coverage for the gateway send handoff and Feishu media upload client credentials

Fixes #89338.

## Validation
- node scripts/run-vitest.mjs extensions/feishu/src/media.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/accounts.test.ts extensions/feishu/src/client.test.ts src/gateway/server-methods/send.test.ts: passed (gateway 57 tests, Feishu 126 tests)
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
- git diff --check

## Remaining
- redacted live Feishu proof is still needed before this draft should be marked ready