### PR TITLE
fix: keep inbound metadata in runtime context

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1197,6 +1197,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
   it("adds current-turn context to the current model input without exposing internal runtime context", async () => {
     let seenPrompt: string | undefined;
+    let seenMessages: unknown[] | undefined;
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -1230,6 +1231,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session, prompt) => {
         seenPrompt = prompt;
+        seenMessages = [...session.messages];
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -1237,16 +1239,26 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("what does this mean?");
-    expect(seenPrompt).toContain("Reply target of current user message (untrusted, for context):");
-    expect(seenPrompt).toContain('"sender_label": "Mike"');
-    expect(seenPrompt).toContain("WT daily plan - Sat May 2");
-    expect(seenPrompt).toContain("./quoted-secret.png");
-    expect(seenPrompt).toContain("media://inbound/quoted.png");
+    expect(seenPrompt).toBe("what does this mean?");
+    expect(seenPrompt).not.toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
     expect(seenPrompt).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
     expect(seenPrompt).not.toContain("secret runtime context");
-    expect(seenPrompt?.trim().startsWith("Reply target of current user message")).toBe(true);
     expect(result.finalPromptText).toBe(seenPrompt);
+    const runtimeContext = findRecord(
+      requireRecords(seenMessages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "runtime context message",
+    );
+    expect(runtimeContext.content).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(runtimeContext.content).toContain('"sender_label": "Mike"');
+    expect(runtimeContext.content).toContain("WT daily plan - Sat May 2");
+    expect(runtimeContext.content).toContain("./quoted-secret.png");
+    expect(runtimeContext.content).toContain("media://inbound/quoted.png");
+    expect(runtimeContext.content).toContain("secret runtime context");
     expect(hoisted.detectAndLoadPromptImagesMock).toHaveBeenCalledTimes(1);
     expect(mockParams(hoisted.detectAndLoadPromptImagesMock, 0, "prompt image params").prompt).toBe(
       "what does this mean?",
@@ -1259,7 +1271,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const promptSubmitted = trajectoryEvents.find((event) => event.type === "prompt.submitted");
     expect(promptSubmitted?.data?.prompt).toBe(seenPrompt);
-    expect(promptSubmitted?.data?.prompt).toContain("WT daily plan - Sat May 2");
+    expect(promptSubmitted?.data?.prompt).not.toContain("WT daily plan - Sat May 2");
     expect(promptSubmitted?.data?.prompt).not.toContain("secret runtime context");
   });
 
@@ -1459,6 +1471,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
   it("keeps current inbound context visible on runtime-only turns", async () => {
     let seenPrompt: string | undefined;
+    let seenSystemPrompt: string | undefined;
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -1483,6 +1496,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session, prompt) => {
         seenPrompt = prompt;
+        seenSystemPrompt = session.agent.state.systemPrompt;
         session.messages = [
           ...session.messages,
           { role: "assistant", content: "done", timestamp: 2 },
@@ -1490,9 +1504,11 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("Reply target of current user message (untrusted, for context):");
-    expect(seenPrompt).toContain("Hello from the replied message");
-    expect(seenPrompt).toContain("Continue the OpenClaw runtime event.");
+    expect(seenPrompt).toBe("Continue the OpenClaw runtime event.");
+    expect(seenSystemPrompt).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(seenSystemPrompt).toContain("Hello from the replied message");
     expect(result.finalPromptText).toBe(seenPrompt);
     const trajectoryEvents = (
       await fs.readFile(path.join(tempPaths[0] ?? "", "session.trajectory.jsonl"), "utf8")
@@ -1501,12 +1517,14 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
-    expect(contextCompiled?.data?.prompt).toContain("Hello from the replied message");
+    expect(contextCompiled?.data?.prompt).toBe("Continue the OpenClaw runtime event.");
     expect(contextCompiled?.data?.systemPrompt).toContain("runtime bare mention event");
+    expect(contextCompiled?.data?.systemPrompt).toContain("Hello from the replied message");
   });
 
-  it("submits suppressed room event context as the model prompt", async () => {
+  it("submits suppressed room event context as runtime context", async () => {
     let seenPrompt: string | undefined;
+    let seenMessages: unknown[] | undefined;
     let seenModelMessages: unknown[] | undefined;
     const runBeforePromptBuild = vi.fn(async () => ({
       prependContext: "dynamic hook context",
@@ -1541,6 +1559,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
       sessionPrompt: async (session, prompt) => {
         seenPrompt = prompt;
+        seenMessages = [...session.messages];
         const transformContext = (
           session.agent as {
             transformContext?: (messages: AgentMessage[]) => Promise<AgentMessage[]>;
@@ -1556,14 +1575,23 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    expect(seenPrompt).toContain("[OpenClaw room event]");
-    expect(seenPrompt).toContain("inbound_event_kind: room_event");
-    expect(seenPrompt).toContain("visible_reply_contract: message_tool_only");
-    expect(seenPrompt).toContain("Current event:\n#2003 Bob: hey claw summarize the plan");
-    expect(seenPrompt?.trim().endsWith("[OpenClaw room event]")).toBe(true);
+    expect(seenPrompt).toBe("[OpenClaw room event]");
+    expect(seenPrompt).not.toContain("inbound_event_kind: room_event");
+    expect(seenPrompt).not.toContain("visible_reply_contract: message_tool_only");
+    expect(seenPrompt).not.toContain("Current event:\n#2003 Bob: hey claw summarize the plan");
     expect(seenPrompt).not.toBe("Continue the OpenClaw runtime event.");
     expect(seenPrompt).not.toContain("dynamic hook context");
     expect(seenPrompt).not.toContain("dynamic hook tail");
+    const runtimeContext = findRecord(
+      requireRecords(seenMessages, "seen messages"),
+      (message) => message.customType === "openclaw.runtime-context",
+      "runtime context message",
+    );
+    expect(runtimeContext.content).toContain("inbound_event_kind: room_event");
+    expect(runtimeContext.content).toContain("visible_reply_contract: message_tool_only");
+    expect(runtimeContext.content).toContain(
+      "Current event:\n#2003 Bob: hey claw summarize the plan",
+    );
     expect(JSON.stringify(seenModelMessages)).toContain("dynamic hook context");
     expect(JSON.stringify(seenModelMessages)).toContain("dynamic hook tail");
     expect(result.finalPromptText).toBe(seenPrompt);
@@ -1574,8 +1602,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as TrajectoryEvent);
     const contextCompiled = trajectoryEvents.find((event) => event.type === "context.compiled");
-    expect(contextCompiled?.data?.prompt).toContain("visible_reply_contract: message_tool_only");
     expect(contextCompiled?.data?.prompt).toContain("[OpenClaw room event]");
+    expect(contextCompiled?.data?.prompt).not.toContain(
+      "visible_reply_contract: message_tool_only",
+    );
   });
 
   it("skips blank visible prompts with replay history before provider submission", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -451,7 +451,6 @@ import {
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
 import {
-  buildCurrentInboundPrompt,
   buildRuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
@@ -3813,18 +3812,13 @@ export async function runEmbeddedAttempt(
             modelPrompt: hasPromptBuildContext
               ? promptForModelBeforeRuntimeContextSplit
               : undefined,
+            currentInboundContext: params.currentInboundContext,
             emptyTranscriptMode: params.suppressNextUserMessagePersistence
               ? "model-prompt"
               : "runtime-event",
           });
-          const promptForSession = buildCurrentInboundPrompt({
-            context: params.currentInboundContext,
-            prompt: promptSubmission.prompt,
-          });
-          const promptForModel = buildCurrentInboundPrompt({
-            context: params.currentInboundContext,
-            prompt: promptSubmission.modelPrompt ?? promptSubmission.prompt,
-          });
+          const promptForSession = promptSubmission.prompt;
+          const promptForModel = promptSubmission.modelPrompt ?? promptSubmission.prompt;
           const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();
           if (promptSubmission.runtimeOnly && runtimeSystemContext) {
             const runtimeSystemPrompt = composeSystemPromptWithHookContext({

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -354,4 +354,62 @@ describe("runtime context prompt submission", () => {
     expect(buildRuntimeEventSystemContext("internal event")).toContain("OpenClaw runtime event.");
     expect(buildRuntimeEventSystemContext("internal event")).toContain("not user-authored");
   });
+
+  it("keeps current inbound metadata out of the visible user prompt", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: "visible ask",
+      transcriptPrompt: "visible ask",
+      currentInboundContext: {
+        text: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"42"}\n```',
+      },
+    });
+    expect(parts.prompt).toBe("visible ask");
+    expect(parts.prompt).not.toContain("Conversation info");
+    expect(parts.runtimeContext).toContain("Conversation info (untrusted metadata):");
+    expect(parts.runtimeContext).toContain('"message_id":"42"');
+  });
+
+  it("keeps current inbound metadata out of the model prompt", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: "hook context\n\nvisible ask\n\nhook tail",
+      transcriptPrompt: "visible ask",
+      modelPrompt: "hook context\n\nvisible ask\n\nhook tail",
+      currentInboundContext: {
+        text: 'Sender (untrusted metadata):\n```json\n{"id":"u1"}\n```',
+      },
+    });
+    const modelPrompt = parts.modelPrompt ?? parts.prompt;
+    expect(modelPrompt).toBe("hook context\n\nvisible ask\n\nhook tail");
+    expect(modelPrompt).not.toContain("Sender (untrusted metadata)");
+    expect(parts.runtimeContext).toContain("Sender (untrusted metadata):");
+  });
+
+  it("combines current inbound metadata with extracted hidden runtime context", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt:
+        "visible ask\n\n__openclaw_runtime_context__\ninternal block\n__/openclaw_runtime_context__",
+      transcriptPrompt: "visible ask",
+      currentInboundContext: {
+        text: "Conversation info (untrusted metadata):\n```json\n{}\n```",
+      },
+    });
+    expect(parts.prompt).toBe("visible ask");
+    expect(parts.runtimeContext).toContain("Conversation info (untrusted metadata):");
+    expect(parts.runtimeContext).toContain("internal block");
+  });
+
+  it("preserves current inbound metadata in the empty-transcript model-prompt branch", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: "[OpenClaw room event]",
+      transcriptPrompt: "",
+      emptyTranscriptMode: "model-prompt",
+      currentInboundContext: {
+        text: "Room context:\nAlice: hi\n\nCurrent event:\nBob: hi",
+      },
+    });
+    expect(parts.prompt).toBe("[OpenClaw room event]");
+    expect(parts.prompt).not.toContain("Room context:");
+    expect(parts.runtimeContext).toContain("Room context:");
+    expect(parts.runtimeContext).toContain("Current event:\nBob: hi");
+  });
 });

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -82,6 +82,7 @@ export function resolveRuntimeContextPromptParts(params: {
   effectivePrompt: string;
   transcriptPrompt?: string;
   modelPrompt?: string;
+  currentInboundContext?: CurrentInboundPromptContext;
   emptyTranscriptMode?: EmptyTranscriptMode;
 }): RuntimeContextPromptParts {
   const transcriptPrompt = params.transcriptPrompt;
@@ -97,13 +98,20 @@ export function resolveRuntimeContextPromptParts(params: {
         : { text: params.modelPrompt };
   const modelPromptText = modelPrompt?.text ?? transcriptPrompt ?? extracted.text;
   const prompt = transcriptPrompt ?? extracted.text;
+  const currentInboundContextText = buildCurrentInboundPromptContextPrefix(
+    params.currentInboundContext,
+  );
   if (!prompt.trim() && params.emptyTranscriptMode === "model-prompt") {
+    const runtimeContext =
+      [currentInboundContextText, extracted.runtimeContext]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join("\n\n") || undefined;
     return {
       prompt: extracted.text,
       ...(modelPromptText.trim() && modelPromptText !== extracted.text
         ? { modelPrompt: modelPromptText }
         : {}),
-      ...(extracted.runtimeContext ? { runtimeContext: extracted.runtimeContext } : {}),
+      ...(runtimeContext ? { runtimeContext } : {}),
     };
   }
   const hiddenRuntimeContext = modelPrompt
@@ -116,10 +124,17 @@ export function resolveRuntimeContextPromptParts(params: {
       : undefined;
   // The hidden context is whatever remains after removing the last visible
   // prompt occurrence, plus any explicit internal runtime-context block.
+  const runtimeContextParts = [
+    currentInboundContextText,
+    hiddenRuntimeContext,
+    extracted.runtimeContext,
+  ];
+  if (!prompt.trim()) {
+    runtimeContextParts.push(extracted.text);
+  }
   const runtimeContext =
-    [hiddenRuntimeContext, extracted.runtimeContext]
-      .filter((value): value is string => Boolean(value?.trim()))
-      .join("\n\n") || (!prompt.trim() ? extracted.text.trim() : undefined);
+    runtimeContextParts.filter((value): value is string => Boolean(value?.trim())).join("\n\n") ||
+    (!prompt.trim() ? extracted.text.trim() : undefined);
   if (!prompt.trim()) {
     return runtimeContext
       ? {


### PR DESCRIPTION
## Summary

Fixes the remaining #72704-shaped path where current-turn inbound channel metadata was still prepended into the user prompt text.

Current `main` already builds ordinary inbound metadata as `currentInboundContext`, but `run/attempt.ts` immediately merged that context back into both `promptForSession` and `promptForModel` via `buildCurrentInboundPrompt(...)`. That kept Telegram `Conversation info` / `Sender` blocks on the model-visible user prompt path and could still persist the metadata-heavy prompt shape into active session state.

This PR moves `currentInboundContext` into the existing runtime-context channel instead:

- user prompt text stays user-authored (`promptForSession` / `promptForModel` are no longer prefixed with current inbound metadata)
- current-turn metadata is still available to the model as hidden prompt-local runtime context before the active user turn
- extracted hidden runtime context and current inbound context are combined in one runtime-context payload
- transcript/user prompt text remains clean

## Linked Issue

Closes #72704

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram/channel current-turn metadata (`Conversation info` / `Sender`) was still being prepended into the user prompt path after it had been assembled as `currentInboundContext`.
- Real environment tested: Local OpenClaw checkout from this PR branch on Linux, running the real TypeScript runtime module through `node --import tsx` (no mocks, no test runner).
- Exact steps or command run after this patch:

```bash
node --import tsx -e 'const { resolveRuntimeContextPromptParts, buildRuntimeContextCustomMessage } = await import("./src/agents/embedded-agent-runner/run/runtime-context-prompt.ts"); const parts = resolveRuntimeContextPromptParts({ effectivePrompt: "Please execute your workflow", transcriptPrompt: "Please execute your workflow", currentInboundContext: { text: ["Conversation info (untrusted metadata):", "```json", JSON.stringify({ channel: "telegram", message_id: "14636" }), "```", "", "Sender (untrusted metadata):", "```json", JSON.stringify({ id: "redacted", name: "Sherina" }), "```"].join("\n") } }); const runtimeMessage = buildRuntimeContextCustomMessage(parts.runtimeContext); console.log(JSON.stringify({ prompt: parts.prompt, modelPrompt: parts.modelPrompt ?? null, promptContainsMetadata: parts.prompt.includes("Conversation info") || parts.prompt.includes("Sender (untrusted metadata)"), runtimeContextContainsMetadata: Boolean(parts.runtimeContext?.includes("Conversation info (untrusted metadata):") && parts.runtimeContext?.includes("Sender (untrusted metadata):")), runtimeMessageCustomType: runtimeMessage?.customType, runtimeMessageDisplay: runtimeMessage?.display }, null, 2));'
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "prompt": "Please execute your workflow",
  "modelPrompt": null,
  "promptContainsMetadata": false,
  "runtimeContextContainsMetadata": true,
  "runtimeMessageCustomType": "openclaw.runtime-context",
  "runtimeMessageDisplay": false
}
```

- Observed result after fix: the active user prompt remains exactly the user-authored text, metadata is not present in `prompt`/`modelPrompt`, and the same metadata is preserved in a non-displayed `openclaw.runtime-context` custom message.
- What was not tested: a full live Telegram delivery round-trip with an actual bot account and model call.
- Proof limitations or environment constraints: this is a local runtime-boundary proof rather than a provider-level screenshot; it exercises the real OpenClaw prompt/runtime-context code path without mocks.
- Before evidence (optional but encouraged): on current `main`, `run/attempt.ts` called `buildCurrentInboundPrompt({ context: params.currentInboundContext, ... })` for both `promptForSession` and `promptForModel`, which prepended the metadata context into the prompt text.

## Tests and validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts` - 78 files / 1299 tests passed
- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts` - 35 tests passed across 2 shards
- `pnpm tsgo:core:test` - passed
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.ts src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts` - passed

Regression coverage added:

- Telegram-style `Conversation info` / `Sender` metadata remains out of `parts.prompt`
- that metadata remains available in `parts.runtimeContext`
- current inbound metadata combines with extracted hidden runtime context instead of replacing it
- embedded-agent context-engine turns preserve reply/event context through `openclaw.runtime-context` without prepending it to the active prompt
