### PR TITLE
fix(openai): quarantine unreadable projected tools

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearOpenAIToolSchemaCacheForTest,
+  findOpenAIStrictToolSchemaDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
+  snapshotOpenAIToolProjectionInputs,
 } from "./openai-tool-schema.js";
 
 describe("OpenAI strict tool schema normalization", () => {
@@ -90,5 +92,40 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("records unreadable tool projection fields as diagnostics instead of throwing", () => {
+    const unreadableTool = {
+      name: "bad_schema",
+      get parameters(): unknown {
+        throw new Error("boom");
+      },
+    };
+    const healthyTool = {
+      name: "healthy_lookup",
+      description: "Lookup",
+      parameters: {},
+    };
+
+    const snapshot = snapshotOpenAIToolProjectionInputs([unreadableTool, healthyTool]);
+
+    expect(snapshot.tools.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+    expect(snapshot.diagnostics).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "bad_schema",
+        violations: ["bad_schema.unreadable: boom"],
+      },
+    ]);
+    expect(findOpenAIStrictToolSchemaDiagnostics([unreadableTool, healthyTool])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "bad_schema",
+        violations: ["bad_schema.unreadable: boom"],
+      },
+    ]);
+    expect(resolveOpenAIStrictToolFlagForInventory([unreadableTool, healthyTool], true)).toBe(
+      false,
+    );
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -9,8 +9,18 @@ type ToolSchemaCompatInput = {
 
 type ToolWithParameters = {
   name?: unknown;
+  description?: unknown;
   parameters: unknown;
 };
+
+type OpenAIToolProjectionSnapshot = {
+  toolIndex: number;
+  name: string;
+  description?: string;
+  parameters: unknown;
+};
+
+type OpenAIToolProjectionSnapshotDiagnostic = OpenAIStrictToolSchemaDiagnostic;
 
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
@@ -163,25 +173,69 @@ type OpenAIStrictToolSchemaDiagnostic = {
   violations: string[];
 };
 
+export function snapshotOpenAIToolProjectionInputs(tools: readonly ToolWithParameters[]): {
+  tools: OpenAIToolProjectionSnapshot[];
+  diagnostics: OpenAIToolProjectionSnapshotDiagnostic[];
+} {
+  const snapshots: OpenAIToolProjectionSnapshot[] = [];
+  const diagnostics: OpenAIToolProjectionSnapshotDiagnostic[] = [];
+  tools.forEach((tool, toolIndex) => {
+    const fallbackPath = `tool[${toolIndex}]`;
+    let toolName: string | undefined;
+    try {
+      if (!tool || typeof tool !== "object") {
+        diagnostics.push({ toolIndex, violations: [`${fallbackPath}.tool`] });
+        return;
+      }
+      const name = Reflect.get(tool, "name");
+      if (typeof name !== "string" || name.length === 0) {
+        diagnostics.push({ toolIndex, violations: [`${fallbackPath}.name`] });
+        return;
+      }
+      toolName = name;
+      const description = Reflect.get(tool, "description");
+      const parameters = Reflect.get(tool, "parameters");
+      snapshots.push({
+        toolIndex,
+        name,
+        ...(typeof description === "string" ? { description } : {}),
+        parameters,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      diagnostics.push({
+        toolIndex,
+        ...(toolName ? { toolName } : {}),
+        violations: [`${toolName ?? fallbackPath}.unreadable: ${message}`],
+      });
+    }
+  });
+  return { tools: snapshots, diagnostics };
+}
+
 export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
-  return tools.flatMap((tool, toolIndex) => {
-    const violations = findStrictOpenAIJsonSchemaViolations(
-      normalizeStrictOpenAIJsonSchema(tool.parameters),
-      `${typeof tool.name === "string" && tool.name ? tool.name : `tool[${toolIndex}]`}.parameters`,
-    );
-    if (violations.length === 0) {
-      return [];
-    }
-    return [
-      {
-        toolIndex,
-        ...(typeof tool.name === "string" && tool.name ? { toolName: tool.name } : {}),
-        violations,
-      },
-    ];
-  });
+  const snapshot = snapshotOpenAIToolProjectionInputs(tools);
+  return [
+    ...snapshot.diagnostics,
+    ...snapshot.tools.flatMap((tool) => {
+      const violations = findStrictOpenAIJsonSchemaViolations(
+        normalizeStrictOpenAIJsonSchema(tool.parameters),
+        `${tool.name}.parameters`,
+      );
+      if (violations.length === 0) {
+        return [];
+      }
+      return [
+        {
+          toolIndex: tool.toolIndex,
+          toolName: tool.name,
+          violations,
+        },
+      ];
+    }),
+  ];
 }
 
 function isStrictOpenAIJsonSchemaCompatibleRecursive(schema: unknown): boolean {
@@ -304,5 +358,9 @@ export function resolveOpenAIStrictToolFlagForInventory(
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
-  return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
+  const snapshot = snapshotOpenAIToolProjectionInputs(tools);
+  return (
+    snapshot.diagnostics.length === 0 &&
+    snapshot.tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters))
+  );
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4573,6 +4573,207 @@ describe("openai transport stream", () => {
     expect(params.tools?.[0]).not.toHaveProperty("strict");
   });
 
+  it("skips unreadable tools before building OpenAI Responses params", () => {
+    const unreadableNameTool = {
+      get name(): string {
+        throw new Error("boom name");
+      },
+      description: "Bad",
+      parameters: {},
+    };
+    const unreadableParametersTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): unknown {
+        throw new Error("boom parameters");
+      },
+    };
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          unreadableNameTool,
+          {
+            name: "healthy_lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+          unreadableParametersTool,
+        ],
+      } as never,
+      undefined,
+    ) as { tools?: Array<{ name?: string }> };
+
+    expect(params.tools?.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+  });
+
+  it("drops pinned OpenAI Responses tool choice when that tool is unreadable", () => {
+    const unreadablePinnedTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): unknown {
+        throw new Error("boom parameters");
+      },
+    };
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          unreadablePinnedTool,
+          {
+            name: "healthy_lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+        ],
+      } as never,
+      {
+        toolChoice: { type: "function", name: "bad_parameters" },
+      },
+    ) as { tools?: Array<{ name?: string }>; tool_choice?: unknown };
+
+    expect(params.tools?.map((tool) => tool.name)).toEqual(["healthy_lookup"]);
+    expect(params.tool_choice).toBeUndefined();
+  });
+
+  it("drops forced OpenAI Responses tool choice when every tool is unreadable", () => {
+    const unreadableTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): unknown {
+        throw new Error("boom parameters");
+      },
+    };
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [unreadableTool],
+      } as never,
+      {
+        toolChoice: "required",
+      },
+    ) as { tools?: unknown[]; tool_choice?: unknown };
+
+    expect(params.tools).toBeUndefined();
+    expect(params.tool_choice).toBeUndefined();
+  });
+
+  it("drops forced OpenAI completions tool choice when every tool is unreadable", () => {
+    const unreadableTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): unknown {
+        throw new Error("boom parameters");
+      },
+    };
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [unreadableTool],
+      } as never,
+      {
+        toolChoice: "required",
+      },
+    ) as { tools?: unknown[]; tool_choice?: unknown };
+
+    expect(params.tools).toBeUndefined();
+    expect(params.tool_choice).toBeUndefined();
+  });
+
+  it("drops pinned OpenAI completions tool choice when that tool is unreadable", () => {
+    const unreadablePinnedTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): unknown {
+        throw new Error("boom parameters");
+      },
+    };
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          unreadablePinnedTool,
+          {
+            name: "healthy_lookup",
+            description: "Lookup",
+            parameters: {},
+          },
+        ],
+      } as never,
+      {
+        toolChoice: { type: "function", function: { name: "bad_parameters" } },
+      },
+    ) as { tools?: Array<{ function?: { name?: string } }>; tool_choice?: unknown };
+
+    expect(params.tools?.map((tool) => tool.function?.name)).toEqual(["healthy_lookup"]);
+    expect(params.tool_choice).toBeUndefined();
+  });
+
   it("still normalizes responses tool parameters when strict is omitted", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -65,6 +65,7 @@ import {
   findOpenAIStrictToolSchemaDiagnostics,
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIStrictToolFlagForInventory,
+  snapshotOpenAIToolProjectionInputs,
 } from "./openai-tool-schema.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 import {
@@ -203,6 +204,32 @@ type OpenAICompletionsOptions = BaseStreamOptions & {
   reasoningEffort?: OpenAIReasoningEffort;
 };
 
+function isToolChoiceCompatibleWithProjectedTools(
+  toolChoice: unknown,
+  toolNames: ReadonlySet<string>,
+): boolean {
+  if (!toolChoice) {
+    return false;
+  }
+  if (typeof toolChoice === "string") {
+    return toolNames.size > 0;
+  }
+  if (typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
+    return false;
+  }
+  const choice = toolChoice as { type?: unknown; name?: unknown; function?: { name?: unknown } };
+  if (choice.type !== "function") {
+    return toolNames.size > 0;
+  }
+  const toolName =
+    typeof choice.name === "string"
+      ? choice.name
+      : typeof choice.function?.name === "string"
+        ? choice.function.name
+        : undefined;
+  return toolName ? toolNames.has(toolName) : false;
+}
+
 type OpenAIModeCompatInput = Omit<ModelCompatConfig, "thinkingFormat"> & {
   thinkingFormat?: string;
 };
@@ -210,6 +237,8 @@ type OpenAIModeCompatInput = Omit<ModelCompatConfig, "thinkingFormat"> & {
 type OpenAIModeModel = Omit<Model, "compat"> & {
   compat?: OpenAIModeCompatInput | null;
 };
+
+type OpenAIStrictToolInventory = Parameters<typeof resolveOpenAIStrictToolFlagForInventory>[0];
 
 type MutableAssistantOutput = {
   role: "assistant";
@@ -1273,11 +1302,12 @@ function convertResponsesTools(
   model: OpenAIModeModel,
   options?: { strict?: boolean | null },
 ): FunctionTool[] {
-  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(tools, options?.strict, {
+  const projection = snapshotOpenAIToolProjectionInputs(tools);
+  const strict = resolveOpenAIStrictToolFlagWithDiagnostics(projection.tools, options?.strict, {
     transport: "responses",
     model,
   });
-  return sortTransportToolsByName(tools).map((tool): FunctionTool => {
+  return sortTransportToolsByName(projection.tools).map((tool): FunctionTool => {
     const result = {
       type: "function" as const,
       name: tool.name,
@@ -1296,7 +1326,7 @@ function convertResponsesTools(
 }
 
 function resolveOpenAIStrictToolFlagWithDiagnostics(
-  tools: NonNullable<Context["tools"]>,
+  tools: OpenAIStrictToolInventory,
   strictSetting: boolean | null | undefined,
   context: { transport: "responses" | "completions"; model: OpenAIModeModel },
 ): boolean | undefined {
@@ -2244,12 +2274,21 @@ export function buildOpenAIResponsesParams(
     params.service_tier = options.serviceTier;
   }
   if (context.tools) {
-    params.tools = convertResponsesTools(context.tools, model as OpenAIModeModel, {
+    const tools = convertResponsesTools(context.tools, model as OpenAIModeModel, {
       strict: resolveOpenAIStrictToolSetting(model as OpenAIModeModel, {
         transport: "stream",
       }),
     });
-    if (options?.toolChoice) {
+    if (tools.length > 0 || context.tools.length === 0) {
+      params.tools = tools;
+    }
+    if (
+      options?.toolChoice &&
+      isToolChoiceCompatibleWithProjectedTools(
+        options.toolChoice,
+        new Set(tools.map((tool) => tool.name)),
+      )
+    ) {
       params.tool_choice = options.toolChoice;
     }
   }
@@ -3607,8 +3646,9 @@ function convertTools(
   compat: ReturnType<typeof getCompat>,
   model: OpenAIModeModel,
 ) {
+  const projection = snapshotOpenAIToolProjectionInputs(tools);
   const strict = resolveOpenAIStrictToolFlagWithDiagnostics(
-    tools,
+    projection.tools,
     resolveOpenAIStrictToolSetting(model, {
       transport: "stream",
       supportsStrictMode: compat?.supportsStrictMode,
@@ -3618,7 +3658,7 @@ function convertTools(
       model,
     },
   );
-  return sortTransportToolsByName(tools).map((tool) => {
+  return sortTransportToolsByName(projection.tools).map((tool) => {
     const functionTool: {
       name: string;
       description: string | undefined;
@@ -4041,8 +4081,17 @@ export function buildOpenAICompletionsParams(
   }
   if (supportsModelTools(model)) {
     if (context.tools) {
-      params.tools = convertTools(context.tools, compat, model);
-      if (options?.toolChoice) {
+      const tools = convertTools(context.tools, compat, model);
+      if (tools.length > 0 || context.tools.length === 0) {
+        params.tools = tools;
+      }
+      if (
+        options?.toolChoice &&
+        isToolChoiceCompatibleWithProjectedTools(
+          options.toolChoice,
+          new Set(tools.map((tool) => tool.function.name)),
+        )
+      ) {
         params.tool_choice = options.toolChoice;
       } else if (
         compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -508,7 +508,13 @@ function buildRequestBody(
   }
 
   if (context.tools && context.tools.length > 0) {
-    body.tools = convertResponsesTools(context.tools, { strict: null });
+    const tools = convertResponsesTools(context.tools, { strict: null });
+    if (tools.length > 0) {
+      body.tools = tools;
+    } else {
+      delete body.tool_choice;
+      delete body.parallel_tool_calls;
+    }
   }
 
   if (options?.reasoningEffort !== undefined) {

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -1,7 +1,7 @@
 import type { Tool as OpenAIResponsesTool } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
 import type { Context, Model, Tool } from "../types.js";
-import { convertResponsesMessages } from "./openai-responses-shared.js";
+import { applyCommonResponsesParams, convertResponsesMessages } from "./openai-responses-shared.js";
 import { convertResponsesTools } from "./openai-responses-tools.js";
 
 type ResponsesFunctionTool = Extract<OpenAIResponsesTool, { type: "function" }>;
@@ -121,6 +121,60 @@ describe("convertResponsesTools", () => {
     expect(
       convertResponsesTools([zeta, alpha]).map((tool) => expectResponsesFunctionTool(tool).name),
     ).toEqual(["alpha", "zeta"]);
+  });
+
+  it("skips unreadable tool descriptors before Responses payload conversion", () => {
+    const unreadableNameTool = {
+      get name(): string {
+        throw new Error("boom name");
+      },
+      description: "Bad",
+      parameters: {},
+    } as Tool;
+    const unreadableParametersTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): Tool["parameters"] {
+        throw new Error("boom parameters");
+      },
+    } as Tool;
+    const healthyTool = {
+      name: "healthy_lookup",
+      description: "Lookup",
+      parameters: {},
+    } satisfies Tool;
+
+    const converted = convertResponsesTools(
+      [unreadableNameTool, healthyTool, unreadableParametersTool],
+      { model: nativeOpenAIModel },
+    );
+
+    expect(converted.map((tool) => expectResponsesFunctionTool(tool).name)).toEqual([
+      "healthy_lookup",
+    ]);
+  });
+
+  it("omits common Responses tools when every descriptor is unreadable", () => {
+    const unreadableTool = {
+      name: "bad_parameters",
+      description: "Bad",
+      get parameters(): Tool["parameters"] {
+        throw new Error("boom parameters");
+      },
+    } as Tool;
+    const params = {
+      model: nativeOpenAIModel.id,
+      input: [],
+      stream: true as const,
+    };
+
+    applyCommonResponsesParams(params, nativeOpenAIModel, {
+      systemPrompt: "system",
+      messages: [],
+      tools: [unreadableTool],
+    });
+
+    expect(params).not.toHaveProperty("tools");
   });
 });
 

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -427,7 +427,10 @@ export function applyCommonResponsesParams<TApi extends Api>(
   }
 
   if (context.tools && context.tools.length > 0) {
-    params.tools = convertResponsesTools(context.tools, { model });
+    const tools = convertResponsesTools(context.tools, { model });
+    if (tools.length > 0) {
+      params.tools = tools;
+    }
   }
 
   if (!model.reasoning) {

--- a/src/llm/providers/openai-responses-tools.ts
+++ b/src/llm/providers/openai-responses-tools.ts
@@ -5,6 +5,7 @@ import {
   findOpenAIStrictToolSchemaDiagnostics,
   normalizeOpenAIStrictToolParameters,
   resolveOpenAIStrictToolFlagForInventory,
+  snapshotOpenAIToolProjectionInputs,
 } from "../../agents/openai-tool-schema.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { Model, Tool } from "../types.js";
@@ -16,6 +17,7 @@ export interface ConvertResponsesToolsOptions {
 }
 
 type OpenAIToolSchemaCompat = Parameters<typeof normalizeOpenAIStrictToolParameters>[2];
+type OpenAIStrictToolInventory = Parameters<typeof resolveOpenAIStrictToolFlagForInventory>[0];
 type ResponsesFunctionTool = {
   type: "function";
   name: string;
@@ -32,9 +34,10 @@ export function convertResponsesTools(
   tools: Tool[],
   options?: ConvertResponsesToolsOptions,
 ): OpenAITool[] {
+  const projection = snapshotOpenAIToolProjectionInputs(tools);
   const strictSetting = resolveResponsesStrictToolSetting(options);
-  const strict = resolveResponsesStrictToolFlag(tools, strictSetting, options?.model);
-  return sortResponsesToolsByName(tools).map((tool) => {
+  const strict = resolveResponsesStrictToolFlag(projection.tools, strictSetting, options?.model);
+  return sortResponsesToolsByName(projection.tools).map((tool) => {
     const result: ResponsesFunctionTool = {
       type: "function",
       name: tool.name,
@@ -68,7 +71,7 @@ function resolveResponsesStrictToolSetting(
 }
 
 function resolveResponsesStrictToolFlag(
-  tools: Tool[],
+  tools: OpenAIStrictToolInventory,
   strictSetting: boolean | null | undefined,
   model: Model | undefined,
 ): boolean | undefined {


### PR DESCRIPTION
## Summary

- Quarantines unreadable OpenAI tool descriptors before strict-schema diagnostics, Responses payload conversion, and private transport payload construction.
- Keeps healthy sibling tools available when one descriptor has a hostile getter for `name`, `description`, or `parameters`.
- Drops forced or pinned `tool_choice` values when the referenced tool is filtered out, avoiding invalid OpenAI payloads.
- Intentionally out of scope: live OpenAI API behavior changes beyond payload construction hardening.

## Linked context

Closes #

Related #89404
Related #89406

Maintainer fuzzing follow-up for OpenClaw tool-schema ingress hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: provider-facing OpenAI tool projection could throw while reading caller-owned tool descriptors, and filtered-out tools could leave stale forced/pinned `tool_choice` in the outgoing payload.
- Real environment tested: local OpenClaw checkout on the focused OpenAI provider and transport tests.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts src/llm/providers/openai-responses-shared.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=dot`
- Evidence after fix: the focused Vitest wrapper passed 3 shards: `src/agents/openai-tool-schema.test.ts` 5 tests, `src/llm/providers/openai-responses-shared.test.ts` 9 tests, and `src/agents/openai-transport-stream.test.ts` 238 tests.
- Observed result after fix: unreadable tool descriptors are skipped, healthy descriptors still project, and stale forced or pinned `tool_choice` values are omitted when their tool no longer survives projection.
- What was not tested: live OpenAI API calls.
- Proof limitations or environment constraints: live OpenAI API calls were not run.
- Before evidence: local fuzzing reproduced getter-triggered projection crashes and autoreview found the stale `tool_choice`/empty-tools payload issue before the final patch. The first remote changed gate also caught a TS literal-widening issue in the new test; the commit was amended before the passing run below.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts src/llm/providers/openai-responses-shared.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.ts src/llm/providers/openai-responses-shared.test.ts src/llm/providers/openai-chatgpt-responses.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.ts src/llm/providers/openai-responses-shared.test.ts src/llm/providers/openai-chatgpt-responses.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh PR gate for `openclaw/openclaw#89413`: `run_5fc51194c966`, lease `cbx_c3a0b996bb98`, type `c7a.8xlarge`, lanes `core, coreTests`, exit `0`, total `4m11.861s`.

Regression coverage added:

- Strict-schema diagnostics and inventory checks tolerate unreadable parameters while preserving healthy siblings.
- Responses tool conversion skips unreadable descriptor fields and omits `tools` when every descriptor is filtered out.
- OpenAI transport builders drop incompatible forced/pinned tool choices after projection for both Responses and chat completions.

What failed before this fix:

- Hostile descriptor getters could throw during diagnostic or payload projection before OpenClaw could produce a model request.
- Filtering all tools could still leave an incompatible forced or pinned `tool_choice` in some OpenAI payloads.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Invalid caller-owned OpenAI tool descriptors are now skipped instead of crashing provider payload construction.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This changes provider tool projection and tool-choice payload behavior, but it does not add new tool execution capability or credential handling.

What is the highest-risk area?

OpenAI `tool_choice` semantics when projection removes some or all tools.

How is that risk mitigated?

Regression tests cover forced choices, pinned choices, mixed healthy/unreadable descriptors, and the existing intentional empty-tool behavior.

## Current review state

What is the next action?

Review the draft PR. Remote changed-gate proof is complete.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before PR creation: projected-away tools no longer leave incompatible `tool_choice`, and shared Responses callers no longer send an empty tools array when all original tools were filtered out.
