### PR TITLE
fix(llm): filter out reasoning_content from streaming output when reasoning is disabled

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2887,6 +2887,10 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    // Strip reasoning_content when model does not support reasoning
+    if (model.reasoning != null && !model.reasoning) {
+      delete (choiceDelta as Record<string, unknown>).reasoning_content;
+    }
     const reasoningDeltas = getCompletionsReasoningDeltas(
       choiceDelta as Record<string, unknown>,
       compat.visibleReasoningDetailTypes,


### PR DESCRIPTION
## Real behavior proof

**问题描述**：
在 OpenClaw 中配置 `reasoning: false` 后，某些模型（如 MiMo）仍然在流式响应中返回 `reasoning_content` 字段，导致思考过程泄漏到最终输出中。

**环境信息**：
- OpenClaw 版本：[你测试的版本或 commit]
- 操作系统：[Ubuntu 22.04 / 你的系统]
- 测试模型：MiMo / Qwen（任意能复现问题的模型）

**修复前**：
执行以下请求：
```bash
curl -X POST http://localhost:38817/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen3","messages":[{"role":"user","content":"hi"}],"stream":true}'
证据：
   （
<img width="1440" height="3200" alt="Screenshot_2026-06-02-19-22-20-667_com tencent mobileqq" src="https://github.com/user-attachments/assets/2965344f-77a7-4120-b74b-d01271b65309" />
<img width="1440" height="3200" alt="Screenshot_2026-06-02-19-22-14-198_com tencent mobileqq" src="https://github.com/user-attachments/assets/b1c3ec00-0cae-4aa3-9890-bfd6b32baf80" />
）
   修复方式：
   在 src/agents/openai-transport-stream.ts 中，发送响应给客户端之前，增加了一层过滤：当 model.reasoning === false 时，删除 delta.reasoning_content 字段。不修改其他任何内部逻辑。
   改动范围：
   · 文件：src/agents/openai-transport-stream.ts
   · 改动：+4 行