### PR TITLE
fix(google): quarantine invalid tool declarations

### DIFF
--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -247,6 +247,115 @@ describe("google prompt cache", () => {
     ]);
   });
 
+  it("quarantines invalid tools before creating cached content", async () => {
+    const now = 1_500_000;
+    const expireTime = new Date(now + 3_600_000).toISOString();
+    const entries: SessionCustomEntry[] = [];
+    const sessionManager = makeSessionManager(entries);
+    const fetchMock = createCacheFetchMock({
+      name: "cachedContents/system-cache-filtered-tools",
+      expireTime,
+    });
+    const { streamFn: innerStreamFn } = createCapturingStreamFn();
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now,
+      sessionManager,
+      streamFn: innerStreamFn,
+    });
+
+    await Promise.resolve(
+      wrapped?.(
+        makeGoogleModel(),
+        {
+          systemPrompt: "Follow policy.",
+          messages: [],
+          tools: [
+            unreadable,
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: { type: "object" },
+            },
+          ],
+        } as never,
+        { toolChoice: "auto" } as never,
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const createBody = JSON.parse(fetchInit(fetchMock).body as string) as Record<string, unknown>;
+    expect(createBody.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parametersJsonSchema: { type: "object" },
+          },
+        ],
+      },
+    ]);
+    expect(createBody.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: "AUTO",
+      },
+    });
+  });
+
+  it("drops unreadable tool lists before creating cached content", async () => {
+    const now = 1_600_000;
+    const expireTime = new Date(now + 3_600_000).toISOString();
+    const entries: SessionCustomEntry[] = [];
+    const sessionManager = makeSessionManager(entries);
+    const fetchMock = createCacheFetchMock({
+      name: "cachedContents/system-cache-no-tools",
+      expireTime,
+    });
+    const { streamFn: innerStreamFn } = createCapturingStreamFn();
+    const tools = new Proxy([] as unknown[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const wrapped = await preparePromptCacheStream({
+      fetchMock,
+      now,
+      sessionManager,
+      streamFn: innerStreamFn,
+    });
+
+    await Promise.resolve(
+      wrapped?.(
+        makeGoogleModel(),
+        {
+          systemPrompt: "Follow policy.",
+          messages: [],
+          tools,
+        } as never,
+        { toolChoice: "auto" } as never,
+      ),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const createBody = JSON.parse(fetchInit(fetchMock).body as string) as Record<string, unknown>;
+    expect(createBody).not.toHaveProperty("tools");
+    expect(createBody).not.toHaveProperty("toolConfig");
+    expect(streamContext(innerStreamFn).tools).toBeUndefined();
+  });
+
   it("reuses a persisted cache entry without creating a second cache", async () => {
     const now = 2_000_000;
     const entries: SessionCustomEntry[] = [];

--- a/src/agents/embedded-agent-runner/google-prompt-cache.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.ts
@@ -7,6 +7,7 @@ import {
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { parseGeminiAuth } from "../../infra/gemini-auth.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
+import { convertTools as convertGoogleTools } from "../../llm/providers/google-shared.js";
 import { streamWithPayloadPatch } from "../../llm/providers/stream-wrappers/stream-payload-utils.js";
 import type { Model } from "../../llm/types.js";
 import { buildGuardedModelFetch } from "../provider-transport-fetch.js";
@@ -193,21 +194,6 @@ function parseExpireTimeMs(expireTime: string | undefined): number | null {
   return asDateTimestampMs(Date.parse(expireTime)) ?? null;
 }
 
-function convertManagedGoogleTools(tools: NonNullable<GooglePromptCacheContext["tools"]>) {
-  if (tools.length === 0) {
-    return undefined;
-  }
-  return [
-    {
-      functionDeclarations: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        parametersJsonSchema: tool.parameters,
-      })),
-    },
-  ];
-}
-
 function mapManagedGoogleToolChoice(
   choice: unknown,
 ): { mode: "AUTO" | "NONE" | "ANY"; allowedFunctionNames?: string[] } | undefined {
@@ -239,7 +225,7 @@ function buildManagedGooglePromptCacheConfig(
   context: GooglePromptCacheContext,
   options: GooglePromptCacheOptions,
 ) {
-  const tools = context.tools?.length ? convertManagedGoogleTools(context.tools) : undefined;
+  const tools = convertGoogleTools((context.tools ?? []) as never);
   const toolChoice = tools
     ? mapManagedGoogleToolChoice((options as { toolChoice?: unknown } | undefined)?.toolChoice)
     : undefined;
@@ -259,7 +245,7 @@ function buildManagedGooglePromptCacheConfig(
 }
 
 function buildManagedContextForCachedContent(context: GooglePromptCacheContext) {
-  if (!context.systemPrompt && !context.tools?.length) {
+  if (!context.systemPrompt && context.tools === undefined) {
     return context;
   }
   return {

--- a/src/llm/providers/google-shared.convert.test.ts
+++ b/src/llm/providers/google-shared.convert.test.ts
@@ -29,6 +29,65 @@ function requireRecordProperty(
 }
 
 describe("google-shared convertTools", () => {
+  it("skips unreadable and runtime-invalid tools while preserving healthy siblings", () => {
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+    const dynamicSchema = {
+      name: "dynamic_schema",
+      description: "dynamic",
+      parameters: {
+        type: "object",
+        properties: {
+          target: { $dynamicRef: "#target" },
+        },
+      },
+    };
+    const healthy = {
+      name: "healthy",
+      description: "Healthy tool",
+      parameters: {
+        type: "object",
+        properties: { action: { type: "string" } },
+        required: ["action"],
+      },
+    };
+
+    const converted = convertTools([unreadable, dynamicSchema, healthy] as unknown as Tool[]);
+
+    expect(converted).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "healthy",
+            description: "Healthy tool",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { action: { type: "string" } },
+              required: ["action"],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("omits the Google tools payload when every tool is quarantined", () => {
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    expect(convertTools([unreadable] as unknown as Tool[])).toBeUndefined();
+  });
+
   it("preserves parameters when type is missing", () => {
     const tools = [
       {

--- a/src/llm/providers/google-shared.test.ts
+++ b/src/llm/providers/google-shared.test.ts
@@ -1,6 +1,6 @@
 import { FinishReason, type GenerateContentResponse } from "@google/genai";
 import { describe, expect, it } from "vitest";
-import type { AssistantMessage, Model } from "../types.js";
+import type { AssistantMessage, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import {
   buildGoogleGenerateContentParams,
@@ -144,5 +144,50 @@ describe("buildGoogleGenerateContentParams", () => {
     );
 
     expect(params.config?.stopSequences).toEqual(["STOP"]);
+  });
+
+  it("omits tool config when every tool is quarantined", () => {
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    const params = buildGoogleGenerateContentParams(
+      model,
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [unreadable as unknown as Tool],
+      },
+      { toolChoice: "any" },
+    );
+
+    expect(params.config).not.toHaveProperty("tools");
+    expect(params.config).not.toHaveProperty("toolConfig");
+  });
+
+  it("omits tools and tool config when the tool list length is unreadable", () => {
+    const tools = new Proxy([] as unknown as Tool[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const params = buildGoogleGenerateContentParams(
+      model,
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools,
+      },
+      { toolChoice: "any" },
+    );
+
+    expect(params.config).not.toHaveProperty("tools");
+    expect(params.config).not.toHaveProperty("toolConfig");
   });
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -12,6 +12,7 @@ import {
   type Part,
   type ThinkingConfig,
 } from "@google/genai";
+import { projectRuntimeToolInputSchema } from "../../agents/tool-schema-projection.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
   Api,
@@ -338,6 +339,80 @@ const JSON_SCHEMA_META_DECLARATIONS = new Set([
   "definitions", // pre-draft-2019-09 equivalent of $defs
 ]);
 
+type GoogleProjectedTool = {
+  readonly name: string;
+  readonly description?: string;
+  readonly parameters: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readToolField(
+  tool: object,
+  field: "name" | "description" | "parameters",
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: Reflect.get(tool, field) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readToolEntry(
+  tools: readonly Tool[],
+  toolIndex: number,
+): { ok: true; tool: unknown } | { ok: false } {
+  try {
+    return { ok: true, tool: Reflect.get(tools, String(toolIndex)) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function snapshotGoogleTools(tools: readonly Tool[]): GoogleProjectedTool[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [];
+  }
+
+  const projectedTools: GoogleProjectedTool[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    const entry = readToolEntry(tools, toolIndex);
+    if (!entry.ok || !isRecord(entry.tool)) {
+      continue;
+    }
+
+    const name = readToolField(entry.tool, "name");
+    if (!name.ok || typeof name.value !== "string" || !name.value) {
+      continue;
+    }
+
+    const parameters = readToolField(entry.tool, "parameters");
+    if (!parameters.ok) {
+      continue;
+    }
+
+    const projection = projectRuntimeToolInputSchema(parameters.value, `${name.value}.parameters`);
+    if (projection.violations.length > 0 || !isRecord(projection.schema)) {
+      continue;
+    }
+
+    const description = readToolField(entry.tool, "description");
+    projectedTools.push({
+      name: name.value,
+      ...(description.ok && typeof description.value === "string"
+        ? { description: description.value }
+        : {}),
+      parameters: projection.schema,
+    });
+  }
+  return projectedTools;
+}
+
 /**
  * Strip meta-declarations from a schema obj
  */
@@ -368,18 +443,24 @@ export function convertTools(
   tools: Tool[],
   useParameters = false,
 ): { functionDeclarations: Record<string, unknown>[] }[] | undefined {
-  if (tools.length === 0) {
+  const projectedTools = snapshotGoogleTools(tools);
+  if (projectedTools.length === 0) {
     return undefined;
   }
   return [
     {
-      functionDeclarations: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        ...(useParameters
-          ? { parameters: sanitizeForOpenApi(tool.parameters as unknown) }
-          : { parametersJsonSchema: tool.parameters }),
-      })),
+      functionDeclarations: projectedTools.map((tool) => {
+        const declaration: Record<string, unknown> = {
+          name: tool.name,
+          description: tool.description,
+        };
+        if (useParameters) {
+          declaration.parameters = sanitizeForOpenApi(tool.parameters);
+        } else {
+          declaration.parametersJsonSchema = tool.parameters;
+        }
+        return declaration;
+      }),
     },
   ];
 }
@@ -473,6 +554,7 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   },
 ): GenerateContentParameters {
   const contents = convertMessages(model, context);
+  const tools = convertTools(context.tools ?? []);
 
   const generationConfig: GenerateContentConfig = {};
   if (options.temperature !== undefined) {
@@ -488,17 +570,15 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   const config: GenerateContentConfig = {
     ...(Object.keys(generationConfig).length > 0 && generationConfig),
     ...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-    ...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
+    ...(tools && { tools }),
   };
 
-  if (context.tools && context.tools.length > 0 && options.toolChoice) {
+  if (tools && options.toolChoice) {
     config.toolConfig = {
       functionCallingConfig: {
         mode: mapToolChoice(options.toolChoice),
       },
     };
-  } else {
-    config.toolConfig = undefined;
   }
 
   if (options.thinking?.enabled && model.reasoning) {


### PR DESCRIPTION
## Summary

- Quarantines unreadable or runtime-invalid Google/Gemini tool declarations before they reach Google request payloads.
- Reuses the shared Google converter for prompt-cache cached-content tool declarations so cached and live payloads follow the same schema projection rules.
- Gates `toolConfig` on converted tools, not the original tool list, so fully quarantined tool sets become tool-less requests instead of invalid function-calling requests.
- Intentionally out of scope: changing provider-wide tool-call semantics or adding compatibility for malformed public config.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #89404
Related #89406
Related #89413
Related #89418
Related #89429

Was this requested by a maintainer or owner?

Maintainer fuzzing sweep for tool-schema ingress hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: malformed Google/Gemini tool descriptors with throwing getters or unsupported runtime schema constructs no longer crash request construction or prompt-cache cached-content creation.
- Real environment tested: local OpenClaw checkout on current `origin/main` after rebasing this branch; AWS Crabbox fresh PR checkout for `openclaw/openclaw#89437`.
- Exact steps or command run after this patch: `node --import tsx - <<'TS' ... convertTools([bad]) ... TS`; `node scripts/run-vitest.mjs src/llm/providers/google-shared.test.ts src/llm/providers/google-shared.convert.test.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts -- --reporter=dot`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/llm/providers/google-shared.ts src/llm/providers/google-shared.test.ts src/llm/providers/google-shared.convert.test.ts src/agents/embedded-agent-runner/google-prompt-cache.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts`; `git diff --check origin/main..HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`; AWS Crabbox `corepack pnpm check:changed` on the fresh PR checkout.
- Evidence after fix: the direct repro prints `undefined` instead of throwing `parameters getter exploded`; focused Vitest passed 25 tests across 2 shards; oxlint exited 0; diff whitespace check exited 0; autoreview reported `autoreview clean: no accepted/actionable findings reported`; AWS Crabbox `run_22ddb0ebff49` / `cbx_187a41a2b774` exited 0.
- Observed result after fix: bad Google tools are dropped, healthy sibling tools remain, fully dropped tool lists omit both `tools` and `toolConfig`, prompt-cache cached content uses the same filtered tool declarations, and `pnpm check:changed` passes on Linux.
- What was not tested: live Google API calls with real credentials.
- Proof limitations or environment constraints: this is a schema-ingress hardening path covered with targeted unit tests, a local crash repro, and Linux changed-gate proof; no real external provider request was sent.
- Before evidence (optional but encouraged): the direct `convertTools([bad])` repro threw `parameters getter exploded` when the tool's `parameters` getter was unreadable.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/llm/providers/google-shared.test.ts src/llm/providers/google-shared.convert.test.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts -- --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/llm/providers/google-shared.ts src/llm/providers/google-shared.test.ts src/llm/providers/google-shared.convert.test.ts src/agents/embedded-agent-runner/google-prompt-cache.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/google-shared.ts src/llm/providers/google-shared.test.ts src/llm/providers/google-shared.convert.test.ts src/agents/embedded-agent-runner/google-prompt-cache.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`
- AWS Crabbox `run_22ddb0ebff49` / `cbx_187a41a2b774`: `corepack pnpm check:changed` on fresh PR checkout, exit 0

What regression coverage was added or updated?

- Google tool conversion now covers unreadable `parameters`, unsupported dynamic schema projection, healthy sibling preservation, and fully quarantined tool lists.
- Google generate-content params now cover no `toolConfig` when converted tools are empty, including unreadable tool-list `length`.
- Google prompt-cache now covers shared converter filtering and unreadable tool-list quarantine before cached-content creation.

What failed before this fix, if known?

- A direct `convertTools([bad])` repro threw `parameters getter exploded` before the patch.

If no test was added, why not?

- Tests were added for all changed runtime paths.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed Google/Gemini tool descriptors are now omitted instead of crashing or producing invalid function-calling config.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This hardens tool schema ingestion before provider request construction; no auth or secret handling changed.

What is the highest-risk area?

Dropping a tool that previously crashed request construction could reduce tool availability for malformed providers or plugins.

How is that risk mitigated?

The projection only keeps readable named tools with valid runtime input schema objects, preserving healthy sibling tools and keeping function-calling config aligned with the converted declarations.

## Current review state

What is the next action?

Ready for maintainer review once normal PR CI settles.

What is still waiting on author, maintainer, CI, or external proof?

Normal PR CI may still be running; remote changed-gate proof is complete.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed: `toolConfig` is now gated on converted tools, and callers no longer read tool-list `.length` before quarantine.
