### PR TITLE
fix(llm): gate OpenAI-compatible reasoning output

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1294,6 +1294,9 @@ describe("openai transport stream", () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 256_000,
         maxTokens: 16_384,
+        compat: {
+          supportsReasoningEffort: true,
+        },
       } satisfies Model<"openai-completions">;
       const stream = createOpenAICompletionsTransportStreamFn()(
         model,
@@ -1302,7 +1305,7 @@ describe("openai transport stream", () => {
           messages: [{ role: "user", content: "Reply live-ok", timestamp: Date.now() }],
           tools: [],
         } as never,
-        { apiKey: "test-key" } as never,
+        { apiKey: "test-key", reasoningEffort: "high" } as never,
       );
 
       let doneReason: string | undefined;
@@ -1333,6 +1336,140 @@ describe("openai transport stream", () => {
         server.close((error) => (error ? reject(error) : resolve()));
       });
     }
+  });
+
+  it("emits Qwen thinking streams when enabled without reasoning_effort support", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        capturedPayload = JSON.parse(body) as Record<string, unknown>;
+        res.writeHead(200, {
+          "content-type": "application/json; charset=utf-8",
+        });
+        res.end(
+          JSON.stringify({
+            id: "chatcmpl-qwen-thinking",
+            object: "chat.completion",
+            model: "qwen3.5-32b",
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  reasoning_content: "Need a Qwen answer.",
+                  content: "qwen-ok",
+                },
+                finish_reason: "stop",
+              },
+            ],
+          }),
+        );
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "qwen3.5-32b",
+        name: "Qwen 3.5 32B",
+        api: "openai-completions",
+        provider: "qwen",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: {
+          thinkingFormat: "qwen",
+          supportsReasoningEffort: false,
+        },
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Reply qwen-ok", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key", reasoning: "medium" } as never,
+      );
+
+      let thinking = "";
+      let text = "";
+      for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+        if (event.type === "thinking_delta") {
+          thinking += event.delta ?? "";
+        }
+        if (event.type === "text_delta") {
+          text += event.delta ?? "";
+        }
+      }
+
+      expect(capturedPayload?.enable_thinking).toBe(true);
+      expect(capturedPayload).not.toHaveProperty("reasoning_effort");
+      expect(thinking).toBe("Need a Qwen answer.");
+      expect(text).toBe("qwen-ok");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("does not emit thinking streams when reasoning is disabled", () => {
+    const model = {
+      id: "grok-4.20-beta-latest-reasoning",
+      name: "Grok 4.20 Beta Latest (Reasoning)",
+      api: "openai-completions",
+      provider: "xai",
+      baseUrl: "https://api.x.ai/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 2_000_000,
+      maxTokens: 30_000,
+    } satisfies Model<"openai-completions">;
+
+    expect(
+      testing.shouldEmitOpenAICompletionsReasoningForModel(model, {
+        apiKey: "test-key",
+        reasoning: "off",
+      } as never),
+    ).toBe(false);
+  });
+
+  it("emits Z.ai thinking streams when enabled without reasoning_effort support", () => {
+    const model = {
+      id: "glm-4.7",
+      name: "GLM 4.7",
+      api: "openai-completions",
+      provider: "zai",
+      baseUrl: "",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    expect(
+      testing.shouldEmitOpenAICompletionsReasoningForModel(model, {
+        apiKey: "test-key",
+        reasoning: "medium",
+      } as never),
+    ).toBe(true);
   });
 
   it("preserves OpenAI-compatible error metadata on failed chat requests", async () => {
@@ -7394,6 +7531,73 @@ describe("openai transport stream", () => {
     expect(visibleText).not.toContain("private reasoning");
     expect(thinkingText).toBe("private reasoning");
     expect(events.filter((event) => event.type === "thinking_delta")).toHaveLength(1);
+  });
+
+  it("drops mirrored reasoning when disabled without recovering hidden reasoning tags", async () => {
+    const model = {
+      id: "MiniMax-M2.7",
+      name: "MiniMax M2.7",
+      api: "openai-completions",
+      provider: "minimax",
+      baseUrl: "https://api.minimax.test/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-reasoning-disabled",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "<think>private reasoning",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-reasoning-disabled",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                reasoning_content: "private reasoning",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+      { emitReasoning: false },
+    );
+
+    const visibleText = output.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("");
+    expect(output.content.some((block) => block.type === "thinking")).toBe(false);
+    expect(events.some((event) => event.type === "thinking_delta")).toBe(false);
   });
 
   it("keeps literal reasoning tag examples visible without mirrored reasoning", async () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2588,6 +2588,10 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         if (compat.requiresNonEmptyUserOrAssistantMessage) {
           assertOpenAICompletionsPayloadHasConversationTurn(params, model);
         }
+        const emitReasoning = shouldEmitOpenAICompletionsReasoning(
+          model as OpenAIModeModel,
+          options as OpenAICompletionsOptions | undefined,
+        );
         const responseStream = (await client.chat.completions.create(
           params as never,
           buildOpenAISdkRequestOptions(model, options?.signal),
@@ -2595,6 +2599,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream, {
           signal: options?.signal,
+          emitReasoning,
         });
         if (options?.signal?.aborted) {
           throw new Error("Request was aborted");
@@ -2616,10 +2621,11 @@ async function processOpenAICompletionsStream(
   output: MutableAssistantOutput,
   model: Model,
   stream: { push(event: unknown): void },
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; emitReasoning?: boolean },
 ) {
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
   const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256_000;
+  const emitReasoning = options?.emitReasoning ?? true;
   const compat = getCompat(model as OpenAIModeModel);
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
@@ -2734,7 +2740,7 @@ async function processOpenAICompletionsStream(
     for (const delta of bufferedDeltas) {
       if (delta.kind === "text") {
         appendTextDeltaInternal(delta.text);
-      } else {
+      } else if (emitReasoning) {
         appendThinkingDeltaInternal(delta);
       }
     }
@@ -2833,6 +2839,9 @@ async function processOpenAICompletionsStream(
       appendFilteredVisibleTextDelta(delta.text);
       return;
     }
+    if (!emitReasoning) {
+      return;
+    }
     if (currentBlock?.type === "toolCall") {
       queuePostToolCallDelta(delta);
     } else {
@@ -2914,13 +2923,16 @@ async function processOpenAICompletionsStream(
       }
     }
     for (const reasoningDelta of reasoningDeltas) {
+      if (reasoningDelta.kind === "thinking" && !emitReasoning) {
+        continue;
+      }
       if (currentBlock?.type === "toolCall") {
         queuePostToolCallDelta({ ...reasoningDelta });
         continue;
       }
       if (reasoningDelta.kind === "text") {
         appendTextDelta(reasoningDelta.text);
-      } else {
+      } else if (emitReasoning) {
         appendThinkingDelta(reasoningDelta);
       }
     }
@@ -3418,6 +3430,27 @@ type OpenAIResponsesRequestParams = {
 
 function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {
   return options?.reasoningEffort ?? options?.reasoning ?? "high";
+}
+
+function shouldEmitOpenAICompletionsReasoning(
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+) {
+  if (!model.reasoning) {
+    return false;
+  }
+  const effort = resolveOpenAICompletionsReasoningEffort(options);
+  if (!effort || !isOpenAICompletionsThinkingEnabled(effort)) {
+    return false;
+  }
+  return true;
+}
+
+function shouldEmitOpenAICompletionsReasoningForModel(
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+) {
+  return shouldEmitOpenAICompletionsReasoning(model, options);
 }
 
 function resolveOpenAICompletionsMaxTokens(
@@ -4213,6 +4246,7 @@ export const testing = {
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
   processResponsesStream,
+  shouldEmitOpenAICompletionsReasoningForModel,
   formatModelTransportDebugBaseUrl,
   buildResponsesFailedNoDetailsObservation,
   buildOpenAIResponsesReasoningReplayMetadata,

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -53,6 +53,11 @@ const model = {
   maxTokens: 4096,
 } satisfies Model<"openai-completions">;
 
+const reasoningModel = {
+  ...model,
+  reasoning: true,
+} satisfies Model<"openai-completions">;
+
 const context = {
   messages: [{ role: "user", content: "hi", timestamp: 1 }],
 } satisfies Context;
@@ -153,8 +158,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -171,8 +177,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -189,8 +196,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -207,8 +215,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -225,8 +234,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -264,8 +274,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
 
@@ -308,8 +319,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
     const visibleText = result.content
@@ -353,8 +365,9 @@ describe("openai-completions stop-reason tool-call guard", () => {
       makeFinishChunk("stop"),
     ];
 
-    const stream = streamOpenAICompletions(model, context, {
+    const stream = streamOpenAICompletions(reasoningModel, context, {
       apiKey: "sk-test",
+      reasoningEffort: "medium",
     });
     const result = await stream.result();
     const visibleText = result.content
@@ -368,6 +381,46 @@ describe("openai-completions stop-reason tool-call guard", () => {
       thinking: "private reasoning",
       thinkingSignature: "reasoning_content",
     });
+  });
+
+  it("drops mirrored reasoning output when reasoning is disabled but keeps strict text partitioning", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "<think>private reasoning",
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_content: "private reasoning",
+            },
+          },
+        ],
+      },
+      makeFinishChunk("stop"),
+    ];
+
+    const stream = streamOpenAICompletions(reasoningModel, context, {
+      apiKey: "sk-test",
+    });
+    const result = await stream.result();
+    const visibleText = result.content
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .join("");
+
+    expect(visibleText).toBe("");
+    expect(result.content.some((block) => block.type === "thinking")).toBe(false);
   });
 
   it("promotes silent tool_calls with finish_reason stop to toolUse", async () => {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -366,12 +366,15 @@ export const streamOpenAICompletions: StreamFunction<
           // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
           const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
           const deltaFields = choice.delta as Record<string, unknown>;
+          const reasoningEnabled = Boolean(model.reasoning && options?.reasoningEffort);
           let foundReasoningField: string | null = null;
-          for (const field of reasoningFields) {
-            const value = deltaFields[field];
-            if (typeof value === "string" && value.length > 0) {
-              foundReasoningField = field;
-              break;
+          if (reasoningEnabled) {
+            for (const field of reasoningFields) {
+              const value = deltaFields[field];
+              if (typeof value === "string" && value.length > 0) {
+                foundReasoningField = field;
+                break;
+              }
             }
           }
           if (foundReasoningField) {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -366,15 +366,13 @@ export const streamOpenAICompletions: StreamFunction<
           // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
           const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
           const deltaFields = choice.delta as Record<string, unknown>;
-          const reasoningEnabled = Boolean(model.reasoning && options?.reasoningEffort);
+          const shouldEmitReasoning = Boolean(model.reasoning && options?.reasoningEffort);
           let foundReasoningField: string | null = null;
-          if (reasoningEnabled) {
-            for (const field of reasoningFields) {
-              const value = deltaFields[field];
-              if (typeof value === "string" && value.length > 0) {
-                foundReasoningField = field;
-                break;
-              }
+          for (const field of reasoningFields) {
+            const value = deltaFields[field];
+            if (typeof value === "string" && value.length > 0) {
+              foundReasoningField = field;
+              break;
             }
           }
           if (foundReasoningField) {
@@ -388,7 +386,7 @@ export const streamOpenAICompletions: StreamFunction<
             appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
           }
 
-          if (foundReasoningField) {
+          if (shouldEmitReasoning && foundReasoningField) {
             const delta = deltaFields[foundReasoningField];
             if (typeof delta === "string" && delta.length > 0) {
               const thinkingSignature =


### PR DESCRIPTION
## Summary
- Replaces #89343 because the contributor fork does not allow maintainer pushes.
- Keeps OpenAI-compatible mirrored reasoning fields as strict reasoning-tag partition signals, but only emits thinking blocks when the effective reasoning request is enabled.
- Covers both the legacy completions stream and the transport stream, including enabled OpenRouter/Qwen/Z.ai-style reasoning and disabled hidden-reasoning drops.

## Verification
Behavior addressed: OpenAI-compatible providers that mirror hidden reasoning no longer leak disabled reasoning into visible output or thinking blocks, while enabled provider-native thinking still emits.
Real environment tested: local OpenClaw targeted unit/agent tests and type/format gates in a normal source checkout.
Exact steps or command run after this patch: node ./node_modules/.bin/oxfmt --check src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts && git diff --check; node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts src/agents/openai-transport-stream.test.ts; pnpm check:test-types; .agents/skills/autoreview/scripts/autoreview --mode local
Evidence after fix: provider tests passed 17/17; transport tests passed 237/237; test type gate passed; formatter/diff check passed; autoreview reported no accepted/actionable findings.
Observed result after fix: disabled mirrored reasoning is stripped without recovering hidden <think> text, enabled reasoningEffort/OpenRouter/Qwen/Z.ai cases still emit thinking deltas, and transport buffering does not persist disabled thinking deltas after tool calls.
What was not tested: no live external provider call was run for this replacement PR.

Co-authored-by: zz327455573 <327455573@qq.com>
