### PR TITLE
fix(agents): quarantine unreadable extension tools

### DIFF
--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadExtensions } from "./loader.js";
+import type { ExtensionContext } from "./types.js";
 
 const tempDirs: string[] = [];
 
@@ -42,5 +43,82 @@ export default async function(api) {
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(1);
     expect(result.extensions[0]?.commands.has("sdk-subpath-probe")).toBe(true);
+  });
+
+  it("skips unreadable registered tools without failing the extension", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-bad-tool-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+export default async function(api) {
+  const unreadableNameTool = {
+    get name() {
+      throw new Error("boom name");
+    },
+    label: "Bad Name",
+    description: "Breaks while reading the name.",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }], details: {} };
+    },
+  };
+  const unreadableParametersTool = {
+    name: "bad_parameters",
+    label: "Bad Parameters",
+    description: "Breaks while reading the schema.",
+    get parameters() {
+      throw new Error("boom params");
+    },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }], details: {} };
+    },
+  };
+  const healthyTool = {
+    name: "healthy_lookup",
+    label: "Healthy Lookup",
+    description: "Uses state from the original tool object.",
+    parameters: { type: "object", properties: {} },
+    calls: 0,
+    async execute() {
+      this.calls += 1;
+      return { content: [{ type: "text", text: String(this.calls) }], details: {} };
+    },
+  };
+  api.registerTool(unreadableNameTool);
+  api.registerTool(unreadableParametersTool);
+  api.registerTool(healthyTool);
+  api.registerCommand("after-bad-tool", {
+    description: "probe",
+    handler() {},
+  });
+}
+`,
+    );
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.errors).toEqual([
+      { path: extensionPath, error: "skipped extension tool registration: boom name" },
+      {
+        path: extensionPath,
+        error: 'skipped extension tool registration for "bad_parameters": boom params',
+      },
+    ]);
+    expect(result.extensions).toHaveLength(1);
+    expect(Array.from(result.extensions[0]?.tools.keys() ?? [])).toEqual(["healthy_lookup"]);
+    expect(result.extensions[0]?.commands.has("after-bad-tool")).toBe(true);
+
+    const definition = result.extensions[0]?.tools.get("healthy_lookup")?.definition;
+    const toolResult = await definition?.execute(
+      "call-1",
+      {},
+      undefined,
+      undefined,
+      undefined as unknown as ExtensionContext,
+    );
+
+    expect(toolResult?.content).toEqual([{ type: "text", text: "1" }]);
   });
 });

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -214,6 +214,7 @@ function createExtensionAPI(
   runtime: ExtensionRuntime,
   cwd: string,
   eventBus: EventBus,
+  onRegistrationError?: (error: string) => void,
 ): ExtensionAPI {
   const api = {
     // Registration methods - write to extension
@@ -226,8 +227,13 @@ function createExtensionAPI(
 
     registerTool(tool: ToolDefinition): void {
       runtime.assertActive();
-      extension.tools.set(tool.name, {
-        definition: tool,
+      const snapshot = snapshotExtensionToolDefinition(tool);
+      if ("error" in snapshot) {
+        onRegistrationError?.(snapshot.error);
+        return;
+      }
+      extension.tools.set(snapshot.definition.name, {
+        definition: snapshot.definition,
         sourceInfo: extension.sourceInfo,
       });
       runtime.refreshTools();
@@ -365,6 +371,75 @@ function createExtensionAPI(
   return api;
 }
 
+function snapshotExtensionToolDefinition(
+  definition: ToolDefinition,
+): { definition: ToolDefinition } | { error: string } {
+  let toolName: string | undefined;
+  try {
+    if (!definition || typeof definition !== "object") {
+      return { error: "skipped extension tool registration: tool definition is not an object" };
+    }
+    const name = Reflect.get(definition, "name");
+    toolName = typeof name === "string" ? name : undefined;
+    const execute = Reflect.get(definition, "execute");
+    if (!toolName) {
+      return { error: "skipped extension tool registration: tool name is missing or invalid" };
+    }
+    if (typeof execute !== "function") {
+      return {
+        error: `skipped extension tool registration for "${toolName}": execute is missing or invalid`,
+      };
+    }
+    const promptGuidelines = Reflect.get(definition, "promptGuidelines");
+    const prepareArguments = Reflect.get(definition, "prepareArguments");
+    const renderCall = Reflect.get(definition, "renderCall");
+    const renderResult = Reflect.get(definition, "renderResult");
+    const executeWithReceiver = ((...args: Parameters<ToolDefinition["execute"]>) =>
+      Reflect.apply(execute, definition, args)) as ToolDefinition["execute"];
+    return {
+      definition: {
+        name: toolName,
+        label: Reflect.get(definition, "label"),
+        description: Reflect.get(definition, "description"),
+        promptSnippet: Reflect.get(definition, "promptSnippet"),
+        promptGuidelines: Array.isArray(promptGuidelines)
+          ? [...promptGuidelines]
+          : promptGuidelines,
+        parameters: Reflect.get(definition, "parameters"),
+        renderShell: Reflect.get(definition, "renderShell"),
+        prepareArguments:
+          typeof prepareArguments === "function"
+            ? (((...args: Parameters<NonNullable<ToolDefinition["prepareArguments"]>>) =>
+                Reflect.apply(
+                  prepareArguments,
+                  definition,
+                  args,
+                )) as ToolDefinition["prepareArguments"])
+            : prepareArguments,
+        executionMode: Reflect.get(definition, "executionMode"),
+        execute: executeWithReceiver,
+        renderCall:
+          typeof renderCall === "function"
+            ? (((...args: Parameters<NonNullable<ToolDefinition["renderCall"]>>) =>
+                Reflect.apply(renderCall, definition, args)) as ToolDefinition["renderCall"])
+            : renderCall,
+        renderResult:
+          typeof renderResult === "function"
+            ? (((...args: Parameters<NonNullable<ToolDefinition["renderResult"]>>) =>
+                Reflect.apply(renderResult, definition, args)) as ToolDefinition["renderResult"])
+            : renderResult,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      error: toolName
+        ? `skipped extension tool registration for "${toolName}": ${message}`
+        : `skipped extension tool registration: ${message}`,
+    };
+  }
+}
+
 function resolveExtensionFactory(module: unknown): ExtensionFactory | undefined {
   const candidate =
     typeof module === "object" && module !== null && "default" in module
@@ -487,8 +562,9 @@ async function loadExtension(
   cwd: string,
   eventBus: EventBus,
   runtime: ExtensionRuntime,
-): Promise<{ extension: Extension | null; error: string | null }> {
+): Promise<{ extension: Extension | null; error: string | null; registrationErrors: string[] }> {
   const resolvedPath = resolvePath(extensionPath, cwd);
+  const registrationErrors: string[] = [];
 
   try {
     const factory = await loadExtensionModule(resolvedPath);
@@ -496,17 +572,24 @@ async function loadExtension(
       return {
         extension: null,
         error: `Extension does not export a valid factory function: ${extensionPath}`,
+        registrationErrors,
       };
     }
 
     const extension = createExtension(extensionPath, resolvedPath);
-    const api = createExtensionAPI(extension, runtime, cwd, eventBus);
+    const api = createExtensionAPI(extension, runtime, cwd, eventBus, (error) => {
+      registrationErrors.push(error);
+    });
     await factory(api);
 
-    return { extension, error: null };
+    return { extension, error: null, registrationErrors };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { extension: null, error: `Failed to load extension: ${message}` };
+    return {
+      extension: null,
+      error: `Failed to load extension: ${message}`,
+      registrationErrors,
+    };
   }
 }
 
@@ -519,9 +602,12 @@ export async function loadExtensionFromFactory(
   eventBus: EventBus,
   runtime: ExtensionRuntime,
   extensionPath = "<inline>",
+  registrationErrors?: string[],
 ): Promise<Extension> {
   const extension = createExtension(extensionPath, extensionPath);
-  const api = createExtensionAPI(extension, runtime, cwd, eventBus);
+  const api = createExtensionAPI(extension, runtime, cwd, eventBus, (error) => {
+    registrationErrors?.push(error);
+  });
   await factory(api);
   return extension;
 }
@@ -540,15 +626,26 @@ export async function loadExtensions(
   const runtime = createExtensionRuntime();
 
   for (const extPath of paths) {
-    const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime);
+    const { extension, error, registrationErrors } = await loadExtension(
+      extPath,
+      cwd,
+      resolvedEventBus,
+      runtime,
+    );
 
     if (error) {
       errors.push({ path: extPath, error });
+      for (const registrationError of registrationErrors) {
+        errors.push({ path: extPath, error: registrationError });
+      }
       continue;
     }
 
     if (extension) {
       extensions.push(extension);
+    }
+    for (const registrationError of registrationErrors) {
+      errors.push({ path: extPath, error: registrationError });
     }
   }
 

--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -880,6 +880,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 
     for (const [index, factory] of this.extensionFactories.entries()) {
       const extensionPath = `<inline:${index + 1}>`;
+      const registrationErrors: string[] = [];
       try {
         const extension = await loadExtensionFromFactory(
           factory,
@@ -887,10 +888,17 @@ export class DefaultResourceLoader implements ResourceLoader {
           this.eventBus,
           runtime,
           extensionPath,
+          registrationErrors,
         );
         extensions.push(extension);
+        for (const registrationError of registrationErrors) {
+          errors.push({ path: extensionPath, error: registrationError });
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : "failed to load extension";
+        for (const registrationError of registrationErrors) {
+          errors.push({ path: extensionPath, error: registrationError });
+        }
         errors.push({ path: extensionPath, error: message });
       }
     }


### PR DESCRIPTION
## Summary

- Guard `api.registerTool(...)` so unreadable extension tool descriptors are skipped instead of failing the whole extension load.
- Preserve healthy tools, commands, and stateful method-style tool receivers after snapshotting registered tools.
- Propagate skipped-tool diagnostics through both path-based and inline extension loading.

This is scoped to extension registration. It does not add provider-specific schema compatibility checks or doctor runtime projection validation.

## Linked context

No tracked issue. Part of the tool-schema/runtime ingress fuzzing sweep.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: one extension tool with a throwing descriptor getter no longer prevents the extension from loading or blocks healthy sibling registrations.
- Real environment tested: local OpenClaw Codex worktree on macOS, using the repo Vitest wrapper.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/resource-loader.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/resource-loader.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; AWS Crabbox fresh PR `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.
- Evidence after fix: focused loader test passed 2/2 after the rebase; oxfmt, targeted oxlint, diff-check, and autoreview were clean. AWS Crabbox `run_009f40ac4028` on lease `cbx_816e7d563d3a` (`c7a.8xlarge`) passed `pnpm check:changed` with lanes `core, coreTests`, exit 0.
- Observed result after fix: bad registered tools produce loader diagnostics, healthy `healthy_lookup` remains registered, the extension command registered after the bad tools remains present, and the healthy tool method keeps its original receiver.
- What was not tested: full repo-wide test suite.
- Proof limitations or environment constraints: local proof is focused on extension registration and loader diagnostics; Crabbox proved the changed `core, coreTests` lanes in a fresh PR checkout.
- Before evidence: `registerTool` read `tool.name` directly and stored the raw definition, so a throwing `name` or later schema getter could fail extension loading or crash later registry reads.

## Tests and validation

Focused commands run:

- `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/resource-loader.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/resource-loader.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:

- Extension loader skips unreadable registered tools while keeping the extension alive.
- Loader diagnostics identify skipped tool registrations.
- A healthy stateful tool registered after bad tools keeps its method receiver.

## Risk checklist

- Did user-visible behavior change? `Yes`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `Yes`
- Highest-risk area: changing extension tool registration from fail-fast to per-tool quarantine.
- Mitigation: only invalid/unreadable tool descriptors are skipped; extension factory failures still fail the extension load, registration diagnostics are surfaced, and regression coverage verifies healthy registrations continue.

## Current review state

Next action: maintainer review.

Waiting on: CI/maintainer review.

Reviewer comments addressed: local `$autoreview` reported no accepted/actionable findings.
