### PR TITLE
fix(telegram): expose thread create CLI remap

### DIFF
--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -36,4 +36,26 @@ describe("telegram actions contract", () => {
 
     expect(capabilities).toContain("richText");
   });
+
+  it("exposes Telegram thread create CLI remapping through the exported plugin", () => {
+    const request = telegramPlugin.actions?.resolveCliActionRequest?.({
+      action: "thread-create",
+      args: {
+        channel: "telegram",
+        target: "-1003894873578",
+        threadName: "Build Updates",
+        message: "hello",
+      },
+    });
+
+    expect(request).toEqual({
+      action: "topic-create",
+      args: {
+        channel: "telegram",
+        target: "-1003894873578",
+        name: "Build Updates",
+        message: "hello",
+      },
+    });
+  });
 });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -277,6 +277,14 @@ const telegramMessageActions: ChannelMessageActionAdapter = {
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.describeMessageTool?.(ctx) ??
     telegramMessageActionsImpl.describeMessageTool?.(ctx) ??
     null,
+  resolveCliActionRequest: (ctx) =>
+    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveCliActionRequest?.(
+      ctx,
+    ) ??
+    telegramMessageActionsImpl.resolveCliActionRequest?.(ctx) ?? {
+      action: ctx.action,
+      args: ctx.args,
+    },
   extractToolSend: (ctx) =>
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.extractToolSend?.(ctx) ??
     telegramMessageActionsImpl.extractToolSend?.(ctx) ??


### PR DESCRIPTION
## Summary

- Expose Telegram's existing `resolveCliActionRequest` hook through the exported channel action adapter.
- Preserve the plugin-owned `thread-create` to `topic-create` CLI remap for `openclaw message thread create --channel telegram`.
- Add contract coverage so the exported `telegramPlugin` surface cannot drop this remap again.

Fixes #81581.

## Why

The Telegram action implementation already knew how to translate the generic CLI thread action into Telegram's forum topic action, but the exported Telegram action wrapper did not forward that hook. As a result, the CLI could fall back to sending bare `thread-create` to the gateway, where Telegram rejects it as an unsupported action.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/channel-actions.contract.test.ts extensions/telegram/src/channel-actions.test.ts src/cli/program/message/register.thread.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/channel.ts extensions/telegram/src/channel-actions.contract.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/channel.ts extensions/telegram/src/channel-actions.contract.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `git diff --check`

## Real behavior proof

Behavior addressed: `openclaw message thread create --channel telegram` now resolves the generic thread creation request to Telegram's `topic-create` action instead of letting bare `thread-create` reach the gateway.

Real environment tested: Local OpenClaw checkout on macOS, using a temporary config with a fake Telegram bot token and CLI `--dry-run --json` so no real Telegram API call was made.

Exact steps or command run after this patch: `OPENCLAW_CONFIG_PATH="$tmp_config" PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm openclaw message thread create --channel telegram --target <telegram-supergroup-id> --thread-name "Build Updates" --message hello --dry-run --json`

Evidence after fix: The dry-run output included `"action": "topic-create"` at the top level and inside `payload.action`, with `"handledBy": "dry-run"`.

Copied live output:

```json
{
  "action": "topic-create",
  "channel": "telegram",
  "dryRun": true,
  "handledBy": "dry-run",
  "payload": {
    "ok": true,
    "dryRun": true,
    "channel": "telegram",
    "action": "topic-create"
  }
}
```

Observed result after fix: The CLI resolved the Telegram thread-create command through the exported plugin hook and produced a Telegram `topic-create` payload without attempting to send to Telegram.

What was not tested: A live Telegram forum topic creation against a real bot/supergroup was not run; this proof covers the CLI/plugin remap boundary that caused the unsupported `thread-create` gateway action.



## Maintainer update

Maintainer rebase preserved the current Telegram rich-text contract test and re-ran the dry-run proof with sanitized output; no live Telegram API call was made.
