### PR TITLE
fix(anthropic): quarantine invalid projected tools

### DIFF
--- a/src/agents/anthropic-tool-schema.ts
+++ b/src/agents/anthropic-tool-schema.ts
@@ -1,0 +1,192 @@
+import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
+import { projectRuntimeToolInputSchema } from "./tool-schema-projection.js";
+
+type ToolProjectionField = "name" | "description" | "parameters";
+type AnthropicToolChoiceMode = "auto" | "any" | "none";
+type AnthropicToolChoiceWithDisable = {
+  readonly disable_parallel_tool_use?: boolean;
+};
+export type AnthropicResolvedToolChoice =
+  | AnthropicToolChoiceMode
+  | ({ readonly type: "auto" } & AnthropicToolChoiceWithDisable)
+  | ({ readonly type: "any" } & AnthropicToolChoiceWithDisable)
+  | { readonly type: "none" }
+  | ({ readonly type: "tool"; readonly name: string } & AnthropicToolChoiceWithDisable);
+
+type AnthropicToolProjectionDescriptor = {
+  readonly [key in ToolProjectionField]?: unknown;
+};
+
+export type AnthropicProjectedTool = {
+  readonly originalIndex: number;
+  readonly name: string;
+  readonly description?: string;
+  readonly parameters: Record<string, unknown> & { required?: string[] };
+};
+
+export type AnthropicToolProjectionSnapshot = {
+  readonly tools: readonly AnthropicProjectedTool[];
+  readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
+};
+
+function readObjectStringField(value: unknown, field: string): string | undefined {
+  return isRecord(value) && typeof value[field] === "string" ? value[field] : undefined;
+}
+
+function readDisableParallelToolUse(value: unknown): AnthropicToolChoiceWithDisable {
+  return isRecord(value) && typeof value.disable_parallel_tool_use === "boolean"
+    ? { disable_parallel_tool_use: value.disable_parallel_tool_use }
+    : {};
+}
+
+function isAnthropicToolChoiceMode(value: string): value is AnthropicToolChoiceMode {
+  return value === "auto" || value === "any" || value === "none";
+}
+
+function readToolField(
+  tool: object,
+  field: ToolProjectionField,
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: Reflect.get(tool, field) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readToolEntry(
+  tools: readonly AnthropicToolProjectionDescriptor[],
+  toolIndex: number,
+): { ok: true; tool: unknown } | { ok: false } {
+  try {
+    return { ok: true, tool: Reflect.get(tools, String(toolIndex)) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function unreadableDiagnostic(toolIndex: number): RuntimeToolSchemaDiagnostic {
+  return {
+    toolName: `tool[${toolIndex}]`,
+    toolIndex,
+    violations: [`tool[${toolIndex}] is unreadable`],
+  };
+}
+
+function normalizeRequired(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
+export function snapshotAnthropicToolProjectionInputs(
+  tools: readonly AnthropicToolProjectionDescriptor[] | undefined,
+): AnthropicToolProjectionSnapshot {
+  if (!tools) {
+    return { tools: [], diagnostics: [] };
+  }
+
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return { tools: [], diagnostics: [unreadableDiagnostic(0)] };
+  }
+
+  const projectedTools: AnthropicProjectedTool[] = [];
+  const diagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    const entry = readToolEntry(tools, toolIndex);
+    if (!entry.ok || !isRecord(entry.tool)) {
+      diagnostics.push(unreadableDiagnostic(toolIndex));
+      continue;
+    }
+
+    const name = readToolField(entry.tool, "name");
+    const toolName =
+      name.ok && typeof name.value === "string" && name.value ? name.value : `tool[${toolIndex}]`;
+    const descriptorViolations = name.ok ? [] : [`${toolName}.name is unreadable`];
+    if (!name.ok || typeof name.value !== "string" || !name.value) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations:
+          descriptorViolations.length > 0
+            ? descriptorViolations
+            : [`${toolName}.name must be a non-empty string`],
+      });
+      continue;
+    }
+
+    const parameters = readToolField(entry.tool, "parameters");
+    if (!parameters.ok) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations: [`${toolName}.parameters is unreadable`],
+      });
+      continue;
+    }
+
+    const schemaProjection = projectRuntimeToolInputSchema(
+      parameters.value,
+      `${toolName}.parameters`,
+    );
+    if (schemaProjection.violations.length > 0 || !isRecord(schemaProjection.schema)) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations: schemaProjection.violations,
+      });
+      continue;
+    }
+
+    const description = readToolField(entry.tool, "description");
+    const required = normalizeRequired(schemaProjection.schema.required);
+    projectedTools.push({
+      originalIndex: toolIndex,
+      name: name.value,
+      ...(description.ok && typeof description.value === "string"
+        ? { description: description.value }
+        : {}),
+      parameters: {
+        ...schemaProjection.schema,
+        ...(required ? { required } : {}),
+      },
+    });
+  }
+
+  return { tools: projectedTools, diagnostics };
+}
+
+export function resolveAnthropicToolChoiceForProjectedTools(
+  toolChoice: unknown,
+  toolNames: readonly string[],
+): AnthropicResolvedToolChoice | undefined {
+  if (typeof toolChoice === "string") {
+    return isAnthropicToolChoiceMode(toolChoice) && (toolChoice === "none" || toolNames.length > 0)
+      ? toolChoice
+      : undefined;
+  }
+  if (!isRecord(toolChoice)) {
+    return undefined;
+  }
+  const type = readObjectStringField(toolChoice, "type");
+  if (type === "none") {
+    return { type };
+  }
+  if ((type === "auto" || type === "any") && toolNames.length > 0) {
+    return { type, ...readDisableParallelToolUse(toolChoice) };
+  }
+  if (type === "tool") {
+    const name = readObjectStringField(toolChoice, "name");
+    return name && toolNames.includes(name)
+      ? { type, name, ...readDisableParallelToolUse(toolChoice) }
+      : { type: "none" };
+  }
+  return undefined;
+}

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -672,6 +672,7 @@ describe("anthropic transport stream", () => {
         } as unknown as Parameters<typeof streamFn>[1],
         {
           apiKey: "sk-ant-oat-example",
+          toolChoice: { type: "tool", name: "Read" },
         } as Parameters<typeof streamFn>[2],
       ),
     );
