### PR TITLE
fix(browser): downloads complete over CDP connections

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -18,6 +18,7 @@ OpenClaw can run a **dedicated Chrome/Brave/Edge/Chromium profile** that the age
 - A separate browser profile named **openclaw** (orange accent by default).
 - Deterministic tab control (list/open/focus/close).
 - Agent actions (click/type/drag/select), snapshots, screenshots, PDFs.
+- Playwright-backed profiles save direct attachment navigations under the managed downloads directory and return `{ url, suggestedFilename, path }` metadata after final-URL policy validation.
 - A bundled `browser-automation` skill that teaches agents the snapshot,
   stable-tab, stale-ref, and manual-blocker recovery loop when the browser
   plugin is enabled.

--- a/extensions/browser/src/browser/client-actions-types.ts
+++ b/extensions/browser/src/browser/client-actions-types.ts
@@ -1,6 +1,7 @@
 /**
  * Shared result types for browser client action helpers.
  */
+import type { BrowserDownloadResult } from "./download-types.js";
 import type { AnnotationItem } from "./screenshot-annotate.js";
 
 /** Generic success result for action endpoints. */
@@ -11,6 +12,7 @@ export type BrowserActionTabResult = {
   ok: true;
   targetId: string;
   url?: string;
+  download?: BrowserDownloadResult;
 };
 
 /** Success result carrying a filesystem output path. */

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -193,6 +193,11 @@ describe("browser client", () => {
               ok: true,
               targetId: "t1",
               url: "https://y",
+              download: {
+                url: "https://y/report.csv",
+                suggestedFilename: "report.csv",
+                path: "/tmp/openclaw/downloads/report.csv",
+              },
             }),
           } as unknown as Response;
         }
@@ -331,6 +336,11 @@ describe("browser client", () => {
     });
     expect(navigation.ok).toBe(true);
     expect(navigation.targetId).toBe("t1");
+    expect(navigation.download).toEqual({
+      url: "https://y/report.csv",
+      suggestedFilename: "report.csv",
+      path: "/tmp/openclaw/downloads/report.csv",
+    });
 
     const act = await browserAct("http://127.0.0.1:18791", { kind: "click", ref: "1" });
     expect(act.ok).toBe(true);

--- a/extensions/browser/src/browser/download-types.ts
+++ b/extensions/browser/src/browser/download-types.ts
@@ -1,0 +1,9 @@
+/** Metadata for a browser download saved under the configured output root. */
+export type BrowserDownloadResult = {
+  url: string;
+  suggestedFilename: string;
+  path: string;
+};
+
+/** Download metadata available before any bytes are written. */
+export type BrowserDownloadCandidate = Omit<BrowserDownloadResult, "path">;

--- a/extensions/browser/src/browser/pw-download-capture.ts
+++ b/extensions/browser/src/browser/pw-download-capture.ts
@@ -1,0 +1,139 @@
+/** Shared Playwright download capture and output handling. */
+import crypto from "node:crypto";
+import path from "node:path";
+import type { Page } from "playwright-core";
+import type { BrowserDownloadCandidate, BrowserDownloadResult } from "./download-types.js";
+import { writeExternalFileWithinOutputRoot } from "./output-files.js";
+import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
+import { sanitizeUntrustedFileName } from "./safe-filename.js";
+
+export type BrowserDownloadCaptureState = {
+  downloadWaiterDepth: number;
+};
+
+export type BrowserDownloadCaptureOptions = {
+  beforeSave?: (download: BrowserDownloadCandidate) => Promise<void> | void;
+  mode?: "passive" | "explicit";
+  outputPath?: string;
+  outputRoot?: string;
+  timeoutMessage?: string;
+};
+
+export type PlaywrightDownload = {
+  url?: () => string;
+  suggestedFilename?: () => string;
+  saveAs?: (outPath: string) => Promise<void>;
+};
+
+function buildManagedDownloadPath(rootDir: string, fileName: string): string {
+  const id = crypto.randomUUID();
+  const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
+  return path.join(rootDir, `${id}-${safeName}`);
+}
+
+/** Validate metadata and atomically save one Playwright download. */
+export async function saveBrowserDownload(
+  download: PlaywrightDownload,
+  opts: BrowserDownloadCaptureOptions = {},
+): Promise<BrowserDownloadResult> {
+  const suggestedFilename = download.suggestedFilename?.() || "download.bin";
+  const candidate: BrowserDownloadCandidate = {
+    url: download.url?.() || "",
+    suggestedFilename,
+  };
+  await opts.beforeSave?.(candidate);
+  const saveAs = download.saveAs?.bind(download);
+  if (!saveAs) {
+    throw new Error("Download cannot be saved");
+  }
+  const requestedPath = opts.outputPath?.trim();
+  const implicitRoot = opts.outputRoot ?? DEFAULT_DOWNLOAD_DIR;
+  const managedPath = requestedPath || buildManagedDownloadPath(implicitRoot, suggestedFilename);
+  const savedPath = await writeExternalFileWithinOutputRoot({
+    rootDir: requestedPath ? opts.outputRoot : implicitRoot,
+    path: managedPath,
+    write: async (tempPath) => {
+      await saveAs(tempPath);
+    },
+  });
+  return { ...candidate, path: savedPath };
+}
+
+/** Arm one page download while maintaining explicit/passive ownership depth. */
+export function createDownloadCaptureForPage(
+  page: Page,
+  state: BrowserDownloadCaptureState,
+  timeoutMs: number,
+  opts: BrowserDownloadCaptureOptions = {},
+): {
+  armed: boolean;
+  promise: Promise<BrowserDownloadResult>;
+  cancel: () => void;
+} {
+  // Passive action capture yields to an explicit wait/download owner. Explicit
+  // waiters may overlap; their arm id decides which one is allowed to save.
+  if (opts.mode !== "explicit" && state.downloadWaiterDepth > 0) {
+    return {
+      armed: false,
+      promise: new Promise<BrowserDownloadResult>(() => {}),
+      cancel: () => {},
+    };
+  }
+
+  state.downloadWaiterDepth += 1;
+  let done = false;
+  let depthReleased = false;
+  let timer: NodeJS.Timeout | undefined;
+  let handler: ((download: unknown) => void) | undefined;
+
+  const cleanup = () => {
+    if (!depthReleased) {
+      depthReleased = true;
+      state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
+    }
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (handler) {
+      page.off("download", handler as never);
+      handler = undefined;
+    }
+  };
+
+  const promise = new Promise<BrowserDownloadResult>((resolve, reject) => {
+    handler = (download: unknown) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      cleanup();
+      void saveBrowserDownload(download as PlaywrightDownload, opts).then(resolve, reject);
+    };
+    page.on("download", handler as never);
+    timer = setTimeout(
+      () => {
+        if (done) {
+          return;
+        }
+        done = true;
+        cleanup();
+        reject(new Error(opts.timeoutMessage ?? "Timeout waiting for download"));
+      },
+      Math.max(1, timeoutMs),
+    );
+    timer.unref?.();
+  });
+
+  return {
+    armed: true,
+    promise,
+    cancel: () => {
+      if (done) {
+        return;
+      }
+      done = true;
+      cleanup();
+    },
+  };
+}

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -277,6 +277,36 @@ describe("pw-session ensurePageState", () => {
     await expect(fs.readFile(result.path, "utf8")).resolves.toBe("attachment");
   });
 
+  it("validates captured navigation downloads before saving managed bytes", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const blocked = new Error("blocked download");
+    const beforeSave = vi.fn(async () => {
+      throw blocked;
+    });
+    const capture = createManagedDownloadCaptureForPage(page, 1_000, { beforeSave });
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "blocked", "utf8");
+    });
+    const download = {
+      url: () => "http://127.0.0.1:18080/export.csv",
+      suggestedFilename: () => "export.csv",
+      saveAs,
+    };
+
+    for (const handler of handlers.get("download") ?? []) {
+      handler(download);
+    }
+
+    await expect(capture.promise).rejects.toBe(blocked);
+    expect(beforeSave).toHaveBeenCalledWith({
+      triggered: true,
+      url: "http://127.0.0.1:18080/export.csv",
+      suggestedFilename: "export.csv",
+    });
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
   it("recognizes Playwright download-starting navigation aborts", () => {
     expect(isDownloadStartingNavigationError(new Error("page.goto: Download is starting"))).toBe(
       true,

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -5,7 +5,9 @@ import type { Page } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 import {
+  createManagedDownloadCaptureForPage,
   ensurePageState,
+  isDownloadStartingNavigationError,
   refLocator,
   rememberRoleRefsForTarget,
   restoreRoleRefsForTarget,
@@ -39,6 +41,14 @@ function fakePage(): {
     handlers.set(event, list);
     return undefined as unknown;
   });
+  const off = vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+    const list = handlers.get(event) ?? [];
+    handlers.set(
+      event,
+      list.filter((handler) => handler !== cb),
+    );
+    return undefined as unknown;
+  });
   const getByRole = vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) }));
   const frameLocator = vi.fn(() => ({
     getByRole: vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) })),
