### PR TITLE
fix(plugin-sdk): quarantine invalid provider tool schemas

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   inspectProviderToolSchemasWithPlugin: vi.fn(),
@@ -22,6 +22,13 @@ const { logProviderToolSchemaDiagnostics, normalizeProviderToolSchemas } =
   await import("./tool-schema-runtime.js");
 
 describe("tool schema runtime diagnostics", () => {
+  beforeEach(() => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockReset();
+    mocks.normalizeProviderToolSchemasWithPlugin.mockReset();
+    mocks.log.info.mockReset();
+    mocks.log.warn.mockReset();
+  });
+
   it("stays quiet when a provider reports no diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([]);
 
@@ -80,6 +87,44 @@ describe("tool schema runtime diagnostics", () => {
         diagnostics: [
           { index: 0, tool: "alpha", violations: ["one", "two"], violationCount: 2 },
           { index: 1, tool: "beta", violations: ["one"], violationCount: 1 },
+        ],
+      },
+    );
+  });
+
+  it("logs provider diagnostics without rereading unreadable tool names", () => {
+    const unreadableName = {};
+    Object.defineProperty(unreadableName, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("tool name getter exploded");
+      },
+    });
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
+      { toolName: "tool[0]", toolIndex: 0, violations: ["tool[0].name is unreadable"] },
+    ]);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [unreadableName] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics: 1 tool for example: tool[0] (1 violation)",
+      {
+        provider: "example",
+        toolCount: 1,
+        diagnosticCount: 1,
+        tools: ["0:tool[0]"],
+        diagnostics: [
+          {
+            index: 0,
+            tool: "tool[0]",
+            violations: ["tool[0].name is unreadable"],
+            violationCount: 1,
+          },
         ],
       },
     );

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -89,9 +89,9 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
     `provider tool schema diagnostics: ${diagnostics.length} ${diagnostics.length === 1 ? "tool" : "tools"} for ${params.provider}: ${summary}`,
     {
       provider: params.provider,
-      toolCount: params.tools.length,
+      toolCount: readToolListLength(params.tools),
       diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
+      tools: summarizeToolNames(params.tools),
       diagnostics: diagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
@@ -100,6 +100,42 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
       })),
     },
   );
+}
+
+function readToolListLength(tools: readonly unknown[]): number {
+  try {
+    return tools.length;
+  } catch {
+    return 0;
+  }
+}
+
+function readToolName(tool: unknown, index: number): string {
+  if (!tool || typeof tool !== "object") {
+    return `tool[${index}]`;
+  }
+  try {
+    const name = Reflect.get(tool, "name");
+    return typeof name === "string" && name ? name : `tool[${index}]`;
+  } catch {
+    return `tool[${index}]`;
+  }
+}
+
+function summarizeToolNames(tools: readonly unknown[]): string[] {
+  const length = readToolListLength(tools);
+  const names: string[] = [];
+  for (let index = 0; index < length; index += 1) {
+    let tool: unknown;
+    try {
+      tool = Reflect.get(tools, String(index));
+    } catch {
+      names.push(`${index}:tool[${index}]`);
+      continue;
+    }
+    names.push(`${index}:${readToolName(tool, index)}`);
+  }
+  return names;
 }
 
 function summarizeProviderToolSchemaDiagnostics(

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -56,6 +56,125 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     }
   });
 
