### PR TITLE
fix(config): allow explicit main agent bindings when agents.list is non-empty

### DIFF
--- a/src/commands/doctor/shared/legacy-config-binding-repair.ts
+++ b/src/commands/doctor/shared/legacy-config-binding-repair.ts
@@ -1,6 +1,6 @@
 // Repairs canonical binding references after agent config migration.
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { normalizeAgentId } from "../../../routing/session-key.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../../routing/session-key.js";
 
 export function pruneBindingsForMissingAgents(
   cfg: OpenClawConfig,
@@ -22,7 +22,11 @@ export function pruneBindingsForMissingAgents(
   const agentIds = new Set(validAgents.map((agent) => normalizeAgentId(agent.id)));
   const nextBindings = bindings.filter((binding) => {
     const agentId = binding && typeof binding === "object" ? binding.agentId : undefined;
-    return typeof agentId !== "string" || agentIds.has(normalizeAgentId(agentId));
+    return (
+      typeof agentId !== "string" ||
+      agentId === DEFAULT_AGENT_ID ||
+      agentIds.has(normalizeAgentId(agentId))
+    );
   });
   const removed = bindings.length - nextBindings.length;
   if (removed === 0) {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -89,6 +89,22 @@ describe("compatibility binding repair migrate", () => {
     expect(res.changes).toContain("Removed 1 binding that referenced missing agents.list ids.");
   });
 
+  it("preserves exact main bindings because the implicit main agent always exists", () => {
+    const res = repairBindingsForTest({
+      agents: {
+        list: [{ id: "alpha" }],
+      },
+      bindings: [
+        { agentId: "main", match: { channel: "discord" } },
+        { agentId: "MAIN", match: { channel: "discord" } },
+        { agentId: "ghost", match: { channel: "discord" } },
+      ],
+    } as OpenClawConfig);
+
+    expect(res.config.bindings).toEqual([{ agentId: "main", match: { channel: "discord" } }]);
+    expect(res.changes).toContain("Removed 2 bindings that referenced missing agents.list ids.");
+  });
+
   it("leaves bindings untouched when agents.list has malformed entries", () => {
     const cfg = {
       agents: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -105,6 +105,21 @@ describe("compatibility binding repair migrate", () => {
     expect(res.changes).toContain("Removed 2 bindings that referenced missing agents.list ids.");
   });
 
+  it("preserves normalized main bindings when the agent is explicitly listed", () => {
+    const res = repairBindingsForTest({
+      agents: {
+        list: [{ id: "MAIN" }],
+      },
+      bindings: [
+        { agentId: "MAIN", match: { channel: "discord" } },
+        { agentId: "ghost", match: { channel: "discord" } },
+      ],
+    } as OpenClawConfig);
+
+    expect(res.config.bindings).toEqual([{ agentId: "MAIN", match: { channel: "discord" } }]);
+    expect(res.changes).toContain("Removed 1 binding that referenced missing agents.list ids.");
+  });
+
   it("leaves bindings untouched when agents.list has malformed entries", () => {
     const cfg = {
       agents: {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -437,6 +437,23 @@ describe("config schema regressions", () => {
     }
   });
 
+  it("accepts a normalized main binding variant when that agent is explicitly configured", () => {
+    const res = validateConfigObject({
+      agents: {
+        entries: { MAIN: { model: "anthropic/claude-3-5-sonnet" } },
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "MAIN",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects non-default bindings when the implicit-main roster is materialized", () => {
     const res = validateConfigObject({
       bindings: [

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -400,6 +400,43 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("accepts exact main bindings when agents.entries omits the implicit main agent", () => {
+    const res = validateConfigObject({
+      agents: {
+        entries: { alpha: { model: "anthropic/claude-3-5-sonnet" } },
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects normalized main binding variants when agents.entries omits them", () => {
+    const res = validateConfigObject({
+      agents: {
+        entries: { alpha: { model: "anthropic/claude-3-5-sonnet" } },
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "MAIN",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((iss) => iss.message.includes('Unknown agent id "MAIN"'))).toBe(true);
+    }
+  });
+
   it("rejects non-default bindings when the implicit-main roster is materialized", () => {
     const res = validateConfigObject({
       bindings: [

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 import { OpenClawSchemaShape } from "./zod-schema.root-shape.js";
 
@@ -61,7 +61,11 @@ export const OpenClawSchema = z.strictObject(OpenClawSchemaShape).superRefine((c
         continue;
       }
       const agentId = (binding as { agentId?: unknown }).agentId;
-      if (typeof agentId === "string" && !effectiveAgentIds.has(normalizeAgentId(agentId))) {
+      if (
+        typeof agentId === "string" &&
+        agentId !== DEFAULT_AGENT_ID &&
+        !effectiveAgentIds.has(normalizeAgentId(agentId))
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["bindings", idx, "agentId"],

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -116,6 +116,35 @@ describe("resolveAgentRoute", () => {
     });
   });
 
+  test("preserves explicit main bindings when agents.list has other agents", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alpha" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "discord", accountId: "default" },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "direct", id: "user-1" },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      matchedBy: "binding.account",
+      lastRoutePolicy: "main",
+    });
+  });
+
   test("uses the configured main session key for shared direct routes", () => {
     const route = resolveRoute({
       cfg: { session: { dmScope: "main", mainKey: "work" } },

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1,5 +1,6 @@
 // Route resolution tests cover resolving channel route targets from input.
 import { describe, expect, test, vi } from "vitest";
+import { resolveAgentConfig } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as routingBindings from "./bindings.js";
 import {
@@ -143,6 +144,36 @@ describe("resolveAgentRoute", () => {
       matchedBy: "binding.account",
       lastRoutePolicy: "main",
     });
+  });
+
+  test("resolves an explicitly configured normalized main-like agent id through the roster", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "MAIN", model: "anthropic/claude-3-5-sonnet" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "MAIN",
+          match: { channel: "discord", accountId: "default" },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "direct", id: "user-1" },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      matchedBy: "binding.account",
+      lastRoutePolicy: "main",
+    });
+    expect(resolveAgentConfig(cfg, route.agentId)?.model).toBe("anthropic/claude-3-5-sonnet");
   });
 
   test("uses the configured main session key for shared direct routes", () => {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -117,10 +117,10 @@ describe("resolveAgentRoute", () => {
     });
   });
 
-  test("preserves explicit main bindings when agents.list has other agents", () => {
+  test("preserves explicit main bindings when agents.entries has other agents", () => {
     const cfg: OpenClawConfig = {
       agents: {
-        list: [{ id: "alpha" }],
+        entries: { alpha: {} },
       },
       bindings: [
         {
@@ -146,15 +146,17 @@ describe("resolveAgentRoute", () => {
     });
   });
 
-  test("resolves an explicitly configured normalized main-like agent id through the roster", () => {
+  test("resolves exact main bindings through a configured normalized main-like roster entry", () => {
     const cfg: OpenClawConfig = {
       agents: {
-        list: [{ id: "MAIN", model: "anthropic/claude-3-5-sonnet" }],
+        entries: {
+          MAIN: { model: "anthropic/claude-3-5-sonnet" },
+        },
       },
       bindings: [
         {
           type: "route",
-          agentId: "MAIN",
+          agentId: "main",
           match: { channel: "discord", accountId: "default" },
         },
       ],

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -160,15 +160,15 @@ export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): 
     return lookup.fallbackDefaultAgentId;
   }
   const normalized = normalizeAgentId(trimmed);
-  if (normalized === DEFAULT_AGENT_ID) {
+  const resolved = lookup.byNormalizedId.get(normalized);
+  if (resolved) {
+    return resolved;
+  }
+  if (trimmed === DEFAULT_AGENT_ID) {
     return DEFAULT_AGENT_ID;
   }
   if (lookup.byNormalizedId.size === 0) {
     return sanitizeAgentId(trimmed);
-  }
-  const resolved = lookup.byNormalizedId.get(normalized);
-  if (resolved) {
-    return resolved;
   }
   return lookup.fallbackDefaultAgentId;
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -17,6 +17,7 @@ import {
   buildAgentMainSessionKey,
   buildAgentPeerSessionKey,
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   normalizeAccountId,
   normalizeAgentId,
@@ -159,6 +160,9 @@ export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): 
     return lookup.fallbackDefaultAgentId;
   }
   const normalized = normalizeAgentId(trimmed);
+  if (normalized === DEFAULT_AGENT_ID) {
+    return DEFAULT_AGENT_ID;
+  }
   if (lookup.byNormalizedId.size === 0) {
     return sanitizeAgentId(trimmed);
   }


### PR DESCRIPTION
Closes #89412

## What Problem This Solves

An explicit binding to the implicit default agent `main` was rejected at config load and removed by `doctor --fix` when other agents were configured. This breaks the documented pattern where named agents coexist with an implicit-main catch-all route.

The previous repair also needed to preserve the established normalized roster contract: an explicitly configured `MAIN` entry remains a valid roster target and must resolve through that roster before the implicit-main fallback applies.

## Why This Change Was Made

- schema validation accepts only the raw reserved literal `main` when it is absent from `agents.entries`
- Doctor preserves raw `main` and preserves `MAIN` when that normalized agent is explicitly listed; missing agents are still pruned
- route resolution consults the configured roster before using the raw `main` fallback, so an explicitly configured main-like entry retains its agent configuration

Agent identities are canonicalized to `main` internally; the regression verifies that the selected canonical id still resolves the explicitly configured `MAIN` entry and its model.

## Evidence

- Base checked locally: `b9ec38a72095be2fe3b56527281c802ee6836f23`
- Exact head: `4386d67875631bf69920ad537cb1b6e05e81beba`
- Environment: isolated macOS source checkout, Node.js 22.23.0 for the production-function probe. The worktree dependencies were installed from the lockfile.

Before the repair, the resolver special-cased every value that normalized to `main` before consulting the configured roster. That bypass could discard the explicit-roster resolution path.

On the exact current head, a redacted local production probe called the real config validator, Doctor binding repair, route resolver, and configured-agent resolver:

```json
{
  "implicitMain": {
    "schemaAccepted": true,
    "route": {
      "agentId": "main",
      "sessionKey": "agent:main:main",
      "matchedBy": "binding.account"
    }
  },
  "configuredMainVariant": {
    "schemaAccepted": true,
    "route": {
      "agentId": "main",
      "sessionKey": "agent:main:main",
      "matchedBy": "binding.account"
    },
    "resolvedModel": "anthropic/claude-3-5-sonnet"
  },
  "doctor": {
    "bindings": [{ "agentId": "MAIN", "match": { "channel": "discord" } }],
    "changes": ["Removed 1 binding that referenced missing agents.list ids."]
  }
}
```

This demonstrates both intended paths on the exact head: raw `main` reaches the implicit main session, while an explicit `MAIN` binding is accepted, retained, resolved through the roster, and retains its configured model.

## Validation

```text
node scripts/run-vitest.mjs run src/commands/doctor/shared/legacy-config-migrate.test.ts src/config/config.schema-regressions.test.ts src/routing/resolve-route.test.ts

Test Files  3 passed (3)
Tests       252 passed (252)
```

- Core test TypeScript check: passed
- Scoped `oxfmt --check`: passed
- Scoped `oxlint`: passed
- `git diff --check`: passed
- No credentials, live channel endpoints, external API calls, or public configuration format changes were used.