### PR TITLE
fix(agents): snapshot SDK custom tools safely

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -93,7 +93,10 @@ import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-promp
 import type { BashOperations } from "./tools/bash-operations.js";
 import { createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
-import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
+import {
+  createToolDefinitionFromAgentTool,
+  snapshotToolDefinitions,
+} from "./tools/tool-definition-wrapper.js";
 
 function unwrapCoreResult<T>(result: { ok: true; value: T } | { ok: false; error: Error }): T {
   if (result.ok) {
@@ -383,7 +386,7 @@ export class AgentSession {
     this.settingsManager = config.settingsManager;
     this.scopedModelEntries = config.scopedModels ?? [];
     this.sessionResourceLoader = config.resourceLoader;
-    this.customTools = config.customTools ?? [];
+    this.customTools = snapshotToolDefinitions(config.customTools);
     this.cwd = config.cwd;
     this.sessionModelRegistry = config.modelRegistry;
     this.extensionRunnerRef = config.extensionRunnerRef;

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -117,6 +117,115 @@ describe("createAgentSession tool defaults", () => {
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
   });
 
+  it("drops unreadable SDK custom tool descriptors before session setup", async () => {
+    const healthyTool: ToolDefinition = {
+      name: "healthy_lookup",
+      label: "Healthy Lookup",
+      description: "Looks up a test value.",
+      promptSnippet: "Lookup test values",
+      promptGuidelines: ["Use healthy_lookup for test values."],
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        details: {},
+      }),
+    };
+    const unreadableNameTool = {
+      get name(): string {
+        throw new Error("boom");
+      },
+      label: "Broken",
+      description: "Breaks when read.",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "bad" }],
+        details: {},
+      }),
+    } as unknown as ToolDefinition;
+    const unreadableGuidelinesTool = {
+      name: "bad_guidelines",
+      label: "Broken Guidelines",
+      description: "Breaks when prompt metadata is read.",
+      get promptGuidelines(): string[] {
+        throw new Error("boom");
+      },
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "bad" }],
+        details: {},
+      }),
+    } as unknown as ToolDefinition;
+    const unreadableParametersTool = {
+      name: "bad_parameters",
+      label: "Broken Parameters",
+      description: "Breaks when schema is read.",
+      get parameters(): ToolDefinition["parameters"] {
+        throw new Error("boom");
+      },
+      execute: async () => ({
+        content: [{ type: "text", text: "bad" }],
+        details: {},
+      }),
+    } as unknown as ToolDefinition;
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [
+        unreadableNameTool,
+        unreadableGuidelinesTool,
+        healthyTool,
+        unreadableParametersTool,
+      ],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["healthy_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("preserves the original custom tool receiver after snapshotting", async () => {
+    const statefulTool = {
+      name: "stateful_lookup",
+      label: "Stateful Lookup",
+      description: "Uses state from the tool object.",
+      parameters: Type.Object({}),
+      calls: 0,
+      async execute() {
+        this.calls += 1;
+        return {
+          content: [{ type: "text" as const, text: String(this.calls) }],
+          details: {},
+        };
+      },
+    } as ToolDefinition & { calls: number };
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [statefulTool],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    const definition = session.getToolDefinition("stateful_lookup");
+    const result = await definition?.execute(
+      "call-1",
+      {},
+      undefined,
+      undefined,
+      undefined as unknown as Parameters<ToolDefinition["execute"]>[4],
+    );
+
+    expect(result?.content).toEqual([{ type: "text", text: "1" }]);
+    expect(statefulTool.calls).toBe(1);
+  });
+
   it("preserves an exact base system prompt when active tools change", async () => {
     const customTool: ToolDefinition = {
       name: "custom_lookup",

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -35,6 +35,7 @@ import {
   type ToolName,
   withFileMutationQueue,
 } from "./tools/index.js";
+import { snapshotToolDefinitions } from "./tools/tool-definition-wrapper.js";
 
 export interface CreateAgentSessionOptions {
   /** Working directory for project-local discovery. Default: process.cwd() */
@@ -283,7 +284,8 @@ export async function createAgentSession(
   }
 
   const defaultActiveToolNames: ToolName[] = ["read", "bash", "edit", "write"];
-  const customToolNames = options.customTools?.map((tool) => tool.name) ?? [];
+  const customTools = snapshotToolDefinitions(options.customTools);
+  const customToolNames = customTools.map((tool) => tool.name);
   const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
   const disableBuiltInTools = !options.tools && options.noTools === "builtin";
   const initialActiveToolNames: string[] = options.tools
@@ -426,7 +428,7 @@ export async function createAgentSession(
     cwd,
     scopedModels: options.scopedModels,
     resourceLoader,
-    customTools: options.customTools,
+    customTools,
     modelRegistry,
     initialActiveToolNames,
     allowedToolNames,

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -2,6 +2,71 @@ import type { TSchema } from "typebox";
 import type { AgentTool } from "../../runtime/index.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 
+/** Snapshot caller-owned tool definitions before registry code reads their fields. */
+export function snapshotToolDefinitions(
+  definitions: readonly ToolDefinition[] | undefined,
+): ToolDefinition[] {
+  const snapshots: ToolDefinition[] = [];
+  for (const definition of definitions ?? []) {
+    const snapshot = snapshotToolDefinition(definition);
+    if (snapshot) {
+      snapshots.push(snapshot);
+    }
+  }
+  return snapshots;
+}
+
+function snapshotToolDefinition(definition: ToolDefinition): ToolDefinition | undefined {
+  try {
+    if (!definition || typeof definition !== "object") {
+      return undefined;
+    }
+    const name = Reflect.get(definition, "name");
+    const execute = Reflect.get(definition, "execute");
+    if (typeof name !== "string" || name.length === 0 || typeof execute !== "function") {
+      return undefined;
+    }
+    const promptGuidelines = Reflect.get(definition, "promptGuidelines");
+    const prepareArguments = Reflect.get(definition, "prepareArguments");
+    const renderCall = Reflect.get(definition, "renderCall");
+    const renderResult = Reflect.get(definition, "renderResult");
+    const executeWithReceiver = ((...args: Parameters<ToolDefinition["execute"]>) =>
+      Reflect.apply(execute, definition, args)) as ToolDefinition["execute"];
+    return {
+      name,
+      label: Reflect.get(definition, "label"),
+      description: Reflect.get(definition, "description"),
+      promptSnippet: Reflect.get(definition, "promptSnippet"),
+      promptGuidelines: Array.isArray(promptGuidelines) ? [...promptGuidelines] : promptGuidelines,
+      parameters: Reflect.get(definition, "parameters"),
+      renderShell: Reflect.get(definition, "renderShell"),
+      prepareArguments:
+        typeof prepareArguments === "function"
+          ? (((...args: Parameters<NonNullable<ToolDefinition["prepareArguments"]>>) =>
+              Reflect.apply(
+                prepareArguments,
+                definition,
+                args,
+              )) as ToolDefinition["prepareArguments"])
+          : prepareArguments,
+      executionMode: Reflect.get(definition, "executionMode"),
+      execute: executeWithReceiver,
+      renderCall:
+        typeof renderCall === "function"
+          ? (((...args: Parameters<NonNullable<ToolDefinition["renderCall"]>>) =>
+              Reflect.apply(renderCall, definition, args)) as ToolDefinition["renderCall"])
+          : renderCall,
+      renderResult:
+        typeof renderResult === "function"
+          ? (((...args: Parameters<NonNullable<ToolDefinition["renderResult"]>>) =>
+              Reflect.apply(renderResult, definition, args)) as ToolDefinition["renderResult"])
+          : renderResult,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /** Wrap a ToolDefinition into an AgentTool for the core runtime. */
 export function wrapToolDefinition<
   TParams extends TSchema = TSchema,


### PR DESCRIPTION
## Summary

- Snapshot SDK custom tool definitions before session startup and registry refresh code reads caller-owned fields.
- Drop unreadable custom tool descriptors so one hostile getter cannot crash `createAgentSession` or block healthy sibling tools.
- Preserve callable tool receivers when wrapping `execute`, renderers, and argument preparation.

This is scoped to SDK/session custom tool ingestion. It does not change provider-side schema normalization or extension registration policy.

## Linked context

No tracked issue. Part of the tool-schema/runtime ingress fuzzing sweep.

## Real behavior proof (required for external PRs)

- Behavior addressed: SDK custom tools with throwing descriptor getters no longer crash session setup; valid sibling tools remain registered and active.
- Real environment tested: local OpenClaw Codex worktree on macOS, using the repo Vitest wrapper.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/sdk.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/sdk.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; AWS Crabbox fresh PR `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.
- Evidence after fix: `src/agents/sessions/sdk.test.ts` passed 8/8 after the rebase; oxfmt, targeted oxlint, diff-check, and autoreview were clean. AWS Crabbox `run_48879f533e2f` on lease `cbx_7c36dafccedd` (`c7a.8xlarge`) passed `pnpm check:changed` with lanes `core, coreTests`, exit 0.
- Observed result after fix: unreadable `name`, `promptGuidelines`, and `parameters` getters are dropped before startup while `healthy_lookup` remains active; stateful custom tool methods keep their original receiver.
- What was not tested: full repo-wide test suite.
- Proof limitations or environment constraints: local core-test tsgo could not run from the sparse Codex worktree because required `ui/config` inputs are not present there; the same lane passed in the full Crabbox fresh PR checkout.
- Before evidence: the previous SDK code mapped `options.customTools?.map((tool) => tool.name)` directly, so a throwing `name` getter crashed before `AgentSession` could be built.

## Tests and validation

Focused commands run:

- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/sdk.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/sdk.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:

- Unreadable SDK custom tool descriptors are dropped before session setup.
- Snapshot wrapping preserves the original receiver for stateful custom tool methods.

## Risk checklist

- Did user-visible behavior change? `Yes`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `Yes`
- Highest-risk area: custom SDK tools implemented with stateful object methods.
- Mitigation: callable fields are wrapped with `Reflect.apply` against the original descriptor, and a receiver-preservation regression test covers the compatibility shape.

## Current review state

Next action: maintainer review.

Waiting on: CI/maintainer review.

Reviewer comments addressed: local `$autoreview` initially flagged receiver loss; the patch now preserves receivers and the rerun reported no accepted/actionable findings.