@@ -700,6 +701,7 @@ describe("anthropic transport stream", () => {
         (item) => requireRecord(item, "tool").name === "Read",
       ),
     ).toBe(true);
+    expect(firstCallParams.tool_choice).toEqual({ type: "tool", name: "Read" });
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.some((item) => item.type === "toolCall" && item.name === "read")).toBe(
       true,
@@ -1221,11 +1223,20 @@ describe("anthropic transport stream", () => {
   });
 
   it("skips malformed tools when building Anthropic payloads", async () => {
+    const unreadableTool = {
+      name: "unreadable_plugin_tool",
+      description: "unreadable schema",
+      get parameters(): unknown {
+        throw new Error("fuzz parameters getter exploded");
+      },
+    };
+
     await runTransportStream(
       makeAnthropicTransportModel(),
       {
         messages: [{ role: "user", content: "hello" }],
         tools: [
+          unreadableTool,
           {
             name: "bad_plugin_tool",
             description: "missing schema",
@@ -1256,6 +1267,70 @@ describe("anthropic transport stream", () => {
     expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },
     });
+  });
+
+  it("omits Anthropic tools and forced tool_choice when all tools are quarantined", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "bad_plugin_tool",
+            description: "array schema",
+            parameters: { type: "array", items: { type: "number" } },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        toolChoice: "any",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("disables pinned Anthropic tool_choice when the pinned tool is quarantined", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "bad_plugin_tool",
+            description: "dynamic schema",
+            parameters: {
+              type: "object",
+              properties: {
+                target: { $dynamicRef: "#target" },
+              },
+            },
+          },
+          {
+            name: "good_plugin_tool",
+            description: "valid schema",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+            },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        toolChoice: { type: "tool", name: "bad_plugin_tool" },
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    const tools = requireArray(payload.tools, "tools");
+    expect(tools.map((tool) => requireRecord(tool, "tool").name)).toEqual(["good_plugin_tool"]);
+    expect(payload.tool_choice).toEqual({ type: "none" });
   });
 
   it("coerces replayed malformed tool-call args to an object for Anthropic payloads", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -9,6 +9,10 @@ import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
+import {
+  resolveAnthropicToolChoiceForProjectedTools,
+  snapshotAnthropicToolProjectionInputs,
+} from "./anthropic-tool-schema.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
@@ -475,9 +479,7 @@ function ensureNonEmptyAnthropicMessages(messages: Array<Record<string, unknown>
 }
 
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
-  if (!tools) {
-    return [];
-  }
+  const projection = snapshotAnthropicToolProjectionInputs(tools);
   const converted: Array<{
     name: string;
     description?: string;
@@ -487,27 +489,18 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
       required: unknown;
     };
   }> = [];
-  for (const tool of tools) {
-    // Main quarantine happens when plugin tools materialize; this keeps Anthropic
-    // safe for direct/custom tool arrays that bypass the plugin registry.
-    const parameters =
-      tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters)
-        ? (tool.parameters as Record<string, unknown>)
-        : undefined;
-    if (!parameters) {
-      continue;
-    }
+  for (const tool of projection.tools) {
     converted.push({
       name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
       description: tool.description,
       input_schema: {
         type: "object",
-        properties: parameters.properties || {},
-        required: parameters.required || [],
+        properties: tool.parameters.properties || {},
+        required: tool.parameters.required || [],
       },
     });
   }
-  return converted;
+  return { tools: converted, toolNames: converted.map((tool) => tool.name) };
 }
 
 function parseAnthropicToolCallArguments(inputJson: string): unknown {
@@ -860,8 +853,13 @@ function buildAnthropicParams(
   if (options?.stop !== undefined && options.stop.length > 0) {
     params.stop_sequences = options.stop;
   }
+  let projectedToolNames: string[] = [];
   if (context.tools) {
-    params.tools = convertAnthropicTools(context.tools, isOAuthToken);
+    const convertedTools = convertAnthropicTools(context.tools, isOAuthToken);
+    projectedToolNames = convertedTools.toolNames;
+    if (convertedTools.tools.length > 0) {
+      params.tools = convertedTools.tools;
+    }
   }
   if (model.reasoning) {
     if (options?.thinkingEnabled) {
@@ -883,9 +881,12 @@ function buildAnthropicParams(
   if (options?.metadata && typeof options.metadata.user_id === "string") {
     params.metadata = { user_id: options.metadata.user_id };
   }
-  if (options?.toolChoice) {
+  const projectedToolChoice =
+    options?.toolChoice &&
+    resolveAnthropicToolChoiceForProjectedTools(options.toolChoice, projectedToolNames);
+  if (projectedToolChoice) {
     params.tool_choice =
-      typeof options.toolChoice === "string" ? { type: options.toolChoice } : options.toolChoice;
+      typeof projectedToolChoice === "string" ? { type: projectedToolChoice } : projectedToolChoice;
   }
   applyAnthropicPayloadPolicyToParams(params, payloadPolicy);
   return params;

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Context, Model } from "../types.js";
+import type { Context, Model, Tool } from "../types.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
@@ -196,7 +196,7 @@ describe("Anthropic provider", () => {
 
   it("forwards simple stop sequences to Anthropic stop_sequences", async () => {
     let capturedPayload: unknown;
-    const stream = streamSimpleAnthropic(
+    const stream = streamAnthropic(
       makeAnthropicModel(),
       {
         messages: [{ role: "user", content: "hello", timestamp: 0 }],
@@ -215,5 +215,97 @@ describe("Anthropic provider", () => {
 
     expect(result.stopReason).toBe("error");
     expect((capturedPayload as { stop_sequences?: unknown }).stop_sequences).toEqual(["STOP"]);
+  });
+
+  it("quarantines unreadable Anthropic provider tools before payload projection", async () => {
+    let capturedPayload: unknown;
+    const unreadableTool = {
+      name: "bad_plugin_tool",
+      description: "bad schema",
+      get parameters(): Tool["parameters"] {
+        throw new Error("fuzz parameters getter exploded");
+      },
+    } as Tool;
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          unreadableTool,
+          {
+            name: "good_plugin_tool",
+            description: "good schema",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+            },
+          } as Tool,
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        toolChoice: { type: "tool", name: "bad_plugin_tool" },
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const payload = capturedPayload as {
+      tools?: Array<{ name?: string; input_schema?: unknown }>;
+      tool_choice?: unknown;
+    };
+    expect(payload.tools?.map((tool) => tool.name)).toEqual(["good_plugin_tool"]);
+    expect(payload.tools?.[0]?.input_schema).toMatchObject({
+      properties: { query: { type: "string" } },
+    });
+    expect(payload.tool_choice).toEqual({ type: "none" });
+  });
+
+  it("preserves Anthropic provider OAuth pinned tool_choice against wire tool names", async () => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+              },
+              required: ["path"],
+            },
+          } as Tool,
+        ],
+      },
+      {
+        apiKey: "sk-ant-oat-provider",
+        toolChoice: { type: "tool", name: "Read" },
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const payload = capturedPayload as {
+      tools?: Array<{ name?: string }>;
+      tool_choice?: unknown;
+    };
+    expect(payload.tools?.map((tool) => tool.name)).toEqual(["Read"]);
+    expect(payload.tool_choice).toEqual({ type: "tool", name: "Read" });
   });
 });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -6,6 +6,10 @@ import type {
   MessageParam,
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages.js";
+import {
+  resolveAnthropicToolChoiceForProjectedTools,
+  snapshotAnthropicToolProjectionInputs,
+} from "../../agents/anthropic-tool-schema.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -977,14 +981,19 @@ function buildParams(
     params.stop_sequences = options.stop;
   }
 
+  let projectedToolNames: string[] = [];
   if (context.tools && context.tools.length > 0) {
     const compat = getAnthropicCompat(model);
-    params.tools = convertTools(
+    const convertedTools = convertTools(
       context.tools,
       isOAuthTokenResult,
       compat.supportsEagerToolInputStreaming,
       compat.supportsCacheControlOnTools ? cacheControl : undefined,
     );
+    projectedToolNames = convertedTools.toolNames;
+    if (convertedTools.tools.length > 0) {
+      params.tools = convertedTools.tools;
+    }
   }
 
   // Configure thinking mode: adaptive (Opus 4.6+ and Sonnet 4.6),
@@ -1026,11 +1035,14 @@ function buildParams(
     }
   }
 
-  if (options?.toolChoice) {
-    if (typeof options.toolChoice === "string") {
-      params.tool_choice = { type: options.toolChoice };
+  const projectedToolChoice =
+    options?.toolChoice &&
+    resolveAnthropicToolChoiceForProjectedTools(options.toolChoice, projectedToolNames);
+  if (projectedToolChoice) {
+    if (typeof projectedToolChoice === "string") {
+      params.tool_choice = { type: projectedToolChoice };
     } else {
-      params.tool_choice = options.toolChoice;
+      params.tool_choice = projectedToolChoice;
     }
   }
 
@@ -1234,26 +1246,34 @@ function convertTools(
   isOAuthTokenLocal: boolean,
   supportsEagerToolInputStreaming: boolean,
   cacheControl?: CacheControlEphemeral,
-): Anthropic.Messages.Tool[] {
-  if (!tools) {
-    return [];
-  }
-
-  return tools.map((tool, index) => {
-    const schema = tool.parameters as { properties?: unknown; required?: string[] };
-
-    return {
+): {
+  tools: Anthropic.Messages.Tool[];
+  toolNames: string[];
+} {
+  const projection = snapshotAnthropicToolProjectionInputs(tools);
+  const convertedTools: Anthropic.Messages.Tool[] = [];
+  for (const [index, tool] of projection.tools.entries()) {
+    const convertedTool: Anthropic.Messages.Tool = {
       name: isOAuthTokenLocal ? toClaudeCodeName(tool.name) : tool.name,
       description: tool.description,
-      ...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
       input_schema: {
-        type: "object",
-        properties: schema.properties ?? {},
-        required: schema.required ?? [],
+        type: "object" as const,
+        properties: tool.parameters.properties ?? {},
+        required: tool.parameters.required ?? [],
       },
-      ...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
     };
-  });
+    if (supportsEagerToolInputStreaming) {
+      convertedTool.eager_input_streaming = true;
+    }
+    if (cacheControl && index === projection.tools.length - 1) {
+      convertedTool.cache_control = cacheControl;
+    }
+    convertedTools.push(convertedTool);
+  }
+  return {
+    tools: convertedTools,
+    toolNames: convertedTools.map((tool) => tool.name),
+  };
 }
 
 function mapStopReason(reason: string): StopReason {


### PR DESCRIPTION
## Summary

- Quarantines unreadable or runtime-invalid Anthropic tool descriptors before private transport and SDK provider payload construction.
- Skips tools with unsupported runtime schemas, including dynamic JSON Schema keywords, while preserving healthy sibling tools.
- Avoids sending empty Anthropic tool arrays and prevents stale forced `tool_choice` values from broadening into auto tool use.
- Intentionally out of scope: live Anthropic API calls and generic OpenAI provider projection hardening, which is handled in a separate draft PR.

## Linked context

Related #89413

Maintainer fuzzing follow-up for OpenClaw tool-schema ingress hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: Anthropic payload builders could still read caller-owned tool descriptors directly, allowing unreadable or unsupported schemas to abort assistant turns or produce stale forced-tool payloads.
- Real environment tested: local OpenClaw checkout on the Anthropic SDK provider and private Anthropic transport tests, plus AWS Crabbox fresh-PR `pnpm check:changed`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.test.ts -- --reporter=dot`
- Evidence after fix: the focused Vitest wrapper passed 2 shards: `src/llm/providers/anthropic.test.ts` 6 tests and `src/agents/anthropic-transport-stream.test.ts` 53 tests.
- Observed result after fix: unreadable and invalid Anthropic tools are omitted, healthy siblings still project, OAuth Claude Code wire names keep valid pinned choices, and unavailable pinned choices become explicit `tool_choice: none`.
- What was not tested: live Anthropic API calls.
- Proof limitations or environment constraints: local TS core typecheck was left to remote `check:changed` because this sparse Codex worktree is missing full local typecheck inputs.
- Before evidence: fuzzing reproduced direct getter hazards in Anthropic tool projection; autoreview found and drove fixes for wrapper coverage, OAuth wire-name compatibility, and forced pinned-tool semantics.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/anthropic-tool-schema.ts src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/anthropic-tool-schema.ts src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `/opt/homebrew/bin/crabbox run --provider aws --fresh-pr openclaw/openclaw#89418 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Remote proof:

- Final AWS Crabbox fresh-PR changed gate passed. Provider: `aws`; run: `run_77c2449ac231`; lease: `cbx_79c5bc2aed84`; slug: `harbor-barnacle`; exit 0; lanes: `core`, `coreTests`; command 3m47.222s; total 4m3.878s; lease stopped.
- Earlier remote attempts failed in `typecheck core` and were fixed before this update:
  - `run_e3a6b856ff1c` / `cbx_a490cb3b0581`: helper returned a broad string for SDK `tool_choice.type`.
  - `run_88a3d69d0148` / `cbx_bf90cb955c7f`: helper returned a generic record object for SDK `tool_choice`.

Regression coverage added:

- Anthropic transport skips unreadable and unsupported schemas while preserving healthy sibling tools.
- Anthropic transport omits tools and forced choices when all tools are quarantined.
- Anthropic transport and provider preserve OAuth pinned choices against Claude Code wire names.
- Anthropic transport and provider convert unavailable pinned tool choices to `tool_choice: none`.

What failed before this fix:

- Direct/custom Anthropic tool arrays could still throw while reading descriptor fields.
- A pinned tool choice for a quarantined tool could become implicit auto tool use against surviving tools.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Invalid caller-owned Anthropic tool descriptors are now skipped instead of crashing or poisoning Anthropic payloads.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. Provider tool projection and forced-tool-choice behavior changed, but no new execution capability or credential handling was added.

What is the highest-risk area?

Anthropic `tool_choice` semantics when projection removes the pinned tool.

How is that risk mitigated?

Regression tests cover all-tools-removed, mixed healthy/quarantined descriptors, pinned unavailable choices, and OAuth wire-name remapping.

## Current review state

What is the next action?

Wait for maintainer review/CI.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side proof is pending.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before and after PR creation: provider test coverage now uses the real Anthropic wrapper, OAuth pinned choices compare against wire names, unavailable pinned choices force `tool_choice: none` instead of broadening to auto, and the shared resolver now returns SDK-shaped tool-choice objects instead of generic records.