+  it("quarantines unreadable provider hook tools before family normalization", () => {
+    const cases = [
+      {
+        family: "deepseek" as const,
+        provider: "deepseek",
+        modelApi: "openai-completions",
+      },
+      {
+        family: "gemini" as const,
+        provider: "google",
+        modelApi: "google",
+      },
+      {
+        family: "openai" as const,
+        provider: "openai",
+        modelApi: "openai-responses",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const hooks = buildProviderToolCompatFamilyHooks(testCase.family);
+      const unreadable = { name: "fuzzplugin_unreadable", description: "" };
+      Object.defineProperty(unreadable, "parameters", {
+        enumerable: true,
+        get() {
+          throw new Error(`${testCase.family} parameters getter exploded`);
+        },
+      });
+      const healthy = {
+        name: "healthy",
+        description: "",
+        parameters: { type: "object", properties: {} },
+      };
+      const context = {
+        provider: testCase.provider,
+        modelId: "model",
+        modelApi: testCase.modelApi,
+        model: {
+          provider: testCase.provider,
+          api: testCase.modelApi,
+          baseUrl: "https://api.openai.com/v1",
+          id: "model",
+        } as never,
+        tools: [unreadable, healthy],
+      } as never;
+
+      const normalized = hooks.normalizeToolSchemas(context);
+
+      expect(
+        normalized.map((tool) => tool.name),
+        `${testCase.family} normalized tools`,
+      ).toStrictEqual(["healthy"]);
+      expect(
+        hooks
+          .inspectToolSchemas(context)
+          .some(
+            (diagnostic) =>
+              diagnostic.toolName === "fuzzplugin_unreadable" &&
+              diagnostic.toolIndex === 0 &&
+              diagnostic.violations.includes("fuzzplugin_unreadable.parameters is unreadable"),
+          ),
+        `${testCase.family} diagnostics`,
+      ).toBe(true);
+    }
+  });
+
+  it("does not reread provider hook tool parameters while normalizing schemas", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("gemini");
+    let reads = 0;
+    const oneShot = { name: "oneshot", description: "" };
+    Object.defineProperty(oneShot, "parameters", {
+      enumerable: true,
+      get() {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("parameters getter was reread");
+        }
+        return {
+          type: "object",
+          properties: { value: { type: "string", minLength: 2 } },
+        };
+      },
+    });
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "google",
+      modelId: "gemini-2.5-pro",
+      modelApi: "google",
+      tools: [oneShot],
+    } as never);
+
+    expect(reads).toBe(1);
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: { value: { type: "string" } },
+    });
+  });
+
+  it("keeps provider hook tool identity when family normalization is a no-op", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tool = {
+      name: "identity",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: { value: { type: "string" } },
+      },
+    } as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      tools: [tool],
+    } as never);
+
+    expect(normalized[0]).toBe(tool);
+  });
+
   it("normalizes canonical OpenAI Codex Responses tool schemas", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [{ name: "demo", description: "", parameters: {} }] as never;

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -3,6 +3,7 @@ import {
   cleanSchemaForGemini,
   GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
 } from "../agents/schema/clean-for-gemini.js";
+import { projectRuntimeToolInputSchema } from "../agents/tool-schema-projection.js";
 import { stripUnsupportedSchemaKeywords } from "../shared/schema-keyword-strip.js";
 import type {
   AnyAgentTool,
@@ -12,6 +13,166 @@ import type {
 
 // Shared provider-tool helpers for plugin-owned schema compatibility rewrites.
 export { cleanSchemaForGemini, GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS, stripUnsupportedSchemaKeywords };
+
+type ProviderToolSnapshot = {
+  readonly entries: readonly {
+    readonly source: AnyAgentTool;
+    readonly name: string;
+    readonly parameters: unknown;
+    readonly originalIndex: number;
+  }[];
+  readonly tools: AnyAgentTool[];
+  readonly diagnostics: ProviderToolSchemaDiagnostic[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function unreadableProviderToolDiagnostic(toolIndex: number): ProviderToolSchemaDiagnostic {
+  return {
+    toolName: `tool[${toolIndex}]`,
+    toolIndex,
+    violations: [`tool[${toolIndex}] is unreadable`],
+  };
+}
+
+function readProviderToolEntry(
+  tools: readonly AnyAgentTool[],
+  toolIndex: number,
+): { ok: true; tool: unknown } | { ok: false } {
+  try {
+    return { ok: true, tool: Reflect.get(tools, String(toolIndex)) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readProviderToolField(
+  tool: Record<string, unknown>,
+  field: "name" | "parameters",
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: Reflect.get(tool, field) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function providerNormalizableProjectionViolations(violations: readonly string[]): string[] {
+  return violations.filter(
+    (violation) => !violation.endsWith(".$dynamicRef") && !violation.endsWith(".$dynamicAnchor"),
+  );
+}
+
+function cloneProviderToolWithParameters(
+  source: AnyAgentTool,
+  name: string,
+  parameters: unknown,
+): AnyAgentTool {
+  const clone = Object.create(Object.getPrototypeOf(source)) as AnyAgentTool;
+  const descriptors = Object.getOwnPropertyDescriptors(source);
+  Reflect.deleteProperty(descriptors, "name");
+  Reflect.deleteProperty(descriptors, "parameters");
+  Object.defineProperties(clone, descriptors);
+  Object.defineProperty(clone, "name", {
+    configurable: true,
+    enumerable: true,
+    value: name,
+    writable: true,
+  });
+  Object.defineProperty(clone, "parameters", {
+    configurable: true,
+    enumerable: true,
+    value: parameters,
+    writable: true,
+  });
+  return clone;
+}
+
+function replaceProviderToolParameters(
+  entry: ProviderToolSnapshot["entries"][number],
+  parameters: unknown,
+): AnyAgentTool {
+  return parameters === entry.parameters
+    ? entry.source
+    : cloneProviderToolWithParameters(entry.source, entry.name, parameters);
+}
+
+function snapshotProviderNormalizableTools(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSnapshot {
+  let length: number;
+  try {
+    length = ctx.tools.length;
+  } catch {
+    return { entries: [], tools: [], diagnostics: [unreadableProviderToolDiagnostic(0)] };
+  }
+
+  const entries: ProviderToolSnapshot["entries"][number][] = [];
+  const tools: AnyAgentTool[] = [];
+  const diagnostics: ProviderToolSchemaDiagnostic[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    const entry = readProviderToolEntry(ctx.tools, toolIndex);
+    if (!entry.ok || !isRecord(entry.tool)) {
+      diagnostics.push(unreadableProviderToolDiagnostic(toolIndex));
+      continue;
+    }
+
+    const name = readProviderToolField(entry.tool, "name");
+    const toolName =
+      name.ok && typeof name.value === "string" && name.value ? name.value : `tool[${toolIndex}]`;
+    const descriptorViolations = name.ok ? [] : [`${toolName}.name is unreadable`];
+    if (!name.ok || typeof name.value !== "string" || !name.value) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations:
+          descriptorViolations.length > 0
+            ? descriptorViolations
+            : [`${toolName}.name must be a non-empty string`],
+      });
+      continue;
+    }
+
+    const parameters = readProviderToolField(entry.tool, "parameters");
+    if (!parameters.ok) {
+      diagnostics.push({
+        toolName,
+        toolIndex,
+        violations: [`${toolName}.parameters is unreadable`],
+      });
+      continue;
+    }
+    if (parameters.value === undefined) {
+      const source = entry.tool as AnyAgentTool;
+      entries.push({ source, name: toolName, parameters: undefined, originalIndex: toolIndex });
+      tools.push(source);
+      continue;
+    }
+
+    const schemaProjection = projectRuntimeToolInputSchema(
+      parameters.value,
+      `${toolName}.parameters`,
+    );
+    const violations = providerNormalizableProjectionViolations(schemaProjection.violations);
+    if (violations.length > 0) {
+      diagnostics.push({ toolName, toolIndex, violations });
+      continue;
+    }
+
+    const source = entry.tool as AnyAgentTool;
+    entries.push({
+      source,
+      name: toolName,
+      parameters: schemaProjection.schema,
+      originalIndex: toolIndex,
+    });
+    tools.push(source);
+  }
+
+  return { entries, tools, diagnostics };
+}
 
 export function findUnsupportedSchemaKeywords(
   schema: unknown,
@@ -58,53 +219,52 @@ export function findUnsupportedSchemaKeywords(
 export function normalizeGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
+  return snapshotProviderNormalizableTools(ctx).entries.map((entry) => {
+    if (!entry.parameters || typeof entry.parameters !== "object") {
+      return entry.source;
     }
-    return {
-      ...tool,
-      parameters: cleanSchemaForGemini(tool.parameters),
-    };
+    return replaceProviderToolParameters(entry, cleanSchemaForGemini(entry.parameters));
   });
 }
 
 export function inspectGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
-  return ctx.tools.flatMap((tool, toolIndex) => {
-    const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
-      GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
-    );
-    if (violations.length === 0) {
-      return [];
-    }
-    return [{ toolName: tool.name, toolIndex, violations }];
-  });
+  const snapshot = snapshotProviderNormalizableTools(ctx);
+  return [
+    ...snapshot.diagnostics,
+    ...snapshot.entries.flatMap(({ name, parameters, originalIndex }) => {
+      const violations = findUnsupportedSchemaKeywords(
+        parameters,
+        `${name}.parameters`,
+        GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
+      );
+      if (violations.length === 0) {
+        return [];
+      }
+      return [{ toolName: name, toolIndex: originalIndex, violations }];
+    }),
+  ];
 }
 
 export function normalizeOpenAIToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
+  const snapshot = snapshotProviderNormalizableTools(ctx);
   if (!shouldApplyOpenAIToolCompat(ctx)) {
-    return ctx.tools;
+    return snapshot.diagnostics.length > 0 ? snapshot.tools : ctx.tools;
   }
-  return ctx.tools.map((tool) => {
-    if (tool.parameters == null) {
-      return {
-        ...tool,
-        parameters: normalizeOpenAIStrictCompatSchema({}),
-      };
+  return snapshot.entries.map((entry) => {
+    if (entry.parameters == null) {
+      return replaceProviderToolParameters(entry, normalizeOpenAIStrictCompatSchema({}));
     }
-    if (typeof tool.parameters !== "object") {
-      return tool;
+    if (typeof entry.parameters !== "object") {
+      return entry.source;
     }
-    return {
-      ...tool,
-      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
-    };
+    return replaceProviderToolParameters(
+      entry,
+      normalizeOpenAIStrictCompatSchema(entry.parameters),
+    );
   });
 }
 
@@ -351,12 +511,10 @@ export function findOpenAIStrictSchemaViolations(
 export function inspectOpenAIToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
-  if (!shouldApplyOpenAIToolCompat(ctx)) {
-    return [];
-  }
+  const snapshot = snapshotProviderNormalizableTools(ctx);
   // Native OpenAI transports fall back to `strict: false` when any tool schema is not
   // strict-compatible, so these findings are expected for optional-heavy tool schemas.
-  return [];
+  return snapshot.diagnostics;
 }
 
 export const DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["anyOf", "oneOf"]);
@@ -465,34 +623,35 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
 export function normalizeDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
+  return snapshotProviderNormalizableTools(ctx).entries.map((entry) => {
+    if (!entry.parameters || typeof entry.parameters !== "object") {
+      return entry.source;
     }
-    const parameters = normalizeDeepSeekSchema(tool.parameters);
-    return parameters === tool.parameters
-      ? tool
-      : {
-          ...tool,
-          parameters: parameters as TSchema,
-        };
+    return replaceProviderToolParameters(
+      entry,
+      normalizeDeepSeekSchema(entry.parameters) as TSchema,
+    );
   });
 }
 
 export function inspectDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
-  return ctx.tools.flatMap((tool, toolIndex) => {
-    const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
-      DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
-    );
-    if (violations.length === 0) {
-      return [];
-    }
-    return [{ toolName: tool.name, toolIndex, violations }];
-  });
+  const snapshot = snapshotProviderNormalizableTools(ctx);
+  return [
+    ...snapshot.diagnostics,
+    ...snapshot.entries.flatMap(({ name, parameters, originalIndex }) => {
+      const violations = findUnsupportedSchemaKeywords(
+        parameters,
+        `${name}.parameters`,
+        DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
+      );
+      if (violations.length === 0) {
+        return [];
+      }
+      return [{ toolName: name, toolIndex: originalIndex, violations }];
+    }),
+  ];
 }
 
 export type ProviderToolCompatFamily = "deepseek" | "gemini" | "openai";


### PR DESCRIPTION
## Summary

- Snapshots provider-family tool descriptors before SDK normalization/inspection so unreadable plugin-owned entries are quarantined instead of throwing.
- Applies the guarded path to Gemini, DeepSeek, and OpenAI provider-tool compat hooks while preserving original tool identity when normalization is a no-op.
- Hardens provider tool-schema diagnostic logging so warning metadata does not reread hostile raw tool names.
- Intentionally out of scope: live provider API calls and unrelated provider payload converters.

## Linked context

Related #89413
Related #89418

Maintainer fuzzing follow-up for OpenClaw tool-schema ingress hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: direct SDK provider-family tool hooks could throw while inspecting or normalizing a plugin-owned tool whose `name` or `parameters` field was unreadable, and provider diagnostic logging could rethrow while formatting raw tool names.
- Real environment tested: local OpenClaw Codex worktree with focused Plugin SDK provider-tool and embedded runner diagnostic tests, plus AWS Crabbox fresh-PR `pnpm check:changed`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts -- --reporter=dot`
- Evidence after fix: the focused Vitest wrapper passed 2 shards: `src/plugin-sdk/provider-tools.test.ts` 13 tests and `src/agents/embedded-agent-runner/tool-schema-runtime.test.ts` 4 tests.
- Observed result after fix: malformed provider-hook tools produce schema diagnostics or are omitted from normalized output; healthy siblings remain; no-op normalization returns the original tool object; diagnostic logging labels unreadable names as `tool[index]` instead of throwing.
- What was not tested: live provider API calls.
- Before evidence: a direct repro against `inspectGeminiToolSchemas` threw `parameters getter exploded`; after the patch the same repro returns a diagnostic for `fuzzplugin_bad.parameters is unreadable`.

## Tests and validation

Commands run:

- `node --import tsx - <<'TS' ... inspectGeminiToolSchemas bad getter repro ... TS`
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `crabbox run --provider aws --fresh-pr openclaw/openclaw#89429 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Remote proof:

- Final AWS Crabbox fresh-PR changed gate passed. Provider: `aws`; run: `run_d03ab7df115b`; lease: `cbx_22b585dd591c`; slug: `quick-crayfish`; exit 0; lanes: `core`, `coreTests`, `extensions`, `extensionTests`; command 6m35.232s; total 6m53.403s; lease stopped.
- Earlier AWS Crabbox fresh-PR changed gate failed in `typecheck core` because the descriptor clone used `delete` on required typed properties. Provider: `aws`; run: `run_961c486856f0`; lease: `cbx_665e7ef174c3`; slug: `blue-hermit`; exit 2; lease stopped. The commit was amended to use `Reflect.deleteProperty`.

Regression coverage added:

- Provider compat hooks quarantine unreadable tool descriptors across DeepSeek, Gemini, and OpenAI families.
- Gemini normalization does not reread one-shot `parameters` getters.
- DeepSeek no-op normalization preserves original tool identity.
- Provider diagnostics logging summarizes unreadable tool names without throwing.

What failed before this fix:

- `inspectGeminiToolSchemas` and `inspectDeepSeekToolSchemas` read `tool.name` and `tool.parameters` directly from raw plugin-owned descriptors.
- SDK family normalizers read `tool.parameters` directly and could crash before returning healthy sibling tools.
- Provider diagnostic logging mapped raw `tool.name` values and could throw while trying to emit the warning.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Bad provider-hook tools are now omitted/reported instead of crashing normalization or diagnostics.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. Provider tool-schema compatibility hooks now sanitize plugin-owned tool descriptors before family-specific schema rewrites. No new execution capability or credential handling was added.

What is the highest-risk area?

Tool identity/proxy behavior around provider schema normalization.

How is that risk mitigated?

No-op normalization returns the original tool object, and tests cover identity preservation while still cloning only when schema replacement is required.

## Current review state

What is the next action?

Wait for maintainer review/CI.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side proof is pending.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before and after PR creation: the snapshot path no longer clones no-op tools, the mutable snapshot builder uses a mutable local entries array while exposing readonly results, and the descriptor clone uses `Reflect.deleteProperty` to satisfy strict TypeScript.