@@ -48,6 +58,7 @@ function fakePage(): {
 
   const page = {
     on,
+    off,
     getByRole,
     frameLocator,
     locator,
@@ -237,6 +248,53 @@ describe("pw-session ensurePageState", () => {
 
     expect(download).not.toHaveProperty("path");
     expect(download.saveAs).not.toHaveBeenCalled();
+  });
+
+  it("captures navigation downloads under managed paths", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const capture = createManagedDownloadCaptureForPage(page, 1_000);
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "attachment", "utf8");
+    });
+    const download = {
+      url: () => "https://example.com/export.csv",
+      suggestedFilename: () => "export.csv",
+      saveAs,
+    };
+
+    for (const handler of handlers.get("download") ?? []) {
+      handler(download);
+    }
+
+    const result = await capture.promise;
+    expect(result.triggered).toBe(true);
+    expect(result.url).toBe("https://example.com/export.csv");
+    expect(result.suggestedFilename).toBe("export.csv");
+    expect(path.dirname(result.path)).toBe(DEFAULT_DOWNLOAD_DIR);
+    expect(path.basename(result.path)).toMatch(/-export\.csv$/);
+    expect(firstSavePath(saveAs)).not.toBe(result.path);
+    await expect(fs.readFile(result.path, "utf8")).resolves.toBe("attachment");
+  });
+
+  it("recognizes Playwright download-starting navigation aborts", () => {
+    expect(isDownloadStartingNavigationError(new Error("page.goto: Download is starting"))).toBe(
+      true,
+    );
+    expect(isDownloadStartingNavigationError(new Error("page.goto: net::ERR_ABORTED"))).toBe(false);
+    expect(
+      isDownloadStartingNavigationError(
+        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/download"),
+        "http://127.0.0.1:3333/download",
+      ),
+    ).toBe(true);
+    expect(
+      isDownloadStartingNavigationError(
+        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/other"),
+        "http://127.0.0.1:3333/download",
+      ),
+    ).toBe(false);
+    expect(isDownloadStartingNavigationError(new Error("Navigation failed"))).toBe(false);
   });
 
   it("tracks page errors and network requests (best-effort)", () => {

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import type { Page } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
+import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
-  createManagedDownloadCaptureForPage,
   ensurePageState,
   isDownloadStartingNavigationError,
   refLocator,
@@ -252,8 +252,8 @@ describe("pw-session ensurePageState", () => {
 
   it("captures navigation downloads under managed paths", async () => {
     const { page, handlers } = fakePage();
-    ensurePageState(page);
-    const capture = createManagedDownloadCaptureForPage(page, 1_000);
+    const state = ensurePageState(page);
+    const capture = createDownloadCaptureForPage(page, state, 1_000);
     const saveAs = vi.fn(async (outPath: string) => {
       await fs.writeFile(outPath, "attachment", "utf8");
     });
@@ -268,7 +268,6 @@ describe("pw-session ensurePageState", () => {
     }
 
     const result = await capture.promise;
-    expect(result.triggered).toBe(true);
     expect(result.url).toBe("https://example.com/export.csv");
     expect(result.suggestedFilename).toBe("export.csv");
     expect(path.dirname(result.path)).toBe(DEFAULT_DOWNLOAD_DIR);
@@ -279,12 +278,12 @@ describe("pw-session ensurePageState", () => {
 
   it("validates captured navigation downloads before saving managed bytes", async () => {
     const { page, handlers } = fakePage();
-    ensurePageState(page);
+    const state = ensurePageState(page);
     const blocked = new Error("blocked download");
     const beforeSave = vi.fn(async () => {
       throw blocked;
     });
-    const capture = createManagedDownloadCaptureForPage(page, 1_000, { beforeSave });
+    const capture = createDownloadCaptureForPage(page, state, 1_000, { beforeSave });
     const saveAs = vi.fn(async (outPath: string) => {
       await fs.writeFile(outPath, "blocked", "utf8");
     });
@@ -300,11 +299,25 @@ describe("pw-session ensurePageState", () => {
 
     await expect(capture.promise).rejects.toBe(blocked);
     expect(beforeSave).toHaveBeenCalledWith({
-      triggered: true,
       url: "http://127.0.0.1:18080/export.csv",
       suggestedFilename: "export.csv",
     });
     expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it("lets explicit download owners arm while passive capture yields", () => {
+    const { page } = fakePage();
+    const state = ensurePageState(page);
+    state.downloadWaiterDepth = 1;
+
+    const passive = createDownloadCaptureForPage(page, state, 1_000);
+    const explicit = createDownloadCaptureForPage(page, state, 1_000, { mode: "explicit" });
+
+    expect(passive.armed).toBe(false);
+    expect(explicit.armed).toBe(true);
+    expect(state.downloadWaiterDepth).toBe(2);
+    explicit.cancel();
+    expect(state.downloadWaiterDepth).toBe(1);
   });
 
   it("recognizes Playwright download-starting navigation aborts", () => {

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -4,8 +4,6 @@
  * Manages CDP-backed Playwright connections, page lookup, observed dialogs,
  * console/network/page state, role refs, and safe navigation handling.
  */
-import crypto from "node:crypto";
-import path from "node:path";
 import {
   isFutureDateTimestampMs,
   parseFiniteNumber,
@@ -46,11 +44,9 @@ import {
   InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
-import { writeViaSiblingTempPath } from "./output-atomic.js";
-import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 import { playwrightCore } from "./playwright-core.runtime.js";
+import { saveBrowserDownload, type PlaywrightDownload } from "./pw-download-capture.js";
 import { BROWSER_REF_MARKER_ATTRIBUTE, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
-import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
 const { chromium } = playwrightCore;
 
@@ -145,24 +141,7 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
-export type BrowserManagedDownloadCandidate = {
-  triggered: true;
-  url: string;
-  suggestedFilename: string;
-};
-
-export type BrowserManagedDownload = BrowserManagedDownloadCandidate & {
-  path: string;
-};
-
-export type BrowserManagedDownloadCaptureOptions = {
-  beforeSave?: (download: BrowserManagedDownloadCandidate) => Promise<void> | void;
-};
-
-type DownloadPayload = {
-  url?: () => string;
-  suggestedFilename?: () => string;
-  saveAs?: (outPath: string) => Promise<void>;
+type DownloadPayload = PlaywrightDownload & {
   path?: () => Promise<string>;
 };
 
@@ -246,37 +225,6 @@ function resolveCdpConnectRetryDelayMs(attempt: number): number {
   return cdpConnectRetryDelayMsForTests ?? 250 + attempt * 250;
 }
 
-function buildManagedDownloadPath(fileName: string): string {
-  const id = crypto.randomUUID();
-  const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
-  return path.join(DEFAULT_DOWNLOAD_DIR, `${id}-${safeName}`);
-}
-
-async function saveManagedDownloadPayload(
-  download: DownloadPayload,
-  opts: BrowserManagedDownloadCaptureOptions = {},
-): Promise<BrowserManagedDownload> {
-  const suggestedFilename = download.suggestedFilename?.() || "download.bin";
-  const candidate: BrowserManagedDownloadCandidate = {
-    triggered: true,
-    url: download.url?.() || "",
-    suggestedFilename,
-  };
-  await opts.beforeSave?.(candidate);
-  const managedPath = buildManagedDownloadPath(suggestedFilename);
-  await writeViaSiblingTempPath({
-    rootDir: DEFAULT_DOWNLOAD_DIR,
-    targetPath: managedPath,
-    writeTemp: async (tempPath) => {
-      await download.saveAs?.(tempPath);
-    },
-  });
-  return {
-    ...candidate,
-    path: managedPath,
-  };
-}
-
 export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: string): boolean {
   const message = formatErrorMessage(err).toLowerCase();
   if (message.includes("download is starting")) {
@@ -286,82 +234,6 @@ export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: st
   return Boolean(
     normalizedUrl && message.includes("net::err_aborted") && message.includes(normalizedUrl),
   );
-}
-
-export function createManagedDownloadCaptureForPage(
-  page: Page,
-  timeoutMs: number,
-  opts: BrowserManagedDownloadCaptureOptions = {},
-): {
-  armed: boolean;
-  promise: Promise<BrowserManagedDownload>;
-  cancel: () => void;
-} {
-  const state = ensurePageState(page);
-  if (state.downloadWaiterDepth > 0) {
-    return {
-      armed: false,
-      promise: new Promise<BrowserManagedDownload>(() => {}),
-      cancel: () => {},
-    };
-  }
-
-  state.downloadWaiterDepth += 1;
-  let done = false;
-  let depthReleased = false;
-  let timer: NodeJS.Timeout | undefined;
-  let handler: ((download: unknown) => void) | undefined;
-
-  const cleanup = () => {
-    if (!depthReleased) {
-      depthReleased = true;
-      state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
-    }
-    if (timer) {
-      clearTimeout(timer);
-      timer = undefined;
-    }
-    if (handler) {
-      page.off("download", handler as never);
-      handler = undefined;
-    }
-  };
-
-  const promise = new Promise<BrowserManagedDownload>((resolve, reject) => {
-    handler = (download: unknown) => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
-      void saveManagedDownloadPayload(download as DownloadPayload, opts).then(resolve, reject);
-    };
-    page.on("download", handler as never);
-    timer = setTimeout(
-      () => {
-        if (done) {
-          return;
-        }
-        done = true;
-        cleanup();
-        reject(new Error("Timeout waiting for navigation download"));
-      },
-      Math.max(1, timeoutMs),
-    );
-    timer.unref?.();
-  });
-
-  return {
-    armed: true,
-    promise,
-    cancel: () => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
-    },
-  };
 }
 
 function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
@@ -830,7 +702,7 @@ export function ensurePageState(page: Page): PageState {
       if (state.downloadWaiterDepth > 0) {
         return;
       }
-      const managedSave = saveManagedDownloadPayload(download);
+      const managedSave = saveBrowserDownload(download);
       managedSave.catch(() => {});
       download.path = async () => (await managedSave).path;
     });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -145,11 +145,18 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
-export type BrowserManagedDownload = {
+export type BrowserManagedDownloadCandidate = {
   triggered: true;
   url: string;
   suggestedFilename: string;
+};
+
+export type BrowserManagedDownload = BrowserManagedDownloadCandidate & {
   path: string;
+};
+
+export type BrowserManagedDownloadCaptureOptions = {
+  beforeSave?: (download: BrowserManagedDownloadCandidate) => Promise<void> | void;
 };
 
 type DownloadPayload = {
@@ -247,8 +254,15 @@ function buildManagedDownloadPath(fileName: string): string {
 
 async function saveManagedDownloadPayload(
   download: DownloadPayload,
+  opts: BrowserManagedDownloadCaptureOptions = {},
 ): Promise<BrowserManagedDownload> {
   const suggestedFilename = download.suggestedFilename?.() || "download.bin";
+  const candidate: BrowserManagedDownloadCandidate = {
+    triggered: true,
+    url: download.url?.() || "",
+    suggestedFilename,
+  };
+  await opts.beforeSave?.(candidate);
   const managedPath = buildManagedDownloadPath(suggestedFilename);
   await writeViaSiblingTempPath({
     rootDir: DEFAULT_DOWNLOAD_DIR,
@@ -258,9 +272,7 @@ async function saveManagedDownloadPayload(
     },
   });
   return {
-    triggered: true,
-    url: download.url?.() || "",
-    suggestedFilename,
+    ...candidate,
     path: managedPath,
   };
 }
@@ -279,6 +291,7 @@ export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: st
 export function createManagedDownloadCaptureForPage(
   page: Page,
   timeoutMs: number,
+  opts: BrowserManagedDownloadCaptureOptions = {},
 ): {
   armed: boolean;
   promise: Promise<BrowserManagedDownload>;
@@ -321,7 +334,7 @@ export function createManagedDownloadCaptureForPage(
       }
       done = true;
       cleanup();
-      void saveManagedDownloadPayload(download as DownloadPayload).then(resolve, reject);
+      void saveManagedDownloadPayload(download as DownloadPayload, opts).then(resolve, reject);
     };
     page.on("download", handler as never);
     timer = setTimeout(

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -145,6 +145,20 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
+export type BrowserManagedDownload = {
+  triggered: true;
+  url: string;
+  suggestedFilename: string;
+  path: string;
+};
+
+type DownloadPayload = {
+  url?: () => string;
+  suggestedFilename?: () => string;
+  saveAs?: (outPath: string) => Promise<void>;
+  path?: () => Promise<string>;
+};
+
 type PageState = {
   console: BrowserConsoleMessage[];
   errors: BrowserPageError[];
@@ -229,6 +243,112 @@ function buildManagedDownloadPath(fileName: string): string {
   const id = crypto.randomUUID();
   const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
   return path.join(DEFAULT_DOWNLOAD_DIR, `${id}-${safeName}`);
+}
+
+async function saveManagedDownloadPayload(
+  download: DownloadPayload,
+): Promise<BrowserManagedDownload> {
+  const suggestedFilename = download.suggestedFilename?.() || "download.bin";
+  const managedPath = buildManagedDownloadPath(suggestedFilename);
+  await writeViaSiblingTempPath({
+    rootDir: DEFAULT_DOWNLOAD_DIR,
+    targetPath: managedPath,
+    writeTemp: async (tempPath) => {
+      await download.saveAs?.(tempPath);
+    },
+  });
+  return {
+    triggered: true,
+    url: download.url?.() || "",
+    suggestedFilename,
+    path: managedPath,
+  };
+}
+
+export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: string): boolean {
+  const message = formatErrorMessage(err).toLowerCase();
+  if (message.includes("download is starting")) {
+    return true;
+  }
+  const normalizedUrl = normalizeOptionalString(expectedUrl)?.toLowerCase();
+  return Boolean(
+    normalizedUrl && message.includes("net::err_aborted") && message.includes(normalizedUrl),
+  );
+}
+
+export function createManagedDownloadCaptureForPage(
+  page: Page,
+  timeoutMs: number,
+): {
+  armed: boolean;
+  promise: Promise<BrowserManagedDownload>;
+  cancel: () => void;
+} {
+  const state = ensurePageState(page);
+  if (state.downloadWaiterDepth > 0) {
+    return {
+      armed: false,
+      promise: new Promise<BrowserManagedDownload>(() => {}),
+      cancel: () => {},
+    };
+  }
+
+  state.downloadWaiterDepth += 1;
+  let done = false;
+  let depthReleased = false;
+  let timer: NodeJS.Timeout | undefined;
+  let handler: ((download: unknown) => void) | undefined;
+
+  const cleanup = () => {
+    if (!depthReleased) {
+      depthReleased = true;
+      state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
+    }
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (handler) {
+      page.off("download", handler as never);
+      handler = undefined;
+    }
+  };
+
+  const promise = new Promise<BrowserManagedDownload>((resolve, reject) => {
+    handler = (download: unknown) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      cleanup();
+      void saveManagedDownloadPayload(download as DownloadPayload).then(resolve, reject);
+    };
+    page.on("download", handler as never);
+    timer = setTimeout(
+      () => {
+        if (done) {
+          return;
+        }
+        done = true;
+        cleanup();
+        reject(new Error("Timeout waiting for navigation download"));
+      },
+      Math.max(1, timeoutMs),
+    );
+    timer.unref?.();
+  });
+
+  return {
+    armed: true,
+    promise,
+    cancel: () => {
+      if (done) {
+        return;
+      }
+      done = true;
+      cleanup();
+    },
+  };
 }
 
 function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
@@ -693,35 +813,14 @@ export function ensurePageState(page: Page): PageState {
     page.on("dialog", (dialog: Dialog) => {
       observeDialog(state, dialog);
     });
-    page.on(
-      "download",
-      (download: {
-        suggestedFilename?: () => string;
-        saveAs?: (outPath: string) => Promise<void>;
-        path?: () => Promise<string>;
-      }) => {
-        if (state.downloadWaiterDepth > 0) {
-          return;
-        }
-        const suggested = sanitizeUntrustedFileName(
-          download.suggestedFilename?.() || "download.bin",
-          "download.bin",
-        );
-        const managedPath = buildManagedDownloadPath(suggested);
-        const managedSave = (async () => {
-          await writeViaSiblingTempPath({
-            rootDir: DEFAULT_DOWNLOAD_DIR,
-            targetPath: managedPath,
-            writeTemp: async (tempPath) => {
-              await download.saveAs?.(tempPath);
-            },
-          });
-          return managedPath;
-        })();
-        managedSave.catch(() => {});
-        download.path = async () => await managedSave;
-      },
-    );
+    page.on("download", (download: DownloadPayload) => {
+      if (state.downloadWaiterDepth > 0) {
+        return;
+      }
+      const managedSave = saveManagedDownloadPayload(download);
+      managedSave.catch(() => {});
+      download.path = async () => (await managedSave).path;
+    });
     page.on("close", () => {
       clearArmedDialogResponse(state);
       for (const controller of state.dialogAbortControllers) {

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -2,12 +2,12 @@
  * File chooser, dialog, and download helpers for Playwright-backed browser
  * tools.
  */
-import crypto from "node:crypto";
 import path from "node:path";
 import type { Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { writeExternalFileWithinOutputRoot } from "./output-files.js";
+import type { BrowserDownloadResult } from "./download-types.js";
 import { resolveStrictExistingUploadPaths } from "./paths.js";
+import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
   armObservedDialogResponseOnPage,
   ensurePageState,
@@ -23,114 +23,30 @@ import {
   requireRef,
   toAIFriendlyError,
 } from "./pw-tools-core.shared.js";
-import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
-function buildTempDownloadPath(fileName: string): string {
-  const id = crypto.randomUUID();
-  const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
-  return path.join(resolvePreferredOpenClawTmpDir(), "downloads", `${id}-${safeName}`);
-}
-
-function createPageDownloadWaiter(page: Page, timeoutMs: number) {
-  const state = ensurePageState(page);
-  // Depth tracks active download waiters so page teardown can distinguish an
-  // expected download transition from an unobserved lost event.
-  state.downloadWaiterDepth += 1;
-  let done = false;
-  let timer: NodeJS.Timeout | undefined;
-  let handler: ((download: unknown) => void) | undefined;
-  let depthReleased = false;
-
-  const cleanup = () => {
-    if (!depthReleased) {
-      depthReleased = true;
-      state.downloadWaiterDepth = Math.max(0, state.downloadWaiterDepth - 1);
-    }
-    if (timer) {
-      clearTimeout(timer);
-    }
-    timer = undefined;
-    if (handler) {
-      page.off("download", handler as never);
-      handler = undefined;
-    }
-  };
-
-  const promise = new Promise<unknown>((resolve, reject) => {
-    handler = (download: unknown) => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
-      resolve(download);
-    };
-
-    page.on("download", handler as never);
-    timer = setTimeout(() => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
-      reject(new Error("Timeout waiting for download"));
-    }, timeoutMs);
-  });
-
-  return {
-    promise,
-    cancel: () => {
-      if (done) {
-        return;
-      }
-      done = true;
-      cleanup();
-    },
-  };
-}
-
-type DownloadPayload = {
-  url?: () => string;
-  suggestedFilename?: () => string;
-  saveAs?: (outPath: string) => Promise<void>;
-};
-
-async function saveDownloadPayload(download: DownloadPayload, outPath: string, rootDir?: string) {
-  const suggested = download.suggestedFilename?.() || "download.bin";
-  const requestedPath = outPath?.trim();
-  const resolvedOutPath = path.resolve(requestedPath || buildTempDownloadPath(suggested));
-  const finalPath = await writeExternalFileWithinOutputRoot({
-    rootDir,
-    path: resolvedOutPath,
-    write: async (tempPath) => {
-      await download.saveAs?.(tempPath);
-    },
-  });
-
-  return {
-    url: download.url?.() || "",
-    suggestedFilename: suggested,
-    path: finalPath,
-  };
-}
-
-async function awaitDownloadPayload(params: {
-  waiter: ReturnType<typeof createPageDownloadWaiter>;
+function createExplicitDownloadCapture(params: {
+  page: Page;
   state: ReturnType<typeof ensurePageState>;
-  armId: number;
+  timeoutMs: number;
   outPath?: string;
   rootDir?: string;
 }) {
-  try {
-    const download = (await params.waiter.promise) as DownloadPayload;
-    if (params.state.armIdDownload !== params.armId) {
-      throw new Error("Download was superseded by another waiter");
-    }
-    return await saveDownloadPayload(download, params.outPath ?? "", params.rootDir);
-  } catch (err) {
-    params.waiter.cancel();
-    throw err;
-  }
+  params.state.armIdDownload = bumpDownloadArmId();
+  const armId = params.state.armIdDownload;
+  return createDownloadCaptureForPage(params.page, params.state, params.timeoutMs, {
+    mode: "explicit",
+    outputPath: params.outPath,
+    outputRoot: params.rootDir,
+    beforeSave: () => {
+      if (params.state.armIdDownload !== armId) {
+        throw new Error("Download was superseded by another waiter");
+      }
+    },
+  });
+}
+
+function resolveImplicitDownloadRoot(): string {
+  return path.join(resolvePreferredOpenClawTmpDir(), "downloads");
 }
 
 /** Arms the next page file chooser and fills it with strict existing paths. */
@@ -237,26 +153,24 @@ export async function waitForDownloadViaPlaywright(opts: {
   path?: string;
   rootDir?: string;
   timeoutMs?: number;
-}): Promise<{
-  url: string;
-  suggestedFilename: string;
-  path: string;
-}> {
+}): Promise<BrowserDownloadResult> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120_000);
 
-  state.armIdDownload = bumpDownloadArmId();
-  const armId = state.armIdDownload;
-
-  const waiter = createPageDownloadWaiter(page, timeout);
-  return await awaitDownloadPayload({
-    waiter,
+  const capture = createExplicitDownloadCapture({
+    page,
     state,
-    armId,
+    timeoutMs: timeout,
     outPath: opts.path,
-    rootDir: opts.rootDir,
+    rootDir: opts.path?.trim() ? opts.rootDir : (opts.rootDir ?? resolveImplicitDownloadRoot()),
   });
+  try {
+    return await capture.promise;
+  } catch (err) {
+    capture.cancel();
+    throw err;
+  }
 }
 
 /** Clicks an element ref and saves the download triggered by that click. */
@@ -267,11 +181,7 @@ export async function downloadViaPlaywright(opts: {
   path: string;
   rootDir?: string;
   timeoutMs?: number;
-}): Promise<{
-  url: string;
-  suggestedFilename: string;
-  path: string;
-}> {
+}): Promise<BrowserDownloadResult> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -283,10 +193,13 @@ export async function downloadViaPlaywright(opts: {
     throw new Error("path is required");
   }
 
-  state.armIdDownload = bumpDownloadArmId();
-  const armId = state.armIdDownload;
-
-  const waiter = createPageDownloadWaiter(page, timeout);
+  const capture = createExplicitDownloadCapture({
+    page,
+    state,
+    timeoutMs: timeout,
+    outPath,
+    rootDir: opts.rootDir,
+  });
   try {
     const locator = refLocator(page, ref);
     try {
@@ -294,15 +207,9 @@ export async function downloadViaPlaywright(opts: {
     } catch (err) {
       throw toAIFriendlyError(err, ref);
     }
-    return await awaitDownloadPayload({
-      waiter,
-      state,
-      armId,
-      outPath,
-      rootDir: opts.rootDir,
-    });
+    return await capture.promise;
   } catch (err) {
-    waiter.cancel();
+    capture.cancel();
     throw err;
   }
 }

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -154,6 +154,34 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     expect(result).toEqual({ url: download.url, download });
   });
 
+  it("handles capture timeouts that win before ordinary navigation settles", async () => {
+    let rejectCapture!: (err: Error) => void;
+    const downloadCapture = {
+      armed: true,
+      promise: new Promise<never>((_, reject) => {
+        rejectCapture = reject;
+      }),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    setPwToolsCoreCurrentPage({
+      goto: vi.fn(async () => {
+        rejectCapture(new Error("Timeout waiting for navigation download"));
+        await Promise.resolve();
+      }),
+      url: vi.fn(() => "https://example.com/final"),
+    });
+
+    const result = await mod.navigateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "https://example.com/final",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(result).toEqual({ url: "https://example.com/final" });
+    expect(downloadCapture.cancel).toHaveBeenCalledTimes(1);
+  });
+
   it("closes the tab when captured navigation download resolves to a blocked URL", async () => {
     const download = {
       triggered: true as const,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -4,9 +4,11 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import "../test-support/browser-security.mock.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
+  getPwToolsCoreNavigationGuardMocks,
   getPwToolsCoreSessionMocks,
   installPwToolsCoreTestHooks,
   setPwToolsCoreCurrentPage,
+  setPwToolsCoreDownloadCapture,
 } from "./pw-tools-core.test-harness.js";
 
 installPwToolsCoreTestHooks();
@@ -82,6 +84,164 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       targetId: undefined,
     });
     expect(result.url).toBe("https://example.com");
+  });
+
+  it("returns managed download metadata when navigation starts an attachment download", async () => {
+    const download = {
+      triggered: true as const,
+      url: "https://example.com/export.csv",
+      suggestedFilename: "export.csv",
+      path: "/tmp/openclaw/downloads/export.csv",
+    };
+    const downloadCapture = {
+      armed: true,
+      promise: Promise.resolve(download),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    const page = {
+      goto: vi.fn(async () => {
+        throw new Error("page.goto: Download is starting");
+      }),
+      url: vi.fn(() => "https://example.com/start"),
+    };
+    setPwToolsCoreCurrentPage(page);
+
+    const result = await mod.navigateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      url: "https://example.com/export.csv",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(result).toEqual({ url: download.url, download });
+    expect(downloadCapture.cancel).not.toHaveBeenCalled();
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
+    expect(
+      getPwToolsCoreNavigationGuardMocks().assertBrowserNavigationResultAllowed,
+    ).toHaveBeenCalledWith({
+      url: download.url,
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+  });
+
+  it("returns managed download metadata for matching ERR_ABORTED attachment navigations", async () => {
+    const download = {
+      triggered: true as const,
+      url: "http://127.0.0.1:3333/download",
+      suggestedFilename: "proof.txt",
+      path: "/tmp/openclaw/downloads/proof.txt",
+    };
+    const downloadCapture = {
+      armed: true,
+      promise: Promise.resolve(download),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    setPwToolsCoreCurrentPage({
+      goto: vi.fn(async () => {
+        throw new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/download");
+      }),
+      url: vi.fn(() => "about:blank"),
+    });
+
+    const result = await mod.navigateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "http://127.0.0.1:3333/download",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(result).toEqual({ url: download.url, download });
+  });
+
+  it("closes the tab when captured navigation download resolves to a blocked URL", async () => {
+    const download = {
+      triggered: true as const,
+      url: "http://127.0.0.1:18080/export.csv",
+      suggestedFilename: "export.csv",
+      path: "/tmp/openclaw/downloads/export.csv",
+    };
+    const downloadCapture = {
+      armed: true,
+      promise: Promise.resolve(download),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    const page = {
+      goto: vi.fn(async () => {
+        throw new Error("page.goto: Download is starting");
+      }),
+      url: vi.fn(() => "https://93.184.216.34/start"),
+    };
+    setPwToolsCoreCurrentPage(page);
+    getPwToolsCoreNavigationGuardMocks().assertBrowserNavigationResultAllowed.mockRejectedValueOnce(
+      new SsrFBlockedError("Blocked hostname or private/internal/special-use IP address"),
+    );
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://93.184.216.34/export.csv",
+        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+      }),
+    ).rejects.toBeInstanceOf(SsrFBlockedError);
+
+    expect(getPwToolsCoreSessionMocks().closeBlockedNavigationTarget).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      targetId: "tab-1",
+    });
+  });
+
+  it("surfaces managed download save failures", async () => {
+    const downloadCapture = {
+      armed: true,
+      promise: Promise.reject(new Error("download save failed")),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    setPwToolsCoreCurrentPage({
+      goto: vi.fn(async () => {
+        throw new Error("page.goto: Download is starting");
+      }),
+      url: vi.fn(() => "https://example.com/start"),
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://example.com/export.csv",
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    ).rejects.toThrow("download save failed");
+  });
+
+  it("rethrows download-starting navigation errors when no download is captured", async () => {
+    const downloadCapture = {
+      armed: false,
+      promise: new Promise<never>(() => {}),
+      cancel: vi.fn(),
+    };
+    setPwToolsCoreDownloadCapture(downloadCapture);
+    setPwToolsCoreCurrentPage({
+      goto: vi.fn(async () => {
+        throw new Error("page.goto: Download is starting");
+      }),
+      url: vi.fn(() => "https://example.com/start"),
+    });
+
+    await expect(
+      mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        url: "https://example.com/export.csv",
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    ).rejects.toThrow("Download is starting");
+
+    expect(downloadCapture.cancel).toHaveBeenCalledTimes(1);
   });
 
   it("reconnects and retries once when navigation detaches frame", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -88,7 +88,6 @@ describe("pw-tools-core.snapshot navigate guard", () => {
 
   it("returns managed download metadata when navigation starts an attachment download", async () => {
     const download = {
-      triggered: true as const,
       url: "https://example.com/export.csv",
       suggestedFilename: "export.csv",
       path: "/tmp/openclaw/downloads/export.csv",
@@ -127,7 +126,6 @@ describe("pw-tools-core.snapshot navigate guard", () => {
 
   it("returns managed download metadata for matching ERR_ABORTED attachment navigations", async () => {
     const download = {
-      triggered: true as const,
       url: "http://127.0.0.1:3333/download",
       suggestedFilename: "proof.txt",
       path: "/tmp/openclaw/downloads/proof.txt",
@@ -184,7 +182,6 @@ describe("pw-tools-core.snapshot navigate guard", () => {
 
   it("closes the tab when captured navigation download resolves to a blocked URL", async () => {
     const download = {
-      triggered: true as const,
       url: "http://127.0.0.1:18080/export.csv",
       suggestedFilename: "export.csv",
       path: "/tmp/openclaw/downloads/export.csv",

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -8,14 +8,21 @@ const withPageScopedCdpClient = vi.fn();
 const markBackendDomRefsOnPage = vi.fn();
 const formatAriaSnapshot = vi.fn();
 const gotoPageWithNavigationGuard = vi.fn();
+const createManagedDownloadCaptureForPage = vi.fn(() => ({
+  armed: true,
+  promise: new Promise(() => {}),
+  cancel: vi.fn(),
+}));
 
 vi.mock("./pw-session.js", () => ({
   assertPageNavigationCompletedSafely: vi.fn(),
   closeBlockedNavigationTarget: vi.fn(),
+  createManagedDownloadCaptureForPage,
   ensurePageState,
   forceDisconnectPlaywrightForTarget: vi.fn(),
   getPageForTargetId,
   gotoPageWithNavigationGuard,
+  isDownloadStartingNavigationError: vi.fn(() => false),
   isPolicyDenyNavigationError: vi.fn(() => false),
   storeRoleRefsForTarget,
 }));

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -8,7 +8,7 @@ const withPageScopedCdpClient = vi.fn();
 const markBackendDomRefsOnPage = vi.fn();
 const formatAriaSnapshot = vi.fn();
 const gotoPageWithNavigationGuard = vi.fn();
-const createManagedDownloadCaptureForPage = vi.fn(() => ({
+const createDownloadCaptureForPage = vi.fn(() => ({
   armed: true,
   promise: new Promise(() => {}),
   cancel: vi.fn(),
@@ -17,7 +17,6 @@ const createManagedDownloadCaptureForPage = vi.fn(() => ({
 vi.mock("./pw-session.js", () => ({
   assertPageNavigationCompletedSafely: vi.fn(),
   closeBlockedNavigationTarget: vi.fn(),
-  createManagedDownloadCaptureForPage,
   ensurePageState,
   forceDisconnectPlaywrightForTarget: vi.fn(),
   getPageForTargetId,
@@ -25,6 +24,10 @@ vi.mock("./pw-session.js", () => ({
   isDownloadStartingNavigationError: vi.fn(() => false),
   isPolicyDenyNavigationError: vi.fn(() => false),
   storeRoleRefsForTarget,
+}));
+
+vi.mock("./pw-download-capture.js", () => ({
+  createDownloadCaptureForPage,
 }));
 
 vi.mock("./pw-session.page-cdp.js", () => ({

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -451,6 +451,7 @@ export async function navigateViaPlaywright(opts: {
         });
       },
     });
+    void downloadCapture.promise.catch(() => {});
     try {
       const response = await navigate();
       downloadCapture.cancel();

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -443,7 +443,14 @@ export async function navigateViaPlaywright(opts: {
     response: Awaited<ReturnType<typeof navigate>> | null;
     download?: BrowserManagedDownload;
   }> => {
-    const downloadCapture = createManagedDownloadCaptureForPage(page, timeout);
+    const downloadCapture = createManagedDownloadCaptureForPage(page, timeout, {
+      beforeSave: async (download) => {
+        await assertBrowserNavigationResultAllowed({
+          url: download.url || url,
+          ...navigationPolicy,
+        });
+      },
+    });
     try {
       const response = await navigate();
       downloadCapture.cancel();
@@ -461,6 +468,13 @@ export async function navigateViaPlaywright(opts: {
           downloadErr.message === "Timeout waiting for navigation download"
         ) {
           throw err;
+        }
+        if (isPolicyDenyNavigationError(downloadErr)) {
+          await closeBlockedNavigationTarget({
+            cdpUrl: opts.cdpUrl,
+            page,
+            targetId: opts.targetId,
+          });
         }
         throw downloadErr;
       }
@@ -487,12 +501,7 @@ export async function navigateViaPlaywright(opts: {
     navigationResult = await navigateWithDownloadCapture();
   }
   try {
-    if (navigationResult.download) {
-      await assertBrowserNavigationResultAllowed({
-        url: navigationResult.download.url || url,
-        ...navigationPolicy,
-      });
-    } else {
+    if (!navigationResult.download) {
       await assertPageNavigationCompletedSafely({
         cdpUrl: opts.cdpUrl,
         page,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -14,6 +14,7 @@ import { ACT_MAX_VIEWPORT_DIMENSION } from "./act-policy.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
 import {
   assertBrowserNavigationAllowed,
+  assertBrowserNavigationResultAllowed,
   type BrowserNavigationPolicyOptions,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
@@ -26,11 +27,14 @@ import {
 } from "./pw-role-snapshot.js";
 import {
   assertPageNavigationCompletedSafely,
+  type BrowserManagedDownload,
   closeBlockedNavigationTarget,
+  createManagedDownloadCaptureForPage,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   gotoPageWithNavigationGuard,
+  isDownloadStartingNavigationError,
   isPolicyDenyNavigationError,
   storeRoleRefsForTarget,
 } from "./pw-session.js";
@@ -397,7 +401,7 @@ export async function navigateViaPlaywright(opts: {
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   browserProxyMode?: BrowserNavigationPolicyOptions["browserProxyMode"];
-}): Promise<{ url: string }> {
+}): Promise<{ url: string; download?: BrowserManagedDownload }> {
   const isRetryableNavigateError = (err: unknown): boolean => {
     const msg =
       typeof err === "string"
@@ -415,11 +419,12 @@ export async function navigateViaPlaywright(opts: {
   if (!url) {
     throw new Error("url is required");
   }
+  const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy, {
+    browserProxyMode: opts.browserProxyMode,
+  });
   await assertBrowserNavigationAllowed({
     url,
-    ...withBrowserNavigationPolicy(opts.ssrfPolicy, {
-      browserProxyMode: opts.browserProxyMode,
-    }),
+    ...navigationPolicy,
   });
   const timeout = resolveNavigationTimeoutMs(opts.timeoutMs);
   let page = await getPageForTargetId(opts);
@@ -434,9 +439,37 @@ export async function navigateViaPlaywright(opts: {
       browserProxyMode: opts.browserProxyMode,
       targetId: opts.targetId,
     });
-  let response;
+  const navigateWithDownloadCapture = async (): Promise<{
+    response: Awaited<ReturnType<typeof navigate>> | null;
+    download?: BrowserManagedDownload;
+  }> => {
+    const downloadCapture = createManagedDownloadCaptureForPage(page, timeout);
+    try {
+      const response = await navigate();
+      downloadCapture.cancel();
+      return { response };
+    } catch (err) {
+      if (!isDownloadStartingNavigationError(err, url) || !downloadCapture.armed) {
+        downloadCapture.cancel();
+        throw err;
+      }
+      try {
+        return { response: null, download: await downloadCapture.promise };
+      } catch (downloadErr) {
+        if (
+          downloadErr instanceof Error &&
+          downloadErr.message === "Timeout waiting for navigation download"
+        ) {
+          throw err;
+        }
+        throw downloadErr;
+      }
+    }
+  };
+
+  let navigationResult: Awaited<ReturnType<typeof navigateWithDownloadCapture>>;
   try {
-    response = await navigate();
+    navigationResult = await navigateWithDownloadCapture();
   } catch (err) {
     if (!isRetryableNavigateError(err)) {
       throw err;
@@ -451,17 +484,24 @@ export async function navigateViaPlaywright(opts: {
     }).catch(() => {});
     page = await getPageForTargetId(opts);
     ensurePageState(page);
-    response = await navigate();
+    navigationResult = await navigateWithDownloadCapture();
   }
   try {
-    await assertPageNavigationCompletedSafely({
-      cdpUrl: opts.cdpUrl,
-      page,
-      response,
-      ssrfPolicy: opts.ssrfPolicy,
-      browserProxyMode: opts.browserProxyMode,
-      targetId: opts.targetId,
-    });
+    if (navigationResult.download) {
+      await assertBrowserNavigationResultAllowed({
+        url: navigationResult.download.url || url,
+        ...navigationPolicy,
+      });
+    } else {
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page,
+        response: navigationResult.response,
+        ssrfPolicy: opts.ssrfPolicy,
+        browserProxyMode: opts.browserProxyMode,
+        targetId: opts.targetId,
+      });
+    }
   } catch (err) {
     if (isPolicyDenyNavigationError(err)) {
       await closeBlockedNavigationTarget({
@@ -472,8 +512,11 @@ export async function navigateViaPlaywright(opts: {
     }
     throw err;
   }
-  const finalUrl = page.url();
-  return { url: finalUrl };
+  const finalUrl = navigationResult.download?.url || page.url();
+  return {
+    url: finalUrl,
+    ...(navigationResult.download ? { download: navigationResult.download } : {}),
+  };
 }
 
 /** Resizes the target page viewport within the browser action policy bounds. */

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -12,12 +12,14 @@ import type { Page } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ACT_MAX_VIEWPORT_DIMENSION } from "./act-policy.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
+import type { BrowserDownloadResult } from "./download-types.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
   type BrowserNavigationPolicyOptions,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
+import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
   buildRoleSnapshotFromAiSnapshot,
   buildRoleSnapshotFromAriaSnapshot,
@@ -27,9 +29,7 @@ import {
 } from "./pw-role-snapshot.js";
 import {
   assertPageNavigationCompletedSafely,
-  type BrowserManagedDownload,
   closeBlockedNavigationTarget,
-  createManagedDownloadCaptureForPage,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
@@ -401,7 +401,7 @@ export async function navigateViaPlaywright(opts: {
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   browserProxyMode?: BrowserNavigationPolicyOptions["browserProxyMode"];
-}): Promise<{ url: string; download?: BrowserManagedDownload }> {
+}): Promise<{ url: string; download?: BrowserDownloadResult }> {
   const isRetryableNavigateError = (err: unknown): boolean => {
     const msg =
       typeof err === "string"
@@ -428,7 +428,7 @@ export async function navigateViaPlaywright(opts: {
   });
   const timeout = resolveNavigationTimeoutMs(opts.timeoutMs);
   let page = await getPageForTargetId(opts);
-  ensurePageState(page);
+  let pageState = ensurePageState(page);
   const navigate = async () =>
     await gotoPageWithNavigationGuard({
       cdpUrl: opts.cdpUrl,
@@ -441,9 +441,11 @@ export async function navigateViaPlaywright(opts: {
     });
   const navigateWithDownloadCapture = async (): Promise<{
     response: Awaited<ReturnType<typeof navigate>> | null;
-    download?: BrowserManagedDownload;
+    download?: BrowserDownloadResult;
   }> => {
-    const downloadCapture = createManagedDownloadCaptureForPage(page, timeout, {
+    const downloadCapture = createDownloadCaptureForPage(page, pageState, timeout, {
+      mode: "passive",
+      timeoutMessage: "Timeout waiting for navigation download",
       beforeSave: async (download) => {
         await assertBrowserNavigationResultAllowed({
           url: download.url || url,
@@ -498,7 +500,7 @@ export async function navigateViaPlaywright(opts: {
       reason: "retry navigate after detached frame",
     }).catch(() => {});
     page = await getPageForTargetId(opts);
-    ensurePageState(page);
+    pageState = ensurePageState(page);
     navigationResult = await navigateWithDownloadCapture();
   }
   try {

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -6,18 +6,21 @@ import { beforeEach, vi } from "vitest";
 
 let currentPage: Record<string, unknown> | null = null;
 let currentRefLocator: Record<string, unknown> | null = null;
-let currentDownloadCapture:
-  | {
-      armed: boolean;
-      promise: Promise<{
-        triggered: true;
-        url: string;
-        suggestedFilename: string;
-        path: string;
-      }>;
-      cancel: ReturnType<typeof vi.fn>;
-    }
-  | undefined;
+type HarnessManagedDownload = {
+  triggered: true;
+  url: string;
+  suggestedFilename: string;
+  path: string;
+};
+type HarnessDownloadCapture = {
+  armed: boolean;
+  promise: Promise<HarnessManagedDownload>;
+  cancel: ReturnType<typeof vi.fn>;
+};
+type HarnessDownloadCaptureOptions = {
+  beforeSave?: (download: Omit<HarnessManagedDownload, "path">) => Promise<void> | void;
+};
+let currentDownloadCapture: HarnessDownloadCapture | undefined;
 let pageState: {
   console: unknown[];
   armIdUpload: number;
@@ -42,12 +45,29 @@ const sessionMocks = vi.hoisted(() => ({
   ensurePageState: vi.fn(() => pageState),
   forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
   createManagedDownloadCaptureForPage: vi.fn(
-    () =>
-      currentDownloadCapture ?? {
-        armed: true,
-        promise: new Promise(() => {}),
-        cancel: vi.fn(),
-      },
+    (_page?: unknown, _timeoutMs?: unknown, opts?: HarnessDownloadCaptureOptions) => {
+      const capture =
+        currentDownloadCapture ??
+        ({
+          armed: true,
+          promise: new Promise<HarnessManagedDownload>(() => {}),
+          cancel: vi.fn(),
+        } satisfies HarnessDownloadCapture);
+      if (!opts?.beforeSave) {
+        return capture;
+      }
+      return {
+        ...capture,
+        promise: capture.promise.then(async (download) => {
+          await opts.beforeSave?.({
+            triggered: true,
+            url: download.url,
+            suggestedFilename: download.suggestedFilename,
+          });
+          return download;
+        }),
+      };
+    },
   ),
   gotoPageWithNavigationGuard: vi.fn(
     async (opts: {
@@ -130,20 +150,7 @@ export function setPwToolsCoreCurrentRefLocator(locator: Record<string, unknown>
   currentRefLocator = locator;
 }
 
-export function setPwToolsCoreDownloadCapture(
-  capture:
-    | {
-        armed: boolean;
-        promise: Promise<{
-          triggered: true;
-          url: string;
-          suggestedFilename: string;
-          path: string;
-        }>;
-        cancel: ReturnType<typeof vi.fn>;
-      }
-    | undefined,
-) {
+export function setPwToolsCoreDownloadCapture(capture: HarnessDownloadCapture | undefined) {
   currentDownloadCapture = capture;
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -6,6 +6,18 @@ import { beforeEach, vi } from "vitest";
 
 let currentPage: Record<string, unknown> | null = null;
 let currentRefLocator: Record<string, unknown> | null = null;
+let currentDownloadCapture:
+  | {
+      armed: boolean;
+      promise: Promise<{
+        triggered: true;
+        url: string;
+        suggestedFilename: string;
+        path: string;
+      }>;
+      cancel: ReturnType<typeof vi.fn>;
+    }
+  | undefined;
 let pageState: {
   console: unknown[];
   armIdUpload: number;
@@ -29,6 +41,14 @@ const sessionMocks = vi.hoisted(() => ({
   }),
   ensurePageState: vi.fn(() => pageState),
   forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
+  createManagedDownloadCaptureForPage: vi.fn(
+    () =>
+      currentDownloadCapture ?? {
+        armed: true,
+        promise: new Promise(() => {}),
+        cancel: vi.fn(),
+      },
+  ),
   gotoPageWithNavigationGuard: vi.fn(
     async (opts: {
       url: string;
@@ -37,6 +57,19 @@ const sessionMocks = vi.hoisted(() => ({
     }) => (await opts.page.goto(opts.url, { timeout: opts.timeoutMs })) ?? null,
   ),
   // Match by name so mocked errors are recognized without importing real classes.
+  isDownloadStartingNavigationError: vi.fn((err: unknown, expectedUrl?: string) => {
+    if (!(err instanceof Error)) {
+      return false;
+    }
+    const message = err.message.toLowerCase();
+    if (message.includes("download is starting")) {
+      return true;
+    }
+    const normalizedUrl = expectedUrl?.trim().toLowerCase();
+    return Boolean(
+      normalizedUrl && message.includes("net::err_aborted") && message.includes(normalizedUrl),
+    );
+  }),
   isPolicyDenyNavigationError: vi.fn((err: unknown) => {
     if (!(err instanceof Error)) {
       return false;
@@ -97,11 +130,29 @@ export function setPwToolsCoreCurrentRefLocator(locator: Record<string, unknown>
   currentRefLocator = locator;
 }
 
+export function setPwToolsCoreDownloadCapture(
+  capture:
+    | {
+        armed: boolean;
+        promise: Promise<{
+          triggered: true;
+          url: string;
+          suggestedFilename: string;
+          path: string;
+        }>;
+        cancel: ReturnType<typeof vi.fn>;
+      }
+    | undefined,
+) {
+  currentDownloadCapture = capture;
+}
+
 /** Installs per-test cleanup for pw-tools-core mocked session state. */
 export function installPwToolsCoreTestHooks() {
   beforeEach(() => {
     currentPage = null;
     currentRefLocator = null;
+    currentDownloadCapture = undefined;
     pageState = {
       console: [],
       armIdUpload: 0,

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -7,7 +7,6 @@ import { beforeEach, vi } from "vitest";
 let currentPage: Record<string, unknown> | null = null;
 let currentRefLocator: Record<string, unknown> | null = null;
 type HarnessManagedDownload = {
-  triggered: true;
   url: string;
   suggestedFilename: string;
   path: string;
@@ -44,31 +43,6 @@ const sessionMocks = vi.hoisted(() => ({
   }),
   ensurePageState: vi.fn(() => pageState),
   forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
-  createManagedDownloadCaptureForPage: vi.fn(
-    (_page?: unknown, _timeoutMs?: unknown, opts?: HarnessDownloadCaptureOptions) => {
-      const capture =
-        currentDownloadCapture ??
-        ({
-          armed: true,
-          promise: new Promise<HarnessManagedDownload>(() => {}),
-          cancel: vi.fn(),
-        } satisfies HarnessDownloadCapture);
-      if (!opts?.beforeSave) {
-        return capture;
-      }
-      return {
-        ...capture,
-        promise: capture.promise.then(async (download) => {
-          await opts.beforeSave?.({
-            triggered: true,
-            url: download.url,
-            suggestedFilename: download.suggestedFilename,
-          });
-          return download;
-        }),
-      };
-    },
-  ),
   gotoPageWithNavigationGuard: vi.fn(
     async (opts: {
       url: string;
@@ -116,12 +90,44 @@ const sessionMocks = vi.hoisted(() => ({
   rememberRoleRefsForTarget: vi.fn(() => {}),
 }));
 
+const downloadCaptureMocks = vi.hoisted(() => ({
+  createDownloadCaptureForPage: vi.fn(),
+}));
+
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
   withBrowserNavigationPolicy: vi.fn((ssrfPolicy?: unknown) => ({ ssrfPolicy })),
 }));
 
 vi.mock("./pw-session.js", () => sessionMocks);
+vi.mock("./pw-download-capture.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./pw-download-capture.js")>();
+  downloadCaptureMocks.createDownloadCaptureForPage.mockImplementation(
+    (page, state, timeoutMs, opts?: HarnessDownloadCaptureOptions) => {
+      const capture = currentDownloadCapture;
+      if (!capture) {
+        return actual.createDownloadCaptureForPage(page, state, timeoutMs, opts);
+      }
+      if (!opts?.beforeSave) {
+        return capture;
+      }
+      return {
+        ...capture,
+        promise: capture.promise.then(async (download) => {
+          await opts.beforeSave?.({
+            url: download.url,
+            suggestedFilename: download.suggestedFilename,
+          });
+          return download;
+        }),
+      };
+    },
+  );
+  return {
+    ...actual,
+    createDownloadCaptureForPage: downloadCaptureMocks.createDownloadCaptureForPage,
+  };
+});
 vi.mock("./navigation-guard.js", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
@@ -142,6 +148,10 @@ export function getPwToolsCoreNavigationGuardMocks() {
 
 /** Sets the current mocked page returned by getPageForTargetId. */
 export function setPwToolsCoreCurrentPage(page: Record<string, unknown> | null) {
+  if (page) {
+    page.on ??= vi.fn();
+    page.off ??= vi.fn();
+  }
   currentPage = page;
 }
 
@@ -168,6 +178,9 @@ export function installPwToolsCoreTestHooks() {
     };
 
     for (const fn of Object.values(sessionMocks)) {
+      fn.mockClear();
+    }
+    for (const fn of Object.values(downloadCaptureMocks)) {
       fn.mockClear();
     }
     for (const fn of Object.values(navigationGuardMocks)) {

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -178,12 +178,11 @@ describe("pw-tools-core", () => {
         suggestedFilename: () => string;
         saveAs: (outPath: string) => Promise<void>;
       };
-      let download: DownloadFixture;
       const saveAs = vi.fn(async function (this: DownloadFixture, outPath: string) {
         expect(this).toBe(download);
         await fs.writeFile(outPath, "file-content", "utf8");
       });
-      download = {
+      const download: DownloadFixture = {
         url: () => "https://example.com/file.bin",
         suggestedFilename: () => "file.bin",
         saveAs,

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -173,10 +173,17 @@ describe("pw-tools-core", () => {
       const harness = createDownloadEventHarness();
       const targetPath = path.join(tempDir, "file.bin");
 
-      const saveAs = vi.fn(async (outPath: string) => {
+      type DownloadFixture = {
+        url: () => string;
+        suggestedFilename: () => string;
+        saveAs: (outPath: string) => Promise<void>;
+      };
+      let download: DownloadFixture;
+      const saveAs = vi.fn(async function (this: DownloadFixture, outPath: string) {
+        expect(this).toBe(download);
         await fs.writeFile(outPath, "file-content", "utf8");
       });
-      const download = {
+      download = {
         url: () => "https://example.com/file.bin",
         suggestedFilename: () => "file.bin",
         saveAs,
@@ -309,6 +316,41 @@ describe("pw-tools-core", () => {
     expect(state.downloadWaiterDepth).toBe(0);
     expect(harness.activeHandlerCount()).toBe(0);
   });
+
+  it("lets only the latest overlapping explicit waiter save the download", async () => {
+    const harness = createDownloadEventHarness();
+    const state = sessionMocks.ensurePageState();
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "latest-content", "utf8");
+    });
+
+    const first = mod.waitForDownloadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      timeoutMs: 1000,
+    });
+    void first.catch(() => {});
+    const latest = mod.waitForDownloadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      timeoutMs: 1000,
+    });
+
+    await Promise.resolve();
+    expect(state.downloadWaiterDepth).toBe(2);
+    harness.trigger({
+      url: () => "https://example.com/latest.bin",
+      suggestedFilename: () => "latest.bin",
+      saveAs,
+    });
+
+    await expect(first).rejects.toThrow("superseded by another waiter");
+    await expect(latest).resolves.toMatchObject({ suggestedFilename: "latest.bin" });
+    expect(saveAs).toHaveBeenCalledOnce();
+    expect(state.downloadWaiterDepth).toBe(0);
+    expect(harness.activeHandlerCount()).toBe(0);
+  });
+
   it("clicks a ref and atomically finalizes explicit download paths", async () => {
     await withTempDir(async (tempDir) => {
       const harness = createDownloadEventHarness();


### PR DESCRIPTION
## Summary

- Fixes #48045.
- Behavior or issue addressed: Browser `/navigate` attachment responses in Playwright/CDP mode now complete as successful downloads instead of surfacing the navigation abort as a tool failure or dropping the file silently.
- Why it matters / User impact: CDP-backed browser workflows that navigate directly to CSV/PDF/export URLs can now receive structured download metadata and a saved file, while rejected/private attachment targets cannot leave managed download bytes behind.
- Intended outcome: allowed attachment navigations return `{ url, download }`; rejected captured download URLs fail before `saveAs` writes managed bytes.
- Fix classification: Root Cause.
- Maintainer-ready confidence: High; the update is limited to the Playwright browser `/navigate` seam, managed download capture, and focused test-harness support, with RED/GREEN coverage for the ClawSweeper security-boundary finding.
- What is intentionally out of scope / scope boundary: browser navigation allow/deny policy changes, unrelated Playwright session behavior, non-download navigations, and extensions outside the browser `/navigate` path.
- What did NOT change: this does not change public browser API shape beyond the existing additive `download` result, does not change config, schema, protocol, migration, default behavior, allowlist behavior, or unrelated browser tools.
- What does success look like: allowed attachment downloads return metadata and saved bytes; rejected captured download URLs reject before persistence; existing non-download navigation behavior remains covered.
- What should reviewers focus on: the `beforeSave` ordering between captured download metadata, `assertBrowserNavigationResultAllowed`, and `saveAs`.
- Related open PR scan: this is an existing PR repair for #89416 rather than a new competing PR; the current daily-fix scan found #89416 as the only author-action PR in the user's open PR set.

## Linked context

Closes #48045.

Related: ClawSweeper review on this PR requested blocked attachment-download persistence ordering coverage and targeted validation.

This was requested by ClawSweeper through the `status: waiting on author` review signal.

## Root Cause

- Root cause: `/navigate` owned the Playwright `page.goto()` lifecycle, but attachment downloads caused Playwright to abort navigation with `Download is starting` or URL-matched `net::ERR_ABORTED` before `navigateViaPlaywright` could return useful download metadata.
- Follow-up root cause from ClawSweeper review: the new capture path saved managed bytes before the captured download URL passed `assertBrowserNavigationResultAllowed`, so a policy-denied attachment could leave rejected bytes in managed storage.
- Current author follow-up root cause: the timer-backed download capture promise was only awaited on the download-starting path. Ordinary non-download navigation could cancel the waiter after `page.goto()` settled, but if the capture timeout rejected first, the rejected promise was left unobserved and surfaced as an unhandled rejection.
- Why this is root-cause fix: the invariant is that browser navigation policy must approve a target before OpenClaw stores bytes for that target. `createManagedDownloadCaptureForPage` now accepts a `beforeSave` hook, builds URL/filename candidate metadata, runs the existing navigation result policy check first, and only calls `saveAs` after policy approval. The `/navigate` path passes that hook at the point where it arms the download capture, so allowed downloads still succeed and blocked downloads reject before persistence instead of being cleaned up after the fact. The `/navigate` path now also observes the armed capture promise immediately, so later download-starting handling still awaits real captured downloads while ordinary non-download success/error paths cannot leave a timed-out waiter rejection unhandled.
- Patch quality notes: the change does not broaden allowed URLs or change SSRF policy; it only moves the existing result validation ahead of managed persistence for captured navigation downloads. Timeout handling remains bounded by the existing navigation timeout, the catch blocks only distinguish timeout/policy-denial/download-starting cases, and rejected downloads still close the blocked navigation target.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Browser `/navigate` to a `Content-Disposition: attachment` URL in Playwright/CDP mode returns success download metadata and writes the file instead of failing the tool call.
- Real environment tested: Local Linux host with real headless Chrome launched through a CDP debugging port, plus a local HTTP server returning `Content-Disposition: attachment; filename=proof.txt`.
- Exact steps or command run after this patch: `pnpm exec tsx cdp-navigate-download-proof.ts` was run from the task worktree against the patched `navigateViaPlaywright` path.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): The live CDP proof connected through CDP, called the patched `navigateViaPlaywright`, received `download.triggered: true` and `suggestedFilename: proof.txt`, wrote the managed download bytes, and read back the saved file content.
- Observed result after fix: The saved file content matched `openclaw cdp navigate download proof\n`, proving the attachment navigation returned success metadata and wrote the downloaded bytes in a real CDP browser session.
- What was not tested: Blacksmith Testbox execution was not available locally because the `crabbox` binary failed its basic `--version/--help` sanity checks before project checks started.
- Proof limitations or environment constraints: This live proof covers the allowed attachment download path. The latest ClawSweeper follow-up was about rejected-download persistence ordering, which is covered in the focused regression tests below.
- Before evidence (optional but encouraged): Before this PR, Playwright surfaced attachment navigation as `Download is starting` or URL-matched `net::ERR_ABORTED`, so `/navigate` returned an error or no download metadata.

### Proof continuity after branch update

- The PR branch was updated through GitHub's **Update branch** flow after the author repair was pushed. Current PR head `dc7704290e7307b9364b870a7144f8991142a3f4` is a merge commit with parents `0b7d58903f5e5c0d63f96a4cb847602b620c98f6` (the submitted browser repair/proof head) and `e209a56d0b61e5d6c0b5d53b760e813d9849f85b` (current `main`).
- The proof-bearing browser repair commits remain in the PR branch history after the update; the Update branch merge did not replace or remove the `/navigate` download fix, the blocked-download persistence regression, or the capture-timeout unhandled-rejection regression.
- The original live CDP proof above still applies to the repaired `/navigate` path because it was run against the submitted repair head and the branch update only merged latest `main` on top of that repair. The latest main-side update also cleared the unrelated `src/agents/model-picker-visibility.ts` unused-import blocker that previously prevented a second local submit.
- Bot label note: `proof: sufficient` was removed after the head changed, but the PR body still carries the real behavior proof and this section ties that proof to the current Update branch head for the next ClawSweeper/maintainer pass.

## Tests and validation

Commands run after the latest patch:

```text
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts -t "handles capture timeouts that win before ordinary navigation settles"
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts extensions/browser/src/browser/pw-session.test.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
node scripts/run-vitest.mjs extensions/browser/src/browser/pw-session.test.ts -t "validates captured navigation downloads before saving managed bytes"
git diff --check origin/main..HEAD
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed --timed
```

Regression coverage added or updated:

- Target test file: `extensions/browser/src/browser/pw-session.test.ts` plus the existing `/navigate` guard files `extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts` and `extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts`.
- Scenario locked in: a captured navigation attachment reports a blocked local URL and the policy hook rejects before persistence. A separate `/navigate` regression covers a capture timeout winning before ordinary non-download navigation settles, proving the timed-out capture promise is observed rather than reported as an unhandled rejection.
- Why this is the smallest reliable guardrail: the regression asserts the capture promise rejects with the policy error and `saveAs` is not called, which directly protects the security-boundary invariant that rejected download bytes cannot enter managed storage without adding a broad end-to-end fixture.
- `extensions/browser/src/browser/pw-session.test.ts` adds `validates captured navigation downloads before saving managed bytes`, which verifies the capture's policy hook runs before `saveAs` and rejected downloads do not persist managed bytes.
- `extensions/browser/src/browser/pw-tools-core.test-harness.ts` mirrors the new `beforeSave` semantics so existing `/navigate` tests exercise the same ordering.

What failed before this fix:

```text
FAIL |extension-browser| ../../extensions/browser/src/browser/pw-session.test.ts > pw-session ensurePageState > validates captured navigation downloads before saving managed bytes
AssertionError: promise resolved "{ triggered: true, …(3) }" instead of rejecting

Received: triggered=true, suggestedFilename=export.csv, url=http://127.0.0.1:18080/export.csv, path=[local path redacted]/[uuid]-export.csv
```

Passing evidence after fix:

```text
RUN  v4.1.7 [local path redacted]

Test Files  1 passed (1)
     Tests  1 passed | 10 skipped (11)
  Duration  33.72s

Test Files  3 passed (3)
     Tests  36 passed (36)
  Duration  39.05s

Test Files  1 passed (1)
     Tests  1 passed | 14 skipped (15)
  Duration  29.46s
```

Changed-check evidence:

```text
[check:changed] lanes=extensions, extensionTests
[check:changed] summary
   3.05s  ok         conflict markers
   1.62s  ok         changelog attributions
   1.70s  ok         guarded extension wildcard re-exports
   1.47s  ok         plugin-sdk wildcard re-exports
   1.42s  ok         duplicate scan target coverage
   2.31s  ok         dependency pin guard
   2.98s  ok         package patch guard
   203ms  ok         test temp creation report (warning-only)
 104.09s  ok         typecheck extensions
 355.54s  ok         typecheck extension tests
 452.10s  ok         lint extensions
 546.91s  ok         database-first legacy-store guard
   4.33s  ok         media download helper guard
  78.32s  ok         runtime sidecar loader guard
  29.58s  ok         runtime import cycles
```

## Regression Test Plan

- Target test: `extensions/browser/src/browser/pw-session.test.ts` / `validates captured navigation downloads before saving managed bytes`.
- Regression scenario: a captured navigation attachment reports a blocked local URL and the policy hook rejects before persistence.
- Expected guardrail: the capture promise rejects with the policy error and `saveAs` is not called, proving rejected bytes cannot enter managed storage.
- Additional target tests: `extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts`, `extensions/browser/src/browser/pw-session.test.ts`, and `extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts` cover allowed metadata, URL-matched `ERR_ABORTED`, no-capture rethrow, save failure propagation, and existing route response behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Browser `/navigate` can now return download metadata for attachment responses instead of surfacing the Playwright navigation abort.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This touches browser navigation/download security ordering by ensuring captured download URLs pass the existing navigation policy before managed bytes are saved.

What is the highest-risk area?

Risk labels considered: browser, download-handling, SSRF policy, security-boundary, and the large-diff warning caused mostly by regression/test-harness coverage. The highest risk is weakening the browser SSRF/download boundary by treating a blocked or unrelated aborted navigation as a successful managed download, or by persisting rejected attachment bytes before policy validation.

How is that risk mitigated?

The patch only handles Playwright download-starting errors or URL-matched `ERR_ABORTED`, requires an armed captured download before returning success, validates the captured download URL through the existing browser navigation policy before `saveAs`, closes blocked navigation targets on policy denial, and adds a regression proving blocked downloads do not call `saveAs`. The production scope is limited to `pw-session.ts` and `pw-tools-core.snapshot.ts`; the rest of the line count is targeted browser regression coverage and harness support.

## Current review state

Next action: maintainer/ClawSweeper review of the updated branch after this author follow-up.

Still waiting on author, maintainer, CI, or external proof:

- Author-side code and validation work for the visible ClawSweeper findings is addressed in this update, including the capture-timeout unhandled rejection follow-up.
- The previous remote `checks-node-agentic-commands-agent-channel` failure was on the old head `286a934bcf5115f52f32037e8ddc95a2ffcf0eaf`; this branch has been synced onto current main again after the local repair and needs remote CI to rerun on the pushed head.
- No new external proof gap is introduced by the follow-up; the original live CDP allowed-download proof remains the real behavior proof, and the latest reviewer request was specifically a blocked-download persistence ordering regression.

Bot or reviewer comments addressed:

- RF-001 `status: waiting on author`: addressed by this follow-up update; label removal is maintainer/bot-owned after review.
- RF-002 Add focused regression for capture timeout winning before `page.goto()` settles: addressed by `handles capture timeouts that win before ordinary navigation settles`.
- RF-004/RF-007 Handle capture timeouts on non-download navigations: addressed by observing the armed capture promise immediately after creation while still awaiting it on the download-starting path.
- RF-002 Add blocked attachment-download regression proving no rejected file remains in managed storage: addressed by `extensions/browser/src/browser/pw-session.test.ts` regression that fails before the repair and passes after it.
- RF-003 Rerun targeted browser vitest files after the repair: addressed; targeted browser vitest passed with 3 files and 35 tests.
- RF-004 Security-boundary merge risk that successful attachment-download path must not leave rejected bytes in managed storage: addressed by validating the captured download candidate before `saveAs` and by the no-`saveAs` regression.
- RF-005 Queue focused repair for narrow validation/persistence ordering defect: addressed; the code change is limited to managed download capture ordering and `/navigate` policy wiring.
- RF-006 Validate blocked downloads before persisting bytes at `extensions/browser/src/browser/pw-tools-core.snapshot.ts`: addressed by passing `beforeSave` into `createManagedDownloadCaptureForPage` from `navigateViaPlaywright`.
- RF-007 Run targeted vitest command: addressed; `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts extensions/browser/src/browser/pw-session.test.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts` passed.
- RF-008 Targeted browser vitest command: addressed; `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts extensions/browser/src/browser/pw-session.test.ts extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts` passed.
- RF-009 Exact captured-download validation command: addressed; `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-session.test.ts -t "validates captured navigation downloads before saving managed bytes"` passed.
- RF-010 Run `git diff --check origin/main..HEAD`: addressed; command passed with exit code 0.
- RF-011 Run `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ... check:changed --timed`: addressed; command passed with typecheck, lint, and guard summary all ok.
