### PR TITLE
docs: document node capability policy contracts

### DIFF
--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -3,12 +3,14 @@ import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
+/** Materialized MCP tools plus cleanup for one bundled MCP runtime attachment. */
 export type BundleMcpToolRuntime = {
   tools: AnyAgentTool[];
   diagnostics?: readonly McpToolCatalogDiagnostic[];
   dispose: () => Promise<void>;
 };
 
+/** Per-server catalog metadata exposed to prompts and diagnostics. */
 export type McpServerCatalog = {
   serverName: string;
   safeServerName?: string;
@@ -32,6 +34,7 @@ export type McpServerCatalog = {
   };
 };
 
+/** One MCP tool entry after server-name sanitization and schema normalization. */
 export type McpCatalogTool = {
   serverName: string;
   safeServerName: string;
@@ -42,6 +45,7 @@ export type McpCatalogTool = {
   fallbackDescription: string;
 };
 
+/** Versioned MCP catalog snapshot for a session runtime. */
 export type McpToolCatalog = {
   version: number;
   generatedAt: number;
@@ -50,6 +54,7 @@ export type McpToolCatalog = {
   diagnostics?: readonly McpToolCatalogDiagnostic[];
 };
 
+/** Catalog diagnostic tied back to the MCP server launch summary. */
 export type McpToolCatalogDiagnostic = {
   serverName: string;
   safeServerName: string;
@@ -57,6 +62,7 @@ export type McpToolCatalogDiagnostic = {
   message: string;
 };
 
+/** Long-lived MCP runtime bound to an agent session and workspace. */
 export type SessionMcpRuntime = {
   sessionId: string;
   sessionKey?: string;
@@ -79,6 +85,7 @@ export type SessionMcpRuntime = {
   dispose: () => Promise<void>;
 };
 
+/** Owns session MCP runtime reuse, lookup, binding, idle sweeping, and disposal. */
 export type SessionMcpRuntimeManager = {
   getOrCreate: (params: {
     sessionId: string;

--- a/src/agents/embedded-agent-runner/run/abortable.ts
+++ b/src/agents/embedded-agent-runner/run/abortable.ts
@@ -14,6 +14,7 @@ function makeAbortError(signal: AbortSignal): Error {
   return err;
 }
 
+/** Races a promise against an AbortSignal and normalizes abort rejections. */
 export function abortable<T>(signal: AbortSignal, promise: Promise<T>): Promise<T> {
   if (signal.aborted) {
     return Promise.reject(makeAbortError(signal));
@@ -24,6 +25,8 @@ export function abortable<T>(signal: AbortSignal, promise: Promise<T>): Promise<
       reject(makeAbortError(signal));
     };
     signal.addEventListener("abort", onAbort, { once: true });
+    // Always remove the listener after either side settles so long-running
+    // agent attempts do not retain stale promise closures.
     promise.then(
       (value) => {
         signal.removeEventListener("abort", onAbort);

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -32,6 +32,7 @@ type AssistantFailoverOutcome =
       error: FailoverError;
     };
 
+/** Resolves assistant-stage failover, profile rotation, retry, or surfaced error handling. */
 export async function handleAssistantFailover(params: {
   initialDecision: AssistantFailoverDecision;
   aborted: boolean;
@@ -155,6 +156,8 @@ export async function handleAssistantFailover(params: {
 
     const rotated = await params.advanceAuthProfile();
     const markFailedProfilePromise = markFailedProfile();
+    // Start rotation before waiting on profile-failure persistence so auth
+    // failover stays responsive even if the profile store is slow.
     if (timeoutFailure && !params.isProbeSession && failedProfileId) {
       const timeoutLabel = params.idleTimedOut ? "idle timeout (model silent)" : "timed out";
       params.warn(`Profile ${failedProfileId} ${timeoutLabel}. Trying next account...`);
@@ -183,6 +186,8 @@ export async function handleAssistantFailover(params: {
       return sameModelIdleTimeoutRetry();
     }
 
+    // No profile was available. Recompute the decision with profileRotated=true
+    // so fallback/surface handling can distinguish exhausted rotation attempts.
     decision = resolveRunFailoverDecision({
       stage: "assistant",
       allowFormatRetry: params.cloudCodeAssistFormatError,

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -4,12 +4,15 @@ type AbortLockReleaseLog = {
   warn(message: string): void;
 };
 
+/** Releases the retained session lock in the background when a run aborts. */
 export function releaseEmbeddedAttemptSessionLockForAbort(params: {
   sessionLockController: Pick<EmbeddedAttemptSessionLockController, "releaseHeldLockForAbort">;
   log: AbortLockReleaseLog;
   runId: string;
   abortKind: "abort" | "timeout abort";
 }): void {
+  // The abort path cannot await cleanup without delaying cancellation. Log
+  // failures instead of rethrowing into caller-owned abort handlers.
   void params.sessionLockController.releaseHeldLockForAbort().catch((err: unknown) => {
     params.log.warn(
       `failed to release session lock on ${params.abortKind}: runId=${params.runId} ${String(err)}`,

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
@@ -28,6 +28,7 @@ export type AttemptWorkspaceBootstrapRoutingInput = Omit<
   bootstrapFiles?: readonly WorkspaceBootstrapFile[];
 };
 
+/** Maps a resolved bootstrap mode onto the context channels used by an attempt. */
 export function resolveBootstrapContextTargets(params: {
   bootstrapMode: BootstrapMode;
 }): Pick<
@@ -60,6 +61,7 @@ function resolveAttemptBootstrapRouting(
   };
 }
 
+/** Returns true when hook-provided bootstrap files contain usable bootstrap text. */
 export function hasBootstrapFileContent(files?: readonly WorkspaceBootstrapFile[]): boolean {
   return (
     files?.some(
@@ -72,6 +74,7 @@ export function hasBootstrapFileContent(files?: readonly WorkspaceBootstrapFile[
   );
 }
 
+/** Resolves workspace bootstrap routing from durable pending state plus hook files. */
 export async function resolveAttemptWorkspaceBootstrapRouting(
   params: AttemptWorkspaceBootstrapRoutingInput,
 ): Promise<AttemptBootstrapRouting> {

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
@@ -28,7 +28,11 @@ export type AttemptWorkspaceBootstrapRoutingInput = Omit<
   bootstrapFiles?: readonly WorkspaceBootstrapFile[];
 };
 
-/** Maps a resolved bootstrap mode onto the context channels used by an attempt. */
+/**
+ * Maps a resolved bootstrap mode onto the context channels used by an attempt.
+ * Full bootstrap still lives in system context; runtime context is reserved for
+ * dynamic per-turn details that should not rewrite the static prompt prefix.
+ */
 export function resolveBootstrapContextTargets(params: {
   bootstrapMode: BootstrapMode;
 }): Pick<
@@ -74,7 +78,10 @@ export function hasBootstrapFileContent(files?: readonly WorkspaceBootstrapFile[
   );
 }
 
-/** Resolves workspace bootstrap routing from durable pending state plus hook files. */
+/**
+ * Resolves workspace bootstrap routing from durable pending state plus hook
+ * files, treating hook-provided bootstrap content as both pending and readable.
+ */
 export async function resolveAttemptWorkspaceBootstrapRouting(
   params: AttemptWorkspaceBootstrapRoutingInput,
 ): Promise<AttemptBootstrapRouting> {

--- a/src/agents/embedded-agent-runner/run/attempt-http-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-http-runtime.ts
@@ -4,7 +4,10 @@ import {
   ensureGlobalUndiciEnvProxyDispatcher,
 } from "../../../infra/net/undici-global-dispatcher.js";
 
-/** Configures the process-wide HTTP runtime used by one embedded attempt. */
+/**
+ * Configures the process-wide HTTP runtime used by embedded attempts. Proxy
+ * setup runs first so timeout tuning wraps the active dispatcher.
+ */
 export function configureEmbeddedAttemptHttpRuntime(params: { timeoutMs: number }): void {
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.

--- a/src/agents/embedded-agent-runner/run/attempt-http-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-http-runtime.ts
@@ -4,6 +4,7 @@ import {
   ensureGlobalUndiciEnvProxyDispatcher,
 } from "../../../infra/net/undici-global-dispatcher.js";
 
+/** Configures the process-wide HTTP runtime used by one embedded attempt. */
 export function configureEmbeddedAttemptHttpRuntime(params: { timeoutMs: number }): void {
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -1,6 +1,10 @@
 import type { CreateAgentSessionOptions } from "../../sessions/index.js";
 
-/** Session options passed through the embedded runner's resource-loader seam. */
+/**
+ * Session options passed through the embedded runner's resource-loader seam.
+ * Keep this shape aligned with CreateAgentSessionOptions fields that the runner
+ * intentionally owns so tests can prove the exact injected resourceLoader path.
+ */
 export type EmbeddedAgentSessionOptions = {
   cwd: string;
   agentDir: string;
@@ -17,8 +21,11 @@ export type EmbeddedAgentSessionOptions = {
 };
 
 /**
- * Create an embedded agent session while preserving the explicit resourceLoader
- * object supplied by the runner.
+ * Create an embedded agent session while preserving the exact options object
+ * assembled by the runner.
+ *
+ * This wrapper is intentionally thin: tests assert the resourceLoader and
+ * session-write-lock seams cross this boundary without being reconstructed.
  */
 export async function createEmbeddedAgentSessionWithResourceLoader<Result>(params: {
   createAgentSession: (options: EmbeddedAgentSessionOptions) => Promise<Result> | Result;

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -1,5 +1,6 @@
 import type { CreateAgentSessionOptions } from "../../sessions/index.js";
 
+/** Session options passed through the embedded runner's resource-loader seam. */
 export type EmbeddedAgentSessionOptions = {
   cwd: string;
   agentDir: string;
@@ -15,6 +16,10 @@ export type EmbeddedAgentSessionOptions = {
   withSessionWriteLock?: CreateAgentSessionOptions["withSessionWriteLock"];
 };
 
+/**
+ * Create an embedded agent session while preserving the explicit resourceLoader
+ * object supplied by the runner.
+ */
 export async function createEmbeddedAgentSessionWithResourceLoader<Result>(params: {
   createAgentSession: (options: EmbeddedAgentSessionOptions) => Promise<Result> | Result;
   options: EmbeddedAgentSessionOptions;

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.ts
@@ -1,19 +1,27 @@
 export type EmbeddedRunStageTiming = {
+  /** Stable stage label used in slow-startup logs. */
   name: string;
+  /** Time spent since the previous mark. */
   durationMs: number;
+  /** Time elapsed since tracker creation. */
   elapsedMs: number;
 };
 
 export type EmbeddedRunStageSummary = {
+  /** Total time since tracker creation at snapshot time. */
   totalMs: number;
+  /** Ordered stage marks captured so far. */
   stages: EmbeddedRunStageTiming[];
 };
 
 export type EmbeddedRunStageTracker = {
+  /** Records the next stage boundary using the configured clock. */
   mark: (name: string) => void;
+  /** Returns a copy of current timings without mutating the tracker. */
   snapshot: () => EmbeddedRunStageSummary;
 };
 
+/** First-attempt startup subspans emitted in slow dispatch diagnostics. */
 export const EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE = {
   workspace: "attempt-workspace",
   prompt: "attempt-prompt",
@@ -24,6 +32,7 @@ export const EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE = {
 const EMBEDDED_RUN_STAGE_WARN_TOTAL_MS = 10_000;
 const EMBEDDED_RUN_STAGE_WARN_STAGE_MS = 5_000;
 
+/** Creates a monotonic stage tracker for embedded-run startup diagnostics. */
 export function createEmbeddedRunStageTracker(options?: {
   now?: () => number;
 }): EmbeddedRunStageTracker {
@@ -53,6 +62,7 @@ export function createEmbeddedRunStageTracker(options?: {
   };
 }
 
+/** Returns whether a summary crosses the default or caller-provided slow thresholds. */
 export function shouldWarnEmbeddedRunStageSummary(
   summary: EmbeddedRunStageSummary,
   options?: {
@@ -68,6 +78,7 @@ export function shouldWarnEmbeddedRunStageSummary(
   );
 }
 
+/** Formats stage timings as a compact single-line log suffix. */
 export function formatEmbeddedRunStageSummary(
   prefix: string,
   summary: EmbeddedRunStageSummary,

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.ts
@@ -10,6 +10,7 @@ type ProviderSystemPromptTransform = (params: {
   context: ProviderTransformSystemPromptContext;
 }) => string;
 
+/** Inputs needed to build the base prompt and provider-specific final prompt. */
 export type BuildAttemptSystemPromptParams = {
   isRawModelRun: boolean;
   embeddedSystemPrompt: EmbeddedSystemPromptParams;
@@ -22,15 +23,19 @@ export type BuildAttemptSystemPromptParams = {
   };
 };
 
+/** Base prompt before provider transforms, plus the prompt submitted to the model. */
 export type AttemptSystemPrompt = {
   baseSystemPrompt: string;
   systemPrompt: string;
 };
 
+/** Builds an attempt system prompt while preserving raw model probes as prompt-free. */
 export function buildAttemptSystemPrompt(
   params: BuildAttemptSystemPromptParams,
 ): AttemptSystemPrompt {
   const baseSystemPrompt = buildEmbeddedSystemPrompt(params.embeddedSystemPrompt);
+  // Raw model probes measure the user prompt against the provider directly;
+  // still return baseSystemPrompt so callers can inspect what was skipped.
   const systemPrompt = params.isRawModelRun
     ? ""
     : params.transformProviderSystemPrompt({

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -89,6 +89,11 @@ function isKnownLocalCodingToolName(normalized: string): boolean {
   );
 }
 
+/**
+ * Apply the final runtime tool allowlist to already-constructed tools.
+ * Construction may be broader than delivery so plugin groups can expand with
+ * live plugin metadata before the actual model-facing list is filtered.
+ */
 export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   tools: T[],
   toolsAllow?: string[],
@@ -114,6 +119,10 @@ export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
   return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
 }
 
+/**
+ * Add the message tool to an explicit allowlist when the caller requires
+ * deterministic channel delivery while preserving wildcard/default semantics.
+ */
 export function mergeForcedEmbeddedAttemptToolsAllow(
   toolsAllow: string[] | undefined,
   params: { forceMessageTool?: boolean },
@@ -154,6 +163,8 @@ function resolveCodingToolConstructionPlanForAllowlist(
   const includePluginTools = normalized.some(
     (name) =>
       name === "group:plugins" ||
+      // Unknown names are treated as plugin/channel candidates so narrow
+      // allowlists can still materialize tools registered outside local factories.
       (!isBundleMcpAllowlistName(name) && !isKnownLocalCodingToolName(name)),
   );
   const includeChannelTools = includePluginTools;
@@ -167,6 +178,10 @@ function resolveCodingToolConstructionPlanForAllowlist(
   };
 }
 
+/**
+ * Resolve which tool families need construction before the attempt builds the
+ * runtime model-facing tool list.
+ */
 export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   disableTools?: boolean;
   isRawModelRun?: boolean;
@@ -206,10 +221,15 @@ export function resolveEmbeddedAttemptToolConstructionPlan(params: {
   };
 }
 
+/** Convenience predicate for call sites that only need local core construction. */
 export function shouldBuildCoreCodingToolsForAllowlist(toolsAllow?: string[]): boolean {
   return resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow }).includeCoreTools;
 }
 
+/**
+ * Decide whether bundled MCP runtime startup is needed for this attempt's
+ * allowlist without forcing broader local tool construction.
+ */
 export function shouldCreateBundleMcpRuntimeForAttempt(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
@@ -233,6 +253,10 @@ export function shouldCreateBundleMcpRuntimeForAttempt(params: {
   });
 }
 
+/**
+ * Decide whether bundled LSP runtime startup is needed for explicit LSP tool
+ * names while honoring global tool disablement.
+ */
 export function shouldCreateBundleLspRuntimeForAttempt(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.ts
@@ -1,10 +1,12 @@
 import { runAgentCleanupStep } from "../../run-cleanup-timeout.js";
 
+/** Minimal recorder surface needed during embedded-attempt cleanup. */
 export type EmbeddedAttemptTrajectoryRecorder = {
   describeFlushState: () => string | undefined;
   flush: () => Promise<void>;
 };
 
+/** Flushes trajectory records without letting a stalled flush block cleanup forever. */
 export async function flushEmbeddedAttemptTrajectoryRecorder(params: {
   runId: string;
   sessionId: string;

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -3,15 +3,19 @@ import {
   type AcceptedSessionSpawn,
 } from "../../accepted-session-spawn.js";
 
+/** Terminal status stored for the attempt trajectory. */
 export type AttemptTrajectoryTerminalStatus = "success" | "error" | "interrupted";
 
+/** Error reason for turns that ended without user-visible delivery or progress. */
 export const NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
 
+/** Terminal trajectory result with an optional non-deliverable failure reason. */
 export type AttemptTrajectoryTerminal = {
   status: AttemptTrajectoryTerminalStatus;
   terminalError?: typeof NON_DELIVERABLE_TERMINAL_TURN_REASON;
 };
 
+/** Inputs used to classify whether the attempt delivered anything terminal. */
 export type ResolveAttemptTrajectoryTerminalParams = {
   promptError?: unknown;
   aborted: boolean;
@@ -42,6 +46,7 @@ export type ResolveAttemptTrajectoryTerminalParams = {
   lastAssistantStopReason?: string;
 };
 
+/** Adds safe visible fallback text unless the last assistant state was error-like. */
 export function resolveTerminalAssistantTexts(params: {
   assistantTexts: string[];
   lastAssistantStopReason?: string;
@@ -82,6 +87,7 @@ function hasAsyncStartedToolActivity(toolMetas?: readonly { asyncStarted?: boole
   return (toolMetas ?? []).some((entry) => entry.asyncStarted === true);
 }
 
+/** Classifies the attempt's final trajectory status from delivery/progress evidence. */
 export function resolveAttemptTrajectoryTerminal(
   params: ResolveAttemptTrajectoryTerminalParams,
 ): AttemptTrajectoryTerminal {
@@ -105,6 +111,8 @@ export function resolveAttemptTrajectoryTerminal(
     params.lastToolError !== undefined ||
     hasAsyncStartedToolActivity(params.toolMetas);
 
+  // A terminal tool-use stop with no committed delivery is a failed turn even
+  // when the assistant narrated intent, because no final result reached users.
   if (params.lastAssistantStopReason === "toolUse" && !hasExplicitTerminalDelivery) {
     return {
       status: "error",

--- a/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
@@ -4,6 +4,7 @@ type AbortSettleTimeoutEnv = Partial<
   Pick<NodeJS.ProcessEnv, "OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS" | "OPENCLAW_TEST_FAST">
 >;
 
+/** Resolves how long cleanup waits for an aborted attempt to settle background work. */
 export function resolveEmbeddedAbortSettleTimeoutMs(
   env: AbortSettleTimeoutEnv = process.env,
 ): number {

--- a/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.ts
@@ -4,7 +4,14 @@ type AbortSettleTimeoutEnv = Partial<
   Pick<NodeJS.ProcessEnv, "OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS" | "OPENCLAW_TEST_FAST">
 >;
 
-/** Resolves how long cleanup waits for an aborted attempt to settle background work. */
+/**
+ * Resolves how long cleanup waits for an aborted attempt to settle background
+ * work before flushing pending tool results and releasing the session lock.
+ *
+ * The override intentionally accepts only strict positive decimal integers so
+ * operator typos fall back to the known cleanup budget instead of producing
+ * surprising timer coercions.
+ */
 export function resolveEmbeddedAbortSettleTimeoutMs(
   env: AbortSettleTimeoutEnv = process.env,
 ): number {

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -6,6 +6,7 @@ import {
   listTasksForOwnerOrRequesterSessionKeyForStatus,
 } from "../../../tasks/task-status-access.js";
 
+/** Tool-result metadata used to discover detached work started by this attempt. */
 export type AsyncStartedToolMeta = {
   toolName?: string;
   asyncStarted?: boolean;
@@ -13,6 +14,7 @@ export type AsyncStartedToolMeta = {
   asyncTaskId?: string;
 };
 
+/** Summary of completion-required async work observed before the attempt can finish. */
 export type CompletionRequiredAsyncTaskWaitResult = {
   waitedRunIds: string[];
   timedOutRunIds: string[];
@@ -108,6 +110,8 @@ function collectAsyncTaskRunIds(
     if (isTerminalTaskStatus(task.status)) {
       continue;
     }
+    // Registry lookup catches media tasks started by detached runtimes after
+    // the tool meta snapshot, so cron delivery waits for all visible work.
     addRunId(task.runId);
   }
   return runIds;
@@ -130,6 +134,7 @@ function findTerminalTasks(runIds: readonly string[]): {
   return { pendingRunIds, terminalTasks };
 }
 
+/** Returns whether this cron attempt has media work that must finish first. */
 export function requiresCompletionRequiredAsyncTaskWait(params: {
   sessionKey: string | undefined;
   toolMetas: readonly AsyncStartedToolMeta[];
@@ -153,6 +158,7 @@ export function requiresCompletionRequiredAsyncTaskWait(params: {
   );
 }
 
+/** Waits for cron-owned media tasks that must finish before final delivery. */
 export async function waitForCompletionRequiredAsyncTasks(params: {
   getToolMetas: () => readonly AsyncStartedToolMeta[];
   sessionKey?: string;
@@ -184,6 +190,8 @@ export async function waitForCompletionRequiredAsyncTasks(params: {
       waitedRunIds.add(runId);
     }
 
+    // A completed tool can enqueue a second completion-required task, so the
+    // outer loop re-reads tool metas and registry state after each batch.
     let pendingRunIds = runIds;
     while (pendingRunIds.length > 0) {
       throwIfAborted(params.abortSignal);

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -62,6 +62,8 @@ async function sleepWithAbort(
     return;
   }
   throwIfAborted(signal);
+  // The abort listener is removed on every path so repeated polling does not
+  // accumulate listeners during long media-generation waits.
   await new Promise<void>((resolve, reject) => {
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
@@ -125,6 +127,8 @@ function findTerminalTasks(runIds: readonly string[]): {
   const terminalTasks: TaskRecord[] = [];
   for (const runId of runIds) {
     const task = findTaskByRunIdForStatus(runId);
+    // Missing task records stay pending until the deadline; detached runtimes
+    // can register after the tool meta that announced their run id.
     if (task && isTerminalTaskStatus(task.status)) {
       terminalTasks.push(task);
       continue;
@@ -186,6 +190,8 @@ export async function waitForCompletionRequiredAsyncTasks(params: {
       };
     }
 
+    // Mark run ids as waited before polling so a task that never appears again
+    // cannot be rediscovered forever across outer-loop iterations.
     for (const runId of runIds) {
       waitedRunIds.add(runId);
     }

--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.ts
@@ -14,7 +14,11 @@ export type AsyncStartedToolMeta = {
   asyncTaskId?: string;
 };
 
-/** Summary of completion-required async work observed before the attempt can finish. */
+/**
+ * Summary of completion-required async work observed before the attempt can
+ * finish. `waitedRunIds` records every run id claimed by this wait call so the
+ * outer attempt loop will not rediscover the same unfinished task forever.
+ */
 export type CompletionRequiredAsyncTaskWaitResult = {
   waitedRunIds: string[];
   timedOutRunIds: string[];
@@ -138,7 +142,11 @@ function findTerminalTasks(runIds: readonly string[]): {
   return { pendingRunIds, terminalTasks };
 }
 
-/** Returns whether this cron attempt has media work that must finish first. */
+/**
+ * Returns whether this cron attempt has media work that must finish first.
+ * Non-cron runs can surface async media later, but cron deliveries need the
+ * final payload before the scheduled message is sent.
+ */
 export function requiresCompletionRequiredAsyncTaskWait(params: {
   sessionKey: string | undefined;
   toolMetas: readonly AsyncStartedToolMeta[];
@@ -162,7 +170,11 @@ export function requiresCompletionRequiredAsyncTaskWait(params: {
   );
 }
 
-/** Waits for cron-owned media tasks that must finish before final delivery. */
+/**
+ * Waits for cron-owned media tasks that must finish before final delivery.
+ * Discovery is repeated after each completed batch because one media task can
+ * enqueue another completion-required task from a detached runtime.
+ */
 export async function waitForCompletionRequiredAsyncTasks(params: {
   getToolMetas: () => readonly AsyncStartedToolMeta[];
   sessionKey?: string;

--- a/src/agents/embedded-agent-runner/run/attempt.bootstrap-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.bootstrap-context.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import type { EmbeddedContextFile } from "../../embedded-agent-helpers.js";
 
-/** Only top-level user sessions own primary workspace bootstrap injection. */
+/**
+ * Only top-level user sessions own primary workspace bootstrap injection.
+ * Subagents and ACP sessions receive context through their parent/session
+ * routing, so injecting primary bootstrap files there would duplicate context.
+ */
 export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
   return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
 }
@@ -19,6 +23,9 @@ function isRelativePathInsideOrEqual(relativePath: string): boolean {
 /**
  * Rebase injected context-file paths from the real workspace to the effective
  * attempt workspace while leaving out-of-workspace files untouched.
+ *
+ * This keeps sandboxed file references pointing at the copy the model can read,
+ * without rewriting external absolute paths that were intentionally attached.
  */
 export function remapInjectedContextFilesToWorkspace(params: {
   files: EmbeddedContextFile[];

--- a/src/agents/embedded-agent-runner/run/attempt.bootstrap-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.bootstrap-context.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import type { EmbeddedContextFile } from "../../embedded-agent-helpers.js";
 
+/** Only top-level user sessions own primary workspace bootstrap injection. */
 export function isPrimaryBootstrapRun(sessionKey?: string): boolean {
   return !isSubagentSessionKey(sessionKey) && !isAcpSessionKey(sessionKey);
 }
@@ -15,6 +16,10 @@ function isRelativePathInsideOrEqual(relativePath: string): boolean {
   );
 }
 
+/**
+ * Rebase injected context-file paths from the real workspace to the effective
+ * attempt workspace while leaving out-of-workspace files untouched.
+ */
 export function remapInjectedContextFilesToWorkspace(params: {
   files: EmbeddedContextFile[];
   sourceWorkspaceDir: string;
@@ -25,6 +30,8 @@ export function remapInjectedContextFilesToWorkspace(params: {
   }
   return params.files.map((file) => {
     const relative = path.relative(params.sourceWorkspaceDir, file.path);
+    // Only remap paths that remain inside the source workspace; external
+    // context files keep their absolute path instead of being pulled into the sandbox.
     const canRemap = isRelativePathInsideOrEqual(relative);
     return canRemap
       ? {

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -11,13 +11,16 @@ export {
   finalizeHarnessContextEngineTurn as finalizeAttemptContextEngineTurn,
 } from "../../harness/context-engine-lifecycle.js";
 
+/** Context-engine instance used by the embedded attempt runner. */
 export type AttemptContextEngine = ContextEngine;
 
+/** Bootstrap/context files resolved for one attempt before prompt assembly. */
 export type AttemptBootstrapContext<TBootstrapFile = unknown, TContextFile = unknown> = {
   bootstrapFiles: TBootstrapFile[];
   contextFiles: TContextFile[];
 };
 
+/** Resolves whether bootstrap/context files should be injected for this attempt. */
 export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFile>(params: {
   contextInjectionMode: "always" | "continuation-skip" | "never";
   bootstrapContextMode?: string;
@@ -41,6 +44,8 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
     (await params.hasCompletedBootstrapTurn(params.sessionFile));
   const shouldSkipBootstrapInjection =
     params.contextInjectionMode === "never" || isContinuationTurn;
+  // Lightweight/heartbeat/full-mode checks mirror persistence rules so a
+  // skipped or partial bootstrap turn is not recorded as completed.
   const shouldRecordCompletedBootstrapTurn =
     !shouldSkipBootstrapInjection &&
     params.bootstrapContextMode !== "lightweight" &&
@@ -58,6 +63,7 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
   };
 }
 
+/** Builds compact prompt-cache metadata for attempt results and after-turn hooks. */
 export function buildContextEnginePromptCacheInfo(params: {
   retention?: "none" | "short" | "long";
   lastCallUsage?: NormalizedUsage;
@@ -103,6 +109,7 @@ export function buildContextEnginePromptCacheInfo(params: {
   return Object.keys(promptCache).length > 0 ? promptCache : undefined;
 }
 
+/** Finds the assistant message produced during the current attempt loop. */
 export function findCurrentAttemptAssistantMessage(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
@@ -138,6 +145,8 @@ export function resolvePromptCacheTouchTimestamp(params: {
   if (!hasCacheUsage) {
     return params.fallbackLastCacheTouchAt ?? null;
   }
+  // Only cache read/write usage means the assistant timestamp touched prompt
+  // cache state. Plain token usage carries the previous touch forward.
   return (
     parsePromptCacheTouchTimestamp(params.assistantTimestamp) ??
     params.fallbackLastCacheTouchAt ??
@@ -145,6 +154,7 @@ export function resolvePromptCacheTouchTimestamp(params: {
   );
 }
 
+/** Builds prompt-cache metadata from the assistant produced in this loop. */
 export function buildLoopPromptCacheInfo(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -20,7 +20,11 @@ export type AttemptBootstrapContext<TBootstrapFile = unknown, TContextFile = unk
   contextFiles: TContextFile[];
 };
 
-/** Resolves whether bootstrap/context files should be injected for this attempt. */
+/**
+ * Resolves bootstrap/context files and records whether this attempt should mark
+ * the bootstrap turn complete. The skip and record decisions intentionally
+ * share inputs so lightweight or continuation turns cannot poison future runs.
+ */
 export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFile>(params: {
   contextInjectionMode: "always" | "continuation-skip" | "never";
   bootstrapContextMode?: string;
@@ -63,7 +67,11 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
   };
 }
 
-/** Builds compact prompt-cache metadata for attempt results and after-turn hooks. */
+/**
+ * Builds compact prompt-cache metadata for attempt results and after-turn hooks.
+ * Empty inputs return undefined so callers do not persist placeholder cache
+ * objects in session metadata.
+ */
 export function buildContextEnginePromptCacheInfo(params: {
   retention?: "none" | "short" | "long";
   lastCallUsage?: NormalizedUsage;
@@ -109,7 +117,7 @@ export function buildContextEnginePromptCacheInfo(params: {
   return Object.keys(promptCache).length > 0 ? promptCache : undefined;
 }
 
-/** Finds the assistant message produced during the current attempt loop. */
+/** Finds the newest assistant message produced after the current attempt's prompt boundary. */
 export function findCurrentAttemptAssistantMessage(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;

--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -46,6 +46,8 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     const bootstrapCall = hoisted.resolveBootstrapFilesForRunMock.mock.calls[0]?.[0] as
       | { agentId?: string; workspaceDir?: string }
       | undefined;
+    // Bootstrap/session ownership stays rooted in the agent workspace even when
+    // runtime tools execute from a task-specific cwd.
     expect(bootstrapCall?.workspaceDir).not.toBe("/tmp/task-repo");
     expect(bootstrapCall?.agentId).toBe("main");
 

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -6,6 +6,7 @@ import { normalizeAssistantReplayContent } from "../replay-history.js";
 import { markTranscriptPromptText } from "../tool-result-context-guard.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 
+/** Normalizes replay history before it crosses from OpenClaw state to provider input. */
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   const normalized = stripUnsafeBlockedRunMetadata(
     stripToolResultDetails(normalizeAssistantReplayContent(messages)),
@@ -15,6 +16,7 @@ export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): Agent
   return stripHistoricalRuntimeContextCustomMessages(withoutHistoricalInboundMetadata);
 }
 
+/** Normalizes existing history while preserving the current prompt outside replay. */
 export function normalizeMessagesForCurrentPromptBoundary(params: {
   messages: AgentMessage[];
   prompt: string;
@@ -27,6 +29,7 @@ export function normalizeMessagesForCurrentPromptBoundary(params: {
   return normalizeMessagesForLlmBoundary([...params.messages, promptMessage]).slice(0, -1);
 }
 
+/** Installs a prompt-local runtime-context message and keeps it across retry rebuilds. */
 export function installRuntimeContextMessageForPrompt(params: {
   session: {
     messages: AgentMessage[];
@@ -86,6 +89,7 @@ function appendRuntimeContextMessageForPrompt(params: {
   return [...params.messages, params.message];
 }
 
+/** Inserts runtime context immediately before the active user prompt when possible. */
 export function insertRuntimeContextMessageForPrompt(params: {
   message: RuntimeContextCustomMessage;
   messages: AgentMessage[];
@@ -204,6 +208,8 @@ export function installModelPromptTransform(params: {
       transcriptText: params.transcriptPrompt,
       shouldCapture: (message) => {
         const timestamp = (message as { timestamp?: unknown }).timestamp;
+        // Capture by timestamp after the first armed transform so retries only
+        // rewrite the same prompt, not later user messages appended meanwhile.
         if (targetPromptTimestamp !== undefined) {
           return timestamp === targetPromptTimestamp;
         }
@@ -303,6 +309,8 @@ function stripUnsafeBlockedRunMetadata(messages: AgentMessage[]): AgentMessage[]
     if (typeof blocked.blockedAt === "number") {
       safeBlocked.blockedAt = blocked.blockedAt;
     }
+    // Keep only routing-safe provenance. The original blocked prompt/reason
+    // may contain the exact sensitive text that the hook refused to send.
     const nextOpenClaw = {
       ...(openclaw as Record<string, unknown>),
       beforeAgentRunBlocked: safeBlocked,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -81,6 +81,8 @@ type ModelCallObservationState = {
   lastStreamProgressAt?: number;
 };
 
+// Keep stream progress sparse: the activity clock refreshes on every chunk, but
+// diagnostic events are throttled so token streams do not flood observers.
 const MODEL_CALL_STREAM_PROGRESS_INTERVAL_MS = 30_000;
 const MODEL_CALL_STREAM_PROGRESS_REASON = "model_call:stream_progress";
 const MODEL_CALL_STREAM_RETURN_TIMEOUT_MS = 1000;
@@ -463,6 +465,8 @@ function withDiagnosticTraceparentHeader(
       assignRequestPayloadBytes(state, payload);
       return undefined;
     }
+    // Measure the payload that actually reaches the provider after any
+    // provider/runtime onPayload rewrite, not just the runner's original input.
     const result = originalOnPayload(payload, model);
     if (isPromiseLike(result)) {
       return result.then((replacement) => {
@@ -508,6 +512,8 @@ async function safeReturnIterator(iterator: AsyncIterator<unknown>): Promise<voi
   }
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
+    // Do not let an SDK stream with a stuck async iterator.return() hold the
+    // model-call wrapper forever after consumers stop iterating early.
     await Promise.race([
       Promise.resolve(returnResult).catch(() => undefined),
       new Promise<void>((resolve) => {
@@ -553,6 +559,8 @@ async function* observeModelCallIterator<T>(
     throw err;
   } finally {
     if (!terminalEmitted) {
+      // Early consumer exit still counts as a completed observed call; the
+      // provider stream is closed best-effort first so resources can settle.
       await safeReturnIterator(iterator);
       emitModelCallCompleted(eventBase, startedAt, state);
     }
@@ -613,7 +621,12 @@ function observeModelCallResult(
   return result;
 }
 
-/** Wraps a stream function with model.call diagnostic events and trace propagation. */
+/**
+ * Wraps a stream function with model.call diagnostic events and trace
+ * propagation. The wrapper preserves the provider's result shape while observing
+ * payload bytes, stream bytes, timing, errors, optional model content, and
+ * plugin model_call_started/model_call_ended hooks.
+ */
 export function wrapStreamFnWithDiagnosticModelCallEvents(
   streamFn: StreamFn,
   ctx: ModelCallDiagnosticContext,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -576,6 +576,8 @@ function observeModelCallStream<T extends AsyncIterable<unknown>>(
     hasNonConfigurableIterator = true;
   }
   if (hasNonConfigurableIterator) {
+    // Some SDK streams expose a non-configurable async iterator. Return a thin
+    // iterable facade instead of proxying so diagnostic observation still works.
     return {
       [Symbol.asyncIterator]: observedIterator,
     } as T;
@@ -611,6 +613,7 @@ function observeModelCallResult(
   return result;
 }
 
+/** Wraps a stream function with model.call diagnostic events and trace propagation. */
 export function wrapStreamFnWithDiagnosticModelCallEvents(
   streamFn: StreamFn,
   ctx: ModelCallDiagnosticContext,
@@ -628,6 +631,8 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
       modelContent,
       contentCapture: ctx.contentCapture,
     };
+    // Attach child trace context to provider requests so downstream HTTP/tooling
+    // can correlate stream activity with the model.call lifecycle events.
     const propagatedOptions = withDiagnosticTraceparentHeader(options, trace, state);
 
     try {

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -30,6 +30,11 @@ import { log } from "../logger.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
+/**
+ * Narrow hook surface used while assembling a model prompt for one embedded run.
+ * Callers pass the host implementation in; this module owns ordering, fallback,
+ * and error isolation between the hook families.
+ */
 export type PromptBuildHookRunner = {
   hasHooks: (
     hookName:
@@ -93,6 +98,11 @@ export function forgetPromptBuildDrainCacheForRun(runId: string | undefined): vo
   }
 }
 
+/**
+ * Resolves all plugin-provided prompt additions for one attempt. Next-turn
+ * injections are drained once per run id so retry attempts see the same queued
+ * context instead of consuming an empty session store on the second pass.
+ */
 export async function resolvePromptBuildHookResult(params: {
   config: OpenClawConfig;
   prompt: string;
@@ -182,6 +192,8 @@ export async function resolvePromptBuildHookResult(params: {
           })
       : undefined);
   return {
+    // Preserve legacy before_agent_start ordering as the fallback value, while
+    // allowing before_prompt_build to override the system prompt when present.
     systemPrompt: promptBuildResult?.systemPrompt ?? beforeAgentStartResult?.systemPrompt,
     prependContext: joinPresentTextSegments([
       queuedContext.prependContext,
@@ -208,6 +220,7 @@ export async function resolvePromptBuildHookResult(params: {
   };
 }
 
+/** Subagent and cron sessions use the compact prompt path; user-facing sessions keep full context. */
 export function resolvePromptModeForSession(sessionKey?: string): "minimal" | "full" {
   if (!sessionKey) {
     return "full";
@@ -243,6 +256,10 @@ export function shouldWarnOnOrphanedUserRepair(
 
 export type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
 
+/**
+ * Distinguishes an empty active prompt from a prompt that only became empty
+ * after historical images were pruned out of the visible turn payload.
+ */
 export function resolvePromptSubmissionSkipReason(params: {
   prompt: string;
   messages: readonly unknown[];
@@ -321,6 +338,9 @@ function summarizeStructuredJsonString(value: string): string {
   return value;
 }
 
+// Structured prompt parts can contain nested media refs, circular objects, or
+// provider-specific payloads. Keep the fallback readable and bounded before it
+// is merged into the next prompt.
 function sanitizeStructuredJsonValue(
   value: unknown,
   depth = 0,
@@ -463,6 +483,11 @@ function promptAlreadyIncludesQueuedUserMessage(prompt: string, orphanText: stri
   );
 }
 
+/**
+ * Moves a trailing queued user message back into the active prompt. The leaf is
+ * always removed so replay does not resend the same user turn as both history
+ * and prompt text.
+ */
 export function mergeOrphanedTrailingUserPrompt(params: {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
@@ -483,6 +508,7 @@ export function mergeOrphanedTrailingUserPrompt(params: {
   };
 }
 
+/** Resolves the effective filesystem policy for tools that run inside this attempt workspace. */
 export function resolveAttemptFsWorkspaceOnly(params: {
   config?: OpenClawConfig;
   sessionAgentId: string;
@@ -493,6 +519,7 @@ export function resolveAttemptFsWorkspaceOnly(params: {
   });
 }
 
+/** Inserts dynamic system additions after the cache boundary to preserve the cacheable prefix. */
 export function prependSystemPromptAddition(params: {
   systemPrompt: string;
   systemPromptAddition?: string;
@@ -500,10 +527,9 @@ export function prependSystemPromptAddition(params: {
   return prependSystemPromptAdditionAfterCacheBoundary(params);
 }
 
-// Per-turn media-generation task hints depend on live session state, so they must
-// be routed BELOW the system-prompt cache boundary (via prependSystemPromptAddition)
-// rather than placed in the static prepend slot — keeping them above the boundary
-// shifted the cacheable prefix turn-to-turn and broke prompt caching (#85203).
+// Per-turn media-generation task hints depend on live session state. Keep them
+// below the system-prompt cache boundary so the cacheable prefix stays stable
+// while delivery waits can still tell the model about active media tasks.
 export function resolveAttemptMediaTaskSystemPromptAddition(params: {
   sessionKey?: string;
   trigger?: EmbeddedRunAttemptParams["trigger"];
@@ -610,6 +636,7 @@ export function buildAfterTurnRuntimeContext(params: {
   };
 }
 
+/** Builds after-turn context when the caller only has provider usage metadata. */
 export function buildAfterTurnRuntimeContextFromUsage(
   params: Omit<Parameters<typeof buildAfterTurnRuntimeContext>[0], "currentTokenCount"> & {
     lastCallUsage?: NormalizedUsage;

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -7,6 +7,7 @@ export type EmbeddedAgentActiveSessionSteerTarget = {
   subscribe(listener: (event: unknown) => void): () => void;
 };
 
+/** Default wait for a queued steering message to appear in transcript events. */
 export const DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS = 120_000;
 
 function extractQueuedUserMessageText(message: unknown): string | undefined {
@@ -103,6 +104,7 @@ export async function cancelQueuedSteeringMessage(
   return true;
 }
 
+/** Steers a message and resolves only after the matching user message_end is observed. */
 export async function steerAndWaitForTranscriptCommit(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
@@ -166,6 +168,8 @@ export async function steerAndWaitForTranscriptCommit(
     timer.unref?.();
     const unsubscribe: (() => void) | undefined = activeSession.subscribe((event) => {
       if (isAutoRetryStartEvent(event) || isCompactionStartEvent(event)) {
+        // Auto-retry/compaction reuses the same queued steering message after
+        // agent_end, so cancel only if no continuation event arrives first.
         if (terminalTimer) {
           clearTimeout(terminalTimer);
           terminalTimer = undefined;
@@ -189,6 +193,7 @@ export async function steerAndWaitForTranscriptCommit(
   });
 }
 
+/** Steers immediately or waits for transcript commit when delivery confirmation is requested. */
 export async function steerActiveSessionWithOptionalDeliveryWait(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -1,5 +1,6 @@
 import { log } from "../logger.js";
 
+/** Minimal active-session surface needed to steer queued user text and observe transcript commit. */
 export type EmbeddedAgentActiveSessionSteerTarget = {
   agent?: unknown;
   getSteeringMessages?(): readonly string[];
@@ -77,6 +78,10 @@ function getAgentSteeringQueueMessages(agent: unknown): unknown[] | undefined {
   return Array.isArray(messages) ? messages : undefined;
 }
 
+/**
+ * Removes one queued steering message from both the runtime queue and UI mirror
+ * after delivery wait cancellation.
+ */
 export async function cancelQueuedSteeringMessage(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,
@@ -85,8 +90,8 @@ export async function cancelQueuedSteeringMessage(
   if (!queuedMessages) {
     return false;
   }
-  // The session runtime exposes only all-queue clears publicly; mutate the exact pending message
-  // so unrelated queued messages keep their full payloads.
+  // The session runtime exposes only all-queue clears publicly; mutate the
+  // exact pending message so unrelated queued messages keep their payloads.
   const queueIndex = queuedMessages.findIndex(
     (message) => extractQueuedUserMessageText(message) === text,
   );
@@ -104,7 +109,10 @@ export async function cancelQueuedSteeringMessage(
   return true;
 }
 
-/** Steers a message and resolves only after the matching user message_end is observed. */
+/**
+ * Steers a message and resolves only after the matching user message_end is
+ * observed, so delivery-sensitive callers know the transcript owns the text.
+ */
 export async function steerAndWaitForTranscriptCommit(
   activeSession: EmbeddedAgentActiveSessionSteerTarget,
   text: string,

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -1,6 +1,10 @@
 import { log } from "../logger.js";
 
-/** Minimal active-session surface needed to steer queued user text and observe transcript commit. */
+/**
+ * Minimal active-session surface needed to steer queued user text and observe
+ * transcript commit. Tests use this shape to avoid depending on the full
+ * AgentSession runtime while still exercising queue cancellation behavior.
+ */
 export type EmbeddedAgentActiveSessionSteerTarget = {
   agent?: unknown;
   getSteeringMessages?(): readonly string[];
@@ -8,7 +12,11 @@ export type EmbeddedAgentActiveSessionSteerTarget = {
   subscribe(listener: (event: unknown) => void): () => void;
 };
 
-/** Default wait for a queued steering message to appear in transcript events. */
+/**
+ * Default wait for a queued steering message to appear in transcript events.
+ * Long enough for slow auto-retry/compaction handoff, but still bounded so
+ * delivery-sensitive source replies do not wait forever.
+ */
 export const DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS = 120_000;
 
 function extractQueuedUserMessageText(message: unknown): string | undefined {
@@ -157,6 +165,8 @@ export async function steerAndWaitForTranscriptCommit(
       if (terminalTimer) {
         return;
       }
+      // Give same-tick auto-retry/compaction continuation events a chance to
+      // arrive before treating agent_end as final and cancelling the queued text.
       terminalTimer = setTimeout(() => {
         terminalTimer = undefined;
         rejectAfterCancellation(

--- a/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.run-decisions.ts
@@ -6,6 +6,7 @@ import {
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
+/** Resolves write-lock timing for embedded attempts after prompt compaction. */
 export function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
   config?: OpenClawConfig;
   compactionTimeoutMs: number;
@@ -22,12 +23,14 @@ export function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
   });
 }
 
+/** Returns the auth profile that actually reached the provider stream. */
 export function resolveAttemptStreamAuthProfileId(
   params: Pick<EmbeddedRunAttemptParams, "authProfileId" | "runtimePlan">,
 ): string | undefined {
   return params.runtimePlan?.auth.forwardedAuthProfileId;
 }
 
+/** Resolves the per-attempt unknown-tool loop threshold used by stream repair. */
 export function resolveUnknownToolGuardThreshold(loopDetection?: {
   enabled?: boolean;
   unknownToolThreshold?: number;
@@ -48,10 +51,12 @@ export function resolveUnknownToolGuardThreshold(loopDetection?: {
   return UNKNOWN_TOOL_THRESHOLD;
 }
 
+/** Skips output hooks only when the run was blocked before the model request. */
 export function shouldRunLlmOutputHooksForAttempt(params: { promptErrorSource: string | null }) {
   return params.promptErrorSource !== "hook:before_agent_run";
 }
 
+/** Chooses the provider identity used for tool-policy messaging. */
 export function resolveAttemptToolPolicyMessageProvider(params: {
   messageProvider?: string;
   messageChannel?: string;

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -283,6 +283,9 @@ async function sessionFenceRewriteIsBenign(params: {
   if (currentLines.length <= previousLines.length) {
     return false;
   }
+  // Delivery mirrors may upgrade legacy linear transcript rows by adding
+  // parentId/version metadata while appending only transcript-only OpenClaw
+  // assistant rows. Any other rewrite still counts as a takeover.
   let expectedParentId: string | null = null;
   for (let index = 0; index < previousLines.length; index += 1) {
     const lineMatch = lineMatchesLinearTranscriptMigration({
@@ -350,11 +353,13 @@ const sessionFileOwnerState = resolveGlobalSingleton(
   }),
 );
 
+/** Process-local owner token for serializing embedded attempts by session file. */
 export type EmbeddedAttemptSessionFileOwner = {
   sessionFileKey: string;
   release(): void;
 };
 
+/** Thrown when another embedded attempt owns the same session file too long. */
 export class EmbeddedAttemptSessionFileOwnerTimeoutError extends Error {
   constructor(sessionFile: string, timeoutMs: number) {
     super(`timed out waiting for embedded session file owner after ${timeoutMs}ms: ${sessionFile}`);
@@ -428,6 +433,7 @@ function waitForSessionFileOwnerRelease(params: {
   });
 }
 
+/** Acquires the process-local owner token before session-file lock setup. */
 export async function acquireEmbeddedAttemptSessionFileOwner(params: {
   sessionFile: string;
   timeoutMs?: number;
@@ -453,6 +459,8 @@ export async function acquireEmbeddedAttemptSessionFileOwner(params: {
             return;
           }
           sessionFileOwnerState.owners.delete(sessionFileKey);
+          // Resolve every waiter synchronously after deleting ownership so the
+          // next loop iteration can claim the file without observing a stale owner.
           for (const waiter of current.waiters) {
             waiter.resolve();
           }
@@ -468,6 +476,7 @@ export async function acquireEmbeddedAttemptSessionFileOwner(params: {
   }
 }
 
+/** Clears process-local owner state between tests. */
 export function resetEmbeddedAttemptSessionFileOwnersForTest(): void {
   for (const entry of sessionFileOwnerState.owners.values()) {
     for (const waiter of entry.waiters) {
@@ -568,6 +577,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
   }
 }
 
+/** Coordinates transcript write locking across provider streaming phases. */
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
@@ -583,6 +593,7 @@ export type EmbeddedAttemptSessionLockController = {
   dispose(): Promise<void>;
 };
 
+/** Creates the lock controller that fences external edits during model I/O. */
 export async function createEmbeddedAttemptSessionLockController(params: {
   acquireSessionWriteLock: AcquireSessionWriteLock;
   lockOptions: LockOptions;
@@ -716,6 +727,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       ownedWrite.generation > fenceGeneration &&
       sameSessionFileFingerprint(ownedWrite.fingerprint, current)
     ) {
+      // Same-process controllers publish locked writes with generations. A
+      // newer matching generation is trusted; older states are stale.
       fenceFingerprint = current;
       fenceSnapshot = { fingerprint: current };
       fenceGeneration = ownedWrite.generation;
@@ -757,6 +770,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (!isTrustedSessionFileState(sessionFileFenceKey, beforeWrite)) {
       return null;
     }
+    // Only publish transitions from a trusted pre-write state. Otherwise an
+    // external edit could be laundered as an owned in-process write.
     const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
     return { fingerprint, generation };
   }
@@ -931,6 +946,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         if (options?.publishOwnedWrite !== true) {
           return await run();
         }
+        // Nested publishers need their own before/after fingerprint so broad
+        // owned-write scopes do not hide unrelated interleaved edits.
         const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
         try {
           return await run();

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.ts
@@ -7,11 +7,11 @@ const SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE = "openclaw.sessions_yield";
 
 const SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS = resolveEmbeddedAbortSettleTimeoutMs();
 
-// Persist a hidden context reminder so the next turn knows why the runner stopped.
 function buildSessionsYieldContextMessage(message: string): string {
   return `${message}\n\n[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]`;
 }
 
+/** Waits briefly for the abort path triggered by sessions_yield to settle. */
 export async function waitForSessionsYieldAbortSettle(params: {
   settlePromise: Promise<void> | null;
   runId: string;
@@ -45,7 +45,7 @@ export async function waitForSessionsYieldAbortSettle(params: {
   }
 }
 
-// Return a synthetic aborted response so agent runtime unwinds without a real provider call.
+/** Returns an aborted assistant response so the runtime unwinds without a provider call. */
 export function createYieldAbortedResponse(model: {
   api?: string;
   provider?: string;
@@ -105,8 +105,7 @@ export function createYieldAbortedResponse(model: {
   };
 }
 
-// Queue a hidden steering message so agent runtime injects it before the next
-// LLM call once the current assistant turn finishes executing its tool calls.
+/** Queues hidden steering so the current tool turn exits through sessions_yield. */
 export function queueSessionsYieldInterruptMessage(activeSession: {
   agent: { steer: (message: AgentMessage) => void };
 }) {
@@ -120,7 +119,7 @@ export function queueSessionsYieldInterruptMessage(activeSession: {
   });
 }
 
-// Append the caller-provided yield payload as a hidden session message once the run is idle.
+/** Persists caller-provided yield context for the follow-up turn without triggering one. */
 export async function persistSessionsYieldContextMessage(
   activeSession: {
     sendCustomMessage: (
@@ -146,7 +145,7 @@ export async function persistSessionsYieldContextMessage(
   );
 }
 
-// Remove the synthetic yield interrupt + aborted assistant entry from the live transcript.
+/** Removes synthetic sessions_yield artifacts from live and persisted transcript state. */
 export function stripSessionsYieldArtifacts(activeSession: {
   messages: AgentMessage[];
   agent: { state: { messages: AgentMessage[] } };
@@ -210,6 +209,8 @@ export function stripSessionsYieldArtifacts(activeSession: {
     if (!isYieldAbortAssistant && !isYieldInterruptMessage) {
       break;
     }
+    // Only trim trailing synthetic rows. Earlier artifacts belong to completed
+    // turns and must stay in the transcript graph.
     fileEntries.pop();
     if (last.id) {
       byId.delete(last.id);

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -95,6 +95,11 @@ type AttemptSpawnWorkspaceHoisted = {
   sessionManager: SessionManagerMocks;
 };
 
+/**
+ * Default subscription double used by runner tests that need a complete
+ * embedded-session surface without opting into delivery, compaction, or tool
+ * lifecycle side effects.
+ */
 export function createSubscriptionMock(): SubscriptionMock {
   return {
     assistantTexts: [] as string[],
@@ -237,6 +242,10 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   };
 });
 
+/**
+ * Expose Vitest-hoisted doubles so tests can tune the embedded runner boundary
+ * before the cached attempt module is imported.
+ */
 export function getHoisted(): AttemptSpawnWorkspaceHoisted {
   return hoisted;
 }
@@ -905,6 +914,8 @@ let runEmbeddedAttemptPromise:
 const ATTEMPT_SPAWN_WORKSPACE_TEST_SPECIFIER = "./attempt.ts?spawn-workspace-test";
 
 async function loadRunEmbeddedAttempt() {
+  // Cache the query-suffixed import so every test shares the same module graph
+  // that was initialized with the hoisted mocks above.
   runEmbeddedAttemptPromise ??= (
     import(ATTEMPT_SPAWN_WORKSPACE_TEST_SPECIFIER) as Promise<typeof import("./attempt.js")>
   ).then((mod) => mod.runEmbeddedAttempt);
@@ -915,6 +926,11 @@ export async function preloadRunEmbeddedAttemptForTests(): Promise<void> {
   await loadRunEmbeddedAttempt();
 }
 
+/**
+ * Reset all shared runner doubles to the production-like defaults expected by
+ * the spawn-workspace/context-engine tests. Call this from beforeEach after any
+ * test-specific mock mutation.
+ */
 export function resetEmbeddedAttemptHarness(
   params: {
     includeSpawnSubagent?: boolean;
@@ -1014,6 +1030,10 @@ export function resetEmbeddedAttemptHarness(
   }
 }
 
+/**
+ * Remove temp paths in LIFO order so nested test resources disappear before
+ * their parent workspaces.
+ */
 export async function cleanupTempPaths(tempPaths: string[]) {
   while (tempPaths.length > 0) {
     const target = tempPaths.pop();
@@ -1023,6 +1043,10 @@ export async function cleanupTempPaths(tempPaths: string[]) {
   }
 }
 
+/**
+ * Build the minimal mutable session shape that full-runner tests need without
+ * importing the real session runtime.
+ */
 export function createDefaultEmbeddedSession(params?: {
   initialMessages?: unknown[];
   prompt?: (
@@ -1111,6 +1135,10 @@ export function createDefaultEmbeddedSession(params?: {
   return session;
 }
 
+/**
+ * Pair of context-engine spies for tests that only need bootstrap/assemble
+ * forwarding proof and not maintenance, ingest, or compaction behavior.
+ */
 export function createContextEngineBootstrapAndAssemble() {
   return {
     bootstrap: vi.fn(async (_params: { sessionKey?: string }) => ({ bootstrapped: true })),
@@ -1123,6 +1151,9 @@ export function createContextEngineBootstrapAndAssemble() {
   };
 }
 
+/**
+ * Keep session-key forwarding assertions consistent across context-engine tests.
+ */
 export function expectCalledWithSessionKey(mock: ReturnType<typeof vi.fn>, sessionKey: string) {
   expect(mock).toHaveBeenCalledWith(expect.objectContaining({ sessionKey }));
 }
@@ -1139,6 +1170,10 @@ const testAuthStorage = {
   getApiKey: async () => undefined,
 };
 
+/**
+ * Run a real embedded attempt against an injected context engine while keeping
+ * workspace/session/auth/runtime dependencies mocked at the runner boundary.
+ */
 export async function createContextEngineAttemptRunner(params: {
   contextEngine: {
     bootstrap?: (params: {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -851,6 +851,10 @@ vi.mock("./history-image-prune.js", () => ({
   pruneProcessedHistoryImages: () => null,
 }));
 
+/**
+ * Minimal mutable subset of the real AgentSession that runner tests can safely
+ * mutate while still exercising prompt, custom-message, and system-prompt paths.
+ */
 export type MutableSession = {
   sessionId: string;
   messages: unknown[];

--- a/src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.ts
@@ -111,6 +111,8 @@ function wrapStreamHandleUnhandledStopReason(
             if (!normalizedMessage) {
               throw err;
             }
+            // Emit exactly one synthetic terminal event; otherwise consumers
+            // that keep iterating after the recovered error could see duplicates.
             emittedSyntheticTerminal = true;
             return {
               done: false as const,
@@ -135,6 +137,11 @@ function wrapStreamHandleUnhandledStopReason(
   return stream;
 }
 
+/**
+ * Converts provider "Unhandled stop reason" failures into assistant error
+ * messages so callers get a deliverable terminal turn instead of a raw thrown
+ * provider exception.
+ */
 export function wrapStreamFnHandleSensitiveStopReason(baseFn: StreamFn): StreamFn {
   return (model, context, options) => {
     try {

--- a/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.ts
@@ -46,12 +46,14 @@ async function waitForEmbeddedAbortSettle(params: {
   }
 }
 
+/** Pass-through seam for embedded-session subscription params used by tests and callers. */
 export function buildEmbeddedSubscriptionParams(
   params: SubscribeEmbeddedAgentSessionParams,
 ): SubscribeEmbeddedAgentSessionParams {
   return params;
 }
 
+/** Cleans up per-attempt guards, pending tool results, runtimes, and the session lock. */
 export async function cleanupEmbeddedAttemptResources(params: {
   removeToolResultContextGuard?: () => void;
   flushPendingToolResultsAfterIdle: (params: {
@@ -84,6 +86,8 @@ export async function cleanupEmbeddedAttemptResources(params: {
         sessionId: params.sessionId ?? "unknown",
       });
     }
+    // The session lock must be released even when flushing or runtime disposal
+    // fails, so errors before the finally block are intentionally best-effort.
     // PERF: When the run was aborted (user stop / timeout), skip the expensive
     // waitForIdle (up to 30 s) and flush pending tool results synchronously so
     // the session write-lock is released without leaving orphaned tool calls.

--- a/src/agents/embedded-agent-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.thread-helpers.ts
@@ -2,8 +2,10 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { normalizeStructuredPromptSection } from "../../prompt-cache-stability.js";
 
+/** Custom transcript marker recording when cache-TTL pruning was touched. */
 export const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
 
+/** Combines hook-provided system context around the base prompt. */
 export function composeSystemPromptWithHookContext(params: {
   baseSystemPrompt?: string;
   prependSystemContext?: string;
@@ -25,6 +27,7 @@ export function composeSystemPromptWithHookContext(params: {
   });
 }
 
+/** Returns the workspace dir to expose to spawned subagents under sandbox limits. */
 export function resolveAttemptSpawnWorkspaceDir(params: {
   sandbox?: {
     enabled?: boolean;
@@ -37,6 +40,7 @@ export function resolveAttemptSpawnWorkspaceDir(params: {
     : undefined;
 }
 
+/** Decides whether this attempt may append the cache-TTL transcript marker. */
 function shouldAppendAttemptCacheTtl(params: {
   timedOutDuringCompaction: boolean;
   compactionOccurredThisAttempt: boolean;
@@ -55,6 +59,7 @@ function shouldAppendAttemptCacheTtl(params: {
   );
 }
 
+/** Appends cache-TTL metadata after a clean non-compaction attempt. */
 export function appendAttemptCacheTtlIfNeeded(params: {
   sessionManager: {
     appendCustomEntry?: (customType: string, data: unknown) => void;
@@ -71,6 +76,8 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   if (!shouldAppendAttemptCacheTtl(params)) {
     return false;
   }
+  // Writing the marker after compaction would sit between compacted history and
+  // the next prompt, which breaks the compaction guard's last-entry checks.
   params.sessionManager.appendCustomEntry?.(ATTEMPT_CACHE_TTL_CUSTOM_TYPE, {
     timestamp: params.now ?? Date.now(),
     provider: params.provider,
@@ -79,6 +86,7 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   return true;
 }
 
+/** Decides whether a completed bootstrap turn is safe to persist. */
 export function shouldPersistCompletedBootstrapTurn(params: {
   shouldRecordCompletedBootstrapTurn: boolean;
   promptError: unknown;

--- a/src/agents/embedded-agent-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.thread-helpers.ts
@@ -5,7 +5,12 @@ import { normalizeStructuredPromptSection } from "../../prompt-cache-stability.j
 /** Custom transcript marker recording when cache-TTL pruning was touched. */
 export const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
 
-/** Combines hook-provided system context around the base prompt. */
+/**
+ * Combines hook-provided system context around the base prompt using the same
+ * structured-section normalization as prompt-cache boundaries. Returns
+ * undefined when hooks contributed nothing so callers can avoid rewriting an
+ * otherwise cache-stable system prompt.
+ */
 export function composeSystemPromptWithHookContext(params: {
   baseSystemPrompt?: string;
   prependSystemContext?: string;
@@ -27,7 +32,11 @@ export function composeSystemPromptWithHookContext(params: {
   });
 }
 
-/** Returns the workspace dir to expose to spawned subagents under sandbox limits. */
+/**
+ * Returns the workspace dir to expose to spawned subagents under sandbox limits.
+ * Read-only sandbox runs must spawn from the canonical workspace, not the
+ * sandbox copy, so children inherit the same agent-owned bootstrap context.
+ */
 export function resolveAttemptSpawnWorkspaceDir(params: {
   sandbox?: {
     enabled?: boolean;
@@ -59,7 +68,11 @@ function shouldAppendAttemptCacheTtl(params: {
   );
 }
 
-/** Appends cache-TTL metadata after a clean non-compaction attempt. */
+/**
+ * Appends cache-TTL metadata after a clean non-compaction attempt. The marker is
+ * consumed by later prompt-cache pruning, so it is skipped whenever compaction
+ * already rewrote the transcript in this attempt.
+ */
 export function appendAttemptCacheTtlIfNeeded(params: {
   sessionManager: {
     appendCustomEntry?: (customType: string, data: unknown) => void;
@@ -86,7 +99,11 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   return true;
 }
 
-/** Decides whether a completed bootstrap turn is safe to persist. */
+/**
+ * Decides whether a completed bootstrap turn is safe to persist. A failed,
+ * aborted, or compacted attempt cannot mark bootstrap complete because the next
+ * retry still needs the original bootstrap context available.
+ */
 export function shouldPersistCompletedBootstrapTurn(params: {
   shouldRecordCompletedBootstrapTurn: boolean;
   promptError: unknown;

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -282,6 +282,7 @@ function shouldCloseSmartQuotedValueAt(
     return false;
   }
   if (!TOOLCALL_REPAIR_FREEFORM_VALUE_KEYS.has(valueKey)) {
+    // Non-freeform values close before any known successor key or tool-specific option key.
     return (
       TOOLCALL_REPAIR_KNOWN_ARG_KEYS.has(nextKey) ||
       isToolSpecificValueSuccessor({ toolName, valueKey, nextKey })
@@ -698,6 +699,7 @@ function wrapStreamRepairMalformedToolCallArguments(
       }
       const nextPartialJson = (partialJsonByIndex.get(event.contentIndex) ?? "") + event.delta;
       if (nextPartialJson.length > MAX_TOOLCALL_REPAIR_BUFFER_CHARS) {
+        // Disable repair for this block after the bounded buffer trips; later deltas may be huge.
         partialJsonByIndex.delete(event.contentIndex);
         repairedArgsByIndex.delete(event.contentIndex);
         disabledIndices.add(event.contentIndex);
@@ -769,6 +771,7 @@ function wrapStreamRepairMalformedToolCallArguments(
   return stream;
 }
 
+/** Wrap a stream so malformed provider tool-call argument JSON is repaired before dispatch. */
 export function wrapStreamFnRepairMalformedToolCallArguments(baseFn: StreamFn): StreamFn {
   return (model, context, options) => {
     const maybeStream = baseFn(model, context, options);
@@ -781,6 +784,7 @@ export function wrapStreamFnRepairMalformedToolCallArguments(baseFn: StreamFn): 
   };
 }
 
+/** Decide which provider/API combinations emit repairable malformed tool-call args. */
 export function shouldRepairMalformedToolCallArguments(params: {
   provider?: string;
   modelApi?: string | null;
@@ -793,6 +797,7 @@ export function shouldRepairMalformedToolCallArguments(params: {
   );
 }
 
+/** Decode HTML-entity escaped XAI tool-call arguments in stream events and final messages. */
 export function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
   return createHtmlEntityToolCallArgumentDecodingWrapper(baseFn);
 }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { normalizeLowercaseStringOrEmpty } from "../../../../packages/normalization-core/src/string-coerce.js";
+import { normalizeStringEntries } from "../../../../packages/normalization-core/src/string-normalization.js";
 import {
   extractStandalonePlainTextToolCallText,
   normalizePlainTextToolCallStreamEvents,
@@ -8,8 +10,6 @@ import {
   type PlainTextToolCallNameMatcher,
 } from "../../../../packages/tool-call-repair/src/index.js";
 import { visitObjectContentBlocks } from "../../../shared/message-content-blocks.js";
-import { normalizeLowercaseStringOrEmpty } from "../../../../packages/normalization-core/src/string-coerce.js";
-import { normalizeStringEntries } from "../../../../packages/normalization-core/src/string-normalization.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
@@ -1105,11 +1105,17 @@ function wrapStreamTrimToolCallNames(
   return stream;
 }
 
+/**
+ * Normalizes tool-call names emitted by a stream and applies the unknown-tool
+ * loop guard across both streaming deltas and the final result.
+ */
 export function wrapStreamFnTrimToolCallNames(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,
   guardOptions?: { unknownToolThreshold?: number },
 ): StreamFn {
+  // Keep one guard state per wrapped stream function so repeated retry streams
+  // cannot reset the unknown-tool counter by recreating AssistantStream objects.
   const unknownToolGuardState: UnknownToolLoopGuardState = {
     count: 0,
     countedMessages: new WeakSet<object>(),
@@ -1145,6 +1151,11 @@ export function shouldApplyReplayToolCallIdSanitizer(
   );
 }
 
+/**
+ * Rewrites replayed tool-call ids into the provider-safe id shape while
+ * preserving ids that the target provider requires for signed thinking or
+ * native tool-result pairing.
+ */
 export function sanitizeReplayToolCallIdsForStream(params: {
   messages: AgentMessage[];
   mode: ToolCallIdMode;
@@ -1164,12 +1175,18 @@ export function sanitizeReplayToolCallIdsForStream(params: {
   return sanitizeToolUseResultPairing(sanitized);
 }
 
+/** Normalizes OpenAI Responses replay turns without applying non-Responses id modes. */
 export function sanitizeOpenAIResponsesReplayForStream(messages: AgentMessage[]): AgentMessage[] {
   return downgradeOpenAIFunctionCallReasoningPairs(
     normalizeOpenAIResponsesToolCallIds(downgradeOpenAIReasoningBlocks(messages)),
   );
 }
 
+/**
+ * Sanitizes malformed replay inputs before the provider stream starts. This is
+ * the last boundary before model submission, so provider-specific transcript
+ * validation and thinking-block policy are applied together here.
+ */
 export function wrapStreamFnSanitizeMalformedToolCalls(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,

--- a/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import type { EmbeddedRunTrigger } from "./params.js";
 
+/** Builds the immutable context passed into tools during one embedded attempt. */
 export function buildEmbeddedAttemptToolRunContext(params: {
   trigger?: EmbeddedRunTrigger;
   jobId?: string;

--- a/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-run-context.ts
@@ -4,7 +4,11 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import type { EmbeddedRunTrigger } from "./params.js";
 
-/** Builds the immutable context passed into tools during one embedded attempt. */
+/**
+ * Builds the immutable context passed into tools during one embedded attempt.
+ * The diagnostic trace is frozen here so tool callbacks cannot mutate the
+ * request trace shared with provider/runtime diagnostics.
+ */
 export function buildEmbeddedAttemptToolRunContext(params: {
   trigger?: EmbeddedRunTrigger;
   jobId?: string;

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
@@ -16,6 +16,7 @@ export const TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES = [
 
 type CollectAllowedToolNamesParams = Parameters<typeof collectAllowedToolNames>[0];
 
+/** Tool Search allowlist state split between visible prompt tools and replay-safe tools. */
 export type ToolSearchRunPlan = {
   visibleAllowedToolNames: Set<string>;
   replayAllowedToolNames: Set<string>;
@@ -23,6 +24,7 @@ export type ToolSearchRunPlan = {
   emptyAllowlistCallableNames: string[];
 };
 
+/** Build the callable names used to decide whether an explicit allowlist resolved to nothing. */
 export function buildCallableToolNamesForEmptyAllowlistCheck(params: {
   effectiveToolNames: string[];
   autoAddedToolSearchControlNames?: Set<string>;
@@ -32,6 +34,7 @@ export function buildCallableToolNamesForEmptyAllowlistCheck(params: {
     ...params.effectiveToolNames.filter(
       (toolName) => !params.autoAddedToolSearchControlNames?.has(toolName),
     ),
+    // Cataloged tools are hidden behind Tool Search controls but still count as callable surface.
     ...Array.from(
       { length: params.toolSearchCatalogToolCount },
       (_, index) => `tool-search:${index}`,
@@ -39,6 +42,7 @@ export function buildCallableToolNamesForEmptyAllowlistCheck(params: {
   ];
 }
 
+/** Identify Tool Search controls added by policy rather than explicitly requested by the user. */
 export function buildAutoAddedToolSearchControlNamesForAllowlistCheck(params: {
   toolSearchControlsEnabled: boolean;
   explicitAllowlistSources: Array<{ entries: string[] }>;
@@ -95,6 +99,7 @@ export function buildToolSearchRunPlan(params: {
   if (params.controlsEnabled) {
     for (const controlName of params.controlNames ?? TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES) {
       if (visibleAllowedToolNames.has(controlName)) {
+        // Replay must still accept visible control calls after compaction hides direct tools.
         replayAllowedToolNames.add(controlName);
       }
     }

--- a/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
@@ -13,6 +13,7 @@ function asProviderRuntimeModel(
   return typeof model?.id === "string" ? (model as ProviderRuntimeModel) : undefined;
 }
 
+/** Resolves the transcript policy from the runtime plan, falling back to legacy config rules. */
 export function resolveAttemptTranscriptPolicy(params: {
   runtimePlan?: AgentRuntimePlan;
   runtimePlanModelContext: AttemptRuntimeModelContext;

--- a/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
@@ -3,6 +3,7 @@ import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-mod
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { resolveTranscriptPolicy, type TranscriptPolicy } from "../../transcript-policy.js";
 
+/** Runtime model context forwarded to the transcript policy resolver for one attempt. */
 export type AttemptRuntimeModelContext = NonNullable<
   Parameters<AgentRuntimePlan["transcript"]["resolvePolicy"]>[0]
 >;
@@ -13,7 +14,10 @@ function asProviderRuntimeModel(
   return typeof model?.id === "string" ? (model as ProviderRuntimeModel) : undefined;
 }
 
-/** Resolves the transcript policy from the runtime plan, falling back to legacy config rules. */
+/**
+ * Resolves the transcript policy from the runtime plan first, falling back to
+ * legacy config rules for callers that have not built a runtime plan yet.
+ */
 export function resolveAttemptTranscriptPolicy(params: {
   runtimePlan?: AgentRuntimePlan;
   runtimePlanModelContext: AttemptRuntimeModelContext;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -608,6 +608,8 @@ function shouldPreservePromptErrorAfterCleanupError(params: {
   promptError: unknown;
   cleanupError: unknown;
 }): boolean {
+  // A session takeover during cleanup is a secondary ownership signal; preserving
+  // the prompt failure keeps retry/failover logic focused on the real model error.
   return (
     Boolean(params.promptError) &&
     params.cleanupError instanceof EmbeddedAttemptSessionTakeoverError
@@ -767,6 +769,14 @@ function collectAttemptExplicitToolAllowlistSources(params: {
   ]);
 }
 
+/**
+ * Execute one embedded model attempt from workspace setup through prompt
+ * submission, transcript cleanup, diagnostics, and resource teardown.
+ *
+ * The outer run loop owns retry/failover; this function owns per-attempt state
+ * such as sandbox cwd resolution, session write-lock ownership, hook context,
+ * tool/runtime construction, and final payload derivation.
+ */
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -45,6 +45,7 @@ type LogLike = {
   warn(message: string): void;
 };
 
+/** Builds the auth/profile controller used by an embedded run attempt loop. */
 export function createEmbeddedRunAuthController(params: {
   config: RunEmbeddedAgentParams["config"];
   agentDir: string;
@@ -199,6 +200,8 @@ export function createEmbeddedRunAuthController(params: {
         activeRuntimeAuthState.profileId !== refreshProfileId ||
         activeRuntimeAuthState.sourceApiKey.trim() !== sourceApiKey
       ) {
+        // Auth may rotate while a scheduled refresh is in flight; stale refresh
+        // results must not overwrite the newer profile's runtime credentials.
         params.log.debug(
           `Ignoring stale runtime auth refresh for ${runtimeModel.provider}; auth state advanced before ${reason} refresh completed.`,
         );
@@ -281,6 +284,8 @@ export function createEmbeddedRunAuthController(params: {
           }, RUNTIME_AUTH_REFRESH_RETRY_MS);
           const activeRuntimeAuthState = params.getRuntimeAuthState();
           if (activeRuntimeAuthState) {
+            // Store retry timers on the mutable runtime auth state so later
+            // rotation/cancellation can clear whichever timer is active.
             activeRuntimeAuthState.refreshTimer = retryTimer;
           }
           if (params.getRuntimeAuthRefreshCancelled() && activeRuntimeAuthState) {
@@ -440,6 +445,8 @@ export function createEmbeddedRunAuthController(params: {
     if (preparedAuth?.apiKey) {
       clearRuntimeAuthRefreshTimer();
       params.authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+      // Keep the source credential, not the runtime credential, so scheduled
+      // refresh can mint another short-lived token before expiry.
       params.setRuntimeAuthState({
         generation: nextRuntimeAuthGeneration(),
         sourceApiKey: apiKeyInfo.apiKey,

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -45,7 +45,12 @@ type LogLike = {
   warn(message: string): void;
 };
 
-/** Builds the auth/profile controller used by an embedded run attempt loop. */
+/**
+ * Builds the auth/profile controller used by an embedded run attempt loop. The
+ * controller owns profile rotation, runtime credential preparation, and refresh
+ * timers; callers provide state accessors so retries can keep one canonical
+ * auth view across attempts.
+ */
 export function createEmbeddedRunAuthController(params: {
   config: RunEmbeddedAgentParams["config"];
   agentDir: string;

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -2,7 +2,11 @@ import type { AuthProfileFailureReason } from "../../auth-profiles/types.js";
 import type { FailoverReason } from "../../embedded-agent-helpers/types.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 
-/** Maps attempt-local failover signals onto profile-wide auth health reasons. */
+/**
+ * Maps attempt-local failover signals onto profile-wide auth health reasons.
+ * Only failures that plausibly reflect a reusable credential/provider problem
+ * should escape the attempt and cool down a shared auth profile.
+ */
 export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   providerStarted?: boolean;

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -2,6 +2,7 @@ import type { AuthProfileFailureReason } from "../../auth-profiles/types.js";
 import type { FailoverReason } from "../../embedded-agent-helpers/types.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 
+/** Maps attempt-local failover signals onto profile-wide auth health reasons. */
 export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   providerStarted?: boolean;

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.types.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.types.ts
@@ -1,1 +1,8 @@
+/**
+ * Selects how embedded-attempt auth failures affect profile rotation.
+ *
+ * `shared` lets a failed profile participate in run-level failover; `local`
+ * keeps the failure scoped to the current attempt so callers can preserve an
+ * already-selected runtime auth profile.
+ */
 export type AuthProfileFailurePolicy = "shared" | "local";

--- a/src/agents/embedded-agent-runner/run/backend.ts
+++ b/src/agents/embedded-agent-runner/run/backend.ts
@@ -1,7 +1,7 @@
 import { runAgentHarnessAttempt } from "../../harness/selection.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
-/** Runs the selected agent harness backend for an embedded attempt. */
+/** Runs the selected agent harness backend while preserving the embedded-run result contract. */
 export async function runEmbeddedAttemptWithBackend(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {

--- a/src/agents/embedded-agent-runner/run/backend.ts
+++ b/src/agents/embedded-agent-runner/run/backend.ts
@@ -1,6 +1,7 @@
 import { runAgentHarnessAttempt } from "../../harness/selection.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
+/** Runs the selected agent harness backend for an embedded attempt. */
 export async function runEmbeddedAttemptWithBackend(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {

--- a/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
@@ -1,6 +1,10 @@
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
-/** Decides whether a Codex app-server transport failure can be replayed once. */
+/**
+ * Decides whether a Codex app-server transport failure can be replayed once.
+ * Recovery is restricted to early stdio failures with no assistant/tool/approval
+ * side effects, so retrying cannot duplicate visible output or external work.
+ */
 export function resolveCodexAppServerRecoveryRetry(params: {
   attempt: EmbeddedRunAttemptResult;
   alreadyRetried: boolean;
@@ -54,4 +58,5 @@ export function resolveCodexAppServerRecoveryRetry(params: {
   return { retry: true };
 }
 
+/** Backward-compatible alias for the original client-close-only helper name. */
 export const resolveCodexAppServerClientCloseRetry = resolveCodexAppServerRecoveryRetry;

--- a/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
@@ -1,5 +1,6 @@
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
+/** Decides whether a Codex app-server transport failure can be replayed once. */
 export function resolveCodexAppServerRecoveryRetry(params: {
   attempt: EmbeddedRunAttemptResult;
   alreadyRetried: boolean;
@@ -26,12 +27,16 @@ export function resolveCodexAppServerRecoveryRetry(params: {
   if (params.alreadyRetried) {
     return { retry: false, reason: "retry_exhausted" };
   }
+  // Replay safety must agree at the transport-failure layer and at the
+  // attempt metadata layer; either side can observe non-replayable activity.
   if (!failure.replaySafe || !params.attempt.replayMetadata.replaySafe) {
     return { retry: false, reason: failure.replayBlockedReason ?? "replay_unsafe" };
   }
   if (params.attempt.assistantTexts.some((text) => text.trim().length > 0)) {
     return { retry: false, reason: "assistant_output" };
   }
+  // Tool or approval activity may have had external effects, so app-server
+  // recovery cannot silently replay even when the transport failure looks early.
   if (
     params.attempt.toolMetas.length > 0 ||
     params.attempt.clientToolCalls ||

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
@@ -1,9 +1,6 @@
-/**
- * Wait for compaction retry completion with an aggregate timeout to avoid
- * holding a session lane indefinitely when retry resolution is lost.
- */
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 
+/** Waits for compaction retry completion without holding a session lane indefinitely. */
 export async function waitForCompactionRetryWithAggregateTimeout(params: {
   waitForCompactionRetry: () => Promise<void>;
   abortable: <T>(promise: Promise<T>) => Promise<T>;

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
@@ -1,6 +1,11 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 
-/** Waits for compaction retry completion without holding a session lane indefinitely. */
+/**
+ * Waits for compaction retry completion without holding a session lane
+ * indefinitely. The aggregate timeout becomes terminal only after compaction is
+ * no longer reported in flight, which lets legitimate long compactions finish
+ * while still bounding idle waits.
+ */
 export async function waitForCompactionRetryWithAggregateTimeout(params: {
   waitForCompactionRetry: () => Promise<void>;
   abortable: <T>(promise: Promise<T>) => Promise<T>;
@@ -40,6 +45,8 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
       // Keep extending the timeout window while compaction is actively running.
       // We only trigger the fallback timeout once compaction appears idle.
       if (params.isCompactionStillInFlight?.()) {
+        // Each loop schedules a fresh bounded timer so enormous configured
+        // budgets stay clamped by resolveTimerTimeoutMs on every wait window.
         continue;
       }
 

--- a/src/agents/embedded-agent-runner/run/compaction-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-timeout.ts
@@ -6,6 +6,7 @@ export type CompactionTimeoutSignal = {
   isCompactionInFlight: boolean;
 };
 
+/** Returns true when a run timeout should be attributed to compaction work. */
 export function shouldFlagCompactionTimeout(signal: CompactionTimeoutSignal): boolean {
   if (!signal.isTimeout) {
     return false;
@@ -13,6 +14,7 @@ export function shouldFlagCompactionTimeout(signal: CompactionTimeoutSignal): bo
   return signal.isCompactionPendingOrRetrying || signal.isCompactionInFlight;
 }
 
+/** Decides whether a run timeout gets one compaction grace window or aborts immediately. */
 export function resolveRunTimeoutDuringCompaction(params: {
   isCompactionPendingOrRetrying: boolean;
   isCompactionInFlight: boolean;
@@ -24,6 +26,7 @@ export function resolveRunTimeoutDuringCompaction(params: {
   return params.graceAlreadyUsed ? "abort" : "extend";
 }
 
+/** Combines the normal run timeout with the one-time compaction grace budget. */
 export function resolveRunTimeoutWithCompactionGraceMs(params: {
   runTimeoutMs: number;
   compactionTimeoutMs: number;
@@ -46,6 +49,8 @@ export type SnapshotSelection = {
 };
 
 function canContinueFromMessage(message: AgentMessage | undefined): boolean {
+  // Continuations must resume from a transcript tail that can accept a new model
+  // turn; dangling assistant/tool-call rows would corrupt retry context.
   switch (message?.role) {
     case "user":
     case "toolResult":
@@ -68,6 +73,7 @@ function trimToContinuableTail(messages: AgentMessage[]): AgentMessage[] | null 
   return end > 0 ? messages.slice(0, end) : null;
 }
 
+/** Chooses the safest transcript snapshot after a timeout interrupts compaction. */
 export function selectCompactionTimeoutSnapshot(
   params: SnapshotSelectionParams,
 ): SnapshotSelection {
@@ -80,6 +86,8 @@ export function selectCompactionTimeoutSnapshot(
   }
 
   if (params.preCompactionSnapshot) {
+    // Prefer the pre-compaction transcript so the retry does not inherit a
+    // partial summary that may have been written by the timed-out compactor.
     const continuablePreCompactionSnapshot = trimToContinuableTail(params.preCompactionSnapshot);
     if (continuablePreCompactionSnapshot) {
       return {

--- a/src/agents/embedded-agent-runner/run/compaction-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-timeout.ts
@@ -1,5 +1,10 @@
 import type { AgentMessage } from "../../runtime/index.js";
 
+/**
+ * Timeout state sampled when an attempt exits. `isTimeout` is the trigger,
+ * while the compaction flags explain whether the timeout should be reported as
+ * compaction-related instead of a plain model/tool timeout.
+ */
 export type CompactionTimeoutSignal = {
   isTimeout: boolean;
   isCompactionPendingOrRetrying: boolean;
@@ -34,6 +39,11 @@ export function resolveRunTimeoutWithCompactionGraceMs(params: {
   return params.runTimeoutMs + params.compactionTimeoutMs;
 }
 
+/**
+ * Candidate transcript snapshots used when compaction times out mid-rewrite.
+ * The pre-compaction snapshot is preferred because the current transcript may
+ * include a partial summary or assistant tail that is unsafe for retry.
+ */
 export type SnapshotSelectionParams = {
   timedOutDuringCompaction: boolean;
   preCompactionSnapshot: AgentMessage[] | null;
@@ -42,6 +52,7 @@ export type SnapshotSelectionParams = {
   currentSessionId: string;
 };
 
+/** Transcript selected for retry after trimming to a continuable tail. */
 export type SnapshotSelection = {
   messagesSnapshot: AgentMessage[];
   sessionIdUsed: string;

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -8,7 +8,11 @@ import {
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 import { log } from "../logger.js";
 
-/** Structured context recorded when an embedded run chooses a failover path. */
+/**
+ * Structured context recorded when an embedded run chooses a failover path.
+ * Raw provider text is accepted here, but createFailoverDecisionLogger owns the
+ * redaction and console-suffix suppression before anything is emitted.
+ */
 export type FailoverDecisionLoggerInput = {
   stage: "prompt" | "assistant";
   decision: "rotate_profile" | "fallback_model" | "surface_error";
@@ -27,10 +31,18 @@ export type FailoverDecisionLoggerInput = {
   status?: number;
 };
 
-/** Base failover observation captured before the concrete decision is known. */
+/**
+ * Base failover observation captured before the concrete decision is known.
+ * The caller supplies the source model/profile state once, then the returned
+ * logger records whichever rotation/fallback/surface decision was selected.
+ */
 export type FailoverDecisionLoggerBase = Omit<FailoverDecisionLoggerInput, "decision" | "status">;
 
-/** Fills timeout-derived failure reasons without overriding explicit provider reasons. */
+/**
+ * Fills timeout-derived failure reasons without overriding explicit provider
+ * reasons. Timeout is the fallback classification only when provider/API error
+ * parsing did not produce a stronger reason.
+ */
 export function normalizeFailoverDecisionObservationBase(
   base: FailoverDecisionLoggerBase,
 ): FailoverDecisionLoggerBase {

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -8,6 +8,7 @@ import {
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 import { log } from "../logger.js";
 
+/** Structured context recorded when an embedded run chooses a failover path. */
 export type FailoverDecisionLoggerInput = {
   stage: "prompt" | "assistant";
   decision: "rotate_profile" | "fallback_model" | "surface_error";
@@ -26,8 +27,10 @@ export type FailoverDecisionLoggerInput = {
   status?: number;
 };
 
+/** Base failover observation captured before the concrete decision is known. */
 export type FailoverDecisionLoggerBase = Omit<FailoverDecisionLoggerInput, "decision" | "status">;
 
+/** Fills timeout-derived failure reasons without overriding explicit provider reasons. */
 export function normalizeFailoverDecisionObservationBase(
   base: FailoverDecisionLoggerBase,
 ): FailoverDecisionLoggerBase {
@@ -38,6 +41,7 @@ export function normalizeFailoverDecisionObservationBase(
   };
 }
 
+/** Creates a redacting logger for one embedded-run failover decision point. */
 export function createFailoverDecisionLogger(
   base: FailoverDecisionLoggerBase,
 ): (
@@ -59,6 +63,8 @@ export function createFailoverDecisionLogger(
   return (decision, extra) => {
     const observedError = buildApiErrorObservationFields(normalizedBase.rawError);
     const safeRawErrorPreview = sanitizeForConsole(observedError.rawErrorPreview);
+    // Structured logs keep the raw preview when useful, but HTML/auth bodies
+    // stay out of the console suffix to avoid noisy credential-provider output.
     const rawErrorConsoleSuffix =
       safeRawErrorPreview &&
       !shouldSuppressRawErrorConsoleSuffix(observedError.providerRuntimeFailureKind)

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -70,6 +70,7 @@ export type RunFailoverDecisionParams =
   | PromptDecisionParams
   | AssistantDecisionParams;
 
+/** Returns true when hitting the retry ceiling should leave the current model path. */
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
     reason &&
@@ -85,6 +86,8 @@ function isTerminalFormatFailure(params: {
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
 }): boolean {
+  // Format retries are opt-in because some providers report transcript/request
+  // shape errors deterministically; rotating profiles would only burn attempts.
   return (
     params.failoverFailure && params.failoverReason === "format" && params.allowFormatRetry !== true
   );
@@ -118,6 +121,8 @@ function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   const timeoutFailure = isAssistantTimeoutFailure(params);
   const harnessOwnedTimeout =
     params.harnessOwnsTransport && (timeoutFailure || params.failoverReason === "timeout");
+  // Harness-owned transport handles its own timeout recovery. Only a concrete
+  // provider/model failure should make the shared auth/profile layer rotate.
   if (harnessOwnedTimeout && !isConcreteNonTimeoutAssistantFailure(params)) {
     return false;
   }
@@ -137,6 +142,8 @@ export function mergeRetryFailoverReason(params: {
   failoverReason: FailoverReason | null;
   timedOut?: boolean;
 }): FailoverReason | null {
+  // Keep the most specific fresh signal. A synthetic timeout beats stale state,
+  // but an explicit current failover reason wins over both.
   return params.failoverReason ?? (params.timedOut ? "timeout" : null) ?? params.previous;
 }
 
@@ -147,6 +154,7 @@ export function resolveRunFailoverDecision(params: PromptDecisionParams): Prompt
 export function resolveRunFailoverDecision(
   params: AssistantDecisionParams,
 ): AssistantFailoverDecision;
+/** Decides whether a failed run attempt should rotate auth, fall back, or surface the error. */
 export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): RunFailoverDecision {
   if (params.stage === "retry_limit") {
     if (params.fallbackConfigured && shouldEscalateRetryLimit(params.failoverReason)) {

--- a/src/agents/embedded-agent-runner/run/fallbacks.ts
+++ b/src/agents/embedded-agent-runner/run/fallbacks.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { hasConfiguredModelFallbacks } from "../../agent-scope.js";
 
+/** Resolves whether the embedded run can fall back to another model. */
 export function hasEmbeddedRunConfiguredModelFallbacks(params: {
   cfg: OpenClawConfig | undefined;
   agentId?: string | null;

--- a/src/agents/embedded-agent-runner/run/fallbacks.ts
+++ b/src/agents/embedded-agent-runner/run/fallbacks.ts
@@ -1,7 +1,10 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { hasConfiguredModelFallbacks } from "../../agent-scope.js";
 
-/** Resolves whether the embedded run can fall back to another model. */
+/**
+ * Resolves whether the embedded run can fall back to another model, with an
+ * explicit attempt override taking precedence over agent/session config.
+ */
 export function hasEmbeddedRunConfiguredModelFallbacks(params: {
   cfg: OpenClawConfig | undefined;
   agentId?: string | null;

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -34,14 +34,17 @@ const DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS = 0;
 const DEFAULT_MAX_OVERLOAD_PROFILE_ROTATIONS = 1;
 const DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS = 1;
 
+/** Resolves the backoff delay after an overload-triggered auth/profile rotation. */
 export function resolveOverloadFailoverBackoffMs(cfg?: OpenClawConfig): number {
   return cfg?.auth?.cooldowns?.overloadedBackoffMs ?? DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS;
 }
 
+/** Resolves how many profile rotations an overload can consume in one run. */
 export function resolveOverloadProfileRotationLimit(cfg?: OpenClawConfig): number {
   return cfg?.auth?.cooldowns?.overloadedProfileRotations ?? DEFAULT_MAX_OVERLOAD_PROFILE_ROTATIONS;
 }
 
+/** Resolves how many profile rotations a rate-limit failure can consume in one run. */
 export function resolveRateLimitProfileRotationLimit(cfg?: OpenClawConfig): number {
   return (
     cfg?.auth?.cooldowns?.rateLimitedProfileRotations ?? DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS
@@ -51,7 +54,7 @@ export function resolveRateLimitProfileRotationLimit(cfg?: OpenClawConfig): numb
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
 
-// Avoid Anthropic's refusal test token poisoning session transcripts.
+/** Removes Anthropic's refusal-test token before it can poison persisted transcripts. */
 export function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) {
     return prompt;
@@ -62,6 +65,7 @@ export function scrubAnthropicRefusalMagic(prompt: string): string {
   );
 }
 
+/** Creates a compact diagnostic id for context-overflow/compaction log correlation. */
 export function createCompactionDiagId(): string {
   return `ovf-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
@@ -71,7 +75,7 @@ const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
 
-// Defensive guard for the outer run loop across all retry branches.
+/** Resolves the defensive retry-loop cap across all embedded-run retry branches. */
 export function resolveMaxRunRetryIterations(
   profileCandidateCount: number,
   cfg?: OpenClawConfig,
@@ -87,6 +91,8 @@ export function resolveMaxRunRetryIterations(
   const maxLimit = Math.max(minLimit, configRetries?.max ?? MAX_RUN_RETRY_ITERATIONS);
 
   const scaled = base + Math.max(1, profileCandidateCount) * perProfile;
+  // Scale with profile candidates so real failover has space, but keep a hard
+  // upper bound so pathological retry mixes cannot spin forever.
   return Math.min(maxLimit, Math.max(minLimit, scaled));
 }
 
@@ -136,6 +142,8 @@ export function resolveReportedModelRef(params: {
     };
   }
   if (isEmbeddedHarnessProvider(assistantProvider)) {
+    // The embedded harness provider is a transport shim; user-facing metadata
+    // should report the underlying provider/model that actually served tokens.
     return {
       provider: params.provider,
       model: params.model,
@@ -147,6 +155,7 @@ export function resolveReportedModelRef(params: {
   };
 }
 
+/** Builds usage-related agent meta fields from accumulated and last-call usage. */
 export function buildUsageAgentMetaFields(params: {
   usageAccumulator: UsageAccumulator;
   lastAssistantUsage?: UsageSnapshot | null;
@@ -190,6 +199,8 @@ export function buildErrorAgentMeta(params: {
     lastRunPromptUsage: params.lastRunPromptUsage,
     lastTurnTotal: params.lastTurnTotal,
   });
+  // Error paths still update usage/prompt metadata so session totals do not
+  // remain stuck on the previous successful turn after a failed large prompt.
   return {
     sessionId: params.sessionId,
     ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
@@ -202,6 +213,7 @@ export function buildErrorAgentMeta(params: {
   };
 }
 
+/** Extracts final assistant text visible to users from the last assistant message. */
 export function resolveFinalAssistantVisibleText(
   lastAssistant: AssistantMessage | undefined,
 ): string | undefined {
@@ -212,6 +224,7 @@ export function resolveFinalAssistantVisibleText(
   return visibleText || undefined;
 }
 
+/** Extracts final assistant text for raw persistence/fallback handling. */
 export function resolveFinalAssistantRawText(
   lastAssistant: AssistantMessage | undefined,
 ): string | undefined {

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -18,6 +18,7 @@ type UsageSnapshot = {
 
 export type RuntimeAuthState = {
   generation: number;
+  /** Original credential used to mint short-lived runtime credentials. */
   sourceApiKey: string;
   authMode: string;
   profileId?: string;
@@ -107,6 +108,10 @@ export function resolveActiveErrorContext(params: {
   return resolveReportedModelRef(params);
 }
 
+/**
+ * Returns whether an assistant response belongs to the reported provider/model
+ * after applying embedded-harness normalization.
+ */
 export function isAssistantForModelRef(
   assistant: { provider?: string; model?: string } | undefined,
   ref: { provider: string; model: string },
@@ -125,6 +130,11 @@ function isEmbeddedHarnessProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "openclaw";
 }
 
+/**
+ * Resolves the provider/model pair shown in diagnostics and user-visible error
+ * metadata. Embedded OpenClaw harness responses are transport shims, so they
+ * report the underlying runtime provider/model instead.
+ */
 export function resolveReportedModelRef(params: {
   provider: string;
   model: string;

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -1,6 +1,8 @@
 import type { AgentMessage } from "../../runtime/index.js";
 
+/** Stable replacement text for pruned binary image blocks in replayed history. */
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
+/** Stable replacement text for historical attachment markers that would be reloaded as new images. */
 export const PRUNED_HISTORY_MEDIA_REFERENCE_MARKER =
   "[media reference removed - already processed by model]";
 
@@ -27,6 +29,8 @@ function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
   let currentTurnStart = -1;
   let currentTurnHasAssistantReply = false;
 
+  // A turn is complete only after an assistant reply; current or tool-only
+  // turns keep their original media so retries and follow-ups see the same input.
   for (let i = 0; i < messages.length; i++) {
     const role = messages[i]?.role;
     if (role === "user") {
@@ -86,6 +90,8 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): AgentMess
     return null;
   }
 
+  // Preserve object identity when no media was pruned; callers use null as the
+  // cheap signal that context bytes can remain untouched.
   let prunedMessages: AgentMessage[] | null = null;
   for (let i = 0; i < pruneBeforeIndex; i++) {
     const message = messages[i];
@@ -148,6 +154,10 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): AgentMess
   return prunedMessages;
 }
 
+/**
+ * Wrap an agent context transform with historical image pruning and return a
+ * disposer that restores the original transform for test/runtime teardown.
+ */
 export function installHistoryImagePruneContextTransform(agent: PrunableContextAgent): () => void {
   const originalTransformContext = agent.transformContext;
   agent.transformContext = async (messages: AgentMessage[], signal?: AbortSignal) => {

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -112,6 +112,10 @@ function isOpenClawCliImageCachePath(filePath: string): boolean {
   });
 }
 
+/**
+ * Merge inline attachment images, offloaded attachment images, and prompt-path
+ * images in the order the model should receive them.
+ */
 export function mergePromptAttachmentImages(params: {
   imageOrder?: PromptImageOrderEntry[];
   existingImages?: ImageContent[];
@@ -138,6 +142,8 @@ export function mergePromptAttachmentImages(params: {
         promptImages.push(image);
       }
     }
+    // Keep any images not represented in imageOrder instead of silently
+    // dropping caller-provided attachment blocks from older prompt formats.
     while (inlineIndex < existingImages.length) {
       promptImages.push(existingImages[inlineIndex++]);
     }
@@ -222,6 +228,8 @@ function extractTrailingAttachmentMediaUris(prompt: string, count: number): stri
 
   const lines = prompt.split(/\r?\n/);
   const uris: string[] = [];
+  // Offloaded attachment markers are appended after the prompt body; scanning
+  // backward prevents ordinary prompt mentions from being classified as attachments.
   for (let index = lines.length - 1; index >= 0 && uris.length < count; index--) {
     const line = lines[index]?.trim();
     if (!line || line.includes("\0")) {
@@ -241,6 +249,10 @@ function extractTrailingAttachmentMediaUris(prompt: string, count: number): stri
   return uris;
 }
 
+/**
+ * Partition detected prompt references into attachment-owned refs and genuine
+ * prompt text refs so attachments are loaded once but explicit prompt paths remain.
+ */
 export function splitPromptAndAttachmentRefs(params: {
   prompt: string;
   refs: DetectedImageRef[];
@@ -313,7 +325,6 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   const refs: DetectedImageRef[] = [];
   const seen = new Set<string>();
 
-  // Helper to add a path ref
   const addPathRef = (raw: string) => {
     const trimmed = raw.trim();
     const dedupeKey = normalizeRefForDedupe(trimmed);
@@ -339,9 +350,8 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     refs.push({ raw: trimmed, type: "path", resolved });
   };
 
-  // Pattern for [media attached: path (type) | url] or [media attached N/M: path (type) | url] format
-  // Each bracket = ONE file. The | separates path from URL, not multiple files.
-  // Multi-file format uses separate brackets on separate lines.
+  // Each media-attached bracket represents one file; "|" separates the local
+  // path from its display URL, not multiple files.
   MEDIA_ATTACHED_PATTERN.lastIndex = 0;
   MESSAGE_IMAGE_PATTERN.lastIndex = 0;
   FILE_URL_PATTERN.lastIndex = 0;
@@ -370,10 +380,8 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
       continue;
     }
 
-    // Extract path before the (mime/type) or | delimiter
-    // Format is: path (type) | url  OR  just: path (type)
-    // Path may contain spaces (e.g., "ChatGPT Image Apr 21.png")
-    // Use non-greedy .+? to stop at first image extension
+    // Attachment paths can contain spaces, so the regex stops at the first
+    // image extension before optional mime/display-url metadata.
     const pathMatch = content.match(MEDIA_ATTACHED_PATH_PATTERN);
     if (pathMatch?.[1]) {
       addPathRef(pathMatch[1].trim());
@@ -390,7 +398,8 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
 
   // Remote HTTP(S) URLs are intentionally ignored. Native image injection is local-only.
 
-  // Pattern for file:// URLs - treat as paths since loadWebMedia handles them
+  // Treat file URLs as paths after safe URL decoding so local-root checks see
+  // the same filesystem form as direct path references.
   while ((match = FILE_URL_PATTERN.exec(prompt)) !== null) {
     const raw = match[0];
     const dedupeKey = normalizeRefForDedupe(raw);
@@ -417,14 +426,9 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     }
   }
 
-  // Pattern for file paths (absolute, relative, or home)
-  // Matches:
-  // - /absolute/path/to/file.ext (including paths with special chars like Messages/Attachments)
-  // - ./relative/path.ext
-  // - ../parent/path.ext
-  // - ~/home/path.ext
+  // Scan direct paths last so structured attachment/message patterns get first
+  // chance to normalize and dedupe their refs.
   while ((match = PATH_PATTERN.exec(prompt)) !== null) {
-    // Use capture group 1 (the path without delimiter prefix); skip if undefined
     if (match[1]) {
       addPathRef(match[1]);
     }
@@ -500,8 +504,8 @@ export async function loadImageFromRef(
       return null;
     }
 
-    // EXIF orientation is already normalized by loadWebMedia -> resizeToJpeg
-    // Default to JPEG since optimization converts images to JPEG format
+    // loadWebMedia normalizes orientation via resizeToJpeg; defaulting to JPEG
+    // keeps metadata aligned with the optimized buffer.
     const mimeType = media.contentType ?? "image/jpeg";
     const data = media.buffer.toString("base64");
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -104,6 +104,10 @@ const REPLAY_UNSAFE_FALLBACK_METADATA: EmbeddedRunAttemptResult["replayMetadata"
   replaySafe: false,
 };
 
+/**
+ * Decide whether the last assistant row is terminal in storage but incomplete
+ * for user-visible delivery because it stopped while waiting for tool results.
+ */
 export function isIncompleteTerminalAssistantTurn(params: {
   hasAssistantVisibleText: boolean;
   lastAssistant?: { stopReason?: string } | null;
@@ -166,7 +170,9 @@ const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
 const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2;
 // Allow one immediate continuation plus one follow-up continuation before
 // surfacing the existing incomplete-turn error path.
+/** Default continuation cap for replay-safe reasoning-only assistant turns. */
 export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
+/** Default continuation cap for replay-safe empty assistant turns. */
 export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
 const ACK_EXECUTION_NORMALIZED_SET = new Set([
   "ok",
@@ -214,22 +220,32 @@ const ACTIONABLE_PROMPT_DIRECTIVE_RE =
 const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
 
+/** Retry steering inserted when a supported model only narrates a plan. */
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
+/** Retry steering inserted when provider output has reasoning but no visible answer. */
 export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
+/** Retry steering inserted when a supported model produced no visible content. */
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+/** Fast-path steering for short user approvals after the agent already proposed work. */
 export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
   "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+/** Final blocked text after strict-agentic plan-only retries are exhausted. */
 export const STRICT_AGENTIC_BLOCKED_TEXT =
   "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
 
+/** Structured details extracted from visible plan-only prose for retry diagnostics. */
 export type PlanningOnlyPlanDetails = {
   explanation: string;
   steps: string[];
 };
 
+/**
+ * Summarize whether replaying an attempt is safe after an incomplete turn.
+ * Any mutating, async, delivery, spawn, or cron side effect makes replay unsafe.
+ */
 export function buildAttemptReplayMetadata(
   params: ReplayMetadataAttempt,
 ): EmbeddedRunAttemptResult["replayMetadata"] {
@@ -247,12 +263,17 @@ export function buildAttemptReplayMetadata(
   };
 }
 
+/**
+ * Resolve stored replay metadata, defaulting to unsafe when older attempts lack
+ * explicit metadata.
+ */
 export function resolveAttemptReplayMetadata(attempt: {
   replayMetadata?: EmbeddedRunAttemptResult["replayMetadata"] | null;
 }): EmbeddedRunAttemptResult["replayMetadata"] {
   return attempt.replayMetadata ?? REPLAY_UNSAFE_FALLBACK_METADATA;
 }
 
+/** Build the user-visible incomplete-turn warning, or null when the turn is deliverable. */
 export function resolveIncompleteTurnPayloadText(params: {
   payloadCount: number;
   aborted: boolean;
@@ -321,6 +342,10 @@ export function resolveIncompleteTurnPayloadText(params: {
     : "⚠️ Agent couldn't generate a response. Please try again.";
 }
 
+/**
+ * Decide whether a no-assistant attempt can be retried immediately instead of
+ * surfacing an incomplete-turn warning.
+ */
 export function shouldRetryMissingAssistantTurn(params: {
   payloadCount: number;
   aborted: boolean;
@@ -437,6 +462,10 @@ function hasTrailingSilentToolResult(messages: readonly AgentMessage[]): boolean
   return false;
 }
 
+/**
+ * Preserve cron silent-reply semantics when the final observable work is a
+ * silent tool result and no user-facing assistant payload was generated.
+ */
 export function resolveSilentToolResultReplyPayload(params: {
   isCronTrigger: boolean;
   payloadCount: number;
@@ -464,6 +493,7 @@ export function resolveSilentToolResultReplyPayload(params: {
     : null;
 }
 
+/** Mark transcript replay invalid when retrying could duplicate unsafe work. */
 export function resolveReplayInvalidFlag(params: {
   attempt: RunLivenessAttempt;
   incompleteTurnText?: string | null;
@@ -476,6 +506,7 @@ export function resolveReplayInvalidFlag(params: {
   );
 }
 
+/** Convert incomplete-turn and timeout state into the persisted run liveness bucket. */
 export function resolveRunLivenessState(params: {
   payloadCount: number;
   aborted: boolean;
@@ -588,6 +619,10 @@ function shouldSkipPlanningOnlyRetry(params: {
   );
 }
 
+/**
+ * Allow callers that opted into silent empty replies to suppress non-visible
+ * assistant turns when no side effect or committed delivery needs warning text.
+ */
 export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   allowEmptyAssistantReplyAsSilent?: boolean;
   payloadCount: number;
@@ -607,6 +642,10 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   });
 }
 
+/**
+ * Return retry steering for supported reasoning-only turns that are replay-safe
+ * and have no visible assistant text.
+ */
 export function resolveReasoningOnlyRetryInstruction(params: {
   provider?: string;
   modelId?: string;
@@ -645,6 +684,10 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   return REASONING_ONLY_RETRY_INSTRUCTION;
 }
 
+/**
+ * Return retry steering for replay-safe empty turns on supported providers or
+ * provider-neutral zero-usage stop signals.
+ */
 export function resolveEmptyResponseRetryInstruction(params: {
   provider?: string;
   modelId?: string;
@@ -762,6 +805,7 @@ function normalizeAckPrompt(text: string): string {
   return normalizeLowercaseStringOrEmpty(normalized);
 }
 
+/** Classify short multilingual approvals that should continue prior proposed work. */
 export function isLikelyExecutionAckPrompt(text: string): boolean {
   const trimmed = text.trim();
   if (!trimmed || trimmed.length > 80 || trimmed.includes("\n") || trimmed.includes("?")) {
@@ -781,6 +825,10 @@ function isLikelyActionableUserPrompt(text: string): boolean {
   return ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) || ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed);
 }
 
+/**
+ * Return fast-path steering for supported models when the latest user turn is
+ * just an approval to execute the already-proposed work.
+ */
 export function resolveAckExecutionFastPathInstruction(params: {
   provider?: string;
   modelId?: string;
@@ -820,6 +868,7 @@ function hasStructuredPlanningOnlyFormat(text: string): boolean {
   return (hasPlanningHeading && hasPlanningCueLine) || (bulletLineCount >= 2 && hasPlanningCueLine);
 }
 
+/** Extract compact retry diagnostics from visible plan-only assistant prose. */
 export function extractPlanningOnlyPlanDetails(text: string): PlanningOnlyPlanDetails | null {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -889,6 +938,7 @@ function isSingleActionThenNarrativePattern(params: {
   );
 }
 
+/** Resolve the allowed plan-only retry count for the execution contract. */
 export function resolvePlanningOnlyRetryLimit(
   executionContract?: EmbeddedAgentExecutionContract,
 ): number {
@@ -897,6 +947,10 @@ export function resolvePlanningOnlyRetryLimit(
     : DEFAULT_PLANNING_ONLY_RETRY_LIMIT;
 }
 
+/**
+ * Return retry steering when a supported model narrates future work instead of
+ * taking a concrete action.
+ */
 export function resolvePlanningOnlyRetryInstruction(params: {
   provider?: string;
   modelId?: string;

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -109,7 +109,7 @@ function isOllamaCloudModel(model: { id?: string; provider?: string } | undefine
 }
 
 /**
- * Resolves the LLM idle timeout from configuration.
+ * Resolves the chunk-level LLM idle watchdog from run, agent, and provider config.
  * @returns Idle timeout in milliseconds, or 0 to disable
  */
 export function resolveLlmIdleTimeoutMs(params?: {
@@ -200,8 +200,7 @@ export function resolveLlmIdleTimeoutMs(params?: {
 }
 
 /**
- * Wraps a stream function with idle timeout detection.
- * If no token is received within the specified timeout, the request is aborted.
+ * Wraps a stream function with chunk-level idle timeout detection.
  *
  * @param baseFn - The base stream function to wrap
  * @param timeoutMs - Idle timeout in milliseconds
@@ -243,6 +242,8 @@ export function streamWithIdleTimeout(
       (model as { requestTimeoutMs?: number }).requestTimeoutMs! > 0
         ? Math.floor((model as { requestTimeoutMs?: number }).requestTimeoutMs!)
         : timeoutMs;
+    // Keep provider-level requestTimeoutMs no longer than the stream watchdog,
+    // so transport timeouts and our idle timeout converge on the same failure.
     const wrappedModel =
       typeof model === "object" && model !== null
         ? ({

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
@@ -7,6 +7,7 @@ export type OrphanedTrailingUserPromptMergeParams = {
   leafMessage: { content?: unknown };
 };
 
+/** Result of folding an active-turn user leaf into the next inbound prompt. */
 export type OrphanedTrailingUserPromptMergeResult = {
   prompt: string;
   merged: boolean;
@@ -20,6 +21,7 @@ export type OrphanedTrailingUserPromptMergeResult = {
 
 export type MessageMergeStrategyId = "orphan-trailing-user-prompt";
 
+/** Runtime hook for resolving provider-hostile transcript tails before retrying. */
 export type MessageMergeStrategy = {
   id: MessageMergeStrategyId;
   mergeOrphanedTrailingUserPrompt: (
@@ -37,6 +39,7 @@ const defaultMessageMergeStrategy: MessageMergeStrategy = {
 
 let activeMessageMergeStrategy = defaultMessageMergeStrategy;
 
+/** Returns the currently installed message merge strategy. */
 export function resolveMessageMergeStrategy(): MessageMergeStrategy {
   return activeMessageMergeStrategy;
 }
@@ -49,6 +52,7 @@ function registerMessageMergeStrategy(strategy: MessageMergeStrategy): () => voi
   };
 }
 
+/** Installs a temporary message merge strategy and returns a restore callback. */
 export function registerMessageMergeStrategyForTest(strategy: MessageMergeStrategy): () => void {
   return registerMessageMergeStrategy(strategy);
 }

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
@@ -39,7 +39,7 @@ const defaultMessageMergeStrategy: MessageMergeStrategy = {
 
 let activeMessageMergeStrategy = defaultMessageMergeStrategy;
 
-/** Returns the currently installed message merge strategy. */
+/** Returns the active merge strategy used before retrying a transcript with a hostile tail. */
 export function resolveMessageMergeStrategy(): MessageMergeStrategy {
   return activeMessageMergeStrategy;
 }

--- a/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
+++ b/src/agents/embedded-agent-runner/run/message-merge-strategy.ts
@@ -4,6 +4,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 export type OrphanedTrailingUserPromptMergeParams = {
   prompt: string;
   trigger: EmbeddedRunAttemptParams["trigger"];
+  /** The current session leaf that would otherwise create consecutive user turns. */
   leafMessage: { content?: unknown };
 };
 
@@ -21,7 +22,11 @@ export type OrphanedTrailingUserPromptMergeResult = {
 
 export type MessageMergeStrategyId = "orphan-trailing-user-prompt";
 
-/** Runtime hook for resolving provider-hostile transcript tails before retrying. */
+/**
+ * Runtime hook for resolving provider-hostile transcript tails before retrying.
+ * The strategy object exists so tests can exercise runner behavior without
+ * depending on the default merge text.
+ */
 export type MessageMergeStrategy = {
   id: MessageMergeStrategyId;
   mergeOrphanedTrailingUserPrompt: (
@@ -52,7 +57,10 @@ function registerMessageMergeStrategy(strategy: MessageMergeStrategy): () => voi
   };
 }
 
-/** Installs a temporary message merge strategy and returns a restore callback. */
+/**
+ * Installs a temporary message merge strategy and returns a restore callback.
+ * Keep this test-only so production uses the canonical orphan-user merge path.
+ */
 export function registerMessageMergeStrategyForTest(strategy: MessageMergeStrategy): () => void {
   return registerMessageMergeStrategy(strategy);
 }

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -5,6 +5,8 @@ import type { AfterToolCallContext, AfterToolCallResult, Agent } from "../../run
 import { normalizeToolName } from "../../tool-policy.js";
 
 const MESSAGE_TOOL_NAME = "message";
+// Explicit route args mean the message tool targeted a different destination;
+// source-reply termination is only safe for implicit replies to the active turn.
 const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
 const DRY_RUN_DELIVERY_STATUS = "dry_run";
 const SENT_DELIVERY_STATUS = "sent";
@@ -69,6 +71,11 @@ function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
   );
 }
 
+/**
+ * Returns true when a nested tool/hook envelope proves this was only a preview.
+ * Message adapters can report dry-run status in raw results, detail payloads, or
+ * JSON text blocks, so this scan intentionally mirrors delivered-message parsing.
+ */
 function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
   if (!value || typeof value !== "object" || depth > 4) {
     return false;
@@ -110,6 +117,11 @@ function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
   );
 }
 
+/**
+ * Returns true when a nested tool/hook envelope contains durable delivery
+ * evidence. Status alone is accepted only for the canonical `sent` value;
+ * provider-specific receipts must expose a message id.
+ */
 function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean {
   if (!value || typeof value !== "object" || depth > 4) {
     return false;
@@ -151,7 +163,12 @@ function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean 
   );
 }
 
-/** Returns true when message-tool-only delivery already sent the final reply. */
+/**
+ * Returns true when message-tool-only delivery already sent the final reply.
+ * This is intentionally stricter than "message tool succeeded": explicit
+ * routes, dry runs, failed results, and suppressed sends without delivery proof
+ * must leave the model turn open.
+ */
 export function shouldTerminateAfterMessageToolOnlySend(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   context: AfterToolCallContext;
@@ -190,7 +207,10 @@ export function shouldTerminateAfterMessageToolOnlySend(params: {
   return true;
 }
 
-/** Installs an afterToolCall hook that terminates message-tool-only delivered replies. */
+/**
+ * Installs an afterToolCall hook that terminates message-tool-only delivered
+ * replies while preserving any existing hook rewrite output.
+ */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -103,6 +103,8 @@ function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
     }
   }
 
+  // Delivery adapters may wrap status in provider-specific result/detail
+  // envelopes; bound recursion so malformed tool output cannot hang the hook.
   return RESULT_ENVELOPE_KEYS.some((key) =>
     deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
   );
@@ -142,11 +144,14 @@ function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean 
     }
   }
 
+  // Mirror the dry-run scan shape so terminal detection treats hook rewrites
+  // and raw tool results consistently.
   return RESULT_ENVELOPE_KEYS.some((key) =>
     deliveryEnvelopeIndicatesDelivered(record[key], depth + 1),
   );
 }
 
+/** Returns true when message-tool-only delivery already sent the final reply. */
 export function shouldTerminateAfterMessageToolOnlySend(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   context: AfterToolCallContext;
@@ -167,6 +172,8 @@ export function shouldTerminateAfterMessageToolOnlySend(params: {
   if (isError || isToolResultError(params.context.result)) {
     return false;
   }
+  // Dry-run previews can look structurally successful, but they did not deliver
+  // a channel reply and must not terminate the assistant turn.
   if (
     args.dryRun === true ||
     deliveryEnvelopeIndicatesDryRun(params.context.result) ||
@@ -183,6 +190,7 @@ export function shouldTerminateAfterMessageToolOnlySend(params: {
   return true;
 }
 
+/** Installs an afterToolCall hook that terminates message-tool-only delivered replies. */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;

--- a/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
+++ b/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
@@ -1,9 +1,18 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { AgentMessage } from "../../runtime/index.js";
 
+/**
+ * Synchronous transform for the LLM-boundary message array. Returning the same
+ * array signals a true no-op so the wrapper can preserve the original context
+ * object on hot stream paths.
+ */
 export type MessageTransform = (messages: AgentMessage[], model: unknown) => AgentMessage[];
 
-/** Applies a message transform immediately before invoking a stream function. */
+/**
+ * Applies a message transform immediately before invoking a stream function.
+ * Only the `messages` field is replaced; all other context fields and stream
+ * options are passed through unchanged.
+ */
 export function wrapStreamFnWithMessageTransform(
   streamFn: StreamFn,
   transform: MessageTransform,

--- a/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
+++ b/src/agents/embedded-agent-runner/run/message-transform-stream-wrapper.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "../../runtime/index.js";
 
 export type MessageTransform = (messages: AgentMessage[], model: unknown) => AgentMessage[];
 
+/** Applies a message transform immediately before invoking a stream function. */
 export function wrapStreamFnWithMessageTransform(
   streamFn: StreamFn,
   transform: MessageTransform,
@@ -15,6 +16,8 @@ export function wrapStreamFnWithMessageTransform(
 
     const nextMessages = transform(messages as AgentMessage[], model);
     if (nextMessages === messages) {
+      // Preserve object identity for callers that intentionally no-op the
+      // transform, avoiding an unnecessary context clone on hot stream paths.
       return streamFn(model, context, options);
     }
 

--- a/src/agents/embedded-agent-runner/run/midturn-precheck.ts
+++ b/src/agents/embedded-agent-runner/run/midturn-precheck.ts
@@ -1,5 +1,6 @@
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
+/** Snapshot passed from the tool-result guard when a mid-turn prompt would overflow. */
 export type MidTurnPrecheckRequest = {
   route: Exclude<PreemptiveCompactionRoute, "fits">;
   estimatedPromptTokens: number;
@@ -9,9 +10,11 @@ export type MidTurnPrecheckRequest = {
   effectiveReserveTokens: number;
 };
 
+/** Stable persisted/runtime error text used to identify mid-turn overflow recovery. */
 export const MID_TURN_PRECHECK_ERROR_MESSAGE =
   "Context overflow: prompt too large for the model (mid-turn precheck).";
 
+/** Error signal used to short-circuit the current provider turn for preflight recovery. */
 export class MidTurnPrecheckSignal extends Error {
   readonly request: MidTurnPrecheckRequest;
 
@@ -22,6 +25,7 @@ export class MidTurnPrecheckSignal extends Error {
   }
 }
 
+/** Narrows errors thrown by mid-turn precheck before retry/compaction handling. */
 export function isMidTurnPrecheckSignal(error: unknown): error is MidTurnPrecheckSignal {
   return error instanceof MidTurnPrecheckSignal;
 }

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -29,16 +29,22 @@ import type { EmbeddedAgentExecutionPhase } from "../execution-phase.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
+/** Run origin used for prompt policy, timeout, and heartbeat/memory behavior. */
 export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "overflow" | "user";
 
+/** Current inbound message context that can be prepended without entering persisted transcript. */
 export type CurrentInboundPromptContext = {
   text: string;
+  /** Shorter version used when replaying or retrying a prompt with bounded context. */
   resumableText?: string;
+  /** Separator used when joining current inbound context with the submitted prompt. */
   promptJoiner?: "\n\n" | "\n" | " ";
 };
 
+/** Public run-level API for launching an embedded agent turn. */
 export type RunEmbeddedAgentParams = {
   sessionId: string;
+  /** Logical session key for transcript/policy grouping; may differ from sessionId. */
   sessionKey?: string;
   /** Provider prompt-cache affinity key; distinct from transcript/session identity. */
   promptCacheKey?: string;
@@ -71,8 +77,11 @@ export type RunEmbeddedAgentParams = {
   /** Whether workspaceDir points at the canonical agent workspace for bootstrap purposes. */
   isCanonicalWorkspace?: boolean;
   senderId?: string | null;
+  /** Human display name from the inbound channel, used for prompt and transcript context. */
   senderName?: string | null;
+  /** Channel username/handle from the inbound sender, when distinct from display name. */
   senderUsername?: string | null;
+  /** E.164 sender phone number for owner/contact checks; never log raw values. */
   senderE164?: string | null;
   /** Trusted sender identity bit for command/channel-action auth. */
   senderIsOwner?: boolean;
@@ -115,8 +124,11 @@ export type RunEmbeddedAgentParams = {
   /** User-visible prompt body to submit and persist; runtime context travels separately. */
   transcriptPrompt?: string;
   currentInboundEventKind?: InboundEventKind;
+  /** Ephemeral inbound context shown to the model without mutating the durable user prompt. */
   currentInboundContext?: CurrentInboundPromptContext;
+  /** Images already attached to the current prompt before text reference detection. */
   images?: ImageContent[];
+  /** Ordering metadata that preserves inline/offloaded image attachment order. */
   imageOrder?: PromptImageOrderEntry[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
@@ -131,8 +143,10 @@ export type RunEmbeddedAgentParams = {
   /** Explicit runtime override selected for this turn. Unlike agentHarnessId, this may force OpenClaw. */
   agentHarnessRuntimeOverride?: string;
   authProfileId?: string;
+  /** Whether authProfileId came from user selection or automatic routing. */
   authProfileIdSource?: "auto" | "user";
   thinkLevel?: ThinkLevel;
+  /** Low-latency hint that can reduce reasoning/context work when supported. */
   fastMode?: boolean;
   verboseLevel?: VerboseLevel;
   reasoningLevel?: ReasoningLevel;
@@ -167,8 +181,11 @@ export type RunEmbeddedAgentParams = {
    */
   runTimeoutOverrideMs?: number;
   runId: string;
+  /** Caller abort signal for user-visible cancellation, distinct from internal timeout aborts. */
   abortSignal?: AbortSignal;
+  /** Fired once the embedded run has crossed from queued/setup into execution. */
   onExecutionStarted?: () => void;
+  /** Fine-grained phase callback used by UI/lifecycle diagnostics. */
   onExecutionPhase?: (info: {
     phase: EmbeddedAgentExecutionPhase;
     provider?: string;
@@ -180,6 +197,7 @@ export type RunEmbeddedAgentParams = {
     itemId?: string;
     firstModelCallStarted?: boolean;
   }) => void;
+  /** Coarse progress callback used for provider/model failover and long-running stages. */
   onRunProgress?: (info: {
     reason: string;
     provider?: string;
@@ -187,21 +205,31 @@ export type RunEmbeddedAgentParams = {
     backend?: string;
   }) => void;
   replyOperation?: ReplyOperation;
+  /** Gate for emitting tool result reply payloads after caller state changes. */
   shouldEmitToolResult?: () => boolean;
+  /** Gate for streaming raw tool output after caller state changes. */
   shouldEmitToolOutput?: () => boolean;
+  /** Streaming partial reply callback; may perform async channel delivery. */
   onPartialReply?: (payload: PartialReplyPayload) => void | Promise<void>;
+  /** Called when assistant text emission starts for this turn. */
   onAssistantMessageStart?: () => void | Promise<void>;
+  /** Block-based reply callback for transports that need chunked assistant payloads. */
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
+  /** Flush callback for pending block replies after stream boundaries. */
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
+  /** Reasoning stream callback for providers that expose separate reasoning text/media. */
   onReasoningStream?: (payload: {
     text?: string;
     mediaUrls?: string[];
     isReasoningSnapshot?: boolean;
   }) => void | Promise<void>;
+  /** Called after a provider-specific reasoning stream closes. */
   onReasoningEnd?: () => void | Promise<void>;
+  /** Tool-result reply callback after formatting and policy filtering. */
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
+  /** Raw agent event callback for gateway/session subscribers. */
   onAgentEvent?: (evt: {
     stream: string;
     data: Record<string, unknown>;
@@ -214,14 +242,21 @@ export type RunEmbeddedAgentParams = {
   deferTerminalLifecycleEnd?: boolean;
   lane?: string;
   enqueue?: CommandQueueEnqueueFn;
+  /** Additional system prompt text appended by trusted callers for this run only. */
   extraSystemPrompt?: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   silentReplyPromptMode?: SilentReplyPromptMode;
+  /** Internal events already associated with the run before model execution. */
   internalEvents?: AgentInternalEvent[];
+  /** Provenance for the user input that created this run. */
   inputProvenance?: InputProvenance;
+  /** Provider stream options forwarded after runtime normalization. */
   streamParams?: AgentStreamParams;
+  /** Owner phone numbers used for channel auth decisions; keep out of diagnostics. */
   ownerNumbers?: string[];
+  /** Enforce final-answer tag behavior for prompt profiles that require it. */
   enforceFinalTag?: boolean;
+  /** Caller expects no visible reply unless the model explicitly has one. */
   silentExpected?: boolean;
   /**
    * Treat a clean empty assistant stop as an intentional silent reply.
@@ -239,10 +274,15 @@ export type RunEmbeddedAgentParams = {
    */
   allowTransientCooldownProbe?: boolean;
   suppressNextUserMessagePersistence?: boolean;
+  /** Avoid persisting assistant-only transcript rows created for internal repair. */
   suppressTranscriptOnlyAssistantPersistence?: boolean;
+  /** Avoid persisting assistant error rows when the caller owns error reporting. */
   suppressAssistantErrorPersistence?: boolean;
+  /** Recorder for durable user-turn transcript writes before model execution. */
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
+  /** Hook after durable user message persistence, used to link session-side state. */
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
+  /** Hook after assistant error persistence, used for recovery metadata updates. */
   onAssistantErrorMessagePersisted?: (
     message: Extract<AgentMessage, { role: "assistant" }>,
   ) => void;

--- a/src/agents/embedded-agent-runner/run/payloads.test-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test-helpers.ts
@@ -1,6 +1,7 @@
 import { expect } from "vitest";
 import { buildEmbeddedRunPayloads } from "./payloads.js";
 
+/** Parameter shape shared by payload tests and the production payload builder. */
 export type BuildPayloadParams = Parameters<typeof buildEmbeddedRunPayloads>[0];
 type RunPayloads = ReturnType<typeof buildEmbeddedRunPayloads>;
 

--- a/src/agents/embedded-agent-runner/run/payloads.test-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test-helpers.ts
@@ -4,6 +4,7 @@ import { buildEmbeddedRunPayloads } from "./payloads.js";
 export type BuildPayloadParams = Parameters<typeof buildEmbeddedRunPayloads>[0];
 type RunPayloads = ReturnType<typeof buildEmbeddedRunPayloads>;
 
+/** Builds embedded-run payloads for tests with stable defaults. */
 export function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
   return buildEmbeddedRunPayloads({
     assistantTexts: [],
@@ -23,6 +24,7 @@ export function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
   });
 }
 
+/** Asserts a single text payload with optional error-state verification. */
 export function expectSinglePayloadText(
   payloads: RunPayloads,
   text: string,
@@ -35,6 +37,7 @@ export function expectSinglePayloadText(
   }
 }
 
+/** Asserts the standard single tool-error payload shape used by payload tests. */
 export function expectSingleToolErrorPayload(
   payloads: RunPayloads,
   params: { title: string; detail?: string; absentDetail?: string },

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -199,7 +199,12 @@ function resolveToolErrorWarningPolicy(params: {
   };
 }
 
-/** Builds user-facing reply payloads from assistant text, tool state, and run metadata. */
+/**
+ * Builds user-facing reply payloads from assistant text, tool state, and run
+ * metadata. This is the final projection point before channel delivery, so it
+ * applies directive parsing, source-reply mirrors, tool warnings, and error
+ * shaping in one place.
+ */
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   toolMetas: ToolMetaEntry[];
@@ -277,6 +282,8 @@ export function buildEmbeddedRunPayloads(params: {
       ...(payload.interactive ? { interactive: payload.interactive } : {}),
       ...(payload.channelData ? { channelData: payload.channelData } : {}),
       sourceReplyMirror: {
+        // Source-reply mirrors need deterministic ids so retries do not emit
+        // duplicate channel replies when the message tool already delivered.
         idempotencyKey:
           payload.idempotencyKey ??
           (params.runId ? `${params.runId}:internal-source-reply:${index}` : undefined),

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -199,6 +199,7 @@ function resolveToolErrorWarningPolicy(params: {
   };
 }
 
+/** Builds user-facing reply payloads from assistant text, tool state, and run metadata. */
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   toolMetas: ToolMetaEntry[];

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -40,6 +40,8 @@ export type LlmBoundaryTokenPressure = {
   renderedChars?: number;
 };
 
+// These estimates intentionally favor safety over tokenizer precision. The
+// precheck only needs route selection before paying for a doomed LLM call.
 function estimateStringTokenPressure(text: string, charsPerToken = ESTIMATED_CHARS_PER_TOKEN) {
   return Math.ceil(estimateStringChars(text) / charsPerToken);
 }
@@ -54,6 +56,8 @@ function estimateJsonPayloadTokenPressure(
       ? Math.ceil(estimateStringChars(serialized) / charsPerToken)
       : 1;
   } catch {
+    // Hostile/cyclic payloads still consume prompt space; keep a bounded
+    // estimate so route selection can continue instead of skipping precheck.
     return 256;
   }
 }
@@ -184,6 +188,7 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   return tokens;
 }
 
+/** Estimates the full rendered LLM boundary, including transcript, system prompt, and prompt. */
 export function estimateLlmBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
@@ -202,6 +207,7 @@ export function estimateLlmBoundaryTokenPressure(params: {
   return Math.max(0, Math.ceil((historyTokens + systemTokens + promptTokens) * SAFETY_MARGIN));
 }
 
+/** Estimates only prompt-side rendered content when transcript tokens are known elsewhere. */
 export function estimateRenderedLlmBoundaryTokenPressure(params: {
   systemPrompt?: string;
   prompt: string;
@@ -215,6 +221,7 @@ export function estimateRenderedLlmBoundaryTokenPressure(params: {
   return Math.max(0, Math.ceil((systemTokens + promptTokens) * SAFETY_MARGIN));
 }
 
+/** Back-compatible name for the transcript-inclusive pre-prompt token estimate. */
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
@@ -239,6 +246,7 @@ function normalizeLlmBoundaryTokenPressure(
   };
 }
 
+/** Routes a prompt through fit, compaction, truncation, or mixed preflight handling. */
 export function shouldPreemptivelyCompactBeforePrompt(params: {
   messages: AgentMessage[];
   unwindowedMessages?: AgentMessage[];
@@ -268,6 +276,8 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
       prompt: params.prompt,
     });
     if (unwindowedEstimatedPromptTokens > estimatedPromptTokens) {
+      // Windowed messages can fit while the durable transcript still overflows;
+      // route from the larger view so the next persistence boundary is safe too.
       estimatedPromptTokens = unwindowedEstimatedPromptTokens;
       messagesForPressure = params.unwindowedMessages;
       pressureSource = "unwindowed_transcript_estimate";
@@ -303,6 +313,8 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     if (toolResultReducibleChars <= 0) {
       route = "compact_only";
     } else if (toolResultReducibleChars >= truncateOnlyThresholdChars) {
+      // Leave a buffer so a truncation-only route still has room for boundary
+      // overhead, summaries, and estimator drift after tool-result reduction.
       route = "truncate_tool_results_only";
     } else {
       route = "compact_then_truncate";
@@ -320,6 +332,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   };
 }
 
+/** Formats one-line diagnostics for route decisions before prompt submission. */
 export function formatPrePromptPrecheckLog(params: {
   result: PreemptiveCompactionDecision;
   sessionKey?: string;
@@ -352,6 +365,7 @@ export function formatPrePromptPrecheckLog(params: {
   );
 }
 
+/** Builds the durable session context-budget snapshot shown after a precheck. */
 export function buildPrePromptContextBudgetStatus(params: {
   result: PreemptiveCompactionDecision;
   provider: string;

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.types.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.types.ts
@@ -1,3 +1,10 @@
+/**
+ * Route chosen by the pre-prompt context budget gate.
+ *
+ * Non-`fits` routes are user-visible enough to flow into mid-turn precheck
+ * payloads and attempt results, so keep these string literals stable unless
+ * every consumer and diagnostic surface is updated together.
+ */
 export type PreemptiveCompactionRoute =
   | "fits"
   | "compact_only"

--- a/src/agents/embedded-agent-runner/run/retry-limit.ts
+++ b/src/agents/embedded-agent-runner/run/retry-limit.ts
@@ -3,7 +3,12 @@ import type { EmbeddedRunLivenessState } from "../types.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
 import type { RetryLimitFailoverDecision } from "./failover-policy.js";
 
-/** Converts retry-limit exhaustion into either model failover or a final error payload. */
+/**
+ * Converts retry-limit exhaustion into either model failover or a final error
+ * payload. Fallback decisions throw FailoverError so the outer run loop can
+ * reuse its normal model-switch path; local exhaustion returns a user-visible
+ * retry-limit payload with the latest agent metadata attached.
+ */
 export function handleRetryLimitExhaustion(params: {
   message: string;
   decision: RetryLimitFailoverDecision;

--- a/src/agents/embedded-agent-runner/run/retry-limit.ts
+++ b/src/agents/embedded-agent-runner/run/retry-limit.ts
@@ -3,6 +3,7 @@ import type { EmbeddedRunLivenessState } from "../types.js";
 import type { EmbeddedAgentMeta, EmbeddedAgentRunResult } from "../types.js";
 import type { RetryLimitFailoverDecision } from "./failover-policy.js";
 
+/** Converts retry-limit exhaustion into either model failover or a final error payload. */
 export function handleRetryLimitExhaustion(params: {
   message: string;
   decision: RetryLimitFailoverDecision;

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -18,6 +18,7 @@ type RuntimeContextPromptParts = {
   runtimeSystemContext?: string;
 };
 
+/** Hidden custom transcript row used to carry runtime context between turns. */
 export type RuntimeContextCustomMessage = {
   role: "custom";
   customType: string;
@@ -29,6 +30,7 @@ export type RuntimeContextCustomMessage = {
 
 type EmptyTranscriptMode = "model-prompt" | "runtime-event";
 
+/** Returns current-turn context text, optionally using resumable backend-safe text. */
 export function buildCurrentInboundPromptContextPrefix(
   context: CurrentInboundPromptContext | undefined,
   options?: { preferResumableText?: boolean },
@@ -40,6 +42,7 @@ export function buildCurrentInboundPromptContextPrefix(
   return text?.trim() ?? "";
 }
 
+/** Prepends current inbound context to the user prompt with the context joiner. */
 export function buildCurrentInboundPrompt(params: {
   context: CurrentInboundPromptContext | undefined;
   prompt: string;
@@ -78,6 +81,8 @@ export function resolveRuntimeContextPromptParts(params: {
 }): RuntimeContextPromptParts {
   const transcriptPrompt = params.transcriptPrompt;
   const shouldExtractInternalRuntimeContext = transcriptPrompt !== undefined;
+  // Only transcript-aware calls extract hidden runtime context. Raw provider
+  // probes and no-transcript prompts preserve delimiter text literally.
   const extracted = shouldExtractInternalRuntimeContext
     ? extractInternalRuntimeContext(params.effectivePrompt)
     : { text: params.effectivePrompt };
@@ -106,6 +111,8 @@ export function resolveRuntimeContextPromptParts(params: {
     : transcriptPrompt
       ? removeLastPromptOccurrence(extracted.text, transcriptPrompt)?.trim()
       : undefined;
+  // Runtime context can come from explicit internal blocks or from prompt text
+  // hidden from the transcript. Keep it separate from model-only retry text.
   const runtimeContext =
     [hiddenRuntimeContext, extracted.runtimeContext]
       .filter((value): value is string => Boolean(value?.trim()))
@@ -150,14 +157,17 @@ function buildRuntimeContextMessageContent(params: {
   ].join("\n");
 }
 
+/** Builds prompt-local system context for runtime details tied to the next turn. */
 export function buildRuntimeContextSystemContext(runtimeContext: string): string {
   return buildRuntimeContextMessageContent({ runtimeContext, kind: "next-turn" });
 }
 
+/** Builds prompt-local system context for runtime-generated event turns. */
 export function buildRuntimeEventSystemContext(runtimeContext: string): string {
   return buildRuntimeContextMessageContent({ runtimeContext, kind: "runtime-event" });
 }
 
+/** Converts hidden runtime context into a non-displayed custom transcript row. */
 export function buildRuntimeContextCustomMessage(
   runtimeContext: string | undefined,
 ): RuntimeContextCustomMessage | undefined {

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -30,7 +30,10 @@ export type RuntimeContextCustomMessage = {
 
 type EmptyTranscriptMode = "model-prompt" | "runtime-event";
 
-/** Returns current-turn context text, optionally using resumable backend-safe text. */
+/**
+ * Returns current-turn context text, optionally choosing resumable text for
+ * backends that need a replay-safe prompt after interruption.
+ */
 export function buildCurrentInboundPromptContextPrefix(
   context: CurrentInboundPromptContext | undefined,
   options?: { preferResumableText?: boolean },
@@ -42,7 +45,7 @@ export function buildCurrentInboundPromptContextPrefix(
   return text?.trim() ?? "";
 }
 
-/** Prepends current inbound context to the user prompt with the context joiner. */
+/** Prepends current inbound context to the user prompt with the context-owned joiner. */
 export function buildCurrentInboundPrompt(params: {
   context: CurrentInboundPromptContext | undefined;
   prompt: string;
@@ -73,6 +76,11 @@ function removeLastPromptOccurrence(text: string, prompt: string): string | null
     .trim();
 }
 
+/**
+ * Separates model-visible prompt text from hidden runtime context carried in
+ * transcript-aware prompts. Runtime-only events get a synthetic user prompt so
+ * provider calls remain valid while the real details stay in system context.
+ */
 export function resolveRuntimeContextPromptParts(params: {
   effectivePrompt: string;
   transcriptPrompt?: string;

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -39,7 +39,11 @@ type HookRunnerLike = {
   ): Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
 
-/** Resolves hook-driven provider/model overrides before runtime model lookup. */
+/**
+ * Resolves hook-driven provider/model overrides before runtime model lookup.
+ * before_model_resolve wins over legacy before_agent_start fields so new hooks
+ * can steer provider selection without being overwritten by old integrations.
+ */
 export async function resolveHookModelSelection(params: {
   prompt: string;
   attachments?: PluginHookBeforeModelResolveAttachment[];
@@ -117,7 +121,10 @@ export function buildBeforeModelResolveAttachments(
   }));
 }
 
-/** Applies context-window policy to the runtime model and returns the effective model. */
+/**
+ * Applies context-window policy to the runtime model and returns the effective
+ * model that downstream session runtime should use for auto-compaction limits.
+ */
 export function resolveEffectiveRuntimeModel(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -39,6 +39,7 @@ type HookRunnerLike = {
   ): Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
 
+/** Resolves hook-driven provider/model overrides before runtime model lookup. */
 export async function resolveHookModelSelection(params: {
   prompt: string;
   attachments?: PluginHookBeforeModelResolveAttachment[];
@@ -103,6 +104,7 @@ export async function resolveHookModelSelection(params: {
   };
 }
 
+/** Projects detected image attachments into before_model_resolve hook metadata. */
 export function buildBeforeModelResolveAttachments(
   images: readonly { mimeType?: string }[] | undefined,
 ): PluginHookBeforeModelResolveAttachment[] | undefined {
@@ -115,6 +117,7 @@ export function buildBeforeModelResolveAttachments(
   }));
 }
 
+/** Applies context-window policy to the runtime model and returns the effective model. */
 export function resolveEffectiveRuntimeModel(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;

--- a/src/agents/embedded-agent-runner/run/stream-wrapper.ts
+++ b/src/agents/embedded-agent-runner/run/stream-wrapper.ts
@@ -1,7 +1,11 @@
 import type { MutableAssistantMessageEventStream } from "../../stream-compat.js";
 import { createStreamIteratorWrapper } from "../../stream-iterator-wrapper.js";
 
-/** Wraps stream iteration so each object event can be observed without replacing the stream. */
+/**
+ * Wraps stream iteration so each object event can be observed without replacing
+ * the stream object. Callers that hold provider-specific stream methods keep
+ * those methods, while the async iterator gains observation side effects.
+ */
 export function wrapStreamObjectEvents(
   stream: MutableAssistantMessageEventStream,
   onEvent: (event: Record<string, unknown>) => void | Promise<void>,

--- a/src/agents/embedded-agent-runner/run/stream-wrapper.ts
+++ b/src/agents/embedded-agent-runner/run/stream-wrapper.ts
@@ -1,6 +1,7 @@
 import type { MutableAssistantMessageEventStream } from "../../stream-compat.js";
 import { createStreamIteratorWrapper } from "../../stream-iterator-wrapper.js";
 
+/** Wraps stream iteration so each object event can be observed without replacing the stream. */
 export function wrapStreamObjectEvents(
   stream: MutableAssistantMessageEventStream,
   onEvent: (event: Record<string, unknown>) => void | Promise<void>,

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -7,6 +7,7 @@ import type { EmbeddedAgentRunResult } from "../types.js";
 
 type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number];
 
+/** Merges media emitted by tools into the user-visible embedded-run payload list. */
 export function mergeAttemptToolMediaPayloads(params: {
   payloads?: EmbeddedRunPayload[];
   toolMediaUrls?: string[];
@@ -29,6 +30,8 @@ export function mergeAttemptToolMediaPayloads(params: {
       params.sourceReplyDeliveryMode === "message_tool_only" &&
       getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror
     ) {
+      // The message tool already delivered this source reply externally; do not
+      // attach generated media to its transcript mirror and send it again.
       return payloads;
     }
     const mergedMediaUrls = Array.from(new Set([...(payload.mediaUrls ?? []), ...mediaUrls]));

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -7,7 +7,11 @@ import type { EmbeddedAgentRunResult } from "../types.js";
 
 type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number];
 
-/** Merges media emitted by tools into the user-visible embedded-run payload list. */
+/**
+ * Merges media emitted by tools into the first deliverable embedded-run payload.
+ * Reasoning-only payloads stay untouched, and message-tool transcript mirrors
+ * are not reused for external media delivery.
+ */
 export function mergeAttemptToolMediaPayloads(params: {
   payloads?: EmbeddedRunPayload[];
   toolMediaUrls?: string[];

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -11,6 +11,9 @@ type EmbeddedRunPayload = NonNullable<EmbeddedAgentRunResult["payloads"]>[number
  * Merges media emitted by tools into the first deliverable embedded-run payload.
  * Reasoning-only payloads stay untouched, and message-tool transcript mirrors
  * are not reused for external media delivery.
+ *
+ * Payload metadata is preserved on mutated replies because downstream source
+ * reply delivery uses that hidden metadata to suppress or mirror messages.
  */
 export function mergeAttemptToolMediaPayloads(params: {
   payloads?: EmbeddedRunPayload[];
@@ -38,6 +41,8 @@ export function mergeAttemptToolMediaPayloads(params: {
       // attach generated media to its transcript mirror and send it again.
       return payloads;
     }
+    // Keep media order stable: existing payload media wins, then newly generated
+    // tool media is appended after trimming/deduplication.
     const mergedMediaUrls = Array.from(new Set([...(payload.mediaUrls ?? []), ...mediaUrls]));
     payloads[payloadIndex] = copyReplyPayloadMetadata(payload, {
       ...payload,

--- a/src/agents/embedded-agent-runner/run/trigger-policy.ts
+++ b/src/agents/embedded-agent-runner/run/trigger-policy.ts
@@ -14,6 +14,7 @@ const EMBEDDED_RUN_TRIGGER_POLICY: Partial<Record<EmbeddedRunTrigger, EmbeddedRu
   },
 };
 
+/** Returns true when the trigger needs the heartbeat-specific prompt prefix. */
 export function shouldInjectHeartbeatPromptForTrigger(trigger?: EmbeddedRunTrigger): boolean {
   return (
     (trigger ? EMBEDDED_RUN_TRIGGER_POLICY[trigger] : undefined)?.injectHeartbeatPrompt ??

--- a/src/agents/embedded-agent-runner/run/trigger-policy.ts
+++ b/src/agents/embedded-agent-runner/run/trigger-policy.ts
@@ -14,7 +14,11 @@ const EMBEDDED_RUN_TRIGGER_POLICY: Partial<Record<EmbeddedRunTrigger, EmbeddedRu
   },
 };
 
-/** Returns true when the trigger needs the heartbeat-specific prompt prefix. */
+/**
+ * Returns true when the trigger needs the heartbeat-specific prompt prefix.
+ * Unknown or omitted triggers use the default policy so new trigger names do
+ * not accidentally inherit heartbeat behavior.
+ */
 export function shouldInjectHeartbeatPromptForTrigger(trigger?: EmbeddedRunTrigger): boolean {
   return (
     (trigger ? EMBEDDED_RUN_TRIGGER_POLICY[trigger] : undefined)?.injectHeartbeatPrompt ??

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -32,12 +32,14 @@ type EmbeddedRunAttemptBase = Omit<
   "provider" | "model" | "authProfileId" | "authProfileIdSource" | "thinkLevel" | "lane" | "enqueue"
 >;
 
+/** Resolved context-window budget and provenance used by prompt assembly and diagnostics. */
 export type EmbeddedRunContextWindowInfo = {
   tokens: number;
   referenceTokens?: number;
   source: "model" | "modelsConfig" | "agentContextTokens" | "default";
 };
 
+/** Fully resolved inputs for one embedded model attempt after run-level normalization. */
 export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   initialReplayState?: EmbeddedRunReplayState;
   /** Pluggable context engine for ingest/assemble/compact lifecycle. */
@@ -73,11 +75,15 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   toolAuthProfileStore?: AuthProfileStore;
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
+  /** Hook result captured before attempt creation so retries reuse the same startup decisions. */
   beforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  /** Number of finalize-hook revisions already consumed for this run. */
   beforeAgentFinalizeRevisionAttempts?: number;
+  /** Maximum finalize-hook revision attempts allowed before returning the model result. */
   maxBeforeAgentFinalizeRevisions?: number;
 };
 
+/** Complete attempt outcome consumed by fallback, persistence, lifecycle, and harness callers. */
 export type EmbeddedRunAttemptResult = {
   aborted: boolean;
   /** True when the abort originated from the caller-provided abortSignal. */
@@ -114,10 +120,14 @@ export type EmbeddedRunAttemptResult = {
         handled?: false;
       };
   sessionIdUsed: string;
+  /** Transcript file used for this attempt after session routing and lock acquisition. */
   sessionFileUsed?: string;
+  /** Trace context propagated into model and tool diagnostics for this attempt. */
   diagnosticTrace?: DiagnosticTraceContext;
   agentHarnessId?: string;
+  /** Classification returned to harness selection for retry/fallback decisions. */
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
+  /** Timeout recovery payload surfaced to the outer run loop and session lifecycle. */
   promptTimeoutOutcome?: {
     message?: string;
     replayInvalid?: boolean;
@@ -125,6 +135,7 @@ export type EmbeddedRunAttemptResult = {
     timeoutPhase?: AgentRunTimeoutPhase;
     providerStarted?: boolean;
   };
+  /** App-server transport failure metadata used to decide whether retry is replay-safe. */
   codexAppServerFailure?: {
     kind: "client_closed_before_turn_completed" | "turn_completion_idle_timeout";
     turnWatchTimeoutKind?: "progress" | "completion" | "terminal";
@@ -138,13 +149,18 @@ export type EmbeddedRunAttemptResult = {
       | "potential_side_effect"
       | "active_item";
   };
+  /** Once-mode bootstrap truncation warnings already surfaced in this session. */
   bootstrapPromptWarningSignaturesSeen?: string[];
+  /** Last bootstrap truncation warning signature persisted for UI/session state. */
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;
+  /** Rendered prompt text captured for diagnostics; may be omitted for compact attempts. */
   finalPromptText?: string;
   messagesSnapshot: AgentMessage[];
+  /** Finalize-hook reason that caused a revised assistant turn. */
   beforeAgentFinalizeRevisionReason?: string;
   assistantTexts: string[];
+  /** Tool metadata collected during the attempt before persistence/liveness decisions. */
   toolMetas: Array<{
     toolName: string;
     meta?: string;
@@ -152,19 +168,28 @@ export type EmbeddedRunAttemptResult = {
     asyncTaskRunId?: string;
     asyncTaskId?: string;
   }>;
+  /** Accepted child sessions spawned by this attempt; used as replay side-effect evidence. */
   acceptedSessionSpawns?: AcceptedSessionSpawn[];
   lastAssistant: AssistantMessage | undefined;
+  /** Assistant message emitted by this attempt before fallback may inspect prior attempts. */
   currentAttemptAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
   didSendViaMessagingTool: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
+  /** Texts delivered through messaging tools, tracked separately from assistant prose. */
   messagingToolSentTexts: string[];
+  /** Media URLs delivered through messaging tools for replay and incomplete-turn checks. */
   messagingToolSentMediaUrls: string[];
+  /** Full messaging send records, including target identity for committed delivery checks. */
   messagingToolSentTargets: MessagingToolSend[];
+  /** Source-reply payloads emitted by tools for channel-specific response handling. */
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   heartbeatToolResponse?: HeartbeatToolResponse;
+  /** Media URLs produced by tools and forwarded into reply payloads. */
   toolMediaUrls?: string[];
+  /** Whether tool audio should be delivered through voice-capable reply paths. */
   toolAudioAsVoice?: boolean;
+  /** Whether produced media came from trusted local paths rather than untrusted remote fetches. */
   toolTrustedLocalMedia?: boolean;
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
@@ -184,11 +209,13 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  /** Provider item lifecycle counters used to avoid replaying while work is still active. */
   itemLifecycle: {
     startedCount: number;
     completedCount: number;
     activeCount: number;
   };
+  /** Late lifecycle metadata setter; outer callers wire this to durable run state. */
   setTerminalLifecycleMeta?: (meta: {
     replayInvalid?: boolean;
     livenessState?: EmbeddedRunLivenessState;

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -4,6 +4,7 @@ export const CHARS_PER_TOKEN_ESTIMATE = 4;
 export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 2;
 const IMAGE_CHAR_ESTIMATE = 8_000;
 
+/** WeakMap cache scoped to one prompt/guard pass; message objects are mutated in place sometimes. */
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
@@ -32,10 +33,12 @@ function estimateUnknownChars(value: unknown): number {
     const serialized = JSON.stringify(value);
     return typeof serialized === "string" ? serialized.length : 0;
   } catch {
+    // Cyclic or hostile blocks still need a bounded estimate so guards can keep moving.
     return 256;
   }
 }
 
+/** Accept both current and legacy tool-result shapes before provider conversion. */
 export function isToolResultMessage(msg: AgentMessage): boolean {
   const role = (msg as { role?: unknown }).role;
   const type = (msg as { type?: unknown }).type;
@@ -67,6 +70,7 @@ function estimateContentBlockChars(content: unknown[]): number {
   return chars;
 }
 
+/** Extract only model-visible text from tool results, skipping malformed legacy blocks. */
 export function getToolResultText(msg: AgentMessage): string {
   const content = getToolResultContent(msg);
   const chunks: string[] = [];
@@ -143,6 +147,7 @@ export function createMessageCharEstimateCache(): MessageCharEstimateCache {
   return new WeakMap<AgentMessage, number>();
 }
 
+/** Estimate message size with object-identity caching for repeated guard passes. */
 export function estimateMessageCharsCached(
   msg: AgentMessage,
   cache: MessageCharEstimateCache,
@@ -163,6 +168,7 @@ export function estimateContextChars(
   return messages.reduce((sum, msg) => sum + estimateMessageCharsCached(msg, cache), 0);
 }
 
+/** Drop a cached estimate after a guard mutates the message object in place. */
 export function invalidateMessageCharsCacheEntry(
   cache: MessageCharEstimateCache,
   msg: AgentMessage,

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -50,6 +50,7 @@ type MidTurnPrecheckOptions = {
 
 export { CONTEXT_LIMIT_TRUNCATION_NOTICE, formatContextLimitTruncationNotice };
 
+/** Attach transcript-only prompt text so context-engine ingestion sees the full user prompt. */
 export function markTranscriptPromptText(message: AgentMessage, text: string): void {
   Object.defineProperty(message, TRANSCRIPT_PROMPT_TEXT_KEY, {
     configurable: true,
@@ -194,6 +195,7 @@ function truncateToolResultToChars(
 
   const rawText = getToolResultText(msg);
   if (!rawText) {
+    // Non-text tool outputs are collapsed to a notice when their estimated cost alone is too high.
     const omittedChars = Math.max(
       1,
       estimateBudgetToTextBudget(Math.max(estimatedChars - maxChars, 1)),
@@ -215,6 +217,7 @@ function truncateToolResultToChars(
 }
 
 function cloneMessagesForGuard(messages: AgentMessage[]): AgentMessage[] {
+  // Preserve caller-visible history; only the provider-bound context view is truncated.
   return messages.map(
     (msg) => ({ ...(msg as unknown as Record<string, unknown>) }) as unknown as AgentMessage,
   );
@@ -263,6 +266,7 @@ function applyMessageMutationInPlace(
   }
   Object.assign(targetRecord, sourceRecord);
   if (cache) {
+    // The object identity stays stable, so cached estimates must be invalidated manually.
     invalidateMessageCharsCacheEntry(cache, target);
   }
 }
@@ -360,6 +364,7 @@ export function installContextEngineLoopHook(params: {
             .slice(0, checkedPrefixLength)
             .some((message, index) => message !== lastSourceMessages?.[index])));
     if (sourceHistoryChanged) {
+      // A compaction/rewrite reset invalidates the previous fence and assembled view.
       lastSeenLength = null;
       lastAssembledView = null;
     }
@@ -430,6 +435,7 @@ export function installContextEngineLoopHook(params: {
         Array.isArray(assembled.messages) &&
         assembled.messages !== providerMessages
       ) {
+        // Cache the compacted view so repeated guard calls without new messages stay stable.
         lastAssembledView = assembled.messages;
         return assembled.messages;
       }
@@ -450,6 +456,7 @@ export function installContextEngineLoopHook(params: {
   };
 }
 
+/** Install a provider-context guard that truncates oversized tool results before model calls. */
 export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -99,6 +99,7 @@ function appendBoundedTruncationSuffix(params: {
       return finalText;
     }
     if (keptText.length === 0) {
+      // Extremely small caps must still return a bounded string, even if the suffix is clipped.
       return finalText.slice(0, params.maxChars);
     }
     const overflow = finalText.length - params.maxChars;
@@ -212,6 +213,7 @@ export function calculateMaxToolResultChars(contextWindowTokens: number): number
   );
 }
 
+/** Resolve the default live tool-result hard cap tier for a model context window. */
 export function resolveAutoLiveToolResultMaxChars(contextWindowTokens: number): number {
   if (!Number.isFinite(contextWindowTokens)) {
     return DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
@@ -226,6 +228,7 @@ export function resolveAutoLiveToolResultMaxChars(contextWindowTokens: number): 
   return DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 }
 
+/** Apply the context-share budget and caller hard cap to a model context window. */
 export function calculateMaxToolResultCharsWithCap(
   contextWindowTokens: number,
   hardCapChars: number,
@@ -236,6 +239,7 @@ export function calculateMaxToolResultCharsWithCap(
   return Math.min(maxChars, Math.max(1, hardCapChars));
 }
 
+/** Resolve the active per-agent live tool-result cap, including config overrides. */
 export function resolveLiveToolResultMaxChars(params: {
   contextWindowTokens: number;
   cfg?: OpenClawConfig;
@@ -587,6 +591,7 @@ function buildToolResultReplacementPlan(params: {
     params.branch,
     oversizedReplacements,
   );
+  // Aggregate pressure is calculated after single-result caps so reductions are not double-counted.
   const aggregateReplacements = buildAggregateToolResultReplacements({
     branch: oversizedTrimmedBranch,
     aggregateBudgetChars: params.aggregateBudgetChars,
@@ -605,6 +610,8 @@ function buildToolResultReplacementPlan(params: {
     aggregateReducibleChars,
   };
 }
+
+/** Estimate how much recovery could reclaim from oversized and aggregate tool results. */
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
@@ -796,6 +803,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   };
 }
 
+/** Rewrite oversized tool results in an in-memory SessionManager branch. */
 export function truncateOversizedToolResultsInSessionManager(params: {
   sessionManager: SessionManager;
   contextWindowTokens: number;
@@ -815,6 +823,7 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   }
 }
 
+/** Rewrite oversized tool results in a persisted transcript file under the session write lock. */
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;
@@ -829,6 +838,7 @@ export async function truncateOversizedToolResultsInSession(params: {
   let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
 
   try {
+    // Transcript-file rewrites take the session write lock so recovery cannot race live appends.
     sessionLock = await acquireSessionWriteLock({
       sessionFile,
       ...resolveSessionWriteLockOptions(params.config),
@@ -870,6 +880,7 @@ export function isOversizedToolResult(
   return getToolResultTextLength(msg) > maxChars;
 }
 
+/** Fast gate for deciding whether recovery should attempt a tool-result truncation pass. */
 export function sessionLikelyHasOversizedToolResults(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -9,8 +9,11 @@ import { listAgentEntries, resolveSessionAgentIds } from "./agent-scope.js";
 export type ModelRuntimePolicySource = "model" | "provider";
 
 export type ResolvedModelRuntimePolicy = {
+  /** Runtime policy selected from the most specific model/provider config that applies. */
   policy?: AgentRuntimePolicyConfig;
+  /** Config layer that supplied the policy. */
   source?: ModelRuntimePolicySource;
+  /** Provider prefix matched from agent model maps when the caller provider was empty. */
   matchedProvider?: string;
 };
 
@@ -22,6 +25,7 @@ type AgentModelRuntimePolicyMatch = {
 };
 
 type AgentModelRuntimePolicyResolution = ResolvedModelRuntimePolicy & {
+  /** Multiple provider-prefixed bare-model matches exist, so selecting either would be unsafe. */
   ambiguous?: true;
 };
 
@@ -62,6 +66,7 @@ function normalizeModelIdForProvider(
   if (slash <= 0) {
     return trimmed;
   }
+  // Provider-qualified model ids only match when their prefix agrees with the caller provider.
   const modelProvider = normalizeProviderId(trimmed.slice(0, slash));
   const expectedProvider = normalizeProviderId(provider ?? "");
   if (expectedProvider && modelProvider !== expectedProvider) {
@@ -92,6 +97,7 @@ function resolvePolicyMatch(
   if (!first) {
     return {};
   }
+  // Empty caller providers can match provider-prefixed bare model entries; fail closed on conflicts.
   if (!callerProvider && matches.some((match) => match.provider !== first.provider)) {
     return { ambiguous: true };
   }
@@ -127,6 +133,7 @@ function modelEntryMatchKind(params: {
   if (!providerMatchesCaller(parsed.provider, callerProvider)) {
     return "none";
   }
+  // Provider wildcards are less specific than exact model entries but beat provider defaults.
   if (parsed.modelId === params.modelId) {
     return "exact";
   }
@@ -185,6 +192,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     params.config.agents?.defaults?.models,
   ];
   const callerProvider = normalizeProviderId(params.provider ?? "");
+  // Agent-specific maps have precedence; defaults are consulted only when the scope has no match.
   for (const models of modelMaps) {
     const scopeMatches: AgentModelRuntimePolicyMatch[] = [];
     for (const [key, entry] of Object.entries(models ?? {})) {
@@ -233,6 +241,7 @@ export function resolveModelRuntimePolicy(params: {
     }
   }
 
+  // Precedence: agent exact > provider model exact > agent provider wildcard > provider default.
   const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({ ...params, matchKind: "exact" });
   if (agentModelPolicy.ambiguous) {
     return {};

--- a/src/agents/model-tool-support.ts
+++ b/src/agents/model-tool-support.ts
@@ -1,3 +1,4 @@
+/** Resolve whether a catalog model can receive tool schemas; absent compat means supported. */
 export function supportsModelTools(model: { compat?: unknown }): boolean {
   const compat =
     model.compat && typeof model.compat === "object"

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -15,6 +15,7 @@ type ToolWithParameters = {
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
 
+/** Convert loose model compat input into the schema-normalizer compat subset. */
 function resolveToolSchemaModelCompat(
   compat: ToolSchemaCompatInput | null | undefined,
 ): ModelCompatConfig | undefined {
@@ -35,6 +36,7 @@ function resolveToolSchemaModelCompat(
   };
 }
 
+/** Cache key includes only compat knobs that affect normalized strict OpenAI schemas. */
 function resolveStrictOpenAISchemaCacheKey(
   modelCompat: ToolSchemaCompatInput | null | undefined,
 ): string {
@@ -61,10 +63,12 @@ function rememberStrictOpenAISchema(schema: object, key: string, value: unknown)
   return value;
 }
 
+/** Reset the schema cache between tests so object-identity reuse cannot leak assertions. */
 export function clearOpenAIToolSchemaCacheForTest(): void {
   strictOpenAISchemaCache = new WeakMap();
 }
 
+/** Normalize a schema into OpenAI strict mode, preserving object identity through a compat-aware cache. */
 export function normalizeStrictOpenAIJsonSchema(
   schema: unknown,
   modelCompat?: ToolSchemaCompatInput | null,
@@ -83,6 +87,7 @@ export function normalizeStrictOpenAIJsonSchema(
   if (cached !== undefined) {
     return cached;
   }
+  // Cache by source schema object and compat key because model-specific keyword stripping can differ.
   return rememberStrictOpenAISchema(
     schemaInput,
     cacheKey,
@@ -129,10 +134,12 @@ function normalizeStrictOpenAIJsonSchemaRecursive(schema: unknown, depth: number
         ? (normalized.properties as Record<string, unknown>)
         : undefined;
     if (properties && Object.keys(properties).length === 0 && !Array.isArray(normalized.required)) {
+      // OpenAI strict schemas require required: [] even for object nodes without properties.
       normalized.required = [];
       changed = true;
     }
     if (depth === 0 && !("additionalProperties" in normalized)) {
+      // Only the root object gets implicit closed-object semantics; nested schemas keep caller intent.
       normalized.additionalProperties = false;
       changed = true;
     }
@@ -153,6 +160,7 @@ export function normalizeOpenAIStrictToolParameters<T>(
   return normalizeStrictOpenAIJsonSchema(schema, toolSchemaCompat) as T;
 }
 
+/** Check whether a schema already satisfies the OpenAI strict tool subset after normalization. */
 export function isStrictOpenAIJsonSchemaCompatible(schema: unknown): boolean {
   return isStrictOpenAIJsonSchemaCompatibleRecursive(normalizeStrictOpenAIJsonSchema(schema));
 }
@@ -163,6 +171,7 @@ type OpenAIStrictToolSchemaDiagnostic = {
   violations: string[];
 };
 
+/** Return per-tool strict-schema violation paths for inventory and provider diagnostics. */
 export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
@@ -304,5 +313,6 @@ export function resolveOpenAIStrictToolFlagForInventory(
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
+  // Inventory advertises strict only when every declared tool can actually satisfy strict mode.
   return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
 }

--- a/src/agents/runtime-plan/auth.ts
+++ b/src/agents/runtime-plan/auth.ts
@@ -13,6 +13,7 @@ const EMPTY_PROVIDER_AUTH_ALIAS_METADATA = {
   plugins: [],
 } satisfies NonNullable<ProviderAuthAliasLookupParams["metadataSnapshot"]>;
 
+/** Map wrapper runtimes to the provider whose auth profiles they can legally forward. */
 function resolveHarnessAuthProvider(params: {
   harnessId?: string;
   harnessRuntime?: string;
@@ -22,6 +23,7 @@ function resolveHarnessAuthProvider(params: {
   return harnessId === "codex" || runtime === "codex" ? CODEX_HARNESS_AUTH_PROVIDER : undefined;
 }
 
+/** Build the auth-profile forwarding plan after provider aliases and harness ownership are resolved. */
 export function buildAgentRuntimeAuthPlan(params: {
   provider: string;
   authProfileProvider?: string;

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -90,6 +90,7 @@ function resolveProviderRuntimeHandleForPlugins(params: {
   });
 }
 
+/** Build the channel-delivery portion of a runtime plan without forcing full plan creation. */
 export function buildAgentRuntimeDeliveryPlan(
   params: BuildAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
@@ -131,12 +132,14 @@ export function buildAgentRuntimeDeliveryPlan(
   };
 }
 
+/** Build the provider-result classification hooks shared by all runtime plans. */
 export function buildAgentRuntimeOutcomePlan(): AgentRuntimeOutcomePlan {
   return {
     classifyRunResult: classifyEmbeddedAgentRunResultForModelFallback,
   };
 }
 
+/** Build the provider/model runtime plan once so hot paths reuse resolved plugin/auth/tool state. */
 export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const config = asOpenClawConfig(params.config);
   const model = asProviderRuntimeModel(params.model);
@@ -144,6 +147,7 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
   const transport = params.resolvedTransport;
   const toolPlanningConfig = config ? projectConfigOntoRuntimeSourceSnapshot(config) : undefined;
   let toolPlanningMetadataSnapshot: PluginMetadataSnapshot | undefined;
+  /** Load plugin metadata lazily because most runtime turns do not need tool-planning catalogs. */
   const loadToolPlanningMetadataSnapshot = () => {
     toolPlanningMetadataSnapshot ??= loadManifestMetadataSnapshot({
       config: toolPlanningConfig,

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -45,6 +45,7 @@ function runtimePlanToolContext(params: {
   };
 }
 
+/** Copy plugin/channel ownership metadata across provider schema normalization clones. */
 function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   if (source === target) {
     return;
@@ -53,6 +54,7 @@ function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   copyChannelAgentToolMeta(source as never, target as never);
 }
 
+/** Restore per-tool metadata only when normalized tools can be matched without name ambiguity. */
 function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TResult = unknown>(
   sourceTools: AgentTool<TSchemaType, TResult>[],
   normalizedTools: AgentTool<TSchemaType, TResult>[],
@@ -81,6 +83,7 @@ function preserveRuntimeToolMetadata<TSchemaType extends TSchema = TSchema, TRes
   return normalizedTools;
 }
 
+/** Normalize the runtime tool set with a prepared plan when available, preserving tool metadata. */
 export function normalizeAgentRuntimeTools<
   TSchemaType extends TSchema = TSchema,
   TResult = unknown,
@@ -115,6 +118,7 @@ export function normalizeAgentRuntimeTools<
   return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);
 }
 
+/** Log provider/model-specific tool schema diagnostics through the same runtime-plan boundary. */
 export function logAgentRuntimeToolDiagnostics(params: AgentRuntimeToolPolicyParams): void {
   const planContext = runtimePlanToolContext(params);
   if (params.runtimePlan) {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -319,10 +319,15 @@ export type AgentRuntimeResolvedRef = {
 };
 
 export type AgentRuntimeAuthPlan = {
+  /** Provider id after plugin auth-alias resolution for the requested runtime provider. */
   providerForAuth: string;
+  /** Provider id that owns the selected auth profile after auth-alias resolution. */
   authProfileProviderForAuth: string;
+  /** Harness-owned auth provider used when a wrapper runtime forwards another provider's profile. */
   harnessAuthProvider?: string;
+  /** Session auth profile forwarded only when runtime/harness provider ownership matches. */
   forwardedAuthProfileId?: string;
+  /** Candidate profile ids forwarded with the selected profile for provider-side fallback. */
   forwardedAuthProfileCandidateIds?: string[];
 };
 
@@ -344,12 +349,16 @@ export type AgentRuntimePromptPlan = {
 export type AgentRuntimePreparedMetadataSnapshot = object;
 
 export type PreparedOpenClawToolPlanning = {
+  /** Already materialized plugin metadata snapshot for tool planning callers that prepared it earlier. */
   metadataSnapshot?: AgentRuntimePreparedMetadataSnapshot;
+  /** Lazy snapshot loader so hot paths do not read plugin metadata unless planning needs it. */
   loadMetadataSnapshot?: () => AgentRuntimePreparedMetadataSnapshot;
 };
 
 export type AgentRuntimeToolPlan = {
+  /** Shared planning inputs passed to OpenClaw-owned tools without coupling callers to plugin internals. */
   preparedPlanning?: PreparedOpenClawToolPlanning;
+  /** Normalize tool schemas for the provider/model currently driving the runtime plan. */
   normalize<TSchemaType extends TSchema = TSchema, TResult = unknown>(
     tools: AgentTool<TSchemaType, TResult>[],
     params?: {
@@ -358,6 +367,7 @@ export type AgentRuntimeToolPlan = {
       model?: AgentRuntimeModel;
     },
   ): AgentTool<TSchemaType, TResult>[];
+  /** Emit provider/model-specific diagnostics for the already selected tool set. */
   logDiagnostics(
     tools: AgentTool[],
     params?: {
@@ -369,12 +379,14 @@ export type AgentRuntimeToolPlan = {
 };
 
 export type AgentRuntimeDeliveryPlan = {
+  /** Detect payloads intentionally used as channel-control silence markers. */
   isSilentPayload(
     payload: Pick<
       AgentRuntimeReplyPayload,
       "text" | "mediaUrl" | "mediaUrls" | "presentation" | "interactive" | "channelData"
     >,
   ): boolean;
+  /** Decide where provider fallback follow-up text should be delivered, if anywhere. */
   resolveFollowupRoute(params: {
     payload: AgentRuntimeReplyPayload;
     originatingChannel?: string;
@@ -385,11 +397,14 @@ export type AgentRuntimeDeliveryPlan = {
 };
 
 export type AgentRuntimeOutcomePlan = {
+  /** Classify provider run results into normalized failover reasons. */
   classifyRunResult: AgentRuntimeOutcomeClassifier;
 };
 
 export type AgentRuntimeTransportPlan = {
+  /** Default transport extra params for the resolved model/provider pair. */
   extraParams: Record<string, unknown>;
+  /** Recompute transport extra params for an override context without rebuilding the whole plan. */
   resolveExtraParams(params?: {
     extraParamsOverride?: Record<string, unknown>;
     thinkingLevel?: AgentRuntimeThinkLevel;
@@ -401,13 +416,17 @@ export type AgentRuntimeTransportPlan = {
 };
 
 export type AgentRuntimePlan = {
+  /** Stable provider/model/harness/transport identity for this runtime plan. */
   resolvedRef: AgentRuntimeResolvedRef;
+  /** Provider plugin handle resolved once and shared by plan subsystems. */
   providerRuntimeHandle?: AgentRuntimeProviderHandle;
   auth: AgentRuntimeAuthPlan;
   prompt: AgentRuntimePromptPlan;
   tools: AgentRuntimeToolPlan;
   transcript: {
+    /** Lazily resolved default transcript policy for the plan's base context. */
     policy: AgentRuntimeTranscriptPolicy;
+    /** Resolve transcript policy for a workspace/model override context. */
     resolvePolicy(params?: {
       workspaceDir?: string;
       modelApi?: string;
@@ -418,6 +437,7 @@ export type AgentRuntimePlan = {
   outcome: AgentRuntimeOutcomePlan;
   transport: AgentRuntimeTransportPlan;
   observability: {
+    /** Compact provider/model ref used in logs and diagnostics. */
     resolvedRef: string;
     provider: string;
     modelId: string;

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -50,6 +50,7 @@ export function guardSessionManager(
   },
 ): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
+    // Reused session managers can pass through multiple runtime attempts; avoid stacking patches.
     return sessionManager as GuardedSessionManager;
   }
 
@@ -73,6 +74,7 @@ export function guardSessionManager(
     }
     const redacted = redactTranscriptMessage(message, opts?.config);
     if (redacted !== message) {
+      // Redaction happens after hooks so plugin rewrites cannot reintroduce unredacted payloads.
       message = redacted;
       changed = true;
     }
@@ -113,6 +115,7 @@ export function guardSessionManager(
         ...(prepared ? { preparedMessage: prepared } : {}),
       });
       if (merged !== withProvenance) {
+        // Prepared turn metadata is single-use; later user messages must persist runtime content.
         pendingPreparedUserTurnMessage = undefined;
       }
       return merged;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -72,6 +72,7 @@ function resolveEntryTranscriptSeq(
   if (cached !== undefined) {
     return cached;
   }
+  // Sequence lookup walks the branch once, then memoizes every visited entry for later appends.
   let seq = 0;
   for (const entry of sessionManager.getBranch(entryId)) {
     if (entry.type === "message" || entry.type === "compaction") {
@@ -136,6 +137,7 @@ function redactPersistedDetailString(
     return redactToolPayloadTextWithConfig(value, redactionConfig);
   }
 
+  // Redaction gets a lookahead window so secrets crossing the truncation boundary are removed.
   const scan = `${value.slice(0, maxChars)}${PERSISTED_DETAIL_REDACTION_BOUNDARY}${value.slice(
     maxChars,
     maxChars + MAX_PERSISTED_DETAIL_REDACTION_LOOKAHEAD_CHARS,
@@ -151,6 +153,7 @@ function redactPersistedDetailString(
     maxChars - Math.min(maxChars, MAX_PERSISTED_DETAIL_BOUNDARY_OVERLAP_CHARS),
   );
   const initialPersistedPrefix = redactedPrefix.slice(0, safePrefixChars);
+  // Never persist a prefix that still looks like the start of a secret-bearing field.
   const persistedPrefix =
     PARTIAL_STRUCTURED_SECRET_VALUE_RE.test(initialPersistedPrefix) ||
     PARTIAL_PRIVATE_KEY_BLOCK_RE.test(initialPersistedPrefix)
@@ -204,6 +207,7 @@ function redactPersistedDetailValue(
     return value;
   }
   if (depth >= 8) {
+    // Tool details can be plugin-provided; cap recursion before hostile structures dominate JSONL.
     return "[OpenClaw persisted detail redacted: max depth exceeded]";
   }
   if (Array.isArray(value)) {
@@ -327,6 +331,7 @@ function enforcePersistedDetailsByteCap(
   if (sanitizedBytes <= MAX_PERSISTED_TOOL_RESULT_DETAILS_BYTES) {
     return value;
   }
+  // Prefer a structured summary over dropping details entirely when sanitized output is too large.
   const fallback = buildPersistedDetailsFallback(
     src,
     originalSize,
@@ -426,6 +431,7 @@ function sanitizeToolResultDetailsForPersistence(
   ]) {
     const field = src[key];
     if (field !== undefined) {
+      // Only stable summary fields survive oversized details; raw diagnostics stay out of JSONL.
       out[key] = redactPersistedSummaryField(
         key,
         field,
@@ -496,6 +502,7 @@ function normalizePersistedToolResultName(
 
   const normalizedFallback = normalizeOptionalString(fallbackName);
   if (normalizedFallback) {
+    // Some providers omit toolResult.toolName, so backfill from the matching pending tool call.
     return { ...toolResult, toolName: normalizedFallback };
   }
 
@@ -516,6 +523,7 @@ function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage): boolea
 
 export { getRawSessionAppendMessage };
 
+/** Install guarded transcript persistence that repairs strict tool-call/tool-result ordering. */
 export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
@@ -645,6 +653,7 @@ export function installSessionToolResultGuard(
     }
     if (allowSyntheticToolResults) {
       for (const [id, name] of pendingState.entries()) {
+        // Synthetic results satisfy strict providers when a run exits before real results arrive.
         const synthetic = makeMissingToolResult({
           toolCallId: id,
           toolName: name,
@@ -767,6 +776,7 @@ export function installSessionToolResultGuard(
       toolCalls.length === 0 &&
       opts?.suppressTranscriptOnlyAssistantPersistence === true
     ) {
+      // Delivery-mirror/gateway-injected assistant notes are UI transcript events, not replay input.
       return undefined;
     }
     if (

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -13,6 +13,7 @@ type PendingToolCallState = {
   shouldFlushBeforeNewToolCalls: (toolCallCount: number) => boolean;
 };
 
+/** Track assistant tool calls until matching toolResult messages arrive or must be repaired. */
 export function createPendingToolCallState(): PendingToolCallState {
   const pending = new Map<string, string | undefined>();
 
@@ -35,6 +36,7 @@ export function createPendingToolCallState(): PendingToolCallState {
     shouldFlushForSanitizedDrop: () => pending.size > 0,
     shouldFlushBeforeNonToolResult: (nextRole: unknown, toolCallCount: number) =>
       pending.size > 0 && (toolCallCount === 0 || nextRole !== "assistant"),
+    // A new assistant tool-call turn can safely discard older pending ids when repair is disabled.
     shouldFlushBeforeNewToolCalls: (toolCallCount: number) => pending.size > 0 && toolCallCount > 0,
   };
 }

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -2,11 +2,15 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { normalizeToolList, normalizeToolName } from "./tool-policy.js";
 
 type ExplicitToolAllowlistSource = {
+  /** User-facing config/runtime source shown in fail-closed diagnostics. */
   label: string;
+  /** Normalized requested tool names from this source. */
   entries: string[];
+  /** Runtime allowlists still fail closed when the run explicitly disables tools. */
   enforceWhenToolsDisabled?: boolean;
 };
 
+/** Collect non-empty explicit allowlists while preserving their diagnostic source labels. */
 export function collectExplicitToolAllowlistSources(
   sources: Array<{ label: string; allow?: string[]; enforceWhenToolsDisabled?: boolean }>,
 ): ExplicitToolAllowlistSource[] {
@@ -25,6 +29,7 @@ export function collectExplicitToolAllowlistSources(
   });
 }
 
+/** Build a fail-closed error when explicit allowlists leave no callable tool. */
 export function buildEmptyExplicitToolAllowlistError(params: {
   sources: ExplicitToolAllowlistSource[];
   callableToolNames: string[];
@@ -33,7 +38,8 @@ export function buildEmptyExplicitToolAllowlistError(params: {
 }): Error | null {
   const sources =
     params.disableTools === true
-      ? params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
+      ? // Inherited config allowlists should not block intentional text-only runs; runtime allowlists should.
+        params.sources.filter((source) => source.enforceWhenToolsDisabled === true)
       : params.sources;
   const callableToolNames = normalizeToolList(params.callableToolNames);
   if (sources.length === 0 || callableToolNames.length > 0) {

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -83,12 +83,14 @@ export function extractToolCallsFromAssistant(
   return toolCalls;
 }
 
+/** Return the first tool-result id while preserving provider-specific fallback fields. */
 export function extractToolResultId(
   msg: Extract<AgentMessage, { role: "toolResult" }>,
 ): string | null {
   return extractToolResultIds(msg)[0] ?? null;
 }
 
+/** Extract every unique tool-result id spelling accepted by provider adapters. */
 export function extractToolResultIds(msg: Extract<AgentMessage, { role: "toolResult" }>): string[] {
   const ids: string[] = [];
   const record = msg as {
@@ -136,6 +138,7 @@ function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
 function toolCallNeedsReplayMutation(block: ReplaySafeToolCallBlock): boolean {
   const rawName = typeof block.name === "string" ? block.name : undefined;
   const trimmedName = rawName?.trim();
+  // Preserved signed turns must replay byte-equivalent tool names; trimming would alter signatures.
   return Boolean(rawName) && rawName !== trimmedName;
 }
 
@@ -174,6 +177,7 @@ function isReplaySafeThinkingAssistantMessage(
     ) {
       return false;
     }
+    // Signed thinking replay can preserve ids only when each tool call is complete and unique.
     seenToolCallIds.add(toolCallId);
   }
   return sawThinking && sawToolCall;
@@ -238,6 +242,7 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
       return candidate;
     }
 
+    // Strict9 has no room for readable suffixes, so collision recovery is hash-only.
     for (let i = 0; i < 1000; i += 1) {
       const hashed = shortHash(`${params.id}:${i}`, STRICT9_LEN);
       if (!params.used.has(hashed)) {
@@ -256,7 +261,7 @@ function makeUniqueToolId(params: { id: string; used: Set<string>; mode: ToolCal
   }
 
   const hash = shortHash(params.id);
-  // Use separator based on mode: none for strict, underscore for non-strict variants
+  // Strict mode must remain alphanumeric, so suffixes cannot use separators.
   const separator = params.mode === "strict" ? "" : "_";
   const maxBaseLen = MAX_LEN - separator.length - hash.length;
   const clippedBase = base.length > maxBaseLen ? base.slice(0, maxBaseLen) : base;
@@ -318,6 +323,7 @@ function createOccurrenceAwareResolver(
     assistantOccurrences.set(id, occurrence);
     const next = allocatePreservingNativeAnthropicId(id, occurrence);
     const pending = pendingByRawId.get(id);
+    // Tool results consume rewritten assistant ids in encounter order for duplicate raw ids.
     if (pending) {
       pending.push(next);
     } else {
@@ -353,6 +359,7 @@ function createOccurrenceAwareResolver(
   const preserveAssistantId = (id: string): string => {
     used.add(id);
     const pending = pendingByRawId.get(id);
+    // Preserved signed turns still reserve ids so later unsanitized duplicates are rewritten.
     if (pending) {
       pending.push(id);
     } else {
@@ -456,6 +463,7 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
   const preserveReplaySafeThinkingToolCallIds =
     options?.preserveReplaySafeThinkingToolCallIds === true;
+  // Reserve replay-safe signed-thinking ids before rewriting so later turns cannot collide with them.
   const replaySafeThinking = preserveReplaySafeThinkingToolCallIds
     ? collectReplaySafeThinkingToolIds(messages, allowedToolNames)
     : undefined;

--- a/src/agents/tool-call-shared.ts
+++ b/src/agents/tool-call-shared.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_:.-]+$/;
 
+/** Normalize an optional provider/tool allowlist into lowercase lookup keys. */
 export function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): Set<string> | null {
   if (!allowedToolNames) {
     return null;
@@ -21,6 +22,7 @@ export function normalizeAllowedToolNames(allowedToolNames?: Iterable<string>): 
   return normalized.size > 0 ? normalized : null;
 }
 
+/** Validate a replayed tool-call name against provider-safe syntax and an optional allowlist. */
 export function isAllowedToolCallName(
   name: unknown,
   allowedToolNames: Set<string> | null,
@@ -32,6 +34,7 @@ export function isAllowedToolCallName(
   if (!trimmed) {
     return false;
   }
+  // Reject unexpected names before allowlist lookup so replay preservation cannot widen tool access.
   if (trimmed.length > TOOL_CALL_NAME_MAX_CHARS || !TOOL_CALL_NAME_RE.test(trimmed)) {
     return false;
   }

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -13,11 +13,14 @@ import {
 export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
 
 type ToolProfilePolicy = {
+  /** Normalized tool ids or group ids granted by the profile. */
   allow?: string[];
+  /** Normalized tool ids or group ids removed from the profile grant. */
   deny?: string[];
 };
 
 type CoreToolSection = {
+  /** Stable section id used by catalog RPCs and group ids. */
   id: string;
   label: string;
   tools: Array<{
@@ -28,11 +31,15 @@ type CoreToolSection = {
 };
 
 type CoreToolDefinition = {
+  /** Canonical tool id used by policy allow/deny lists. */
   id: string;
   label: string;
   description: string;
+  /** Section id used for UI grouping and group:<section> policy expansion. */
   sectionId: string;
+  /** Built-in profiles that grant this tool directly. */
   profiles: ToolProfileId[];
+  /** Whether group:openclaw should include this core tool. */
   includeInOpenClawGroup?: boolean;
 };
 
@@ -379,14 +386,17 @@ function buildCoreToolGroupMap() {
   const openclawTools = CORE_TOOL_DEFINITIONS.filter((tool) => tool.includeInOpenClawGroup).map(
     (tool) => tool.id,
   );
+  // Section groups mirror the catalog UI sections; group:openclaw is the curated product tool set.
   return {
     "group:openclaw": openclawTools,
     ...Object.fromEntries(sectionToolMap.entries()),
   };
 }
 
+/** Built-in tool groups consumed by allow/deny policy expansion. */
 export const CORE_TOOL_GROUPS = buildCoreToolGroupMap();
 
+/** Ordered profile choices exposed by tools catalog RPCs and UI controls. */
 export const PROFILE_OPTIONS = [
   { id: "minimal", label: "Minimal" },
   { id: "coding", label: "Coding" },
@@ -394,6 +404,7 @@ export const PROFILE_OPTIONS = [
   { id: "full", label: "Full" },
 ] as const;
 
+/** Resolve a built-in tool profile to a defensive-copy policy object. */
 export function resolveCoreToolProfilePolicy(profile?: string): ToolProfilePolicy | undefined {
   if (!profile) {
     return undefined;
@@ -411,6 +422,7 @@ export function resolveCoreToolProfilePolicy(profile?: string): ToolProfilePolic
   };
 }
 
+/** Return UI/RPC catalog sections with core tools in stable product order. */
 export function listCoreToolSections(): CoreToolSection[] {
   return CORE_TOOL_SECTION_ORDER.map((section) => ({
     id: section.id,
@@ -423,6 +435,7 @@ export function listCoreToolSections(): CoreToolSection[] {
   })).filter((section) => section.tools.length > 0);
 }
 
+/** Return built-in profile ids that directly include a core tool. */
 export function resolveCoreToolProfiles(toolId: string): ToolProfileId[] {
   const tool = CORE_TOOL_BY_ID.get(toolId);
   if (!tool) {
@@ -431,6 +444,7 @@ export function resolveCoreToolProfiles(toolId: string): ToolProfileId[] {
   return [...tool.profiles];
 }
 
+/** Check whether a tool id is part of the built-in core catalog. */
 export function isKnownCoreToolId(toolId: string): boolean {
   return CORE_TOOL_BY_ID.has(toolId);
 }

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -12,6 +12,7 @@ type ToolDisplayActionSpec = {
   detailKeys?: string[];
 };
 
+/** Static display hints loaded from the tool display config for a tool family or action. */
 export type ToolDisplaySpec = {
   title?: string;
   label?: string;
@@ -19,6 +20,7 @@ export type ToolDisplaySpec = {
   actions?: Record<string, ToolDisplayActionSpec>;
 };
 
+/** Parsed bridge-call target used to render tool-search code as the selected downstream tool. */
 export type ToolSearchCodeDisplayTarget = {
   toolName: string;
   displayToolName?: string;
@@ -35,10 +37,12 @@ type CoerceDisplayValueOptions = {
   maxArrayEntries?: number;
 };
 
+/** Normalize missing tool names to the generic display bucket while preserving configured keys. */
 export function normalizeToolName(name?: string): string {
   return (name ?? "tool").trim();
 }
 
+/** Build a readable fallback title for tools that are not in the display config. */
 export function defaultTitle(name: string): string {
   const cleaned = name.replace(/_/g, " ").trim();
   if (!cleaned) {
@@ -75,6 +79,7 @@ function resolveActionArg(args: unknown): string | undefined {
   return action || undefined;
 }
 
+/** Resolve action-specific verb and detail text from raw tool args and configured detail keys. */
 export function resolveToolVerbAndDetailForArgs(params: {
   toolKey: string;
   args?: unknown;
@@ -123,6 +128,7 @@ function coerceDisplayValue(
     }
     const firstLine = redactToolPayloadText(rawLine);
     if (firstLine.length > maxStringChars) {
+      // Keep both ends of long paths/prompts; the omitted middle is least useful in summaries.
       const half = Math.floor((maxStringChars - 1) / 2);
       return `${firstLine.slice(0, half)}…${firstLine.slice(-(maxStringChars - 1 - half))}`;
     }
@@ -178,11 +184,13 @@ function lookupValueByPath(args: unknown, path: string): unknown {
       return undefined;
     }
     const record = current as Record<string, unknown>;
+    // Detail-key paths are config-owned dotted properties, not arbitrary JS expressions.
     current = record[segment];
   }
   return current;
 }
 
+/** Convert a configured detail key into the compact label shown beside summary values. */
 export function formatDetailKey(raw: string, overrides: Record<string, string> = {}): string {
   let last = "";
   for (const segment of raw.split(".")) {
@@ -415,6 +423,7 @@ function resolveToolSearchCallTarget(
   }
   const idReference = target.match(/^([A-Za-z_$][\w$]*)\.id\b/s);
   if (idReference?.[1]) {
+    // Bridge snippets often describe a tool first, then call tool.id; preserve the real catalog id.
     const describedTarget = collectToolSearchDescribeBindings(code).get(idReference[1]);
     if (describedTarget) {
       return describedTarget;
@@ -502,6 +511,7 @@ function extractObjectLiteralSource(raw: string | undefined): string | undefined
     if (char === "}") {
       depth -= 1;
       if (depth === 0) {
+        // Stop at the matching object boundary so later call syntax is not parsed as args.
         return value.slice(start, i + 1);
       }
     }
@@ -565,6 +575,7 @@ function summarizeToolSearchCallInput(raw: string | undefined): string | undefin
   return undefined;
 }
 
+/** Parse tool-search bridge code into the display target that channel renderers should show. */
 export function resolveToolSearchCodeDisplayTarget(
   args: unknown,
 ): ToolSearchCodeDisplayTarget | undefined {
@@ -724,6 +735,7 @@ function resolveToolVerbAndDetail(params: {
   detailFormatKey?: (raw: string) => string;
 }): { verb?: string; detail?: string } {
   const actionSpec = resolveActionSpec(params.spec, params.action);
+  // Unknown tools still need human verbs; config/action labels override the key-derived fallback.
   const fallbackVerb =
     params.toolKey === "web_search"
       ? "search"
@@ -758,6 +770,7 @@ function resolveToolVerbAndDetail(params: {
   const detailKeys =
     actionSpec?.detailKeys ?? params.spec?.detailKeys ?? params.fallbackDetailKeys ?? [];
   if (!detail && detailKeys.length > 0) {
+    // Configured keys are the generic fallback after tool-specific intent summaries fail.
     detail = resolveDetailFromKeys(params.args, detailKeys, {
       mode: params.detailMode,
       coerce: params.detailCoerce,
@@ -771,6 +784,7 @@ function resolveToolVerbAndDetail(params: {
   return { verb, detail };
 }
 
+/** Normalize a resolved detail string for final display, including multi-field separators. */
 export function formatToolDetailText(
   detail: string | undefined,
   opts: { prefixWithWith?: boolean } = {},

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -5,6 +5,7 @@ type PreambleResult = {
   chdirPath?: string;
 };
 
+/** Remove one balanced quote pair used by shell snippets before display parsing. */
 export function stripOuterQuotes(value: string | undefined): string | undefined {
   if (!value) {
     return value;
@@ -20,6 +21,7 @@ export function stripOuterQuotes(value: string | undefined): string | undefined 
   return trimmed;
 }
 
+/** Split a shell-like command into display tokens without executing or fully parsing shell syntax. */
 export function splitShellWords(input: string | undefined, maxWords = 48): string[] {
   if (!input) {
     return [];
@@ -61,6 +63,7 @@ export function splitShellWords(input: string | undefined, maxWords = 48): strin
       }
       words.push(current);
       if (words.length >= maxWords) {
+        // Display parsing is bounded; later words are rarely needed for intent summaries.
         return words;
       }
       current = "";
@@ -76,6 +79,7 @@ export function splitShellWords(input: string | undefined, maxWords = 48): strin
   return words;
 }
 
+/** Normalize a command token to the lowercase executable name used by display heuristics. */
 export function binaryName(token: string | undefined): string | undefined {
   if (!token) {
     return undefined;
@@ -85,6 +89,7 @@ export function binaryName(token: string | undefined): string | undefined {
   return normalizeLowercaseStringOrEmpty(segment);
 }
 
+/** Read a simple option value from tokenized command words, including --name=value forms. */
 export function optionValue(words: string[], names: string[]): string | undefined {
   const lookup = new Set(names);
 
@@ -112,6 +117,7 @@ export function optionValue(words: string[], names: string[]): string | undefine
   return undefined;
 }
 
+/** Return non-option command arguments while skipping known option payloads. */
 export function positionalArgs(
   words: string[],
   from = 1,
@@ -159,6 +165,7 @@ export function positionalArgs(
   return args;
 }
 
+/** Return the first non-option command argument after known option payloads are skipped. */
 export function firstPositional(
   words: string[],
   from = 1,
@@ -167,6 +174,7 @@ export function firstPositional(
   return positionalArgs(words, from, optionsWithValue)[0];
 }
 
+/** Drop leading env assignments/wrappers so command summaries describe the real executable. */
 export function trimLeadingEnv(words: string[]): string[] {
   if (words.length === 0) {
     return words;
@@ -199,6 +207,7 @@ export function trimLeadingEnv(words: string[]): string[] {
   return words.slice(index);
 }
 
+/** Extract the command passed through sh/bash/zsh/fish -c style wrappers for display. */
 export function unwrapShellWrapper(command: string): string {
   const words = splitShellWords(command, 10);
   if (words.length < 3) {
@@ -261,6 +270,7 @@ function scanTopLevelChars(
   }
 }
 
+/** Split commands on top-level sequencing operators while preserving quoted operators. */
 export function splitTopLevelStages(command: string): string[] {
   const parts: string[] = [];
   let start = 0;
@@ -283,6 +293,7 @@ export function splitTopLevelStages(command: string): string[] {
   return parts.map((part) => part.trim()).filter((part) => part.length > 0);
 }
 
+/** Split pipelines on top-level single pipes while preserving quoted pipes and || stages. */
 export function splitTopLevelPipes(command: string): string[] {
   const parts: string[] = [];
   let start = 0;
@@ -317,6 +328,7 @@ function isPopdCommand(head: string): boolean {
   return binaryName(splitShellWords(head, 2)[0]) === "popd";
 }
 
+/** Strip safe shell setup prefixes and return the command plus inferred cwd for display. */
 export function stripShellPreamble(command: string): PreambleResult {
   let rest = command.trim();
   let chdirPath: string | undefined;
@@ -349,6 +361,7 @@ export function stripShellPreamble(command: string): PreambleResult {
 
     if (isChdir) {
       if (isPopdCommand(head)) {
+        // popd cancels a previously inferred cwd; later summaries should not inherit stale paths.
         chdirPath = undefined;
       } else {
         chdirPath = parseChdirTarget(head) ?? chdirPath;

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -14,6 +14,8 @@ import {
 } from "./tool-display-exec-shell.js";
 import { asRecord } from "./tool-display-record.js";
 
+// This table is intentionally heuristic: display text should explain common commands without
+// pretending to be a shell executor or changing approval/security semantics.
 function summarizeKnownExec(words: string[]): string {
   if (words.length === 0) {
     return "run command";
@@ -284,6 +286,7 @@ function summarizeKnownExec(words: string[]): string {
 function summarizePipeline(stage: string): string {
   const pipeline = splitTopLevelPipes(stage);
   if (pipeline.length > 1) {
+    // Pipelines can be long/noisy; first and last commands usually carry the display intent.
     const first = summarizeKnownExec(trimLeadingEnv(splitShellWords(pipeline[0])));
     const last = summarizeKnownExec(trimLeadingEnv(splitShellWords(pipeline[pipeline.length - 1])));
     const extra = pipeline.length > 2 ? ` (+${pipeline.length - 2} steps)` : "";
@@ -344,6 +347,7 @@ function classifyWorkspacePath(
 function formatCwdSuffix(cwd: string): string | undefined {
   const workspace = classifyWorkspacePath(cwd);
   if (workspace === "sandbox") {
+    // Sandbox paths are implementation noise; the command itself is a better user-facing summary.
     return undefined;
   }
   return workspace ? `(${workspace})` : `(in ${cwd})`;
@@ -436,12 +440,15 @@ function compactRawCommand(raw: string, maxLength = 120): string {
   if (oneLine.length <= maxLength) {
     return oneLine;
   }
+  // Preserve command prefix and target suffix; both are useful when commands contain long paths.
   const half = Math.floor((maxLength - 1) / 2);
   return `${oneLine.slice(0, half)}…${oneLine.slice(-(maxLength - 1 - half))}`;
 }
 
+/** Controls whether exec summaries include the compact raw command alongside the explanation. */
 export type ToolDetailMode = "explain" | "raw";
 
+/** Resolve compact, redacted exec/bash command detail for tool progress displays. */
 export function resolveExecDetail(
   args: unknown,
   options?: { detailMode?: ToolDetailMode },
@@ -478,6 +485,7 @@ export function resolveExecDetail(
   const nodeFragment = nodeName ? ` · node: ${nodeName}` : "";
 
   if (result?.allGeneric !== false && isGenericSummary(summary)) {
+    // Unknown commands use compact raw text so summaries do not invent intent.
     const base = cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
     return `${base}${nodeFragment}`;
   }

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -42,6 +42,7 @@ const DETAIL_LABEL_OVERRIDES: Record<string, string> = {
 };
 const MAX_DETAIL_ENTRIES = 8;
 
+/** Resolve configured display metadata plus argument-derived verb/detail text for a tool call. */
 export function resolveToolDisplay(params: {
   name?: string;
   args?: unknown;
@@ -69,6 +70,7 @@ export function resolveToolDisplay(params: {
   let { detail } = toolDisplayParts;
 
   if (detail) {
+    // Display summaries should stay stable across machines while still hinting at user paths.
     detail = shortenHomeInString(detail);
   }
 
@@ -82,11 +84,13 @@ export function resolveToolDisplay(params: {
   };
 }
 
+/** Redact and normalize optional tool detail before it reaches chat/channel renderers. */
 export function formatToolDetail(display: ToolDisplay): string | undefined {
   const detailRaw = display.detail ? redactToolDetail(display.detail) : undefined;
   return formatToolDetailText(detailRaw);
 }
 
+/** Format the compact emoji/title/detail string used by tool progress surfaces. */
 export function formatToolSummary(display: ToolDisplay): string {
   const detail = formatToolDetail(display);
   if (detail && (display.name === "bash" || display.name === "exec")) {

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -7,12 +7,14 @@ import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js
 
 export type { ToolFsPolicy } from "./tool-fs-policy.types.js";
 
+/** Build a normalized filesystem policy for tool runtime call sites. */
 export function createToolFsPolicy(params: { workspaceOnly?: boolean }): ToolFsPolicy {
   return {
     workspaceOnly: params.workspaceOnly === true,
   };
 }
 
+/** Resolve the effective tools.fs config, with agent config overriding global config. */
 export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: string }): {
   workspaceOnly?: boolean;
 } {
@@ -25,6 +27,7 @@ export function resolveToolFsConfig(params: { cfg?: OpenClawConfig; agentId?: st
   };
 }
 
+/** Return whether tools should be restricted to the prepared workspace root. */
 export function resolveEffectiveToolFsWorkspaceOnly(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -32,6 +35,7 @@ export function resolveEffectiveToolFsWorkspaceOnly(params: {
   return resolveToolFsConfig(params).workspaceOnly === true;
 }
 
+/** Return whether tools may expand reads outside the workspace through policy allowlists. */
 export function resolveEffectiveToolFsRootExpansionAllowed(params: {
   cfg?: OpenClawConfig;
   agentId?: string;

--- a/src/agents/tool-fs-policy.types.ts
+++ b/src/agents/tool-fs-policy.types.ts
@@ -1,3 +1,4 @@
+/** Filesystem access constraints passed to tools that can read or write local paths. */
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
 };

--- a/src/agents/tool-loop-detection-config.ts
+++ b/src/agents/tool-loop-detection-config.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
+/** Resolve loop detection config with agent overrides layered over global tool settings. */
 export function resolveToolLoopDetectionConfig(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -22,6 +23,7 @@ export function resolveToolLoopDetectionConfig(params: {
   return {
     ...global,
     ...agent,
+    // Nested knobs merge independently so an agent can override one detector without clearing siblings.
     detectors: {
       ...global.detectors,
       ...agent.detectors,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -22,6 +22,7 @@ type LoopDetectionResult =
   | { stuck: false }
   | {
       stuck: true;
+      /** Warning lets the model self-correct; critical blocks execution. */
       level: "warning" | "critical";
       detector: LoopDetectorKind;
       count: number;
@@ -72,6 +73,7 @@ function selectHistoryForScope(
   scope?: ToolLoopDetectionScope,
 ): ToolCallRecord[] {
   const runId = normalizeRunId(scope?.runId);
+  // Empty and missing run ids share a scope; concrete run ids stay isolated from prior attempts.
   return history.filter((record) => normalizeRunId(record.runId) === runId);
 }
 
@@ -198,6 +200,7 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
   }
 
   if (status === "running") {
+    // Running exec output can grow; tail-only hashes prevent progress checks from pinning huge logs.
     return digestStable({
       status,
       tail: stringField(details.tail) ?? "",
@@ -328,6 +331,7 @@ function getNoProgressStreak(
     if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
       continue;
     }
+    // Pending calls cannot prove no-progress, but they also should not reset older outcome proof.
     if (typeof record.resultHash !== "string" || !record.resultHash) {
       continue;
     }
@@ -399,6 +403,7 @@ function getPingPongStreak(
     return { count: 0, noProgressEvidence: false };
   }
 
+  // Alternation is enough for a warning; critical ping-pong requires stable outcomes on both sides.
   const tailStart = Math.max(0, history.length - alternatingTailCount);
   let firstHashA: string | undefined;
   let firstHashB: string | undefined;
@@ -451,10 +456,7 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
   return [signatureA, signatureB].toSorted().join("|");
 }
 
-/**
- * Detect if an agent is stuck in a repetitive tool call loop.
- * Checks if the same tool+params combination has been called excessively.
- */
+/** Detect repetitive tool-call patterns before executing the next tool call. */
 export function detectToolCallLoop(
   state: SessionState,
   toolName: string,
@@ -474,6 +476,7 @@ export function detectToolCallLoop(
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
 
+  // Missing tools are critical because retrying the same unavailable tool cannot make progress.
   if (unknownToolStreak.count >= resolvedConfig.unknownToolThreshold) {
     return {
       stuck: true,
@@ -610,10 +613,7 @@ export function detectToolCallLoop(
   return { stuck: false };
 }
 
-/**
- * Record a tool call in the session's history for loop detection.
- * Maintains sliding window of last N calls.
- */
+/** Record a pending tool call and maintain the configured per-session sliding history window. */
 export function recordToolCall(
   state: SessionState,
   toolName: string,
@@ -688,6 +688,7 @@ export function recordToolCallOutcome(
     if (call.resultHash !== undefined) {
       continue;
     }
+    // Attach outcomes to the newest matching pending call to preserve order and run scoping.
     call.resultHash = resultHash;
     call.unknownToolName = outcome.unknownToolName;
     matched = true;
@@ -715,9 +716,7 @@ export function recordToolCallOutcome(
   return recordedOutcome;
 }
 
-/**
- * Get current tool call statistics for a session (for debugging/monitoring).
- */
+/** Summarize current tool-call history for diagnostics and monitoring. */
 export function getToolCallStats(state: SessionState): {
   totalCalls: number;
   uniquePatterns: number;

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -126,6 +126,7 @@ function appendFingerprintAlias(
   return false;
 }
 
+/** Fast name-only mutating-tool hint used when payload details are unavailable. */
 export function isLikelyMutatingToolName(toolName: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(toolName);
   if (!normalized) {
@@ -139,6 +140,7 @@ export function isLikelyMutatingToolName(toolName: string): boolean {
   );
 }
 
+/** Classify a concrete tool call as mutating from its tool name plus structured args. */
 export function isMutatingToolCall(toolName: string, args: unknown): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(toolName);
   const record = asRecord(args);
@@ -184,6 +186,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
   }
 }
 
+/** Build a stable mutation identity for matching later successes against prior failures. */
 export function buildToolActionFingerprint(
   toolName: string,
   args: unknown,
@@ -199,6 +202,7 @@ export function buildToolActionFingerprint(
   if (action) {
     parts.push(`action=${action}`);
   }
+  // Prefer explicit target fields so noisy summaries do not split equivalent mutations.
   let hasStableTarget = false;
   hasStableTarget =
     appendFingerprintAlias(parts, record, "path", [
@@ -254,6 +258,7 @@ function readArgFingerprintValue(
   return undefined;
 }
 
+/** Extract the structured same-file target used for edit/write cross-tool recovery. */
 export function extractFileTarget(toolName: string, args: unknown): FileTarget | undefined {
   if (!isFileMutatingToolName(toolName)) {
     return undefined;
@@ -274,6 +279,7 @@ function fileTargetsEqual(a: FileTarget, b: FileTarget): boolean {
   return (a.path ?? "") === (b.path ?? "") && (a.oldpath ?? "") === (b.oldpath ?? "");
 }
 
+/** Build mutation state carried with tool events for display and failure recovery. */
 export function buildToolMutationState(
   toolName: string,
   args: unknown,
@@ -288,6 +294,7 @@ export function buildToolMutationState(
   };
 }
 
+/** Decide whether a later tool action should clear an existing unresolved mutation failure. */
 export function isSameToolMutationAction(existing: ToolActionRef, next: ToolActionRef): boolean {
   if (existing.actionFingerprint != null || next.actionFingerprint != null) {
     // For mutating flows, fail closed: only clear when both fingerprints exist

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -16,13 +16,16 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
   "apply-patch": "apply_patch",
 };
 
+/** Named tool groups expanded by allow/deny policy evaluation. */
 export const TOOL_GROUPS: Record<string, string[]> = { ...CORE_TOOL_GROUPS };
 
+/** Normalize configured tool names and known aliases into policy lookup keys. */
 export function normalizeToolName(name: string) {
   const normalized = normalizeLowercaseStringOrEmpty(name);
   return TOOL_NAME_ALIASES[normalized] ?? normalized;
 }
 
+/** Return whether a partial user prefix could resolve to an allowed normalized tool name. */
 export function couldNormalizeToolNamePrefixToAllowedTool(
   prefix: string,
   allowedToolNames: Set<string>,
@@ -67,6 +70,7 @@ export function couldNormalizeToolNamePrefixToAllowedTool(
   return false;
 }
 
+/** Normalize a policy list while dropping empty values. */
 export function normalizeToolList(list?: string[]) {
   if (!list) {
     return [];
@@ -74,6 +78,7 @@ export function normalizeToolList(list?: string[]) {
   return list.map(normalizeToolName).filter(Boolean);
 }
 
+/** Expand tool groups after normalization and return unique policy entries. */
 export function expandToolGroups(list?: string[]) {
   const normalized = normalizeToolList(list);
   const expanded: string[] = [];
@@ -88,6 +93,7 @@ export function expandToolGroups(list?: string[]) {
   return uniqueStrings(expanded);
 }
 
+/** Resolve a named built-in tool profile into its allow/deny policy. */
 export function resolveToolProfilePolicy(profile?: string): ToolProfilePolicy | undefined {
   return resolveCoreToolProfilePolicy(profile);
 }

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -9,18 +9,24 @@ export type RuntimeToolInputSchemaJson =
   | { [key: string]: RuntimeToolInputSchemaJson };
 
 export type RuntimeToolInputSchemaProjection = {
+  /** JSON-safe schema clone passed on to runtime/provider compatibility checks. */
   readonly schema: RuntimeToolInputSchemaJson;
+  /** Human-readable paths explaining why the original schema cannot be used as-is. */
   readonly violations: readonly string[];
 };
 
 export type RuntimeToolSchemaDiagnostic = {
+  /** Tool name when readable, otherwise a stable tool[index] fallback. */
   readonly toolName: string;
   readonly toolIndex: number;
+  /** Schema or descriptor paths rejected by this inspection pass. */
   readonly violations: readonly string[];
 };
 
 export type RuntimeToolSchemaInspection<TTool extends Pick<AnyAgentTool, "name" | "parameters">> = {
+  /** Tools whose descriptors and input schemas are safe for the selected inspection mode. */
   readonly tools: readonly TTool[];
+  /** Rejected tools with enough path detail for logs and user-facing diagnostics. */
   readonly diagnostics: readonly RuntimeToolSchemaDiagnostic[];
 };
 
@@ -62,6 +68,7 @@ function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "param
   const entries: RuntimeToolEntryRead<TTool>[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
     try {
+      // Tool arrays can be proxy-backed; isolate unreadable entries instead of rejecting all tools.
       entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
     } catch {
       entries.push(unreadableRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
@@ -161,6 +168,7 @@ function findDynamicSchemaKeywordViolations(
     }
     if (schemaMapKeywords.has(key) && isJsonObject(value)) {
       for (const [schemaName, childSchema] of Object.entries(value)) {
+        // JSON Schema map keywords name child schemas, so include the map key in diagnostic paths.
         violations.push(
           ...findDynamicSchemaKeywordViolations(childSchema, `${path}.${key}.${schemaName}`),
         );
@@ -181,6 +189,7 @@ const schemaMapKeywords = new Set([
   "properties",
 ]);
 
+/** Serialize and validate a tool input schema into the runtime's JSON-object schema contract. */
 export function projectRuntimeToolInputSchema(
   schema: unknown,
   path = "parameters",
@@ -230,6 +239,7 @@ function inspectToolSchema(
     mode === "runtime"
       ? projection.violations
       : projection.violations.filter(
+          // Provider normalizers can strip dynamic keywords, but runtime execution cannot accept them.
           (violation) =>
             violation !== `${schemaPath}.$dynamicRef` &&
             violation !== `${schemaPath}.$dynamicAnchor` &&
@@ -261,18 +271,21 @@ function inspectToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameter
   return { tools: compatibleTools, diagnostics };
 }
 
+/** Return diagnostics for tools that cannot be used directly by the runtime. */
 export function inspectRuntimeToolInputSchemas(
   tools: readonly Pick<AnyAgentTool, "name" | "parameters">[],
 ): RuntimeToolSchemaDiagnostic[] {
   return [...inspectToolEntries(readRuntimeToolEntries(tools), "runtime").diagnostics];
 }
 
+/** Keep only tools whose descriptors and schemas are immediately safe for runtime execution. */
 export function filterRuntimeCompatibleTools<
   TTool extends Pick<AnyAgentTool, "name" | "parameters">,
 >(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {
   return inspectToolEntries(readRuntimeToolEntries(tools), "runtime");
 }
 
+/** Keep tools that provider-specific schema normalization can still repair before submission. */
 export function filterProviderNormalizableTools<
   TTool extends Pick<AnyAgentTool, "name" | "parameters">,
 >(tools: readonly TTool[]): RuntimeToolSchemaInspection<TTool> {

--- a/src/gateway/auth-surface-resolution.ts
+++ b/src/gateway/auth-surface-resolution.ts
@@ -43,6 +43,7 @@ function withDiagnostics<T extends object>(params: {
     : params.result;
 }
 
+/** Resolve auth for non-interactive probes, preserving diagnostics for unresolved secret refs. */
 export async function resolveGatewayProbeSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -141,6 +142,7 @@ export async function resolveGatewayProbeSurfaceAuth(params: {
   });
 }
 
+/** Resolve auth for interactive clients, including explicit overrides and actionable failures. */
 export async function resolveGatewayInteractiveSurfaceAuth(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -271,6 +273,8 @@ export async function resolveGatewayInteractiveSurfaceAuth(params: {
 
   const shouldUsePassword =
     Boolean(explicitPassword ?? envPassword) || (hasConfiguredPassword && !hasConfiguredToken);
+  // Auto mode chooses password only when the caller/config clearly supplies
+  // one; otherwise token remains the local interactive default.
   if (shouldUsePassword) {
     const password = await resolvePassword();
     return {

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -9,6 +9,7 @@ import {
 type GatewayAuthTokenResolutionSource = "explicit" | "config" | "secretRef" | "env";
 type GatewayAuthTokenEnvFallback = "never" | "no-secret-ref" | "always";
 
+/** Resolve the local gateway token while reporting whether a secret ref was configured. */
 export async function resolveGatewayAuthToken(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
@@ -57,6 +58,8 @@ export async function resolveGatewayAuthToken(params: {
     return { secretRefConfigured: false };
   }
 
+  // Secret refs are canonical when configured; env fallback is only allowed by
+  // callers that can tolerate legacy shell-token behavior.
   const resolved = await resolveConfiguredSecretInputString({
     config: params.cfg,
     env: params.env,

--- a/src/gateway/auth-token-source-conflict.ts
+++ b/src/gateway/auth-token-source-conflict.ts
@@ -14,6 +14,7 @@ export type GatewayAuthTokenSourceConflict = {
   diagnostic: string;
 };
 
+/** Detect local shell tokens that can override a different configured gateway token. */
 export function resolveGatewayAuthTokenSourceConflict(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -51,6 +51,7 @@ type RegisteredChatAbortController = {
   cleanup: () => void;
 };
 
+/** Returns true for user text that should stop an active chat run instead of sending a prompt. */
 export function isChatStopCommandText(text: string): boolean {
   return isAbortRequestText(text);
 }
@@ -64,6 +65,7 @@ function createChatAbortSignalReason(stopReason: string | undefined): Error | un
   return reason;
 }
 
+/** Computes chat.send abort-entry expiry, bounded so cleanup neither races nor leaks for a day. */
 export function resolveChatRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -93,6 +95,7 @@ export function resolveChatRunExpiresAtMs(params: {
   return Math.min(max, Math.max(min, target));
 }
 
+/** Computes backend agent-run expiry without chat.send's larger minimum retention window. */
 export function resolveAgentRunExpiresAtMs(params: {
   now: number;
   timeoutMs: number;
@@ -108,6 +111,7 @@ export function resolveAgentRunExpiresAtMs(params: {
   });
 }
 
+/** Registers the AbortController and active-run metadata for one cancellable chat/agent run. */
 export function registerChatAbortController(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   runId: string;
@@ -128,11 +132,15 @@ export function registerChatAbortController(params: {
   const cleanup = () => {
     const entry = params.chatAbortControllers.get(params.runId);
     if (entry?.controller === controller) {
+      // Cleanup only removes the controller it registered; a retried/reused run id may already
+      // point at a newer controller that must remain abortable.
       params.chatAbortControllers.delete(params.runId);
     }
   };
 
   if (!params.sessionKey || params.chatAbortControllers.has(params.runId)) {
+    // Return a usable controller even when the registry rejects the run; callers can wire the
+    // same control flow without giving duplicate/malformed runs abort authority.
     return { controller, registered: false, cleanup };
   }
 
@@ -309,6 +317,7 @@ export type TrackedChatRunAbortOps = {
   nodeSendToSession: ChatAbortOps["nodeSendToSession"];
 };
 
+/** Adapts grouped chat-run state into the generic abort helper used by cleanup paths. */
 export function abortTrackedChatRunById(
   ops: TrackedChatRunAbortOps,
   params: Parameters<typeof abortChatRunById>[1],
@@ -396,6 +405,7 @@ function resolveDefaultGlobalAgentId(ops: ChatAbortOps): string | undefined {
   return cfg ? resolveDefaultAgentId(cfg) : undefined;
 }
 
+/** Aborts one active chat run, clears transient state, and broadcasts the terminal event. */
 export function abortChatRunById(
   ops: ChatAbortOps,
   params: {
@@ -448,11 +458,14 @@ export function abortChatRunById(
   });
   ops.agentRunSeq.delete(runId);
   if (removed?.clientRunId) {
+    // Client and server run ids can differ; clear both sequence counters so a later run does not
+    // inherit stale event numbering after an abort.
     ops.agentRunSeq.delete(removed.clientRunId);
   }
   return { aborted: true };
 }
 
+/** Updates provider ownership after the model/auth provider is known for an active run. */
 export function updateChatRunProvider(
   chatAbortControllers: Map<string, ChatAbortControllerEntry>,
   params: {
@@ -470,6 +483,7 @@ export function updateChatRunProvider(
   return true;
 }
 
+/** Aborts all active runs owned by a provider or auth-provider identity. */
 export function abortChatRunsForProvider(
   ops: ChatAbortOps,
   params: {

--- a/src/gateway/connection-auth.ts
+++ b/src/gateway/connection-auth.ts
@@ -18,6 +18,7 @@ function toGatewayCredentialOptions(
   };
 }
 
+/** Resolves gateway auth for connection setup, including secret-input indirection. */
 export async function resolveGatewayConnectionAuth(
   params: GatewayConnectionAuthOptions,
 ): Promise<{ token?: string; password?: string }> {
@@ -27,6 +28,7 @@ export async function resolveGatewayConnectionAuth(
   });
 }
 
+/** Resolves gateway auth from already-materialized config/env values only. */
 export function resolveGatewayConnectionAuthFromConfig(params: GatewayCredentialConfigOptions): {
   token?: string;
   password?: string;

--- a/src/gateway/hooks.types.ts
+++ b/src/gateway/hooks.types.ts
@@ -1,3 +1,4 @@
 import type { ChannelId } from "../channels/plugins/types.public.js";
 
+/** Channel id accepted by hook routing and message dispatch rules. */
 export type HookMessageChannel = ChannelId;

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -17,9 +17,12 @@ function capLiveAssistantBuffer(text: string): string {
   if (text.length <= MAX_LIVE_CHAT_BUFFER_CHARS) {
     return text;
   }
+  // Keep the newest text because live chat recovery is for the visible tail, not transcript
+  // archival; persisted history remains the source of truth for the full response.
   return text.slice(-MAX_LIVE_CHAT_BUFFER_CHARS);
 }
 
+/** Merges assistant snapshots and deltas into one bounded live-chat buffer. */
 export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
@@ -31,6 +34,8 @@ export function resolveMergedAssistantText(params: {
       return capLiveAssistantBuffer(nextText);
     }
     if (previousText.startsWith(nextText) && !nextDelta) {
+      // Providers can resend a shorter snapshot after a fuller one; without a delta, keep the
+      // longer buffer so live UI does not flicker backward.
       return capLiveAssistantBuffer(previousText);
     }
   }
@@ -43,6 +48,7 @@ export function resolveMergedAssistantText(params: {
   return capLiveAssistantBuffer(previousText);
 }
 
+/** Removes runtime-only metadata and directive tags from assistant event text/deltas. */
 export function normalizeLiveAssistantEventText(params: { text: string; delta?: unknown }): {
   text: string;
   delta: string;
@@ -56,6 +62,7 @@ export function normalizeLiveAssistantEventText(params: { text: string; delta?: 
   };
 }
 
+/** Projects buffered assistant text into the user-visible live chat form. */
 export function projectLiveAssistantBufferedText(
   rawText: string,
   options?: { suppressLeadFragments?: boolean },
@@ -71,6 +78,8 @@ export function projectLiveAssistantBufferedText(
     return { text: "", suppress: true, pendingLeadFragment: false };
   }
   if (options?.suppressLeadFragments !== false && isSuppressedControlReplyLeadFragment(rawText)) {
+    // Hold partial control-reply prefixes until enough text arrives to prove whether they should
+    // be hidden entirely or rendered as ordinary assistant output.
     return { text: rawText, suppress: true, pendingLeadFragment: true };
   }
   const text = startsWithSilentToken(rawText, SILENT_REPLY_TOKEN)
@@ -85,6 +94,7 @@ export function projectLiveAssistantBufferedText(
   return { text, suppress: false, pendingLeadFragment: false };
 }
 
+/** Filters assistant commentary events out of live chat while allowing final transcript storage. */
 export function shouldSuppressAssistantEventForLiveChat(data: unknown): boolean {
   return resolveAssistantEventPhase(data) === "commentary";
 }

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -48,10 +48,12 @@ type KnownNodeCatalog = {
   entriesById: Map<string, KnownNodeEntry>;
 };
 
+/** Normalizes node surfaces from live and durable sources into stable sorted lists. */
 function uniqueSortedStrings(...items: Array<readonly unknown[] | undefined>): string[] {
   return normalizeSortedUniqueTrimmedStringList(items.flatMap((item) => item ?? []));
 }
 
+/** Projects paired-device records into the node catalog only after node-role proof. */
 function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSource {
   return {
     nodeId: entry.deviceId,
@@ -66,6 +68,7 @@ function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSo
   };
 }
 
+/** Projects approved node pairing records into the durable catalog source shape. */
 function buildApprovedNodeSource(entry: NodePairingPairedNode): KnownNodeApprovedSource {
   return {
     nodeId: entry.nodeId,
@@ -92,6 +95,8 @@ function resolveEffectiveLastSeen(params: {
   devicePairing?: KnownNodeDevicePairingSource;
   nodePairing?: KnownNodeApprovedSource;
 }): { lastSeenAtMs?: number; lastSeenReason?: string } {
+  // Live connections are one source of last-seen data, but offline lists should
+  // use the newest durable signal from node-pairing or device-pairing metadata.
   const candidates: Array<{ atMs: number; reason?: string }> = [
     params.live?.connectedAtMs ? { atMs: params.live.connectedAtMs, reason: "connect" } : undefined,
     params.nodePairing?.lastSeenAtMs
@@ -119,6 +124,7 @@ function resolveEffectiveLastSeen(params: {
   };
 }
 
+/** Merges live session data over durable node/device pairing metadata. */
 function buildEffectiveKnownNode(entry: {
   nodeId: string;
   devicePairing?: KnownNodeDevicePairingSource;
@@ -139,6 +145,8 @@ function buildEffectiveKnownNode(entry: {
     deviceFamily: live?.deviceFamily ?? nodePairing?.deviceFamily,
     modelIdentifier: live?.modelIdentifier ?? nodePairing?.modelIdentifier,
     remoteIp: live?.remoteIp ?? nodePairing?.remoteIp ?? devicePairing?.remoteIp,
+    // Connected nodes expose their current effective surface; offline nodes
+    // fall back to the approved durable pairing surface.
     caps: live ? uniqueSortedStrings(live.caps) : uniqueSortedStrings(nodePairing?.caps),
     commands: live
       ? uniqueSortedStrings(live.commands)
@@ -169,11 +177,14 @@ function compareKnownNodes(left: NodeListNode, right: NodeListNode): number {
   return left.nodeId.localeCompare(right.nodeId);
 }
 
+/** Builds a lookup catalog across paired devices, approved nodes, and live sessions. */
 export function createKnownNodeCatalog(params: {
   pairedDevices: readonly PairedDevice[];
   pairedNodes?: readonly NodePairingPairedNode[];
   connectedNodes: readonly NodeSession[];
 }): KnownNodeCatalog {
+  // Device pairings are included only when the current effective role includes
+  // node, so revoked historical node tokens do not keep stale nodes visible.
   const devicePairingById = new Map(
     params.pairedDevices
       .filter((entry) => hasEffectivePairedDeviceRole(entry, "node"))
@@ -209,12 +220,14 @@ export function createKnownNodeCatalog(params: {
   return { entriesById };
 }
 
+/** Lists known nodes with connected nodes first, then stable display-name ordering. */
 export function listKnownNodes(catalog: KnownNodeCatalog): NodeListNode[] {
   return [...catalog.entriesById.values()]
     .map((entry) => entry.effective)
     .toSorted(compareKnownNodes);
 }
 
+/** Returns the merged catalog entry plus its source records for diagnostics/tests. */
 export function getKnownNodeEntry(
   catalog: KnownNodeCatalog,
   nodeId: string,
@@ -222,6 +235,7 @@ export function getKnownNodeEntry(
   return catalog.entriesById.get(nodeId) ?? null;
 }
 
+/** Looks up the effective node-list projection for one node id. */
 export function getKnownNode(catalog: KnownNodeCatalog, nodeId: string): NodeListNode | null {
   return getKnownNodeEntry(catalog, nodeId)?.effective ?? null;
 }

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -234,6 +234,7 @@ export function listDangerousPluginNodeCommands(): string[] {
   return normalizeUniqueStringEntries(commands);
 }
 
+/** Lists non-dangerous plugin node commands that default on for this platform. */
 function listDefaultPluginNodeCommands(platformId: PlatformId): string[] {
   const registry = getActiveRuntimePluginRegistry();
   if (!registry) {
@@ -249,6 +250,7 @@ function listDefaultPluginNodeCommands(platformId: PlatformId): string[] {
   return normalizeUniqueStringEntries(commands);
 }
 
+/** Checks whether a plugin command is unsafe to invoke while iOS is backgrounded. */
 export function isForegroundRestrictedPluginNodeCommand(command: string): boolean {
   const registry = getActiveRuntimePluginRegistry();
   if (!registry) {
@@ -282,6 +284,8 @@ function filterDesktopHostCommandDefaults(params: {
   if (params.includeDesktopHostCommands === true || !isDesktopPlatformId(params.platformId)) {
     return [...params.commands];
   }
+  // Desktop host commands require explicit approval/configuration at runtime;
+  // defaults can appear during pairing review but not as live reconnect grants.
   return params.commands.filter((command) => !DESKTOP_HOST_COMMANDS.has(command));
 }
 
@@ -292,6 +296,8 @@ function filterApprovedRuntimeCommands(params: {
   if (!isDesktopPlatformId(params.platformId)) {
     return [];
   }
+  // Existing approvals only keep commands that are still host-command defaults.
+  // Non-default commands must also remain in gateway.nodes.allowCommands.
   return params.commands.filter((command) => DESKTOP_HOST_COMMANDS.has(command.trim()));
 }
 
@@ -343,6 +349,8 @@ function resolveNodeCommandAllowlistInternal(
       .map((cmd) => cmd.trim())
       .filter((cmd) => cmd && !dangerousPluginCommands.has(cmd)),
   );
+  // Operator config is explicit authority: it can opt into dangerous plugin
+  // commands that default/plugin policy intentionally kept out of auto grants.
   for (const cmd of extra) {
     const trimmed = cmd.trim();
     if (trimmed) {
@@ -358,6 +366,7 @@ function resolveNodeCommandAllowlistInternal(
   return allow;
 }
 
+/** Resolves the live node command allowlist used for node.invoke authorization. */
 export function resolveNodeCommandAllowlist(
   cfg: OpenClawConfig,
   node?: NodeCommandPolicyNode,
@@ -365,6 +374,7 @@ export function resolveNodeCommandAllowlist(
   return resolveNodeCommandAllowlistInternal(cfg, node);
 }
 
+/** Resolves the broader pairing-review allowlist, including desktop host defaults. */
 export function resolveNodePairingCommandAllowlist(
   cfg: OpenClawConfig,
   node?: NodeCommandPolicyNode,
@@ -374,6 +384,7 @@ export function resolveNodePairingCommandAllowlist(
   });
 }
 
+/** Normalizes node-declared commands while preserving first-seen order. */
 function normalizeDeclaredCommands(commands?: readonly string[]): string[] {
   if (!Array.isArray(commands)) {
     return [];
@@ -391,6 +402,7 @@ function normalizeDeclaredCommands(commands?: readonly string[]): string[] {
   return normalized;
 }
 
+/** Filters node-declared commands to those currently allowed by policy. */
 export function normalizeDeclaredNodeCommands(params: {
   declaredCommands?: readonly string[];
   allowlist: Set<string>;
@@ -400,6 +412,7 @@ export function normalizeDeclaredNodeCommands(params: {
   );
 }
 
+/** Validates one node.invoke command against policy and the node's declaration. */
 export function isNodeCommandAllowed(params: {
   command: string;
   declaredCommands?: string[];

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -27,6 +27,7 @@ export type NodeConnectPairingReconcileResult = {
   pendingPairing?: RequestNodePairingResult;
 };
 
+/** Replays approved node commands through the current runtime allowlist. */
 function resolveApprovedReconnectCommands(params: {
   pairedCommands: readonly string[] | undefined;
   allowlist: Set<string>;
@@ -49,6 +50,7 @@ function normalizePermissionMap(
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+/** Keeps only declared approval surfaces that were already approved for this node. */
 function intersectApprovalSurfaceList(params: {
   approved: readonly string[] | undefined;
   declared: readonly string[];
@@ -65,6 +67,8 @@ function intersectPermissionSurface(params: {
   for (const [key, declaredValue] of Object.entries(params.declared ?? {})) {
     const approvedValue = params.approved?.[key];
     if (!declaredValue) {
+      // False declarations are explicit downgrades; keep them effective even
+      // when the prior approved surface did not mention the key.
       entries.push([key, false]);
       continue;
     }
@@ -79,6 +83,7 @@ function intersectPermissionSurface(params: {
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+/** Builds the pending approval payload from the normalized connect surfaces. */
 function buildNodePairingRequestInput(params: {
   nodeId: string;
   connectParams: ConnectParams;
@@ -101,6 +106,7 @@ function buildNodePairingRequestInput(params: {
   };
 }
 
+/** Reconciles a node connect declaration with its approved pairing record. */
 export async function reconcileNodePairingOnConnect(params: {
   cfg: OpenClawConfig;
   connectParams: ConnectParams;
@@ -126,6 +132,9 @@ export async function reconcileNodePairingOnConnect(params: {
   const declaredPermissions = normalizePermissionMap(params.connectParams.permissions);
 
   if (!params.pairedNode) {
+    // First connect starts approval with no live capability/command surface.
+    // The node remains connected only with empty effective surfaces until
+    // maintainers approve the pending request.
     const pendingPairing = await params.requestPairing(
       buildNodePairingRequestInput({
         nodeId,
@@ -178,6 +187,8 @@ export async function reconcileNodePairingOnConnect(params: {
   });
 
   if (hasCommandUpgrade || hasCapabilityChange || hasPermissionChange) {
+    // Upgrades/downgrades both create a fresh review item, but the live node
+    // gets only the intersection of declared and already-approved surfaces.
     const pendingPairing = await params.requestPairing(
       buildNodePairingRequestInput({
         nodeId,

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -126,6 +126,8 @@ export async function applyPluginNodeInvokePolicy(params: {
   if (!entry) {
     const dangerousCommand = findDangerousPluginNodeCommand(registry, params.command);
     if (dangerousCommand) {
+      // Dangerous plugin-hosted commands must be owned by a plugin policy before
+      // transport invoke; the generic node allowlist is not enough for them.
       return {
         ok: false,
         code: "PLUGIN_POLICY_MISSING",
@@ -138,6 +140,8 @@ export async function applyPluginNodeInvokePolicy(params: {
   const invokeNode: OpenClawPluginNodeInvokePolicyContext["invokeNode"] = async (
     override = {},
   ): Promise<OpenClawPluginNodeInvokeTransportResult> => {
+    // Policies may override transport params for the final invoke, while omitted
+    // fields inherit the original gateway request so idempotency and timeout stay bound.
     const res = await params.context.nodeRegistry.invoke({
       nodeId: params.nodeSession.nodeId,
       command: params.command,

--- a/src/gateway/node-pairing-auto-approve.ts
+++ b/src/gateway/node-pairing-auto-approve.ts
@@ -12,6 +12,7 @@ type NodePairingAutoApproveClientIpSource =
   | "loopback-trusted-proxy"
   | "none";
 
+/** Classifies whether the reported node IP came directly or through a trusted proxy. */
 export function resolveNodePairingClientIpSource(params: {
   reportedClientIp?: string;
   hasProxyHeaders: boolean;
@@ -27,6 +28,7 @@ export function resolveNodePairingClientIpSource(params: {
   return params.remoteIsLoopback ? "loopback-trusted-proxy" : "trusted-proxy";
 }
 
+/** Allows first-time node pairing only for narrow trusted-CIDR, non-browser connects. */
 export function shouldAutoApproveNodePairingFromTrustedCidrs(params: {
   existingPairedDevice: boolean;
   role: string;
@@ -58,6 +60,8 @@ export function shouldAutoApproveNodePairingFromTrustedCidrs(params: {
     params.reportedClientIpSource === "none" ||
     params.reportedClientIpSource === "loopback-trusted-proxy"
   ) {
+    // Loopback trusted-proxy reports are not enough proof of remote node origin;
+    // require a direct or non-loopback trusted proxy source before CIDR matching.
     return false;
   }
   if (!params.reportedClientIp) {

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -51,6 +51,7 @@ const PRIORITY_RANK: Record<NodePendingWorkPriority, number> = {
 
 const stateByNodeId = new Map<string, NodePendingWorkState>();
 
+/** Returns the mutable in-memory queue state for a node, creating it on first enqueue. */
 function getOrCreateState(nodeId: string): NodePendingWorkState {
   let state = stateByNodeId.get(nodeId);
   if (!state) {
@@ -63,6 +64,7 @@ function getOrCreateState(nodeId: string): NodePendingWorkState {
   return state;
 }
 
+/** Removes expired explicit items and bumps the revision only when the queue changed. */
 function pruneExpired(state: NodePendingWorkState, nowMs: number): boolean {
   const validNowMs = asDateTimestampMs(nowMs);
   if (validNowMs === undefined) {
@@ -84,12 +86,14 @@ function pruneExpired(state: NodePendingWorkState, nowMs: number): boolean {
   return changed;
 }
 
+/** Drops empty node queues so baseline-only drains do not accumulate state. */
 function pruneStateIfEmpty(nodeId: string, state: NodePendingWorkState) {
   if (state.itemsById.size === 0) {
     stateByNodeId.delete(nodeId);
   }
 }
 
+/** Orders explicit work before drain, with high-priority work first and stable ties. */
 function sortedItems(state: NodePendingWorkState): NodePendingWorkItem[] {
   return [...state.itemsById.values()].toSorted((a, b) => {
     const priorityDelta = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
@@ -103,6 +107,7 @@ function sortedItems(state: NodePendingWorkState): NodePendingWorkItem[] {
   });
 }
 
+/** Synthesizes the always-available status refresh item without storing it. */
 function makeBaselineStatusItem(nowMs: number): NodePendingWorkItem {
   return {
     id: DEFAULT_STATUS_ITEM_ID,
@@ -113,6 +118,7 @@ function makeBaselineStatusItem(nowMs: number): NodePendingWorkItem {
   };
 }
 
+/** Converts optional relative expiry into a bounded absolute timestamp. */
 function resolvePendingWorkExpiresAtMs(expiresInMs: unknown, nowMs: number): number | null {
   if (typeof expiresInMs !== "number" || !Number.isFinite(expiresInMs)) {
     return null;
@@ -120,6 +126,7 @@ function resolvePendingWorkExpiresAtMs(expiresInMs: unknown, nowMs: number): num
   return resolveExpiresAtMsFromDurationMs(Math.max(1_000, Math.trunc(expiresInMs)), { nowMs }) ?? 0;
 }
 
+/** Queues one pending work item per node/type and returns the queue revision. */
 export function enqueueNodePendingWork(params: {
   nodeId: string;
   type: NodePendingWorkType;
@@ -137,6 +144,8 @@ export function enqueueNodePendingWork(params: {
   pruneExpired(state, nowMs);
   const existing = [...state.itemsById.values()].find((item) => item.type === params.type);
   if (existing) {
+    // Work is type-deduped so repeated wake requests do not create unbounded
+    // queues while the node is offline.
     return { revision: state.revision, item: existing, deduped: true };
   }
   const item: NodePendingWorkItem = {
@@ -152,6 +161,7 @@ export function enqueueNodePendingWork(params: {
   return { revision: state.revision, item, deduped: false };
 }
 
+/** Drains explicit work plus an optional synthetic baseline status item. */
 export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): DrainResult {
   const normalizedNodeId = nodeId.trim();
   if (!normalizedNodeId) {
@@ -170,6 +180,8 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   const hasExplicitStatus = explicitItems.some((item) => item.type === "status.request");
   const includeBaseline = opts.includeDefaultStatus !== false && !hasExplicitStatus;
   if (includeBaseline && items.length < maxItems) {
+    // Baseline status keeps reconnecting nodes polling their current state even
+    // when no explicit queued work exists.
     items.push(makeBaselineStatusItem(nowMs));
   }
   const explicitReturnedCount = items.filter((item) => item.id !== DEFAULT_STATUS_ITEM_ID).length;
@@ -181,6 +193,7 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   };
 }
 
+/** Acknowledges explicit queue items; the synthetic baseline item is never removed. */
 export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: string[] }): {
   revision: number;
   removedItemIds: string[];

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -87,6 +87,7 @@ export type SerializedEventPayload = {
   readonly [SERIALIZED_EVENT_PAYLOAD]: true;
 };
 
+/** Serializes once for fan-out paths that send the same payload to many node sockets. */
 export function serializeEventPayload(payload: unknown): SerializedEventPayload | null {
   if (payload === undefined) {
     return null;
@@ -162,6 +163,7 @@ export class NodeRegistry {
   private pendingInvokes = new Map<string, PendingInvoke>();
   private authorizedSystemRunEvents = new Map<string, AuthorizedSystemRunEvent>();
 
+  /** Registers the latest live session for a node id and preserves declared/effective surfaces. */
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
     const nodeId = connect.device?.id ?? connect.client.id;
@@ -225,6 +227,8 @@ export class NodeRegistry {
       return null;
     }
     this.nodesByConn.delete(connId);
+    // Only the current connection owns the node-id slot; stale disconnects must not
+    // remove a newer replacement session for the same node id.
     const unregistersCurrentNode = this.nodesById.get(nodeId)?.connId === connId;
     if (unregistersCurrentNode) {
       this.nodesById.delete(nodeId);
@@ -357,6 +361,8 @@ export class NodeRegistry {
       return null;
     }
 
+    // Effective surfaces can only shrink to approved runtime state; they cannot
+    // invent commands/capabilities the node did not declare during connect.
     const declaredCommands = new Set(node.declaredCommands);
     const nextCommands = surface.commands.filter((command) => declaredCommands.has(command));
     node.commands = nextCommands;
@@ -435,6 +441,8 @@ export class NodeRegistry {
         error: { code: "UNAVAILABLE", message: "failed to send invoke to node" },
       };
     }
+    // system.run emits exec lifecycle events after the invoke frame leaves; remember
+    // the run/session binding so later node events cannot spoof unrelated runs.
     const systemRunEvent = resolvePendingSystemRunEvent({
       command: params.command,
       params: invokeParams,
@@ -628,6 +636,8 @@ export class NodeRegistry {
     if (!pending) {
       return false;
     }
+    // Results are accepted only from the connection that received the invoke, so
+    // reconnects cannot complete or fail stale requests from another socket.
     if (pending.nodeId !== params.nodeId || pending.connId !== params.connId) {
       return false;
     }
@@ -703,6 +713,8 @@ export class NodeRegistry {
       return false;
     }
     try {
+      // payloadJSON carries a branded JSON fragment from serializeEventPayload;
+      // this avoids repeated stringify work while keeping raw-string callers out.
       const payloadFragment = payloadJSON ? `,"payload":${payloadJSON.json}` : "";
       node.client.socket.send(
         `{"type":"event","event":${JSON.stringify(event)}${payloadFragment}}`,

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -38,6 +38,8 @@ export function indexPluginNodeCapabilitySurfaces(
       !existing ||
       resolvePluginNodeCapabilityTtlMs(next) < resolvePluginNodeCapabilityTtlMs(existing)
     ) {
+      // Repeated surface declarations collapse to the shortest TTL so a plugin cannot
+      // dilute a stricter grant by registering the same public surface twice.
       indexed[surface] = next;
     }
   }
@@ -68,6 +70,8 @@ function resolvePluginNodeCapabilityStorageKey(surface: PluginNodeCapabilitySurf
     return undefined;
   }
   const scopeKey = surface.scopeKey?.trim();
+  // The NUL separator keeps plugin-owned scopes unambiguous even when either side
+  // contains URL or identifier punctuation that would be valid in a manifest.
   return scopeKey ? `${normalizedSurface}\0${scopeKey}` : normalizedSurface;
 }
 
@@ -178,6 +182,8 @@ export function normalizePluginNodeCapabilityScopedUrl(
       if (!capabilityFromPath || !canonicalPath.startsWith("/")) {
         malformedScopedPath = true;
       } else {
+        // The proxy authorizes against the query token after restoring the original
+        // path, so downstream handlers never need to understand the scoped URL form.
         url.pathname = canonicalPath;
         if (!url.searchParams.has(PLUGIN_NODE_CAPABILITY_QUERY_PARAM)) {
           url.searchParams.set(PLUGIN_NODE_CAPABILITY_QUERY_PARAM, capabilityFromPath);
@@ -287,6 +293,8 @@ export function hasAuthorizedPluginNodeCapability(params: {
       continue;
     }
     if (safeEqualSecret(entry.capability, params.capability)) {
+      // Successful use slides the grant window, but only after the constant-time
+      // compare succeeds for the exact surface and optional plugin scope.
       entry.expiresAtMs = nextExpiresAtMs;
       return true;
     }

--- a/src/gateway/server-broadcast-types.ts
+++ b/src/gateway/server-broadcast-types.ts
@@ -8,12 +8,14 @@ export type GatewayBroadcastOpts = {
   stateVersion?: GatewayBroadcastStateVersion;
 };
 
+/** Broadcasts a scoped gateway event to every connected client authorized for that event. */
 export type GatewayBroadcastFn = (
   event: string,
   payload: unknown,
   opts?: GatewayBroadcastOpts,
 ) => void;
 
+/** Broadcasts a scoped gateway event only to authorized clients in the target connection set. */
 export type GatewayBroadcastToConnIdsFn = (
   event: string,
   payload: unknown,

--- a/src/gateway/server-broadcast-types.ts
+++ b/src/gateway/server-broadcast-types.ts
@@ -1,8 +1,10 @@
+/** State-version counters attached to broadcasts so clients can ignore stale snapshots. */
 type GatewayBroadcastStateVersion = {
   presence?: number;
   health?: number;
 };
 
+/** Delivery controls for gateway broadcasts, including slow-socket backpressure policy. */
 export type GatewayBroadcastOpts = {
   dropIfSlow?: boolean;
   stateVersion?: GatewayBroadcastStateVersion;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -56,6 +56,8 @@ function serializeFrameField(name: "payload" | "stateVersion", value: unknown): 
   const fieldJSON = JSON.stringify({ [name]: value });
   const keyJSON = JSON.stringify(name);
   const prefix = `{${keyJSON}:`;
+  // Reuse JSON.stringify's escaping while splicing fields into a hand-built frame; this avoids
+  // stringifying payload/stateVersion once per client on broad fan-out.
   return fieldJSON.startsWith(prefix) ? `,${keyJSON}:${fieldJSON.slice(prefix.length, -1)}` : "";
 }
 
@@ -92,6 +94,7 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
   return required.some((scope) => scopes.includes(scope));
 }
 
+/** Creates scoped WebSocket event broadcasters for one gateway runtime's live client set. */
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {
   const clientSeq = new WeakMap<GatewayWsClient, number>();
   const reportedSlowPayloadClients = new WeakSet<GatewayWsClient>();
@@ -163,6 +166,8 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       if (slow && opts?.dropIfSlow) {
         if (!isTargeted) {
+          // Broad ephemeral events still advance per-client sequence so the next delivered frame
+          // makes the dropped event observable as a sequence gap.
           clientSeq.set(c, nextSeq);
         }
         continue;
@@ -180,6 +185,8 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
         if (!isTargeted) {
           clientSeq.set(c, nextSeq);
         }
+        // Targeted sends intentionally omit seq: a connection-specific event should not disturb
+        // the broad event stream clients use for missed-frame detection.
         const base = getFrameBase();
         const seqFragment = eventSeq === undefined ? "" : `,"seq":${eventSeq}`;
         const frame = `{"type":"event","event":${base.eventJSON}${base.payloadFragment}${seqFragment}${base.stateVersionFragment}}`;

--- a/src/gateway/server-channel-runtime.types.ts
+++ b/src/gateway/server-channel-runtime.types.ts
@@ -1,5 +1,6 @@
 import type { ChannelId, ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 
+/** Current runtime status for channels, split by default account and named account. */
 export type ChannelRuntimeSnapshot = {
   channels: Partial<Record<ChannelId, ChannelAccountSnapshot>>;
   channelAccounts: Partial<Record<ChannelId, Record<string, ChannelAccountSnapshot>>>;

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -20,6 +20,7 @@ export type ChatRunRegistry = {
   clear: () => void;
 };
 
+/** Tracks queued client run ids per session so streaming completions adopt the right request. */
 export function createChatRunRegistry(): ChatRunRegistry {
   const chatRunSessions = new Map<string, ChatRunEntry[]>();
 
@@ -58,6 +59,8 @@ export function createChatRunRegistry(): ChatRunRegistry {
     if (idx < 0) {
       return undefined;
     }
+    // Runs can finish or abort out of FIFO order; remove by run id while preserving
+    // the remaining queue so the next streamed completion still adopts correctly.
     const [entry] = queue.splice(idx, 1);
     if (!queue.length) {
       chatRunSessions.delete(sessionId);
@@ -89,6 +92,7 @@ export type ChatRunState = {
   clear: () => void;
 };
 
+/** Owns all per-run streaming buffers and broadcast dedupe state for one gateway runtime. */
 export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
@@ -102,6 +106,8 @@ export function createChatRunState(): ChatRunState {
   const abortedRuns = new Map<string, number>();
 
   const clearRun = (runId: string) => {
+    // One runtime run can buffer assistant text plus role-specific agent events; clearing by
+    // all derived keys prevents stale thinking/tool events from leaking into a reused run id.
     rawBuffers.delete(runId);
     buffers.delete(runId);
     bufferUpdatedAt.delete(runId);
@@ -173,6 +179,7 @@ type ToolRecipientEntry = {
 const TOOL_EVENT_RECIPIENT_TTL_MS = 10 * 60 * 1000;
 const TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS = 30 * 1000;
 
+/** Tracks clients interested in all session-list/event changes. */
 export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRegistry {
   const connIds = new Set<string>();
   const empty = new Set<string>();
@@ -199,6 +206,7 @@ export function createSessionEventSubscriberRegistry(): SessionEventSubscriberRe
   };
 }
 
+/** Tracks per-session message subscribers with reverse indexes for disconnect cleanup. */
 export function createSessionMessageSubscriberRegistry(): SessionMessageSubscriberRegistry {
   const sessionToConnIds = new Map<string, Set<string>>();
   const connToSessionKeys = new Map<string, Set<string>>();
@@ -251,6 +259,8 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
       if (!sessionKeys) {
         return;
       }
+      // Keep both indexes in sync on connection teardown; otherwise a dead socket would keep
+      // receiving targeted session.message broadcasts through the session-to-conn map.
       for (const sessionKey of sessionKeys) {
         const connIds = sessionToConnIds.get(sessionKey);
         if (!connIds) {
@@ -277,6 +287,7 @@ export function createSessionMessageSubscriberRegistry(): SessionMessageSubscrib
   };
 }
 
+/** Tracks targeted tool-event recipients long enough for late final tool events to land. */
 export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
   const recipients = new Map<string, ToolRecipientEntry>();
 
@@ -290,6 +301,8 @@ export function createToolEventRecipientRegistry(): ToolEventRecipientRegistry {
         ? entry.finalizedAt + TOOL_EVENT_RECIPIENT_FINAL_GRACE_MS
         : entry.updatedAt + TOOL_EVENT_RECIPIENT_TTL_MS;
       if (now >= cutoff) {
+        // Finalized runs keep a short grace period for trailing transport events; non-final
+        // runs age out by activity so abandoned runs do not retain connection ids forever.
         recipients.delete(runId);
       }
     }

--- a/src/gateway/server-methods/agent-id-shared.ts
+++ b/src/gateway/server-methods/agent-id-shared.ts
@@ -3,6 +3,7 @@ import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RespondFn } from "./types.js";
 
+/** Resolves empty agent ids to the default agent while rejecting unknown explicit ids. */
 export function resolveAgentIdOrRespondError(params: {
   rawAgentId: unknown;
   respond: RespondFn;

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -26,6 +26,9 @@ const agentRunCache = new Map<string, AgentRunSnapshot>();
 const agentRunStarts = new Map<string, number>();
 const pendingAgentRunErrors = new Map<string, PendingAgentRunError>();
 const pendingAgentRunTimeouts = new Map<string, PendingAgentRunTerminal>();
+// Tracks active waiter counts for leak assertions and diagnostics without
+// changing delivery; event subscriptions remain per-waiter so abort cleanup is
+// scoped to the caller that registered it.
 const agentRunWaiterCounts = new Map<string, number>();
 let agentRunListenerStarted = false;
 
@@ -54,6 +57,8 @@ function recordAgentRunSnapshot(entry: AgentRunSnapshot) {
   pruneAgentRunCache(entry.ts);
   const existing = agentRunCache.get(entry.runId);
   if (existing && shouldPreserveTerminalSnapshot(existing, entry)) {
+    // Keep the older terminal cause but refresh liveness so the TTL reflects
+    // the latest event; this avoids turning retries into weaker cache entries.
     agentRunCache.set(entry.runId, {
       ...existing,
       ts: entry.ts,
@@ -302,6 +307,12 @@ function addAgentRunWaiter(runId: string): () => void {
   };
 }
 
+/**
+ * Waits for a Gateway-visible agent lifecycle terminal snapshot.
+ *
+ * The returned snapshot may come from the shared terminal cache unless
+ * `ignoreCachedSnapshot` asks for only future lifecycle events.
+ */
 export async function waitForAgentJob(params: {
   runId: string;
   timeoutMs: number;

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -60,6 +60,8 @@ export async function createAgentConfigEntry(params: {
         identity: params.identity,
         agentDir: params.agentDir,
       });
+      // applyAgentConfig returns the normalized config shape; replace the draft
+      // so derived defaults and bindings stay aligned with persisted state.
       Object.assign(draft, latestNextConfig);
     },
   });
@@ -86,6 +88,7 @@ export async function updateAgentConfigEntry(params: {
         ...(params.model ? { model: params.model } : {}),
         ...(params.identity ? { identity: params.identity } : {}),
       });
+      // Callers pass only changed fields; applyAgentConfig owns merge semantics.
       Object.assign(draft, latestNextConfig);
     },
   });
@@ -106,6 +109,8 @@ export async function deleteAgentConfigEntry(params: { agentId: string }): Promi
       const agentDir = resolveAgentDir(draft, params.agentId);
       const sessionsDir = resolveSessionTranscriptsDirForAgent(params.agentId);
       const result = pruneAgentConfig(draft, params.agentId);
+      // Capture cleanup paths before pruning so filesystem cleanup happens only
+      // after the config mutation commits successfully.
       Object.assign(draft, result.config);
       return {
         workspaceDir,

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -75,6 +75,7 @@ const agentsHandlerDeps = {
   isWorkspaceSetupCompleted,
 };
 
+/** Test-only dependency seam for safe workspace roots and onboarding-state probes. */
 export const testing = {
   setDepsForTests(
     overrides: Partial<{
@@ -181,6 +182,7 @@ async function statWorkspaceFileSafely(
     }
     try {
       // fs-safe roots can reject fixtures that are still valid regular files for listing metadata.
+      // This fallback is metadata-only; content reads still go through fs-safe.
       const stat = await fs.lstat(path.join(workspaceDir, name));
       return toWorkspaceFileMeta(stat);
     } catch {
@@ -361,6 +363,7 @@ async function writeWorkspaceFileOrRespond(params: {
   await fs.mkdir(params.workspaceDir, { recursive: true });
   try {
     const workspaceRoot = await agentsHandlerDeps.root(params.workspaceDir);
+    // Allowlisted filenames still go through fs-safe so links cannot escape the workspace.
     await workspaceRoot.write(params.name, params.content, { encoding: "utf8" });
   } catch (err) {
     if (err instanceof FsSafeError) {
@@ -659,6 +662,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
         workspaceDir && identityWorkspaceDir !== previousWorkspaceDir
           ? previousWorkspaceDir
           : undefined;
+      // Workspace moves may create a blank identity file; prefer the previous
+      // user-edited identity unless the destination already has content.
       const identityContent = await buildIdentityMarkdownOrRespondUnsafe({
         respond,
         workspaceDir: identityWorkspaceDir,
@@ -744,6 +749,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
       const deleteWorkspace = workspaceSharedWith.length === 0;
       const pathsToTrash = [deleteResult.agentDir, deleteResult.sessionsDir];
       if (deleteWorkspace) {
+        // Only trash workspace files and attestations when no other agent
+        // still resolves to the same workspace root.
         pathsToTrash.unshift(deleteResult.workspaceDir);
         for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
           deleteResult.workspaceDir,
@@ -803,6 +810,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
     let safeRead: ReadResult;
     try {
       const workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
+      // Reads reject hardlinks and symlinks, matching write safety for the
+      // UI-editable agent file allowlist.
       safeRead = await workspaceRoot.read(name, {
         hardlinks: "reject",
         nonBlockingRead: true,
@@ -855,6 +864,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     let workspaceRoot: WorkspaceRoot;
     try {
       workspaceRoot = await agentsHandlerDeps.root(workspaceDir);
+      // The name is allowlisted above; fs-safe still owns containment/link rejection.
       await workspaceRoot.write(name, content, { encoding: "utf8" });
     } catch (err) {
       if (!(err instanceof FsSafeError)) {

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -230,6 +230,7 @@ function artifactId(parts: {
 }
 
 function resolveMessageSeq(message: Record<string, unknown>, fallback: number): number {
+  // Persisted transcript metadata wins so artifact ids survive partial scans and file rewrites.
   const meta = asOptionalRecord(message["__openclaw"]);
   const seq = meta?.seq;
   return typeof seq === "number" && Number.isInteger(seq) && seq > 0 ? seq : fallback;
@@ -260,6 +261,8 @@ function resolveBlockDownload(
   mimeType?: string;
   sizeBytes?: number;
 } {
+  // Prefer inline bytes when available; URLs are returned only if they are safe
+  // handoff targets for clients rather than data URLs or protocol-relative paths.
   const data = asNonEmptyString(block.data);
   const content = asNonEmptyString(block.content);
   const url = asNonEmptyString(block.url) ?? asNonEmptyString(block.openUrl);
@@ -317,6 +320,7 @@ function isArtifactBlock(block: Record<string, unknown>): boolean {
   );
 }
 
+/** Extracts deterministic artifact records from transcript messages without reading session files. */
 export function collectArtifactsFromMessages(params: {
   messages: unknown[];
   sessionKey: string;
@@ -380,6 +384,8 @@ function collectArtifactsFromMessage(params: {
     const includeData = params.downloadArtifactId
       ? params.downloadArtifactId === id
       : params.includeDownloadData !== false;
+    // For download requests only the requested artifact carries bytes; list/get
+    // scans keep payloads out of summaries while preserving the same id search.
     const download = resolveBlockDownload(block, { includeData });
     const summary: ArtifactRecord = {
       id,
@@ -404,6 +410,8 @@ function resolveQuerySession(
   query: ArtifactQuery,
   cfg?: OpenClawConfig,
 ): ResolvedArtifactSession | undefined {
+  // Resolve every query form to one transcript store key before scanning so
+  // run/task lookups cannot cross agent-scoped session stores.
   if (query.sessionKey) {
     const sessionKey = resolveScopedArtifactSessionKey(query.sessionKey, query.agentId, cfg);
     if (!sessionKey) {
@@ -522,6 +530,8 @@ async function findArtifact(
 }
 
 function toSummary(artifact: ArtifactRecord): ArtifactSummary {
+  // Summaries intentionally strip transfer fields; artifacts.download is the
+  // only method that returns bytes or handoff URLs.
   const { data: _dataValue, url: _url, ...summary } = artifact;
   return summary;
 }

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -66,6 +66,8 @@ function resolveChannelOperationParams<TParams extends ChannelOperationParams>(p
   respond: RespondFn;
   validate: Validator<TParams>;
 }): { params: TParams; rawChannel: unknown; channelId: ChannelId } | null {
+  // Shared start/stop/logout parsing keeps validator errors and unknown channel
+  // errors consistent across mutating channel RPC methods.
   const rawParams = params.rawParams;
   if (!assertValidParams(rawParams, params.validate, params.method, params.respond)) {
     return null;
@@ -114,6 +116,8 @@ async function raceWithTimeout<T>(params: {
   timeoutMs: number;
   run: () => Promise<T> | T;
 }): Promise<TimeoutRaceResult<T>> {
+  // Status probes should not pin the event loop or the UI request; unref the
+  // timeout and always clear it after the losing branch settles.
   const timeoutMs = params.timeoutMs;
   let timer: ReturnType<typeof setTimeout> | null = null;
   const timeout = new Promise<{ kind: "timeout" }>((resolve) => {
@@ -221,6 +225,8 @@ function resolveRuntimeAccountSnapshot(params: {
   channelId: ChannelId;
   accountId: string;
 }): ChannelAccountSnapshot | undefined {
+  // Runtime snapshots may carry per-account state or the older single-channel
+  // slot; prefer the account entry and fall back only when it is the same id.
   const accounts = params.runtime.channelAccounts[params.channelId];
   const direct = accounts?.[params.accountId];
   if (direct) {
@@ -245,6 +251,7 @@ function resolveChannelGatewayAccountId(params: {
   );
 }
 
+/** Logs out a channel account after stopping its runtime watcher. */
 export async function logoutChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
@@ -279,6 +286,7 @@ export async function logoutChannelAccount(params: {
   };
 }
 
+/** Starts a channel account runtime and reports whether it is running afterward. */
 export async function startChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
@@ -305,6 +313,7 @@ export async function startChannelAccount(params: {
   };
 }
 
+/** Stops a channel account runtime without clearing channel-owned auth/config. */
 export async function stopChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
@@ -328,6 +337,7 @@ export async function stopChannelAccount(params: {
   };
 }
 
+/** Gateway RPC handlers for channel status, start, stop, and logout operations. */
 export const channelsHandlers: GatewayRequestHandlers = {
   "channels.status": async ({ params, respond, context }) => {
     if (!validateChannelsStatusParams(params)) {
@@ -469,6 +479,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
         channel: channelId as never,
         accountId,
       });
+      // Activity tracking is process-local and may be newer than plugin status
+      // hooks; fill missing timestamps without overriding plugin-provided data.
       if (snapshot.lastInboundAt == null) {
         snapshot.lastInboundAt = activity.inboundAt;
       }
@@ -511,6 +523,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
         ),
         limit: probe ? CHANNEL_STATUS_PROBE_CONCURRENCY : accountIds.length || 1,
       });
+      // Preserve configured account order from the plugin; runTasksWithConcurrency
+      // returns results in task order, not completion order.
       const accounts: ChannelAccountSnapshot[] = [];
       for (const result of results) {
         if (result) {

--- a/src/gateway/server-methods/chat.abort.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort.test-helpers.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 import type { Mock } from "vitest";
 import type { GatewayRequestHandler, RespondFn } from "./types.js";
 
+/** Build the active-run record shape used by chat abort handlers. */
 export function createActiveRun(
   sessionKey: string,
   params: {
@@ -47,6 +48,12 @@ type ChatAbortTestContext = Record<string, unknown> & {
 
 type ChatAbortRespondMock = Mock<RespondFn>;
 
+/**
+ * Create a minimal GatewayRequestContext for chat abort tests.
+ *
+ * The default `clearChatRunState` mirrors production cleanup by removing text,
+ * delta, and buffered event state for the run and its derived event channels.
+ */
 export function createChatAbortContext(
   overrides: Record<string, unknown> = {},
 ): ChatAbortTestContext {
@@ -86,6 +93,7 @@ export function createChatAbortContext(
   return context;
 }
 
+/** Invoke a chat abort handler with the shared test context/request wiring. */
 export async function invokeChatAbortHandler(params: {
   handler: GatewayRequestHandler;
   context: ChatAbortTestContext;

--- a/src/gateway/server-methods/chat.test-helpers.ts
+++ b/src/gateway/server-methods/chat.test-helpers.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 
+/** Create a minimal persisted transcript file for tests that need session-parent injection. */
 export function createTranscriptFixtureSync(params: {
   prefix: string;
   sessionId: string;

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -207,6 +207,8 @@ export function buildCommandsListResult(params: {
 }): CommandsListResult {
   const includeArgs = params.includeArgs !== false;
   const scopeFilter = params.scope ?? "both";
+  // Native scope is provider-facing: command names may be channel-specific.
+  // Text scope is user-facing and keeps slashless primary names plus aliases.
   const nameSurface: CommandNameSurface = scopeFilter === "text" ? "text" : "native";
   const provider = normalizeOptionalLowercaseString(params.provider);
 
@@ -233,6 +235,8 @@ export function buildCommandsListResult(params: {
 
   commands.push(...buildPluginCommandEntries({ provider, nameSurface, cfg: params.cfg }));
 
+  // The protocol cap protects Control UI/autocomplete payload size; ordering
+  // follows registry order so truncation remains deterministic.
   return { commands: commands.slice(0, COMMAND_LIST_MAX_ITEMS) };
 }
 

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -36,6 +36,7 @@ function normalizeStringListForAuthCompare(items: readonly string[] | undefined)
   return [...(items ?? [])].toSorted();
 }
 
+/** Normalizes trusted-proxy auth fields before comparing restart/disconnect impact. */
 function normalizeTrustedProxyAuthForCompare(auth: ReturnType<typeof resolveGatewayAuth>): {
   userHeader: string | undefined;
   requiredHeaders: string[];
@@ -117,6 +118,7 @@ function queueSharedGatewayAuthDisconnect(
   });
 }
 
+/** Refreshes auth generations after the write so new clients bind to the new config. */
 function queueSharedGatewayAuthGenerationRefresh(
   shouldRefresh: boolean,
   nextConfig: OpenClawConfig,

--- a/src/gateway/server-methods/config.test-helpers.ts
+++ b/src/gateway/server-methods/config.test-helpers.ts
@@ -25,6 +25,7 @@ function createGatewayLog(): GatewayLogMocks {
   };
 }
 
+/** Build the read/write snapshot fixture shape expected by config mutation handlers. */
 export function createConfigWriteSnapshot(config: OpenClawConfig) {
   return {
     snapshot: {
@@ -46,6 +47,7 @@ export function createConfigWriteSnapshot(config: OpenClawConfig) {
   };
 }
 
+/** Create config handler options with captured response/log/shared-auth disconnect mocks. */
 export function createConfigHandlerHarness(args?: {
   method?: string;
   params?: unknown;
@@ -76,6 +78,7 @@ export function createConfigHandlerHarness(args?: {
   };
 }
 
+/** Let deferred config-write side effects, such as shared-auth disconnects, run once. */
 export async function flushConfigHandlerMicrotasks() {
   await new Promise<void>((resolve) => {
     queueMicrotask(resolve);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -124,6 +124,7 @@ function requireConfigBaseHash(
   return true;
 }
 
+/** Reads the write snapshot only after enforcing the optimistic config hash. */
 async function readConfigWriteSnapshotOrRespond(
   params: unknown,
   respond: RespondFn,
@@ -294,6 +295,7 @@ function parseValidateConfigFromRawOrRespond(
     return null;
   }
   // Validate against runtime shape, but write the source-shaped config the operator submitted.
+  // This preserves redacted/source-only fields while still checking the resolved runtime contract.
   const projectedValidationCandidate = snapshot.valid
     ? applyMergePatch(
         projectSourceOntoRuntimeShape(snapshot.resolved, snapshot.config),
@@ -425,6 +427,7 @@ async function respondWithConfigRestartWrite(params: {
   params.writeResult.queueFollowUp();
 }
 
+/** Captures both raw config diffs and active secrets-expanded auth changes. */
 function shouldDisconnectSharedAuthClientsForConfigWrite(params: {
   prevConfig: OpenClawConfig;
   nextConfig: OpenClawConfig;

--- a/src/gateway/server-methods/connect.ts
+++ b/src/gateway/server-methods/connect.ts
@@ -1,6 +1,7 @@
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Rejects post-handshake connect requests; real connect auth is handled before RPC dispatch. */
 export const connectHandlers: GatewayRequestHandlers = {
   connect: ({ respond }) => {
     respond(

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -207,6 +207,8 @@ function respondMissingCronJobId(respond: RespondFn, method: string): void {
 }
 
 function cronRunLogPageFilters(params: CronRunsRequestParams) {
+  // Keep pagination/filter fields identical for per-job and all-job run log
+  // readers so UI tabs can switch scopes without reshaping request state.
   return {
     limit: params.limit,
     offset: params.offset,
@@ -221,6 +223,8 @@ function cronRunLogPageFilters(params: CronRunsRequestParams) {
 }
 
 function isCronInvalidRequestError(err: unknown): boolean {
+  // Cron service validation throws typed and string-shaped errors from several
+  // ownership layers; map only known user-spec failures to INVALID_REQUEST.
   const message = formatErrorMessage(err);
   return (
     message.startsWith("unknown cron job id:") ||
@@ -239,6 +243,7 @@ function isCronInvalidRequestError(err: unknown): boolean {
   );
 }
 
+/** Gateway RPC handlers for cron wake, job management, manual runs, and run logs. */
 export const cronHandlers: GatewayRequestHandlers = {
   wake: ({ params, respond, context }) => {
     if (!validateWakeParams(params)) {
@@ -311,6 +316,8 @@ export const cronHandlers: GatewayRequestHandlers = {
       sortDir: p.sortDir,
       agentId: p.agentId,
     });
+    // Delivery previews are resolved at list time because they depend on current
+    // gateway config and default-agent routing, not just the stored job shape.
     const deliveryPreviews = await resolveCronDeliveryPreviews({
       cfg: context.getRuntimeConfig(),
       defaultAgentId: context.cron.getDefaultAgentId(),
@@ -626,6 +633,8 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     if (scope === "all") {
       const jobs = await context.cron.list({ includeDisabled: true });
+      // All-job run logs include job names for display; disabled jobs are still
+      // included because historical runs remain visible after disabling.
       const jobNameById = Object.fromEntries(
         jobs
           .filter((job) => typeof job.id === "string" && typeof job.name === "string")

--- a/src/gateway/server-methods/deleted-agent-guard.test-helpers.ts
+++ b/src/gateway/server-methods/deleted-agent-guard.test-helpers.ts
@@ -15,11 +15,13 @@ vi.mock("../session-utils.js", async () => {
   };
 });
 
+/** Reset hoisted session-utils mocks between deleted-agent guard tests. */
 export function resetDeletedAgentSessionMocks(): void {
   deletedAgentSessionMocks.loadSessionEntry.mockReset();
   deletedAgentSessionMocks.resolveDeletedAgentIdFromSessionKey.mockReset();
 }
 
+/** Mock a stored session whose agent id is no longer present in runtime config. */
 export function mockDeletedAgentSession(orphanKey = "agent:deleted-agent:main"): string {
   deletedAgentSessionMocks.loadSessionEntry.mockReturnValue({
     cfg: {},

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -90,6 +90,7 @@ function normalizeCommandSpans(
   return accepted.length > 0 ? accepted : undefined;
 }
 
+/** Creates exec approval RPC handlers, including optional channel and iOS delivery hooks. */
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
   opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: ExecApprovalIosPushDelivery },
@@ -255,6 +256,8 @@ export function createExecApprovalHandlers(
       });
       const sanitizedCommandDisplay =
         sanitizeExecApprovalDisplayTextWithStatus(effectiveCommandText);
+      // Approval UIs and push payloads carry command previews through public
+      // channels, so reject oversized display text before storing the request.
       if (sanitizedCommandDisplay.truncated || sanitizedCommandDisplay.oversized) {
         respond(
           false,
@@ -367,6 +370,8 @@ export function createExecApprovalHandlers(
             deliveryTasks.push(
               opts.iosPushDelivery
                 .handleRequested(requestEvent, {
+                  // Push targets must pass the same visibility rules as live
+                  // gateway clients so device-scoped approvals do not leak.
                   isTargetVisible: (target) =>
                     isApprovalRecordVisibleToClient({
                       record,

--- a/src/gateway/server-methods/gateway-response.test-helpers.ts
+++ b/src/gateway/server-methods/gateway-response.test-helpers.ts
@@ -4,6 +4,7 @@ type MockCallSource = {
   mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
 };
 
+/** Assert the standard failed gateway RPC tuple: no payload, protocol error shape. */
 export function expectGatewayErrorResponse(
   respond: MockCallSource,
   expected: { code: string; message: string },

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -122,6 +122,8 @@ export const healthHandlers: GatewayRequestHandlers = {
     const { getHealthCache, refreshHealthSnapshot, logHealth } = context;
     const wantsProbe = params?.probe === true;
     const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+    // Sensitive fields are operator-only; health probes can be called from
+    // lower-trust clients, so keep the gate tied to connect-time scopes.
     const includeSensitive = scopes.includes(ADMIN_SCOPE);
     const now = Date.now();
     const cached = getHealthCache();
@@ -159,6 +161,8 @@ export const healthHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      // Explicit probes bypass the cache and may run heavier checks; ordinary
+      // health reads prefer cached data unless cheap runtime facts diverged.
       const snap = await refreshHealthSnapshot({ probe: wantsProbe, includeSensitive });
       respond(true, snap, undefined);
     } catch (err) {

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -62,7 +62,9 @@ export type ModelAuthExpiry = {
 };
 
 export type ModelAuthStatusProfile = {
+  /** Stable profile id from the auth-profile store; UI uses it only as a row key. */
   profileId: string;
+  /** Credential family, not the configured provider auth mode. */
   type: "oauth" | "token" | "api_key";
   status: AuthProfileHealthStatus;
   reasonCode?: AuthCredentialReasonCode;
@@ -70,8 +72,10 @@ export type ModelAuthStatusProfile = {
 };
 
 export type ModelAuthStatusProvider = {
+  /** Normalized provider id used by model routing and auth-profile ownership. */
   provider: string;
   displayName: string;
+  /** OAuth-focused rollup for dashboard health; individual profiles stay below. */
   status: AuthProviderHealthStatus;
   expiry?: ModelAuthExpiry;
   profiles: ModelAuthStatusProfile[];
@@ -89,8 +93,11 @@ export type ModelAuthStatusResult = {
 };
 
 export type ModelAuthLogoutResult = {
+  /** Provider requested by the client, after auth alias normalization. */
   provider: string;
+  /** Profile ids removed from every owning auth-profile store. */
   removedProfiles: string[];
+  /** Active gateway run ids aborted because their provider auth was revoked. */
   abortedRunIds: string[];
 };
 

--- a/src/gateway/server-methods/node-child-process.test-support.ts
+++ b/src/gateway/server-methods/node-child-process.test-support.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { mockNodeBuiltinModule } from "../../plugin-sdk/test-helpers/node-builtin-mocks.js";
 
+/** Mock selected node:child_process exports while preserving unmentioned real exports. */
 export async function mockNodeChildProcessModule(
   overrides: Partial<typeof import("node:child_process")>,
 ) {

--- a/src/gateway/server-methods/nodes-pending.ts
+++ b/src/gateway/server-methods/nodes-pending.ts
@@ -51,6 +51,8 @@ export const nodePendingHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    // Drain is bound to the connected node identity; callers cannot pass an
+    // arbitrary nodeId and read another node's offline work.
     const p = params as { maxItems?: number };
     const drained = drainNodePendingWork(nodeId, {
       maxItems: p.maxItems,
@@ -83,6 +85,8 @@ export const nodePendingHandlers: GatewayRequestHandlers = {
       });
       let wakeTriggered = false;
       if (p.wake !== false && !queued.deduped && !context.nodeRegistry.get(p.nodeId)) {
+        // Wake only for newly queued work. Deduped work means an earlier request
+        // already owns the wake/reconnect attempt for this node/type.
         const wakeReqId = queued.item.id;
         context.logGateway.info(
           `node pending wake start node=${p.nodeId} req=${wakeReqId} type=${queued.item.type}`,

--- a/src/gateway/server-methods/nodes-wake-state.ts
+++ b/src/gateway/server-methods/nodes-wake-state.ts
@@ -16,9 +16,12 @@ type NodeWakeState = {
   inFlight?: Promise<NodeWakeAttempt>;
 };
 
+// Wake state is process-local coalescing only; durable APNs registration state
+// lives in infra/push-apns and is cleared independently on invalid responses.
 export const nodeWakeById = new Map<string, NodeWakeState>();
 export const nodeWakeNudgeById = new Map<string, number>();
 
+/** Clears wake throttles for a node after disconnect/registration lifecycle changes. */
 export function clearNodeWakeState(nodeId: string): void {
   nodeWakeById.delete(nodeId);
   nodeWakeNudgeById.delete(nodeId);

--- a/src/gateway/server-methods/nodes.handlers.invoke-result.ts
+++ b/src/gateway/server-methods/nodes.handlers.invoke-result.ts
@@ -7,6 +7,8 @@ import { respondInvalidParams } from "./nodes.helpers.js";
 import type { GatewayRequestHandler } from "./types.js";
 
 function normalizeNodeInvokeResultParams(params: unknown): unknown {
+  // Older node clients sometimes send null payloadJSON/error fields; normalize
+  // them before schema validation so the registry sees one canonical shape.
   if (!params || typeof params !== "object") {
     return params;
   }
@@ -26,6 +28,7 @@ function normalizeNodeInvokeResultParams(params: unknown): unknown {
   return normalized;
 }
 
+/** Handles node.invoke.result frames and completes the matching in-flight registry request. */
 export const handleNodeInvokeResult: GatewayRequestHandler = async ({
   params,
   respond,

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -53,6 +53,8 @@ export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; err
   const nodeCode = normalizeOptionalString(nodeError?.code) ?? "";
   const nodeMessage = normalizeOptionalString(nodeError?.message) ?? "node invoke failed";
   const message = nodeCode ? `${nodeCode}: ${nodeMessage}` : nodeMessage;
+  // Keep the public error message compact, but preserve the raw node error in
+  // details so operator tooling can inspect provider-specific failure payloads.
   respond(
     false,
     undefined,

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -13,6 +13,7 @@ type ValidatorFn = ((value: unknown) => boolean) & {
   errors?: ValidationError[] | null;
 };
 
+/** Converts gateway-protocol validator errors into a uniform JSON-RPC error response. */
 export function respondInvalidParams(params: {
   respond: RespondFn;
   method: string;
@@ -28,6 +29,7 @@ export function respondInvalidParams(params: {
   );
 }
 
+/** Runs a handler body and reports thrown runtime failures as UNAVAILABLE. */
 export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Promise<void>) {
   try {
     await fn();
@@ -36,6 +38,7 @@ export async function respondUnavailableOnThrow(respond: RespondFn, fn: () => Pr
   }
 }
 
+/** Bridges node invoke result objects into gateway UNAVAILABLE responses. */
 export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; error?: unknown }>(
   respond: RespondFn,
   res: T,

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -141,6 +141,8 @@ function isPersistentBrowserProxyMutation(method: string, path: string): boolean
 }
 
 function isForbiddenBrowserProxyMutation(params: unknown): boolean {
+  // node.invoke may proxy browser reads/ephemeral actions, but persistent profile
+  // mutation must stay behind the dedicated browser/profile APIs.
   if (!params || typeof params !== "object") {
     return false;
   }
@@ -166,6 +168,8 @@ function respondRefreshedPluginSurface(params: {
   client: GatewayClient | null;
   respond: RespondFn;
 }) {
+  // Refresh uses the client's current scoped capability record so returned URLs
+  // inherit the same grant expiry and storage key as the original surface.
   const refreshed = params.client
     ? refreshClientPluginNodeCapability({
         client: params.client,
@@ -220,6 +224,8 @@ async function clearStaleApnsRegistrationIfNeeded(
   nodeId: string,
   params: { status: number; reason?: string },
 ) {
+  // Invalid APNs responses retire only the exact registration that was used,
+  // avoiding races with a newer registration from a reconnecting node.
   if (
     !shouldClearStoredApnsRegistration({
       registration,
@@ -273,6 +279,8 @@ function shouldQueueAsPendingForegroundAction(params: {
 }
 
 function prunePendingNodeActions(nodeId: string, nowMs: number): PendingNodeAction[] {
+  // Foreground-action queues are short-lived hints for iOS wake/reopen flows, not
+  // durable command storage; expired empty queues are removed immediately.
   const queue = pendingNodeActionsById.get(nodeId) ?? [];
   const minTimestampMs = nowMs - NODE_PENDING_ACTION_TTL_MS;
   const live = queue.filter((entry) => entry.enqueuedAtMs >= minTimestampMs);
@@ -325,6 +333,8 @@ function refreshConnectedNodeSurfaceCaches(params: {
 }) {
   const cfg = params.cfg ?? params.context.getRuntimeConfig();
   const { nodeSession } = params;
+  // Remote command shims mirror the effective approved surface, so approval
+  // changes update both cached metadata and generated bins.
   recordRemoteNodeInfo({
     nodeId: nodeSession.nodeId,
     displayName: nodeSession.displayName,
@@ -476,6 +486,8 @@ export async function maybeWakeNodeWithApns(
   nodeId: string,
   opts?: { force?: boolean; wakeReason?: string; cfg?: OpenClawConfig },
 ): Promise<NodeWakeAttempt> {
+  // Coalesce concurrent wake attempts per node; callers waiting on the same
+  // reconnect path should observe one APNs send and one result.
   const state = nodeWakeById.get(nodeId) ?? { lastWakeAtMs: 0 };
   nodeWakeById.set(nodeId, state);
 
@@ -592,6 +604,8 @@ export async function maybeSendNodeWakeNudge(
   nodeId: string,
   opts?: { cfg?: OpenClawConfig },
 ): Promise<NodeWakeNudgeAttempt> {
+  // Nudges are user-visible alerts after background wakes fail, so throttle them
+  // separately from silent wake pushes.
   const startedAtMs = Date.now();
   const withDuration = (
     attempt: Omit<NodeWakeNudgeAttempt, "durationMs">,
@@ -681,6 +695,8 @@ export async function waitForNodeReconnect(params: {
   timeoutMs?: number;
   pollMs?: number;
 }): Promise<boolean> {
+  // Poll the live registry instead of sleeping once; reconnect timing varies
+  // across APNs direct, relay, and already-throttled wake paths.
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, NODE_WAKE_RECONNECT_WAIT_MS, 250);
   const pollMs = resolveTimerTimeoutMs(params.pollMs, NODE_WAKE_RECONNECT_POLL_MS, 50);
   const deadline = Date.now() + timeoutMs;
@@ -1115,6 +1131,8 @@ export const nodeHandlers: GatewayRequestHandlers = {
       const cfg = context.getRuntimeConfig();
       let nodeSession = context.nodeRegistry.get(nodeId);
       if (!nodeSession) {
+        // Offline invokes get a silent wake, bounded reconnect wait, forced retry,
+        // then a visible nudge before returning NOT_CONNECTED.
         const wakeReqId = req.id;
         const wakeFlowStartedAtMs = Date.now();
         context.logGateway.info(
@@ -1374,6 +1392,8 @@ export const nodeHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params as { event: string; payload?: unknown; payloadJSON?: string | null };
+    // Normalize node.event to payloadJSON before lazy-loading the event router,
+    // keeping the heavy event handler out of startup unless a node emits events.
     const payloadJSON =
       typeof p.payloadJSON === "string"
         ? p.payloadJSON

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -3,15 +3,24 @@ import type { GatewayRequestContext } from "./types.js";
 
 const OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 750;
 
+// Slow-catalog warnings are keyed by caller surface so one stuck provider does
+// not turn high-frequency list/chat RPCs into repeated diagnostic noise.
 const loggedSlowCatalogKeys = new Set<string>();
 
-/** Best-effort model catalog loader for metadata enrichment in latency-sensitive RPCs. */
+/**
+ * Best-effort model catalog loader for metadata enrichment in latency-sensitive RPCs.
+ *
+ * Returns `undefined` instead of surfacing catalog load failures so callers can
+ * preserve their primary response contract when provider discovery is optional.
+ */
 export async function loadOptionalServerMethodModelCatalog(
   context: GatewayRequestContext,
   surface: string,
   options?: { logOnceKey?: string },
 ): Promise<ModelCatalogEntry[] | undefined> {
   let timeout: NodeJS.Timeout | undefined;
+  // Use a private sentinel so a real catalog value cannot be confused with the
+  // timeout branch even if a future loader broadens its return shape.
   const timedOut = Symbol("server-method-model-catalog-timeout");
   const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
     timeout = setTimeout(() => resolve(timedOut), OPTIONAL_MODEL_CATALOG_TIMEOUT_MS);

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -5,6 +5,7 @@ const OPTIONAL_MODEL_CATALOG_TIMEOUT_MS = 750;
 
 const loggedSlowCatalogKeys = new Set<string>();
 
+/** Best-effort model catalog loader for metadata enrichment in latency-sensitive RPCs. */
 export async function loadOptionalServerMethodModelCatalog(
   context: GatewayRequestContext,
   surface: string,
@@ -25,6 +26,8 @@ export async function loadOptionalServerMethodModelCatalog(
       const logOnceKey = options?.logOnceKey ?? "session-metadata";
       if (!loggedSlowCatalogKeys.has(logOnceKey)) {
         loggedSlowCatalogKeys.add(logOnceKey);
+        // Catalog data is decorative for these responses; log once per surface
+        // and keep the primary RPC responsive when provider discovery stalls.
         context.logGateway.debug(
           `${surface} continuing without model catalog after ${OPTIONAL_MODEL_CATALOG_TIMEOUT_MS}ms`,
         );

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -26,6 +26,7 @@ import {
 } from "./approval-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Creates plugin approval RPC handlers backed by the shared approval manager. */
 export function createPluginApprovalHandlers(
   manager: ExecApprovalManager<PluginApprovalRequestPayload>,
   opts?: { forwarder?: ExecApprovalForwarder },
@@ -71,6 +72,8 @@ export function createPluginApprovalHandlers(
       const normalizeTrimmedString = (value?: string | null): string | null =>
         normalizeOptionalString(value) || null;
 
+      // Store only normalized turn-source routing fields; delivery helpers use
+      // these later to target the originating channel without trusting raw input.
       const request: PluginApprovalRequestPayload = {
         pluginId: p.pluginId ?? null,
         title: p.title,
@@ -122,6 +125,8 @@ export function createPluginApprovalHandlers(
         twoPhase,
         approvalKind: "plugin",
         deliverRequest: () => {
+          // Plugin approvals are optional-channel aware: the RPC remains valid
+          // even when no external forwarder is configured for this gateway.
           if (!opts?.forwarder?.handlePluginApprovalRequested) {
             return false;
           }

--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -190,6 +190,9 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
         );
         return;
       }
+      // Undefined/object results are shorthand for successful plugin actions;
+      // explicit `ok: false` stays in-band so callers can distinguish plugin
+      // refusal from Gateway transport/protocol failure.
       const wireResult = result?.ok === false ? result : { ok: true as const, ...result };
       if (!validatePluginsSessionActionResult(wireResult)) {
         respond(
@@ -202,6 +205,8 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
         );
         return;
       }
+      // Schema validation proves the top-level result shape; this second pass
+      // rejects non-JSON extension payloads before they cross process/UI bounds.
       const jsonFieldError = result ? validatePluginSessionActionJsonFields(result) : undefined;
       if (jsonFieldError) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, jsonFieldError));

--- a/src/gateway/server-methods/push.ts
+++ b/src/gateway/server-methods/push.ts
@@ -27,6 +27,7 @@ import { respondInvalidParams, respondUnavailableOnThrow } from "./nodes.helpers
 import { normalizeTrimmedString } from "./record-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Gateway RPC handlers for APNs test pushes and browser web-push subscriptions. */
 export const pushHandlers: GatewayRequestHandlers = {
   "push.test": async ({ params, respond, context }) => {
     if (!validatePushTestParams(params)) {
@@ -62,6 +63,8 @@ export const pushHandlers: GatewayRequestHandlers = {
       }
 
       const overrideEnvironment = normalizeApnsEnvironment(params.environment);
+      // push.test may override sandbox/production for diagnostics, but the
+      // stored registration keeps its original environment unless APNs rejects it.
       const result =
         registration.transport === "direct"
           ? await (async () => {
@@ -135,6 +138,8 @@ export const pushHandlers: GatewayRequestHandlers = {
     }
 
     await respondUnavailableOnThrow(respond, async () => {
+      // The public VAPID key is safe to expose to browsers; the private key
+      // stays inside infra/push-web storage/env resolution.
       const vapid = await resolveVapidKeys();
       respond(true, { vapidPublicKey: vapid.publicKey }, undefined);
     });
@@ -151,6 +156,8 @@ export const pushHandlers: GatewayRequestHandlers = {
     }
 
     await respondUnavailableOnThrow(respond, async () => {
+      // Store only the browser endpoint/key material needed for later broadcast;
+      // callers receive the generated subscription id, not the persisted record.
       const subscription = await registerWebPushSubscription({
         endpoint: params.endpoint,
         keys: params.keys,
@@ -170,6 +177,8 @@ export const pushHandlers: GatewayRequestHandlers = {
     }
 
     await respondUnavailableOnThrow(respond, async () => {
+      // Endpoint is the browser-owned stable identifier, so unsubscribe by
+      // endpoint even if the local generated subscription id is unknown.
       const removed = await clearWebPushSubscriptionByEndpoint(params.endpoint);
       respond(true, { removed }, undefined);
     });
@@ -189,6 +198,8 @@ export const pushHandlers: GatewayRequestHandlers = {
     const body = normalizeTrimmedString(params.body) ?? "Web push test notification";
 
     await respondUnavailableOnThrow(respond, async () => {
+      // Broadcast test intentionally sends to every stored web subscription so
+      // operators can verify fan-out and stale-subscription cleanup behavior.
       const results = await broadcastWebPush({ title, body });
       if (results.length === 0) {
         respond(

--- a/src/gateway/server-methods/record-shared.ts
+++ b/src/gateway/server-methods/record-shared.ts
@@ -1,5 +1,16 @@
-export { asOptionalRecord as asRecord } from "../../../packages/normalization-core/src/record-coerce.js";
+import { asOptionalRecord } from "../../../packages/normalization-core/src/record-coerce.js";
 
+/**
+ * Returns a non-array record for RPC payload subtrees.
+ *
+ * Malformed JSON subtrees become `undefined` instead of empty objects so
+ * callers can distinguish absent optional config from invalid nested shapes.
+ */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return asOptionalRecord(value);
+}
+
+/** Returns non-empty caller text after trimming, or `undefined` for absent/blank values. */
 export function normalizeTrimmedString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;

--- a/src/gateway/server-methods/restart-request.ts
+++ b/src/gateway/server-methods/restart-request.ts
@@ -34,9 +34,13 @@ function parseRestartDeliveryContext(params: unknown): {
   return { deliveryContext: normalizedContext, threadId };
 }
 
-// Restart sentinels can resume a channel turn after the gateway comes back.
-// Keep only routable delivery fields plus a normalized thread id so malformed
-// UI/tool payloads do not leak arbitrary data into the sentinel file.
+/**
+ * Normalizes restart request payloads before sentinel persistence.
+ *
+ * Restart sentinels can resume a channel turn after the gateway comes back, so
+ * this keeps only routable delivery fields plus a normalized thread id instead
+ * of persisting arbitrary UI/tool payloads.
+ */
 export function parseRestartRequestParams(params: unknown): {
   sessionKey: string | undefined;
   deliveryContext: RestartDeliveryContext | undefined;
@@ -54,7 +58,9 @@ export function parseRestartRequestParams(params: unknown): {
   const restartDelayMsRaw = (params as { restartDelayMs?: unknown }).restartDelayMs;
   const restartDelayMs =
     typeof restartDelayMsRaw === "number" && Number.isFinite(restartDelayMsRaw)
-      ? Math.max(0, Math.floor(restartDelayMsRaw))
+      ? // Sentinel consumers treat this as a timeout value; clamp fractional and
+        // negative input here so restart scheduling never sees non-duration data.
+        Math.max(0, Math.floor(restartDelayMsRaw))
       : undefined;
   return { sessionKey, deliveryContext, threadId, note, continuationMessage, restartDelayMs };
 }

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -16,8 +16,11 @@ function normalizeSkipDeferral(value: unknown): boolean {
   return value === true;
 }
 
+/** Gateway RPC handlers for safe restart scheduling and preflight checks. */
 export const restartHandlers: GatewayRequestHandlers = {
   "gateway.restart.request": async ({ respond, params }) => {
+    // Restart requests always go through the coordinator so active work can
+    // defer or coalesce the process signal consistently.
     const result = requestSafeGatewayRestart({
       reason: normalizeReason(params.reason),
       delayMs: 0,
@@ -26,6 +29,8 @@ export const restartHandlers: GatewayRequestHandlers = {
     respond(true, result);
   },
   "gateway.restart.preflight": async ({ respond }) => {
+    // Preflight is read-only; clients use it to explain blockers before asking
+    // for an actual restart request.
     respond(true, createSafeGatewayRestartPreflight());
   },
 };

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -50,6 +50,7 @@ function invalidSecretsResolveField(
   return "targetIds";
 }
 
+/** Creates secrets RPC handlers with injected reload/resolve dependencies for the live gateway. */
 export function createSecretsHandlers(params: {
   reloadSecrets: () => Promise<{ warningCount: number }>;
   resolveSecrets: (params: {
@@ -78,6 +79,8 @@ export function createSecretsHandlers(params: {
   return {
     "secrets.reload": async ({ respond }) => {
       try {
+        // Reload returns only warning count so callers know whether diagnostics
+        // changed without receiving secret material or raw warning text.
         const result = await params.reloadSecrets();
         respond(true, { ok: true, warningCount: result.warningCount });
       } catch (error) {
@@ -144,6 +147,8 @@ export function createSecretsHandlers(params: {
       }
 
       try {
+        // resolveSecrets owns the actual secret lookup; this handler only
+        // normalizes policy inputs and validates the outbound assignment shape.
         const result = await params.resolveSecrets({
           commandName,
           targetIds,

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -69,6 +69,7 @@ const getInflightMap = (context: GatewayRequestContext) => {
   return inflight;
 };
 
+/** Resolves idempotent send/action/poll state before starting new outbound work. */
 function resolveGatewayInflightMap(params: { context: GatewayRequestContext; dedupeKey: string }):
   | {
       kind: "cached";
@@ -127,6 +128,8 @@ function resolveGatewayInflightRequest(params: {
     return {
       kind: "handled",
       done: inflight.inflight.then((result) => {
+        // Joining callers get cached-style metadata even though the result came
+        // from process-local in-flight work, not the durable dedupe store.
         const meta = result.meta ? { ...result.meta, cached: true } : { cached: true };
         params.respond(result.ok, result.payload, result.error, meta);
       }),
@@ -287,6 +290,8 @@ function buildGatewayDeliveryPayload(params: {
   channel: string;
   result: Record<string, unknown>;
 }): Record<string, unknown> {
+  // Keep the public response to stable delivery identifiers; channel-specific
+  // result objects can carry internal fields that should not become RPC API.
   const payload: Record<string, unknown> = {
     runId: params.runId,
     messageId: params.result.messageId,
@@ -315,6 +320,8 @@ function cacheGatewayDedupeSuccess(params: {
   dedupeKey: string;
   payload: unknown;
 }) {
+  // Persist successful idempotency results so retried gateway requests don't
+  // redeliver messages after the process-local in-flight map has cleared.
   params.context.dedupe.set(params.dedupeKey, {
     ts: Date.now(),
     ok: true,
@@ -378,6 +385,8 @@ function createGatewayInflightUnavailableFailure(params: {
   err: unknown;
 }): InflightResult {
   const error = errorShape(ErrorCodes.UNAVAILABLE, String(params.err));
+  // Cache transport/runtime failures too: a retry with the same idempotency key
+  // must observe the first attempt result instead of issuing a second delivery.
   cacheGatewayDedupeFailure({
     context: params.context,
     dedupeKey: params.dedupeKey,

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -14,6 +14,8 @@ function collectTrackedActiveSessionRuns(
     return runs;
   }
   for (const active of context.chatAbortControllers.values()) {
+    // Only project runs that should be visible in Control UI session lists;
+    // hidden/internal or already-terminal runs stay abortable but not "active".
     if (
       active.projectSessionActive !== false &&
       active.controlUiVisible !== false &&
@@ -41,6 +43,8 @@ function isTrackedActiveSessionRunForKey(
   if (key !== "global") {
     return true;
   }
+  // Global store rows are shared, so use the requested/default agent to avoid
+  // showing one agent's active run on another agent's dashboard view.
   const requestedAgentId = agentId ?? defaultAgentId;
   if (!requestedAgentId) {
     return true;
@@ -51,6 +55,7 @@ function isTrackedActiveSessionRunForKey(
     : false;
 }
 
+/** Checks whether a sessions.list row should show an active run indicator. */
 export function hasTrackedActiveSessionRun(params: {
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
   requestedKey: string;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -24,6 +24,7 @@ import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
+/** Runtime metadata attached to a connected gateway caller while dispatching server methods. */
 export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
@@ -40,6 +41,7 @@ export type GatewayClient = {
   };
 };
 
+/** Callback contract used by gateway server methods to return one protocol response frame. */
 export type RespondFn = (
   ok: boolean,
   payload?: unknown,
@@ -47,6 +49,7 @@ export type RespondFn = (
   meta?: Record<string, unknown>,
 ) => void;
 
+/** Shared runtime services and mutable gateway state available to server-method handlers. */
 export type GatewayRequestContext = {
   deps: CliDeps;
   cron: CronServiceContract;
@@ -143,6 +146,7 @@ export type GatewayRequestContext = {
   unavailableGatewayMethods?: ReadonlySet<string>;
 };
 
+/** Full dispatch input before a method-specific params record has been normalized. */
 export type GatewayRequestOptions = {
   req: RequestFrame;
   client: GatewayClient | null;
@@ -152,6 +156,7 @@ export type GatewayRequestOptions = {
   methodRegistry?: GatewayMethodRegistryView;
 };
 
+/** Method handler input after registry dispatch has selected the params payload. */
 export type GatewayRequestHandlerOptions = {
   req: RequestFrame;
   params: Record<string, unknown>;
@@ -161,6 +166,8 @@ export type GatewayRequestHandlerOptions = {
   context: GatewayRequestContext;
 };
 
+/** Async or sync implementation for one gateway protocol method. */
 export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
 
+/** Method-name keyed handler map exported by each server-method module. */
 export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-methods/skills.test-helpers.ts
+++ b/src/gateway/server-methods/skills.test-helpers.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
+/** Captures the callback-style gateway response tuple for handler tests. */
 export type CapturedGatewayResponse = {
   ok: boolean | null;
   response: unknown;
@@ -8,12 +9,14 @@ export type CapturedGatewayResponse = {
 };
 
 function makeGatewayHandlerTestContext(): GatewayRequestContext {
+  // Skill handler tests exercise method dispatch only, so keep the context to the fields they read.
   return {
     getRuntimeConfig: () => ({}),
     logGateway: vi.fn(),
   } as unknown as GatewayRequestContext;
 }
 
+/** Invoke a server-method handler through the real request shape and capture respond() output. */
 export async function callGatewayHandler(
   handlers: GatewayRequestHandlers,
   method: string,

--- a/src/gateway/server-methods/subagent-followup.test-helpers.ts
+++ b/src/gateway/server-methods/subagent-followup.test-helpers.ts
@@ -1,5 +1,9 @@
 import { expect } from "vitest";
 
+/**
+ * Assert the shared subagent-followup reactivation contract:
+ * replace the completed run, then broadcast the child session as running.
+ */
 export function expectSubagentFollowupReactivation(params: {
   replaceSubagentRunAfterSteerMock: unknown;
   broadcastToConnIds: unknown;

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -27,6 +27,7 @@ import {
 } from "./talk-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Browser-owned Talk RPCs for client-created realtime sessions and agent controls. */
 export const talkClientHandlers: GatewayRequestHandlers = {
   "talk.client.create": async ({ params, respond, context }) => {
     if (!validateTalkClientCreateParams(params)) {
@@ -85,6 +86,8 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       }
       const transport =
         normalizeOptionalLowercaseString(typedParams.transport) ?? realtimeConfig.transport;
+      // Client RPCs own browser media transports; gateway-relay and managed-room
+      // sessions are created through talk.session so ownership and room state stay server-side.
       if (transport === "managed-room") {
         respond(
           false,
@@ -257,6 +260,8 @@ function hasOwnedActiveTalkClientRun(params: {
     return false;
   }
   for (const entry of params.context.chatAbortControllers.values()) {
+    // Browser steering is allowed only for non-agent runs registered by this
+    // socket, preventing another Control UI connection from steering the run.
     if (entry.sessionKey === sessionKey && entry.ownerConnId === connId && entry.kind !== "agent") {
       return true;
     }

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -80,6 +80,7 @@ function normalizeTalkSessionMode(params: { mode?: string; transport?: string })
     : "realtime";
 }
 
+/** Defaults legacy managed-room transport requests to stt-tts while keeping relay realtime first. */
 function normalizeTalkSessionTransport(params: {
   mode: TalkMode;
   transport?: string;
@@ -173,6 +174,8 @@ function respondManagedRoomTurn(params: {
     );
     return;
   }
+  // Turn events are delivered to the active room client only; the handoff
+  // record owns fan-out history for later joins/replacements.
   broadcastTalkRoomEvents(params.context, result.record.room.activeClientId, {
     handoffId: result.record.id,
     roomId: result.record.roomId,
@@ -181,6 +184,7 @@ function respondManagedRoomTurn(params: {
   respondOk(params.respond, { ok: true, turnId: result.turnId, events: result.events });
 }
 
+/** Unified Talk session RPCs for gateway-relay, transcription relay, and managed-room sessions. */
 export const talkSessionHandlers: GatewayRequestHandlers = {
   "talk.session.create": async ({ params, respond, context, client }) => {
     if (
@@ -193,6 +197,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
     const transport = normalizeTalkSessionTransport({ mode, transport: params.transport });
     const brain = normalizeTalkSessionBrain({ mode, brain: params.brain });
 
+    // Browser transports are intentionally split from gateway-managed sessions
+    // so the socket that owns media also owns session lifetime and steering.
     if (transport === "webrtc" || transport === "provider-websocket") {
       respondInvalidRequest(
         respond,
@@ -211,6 +217,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           return;
         }
         const spawnedBy = normalizeOptionalString(params.spawnedBy);
+        // Unscoped session keys can bind existing conversations, so browser
+        // callers must either prove spawn ownership or hold gateway admin scope.
         if (
           normalizeOptionalString(params.sessionKey) &&
           !spawnedBy &&
@@ -389,6 +397,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         );
         return;
       }
+      // Joining can replace another active browser connection; notify both the
+      // displaced client and the newly active client with their tailored event sets.
       broadcastTalkRoomEvents(context, result.replacedClientId, {
         handoffId: result.record.id,
         roomId: result.record.roomId,
@@ -681,6 +691,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           return;
         }
         const result = revokeTalkHandoff(session.handoffId);
+        // Closing a managed room revokes the handoff token before forgetting the
+        // unified session, so any late join observes the revoked room state.
         broadcastTalkRoomEvents(context, result.activeClientId, {
           handoffId: session.handoffId,
           roomId: session.roomId,

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -25,11 +25,13 @@ import { ADMIN_SCOPE } from "../operator-scopes.js";
 import type { TalkHandoffTurnResult } from "../talk-handoff.js";
 import { asRecord } from "./record-shared.js";
 
+/** Return whether a caller can bypass the agent handoff and use Talk direct tools. */
 export function canUseTalkDirectTools(client: { connect?: { scopes?: string[] } } | null): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
 }
 
+/** Fan out Talk room events to the active browser client without blocking slow sockets. */
 export function broadcastTalkRoomEvents(
   context: {
     broadcastToConnIds: (
@@ -57,6 +59,7 @@ export function broadcastTalkRoomEvents(
 
 type TalkHandoffFailureReason = Extract<TalkHandoffTurnResult, { ok: false }>["reason"];
 
+/** Map Talk handoff failure reasons onto the gateway protocol error families clients expect. */
 export function talkHandoffErrorCode(reason: TalkHandoffFailureReason) {
   return reason === "invalid_token" || reason === "no_active_turn" || reason === "stale_turn"
     ? ErrorCodes.INVALID_REQUEST
@@ -107,6 +110,7 @@ function getVoiceCallRealtimeConfig(config: OpenClawConfig): {
   return getVoiceCallProviderConfig(config, "realtime");
 }
 
+/** Read legacy voice-call streaming config used as the Talk transcription fallback. */
 export function getVoiceCallStreamingConfig(config: OpenClawConfig): {
   provider?: string;
   providers?: Record<string, RealtimeTranscriptionProviderConfig>;
@@ -157,6 +161,7 @@ function resolveConfiguredVoiceModelDefaultRef<TConfig extends Record<string, un
   return undefined;
 }
 
+/** Merge Talk realtime config with legacy voice-call defaults and derived voice-model defaults. */
 export function buildTalkRealtimeConfig(config: OpenClawConfig, requestedProvider?: string) {
   const voiceCallRealtime = getVoiceCallRealtimeConfig(config);
   const talkRealtime = getRecord(config.talk?.realtime);
@@ -201,6 +206,7 @@ export function buildTalkRealtimeConfig(config: OpenClawConfig, requestedProvide
   };
 }
 
+/** Resolve Talk transcription config from legacy streaming config plus voice-model defaults. */
 export function buildTalkTranscriptionConfig(config: OpenClawConfig, requestedProvider?: string) {
   const streamingConfig = getVoiceCallStreamingConfig(config);
   const provider = normalizeOptionalString(requestedProvider) ?? streamingConfig.provider;
@@ -218,6 +224,7 @@ export function buildTalkTranscriptionConfig(config: OpenClawConfig, requestedPr
   };
 }
 
+/** Treat provider config probes as false when a provider rejects malformed or incomplete config. */
 export function configuredOrFalse(callback: () => boolean): boolean {
   try {
     return callback();
@@ -226,6 +233,7 @@ export function configuredOrFalse(callback: () => boolean): boolean {
   }
 }
 
+/** Pick the configured realtime transcription provider or the first configured auto-select provider. */
 export function resolveConfiguredRealtimeTranscriptionProvider(params: {
   config: OpenClawConfig;
   configuredProviderId?: string;
@@ -279,6 +287,7 @@ const DEFAULT_REALTIME_INSTRUCTIONS = [
   "For greetings and casual chatter while OpenClaw is working, answer naturally and do not redirect the active work.",
 ].join(" ");
 
+/** Build realtime session instructions while preserving the required Talk tool-control contract. */
 export function buildRealtimeInstructions(configuredInstructions?: string): string {
   const extra = normalizeOptionalString(configuredInstructions);
   if (!extra) {
@@ -307,6 +316,7 @@ type RealtimeVoiceLaunchOptionInput = {
   reasoningEffort?: unknown;
 };
 
+/** Combine config defaults with validated per-request browser launch options. */
 export function buildRealtimeVoiceLaunchOptions(params: {
   requested: RealtimeVoiceLaunchOptionInput;
   defaults: RealtimeVoiceLaunchOptions;
@@ -320,6 +330,7 @@ export function buildRealtimeVoiceLaunchOptions(params: {
   };
 }
 
+/** Apply validated browser launch overrides to provider config without carrying unknown fields. */
 export function withRealtimeBrowserOverrides(
   providerConfig: RealtimeVoiceProviderConfig,
   params: RealtimeVoiceLaunchOptionInput,
@@ -377,6 +388,7 @@ function pickRealtimeVoiceLaunchOptions(
   return options;
 }
 
+/** Identify provider sessions that are typed as browser sessions but unsupported by this Talk flow. */
 export function isUnsupportedBrowserWebRtcSession(session: RealtimeVoiceBrowserSession): boolean {
   const provider = normalizeLowercaseStringOrEmpty(session.provider);
   const transport = (session as { transport?: string }).transport ?? "webrtc";

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -86,6 +86,8 @@ function buildToolsEffectiveCacheKey(params: {
   context: TrustedToolsEffectiveContext;
 }): string {
   const context = params.context;
+  // Key only on stable request/session inputs; MCP runtime catalog state is
+  // appended after the base inventory cache so UI polling can reuse this value.
   return JSON.stringify({
     v: 1,
     config: context.runtimeConfigCacheKey,
@@ -124,6 +126,8 @@ function buildMcpConfigSummaryCacheKey(params: {
   context: TrustedToolsEffectiveContext;
   workspaceDir: string;
 }): string {
+  // MCP config summaries are scoped by workspace because spawned sessions may
+  // run from sandbox copies with different MCP discovery roots.
   return JSON.stringify({
     v: 1,
     config: params.context.runtimeConfigCacheKey,
@@ -372,6 +376,8 @@ function filterMcpTools(params: {
   context: TrustedToolsEffectiveContext;
   mcpTools: Parameters<typeof applyFinalEffectiveToolPolicy>[0]["bundledTools"];
 }) {
+  // MCP tools still pass through the final runtime policy so model/channel
+  // restrictions match the tools actually available during an agent turn.
   return applyFinalEffectiveToolPolicy({
     bundledTools: params.mcpTools,
     config: params.context.cfg,
@@ -588,6 +594,8 @@ export const toolsEffectiveHandlers: GatewayRequestHandlers = {
 };
 
 export const testing = {
+  // Tests own cache lifecycle directly so they can assert stale/fresh behavior
+  // without relying on wall-clock sleeps.
   resetToolsEffectiveCacheForTest() {
     toolsEffectiveCache.clear();
     toolsEffectiveInflight.clear();

--- a/src/gateway/server-methods/tools-invoke.ts
+++ b/src/gateway/server-methods/tools-invoke.ts
@@ -29,6 +29,7 @@ function resolveRpcErrorCode(params: {
   return "internal_error";
 }
 
+/** Gateway RPC entry point for invoking exposed tools without throwing transport-level failures. */
 export const toolsInvokeHandlers: GatewayRequestHandlers = {
   "tools.invoke": async ({ params, respond, context }) => {
     if (!validateToolsInvokeParams(params)) {
@@ -56,6 +57,8 @@ export const toolsInvokeHandlers: GatewayRequestHandlers = {
       cfg: context.getRuntimeConfig(),
       input: params,
       toolCallIdPrefix: "rpc",
+      // RPC callers receive approval-required as structured tool output; the
+      // boolean confirm flag only decides whether the backend may request it.
       approvalMode: params.confirm === true ? "request" : "report",
     });
 
@@ -74,6 +77,8 @@ export const toolsInvokeHandlers: GatewayRequestHandlers = {
       ok: false,
       toolName: outcome.toolName || requestedToolName,
       ...(outcome.error.requiresApproval ? { requiresApproval: true } : {}),
+      // tools.invoke reports tool failures in-band so clients can show the
+      // failed tool call beside successful invocations without retrying the RPC.
       error: {
         code: resolveRpcErrorCode(outcome.error),
         message: outcome.error.message,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -25,6 +25,7 @@ import {
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** Gateway RPC handlers for TTS status, synthesis, provider, and persona preferences. */
 export const ttsHandlers: GatewayRequestHandlers = {
   "tts.status": async ({ respond, context }) => {
     try {
@@ -34,6 +35,8 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const provider = getTtsProvider(config, prefsPath);
       const persona = getTtsPersona(config, prefsPath);
       const autoMode = resolveTtsAutoMode({ config, prefsPath });
+      // Fallback providers are filtered to configured providers so status does
+      // not suggest an automatic handoff that would fail at synthesis time.
       const fallbackProviders = resolveTtsProviderOrder(provider, cfg)
         .slice(1)
         .filter((candidate) => isTtsProviderConfigured(config, candidate, cfg));
@@ -73,6 +76,8 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
+      // Enable/disable writes only the prefs file; provider/persona config stays
+      // in the gateway config so environment-managed defaults remain intact.
       setTtsEnabled(prefsPath, true);
       respond(true, { enabled: true });
     } catch (err) {
@@ -84,6 +89,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
+      // Disable is a preference override, not a config rewrite.
       setTtsEnabled(prefsPath, false);
       respond(true, { enabled: false });
     } catch (err) {
@@ -165,6 +171,8 @@ export const ttsHandlers: GatewayRequestHandlers = {
     try {
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
+      // Store the canonical provider id so aliases and case variants never leak
+      // into the user preference file.
       setTtsProvider(prefsPath, provider);
       respond(true, { provider });
     } catch (err) {
@@ -177,6 +185,8 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       const active = getTtsPersona(config, prefsPath);
+      // Surface persona provider/fallback metadata for UI filtering without
+      // exposing the full configured voice/model payload.
       respond(true, {
         active: active?.id ?? null,
         personas: listTtsPersonas(config).map((persona) => ({
@@ -230,6 +240,8 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const cfg = context.getRuntimeConfig();
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
+      // Provider listing includes raw model/voice ids for picker UIs; configured
+      // is computed with resolved provider config and timeout defaults.
       respond(true, {
         providers: listSpeechProviders(cfg).map((provider) => ({
           id: provider.id,

--- a/src/gateway/server-methods/update-managed-service-handoff.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.ts
@@ -252,8 +252,11 @@ function markUpdateSentinelFailureIfPending(reason) {
 
 export type ManagedServiceUpdateHandoffResult = {
   status: "started";
+  /** PID of the detached helper process when the platform reports one. */
   pid?: number;
+  /** User-facing command equivalent for shell fallback guidance. */
   command: string;
+  /** Helper log path retained after sensitive handoff files are removed. */
   logPath: string;
 };
 
@@ -294,9 +297,12 @@ export function formatManagedServiceUpdateCommand(timeoutMs?: number): string {
   return args.join(" ");
 }
 
+/** Remove restart-supervisor hints that would make the handoff child inherit the live service. */
 export function stripSupervisorHintEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const next = { ...env };
   for (const key of SUPERVISOR_HINT_ENV_VARS) {
+    // Keep the real service identity markers; only transient respawn hints are
+    // stripped so the update command can still diagnose its managed runtime.
     if (SERVICE_IDENTITY_ENV_VARS.has(key)) {
       continue;
     }
@@ -405,6 +411,10 @@ async function resolveHandoffSpawn(params: {
   };
 }
 
+/**
+ * Start a detached helper that waits for the current gateway process to exit,
+ * then runs `openclaw update --yes` outside the live managed service.
+ */
 export async function startManagedServiceUpdateHandoff(params: {
   root: string;
   timeoutMs?: number;
@@ -450,6 +460,8 @@ export async function startManagedServiceUpdateHandoff(params: {
   await fs.writeFile(paramsPath, `${JSON.stringify(helperParams, null, 2)}\n`, { mode: 0o600 });
   await fs.writeFile(metaPath, `${JSON.stringify(metaFile, null, 2)}\n`, { mode: 0o600 });
 
+  // The helper receives the sentinel meta path through env for status reporting,
+  // while the JSON params file carries paths that are deleted after handoff.
   const env = {
     ...stripSupervisorHintEnv(params.env ?? process.env),
     [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
@@ -479,6 +491,7 @@ export async function startManagedServiceUpdateHandoff(params: {
   };
 }
 
+/** Message shown when the gateway cannot safely spawn an out-of-service update helper. */
 export function buildManagedServiceHandoffUnavailableMessage(command: string): string {
   return [
     "Package updates cannot safely run inside the live gateway process.",

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -750,6 +750,7 @@ function mergeDailyModelRows(
     : undefined;
 }
 
+/** Loads cost usage with bounded cache entries and in-flight refresh coalescing. */
 async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
@@ -794,6 +795,8 @@ async function loadCostUsageSummaryCached(params: {
         })
   )
     .then((summary) => {
+      // A refreshing summary is useful to return, but its timestamp is not a
+      // freshness proof; leave updatedAt empty so the next caller can refresh.
       setCostUsageCache(cacheKey, {
         summary,
         updatedAt: summary.cacheStatus?.status === "refreshing" ? undefined : Date.now(),
@@ -874,6 +877,7 @@ async function loadAllAgentCostUsageSummary(params: {
   };
 }
 
+/** Merges per-agent cache statuses, preserving the least-fresh aggregate state. */
 function mergeUsageCacheStatus(
   target: UsageCacheStatus | undefined,
   source: UsageCacheStatus,

--- a/src/gateway/server-methods/voicewake-routing.ts
+++ b/src/gateway/server-methods/voicewake-routing.ts
@@ -7,6 +7,7 @@ import {
 } from "../../infra/voicewake-routing.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** RPC handlers for voice wake routing preferences shared with connected nodes. */
 export const voicewakeRoutingHandlers: GatewayRequestHandlers = {
   "voicewake.routing.get": async ({ respond }) => {
     try {

--- a/src/gateway/server-methods/voicewake.ts
+++ b/src/gateway/server-methods/voicewake.ts
@@ -4,6 +4,7 @@ import { normalizeVoiceWakeTriggers } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+/** RPC handlers for reading/updating global voice wake trigger phrases. */
 export const voicewakeHandlers: GatewayRequestHandlers = {
   "voicewake.get": async ({ respond }) => {
     try {

--- a/src/gateway/server-node-events-types.ts
+++ b/src/gateway/server-node-events-types.ts
@@ -5,6 +5,7 @@ import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import type { DedupeEntry } from "./server-shared.js";
 
+/** Gateway services and mutable chat state available while handling node-originated events. */
 export type NodeEventContext = {
   deps: CliDeps;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
@@ -40,6 +41,7 @@ export type NodeEventContext = {
   logGateway: { warn: (msg: string) => void };
 };
 
+/** Wire event envelope sent by a connected node before payload parsing. */
 export type NodeEvent = {
   event: string;
   payloadJSON?: string | null;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -83,6 +83,8 @@ function dispatchNodeAgentCommand(
 }
 
 function resolveVoiceTranscriptFingerprint(obj: Record<string, unknown>, text: string): string {
+  // Prefer provider ids before text fingerprints; streaming voice providers can
+  // resend identical partial text with stronger per-call sequence metadata.
   const eventId =
     normalizeOptionalString(obj.eventId) ??
     normalizeOptionalString(obj.providerEventId) ??
@@ -131,6 +133,8 @@ function shouldDropDuplicateVoiceTranscript(params: {
   });
 
   if (recentVoiceTranscripts.size > MAX_RECENT_VOICE_TRANSCRIPTS) {
+    // Prune expired entries first, then trim insertion-order overflow to keep
+    // duplicate suppression bounded under noisy transcript streams.
     const cutoff = params.now - VOICE_TRANSCRIPT_DEDUPE_WINDOW_MS * 2;
     for (const [key, value] of recentVoiceTranscripts) {
       if (value.ts < cutoff) {
@@ -214,12 +218,14 @@ function pruneBoundedTimestampMap(
   }
 }
 
+/** Clears process-local node event dedupe state for isolated gateway tests. */
 export function resetNodeEventDeduplicationForTests() {
   recentVoiceTranscripts.clear();
   recentExecFinishedRuns.clear();
   recentNodePresencePersistAt.clear();
 }
 
+/** Exposes node presence throttle-map size so tests can prove bounded pruning. */
 export function getRecentNodePresencePersistCountForTests() {
   return recentNodePresencePersistAt.size;
 }
@@ -297,6 +303,8 @@ function queueSessionStoreTouch(params: {
   sessionId: string;
   now: number;
 }) {
+  // Voice transcripts should not block the node event frame on session metadata
+  // persistence; failures are logged while the agent turn continues.
   void touchSessionStore({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
@@ -707,6 +715,8 @@ export const handleNodeEvent = async (
           terminal: evt.event === "exec.finished" || evt.event === "exec.denied",
         })
       ) {
+        // Exec lifecycle events must correspond to a gateway-issued system.run;
+        // unmatched events are reported as handled=false instead of enqueued.
         return {
           ok: true,
           event: evt.event,
@@ -862,6 +872,8 @@ export const handleNodeEvent = async (
 
       const lastSeenReason = normalizeNodePresenceAliveReason(obj.trigger);
       try {
+        // Persist both node-pairing and device-pairing last-seen metadata so
+        // offline catalog/listing views can use either durable source.
         const [nodeUpdated, deviceUpdated] = await Promise.all([
           updatePairedNodeMetadata(nodeId, {
             lastSeenAtMs: now,

--- a/src/gateway/server-node-session-runtime.ts
+++ b/src/gateway/server-node-session-runtime.ts
@@ -14,6 +14,8 @@ export function createGatewayNodeSessionRuntime(params: {
   const nodeSubscriptions = createNodeSubscriptionManager();
   const sessionEventSubscribers = createSessionEventSubscriberRegistry();
   const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
+  // Session/node fan-out reuses pre-serialized payloads from the subscription
+  // manager so each subscribed node receives identical event bytes.
   const nodeSendEvent = (opts: {
     nodeId: string;
     event: string;

--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -36,6 +36,8 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
   const nodeSubscriptions = new Map<string, Set<string>>();
   const sessionSubscribers = new Map<string, Set<string>>();
 
+  // Keep node->session and session->node indexes in sync so disconnect cleanup
+  // and session fan-out do not need to scan every known subscription.
   const toPayloadJSON = (payload: unknown) => serializeEventPayload(payload);
 
   const subscribe = (nodeId: string, sessionKey: string) => {

--- a/src/gateway/server-runtime-service-shared.ts
+++ b/src/gateway/server-runtime-service-shared.ts
@@ -10,6 +10,7 @@ export type GatewayRuntimeServiceLogger = {
   error: (message: string) => void;
 };
 
+/** No-op heartbeat handle for startup/test paths that share the production shutdown shape. */
 export function createNoopHeartbeatRunner(): HeartbeatRunner {
   return {
     stop: () => {},

--- a/src/gateway/server-runtime-startup-services.ts
+++ b/src/gateway/server-runtime-startup-services.ts
@@ -10,12 +10,14 @@ export type GatewayChannelManager = Parameters<
   typeof startChannelHealthMonitor
 >[0]["channelManager"];
 
+/** Starts channel health checks from gateway config, returning null when explicitly disabled. */
 export function startGatewayChannelHealthMonitor(params: {
   cfg: OpenClawConfig;
   channelManager: GatewayChannelManager;
 }): ChannelHealthMonitor | null {
   const healthCheckMinutes = params.cfg.gateway?.channelHealthCheckMinutes;
   if (healthCheckMinutes === 0) {
+    // Zero is the operator-facing disable switch; undefined keeps the production default.
     return null;
   }
   const staleEventThresholdMinutes = params.cfg.gateway?.channelStaleEventThresholdMinutes;
@@ -30,6 +32,7 @@ export function startGatewayChannelHealthMonitor(params: {
   });
 }
 
+/** Builds the startup-time service handles that are safe before scheduled services activate. */
 export function startGatewayRuntimeServices(params: {
   minimalTestGateway: boolean;
   cfgAtStart: OpenClawConfig;
@@ -45,6 +48,8 @@ export function startGatewayRuntimeServices(params: {
     channelManager: params.channelManager,
   });
 
+  // Startup owns channel health immediately, but heartbeat/model-pricing stay inert until
+  // activateGatewayScheduledServices runs after the core gateway is ready.
   return {
     heartbeatRunner: createNoopHeartbeatRunner(),
     channelHealthMonitor,

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -30,6 +30,8 @@ export function startGatewayEventSubscriptions(params: {
     ReturnType<typeof import("./server-chat.js").createAgentEventHandler>
   > | null = null;
   const getAgentEventHandler = () => {
+    // Agent-event handling pulls in chat/session-key code; keep it lazy so gateway startup can
+    // publish readiness before loading the heavier streaming pipeline.
     agentEventHandlerPromise ??= Promise.all([
       import("./server-chat.js"),
       import("./server-session-key.js"),
@@ -68,6 +70,8 @@ export function startGatewayEventSubscriptions(params: {
   let sessionEventsModulePromise: Promise<typeof import("./server-session-events.js")> | null =
     null;
   const getSessionEventsModule = () => {
+    // Transcript/lifecycle broadcasts are cold for minimal gateways and tests; one shared import
+    // promise also keeps concurrent first events from building duplicate handlers.
     sessionEventsModulePromise ??= import("./server-session-events.js");
     return sessionEventsModulePromise;
   };

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -29,6 +29,8 @@ function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string
     const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(getRuntimeConfig()));
     if (normalizedAgentId) {
       const scopedKey = `agent:${normalizeAgentId(normalizedAgentId)}:global`;
+      // Default-agent global subscribers may still be listening on the legacy unscoped key;
+      // non-default agents stay scoped so their transcript updates do not cross streams.
       return normalizeAgentId(normalizedAgentId) === defaultAgentId
         ? [scopedKey, sessionKey]
         : [scopedKey];
@@ -111,6 +113,7 @@ function buildGatewaySessionSnapshot(params: {
   };
 }
 
+/** Creates the serialized transcript-update broadcaster used by gateway runtime subscriptions. */
 export function createTranscriptUpdateBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;
@@ -118,6 +121,8 @@ export function createTranscriptUpdateBroadcastHandler(params: {
 }) {
   let broadcastQueue = Promise.resolve();
   return (update: SessionTranscriptUpdate): void => {
+    // Transcript writes can arrive faster than snapshot/message-count reads; serialize them so
+    // clients observe message sequence and session metadata in the same order as persistence.
     broadcastQueue = broadcastQueue
       .then(() => handleTranscriptUpdateBroadcast(params, update))
       .catch(() => undefined);
@@ -149,6 +154,8 @@ async function handleTranscriptUpdateBroadcast(
     connIds.add(connId);
   }
   for (const broadcastKey of resolveSessionMessageBroadcastKeys(sessionKey, effectiveAgentId)) {
+    // Direct message subscribers get the same event as broad session-list subscribers, with
+    // de-duping by connection id when a client is subscribed through both paths.
     for (const connId of params.sessionMessageSubscribers.get(broadcastKey)) {
       connIds.add(connId);
     }
@@ -158,6 +165,8 @@ async function handleTranscriptUpdateBroadcast(
   }
   let messageSeq = asPositiveSafeInteger(update.messageSeq);
   if (messageSeq === undefined) {
+    // Older transcript notifications may not carry a sequence; recover it from the persisted
+    // transcript count so late subscribers can order the pushed message deterministically.
     const { entry, storePath } = loadSessionEntry(sessionKey, { agentId: visibleAgentId });
     messageSeq = entry?.sessionId
       ? asPositiveSafeInteger(
@@ -215,6 +224,7 @@ async function handleTranscriptUpdateBroadcast(
   );
 }
 
+/** Creates the lifecycle broadcaster for session list/metadata changes. */
 export function createLifecycleEventBroadcastHandler(params: {
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
   sessionEventSubscribers: SessionEventSubscribers;

--- a/src/gateway/server-talk-nodes.ts
+++ b/src/gateway/server-talk-nodes.ts
@@ -4,11 +4,14 @@ import type { NodeRegistry, NodeSession } from "./node-registry.js";
 const TALK_CAPABILITY = "talk";
 const TALK_COMMAND_PREFIX = "talk.";
 
+/** Returns true when any connected node can handle Talk capture/PTT commands. */
 export function hasConnectedTalkNode(registry: NodeRegistry): boolean {
   return registry.listConnected().some(isTalkCapableNode);
 }
 
 function isTalkCapableNode(node: NodeSession): boolean {
+  // Nodes can advertise Talk support either as a broad capability or as specific
+  // talk.* commands; accept both so older and newer node manifests work.
   return (
     node.caps.some(
       (capability) => normalizeOptionalLowercaseString(capability) === TALK_CAPABILITY,

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -11,6 +11,7 @@ type GatewayWsRuntimeParams = Omit<
   context: GatewayRequestContext;
 };
 
+/** Wires WebSocket connection handling to the already-built gateway request context. */
 export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
   attachGatewayWsConnectionHandler({
     wss: params.wss,
@@ -36,6 +37,8 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     extraHandlers: params.extraHandlers,
     getMethodRegistry: params.getMethodRegistry,
     broadcast: params.broadcast,
+    // WebSocket messages share one runtime context per gateway start; request-scoped
+    // refresh hooks still live on the context so health/auth snapshots stay current.
     buildRequestContext: () => params.context,
   });
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1492,6 +1492,8 @@ export async function startGatewayServer(
         port,
         gatewayHost: bindHost ?? undefined,
         pluginSurfaceScheme,
+        // Capability URLs are minted from the active startup registry at attach time so
+        // node clients receive TLS-aware plugin surface hosts without importing HTTP routes early.
         getPluginNodeCapabilities: () => listPluginNodeCapabilities(pluginRegistry),
         resolvedAuth,
         getResolvedAuth,

--- a/src/gateway/server/preauth-connection-budget.ts
+++ b/src/gateway/server/preauth-connection-budget.ts
@@ -25,6 +25,7 @@ export type PreauthConnectionBudget = {
   release(clientIp: string | undefined): void;
 };
 
+/** Creates a per-client-IP cap for sockets that have not completed gateway auth yet. */
 export function createPreauthConnectionBudget(
   limit = getMaxPreauthConnectionsPerIpFromEnv(),
 ): PreauthConnectionBudget {
@@ -45,6 +46,7 @@ export function createPreauthConnectionBudget(
       const ip = normalizeBudgetKey(clientIp);
       const next = (counts.get(ip) ?? 0) + 1;
       if (next > maxConnectionsPerIp) {
+        // Do not record rejected upgrades; only accepted pre-auth sockets need a matching release.
         return false;
       }
       counts.set(ip, next);
@@ -57,6 +59,7 @@ export function createPreauthConnectionBudget(
         return;
       }
       if (current <= 1) {
+        // Delete empty buckets so rotating client IPs cannot leave unbounded zero-count entries.
         counts.delete(ip);
         return;
       }

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -24,6 +24,7 @@ type HandshakeConnectAuth = {
 
 export type DeviceTokenCandidateSource = "explicit-device-token" | "shared-token-fallback";
 
+/** Captures the first-pass shared-auth result plus deferred device/bootstrap candidates. */
 export type ConnectAuthState = {
   authResult: GatewayAuthResult;
   authOk: boolean;
@@ -47,6 +48,7 @@ type VerifyDeviceTokenResult = {
 };
 type VerifyBootstrapTokenResult = { ok: boolean; reason?: string };
 
+/** Final handshake auth verdict after bootstrap and device-token fallbacks are considered. */
 export type ConnectAuthDecision = {
   authResult: GatewayAuthResult;
   authOk: boolean;
@@ -118,9 +120,13 @@ function resolveDeviceTokenCandidate(connectAuth: HandshakeConnectAuth | null | 
   if (!fallbackToken) {
     return {};
   }
+  // Old clients sent device tokens through `auth.token`; keep the candidate
+  // source so failures preserve the shared-token reason unless the device check
+  // proves a stricter scope mismatch.
   return { token: fallbackToken, source: "shared-token-fallback" };
 }
 
+/** Resolves the immediate shared-auth path and records deferred stronger credentials. */
 export async function resolveConnectAuthState(params: {
   resolvedAuth: ResolvedGatewayAuth;
   connectAuth: HandshakeConnectAuth | null | undefined;
@@ -183,6 +189,7 @@ export async function resolveConnectAuthState(params: {
   };
 }
 
+/** Applies bootstrap-token and device-token fallback checks to a connect auth state. */
 export async function resolveConnectAuthDecision(
   params: ResolveConnectAuthDecisionParams,
 ): Promise<ConnectAuthDecision> {
@@ -196,6 +203,9 @@ export async function resolveConnectAuthDecision(
   if (!shouldSerializeBootstrapAttempt) {
     return await resolveConnectAuthDecisionCore(params);
   }
+  // Bootstrap verification touches the pairing store under a mutex; serialize
+  // by IP before the rate-limit check so a burst cannot all pass the bucket
+  // before earlier failures are recorded.
   return await withSerializedRateLimitAttempt({
     ip: params.clientIp,
     scope: AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN,
@@ -213,6 +223,8 @@ async function resolveConnectAuthDecisionCore(
   let pendingBootstrapFailure = false;
 
   function finish(): ConnectAuthDecision {
+    // Count bootstrap failures only when no later credential succeeded. A valid
+    // device token can rescue the handshake after an expired QR token.
     if (pendingBootstrapFailure && !authOk) {
       params.rateLimiter?.recordFailure(params.clientIp, AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN);
     }
@@ -279,6 +291,9 @@ async function resolveConnectAuthDecisionCore(
     return finish();
   }
 
+  // Device-token fallback is intentionally independent from shared-secret rate
+  // limiting; a locked shared-secret bucket should not block the bound device
+  // credential that can prove the same client.
   let deviceTokenRateLimited = false;
   if (params.rateLimiter) {
     const deviceRateCheck = params.rateLimiter.check(

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -7,6 +7,7 @@ import type { ResolvedGatewayAuth } from "../../auth.js";
 
 export type AuthProvidedKind = "token" | "bootstrap-token" | "device-token" | "password" | "none";
 
+/** Formats client-facing WebSocket auth failures with client-specific remediation hints. */
 export function formatGatewayAuthFailureMessage(params: {
   authMode: ResolvedGatewayAuth["mode"];
   authProvided: AuthProvidedKind;

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -2,6 +2,7 @@ import type { ConnectParams } from "../../../../packages/gateway-protocol/src/in
 import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";
 
+/** Normalized Control UI auth/device policy used before pairing decisions. */
 export type ControlUiAuthPolicy = {
   isControlUi: boolean;
   allowInsecureAuthConfigured: boolean;
@@ -10,6 +11,7 @@ export type ControlUiAuthPolicy = {
   device: ConnectParams["device"] | null | undefined;
 };
 
+/** Collapses raw Control UI config into the fields the handshake policy needs. */
 export function resolveControlUiAuthPolicy(params: {
   isControlUi: boolean;
   controlUiConfig:
@@ -34,6 +36,7 @@ export function resolveControlUiAuthPolicy(params: {
   };
 }
 
+/** Decides whether an operator Control UI session can skip the pairing prompt. */
 export function shouldSkipControlUiPairing(
   policy: ControlUiAuthPolicy,
   role: GatewayRole,
@@ -60,6 +63,7 @@ export function shouldSkipControlUiPairing(
   return role === "operator" && policy.allowBypass;
 }
 
+/** Detects the trusted-proxy Control UI case that replaces per-device proof. */
 export function isTrustedProxyControlUiOperatorAuth(params: {
   isControlUi: boolean;
   role: GatewayRole;
@@ -76,12 +80,14 @@ export function isTrustedProxyControlUiOperatorAuth(params: {
   );
 }
 
+/** Outcome for a connect request that did not include device identity proof. */
 export type MissingDeviceIdentityDecision =
   | { kind: "allow" }
   | { kind: "reject-control-ui-insecure-auth" }
   | { kind: "reject-unauthorized" }
   | { kind: "reject-device-required" };
 
+/** Decides whether shared scopes must be stripped when device identity is missing. */
 export function shouldClearUnboundScopesForMissingDeviceIdentity(params: {
   decision: MissingDeviceIdentityDecision;
   controlUiAuthPolicy: ControlUiAuthPolicy;
@@ -99,6 +105,7 @@ export function shouldClearUnboundScopesForMissingDeviceIdentity(params: {
   );
 }
 
+/** Evaluates the missing-device branch shared by Control UI, nodes, and operators. */
 export function evaluateMissingDeviceIdentity(params: {
   hasDeviceIdentity: boolean;
   role: GatewayRole;
@@ -142,6 +149,8 @@ export function evaluateMissingDeviceIdentity(params: {
     return { kind: "allow" };
   }
   if (!params.authOk && params.hasSharedAuth) {
+    // Preserve unauthorized as the visible failure when credentials were sent
+    // but failed, instead of reporting the secondary missing-device condition.
     return { kind: "reject-unauthorized" };
   }
   return { kind: "reject-device-required" };

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -53,6 +53,7 @@ function resolveBrowserOriginRateLimitKey(requestOrigin?: string): string {
   }
 }
 
+/** Resolves browser-origin hardening and rate-limit routing for one WebSocket handshake. */
 export function resolveHandshakeBrowserSecurityContext(params: {
   requestOrigin?: string;
   clientIp: string | undefined;
@@ -65,6 +66,8 @@ export function resolveHandshakeBrowserSecurityContext(params: {
   return {
     hasBrowserOriginHeader,
     enforceOriginCheckForAnyClient: hasBrowserOriginHeader,
+    // Browser-origin requests from loopback share a synthetic key per origin so localhost pages
+    // cannot bypass auth throttles by hiding behind 127.0.0.1.
     rateLimitClientIp:
       hasBrowserOriginHeader && isLoopbackAddress(params.clientIp)
         ? resolveBrowserOriginRateLimitKey(params.requestOrigin)
@@ -76,6 +79,7 @@ export function resolveHandshakeBrowserSecurityContext(params: {
   };
 }
 
+/** Returns true when a local reconnect can skip an explicit pairing prompt. */
 export function shouldAllowSilentLocalPairing(params: {
   locality: PairingLocalityKind;
   hasBrowserOriginHeader: boolean;
@@ -197,6 +201,7 @@ function isControlUiBrowserContainerLocalEquivalent(params: {
   );
 }
 
+/** Classifies a handshake into the locality bucket used by pairing and metadata policy. */
 export function resolvePairingLocality(params: {
   connectParams: ConnectParams;
   isLocalClient: boolean;
@@ -253,6 +258,7 @@ export function resolvePairingLocality(params: {
   return "remote";
 }
 
+/** Allows first-party local backend clients to avoid device pairing when auth/locality prove trust. */
 export function shouldSkipLocalBackendSelfPairing(params: {
   connectParams: ConnectParams;
   locality: PairingLocalityKind;
@@ -307,6 +313,7 @@ function buildUnauthorizedHandshakeContext(params: {
   };
 }
 
+/** Verifies device signatures against the current payload shape and the v2 compatibility shape. */
 export function resolveDeviceSignaturePayloadVersion(params: {
   device: {
     id: string;
@@ -339,6 +346,7 @@ export function resolveDeviceSignaturePayloadVersion(params: {
     return "v3";
   }
 
+  // v2 remains accepted for already-shipped clients that have not adopted platform/family fields.
   const payloadV2 = buildDeviceAuthPayload(basePayload);
   if (verifyDeviceSignature(params.device.publicKey, payloadV2, params.device.signature)) {
     return "v2";
@@ -360,6 +368,7 @@ function resolveAuthProvidedKind(
           : "none";
 }
 
+/** Builds structured retry guidance for clients after a failed WebSocket auth handshake. */
 export function resolveUnauthorizedHandshakeContext(params: {
   connectAuth: HandshakeConnectAuth | null | undefined;
   failedAuth: GatewayAuthResult;

--- a/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-log-limiter.ts
@@ -20,6 +20,7 @@ export class HandshakeAuthLogLimiter {
     this.maxEntries = resolveIntegerOption(options?.maxEntries, 256, { min: 1 });
   }
 
+  /** Records one handshake-auth failure key and decides whether this attempt should be logged. */
   register(key: string, nowMs = Date.now()): HandshakeAuthLogDecision {
     const entry = this.entries.get(key);
     if (!entry) {
@@ -48,11 +49,13 @@ export class HandshakeAuthLogLimiter {
     }
     const oldestKey = this.entries.keys().next().value;
     if (oldestKey !== undefined) {
+      // Map insertion order gives a cheap bounded cache; stale keys can re-log once evicted.
       this.entries.delete(oldestKey);
     }
   }
 }
 
+/** Builds the suppression key for repeated missing-credential handshake failures. */
 export function buildHandshakeAuthLogKey(params: {
   reason?: string;
   remoteAddr?: string;
@@ -69,6 +72,7 @@ export function buildHandshakeAuthLogKey(params: {
   ].join("|");
 }
 
+/** Returns true only for benign no-credential retries that should share log suppression. */
 export function shouldLimitMissingCredentialAuthLog(params: {
   reason?: string;
   authProvided?: string;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1311,7 +1311,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             } else if (pairing.created) {
               context.broadcast("device.pair.requested", pairing.request, { dropIfSlow: true });
             }
-            // Re-resolve: another connection may have superseded/approved the request since we created it
+            // Re-resolve: another connection may have superseded/approved the
+            // request since we created it, so expose the live request id to the
+            // reconnecting client instead of the stale local request object.
             recoveryRequestId = await resolveLivePendingRequestId();
             if (
               !(
@@ -1498,6 +1500,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                   })
                 : null;
             if (retryBootstrapHandoffProfile) {
+              // Mobile setup may reconnect as node after pairing already
+              // succeeded but before receiving hello-ok. Recreate only the
+              // approved operator handoff token rather than reopening pairing.
               const retryBootstrapOperatorScopes = resolveBootstrapProfileScopesForRole(
                 "operator",
                 retryBootstrapHandoffProfile.scopes,
@@ -1539,6 +1544,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 generation: sessionSharedGatewaySessionGeneration,
               }
             : undefined;
+        // Device tokens issued from browser/webchat shared auth remain tied to
+        // that shared-auth generation; plain paired-device reconnect tokens do
+        // not inherit the shared-secret rotation boundary.
         const deviceToken =
           shouldIssueDeviceToken && device && hasServerApprovedDeviceTokenBaseline
             ? await ensureDeviceToken({
@@ -1595,6 +1603,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
         }
         if (role === "node") {
+          // Node pairing reconciliation can downgrade declared capabilities to
+          // the approved set. Reflect those effective values on the connect
+          // params before registration so downstream method routing sees policy.
           const reconciliation = await reconcileNodePairingOnConnect({
             cfg: getRuntimeConfig(),
             connectParams,
@@ -1657,6 +1668,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }> = [];
         if (pluginSurfaceBaseUrl) {
           for (const pluginCapabilitySurface of Object.values(pluginNodeCapabilitySurfaces)) {
+            // Mint per-client scoped URLs after auth/pairing but before setClient
+            // so plugin callbacks cannot see a surface without a stored grant.
             const capability = mintPluginNodeCapabilityToken();
             const expiresAtMs = resolvePluginNodeCapabilityExpiresAtMs(pluginCapabilitySurface);
             if (expiresAtMs === undefined) {
@@ -1962,6 +1975,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         if (!barrier) {
           break;
         }
+        // Token rotation/revocation mutates the same credential store used by
+        // closeInvalidatedClient(); drain earlier mutation requests before
+        // authorizing later frames from this socket.
         await barrier.catch(() => undefined);
         if (isClosed()) {
           return;
@@ -2046,6 +2062,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
       });
       if (DEVICE_CREDENTIAL_INVALIDATING_METHODS.has(req.method)) {
+        // Later frames on this connection wait for device-token mutations to
+        // finish, preventing a stale in-memory client from racing one more RPC.
         const barrier = dispatch.finally(() => {
           if (deviceCredentialMutationBarrier === barrier) {
             deviceCredentialMutationBarrier = undefined;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -306,6 +306,7 @@ function resolvePinnedClientMetadata(params: {
 }
 
 export type GatewayWsMessageHandlerParams = {
+  /** Raw WebSocket plus upgrade metadata for one gateway connection. */
   socket: WebSocket;
   upgradeReq: IncomingMessage;
   connId: string;
@@ -350,6 +351,7 @@ export type GatewayWsMessageHandlerParams = {
   logWsControl: SubsystemLogger;
 };
 
+/** Wires the full gateway WebSocket frame lifecycle for a single accepted socket. */
 export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerParams) {
   const {
     socket,
@@ -394,6 +396,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     logWsControl,
   } = params;
 
+  // Handshake rejection paths need to flush a JSON-RPC response before closing;
+  // use the callback form so callers can await kernel/socket backpressure.
   const sendFrame = async (obj: unknown): Promise<void> =>
     await new Promise<void>((resolve, reject) => {
       socket.send(JSON.stringify(obj), (err) => {
@@ -473,6 +477,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     if (!client.invalidated) {
       return false;
     }
+    // Device/token repair can invalidate an already-connected client between
+    // frames; close before dispatch so stale auth never reaches method handlers.
     const reason = client.invalidatedReason ?? "invalidated";
     setCloseCause("client-invalidated", {
       reason,
@@ -489,6 +495,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
 
     const preauthPayloadBytes = !getClient() ? getRawDataByteLength(data) : undefined;
     if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
+      // Apply the small pre-auth cap before JSON parsing. Authenticated clients
+      // get the normal WebSocket payload limit after the handshake succeeds.
       logRejectedLargePayload({
         surface: "gateway.ws.preauth",
         bytes: preauthPayloadBytes,
@@ -624,6 +632,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         const { minProtocol, maxProtocol } = connectParams;
         const supportsCurrentProtocol =
           maxProtocol >= PROTOCOL_VERSION && minProtocol <= PROTOCOL_VERSION;
+        // Probe clients may be old enough to predate current protocol support;
+        // keep their restart/health path alive so they can report upgrade state.
         const supportsProbeRestartProtocol =
           connectParams.client.mode === GATEWAY_CLIENT_MODES.PROBE &&
           maxProtocol >= MIN_PROBE_PROTOCOL_VERSION &&
@@ -969,6 +979,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         }
 
         const authDecision = await resolveConnectAuthDecision({
+          // Start from shared-auth state, then allow stronger bootstrap/device
+          // credentials to reclassify the session before pairing decisions run.
           state: {
             authResult,
             authOk,
@@ -1036,6 +1048,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         const sharedGatewaySessionGeneration = usesSharedGatewayAuth
           ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
           : undefined;
+        // Shared-auth sessions are bound to the current secret/proxy generation.
+        // Device tokens issued from that shared-auth generation inherit the same
+        // rotation boundary so a secret change can evict derived sessions too.
         const sessionUsesSharedGatewayAuth =
           usesSharedGatewayAuth || deviceTokenSharedGatewaySessionGeneration !== undefined;
         const sessionSharedGatewaySessionGeneration =

--- a/src/gateway/server/ws-connection/unauthorized-flood-guard.ts
+++ b/src/gateway/server/ws-connection/unauthorized-flood-guard.ts
@@ -27,12 +27,14 @@ export class UnauthorizedFloodGuard {
     this.logEvery = resolveIntegerOption(options?.logEvery, DEFAULT_LOG_EVERY, { min: 1 });
   }
 
+  /** Records one unauthorized response and decides whether to log or close the socket. */
   registerUnauthorized(): UnauthorizedFloodDecision {
     this.count += 1;
     const shouldClose = this.count > this.closeAfter;
     const shouldLog = this.count === 1 || this.count % this.logEvery === 0 || shouldClose;
 
     if (!shouldLog) {
+      // Keep the next logged line useful without logging every repeated unauthorized RPC.
       this.suppressedSinceLastLog += 1;
       return {
         shouldClose,
@@ -52,12 +54,14 @@ export class UnauthorizedFloodGuard {
     };
   }
 
+  /** Resets flood counters after successful authorization or connection teardown. */
   reset(): void {
     this.count = 0;
     this.suppressedSinceLastLog = 0;
   }
 }
 
+/** Detects repeated unauthorized-role RPCs that should feed the flood guard. */
 export function isUnauthorizedRoleError(error?: ErrorShape): boolean {
   if (!error) {
     return false;

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -2,6 +2,7 @@ import type { WebSocket } from "ws";
 import type { ConnectParams } from "../../../packages/gateway-protocol/src/index.js";
 import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
 
+/** Server-side connection state tracked for each authenticated Gateway WebSocket client. */
 export type GatewayWsClient = PluginNodeCapabilityClient & {
   socket: WebSocket;
   connect: ConnectParams;

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -14,6 +14,7 @@ import type {
 } from "../shared/session-types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
+/** Agent defaults projected into sessions.list so clients can render current model choices. */
 export type GatewaySessionsDefaults = {
   modelProvider: string | null;
   model: string | null;
@@ -23,15 +24,19 @@ export type GatewaySessionsDefaults = {
   thinkingDefault?: string;
 };
 
+/** Terminal and active run states surfaced for session rows. */
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";
 
+/** Child-run state used to distinguish active subagents from retained history. */
 type SubagentRunState = "active" | "interrupted" | "historical";
 
+/** Compact checkpoint metadata exposed without loading full checkpoint payloads. */
 export type SessionCompactionCheckpointPreview = Pick<
   SessionCompactionCheckpoint,
   "checkpointId" | "createdAt" | "reason"
 >;
 
+/** Control UI session row assembled from persisted session metadata and live run state. */
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
@@ -97,26 +102,32 @@ export type GatewaySessionRow = {
   pluginExtensions?: PluginSessionExtensionProjection[];
 };
 
+/** Agent row shape shared with the public session-types package. */
 export type GatewayAgentRow = SharedGatewayAgentRow;
 
+/** One transcript preview message returned by sessions.preview. */
 export type SessionPreviewItem = {
   role: "user" | "assistant" | "tool" | "system" | "other";
   text: string;
 };
 
+/** Preview result for a single requested session key. */
 export type SessionsPreviewEntry = {
   key: string;
   status: "ok" | "empty" | "missing" | "error";
   items: SessionPreviewItem[];
 };
 
+/** Batched transcript preview response with a generation timestamp. */
 export type SessionsPreviewResult = {
   ts: number;
   previews: SessionsPreviewEntry[];
 };
 
+/** sessions.list response with Gateway-specific default and row projections. */
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
 
+/** sessions.patch response including the updated persisted entry and resolved runtime fields. */
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;
   resolved?: {

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -91,6 +91,7 @@ export function shouldLogWs(): boolean {
   return shouldLogSubsystemToConsole("gateway/ws");
 }
 
+/** Shortens connection, request, and run identifiers while preserving recognizable edges. */
 export function shortId(value: string): string {
   const s = value.trim();
   if (UUID_RE.test(s)) {
@@ -102,6 +103,7 @@ export function shortId(value: string): string {
   return `${s.slice(0, 12)}…${s.slice(-4)}`;
 }
 
+/** Formats arbitrary WebSocket log metadata with bounded length and secret redaction. */
 export function formatForLog(value: unknown): string {
   try {
     if (value instanceof Error) {
@@ -167,6 +169,8 @@ function renderErrorChainForLog(error: Error): string {
   let current: unknown = (error as unknown as { cause?: unknown }).cause;
   let depth = 0;
   while (current !== undefined && current !== null && depth < 8) {
+    // Cause chains can be self-referential or very deep; keep enough context for diagnostics
+    // without letting a malformed error make logging unbounded.
     if (current instanceof Error) {
       segments.push(renderSingleErrorForLog(current));
       current = (current as unknown as { cause?: unknown }).cause;
@@ -187,6 +191,7 @@ function compactPreview(input: string, maxLen = 160): string {
   return `${oneLine.slice(0, Math.max(0, maxLen - 1))}…`;
 }
 
+/** Builds compact agent-event metadata for gateway/ws logs without dumping full payloads. */
 export function summarizeAgentEventForWsLog(payload: unknown): Record<string, unknown> {
   if (!payload || typeof payload !== "object") {
     return {};
@@ -224,6 +229,8 @@ export function summarizeAgentEventForWsLog(payload: unknown): Record<string, un
   }
 
   if (stream === "assistant") {
+    // Assistant payloads can contain full responses/media lists; keep only preview/count fields
+    // so enabling gateway/ws logs does not duplicate transcript content.
     const text = readStringValue(data.text);
     if (text?.trim()) {
       extra.text = compactPreview(text);
@@ -279,12 +286,15 @@ export function summarizeAgentEventForWsLog(payload: unknown): Record<string, un
   return extra;
 }
 
+/** Writes one gateway/ws log record using the configured verbosity and style. */
 export function logWs(direction: "in" | "out", kind: string, meta?: Record<string, unknown>) {
   if (!shouldLogSubsystemToConsole("gateway/ws")) {
     return;
   }
   const style = getGatewayWsLogStyle();
   if (!isVerbose()) {
+    // Normal logs only surface parse errors, failures, and slow responses; verbose modes opt into
+    // full request/event tracing.
     logWsOptimized(direction, kind, meta);
     return;
   }

--- a/src/gateway/ws-logging.ts
+++ b/src/gateway/ws-logging.ts
@@ -2,10 +2,12 @@ export type GatewayWsLogStyle = "auto" | "full" | "compact";
 
 let gatewayWsLogStyle: GatewayWsLogStyle = "auto";
 
+/** Overrides the gateway/ws console log style for CLI flags and tests. */
 export function setGatewayWsLogStyle(style: GatewayWsLogStyle): void {
   gatewayWsLogStyle = style;
 }
 
+/** Returns the current gateway/ws console log style. */
 export function getGatewayWsLogStyle(): GatewayWsLogStyle {
   return gatewayWsLogStyle;
 }


### PR DESCRIPTION
## Summary
- Document Gateway plugin node capability surface contracts around shortest-TTL indexing, scoped storage keys, scoped URL canonicalization, and sliding grant expiry.
- Document Gateway plugin node invoke policy contracts around dangerous command fail-closed behavior and policy invoke override inheritance.
- Document Gateway startup auth/service contracts around secret-input resolution, materialized config auth, channel-health disable semantics, startup-safe service handles, and no-op heartbeat shutdown shape.
- Document Gateway WebSocket attach contracts around shared runtime context binding and TLS-aware plugin node capability URL minting.
- Document Gateway chat state registry contracts around run adoption queues, per-run buffer cleanup, session subscriber indexes, disconnect cleanup, and tool-event recipient retention.
- Document Gateway session broadcast contracts around global/default-agent key fallback, serialized transcript updates, subscriber de-duping, persisted sequence recovery, lifecycle broadcasts, and lazy subscription imports.
- Document Gateway live chat projection contracts around bounded assistant buffers, snapshot/delta merge behavior, text normalization, suppressed control replies, and commentary filtering.
- Document Gateway chat abort contracts around abort expiry windows, controller registration, duplicate cleanup, terminal abort cleanup/broadcast behavior, run sequence cleanup, and provider-wide aborts.
- Document Gateway broadcast contracts around event scoping, target-only sends, frame serialization reuse, slow-consumer sequence gaps, and targeted-send sequence omission.
- Document Gateway preauth connection budget contracts around per-client-IP caps, rejected-upgrade accounting, and empty-bucket cleanup.
- Document Gateway WebSocket log contracts around log-style accessors, identifier compaction, bounded/redacted formatting, cause-chain limits, compact agent event summaries, and optimized logging selection.
- Document Gateway WebSocket handshake helper contracts around browser-origin hardening, silent local pairing, locality classification, backend self-pairing bypass, signature payload versions, and unauthorized retry guidance.
- Document Gateway WebSocket auth limiter contracts around handshake log suppression, bounded limiter eviction, unauthorized flood logging/close decisions, flood resets, unauthorized-role detection, and auth failure messages.
- Document Gateway WebSocket auth policy contracts around connect auth state/decision fallback ordering, bootstrap verification serialization, device-token rate-limit independence, Control UI pairing bypass rules, missing-device decisions, scope clearing, and unauthorized failure priority.
- Document Gateway WebSocket message handler contracts around single-socket lifecycle wiring, handshake response flushing, invalidated-client close-before-dispatch behavior, pre-auth frame caps, probe protocol compatibility, fallback auth reclassification, and shared-auth generation binding.
- Document Gateway WebSocket pairing handoff contracts around live pairing request recovery, mobile bootstrap retry handoff, shared-auth-issued device token rotation binding, node capability reconciliation, plugin capability grant ordering, and device-token mutation barriers.
- Document Gateway node pairing reconciliation contracts around runtime allowlist replay, declared/approved surface intersections, explicit permission downgrades, pending approval payloads, first-connect empty effective surfaces, upgrade/downgrade live-surface limits, and trusted-CIDR auto-approval source checks.
- Document Gateway node command policy contracts around plugin default/dangerous command handling, foreground restriction lookup, desktop host command runtime-vs-pairing filtering, approved runtime command retention, explicit config override authority, live allowlist resolution, pairing-review allowlists, declared-command normalization, and node.invoke validation.
- Document Gateway node pending-work contracts around queue state lifecycle, expiry pruning/revisions, priority ordering, synthetic baseline status items, expiry conversion, type-level dedupe, drain/ack behavior, identity-bound drain handlers, and deduped wake ownership.
- Document Gateway node catalog contracts around stable surface normalization, paired-device/node source projection, newest last-seen resolution, live-over-durable merge precedence, current node-role filtering, connected-first ordering, source-record diagnostics lookup, and effective node lookup.
- Document Gateway node registry/event contracts around pre-serialized payload reuse, live-session ownership, stale disconnect protection, declared-surface filtering, system.run event authorization, invoke-result socket ownership, subscription reverse indexes, voice transcript dedupe, unmatched exec event handling, and durable node/device presence metadata.
- Document Gateway node handler/wake contracts around APNs wake coalescing, stale registration clearing, wake nudge throttling, reconnect polling, foreground pending-action queues, scoped plugin-surface refresh, node invoke-result normalization, helper response wrappers, and node.event lazy dispatch.
- Document Gateway Talk/voicewake contracts around Talk-capable node detection, global voice wake trigger handlers, and voice wake routing handlers shared with connected nodes.
- Document Gateway channel RPC contracts around shared operation parsing, status timeout races, runtime account snapshot fallback, logout/start/stop helpers, handler map purpose, activity timestamp merge rules, and configured-account ordering.
- Document Gateway TTS RPC contracts around handler map purpose, configured fallback-provider filtering, preference-only enable/disable state, canonical provider persistence, persona UI metadata, and provider picker payloads.
- Document Gateway push/restart RPC contracts around APNs/web-push handler map purpose, APNs test environment overrides, VAPID public/private key separation, web-push subscription and unsubscribe semantics, broadcast test fan-out, safe restart coordinator routing, and read-only restart preflight.
- Document Gateway cron/secrets RPC contracts around run-log filter reuse, cron validation error mapping, cron handler map purpose, delivery preview timing, all-job run-log name enrichment, secrets handler factory wiring, warning-count-only reloads, and secrets resolve normalization/result validation.
- Document Gateway Talk/tools RPC helper contracts around post-handshake connect rejection, tools.invoke in-band approval/error reporting, optional model-catalog timeout/log-once behavior, browser-owned Talk client transports, Talk client steering ownership, unified Talk session default transport selection, managed-room turn fan-out, unscoped session-key authorization, join replacement events, and close/revoke ordering.
- Document Gateway approval RPC contracts around plugin approval handler ownership, normalized turn-source routing, optional forwarder delivery, exec approval handler delivery hooks, public-channel command display size limits, and iOS push target visibility filtering.
- Document Gateway agent workspace RPC contracts around the agents handler test seam, metadata-only fs-safe fallback, fs-safe workspace writes, workspace-move identity merge behavior, shared-workspace delete guards, agent file link rejection, and config mutation normalization/cleanup ordering.
- Document Gateway config RPC helper contracts around optimistic write snapshots, source-vs-runtime validation preservation, secrets-expanded shared-auth comparisons, trusted-proxy auth normalization, auth-generation refresh ordering, and shared agent-id default/error semantics.
- Document Gateway artifact RPC extraction contracts around transcript metadata sequence stability, safe download-mode selection, exported message artifact collection, requested-artifact-only byte inclusion, summary payload stripping, and query-to-session store scoping.
- Document Gateway effective-tools RPC cache contracts around stable base cache keys, workspace-scoped MCP config summaries, final runtime policy filtering for MCP tools, and test-owned cache lifecycle.
- Document Gateway session active-run projection contracts around Control UI-visible run filtering, global-row agent scoping, and the exported sessions.list active-run indicator helper.
- Document Gateway outbound send idempotency contracts around send/action/poll state resolution, in-flight join metadata, public delivery payload projection, durable success caching, and cached transport failure semantics.
- Document Gateway usage cache contracts around bounded/in-flight cost-usage loading, refreshing-summary timestamp semantics, and least-fresh per-agent cache status aggregation.
- Document Gateway agent job waiter contracts around waiter-count diagnostics, terminal-cache precedence refreshes, and cached-vs-future lifecycle waiting.
- Document Gateway restart request normalization contracts around sentinel payload filtering and restartDelayMs duration clamping.
- Document Gateway models auth-status wire contracts around auth-profile row identity, credential-family semantics, provider normalization, OAuth-focused rollups, multi-store logout removal, and auth-revoked run abort reporting.
- Document Gateway commands.list contracts around provider-native vs text command name surfaces and deterministic protocol-limit truncation.
- Document Gateway health handler contracts around operator-scoped sensitive fields and explicit probe cache-bypass behavior.
- Document Gateway plugin session-action contracts around successful result promotion, in-band plugin failure reporting, and JSON-safe extension payload validation.
- Document Gateway node helper error contracts around compact public node invoke errors and raw node-error detail preservation for operator diagnostics.
- Document Gateway optional model-catalog helper contracts around caller-surface log dedupe, optional discovery failure behavior, and timeout sentinel ownership.
- Document Gateway server-method record helper contracts around strict optional-record coercion and non-empty trimmed string normalization.
- Document Gateway managed update handoff contracts around detached helper result fields, supervisor hint stripping, sentinel meta handoff, and unavailable-update guidance.
- Document Gateway chat-abort shared test helper contracts around active-run records, production-like cleanup, and handler invocation wiring.
- Document Gateway config shared test helper contracts around write-snapshot fixtures, handler harness wiring, and deferred side-effect flushing.
- Document Gateway response assertion helper contract around the standard failed RPC tuple and protocol error shape.
- Document Gateway subagent follow-up test helper contract around completed-run replacement and child-session reactivation broadcasts.
- Document Gateway deleted-agent guard test helper contracts around hoisted session-utils reset and orphaned session fixtures.
- Document Gateway test-support helper contracts around partial child-process mocks, transcript fixtures, and handler response capture.
- Document Gateway Talk shared helper API contracts around direct-tool auth, room event fan-out, provider selection, realtime instructions, launch overrides, and unsupported browser sessions.
- Document Gateway server-method shared type contracts around client metadata, respond callbacks, request contexts, dispatch options, handler options, and handler maps.
- Document Gateway broadcast/channel hook type contracts around broadcast state versions, slow-socket delivery options, hook message channel aliases, and channel runtime snapshots.
- Document Gateway session/node/WebSocket type contracts around session rows, preview responses, patch responses, node event dispatch context, node event envelopes, and authenticated WebSocket client state.
- Document Gateway auth resolution contracts around token source precedence, secret-ref env fallback, env/config conflict detection, probe auth diagnostics, interactive auth failure reporting, and auto-mode password-vs-token choice.
- Document agent tool filesystem policy contracts around workspace-only policy construction, agent-vs-global fs config resolution, effective workspace-only checks, and root-expansion allowlist checks.
- Document agent bundled MCP type contracts around materialized tool runtimes, server catalog metadata, catalog tools, catalog snapshots, diagnostics, session runtimes, and runtime-manager ownership.
- Document agent tool policy shared contracts around tool groups, tool-name aliases, partial-prefix matching, policy-list normalization, group expansion, and built-in profile resolution.
- Document agent runtime-plan contracts around auth forwarding, prepared tool planning, tool normalization and diagnostics, delivery, outcome, transcript, transport, observability, and plan construction.
- Document agent model runtime policy contracts around model/provider policy precedence, ambiguous bare-model fail-closed behavior, provider-qualified model matching, wildcard handling, and model tool-support defaults.
- Document agent tool schema contracts around runtime schema projection diagnostics, proxy-safe inspection, dynamic-keyword handling, runtime-vs-provider-normalizable filtering, OpenAI strict schema cache behavior, strict diagnostics, and inventory strict-flag resolution.
- Document agent tool catalog and explicit allowlist contracts around profile policies, catalog sections, group expansion, profile resolution defensive copies, core id helpers, allowlist source labels, and fail-closed diagnostics.
- Document agent tool loop detection contracts around warning-vs-critical results, run-scoped history, no-progress outcome hashes, ping-pong critical proof, missing-tool critical behavior, outcome attachment, stats summaries, and agent-over-global config merging.
- Document agent tool call id contracts around provider result id extraction, replay-safe signed-thinking id preservation, strict9 collision hashing, strict suffix constraints, occurrence-aware assistant/result mapping, preserved-id reservation, and replay tool-name allowlist validation.
- Document agent tool mutation contracts around mutating-tool name hints, concrete mutation classification, stable action fingerprints, explicit target preference, structured file-target extraction, mutation state payloads, and same-mutation recovery matching.
- Document agent tool display contracts around display metadata resolution, detail redaction/summary formatting, display specs, tool-search display targets, normalized fallback titles, argument-derived verb/detail resolution, value truncation, config-owned detail paths, tool-search bridge parsing, and generic detail fallback ordering.
- Document agent exec tool display contracts around exec/bash display heuristics, pipeline first/last summaries, sandbox cwd suppression, raw-command truncation, detail mode behavior, shell word splitting, binary/option/positional helpers, env trimming, shell wrapper unwrapping, top-level stage/pipe splitting, preamble cwd extraction, and popd cwd reset semantics.
- Document agent session tool-result guard contracts around pending tool-call tracking and flush decisions, transcript sequence memoization, persisted detail boundary redaction, secret-prefix omission, hostile detail recursion caps, oversized detail fallback summaries, stable summary-field preservation, missing toolResult name backfill, strict tool-call/tool-result repair ordering, synthetic tool-result flushes, transcript-only assistant suppression, one-time guard installation, post-hook redaction ordering, and single-use prepared turn metadata.
- Document agent tool-result truncation/context contracts around estimate cache scope, legacy tool-result detection, visible-text extraction, hostile unknown-block fallback, cache invalidation after in-place mutation, transcript prompt marker projection, provider-bound guard cloning, non-text overflow notices, context-engine loop fence resets/cache reuse, provider context guard install contract, bounded truncation suffixes, live cap resolution, aggregate-after-oversized replacement planning, reduction-potential estimates, in-memory/session-file rewrite contracts, session write-lock recovery, and oversized-session gate behavior.
- Document agent tool-call repair and Tool Search run-plan contracts around visible-vs-replay allowlists, empty-allowlist callable accounting, auto-added control detection, cataloged hidden tools, replay control retention after compaction, malformed tool-call repair stream wrapping, provider/API repair selection, XAI HTML-entity decoding, repair buffer disablement, and smart-quoted successor-key closing behavior.
- Document agent run decision/session helper contracts around embedded-attempt write-lock option resolution, stream auth provenance, unknown-tool thresholds, LLM output hook gating, tool-policy provider selection, completion-required async-task waits, process-local session ownership, session-lock fences, benign transcript-only rewrites, same-process write generations, trusted-state publishing, and nested owned-write fingerprints.
- Document agent run diagnostic/prompt helper contracts around stage timing summaries, dispatch subspan labels, slow-stage warning thresholds, compact stage formatting, failover decision observations, timeout reason normalization, raw-error console suppression, runtime-context custom messages, current inbound context selection/joining, transcript-aware runtime-context extraction, model-only retry text separation, runtime-event system context, and hidden runtime-context transcript rows.
- Document agent run prompt/thread/trajectory helper contracts around attempt system prompts, raw-model probe prompt omission, hook system-context composition, spawned subagent workspace exposure, cache-TTL transcript markers, safe cache-TTL append timing, bootstrap turn persistence gates, trajectory cleanup timeouts, terminal trajectory status/reason types, safe assistant fallback text, terminal delivery/progress classification, and terminal tool-use non-delivery errors.
- Document agent LLM-boundary/context/yield/precheck contracts around replay normalization, current prompt boundary preservation, prompt-local runtime context retries, model-prompt transform timestamp pinning, safe blocked-run metadata projection, context-engine bootstrap injection decisions, prompt-cache result metadata, current-attempt assistant lookup, cache-touch timestamp semantics, sessions_yield abort-settle waits, synthetic aborted responses, hidden yield steering/context persistence, yield artifact cleanup, mid-turn precheck request shape, stable overflow error text, and signal narrowing.
- Document agent abort/failover helper contracts around abortable promise races, abort listener cleanup, background session-lock release on abort, non-throwing abort cleanup failures, assistant-stage failover routing, profile-rotation-before-persistence ordering, and exhausted-profile decision recomputation.
- Document agent failover/auth/compaction policy contracts around retry escalation, terminal format retries, harness-owned timeout rotation guards, retry reason precedence, auth-profile failure mapping, compaction timeout grace, safe compaction transcript tails, pre-compaction snapshot preference, and aggregate retry timeout lane protection.
- Document agent timeout/preemptive-compaction helper contracts around Codex app-server replay gates, prompt-token estimator safety bias, hostile JSON fallback estimates, LLM-boundary estimate helpers, unwindowed transcript routing, truncation-route buffers, precheck log/status builders, idle-timeout resolution, stream timeout clamping, profile rotation helpers, retry-loop caps, embedded-harness model refs, error-path usage metadata, and final assistant text extraction.
- Document agent image/history helper contracts around stable prune markers, completed-turn image pruning, prompt/attachment image ordering, attachment-ref partitioning, structured image reference parsing, file URL normalization, and loaded-image metadata defaults.
- Document agent incomplete-turn helper contracts around terminal assistant detection, replay-safety metadata, incomplete-turn warnings, missing-assistant retry eligibility, silent tool-result replies, replay-invalid liveness mapping, non-visible retry steering, short approval fast-paths, planning-only diagnostics, and plan-only retry limits.
- Document agent run type contracts around run triggers, ephemeral inbound prompt context, run-level caller API, session/prompt identity keys, sensitive sender/owner fields, image ordering, auth source hints, execution/reply callbacks, persistence hooks, resolved attempt inputs, attempt outcomes, replay lifecycle counters, and terminal lifecycle metadata.
- Document agent tool-construction helper contracts around final runtime allowlist filtering, forced message-tool allowlist merging, local-vs-plugin construction classification, attempt tool-family construction plans, core-tool predicates, and bundled MCP/LSP runtime startup decisions.
- Document agent bootstrap/session helper contracts around resource-loader session options, resource-loader preserving session creation, primary bootstrap-run ownership, context-file workspace rebasing, and external context path preservation.
- Document agent async task wait contracts around abort listener cleanup during polling, late detached-task registration handling, waited-run-id ownership, and cron media-task delivery waits.
- Document agent prompt helper contracts around hook ordering/fallbacks, per-run injection drain reuse, prompt-mode scoping, prompt skip reasons after image pruning, bounded structured-message fallback serialization, orphaned queued-user prompt merging, workspace-only policy resolution, cache-boundary prompt additions, and usage-derived after-turn runtime context.
- Document agent stream normalization contracts around tool-call name normalization, cross-retry unknown-tool guard state, replay tool-call id sanitizer boundaries, OpenAI Responses replay normalization, malformed replay sanitization before provider submission, and sensitive stop-reason recovery into deliverable assistant errors.
- Document agent runtime context contracts around bootstrap/context injection completion recording, prompt-cache metadata omission for empty inputs, current-attempt assistant selection after prompt boundary, inbound prompt resumable text, context-owned prompt joining, and runtime-context prompt part separation for runtime-only events.
- Document agent steering/bootstrap/media helper contracts around active-session steering targets, queued steering transcript-commit waits, runtime/UI queue cancellation, auto-retry/compaction continuation races, optional delivery wait helpers, tool-media payload merging, message-tool-only mirror guards, hostile-tail message merge strategy selection, bootstrap context targets, hook bootstrap detection, and workspace bootstrap routing.
- Document agent auth/policy contracts around embedded auth/profile controller ownership across retries, runtime transcript policy fallback order, immutable tool-run trace freezing, explicit fallback override precedence, and heartbeat trigger defaults for unknown triggers.
- Document agent auth/cleanup/policy helper contracts around heartbeat trigger policy, embedded model fallback detection, immutable tool-run contexts, retry-limit failover/error conversion, abort-settle timeout resolution, resource cleanup, session-lock release invariants, auth controller construction, stale runtime-auth refresh suppression, retry timer ownership, and source-vs-runtime credential refresh state.
- Document agent setup/stream/payload helper contracts around stream event observation, message-transform no-op identity preservation, process-wide HTTP runtime proxy/timeout ordering, embedded backend result preservation, hook model override precedence, before-model-resolve attachment projection, effective runtime model context-window policy, auto-compaction caps, final payload projection, source-reply mirror idempotency, stable payload test defaults/assertions, and embedded-run payload construction.
- Document embedded attempt harness contracts around runEmbeddedAttempt ownership, cleanup takeover error preservation, cached test imports, shared runner doubles, mutable session fixtures, context-engine spies, and injected context-engine attempt runner scope.
- Document agent terminal/diagnostic helper contracts around message-tool-only terminal delivery detection, bounded delivery-envelope recursion, dry-run guards, terminal afterToolCall hook installation, non-configurable stream iterator diagnostic fallback, model.call diagnostic wrapper API, and traceparent propagation into provider requests.

## Verification
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `pnpm test src/gateway/plugin-node-capability.test.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `pnpm test src/gateway/connection-auth.test.ts src/gateway/server-runtime-services.test.ts`
- `pnpm test src/gateway/server.startup-websocket-race.test.ts src/gateway/server-import-boundary.test.ts`
- `pnpm test src/gateway/server-chat.agent-events.test.ts src/gateway/server-maintenance.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/session-message-events.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/server-chat.agent-events.test.ts`
- `pnpm test src/gateway/server-chat.stream-text-merge.test.ts src/gateway/chat-abort.test.ts src/gateway/server-chat.agent-events.test.ts`
- `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/ws-log.test.ts`
- `pnpm test src/gateway/server/preauth-connection-budget.test.ts src/gateway/server.preauth-hardening.test.ts`
- `pnpm test src/gateway/ws-log.test.ts src/gateway/gateway-misc.test.ts`
- `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/auth-messages.test.ts`
- `pnpm test src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts src/gateway/server/ws-connection/unauthorized-flood-guard.test.ts src/gateway/server/ws-connection/auth-messages.test.ts`
- `pnpm test src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`
- `pnpm test src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server-import-boundary.test.ts`
- `pnpm test src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server.shared-auth-rotation.test.ts src/gateway/server.shared-token-session-rotation.test.ts`
- `pnpm test src/gateway/node-connect-reconcile.test.ts src/gateway/node-pairing-auto-approve.test.ts`
- `pnpm test src/gateway/node-command-policy.test.ts src/gateway/node-connect-reconcile.test.ts`
- `pnpm test src/gateway/node-pending-work.test.ts src/gateway/server-methods/nodes-pending.test.ts`
- `pnpm test src/gateway/node-catalog.test.ts`
- `pnpm test src/gateway/node-registry.test.ts src/gateway/server-node-events.test.ts`
- `pnpm test src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server-methods/nodes.wake-leak.test.ts src/gateway/server-methods/nodes-pending.test.ts`
- `pnpm test src/gateway/server-talk-nodes.test.ts src/gateway/server.models-voicewake-misc.test.ts`
- `pnpm test src/gateway/server-methods/channels.status.test.ts src/gateway/server-methods/channels.start.test.ts`
- `pnpm test src/gateway/server-methods/tts.test.ts`
- `pnpm test src/gateway/server-methods/push.test.ts src/gateway/server-methods/restart.test.ts`
- `pnpm test src/gateway/server-methods/cron.validation.test.ts src/gateway/server-methods/secrets.test.ts`
- `pnpm test src/gateway/server-methods/talk.test.ts src/gateway/tools-invoke-http.test.ts src/gateway/server-methods-list.test.ts`
- `pnpm test src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts`
- `pnpm test src/gateway/server-methods/agents-mutate.test.ts src/gateway/server-methods/agent.test.ts`
- `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-methods/agents-mutate.test.ts`
- `pnpm test src/gateway/server-methods/artifacts.test.ts`
- `pnpm test src/gateway/server-methods/tools-effective.test.ts`
- `pnpm test src/gateway/chat-abort.test.ts src/gateway/server.sessions.list-changed.test.ts`
- `pnpm test src/gateway/server-methods/send.test.ts`
- `pnpm test src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/server-methods/restart.test.ts src/gateway/server-methods/update.test.ts`
- `pnpm test src/gateway/server-methods/models-auth-status.test.ts`
- `pnpm test src/gateway/server-methods/commands.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/method-scopes.test.ts src/gateway/call.test.ts`
- `pnpm test src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm test src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm test src/gateway/server-methods/push.test.ts src/gateway/server-methods/doctor.test.ts src/gateway/server-methods/talk.test.ts`
- `pnpm test src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts`
- `pnpm test src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`
- `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts`
- `pnpm test src/gateway/server-methods/models.test.ts src/gateway/server-methods/tts.test.ts`
- `pnpm test src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts`
- `pnpm test src/gateway/server-methods/chat.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-deleted-agent.test.ts`
- `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/server-methods/skills.clawhub.test.ts src/gateway/server-methods/skills.proposals.test.ts`
- `pnpm test src/gateway/server-methods/talk.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts`
- `pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts src/gateway/method-scopes.test.ts src/gateway/call.test.ts`
- `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server/presence-events.test.ts src/gateway/server-methods/channels.status.test.ts src/gateway/server-methods/channels.start.test.ts src/gateway/hooks.test.ts src/gateway/hooks-mapping.test.ts`
- `pnpm test src/gateway/session-utils.test.ts src/gateway/server-node-events.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts`
- `pnpm test src/gateway/auth-surface-resolution.test.ts src/gateway/auth.test.ts src/gateway/startup-auth.test.ts src/commands/doctor/shared/hooks-token-reuse-repair.test.ts src/commands/doctor-gateway-auth-token.test.ts src/gateway/probe-auth.test.ts`
- `pnpm test src/agents/tool-fs-policy.test.ts src/agents/sandbox-tool-policy.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy-pipeline.test.ts`
- `pnpm test src/agents/agent-bundle-mcp-runtime.test.ts src/agents/mcp-oauth.test.ts`
- `pnpm test src/agents/tool-policy.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/agent-tools.policy.test.ts src/agents/agent-tools.message-provider-policy.test.ts`
- `pnpm test src/agents/runtime-plan/types.test.ts src/agents/runtime-plan/types.compat.test.ts src/agents/runtime-plan/build.test.ts src/agents/runtime-plan/auth.test.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.diagnostics.test.ts`
- `pnpm test src/agents/model-runtime-policy.test.ts src/agents/model-tool-support.test.ts`
- `pnpm test src/agents/tool-schema-projection.test.ts src/agents/openai-tool-schema.test.ts`
- `pnpm test src/agents/tool-catalog.test.ts src/agents/tool-allowlist-guard.test.ts src/gateway/server-methods/tools-catalog.test.ts`
- `pnpm test src/agents/tool-loop-detection.test.ts src/agents/embedded-agent-runner/run.compaction-loop-guard.test.ts src/gateway/tools-invoke-http.test.ts`
- `pnpm test src/agents/tool-call-id.test.ts src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts`
- `pnpm test src/agents/tool-mutation.test.ts src/acp/approval-classifier.test.ts src/agents/embedded-agent-subscribe.tools.test.ts`
- `pnpm test src/agents/tool-display.test.ts`
- `pnpm test src/agents/session-tool-result-guard.test.ts src/agents/session-tool-result-guard.transcript-events.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`
- `pnpm test src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts src/agents/embedded-agent-runner/run/failover-observation.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/abortable.test.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts src/agents/embedded-agent-runner/run/transcript-repair-runtime-contract.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/auth-controller.test.ts src/agents/embedded-agent-runner/run/attempt.transcript-policy.test.ts src/agents/embedded-agent-runner/run/fallbacks.test.ts src/agents/embedded-agent-runner/run/trigger-policy.test.ts src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/setup.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.timeout.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.sessions-spawn.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`

## Real Behavior Proof
Behavior addressed: Comment-only documentation for Gateway plugin node capability, plugin node invoke policy, connection auth, runtime startup service, WebSocket attach, chat state registry, session broadcast, live chat projection, chat abort, broadcast, preauth connection budget, WebSocket log, WebSocket handshake helper, WebSocket auth limiter, WebSocket auth policy, WebSocket message handler, WebSocket pairing handoff, node pairing reconciliation, node command policy, node pending-work, node catalog, node registry/event, node handler/wake, Talk/voicewake, channel RPC, TTS RPC, push/restart RPC, cron/secrets RPC, Talk/tools RPC helper, approval RPC, agent workspace RPC, config RPC helper, artifact RPC extraction, effective-tools RPC cache, session active-run projection, outbound send idempotency, usage cache contracts, agent job waiter contracts, restart request normalization contracts, models auth-status wire contracts, commands.list surface contracts, health handler scope/probe contracts, plugin session-action result contracts, node helper error-detail contracts, optional model-catalog fallback contracts, server-method record helper contracts, managed update handoff contracts, chat-abort shared test-helper contracts, config shared test-helper contracts, gateway response assertion helper contracts, subagent follow-up shared test-helper contracts, deleted-agent guard shared test-helper contracts, Gateway test-support helper contracts, Talk shared helper API contracts, server-method shared type contracts, broadcast/channel hook type contracts, session/node/WebSocket type contracts, auth resolution contracts, agent tool filesystem policy contracts, agent bundled MCP type contracts, agent tool policy shared contracts, agent runtime-plan contracts, agent model runtime policy contracts, agent tool schema contracts, agent tool catalog/allowlist contracts, agent tool loop detection contracts, agent tool call id contracts, agent tool mutation contracts, agent tool display contracts, agent exec tool display contracts, agent session tool-result guard contracts, agent tool-result truncation/context contracts, agent tool-call repair/Tool Search run-plan contracts, agent run decision/session helper contracts, agent run diagnostic/prompt helper contracts, agent run prompt/thread/trajectory helper contracts, agent LLM-boundary/context/yield/precheck contracts, agent abort/failover helper contracts, agent image/history helper contracts, agent incomplete-turn helper contracts, agent run type contracts, agent tool-construction helper contracts, agent bootstrap/session helper contracts, agent async task wait contracts, agent prompt helper contracts, agent stream normalization contracts, agent runtime context contracts, agent steering/bootstrap/media helper contracts, agent auth/policy contracts, agent setup/payload contracts, and embedded attempt harness contracts; no runtime behavior changed.

Real environment tested: Local macOS checkout on branch `codex/node-capability-policy-comments-20260602`, rebased on current `origin/main`.

Exact steps or command run after this patch: `git diff --check origin/main..HEAD`; `pnpm test src/gateway/plugin-node-capability.test.ts src/gateway/node-invoke-plugin-policy.test.ts`; `pnpm test src/gateway/connection-auth.test.ts src/gateway/server-runtime-services.test.ts`; `pnpm test src/gateway/server.startup-websocket-race.test.ts src/gateway/server-import-boundary.test.ts`; `pnpm test src/gateway/server-chat.agent-events.test.ts src/gateway/server-maintenance.test.ts src/gateway/gateway-misc.test.ts`; `pnpm test src/gateway/session-message-events.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts src/gateway/server-chat.agent-events.test.ts`; `pnpm test src/gateway/server-chat.stream-text-merge.test.ts src/gateway/chat-abort.test.ts src/gateway/server-chat.agent-events.test.ts`; `pnpm test src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts src/gateway/ws-log.test.ts`; `pnpm test src/gateway/server/preauth-connection-budget.test.ts src/gateway/server.preauth-hardening.test.ts`; `pnpm test src/gateway/ws-log.test.ts src/gateway/gateway-misc.test.ts`; `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/auth-messages.test.ts`; `pnpm test src/gateway/server/ws-connection/handshake-auth-log-limiter.test.ts src/gateway/server/ws-connection/unauthorized-flood-guard.test.ts src/gateway/server/ws-connection/auth-messages.test.ts`; `pnpm test src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server/ws-connection/connect-policy.test.ts`; `pnpm test src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server-import-boundary.test.ts`; `pnpm test src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server.shared-auth-rotation.test.ts src/gateway/server.shared-token-session-rotation.test.ts`; `pnpm test src/gateway/node-connect-reconcile.test.ts src/gateway/node-pairing-auto-approve.test.ts`; `pnpm test src/gateway/node-command-policy.test.ts src/gateway/node-connect-reconcile.test.ts`; `pnpm test src/gateway/node-pending-work.test.ts src/gateway/server-methods/nodes-pending.test.ts`; `pnpm test src/gateway/node-catalog.test.ts`; `pnpm test src/gateway/node-registry.test.ts src/gateway/server-node-events.test.ts`; `pnpm test src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server-methods/nodes.wake-leak.test.ts src/gateway/server-methods/nodes-pending.test.ts`; `pnpm test src/gateway/server-talk-nodes.test.ts src/gateway/server.models-voicewake-misc.test.ts`; `pnpm test src/gateway/server-methods/channels.status.test.ts src/gateway/server-methods/channels.start.test.ts`; `pnpm test src/gateway/server-methods/tts.test.ts`; `pnpm test src/gateway/server-methods/push.test.ts src/gateway/server-methods/restart.test.ts`; `pnpm test src/gateway/server-methods/cron.validation.test.ts src/gateway/server-methods/secrets.test.ts`; `pnpm test src/gateway/server-methods/talk.test.ts src/gateway/tools-invoke-http.test.ts src/gateway/server-methods-list.test.ts`; `pnpm test src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts`; `pnpm test src/gateway/server-methods/agents-mutate.test.ts src/gateway/server-methods/agent.test.ts`; `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-methods/agents-mutate.test.ts`; `pnpm test src/gateway/server-methods/artifacts.test.ts`; `pnpm test src/gateway/server-methods/tools-effective.test.ts`; `pnpm test src/gateway/chat-abort.test.ts src/gateway/server.sessions.list-changed.test.ts`; `pnpm test src/gateway/server-methods/send.test.ts`; `pnpm test src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.test.ts`; `pnpm test src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/server-methods/restart.test.ts src/gateway/server-methods/update.test.ts`; `pnpm test src/gateway/server-methods/models-auth-status.test.ts`; `pnpm test src/gateway/server-methods/commands.test.ts src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/method-scopes.test.ts src/gateway/call.test.ts`; `pnpm test src/gateway/server-methods/nodes-pending.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts src/gateway/server-methods/server-methods.test.ts`; `pnpm test src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`; `pnpm test src/gateway/server-methods/push.test.ts src/gateway/server-methods/doctor.test.ts src/gateway/server-methods/talk.test.ts`; `pnpm test src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts`; `pnpm test src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`; `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts`; `pnpm test src/gateway/server-methods/models.test.ts src/gateway/server-methods/tts.test.ts`; `pnpm test src/gateway/server-methods/sessions.send-followup-status.test.ts src/gateway/server-methods/agent.test.ts`; `pnpm test src/gateway/server-methods/chat.send-deleted-agent.test.ts src/gateway/server-methods/sessions.send-deleted-agent.test.ts`; `pnpm test src/gateway/server-methods/config.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/server-methods/skills.clawhub.test.ts src/gateway/server-methods/skills.proposals.test.ts`; `pnpm test src/gateway/server-methods/talk.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts`; `pnpm test src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods-list.test.ts src/gateway/method-scopes.test.ts src/gateway/call.test.ts`; `pnpm test src/gateway/gateway-misc.test.ts src/gateway/server/presence-events.test.ts src/gateway/server-methods/channels.status.test.ts src/gateway/server-methods/channels.start.test.ts src/gateway/hooks.test.ts src/gateway/hooks-mapping.test.ts`; `pnpm test src/gateway/session-utils.test.ts src/gateway/server-node-events.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/auth-context.test.ts src/gateway/server-methods/sessions.send-followup-status.test.ts`; `pnpm test src/gateway/auth-surface-resolution.test.ts src/gateway/auth.test.ts src/gateway/startup-auth.test.ts src/commands/doctor/shared/hooks-token-reuse-repair.test.ts src/commands/doctor-gateway-auth-token.test.ts src/gateway/probe-auth.test.ts`; `pnpm test src/agents/tool-fs-policy.test.ts src/agents/sandbox-tool-policy.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy-pipeline.test.ts`; `pnpm test src/agents/agent-bundle-mcp-runtime.test.ts src/agents/mcp-oauth.test.ts`; `pnpm test src/agents/tool-policy.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/agent-tools.policy.test.ts src/agents/agent-tools.message-provider-policy.test.ts`; `pnpm test src/agents/runtime-plan/types.test.ts src/agents/runtime-plan/types.compat.test.ts src/agents/runtime-plan/build.test.ts src/agents/runtime-plan/auth.test.ts src/agents/runtime-plan/tools.test.ts src/agents/runtime-plan/tools.diagnostics.test.ts`; `pnpm test src/agents/model-runtime-policy.test.ts src/agents/model-tool-support.test.ts`; `pnpm test src/agents/tool-schema-projection.test.ts src/agents/openai-tool-schema.test.ts`; `pnpm test src/agents/tool-catalog.test.ts src/agents/tool-allowlist-guard.test.ts src/gateway/server-methods/tools-catalog.test.ts`; `pnpm test src/agents/tool-loop-detection.test.ts src/agents/embedded-agent-runner/run.compaction-loop-guard.test.ts src/gateway/tools-invoke-http.test.ts`; `pnpm test src/agents/tool-call-id.test.ts src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts`; `pnpm test src/agents/tool-mutation.test.ts src/acp/approval-classifier.test.ts src/agents/embedded-agent-subscribe.tools.test.ts`; `pnpm test src/agents/tool-display.test.ts`; `pnpm test src/agents/session-tool-result-guard.test.ts src/agents/session-tool-result-guard.transcript-events.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`; `pnpm test src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts src/agents/embedded-agent-runner/run/failover-observation.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-flush-cleanup.test.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/abortable.test.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts`; `git diff --check`; `pnpm test src/agents/embedded-agent-runner/run/failover-policy.test.ts src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts src/agents/embedded-agent-runner/run/compaction-timeout.test.ts src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts src/agents/embedded-agent-runner/run/idle-timeout-breaker.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run/helpers.resolve-error-context.test.ts src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/message-merge-strategy.test.ts src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts src/agents/embedded-agent-runner/run/tool-media-payloads.test.ts src/agents/embedded-agent-runner/run/attempt.bootstrap-context.test.ts src/agents/embedded-agent-runner/run/attempt.transcript-policy.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/trigger-policy.test.ts src/agents/embedded-agent-runner/run/fallbacks.test.ts src/agents/embedded-agent-runner/run/auth-controller.test.ts src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.test.ts src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/run/attempt.memory-flush-forwarding.test.ts src/agents/embedded-agent-runner/run/attempt.run-decisions.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/setup.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.timeout.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/history-image-prune.test.ts src/agents/embedded-agent-runner/run/images.test.ts`; `pnpm test src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`; `pnpm test src/agents/harness/selection.test.ts src/agents/auth-profile-runtime-contract.test.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.resource-loader.test.ts src/agents/embedded-agent-runner/run/attempt.bootstrap-context.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/setup.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.timeout.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`; `pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-injection.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.sessions-spawn.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`.

Evidence after fix: latest pushed commit 059dec62603 documents embedded attempt harness contracts; whitespace/diff checks and targeted runner/context-engine tests passed locally.

Observed result after fix: Existing embedded attempt context-engine, context-injection, sessions-spawn, and attempt wrapper tests, embedded-run setup, payload, timeout, and attempt wrapper tests, embedded-run auth-controller, transcript-policy, fallback, trigger-policy, memory-flush, and attempt wrapper tests, embedded-run steering, bootstrap-routing, media-payload, and message-merge strategy tests, embedded-run runtime-context, context-engine, and context-injection tests, embedded-run stream-normalization, stop-reason, and attempt wrapper tests, embedded-run prompt-helper and transcript-repair tests, embedded-run async-task wait tests, embedded-run bootstrap-context and resource-loader tests, embedded-run tool-construction tests, embedded-run incomplete-turn tests, embedded-run image/history helper tests, embedded-run terminal/diagnostic helper tests, embedded-run setup/stream/payload helper tests, embedded-run timeout/preemptive-compaction/helper tests, embedded-run failover/auth/compaction policy tests, plus prior node capability, node invoke policy, connection auth, runtime service, WebSocket startup, import-boundary, chat state, session broadcast, live chat projection, chat abort, broadcast, preauth connection budget, WebSocket log, WebSocket handshake helper, WebSocket auth limiter, WebSocket auth policy, WebSocket message handler, WebSocket pairing handoff, node pairing reconciliation, node command policy, node pending-work, node catalog, node registry/event, node handler/wake, Talk/voicewake, channel RPC, TTS RPC, push/restart RPC, cron/secrets RPC, Talk/tools RPC, approval RPC, agent workspace RPC, config RPC helper, artifact RPC extraction, effective-tools RPC cache, session active-run projection, outbound send idempotency, usage cache, agent job waiter, restart/update, models auth-status, commands list, gateway call, method-scope, node helper, optional model-catalog caller, record-helper caller, managed update handoff, chat-abort helper, config helper, gateway response helper, subagent follow-up helper, deleted-agent guard helper, Gateway test-support helper, Talk shared helper, server-method shared type, broadcast/channel hook type, session/node/WebSocket type, auth resolution, agent tool filesystem policy, bundled MCP runtime, agent tool policy shared, agent runtime-plan, agent model runtime policy, agent tool schema, agent tool catalog/allowlist, agent tool loop detection, agent tool call id, agent tool mutation, agent tool display, agent exec tool display, agent session tool-result guard, agent tool-result truncation/context, agent tool-call repair/Tool Search run-plan, agent run decision/session helper, agent run diagnostic/prompt helper, agent run prompt/thread/trajectory helper, agent LLM-boundary/context/yield/precheck, and agent abort/failover helper tests still pass with the added comments.

What was not tested: Broader Gateway suites and live plugin/node traffic, because this PR only adds comments.




















