### PR TITLE
fix(slack): warn when channels map is keyed by name instead of channel ID

### DIFF
--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -94,6 +94,7 @@ describe("slack doctor", () => {
   });
 
   it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
+    const overlongName = "a".repeat(81);
     const warnings = await collectSlackWarnings({
       groupPolicy: "open",
       channels: { "root-room": {} },
@@ -111,7 +112,22 @@ describe("slack doctor", () => {
         nameMatching: {
           groupPolicy: "allowlist",
           dangerouslyAllowNameMatching: true,
-          channels: { support: {}, "channel:customers": {} },
+          channels: {
+            support: {},
+            "#help": {},
+            "crème-brûlée": {},
+            "channel:customers": {},
+            "<#C0AL2GDUA7J>": {},
+            "slack:C0AL2GDUA7K": {},
+            "@help": {},
+            "##help": {},
+            "help+": {},
+            Support: {},
+            "-": {},
+            ___: {},
+            "#--": {},
+            [overlongName]: {},
+          },
         },
       },
     });
@@ -119,7 +135,7 @@ describe("slack doctor", () => {
     const nameKeyWarnings = warnings.filter((warning) =>
       warning.includes("Re-key it with the channel's"),
     );
-    expect(nameKeyWarnings).toHaveLength(3);
+    expect(nameKeyWarnings).toHaveLength(13);
     const rootWarning = nameKeyWarnings.find((warning) =>
       warning.includes('channels.slack.channels."root-room"'),
     );
@@ -136,6 +152,32 @@ describe("slack doctor", () => {
         ),
       ),
     ).toBe(true);
+    expect(
+      nameKeyWarnings.some((warning) =>
+        warning.includes('channels.slack.accounts.nameMatching.channels."<#C0AL2GDUA7J>"'),
+      ),
+    ).toBe(true);
+    expect(
+      nameKeyWarnings.some((warning) =>
+        warning.includes('channels.slack.accounts.nameMatching.channels."slack:C0AL2GDUA7K"'),
+      ),
+    ).toBe(true);
+    for (const invalidName of [
+      "@help",
+      "##help",
+      "help+",
+      "Support",
+      "-",
+      "___",
+      "#--",
+      overlongName,
+    ]) {
+      expect(
+        nameKeyWarnings.some((warning) =>
+          warning.includes(`channels.slack.accounts.nameMatching.channels."${invalidName}"`),
+        ),
+      ).toBe(true);
+    }
 
     const sharedOpenWarnings = await collectSlackWarnings(
       { channels: { "shared-room": {} } },

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -2,6 +2,19 @@
 import { describe, expect, it } from "vitest";
 import { slackDoctor } from "./doctor.js";
 
+async function collectSlackWarnings(
+  slack: Record<string, unknown>,
+  defaults?: Record<string, unknown>,
+) {
+  return (
+    (await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: { channels: { ...(defaults ? { defaults } : {}), slack } } as never,
+      }),
+    )) ?? []
+  );
+}
+
 function getSlackCompatibilityNormalizer(): NonNullable<
   typeof slackDoctor.normalizeCompatibilityConfig
 > {
@@ -50,121 +63,58 @@ describe("slack doctor", () => {
     ).toBe(true);
   });
 
-  it("warns when a slack channels map is keyed by name instead of channel ID under allowlist (#81665)", async () => {
-    const warnings = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            slack: {
-              groupPolicy: "allowlist",
-              channels: {
-                "example-channel": { requireMention: false },
-                C0AL2GDUA7J: { requireMention: false },
-              },
-            },
-          },
-        } as never,
-      }),
+  it("warns for name-keyed allowlist channels but accepts routed ID forms (#81665)", async () => {
+    const warnings = await collectSlackWarnings({
+      channels: {
+        "example-channel": {},
+        C0AL2GDUA7J: {},
+        c0al2gdua7k: {},
+        "channel:C0AL2GDUA7L": {},
+        "*": {},
+      },
+    });
+
+    const nameKeyWarnings = warnings.filter((warning) =>
+      warning.includes("keyed by a channel name"),
     );
-    expect(
-      warnings?.some(
-        (warning) =>
-          warning.includes('channels.slack.channels."example-channel"') &&
-          warning.includes("keyed by a channel name"),
-      ),
-    ).toBe(true);
-    // The ID-keyed entry is valid and must not be flagged.
-    expect(warnings?.some((warning) => warning.includes('channels.slack.channels."C0AL2GDUA7J"'))).toBe(
+    expect(nameKeyWarnings).toHaveLength(1);
+    expect(nameKeyWarnings[0]).toContain('channels.slack.channels."example-channel"');
+  });
+
+  it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
+    const warnings = await collectSlackWarnings({
+      groupPolicy: "open",
+      accounts: {
+        inheritedOpen: {
+          channels: { general: {} },
+        },
+        explicitAllowlist: {
+          groupPolicy: "allowlist",
+          channels: { engineering: {} },
+        },
+        nameMatching: {
+          groupPolicy: "allowlist",
+          dangerouslyAllowNameMatching: true,
+          channels: { support: {} },
+        },
+      },
+    });
+
+    const nameKeyWarnings = warnings.filter((warning) =>
+      warning.includes("keyed by a channel name"),
+    );
+    expect(nameKeyWarnings).toHaveLength(1);
+    expect(nameKeyWarnings[0]).toContain(
+      'channels.slack.accounts.explicitAllowlist.channels."engineering"',
+    );
+
+    const sharedOpenWarnings = await collectSlackWarnings(
+      { channels: { general: {} } },
+      { groupPolicy: "open" },
+    );
+    expect(sharedOpenWarnings.some((warning) => warning.includes("keyed by a channel name"))).toBe(
       false,
     );
-  });
-
-  it("does not flag name-keyed slack channels when groupPolicy is open (#81665)", async () => {
-    const warnings = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            slack: {
-              groupPolicy: "open",
-              channels: { "example-channel": { requireMention: false } },
-            },
-          },
-        } as never,
-      }),
-    );
-    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
-  });
-
-  it("accepts lowercase and channel:-prefixed Slack ID keys without flagging them (#81665)", async () => {
-    const warnings = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            slack: {
-              groupPolicy: "allowlist",
-              channels: { c0al2gdua7j: { requireMention: false }, "channel:C0AL2GDUA7J": {} },
-            },
-          },
-        } as never,
-      }),
-    );
-    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
-  });
-
-  it("does not flag name-keyed channels in accounts that inherit an open provider policy (#81665)", async () => {
-    const warnings = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            slack: {
-              groupPolicy: "open",
-              accounts: { work: { channels: { general: { requireMention: false } } } },
-            },
-          },
-        } as never,
-      }),
-    );
-    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
-  });
-
-  it("warns for a configured slack provider that omits groupPolicy (loaded default is allowlist) (#81665)", async () => {
-    const warnings = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: { slack: { channels: { "example-channel": { requireMention: false } } } },
-        } as never,
-      }),
-    );
-    // The loaded Slack default for an omitted groupPolicy is "allowlist", which silently drops
-    // unmatched channels — exactly the config the issue describes — so it must be flagged.
-    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(true);
-  });
-
-  it("honors channels.defaults.groupPolicy when slack omits its own policy (#81665)", async () => {
-    const allowlistDefault = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            defaults: { groupPolicy: "allowlist" },
-            slack: { channels: { "example-channel": {} } },
-          },
-        } as never,
-      }),
-    );
-    expect(allowlistDefault?.some((warning) => warning.includes("keyed by a channel name"))).toBe(
-      true,
-    );
-    const openDefault = await Promise.resolve(
-      slackDoctor.collectMutableAllowlistWarnings?.({
-        cfg: {
-          channels: {
-            defaults: { groupPolicy: "open" },
-            slack: { channels: { "example-channel": {} } },
-          },
-        } as never,
-      }),
-    );
-    expect(openDefault?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
   });
 
   it("normalizes legacy slack streaming aliases into the nested streaming shape", () => {

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -67,11 +67,14 @@ describe("slack doctor", () => {
     const warnings = await collectSlackWarnings({
       channels: {
         "example-channel": {},
-        development: {},
+        community: {},
         C0AL2GDUA7J: {},
         c0al2gdua7k: {},
         "channel:C0AL2GDUA7L": {},
         "channel:c0al2gdua7m": {},
+        D0AL2GDUA7Q: {},
+        "channel:d0al2gdua7r": {},
+        "channel:dabcdefgh": {},
         "channel:customers": {},
         "CHANNEL:C0AL2GDUA7N": {},
         "channel:C0al2gdua7p": {},
@@ -85,12 +88,20 @@ describe("slack doctor", () => {
     expect(nameKeyWarnings).toHaveLength(5);
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."example-channel"');
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."*" applies instead');
-    expect(nameKeyWarnings[1]).toContain('channels.slack.channels."development" is ambiguous');
+    expect(nameKeyWarnings[1]).toContain('channels.slack.channels."community" is ambiguous');
     expect(nameKeyWarnings[2]).toContain(
       'channels.slack.channels."channel:customers" is ambiguous',
     );
     expect(nameKeyWarnings[3]).toContain('channels.slack.channels."CHANNEL:C0AL2GDUA7N"');
     expect(nameKeyWarnings[4]).toContain('channels.slack.channels."channel:C0al2gdua7p"');
+    const dmWarnings = warnings.filter((warning) =>
+      warning.includes("is a Slack DM conversation ID"),
+    );
+    expect(dmWarnings).toHaveLength(3);
+    expect(dmWarnings[0]).toContain('channels.slack.channels."D0AL2GDUA7Q"');
+    expect(dmWarnings[1]).toContain('channels.slack.channels."channel:d0al2gdua7r"');
+    expect(dmWarnings[2]).toContain('channels.slack.channels."channel:dabcdefgh"');
+    expect(dmWarnings[0]).toContain("channels.slack.dmPolicy");
   });
 
   it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
@@ -116,6 +127,8 @@ describe("slack doctor", () => {
             support: {},
             "#help": {},
             "crème-brûlée": {},
+            d0customers: {},
+            dabcdefgh: {},
             "channel:customers": {},
             "<#C0AL2GDUA7J>": {},
             "slack:C0AL2GDUA7K": {},
@@ -198,6 +211,69 @@ describe("slack doctor", () => {
 
     expect(warnings).toEqual([expect.stringContaining('channels.slack.channels."private-room"')]);
     expect(warnings[0]).toContain("the channel remains allowed");
+  });
+
+  it("warns for DM IDs regardless of room policy and uses account-scoped remediation", async () => {
+    const openWarnings = await collectSlackWarnings({
+      groupPolicy: "open",
+      channels: {
+        D0AL2GDUA7S: {},
+      },
+    });
+    expect(openWarnings).toEqual([
+      expect.stringContaining('channels.slack.channels."D0AL2GDUA7S"'),
+    ]);
+
+    const disabledAccountWarnings = await collectSlackWarnings({
+      accounts: {
+        work: {
+          groupPolicy: "disabled",
+          channels: {
+            "channel:d0al2gdua7t": {},
+          },
+        },
+      },
+    });
+    expect(disabledAccountWarnings).toEqual([
+      expect.stringContaining('channels.slack.accounts.work.channels."channel:d0al2gdua7t"'),
+    ]);
+    expect(disabledAccountWarnings[0]).toContain("channels.slack.accounts.work.dmPolicy");
+    expect(disabledAccountWarnings[0]).toContain("channels.slack.accounts.work.allowFrom");
+
+    const inheritedChannelWarnings = await collectSlackWarnings({
+      channels: {
+        D0AL2GDUA7U: {},
+      },
+      accounts: {
+        work: {
+          groupPolicy: "disabled",
+          dmPolicy: "allowlist",
+          allowFrom: ["U0AL2GDUA7U"],
+        },
+      },
+    });
+    expect(inheritedChannelWarnings).toEqual([
+      expect.stringContaining('channels.slack.channels."D0AL2GDUA7U"'),
+    ]);
+    expect(inheritedChannelWarnings[0]).toContain("channels.slack.accounts.work.dmPolicy");
+  });
+
+  it("treats bare lowercase D forms as ambiguous without name matching", async () => {
+    const warnings = await collectSlackWarnings({
+      channels: {
+        d0customers: {},
+        dabcdefgh: {},
+      },
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain(
+      'channels.slack.channels."d0customers" is ambiguous: it may be a lowercase Slack DM conversation ID or a channel name',
+    );
+    expect(warnings[1]).toContain(
+      'channels.slack.channels."dabcdefgh" is ambiguous: it may be a lowercase Slack DM conversation ID or a channel name',
+    );
+    expect(warnings[0]).toContain("stable C/G ID");
   });
 
   it("does not audit provider defaults as a standalone named account (#81665)", async () => {

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -120,14 +120,22 @@ describe("slack doctor", () => {
       warning.includes("Re-key it with the channel's"),
     );
     expect(nameKeyWarnings).toHaveLength(3);
-    expect(nameKeyWarnings[0]).toContain('channels.slack.channels."root-room"');
-    expect(nameKeyWarnings[0]).toContain("messages from the channel are dropped");
-    expect(nameKeyWarnings[1]).toContain(
-      'channels.slack.accounts.explicitAllowlist.channels."engineering"',
+    const rootWarning = nameKeyWarnings.find((warning) =>
+      warning.includes('channels.slack.channels."root-room"'),
     );
-    expect(nameKeyWarnings[2]).toContain(
-      'channels.slack.accounts.nameMatching.channels."channel:customers" is ambiguous',
-    );
+    expect(rootWarning).toContain("messages from the channel are dropped");
+    expect(
+      nameKeyWarnings.some((warning) =>
+        warning.includes('channels.slack.accounts.explicitAllowlist.channels."engineering"'),
+      ),
+    ).toBe(true);
+    expect(
+      nameKeyWarnings.some((warning) =>
+        warning.includes(
+          'channels.slack.accounts.nameMatching.channels."channel:customers" is ambiguous',
+        ),
+      ),
+    ).toBe(true);
 
     const sharedOpenWarnings = await collectSlackWarnings(
       { channels: { "shared-room": {} } },
@@ -136,6 +144,35 @@ describe("slack doctor", () => {
     expect(
       sharedOpenWarnings.some((warning) => warning.includes("not a routable Slack channel ID")),
     ).toBe(true);
+  });
+
+  it("warns when an open-policy override is keyed by channel name (#81665)", async () => {
+    const warnings = await collectSlackWarnings({
+      groupPolicy: "open",
+      channels: {
+        "private-room": { enabled: false },
+      },
+    });
+
+    expect(warnings).toEqual([expect.stringContaining('channels.slack.channels."private-room"')]);
+    expect(warnings[0]).toContain("the channel remains allowed");
+  });
+
+  it("does not audit provider defaults as a standalone named account (#81665)", async () => {
+    const warnings = await collectSlackWarnings({
+      channels: {
+        "provider-room": { enabled: false },
+      },
+      accounts: {
+        work: {
+          channels: {
+            C0AL2GDUA7J: {},
+          },
+        },
+      },
+    });
+
+    expect(warnings.some((warning) => warning.includes("provider-room"))).toBe(false);
   });
 
   it("normalizes legacy slack streaming aliases into the nested streaming shape", () => {

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -50,6 +50,123 @@ describe("slack doctor", () => {
     ).toBe(true);
   });
 
+  it("warns when a slack channels map is keyed by name instead of channel ID under allowlist (#81665)", async () => {
+    const warnings = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            slack: {
+              groupPolicy: "allowlist",
+              channels: {
+                "example-channel": { requireMention: false },
+                C0AL2GDUA7J: { requireMention: false },
+              },
+            },
+          },
+        } as never,
+      }),
+    );
+    expect(
+      warnings?.some(
+        (warning) =>
+          warning.includes('channels.slack.channels."example-channel"') &&
+          warning.includes("keyed by a channel name"),
+      ),
+    ).toBe(true);
+    // The ID-keyed entry is valid and must not be flagged.
+    expect(warnings?.some((warning) => warning.includes('channels.slack.channels."C0AL2GDUA7J"'))).toBe(
+      false,
+    );
+  });
+
+  it("does not flag name-keyed slack channels when groupPolicy is open (#81665)", async () => {
+    const warnings = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            slack: {
+              groupPolicy: "open",
+              channels: { "example-channel": { requireMention: false } },
+            },
+          },
+        } as never,
+      }),
+    );
+    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
+  });
+
+  it("accepts lowercase and channel:-prefixed Slack ID keys without flagging them (#81665)", async () => {
+    const warnings = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            slack: {
+              groupPolicy: "allowlist",
+              channels: { c0al2gdua7j: { requireMention: false }, "channel:C0AL2GDUA7J": {} },
+            },
+          },
+        } as never,
+      }),
+    );
+    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
+  });
+
+  it("does not flag name-keyed channels in accounts that inherit an open provider policy (#81665)", async () => {
+    const warnings = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            slack: {
+              groupPolicy: "open",
+              accounts: { work: { channels: { general: { requireMention: false } } } },
+            },
+          },
+        } as never,
+      }),
+    );
+    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
+  });
+
+  it("warns for a configured slack provider that omits groupPolicy (loaded default is allowlist) (#81665)", async () => {
+    const warnings = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: { slack: { channels: { "example-channel": { requireMention: false } } } },
+        } as never,
+      }),
+    );
+    // The loaded Slack default for an omitted groupPolicy is "allowlist", which silently drops
+    // unmatched channels — exactly the config the issue describes — so it must be flagged.
+    expect(warnings?.some((warning) => warning.includes("keyed by a channel name"))).toBe(true);
+  });
+
+  it("honors channels.defaults.groupPolicy when slack omits its own policy (#81665)", async () => {
+    const allowlistDefault = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            defaults: { groupPolicy: "allowlist" },
+            slack: { channels: { "example-channel": {} } },
+          },
+        } as never,
+      }),
+    );
+    expect(allowlistDefault?.some((warning) => warning.includes("keyed by a channel name"))).toBe(
+      true,
+    );
+    const openDefault = await Promise.resolve(
+      slackDoctor.collectMutableAllowlistWarnings?.({
+        cfg: {
+          channels: {
+            defaults: { groupPolicy: "open" },
+            slack: { channels: { "example-channel": {} } },
+          },
+        } as never,
+      }),
+    );
+    expect(openDefault?.some((warning) => warning.includes("keyed by a channel name"))).toBe(false);
+  });
+
   it("normalizes legacy slack streaming aliases into the nested streaming shape", () => {
     const normalize = getSlackCompatibilityNormalizer();
 

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -72,6 +72,7 @@ describe("slack doctor", () => {
         c0al2gdua7k: {},
         "channel:C0AL2GDUA7L": {},
         "channel:c0al2gdua7m": {},
+        "channel:customers": {},
         "CHANNEL:C0AL2GDUA7N": {},
         "channel:C0al2gdua7p": {},
         "*": {},
@@ -79,13 +80,17 @@ describe("slack doctor", () => {
     });
 
     const nameKeyWarnings = warnings.filter((warning) =>
-      warning.includes("not a routable Slack channel ID"),
+      warning.includes("Re-key it with the channel's"),
     );
-    expect(nameKeyWarnings).toHaveLength(4);
+    expect(nameKeyWarnings).toHaveLength(5);
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."example-channel"');
-    expect(nameKeyWarnings[1]).toContain('channels.slack.channels."development"');
-    expect(nameKeyWarnings[2]).toContain('channels.slack.channels."CHANNEL:C0AL2GDUA7N"');
-    expect(nameKeyWarnings[3]).toContain('channels.slack.channels."channel:C0al2gdua7p"');
+    expect(nameKeyWarnings[0]).toContain('channels.slack.channels."*" applies instead');
+    expect(nameKeyWarnings[1]).toContain('channels.slack.channels."development" is ambiguous');
+    expect(nameKeyWarnings[2]).toContain(
+      'channels.slack.channels."channel:customers" is ambiguous',
+    );
+    expect(nameKeyWarnings[3]).toContain('channels.slack.channels."CHANNEL:C0AL2GDUA7N"');
+    expect(nameKeyWarnings[4]).toContain('channels.slack.channels."channel:C0al2gdua7p"');
   });
 
   it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
@@ -106,22 +111,26 @@ describe("slack doctor", () => {
         nameMatching: {
           groupPolicy: "allowlist",
           dangerouslyAllowNameMatching: true,
-          channels: { support: {} },
+          channels: { support: {}, "channel:customers": {} },
         },
       },
     });
 
     const nameKeyWarnings = warnings.filter((warning) =>
-      warning.includes("not a routable Slack channel ID"),
+      warning.includes("Re-key it with the channel's"),
     );
-    expect(nameKeyWarnings).toHaveLength(2);
+    expect(nameKeyWarnings).toHaveLength(3);
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."root-room"');
+    expect(nameKeyWarnings[0]).toContain("messages from the channel are dropped");
     expect(nameKeyWarnings[1]).toContain(
       'channels.slack.accounts.explicitAllowlist.channels."engineering"',
     );
+    expect(nameKeyWarnings[2]).toContain(
+      'channels.slack.accounts.nameMatching.channels."channel:customers" is ambiguous',
+    );
 
     const sharedOpenWarnings = await collectSlackWarnings(
-      { channels: { general: {} } },
+      { channels: { "shared-room": {} } },
       { groupPolicy: "open" },
     );
     expect(

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -71,24 +71,33 @@ describe("slack doctor", () => {
         C0AL2GDUA7J: {},
         c0al2gdua7k: {},
         "channel:C0AL2GDUA7L": {},
+        "channel:c0al2gdua7m": {},
+        "CHANNEL:C0AL2GDUA7N": {},
+        "channel:C0al2gdua7p": {},
         "*": {},
       },
     });
 
     const nameKeyWarnings = warnings.filter((warning) =>
-      warning.includes("keyed by a channel name"),
+      warning.includes("not a routable Slack channel ID"),
     );
-    expect(nameKeyWarnings).toHaveLength(2);
+    expect(nameKeyWarnings).toHaveLength(4);
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."example-channel"');
     expect(nameKeyWarnings[1]).toContain('channels.slack.channels."development"');
+    expect(nameKeyWarnings[2]).toContain('channels.slack.channels."CHANNEL:C0AL2GDUA7N"');
+    expect(nameKeyWarnings[3]).toContain('channels.slack.channels."channel:C0al2gdua7p"');
   });
 
   it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
     const warnings = await collectSlackWarnings({
       groupPolicy: "open",
+      channels: { "root-room": {} },
       accounts: {
         inheritedOpen: {
           channels: { general: {} },
+        },
+        inheritedAllowlist: {
+          groupPolicy: "allowlist",
         },
         explicitAllowlist: {
           groupPolicy: "allowlist",
@@ -103,10 +112,11 @@ describe("slack doctor", () => {
     });
 
     const nameKeyWarnings = warnings.filter((warning) =>
-      warning.includes("keyed by a channel name"),
+      warning.includes("not a routable Slack channel ID"),
     );
-    expect(nameKeyWarnings).toHaveLength(1);
-    expect(nameKeyWarnings[0]).toContain(
+    expect(nameKeyWarnings).toHaveLength(2);
+    expect(nameKeyWarnings[0]).toContain('channels.slack.channels."root-room"');
+    expect(nameKeyWarnings[1]).toContain(
       'channels.slack.accounts.explicitAllowlist.channels."engineering"',
     );
 
@@ -114,9 +124,9 @@ describe("slack doctor", () => {
       { channels: { general: {} } },
       { groupPolicy: "open" },
     );
-    expect(sharedOpenWarnings.some((warning) => warning.includes("keyed by a channel name"))).toBe(
-      true,
-    );
+    expect(
+      sharedOpenWarnings.some((warning) => warning.includes("not a routable Slack channel ID")),
+    ).toBe(true);
   });
 
   it("normalizes legacy slack streaming aliases into the nested streaming shape", () => {

--- a/extensions/slack/src/doctor.test.ts
+++ b/extensions/slack/src/doctor.test.ts
@@ -67,6 +67,7 @@ describe("slack doctor", () => {
     const warnings = await collectSlackWarnings({
       channels: {
         "example-channel": {},
+        development: {},
         C0AL2GDUA7J: {},
         c0al2gdua7k: {},
         "channel:C0AL2GDUA7L": {},
@@ -77,8 +78,9 @@ describe("slack doctor", () => {
     const nameKeyWarnings = warnings.filter((warning) =>
       warning.includes("keyed by a channel name"),
     );
-    expect(nameKeyWarnings).toHaveLength(1);
+    expect(nameKeyWarnings).toHaveLength(2);
     expect(nameKeyWarnings[0]).toContain('channels.slack.channels."example-channel"');
+    expect(nameKeyWarnings[1]).toContain('channels.slack.channels."development"');
   });
 
   it("uses account policy and name-matching overrides for name-keyed channels (#81665)", async () => {
@@ -113,7 +115,7 @@ describe("slack doctor", () => {
       { groupPolicy: "open" },
     );
     expect(sharedOpenWarnings.some((warning) => warning.includes("keyed by a channel name"))).toBe(
-      false,
+      true,
     );
   });
 

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -1,8 +1,7 @@
 // Slack plugin module implements doctor behavior.
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { GroupPolicy } from "openclaw/plugin-sdk/config-contracts";
+import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
 import { resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import {
@@ -52,11 +51,7 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
-// Slack channel IDs look like C0123ABCD / G… / D… (9+ alphanumerics), optionally `channel:`-prefixed,
-// and case-insensitive since config keys may be lowercase. A `channels` map keyed by a human channel
-// NAME instead of an ID is never matched under groupPolicy:"allowlist" (name matching is off), so
-// messages in that channel are silently dropped with no validation error or diagnostic. Warn so the
-// operator can re-key. #81665
+// Match every ID form accepted by Slack channel routing, including normalized config keys.
 const SLACK_CHANNEL_ID_RE = /^(?:channel:)?[CGD][A-Z0-9]{8,}$/i;
 
 function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
@@ -69,18 +64,14 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
     if (scope.dangerousNameMatchingEnabled) {
-      // Name matching is enabled for this account, so name-keyed channels do resolve.
       continue;
     }
-    // Effective group policy for the warning: an explicit account/provider policy wins, then
-    // channels.defaults.groupPolicy, then the loaded Slack default of "allowlist" for an omitted
-    // policy. Only "allowlist" routing drops unmatched channels, so explicit "open"/"disabled"
-    // are skipped — while omitted / default-allowlist configs (the case the issue describes) warn.
-    const explicitGroupPolicy =
+    const scopedGroupPolicy =
       typeof scope.account.groupPolicy === "string"
         ? (scope.account.groupPolicy as GroupPolicy)
         : providerGroupPolicy;
-    const effectiveGroupPolicy = explicitGroupPolicy ?? defaultGroupPolicy ?? "allowlist";
+    // Doctor reads authored config, while Slack's runtime schema materializes this default.
+    const effectiveGroupPolicy = scopedGroupPolicy ?? defaultGroupPolicy ?? "allowlist";
     if (effectiveGroupPolicy !== "allowlist") {
       continue;
     }

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -57,6 +57,8 @@ const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][0-9][a-z0-9]{7,}$
 // Letter-leading lowercase forms may be valid IDs or human names. Warn conditionally instead of
 // claiming they are unroutable.
 const SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE = /^(?:channel:)?[cgd][a-z][a-z0-9]{7,}$/;
+const SLACK_CHANNEL_NAME_RE = /^[\p{L}\p{M}\p{N}_-]{1,80}$/u;
+const SLACK_CHANNEL_NAME_ALPHANUMERIC_RE = /[\p{L}\p{N}]/u;
 
 function looksLikeSlackChannelId(channelKey: string): boolean {
   return (
@@ -64,6 +66,15 @@ function looksLikeSlackChannelId(channelKey: string): boolean {
     SLACK_LOWERCASE_CHANNEL_ID_RE.test(channelKey) ||
     SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE.test(channelKey) ||
     SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE.test(channelKey)
+  );
+}
+
+function looksLikeSlackChannelNameKey(channelKey: string): boolean {
+  const name = channelKey.startsWith("#") ? channelKey.slice(1) : channelKey;
+  return (
+    name === name.toLowerCase() &&
+    SLACK_CHANNEL_NAME_RE.test(name) &&
+    SLACK_CHANNEL_NAME_ALPHANUMERIC_RE.test(name)
   );
 }
 
@@ -108,8 +119,10 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       if (effectiveGroupPolicy === "open" && Object.keys(channelConfig ?? {}).length === 0) {
         continue;
       }
-      const hasChannelPrefix = channelKey.toLowerCase().startsWith("channel:");
-      if (account.dangerouslyAllowNameMatching === true && !hasChannelPrefix) {
+      if (
+        account.dangerouslyAllowNameMatching === true &&
+        looksLikeSlackChannelNameKey(channelKey)
+      ) {
         continue;
       }
       if (SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE.test(channelKey)) {

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -50,12 +50,13 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
-// Bare lowercase keys overlap Slack's channel-name syntax. Accept the observed lowercase ID form
-// with a numeric second character; explicit `channel:` keys remain unambiguous.
 const SLACK_CANONICAL_CHANNEL_ID_RE = /^[CGD][A-Z0-9]{8,}$/;
 const SLACK_LOWERCASE_CHANNEL_ID_RE = /^[cgd][0-9][a-z0-9]{7,}$/;
 const SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE = /^channel:[CGD][A-Z0-9]{8,}$/;
-const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][a-z0-9]{8,}$/;
+const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][0-9][a-z0-9]{7,}$/;
+// Letter-leading lowercase forms may be valid IDs or human names. Warn conditionally instead of
+// claiming they are unroutable.
+const SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE = /^(?:channel:)?[cgd][a-z][a-z0-9]{7,}$/;
 
 function looksLikeSlackChannelId(channelKey: string): boolean {
   return (
@@ -75,9 +76,6 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       : undefined;
   const providerChannels = asObjectRecord(slackCfg?.channels);
   for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
-    if (scope.dangerousNameMatchingEnabled) {
-      continue;
-    }
     const scopedGroupPolicy =
       typeof scope.account.groupPolicy === "string"
         ? (scope.account.groupPolicy as GroupPolicy)
@@ -93,13 +91,28 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       continue;
     }
     const channelsPrefix = accountChannels ? scope.prefix : "channels.slack";
+    const fallbackDescription = Object.hasOwn(channels, "*")
+      ? `${channelsPrefix}.channels."*" applies instead and this entry's overrides are ignored`
+      : "messages from the channel are dropped";
     for (const channelKey of Object.keys(channels)) {
       if (channelKey === "*" || looksLikeSlackChannelId(channelKey)) {
         continue;
       }
+      const hasChannelPrefix = channelKey.toLowerCase().startsWith("channel:");
+      if (scope.dangerousNameMatchingEnabled && !hasChannelPrefix) {
+        continue;
+      }
+      if (SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE.test(channelKey)) {
+        warnings.add(
+          `${channelsPrefix}.channels."${channelKey}" is ambiguous: it may be a lowercase Slack channel ID or a channel name. ` +
+            `If it is a channel name, inbound allowlist routing will not match it and ${fallbackDescription}. ` +
+            `Re-key it with the channel's stable ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
+        );
+        continue;
+      }
       warnings.add(
         `${channelsPrefix}.channels."${channelKey}" is keyed by a channel name or non-canonical ID form, not a routable Slack channel ID; ` +
-          `under groupPolicy: "allowlist" this entry never matches and messages in that channel are silently dropped. ` +
+          `under groupPolicy: "allowlist" inbound routing does not match this entry, so ${fallbackDescription}. ` +
           `Re-key it with the channel's ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
       );
     }

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -2,7 +2,7 @@
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
+import { listSlackAccountIds, mergeSlackAccountConfig } from "./accounts.js";
 import {
   legacyConfigRules as SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeSlackCompatibilityConfig,
@@ -70,49 +70,57 @@ function looksLikeSlackChannelId(channelKey: string): boolean {
 function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
   const warnings = new Set<string>();
   const slackCfg = asObjectRecord(asObjectRecord(cfg.channels)?.slack);
-  const providerGroupPolicy =
-    slackCfg && typeof slackCfg.groupPolicy === "string"
-      ? (slackCfg.groupPolicy as GroupPolicy)
-      : undefined;
   const providerChannels = asObjectRecord(slackCfg?.channels);
-  for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
-    const scopedGroupPolicy =
-      typeof scope.account.groupPolicy === "string"
-        ? (scope.account.groupPolicy as GroupPolicy)
-        : providerGroupPolicy;
-    // Slack's schema materializes this provider default before runtime account merging.
-    const effectiveGroupPolicy = scopedGroupPolicy ?? "allowlist";
-    if (effectiveGroupPolicy !== "allowlist") {
+  const accounts = asObjectRecord(slackCfg?.accounts);
+  for (const accountId of listSlackAccountIds(cfg)) {
+    const account = asObjectRecord(mergeSlackAccountConfig(cfg, accountId));
+    if (!account || slackCfg?.enabled === false || account.enabled === false) {
       continue;
     }
-    const accountChannels = asObjectRecord(scope.account.channels);
+    const scopedGroupPolicy =
+      typeof account.groupPolicy === "string" ? (account.groupPolicy as GroupPolicy) : undefined;
+    // Slack's schema materializes this provider default before runtime account merging.
+    const effectiveGroupPolicy = scopedGroupPolicy ?? "allowlist";
+    if (effectiveGroupPolicy === "disabled") {
+      continue;
+    }
+    const rawAccount = asObjectRecord(accounts?.[accountId]);
+    const accountChannels = asObjectRecord(rawAccount?.channels);
     const channels = accountChannels ?? providerChannels;
     if (!channels) {
       continue;
     }
-    const channelsPrefix = accountChannels ? scope.prefix : "channels.slack";
+    const channelsPrefix = accountChannels
+      ? `channels.slack.accounts.${accountId}`
+      : "channels.slack";
     const fallbackDescription = Object.hasOwn(channels, "*")
       ? `${channelsPrefix}.channels."*" applies instead and this entry's overrides are ignored`
-      : "messages from the channel are dropped";
+      : effectiveGroupPolicy === "open"
+        ? 'this entry\'s overrides are ignored and the channel remains allowed by groupPolicy: "open"'
+        : "messages from the channel are dropped";
     for (const channelKey of Object.keys(channels)) {
       if (channelKey === "*" || looksLikeSlackChannelId(channelKey)) {
         continue;
       }
+      const channelConfig = asObjectRecord(channels[channelKey]);
+      if (effectiveGroupPolicy === "open" && Object.keys(channelConfig ?? {}).length === 0) {
+        continue;
+      }
       const hasChannelPrefix = channelKey.toLowerCase().startsWith("channel:");
-      if (scope.dangerousNameMatchingEnabled && !hasChannelPrefix) {
+      if (account.dangerouslyAllowNameMatching === true && !hasChannelPrefix) {
         continue;
       }
       if (SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE.test(channelKey)) {
         warnings.add(
           `${channelsPrefix}.channels."${channelKey}" is ambiguous: it may be a lowercase Slack channel ID or a channel name. ` +
-            `If it is a channel name, inbound allowlist routing will not match it and ${fallbackDescription}. ` +
+            `If it is a channel name, inbound routing will not match it and ${fallbackDescription}. ` +
             `Re-key it with the channel's stable ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
         );
         continue;
       }
       warnings.add(
         `${channelsPrefix}.channels."${channelKey}" is keyed by a channel name or non-canonical ID form, not a routable Slack channel ID; ` +
-          `under groupPolicy: "allowlist" inbound routing does not match this entry, so ${fallbackDescription}. ` +
+          `under groupPolicy: "${effectiveGroupPolicy}" inbound routing does not match this entry, so ${fallbackDescription}. ` +
           `Re-key it with the channel's ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
       );
     }

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -3,7 +3,6 @@ import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract"
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import type { GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
-import { resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import {
   legacyConfigRules as SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeSlackCompatibilityConfig,
@@ -51,8 +50,19 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
-// Match every ID form accepted by Slack channel routing, including normalized config keys.
-const SLACK_CHANNEL_ID_RE = /^(?:channel:)?[CGD][A-Z0-9]{8,}$/i;
+// Bare lowercase keys overlap Slack's channel-name syntax. Accept the observed lowercase ID form
+// with a numeric second character; explicit `channel:` keys remain unambiguous.
+const SLACK_CANONICAL_CHANNEL_ID_RE = /^[CGD][A-Z0-9]{8,}$/;
+const SLACK_LOWERCASE_CHANNEL_ID_RE = /^[cgd][0-9][a-z0-9]{7,}$/;
+const SLACK_PREFIXED_CHANNEL_ID_RE = /^channel:[CGD][A-Z0-9]{8,}$/i;
+
+function looksLikeSlackChannelId(channelKey: string): boolean {
+  return (
+    SLACK_CANONICAL_CHANNEL_ID_RE.test(channelKey) ||
+    SLACK_LOWERCASE_CHANNEL_ID_RE.test(channelKey) ||
+    SLACK_PREFIXED_CHANNEL_ID_RE.test(channelKey)
+  );
+}
 
 function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
   const warnings: string[] = [];
@@ -61,7 +71,6 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
     slackCfg && typeof slackCfg.groupPolicy === "string"
       ? (slackCfg.groupPolicy as GroupPolicy)
       : undefined;
-  const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
     if (scope.dangerousNameMatchingEnabled) {
       continue;
@@ -70,8 +79,8 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       typeof scope.account.groupPolicy === "string"
         ? (scope.account.groupPolicy as GroupPolicy)
         : providerGroupPolicy;
-    // Doctor reads authored config, while Slack's runtime schema materializes this default.
-    const effectiveGroupPolicy = scopedGroupPolicy ?? defaultGroupPolicy ?? "allowlist";
+    // Slack's schema materializes this provider default before runtime account merging.
+    const effectiveGroupPolicy = scopedGroupPolicy ?? "allowlist";
     if (effectiveGroupPolicy !== "allowlist") {
       continue;
     }
@@ -80,7 +89,7 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       continue;
     }
     for (const channelKey of Object.keys(channels)) {
-      if (channelKey === "*" || SLACK_CHANNEL_ID_RE.test(channelKey)) {
+      if (channelKey === "*" || looksLikeSlackChannelId(channelKey)) {
         continue;
       }
       warnings.push(

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -57,6 +57,8 @@ const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][0-9][a-z0-9]{7,}$
 // Letter-leading lowercase forms may be valid IDs or human names. Warn conditionally instead of
 // claiming they are unroutable.
 const SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE = /^(?:channel:)?[cgd][a-z][a-z0-9]{7,}$/;
+// Slack supports international channel names, and runtime name matching preserves exact names.
+// Keep Unicode letters/marks/numbers while enforcing lowercase, length, and punctuation rules.
 const SLACK_CHANNEL_NAME_RE = /^[\p{L}\p{M}\p{N}_-]{1,80}$/u;
 const SLACK_CHANNEL_NAME_ALPHANUMERIC_RE = /[\p{L}\p{N}]/u;
 

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -1,6 +1,9 @@
 // Slack plugin module implements doctor behavior.
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { type GroupPolicy, resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
+import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
 import {
   legacyConfigRules as SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeSlackCompatibilityConfig,
@@ -48,6 +51,56 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
+// Slack channel IDs look like C0123ABCD / G… / D… (9+ alphanumerics), optionally `channel:`-prefixed,
+// and case-insensitive since config keys may be lowercase. A `channels` map keyed by a human channel
+// NAME instead of an ID is never matched under groupPolicy:"allowlist" (name matching is off), so
+// messages in that channel are silently dropped with no validation error or diagnostic. Warn so the
+// operator can re-key. #81665
+const SLACK_CHANNEL_ID_RE = /^(?:channel:)?[CGD][A-Z0-9]{8,}$/i;
+
+function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
+  const warnings: string[] = [];
+  const slackCfg = asObjectRecord(asObjectRecord(cfg.channels)?.slack);
+  const providerGroupPolicy =
+    slackCfg && typeof slackCfg.groupPolicy === "string"
+      ? (slackCfg.groupPolicy as GroupPolicy)
+      : undefined;
+  const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+  for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
+    if (scope.dangerousNameMatchingEnabled) {
+      // Name matching is enabled for this account, so name-keyed channels do resolve.
+      continue;
+    }
+    // Effective group policy for the warning: an explicit account/provider policy wins, then
+    // channels.defaults.groupPolicy, then the loaded Slack default of "allowlist" for an omitted
+    // policy. Only "allowlist" routing drops unmatched channels, so explicit "open"/"disabled"
+    // are skipped — while omitted / default-allowlist configs (the case the issue describes) warn.
+    const explicitGroupPolicy =
+      typeof scope.account.groupPolicy === "string"
+        ? (scope.account.groupPolicy as GroupPolicy)
+        : providerGroupPolicy;
+    const effectiveGroupPolicy = explicitGroupPolicy ?? defaultGroupPolicy ?? "allowlist";
+    if (effectiveGroupPolicy !== "allowlist") {
+      continue;
+    }
+    const channels = asObjectRecord(scope.account.channels);
+    if (!channels) {
+      continue;
+    }
+    for (const channelKey of Object.keys(channels)) {
+      if (channelKey === "*" || SLACK_CHANNEL_ID_RE.test(channelKey)) {
+        continue;
+      }
+      warnings.push(
+        `${scope.prefix}.channels."${channelKey}" is keyed by a channel name, not a Slack channel ID; ` +
+          `under groupPolicy: "allowlist" this entry never matches and messages in that channel are silently dropped. ` +
+          `Re-key it with the channel's ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
+      );
+    }
+  }
+  return warnings;
+}
+
 export const slackDoctor: ChannelDoctorAdapter = {
   dmAllowFromMode: "topOnly",
   groupModel: "route",
@@ -55,5 +108,8 @@ export const slackDoctor: ChannelDoctorAdapter = {
   warnOnEmptyGroupSenderAllowlist: false,
   legacyConfigRules: SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig: normalizeSlackCompatibilityConfig,
-  collectMutableAllowlistWarnings: collectSlackMutableAllowlistWarnings,
+  collectMutableAllowlistWarnings: ({ cfg }) => [
+    ...collectSlackMutableAllowlistWarnings({ cfg }),
+    ...collectSlackNameKeyedChannelWarnings({ cfg }),
+  ],
 };

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -50,10 +50,13 @@ const collectSlackMutableAllowlistWarnings =
     },
   });
 
-const SLACK_CANONICAL_CHANNEL_ID_RE = /^[CGD][A-Z0-9]{8,}$/;
-const SLACK_LOWERCASE_CHANNEL_ID_RE = /^[cgd][0-9][a-z0-9]{7,}$/;
-const SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE = /^channel:[CGD][A-Z0-9]{8,}$/;
-const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][0-9][a-z0-9]{7,}$/;
+const SLACK_CANONICAL_CHANNEL_ID_RE = /^[CG][A-Z0-9]{8,}$/;
+const SLACK_LOWERCASE_CHANNEL_ID_RE = /^[cg][0-9][a-z0-9]{7,}$/;
+const SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE = /^channel:[CG][A-Z0-9]{8,}$/;
+const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cg][0-9][a-z0-9]{7,}$/;
+const SLACK_CANONICAL_DM_ID_RE = /^(?:channel:)?D[A-Z0-9]{8,}$/;
+const SLACK_PREFIXED_LOWERCASE_DM_ID_RE = /^channel:d[a-z0-9]{8,}$/;
+const SLACK_AMBIGUOUS_LOWERCASE_DM_ID_RE = /^d[a-z0-9]{8,}$/;
 // Letter-leading lowercase forms may be valid IDs or human names. Warn conditionally instead of
 // claiming they are unroutable.
 const SLACK_AMBIGUOUS_LOWERCASE_CHANNEL_ID_RE = /^(?:channel:)?[cgd][a-z][a-z0-9]{7,}$/;
@@ -68,6 +71,12 @@ function looksLikeSlackChannelId(channelKey: string): boolean {
     SLACK_LOWERCASE_CHANNEL_ID_RE.test(channelKey) ||
     SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE.test(channelKey) ||
     SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE.test(channelKey)
+  );
+}
+
+function looksLikeSlackDmId(channelKey: string): boolean {
+  return (
+    SLACK_CANONICAL_DM_ID_RE.test(channelKey) || SLACK_PREFIXED_LOWERCASE_DM_ID_RE.test(channelKey)
   );
 }
 
@@ -96,10 +105,8 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
       typeof account.groupPolicy === "string" ? (account.groupPolicy as GroupPolicy) : undefined;
     // Slack's schema materializes this provider default before runtime account merging.
     const effectiveGroupPolicy = scopedGroupPolicy ?? "allowlist";
-    if (effectiveGroupPolicy === "disabled") {
-      continue;
-    }
     const rawAccount = asObjectRecord(accounts?.[accountId]);
+    const accountPrefix = rawAccount ? `channels.slack.accounts.${accountId}` : "channels.slack";
     const accountChannels = asObjectRecord(rawAccount?.channels);
     const channels = accountChannels ?? providerChannels;
     if (!channels) {
@@ -114,11 +121,37 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
         ? 'this entry\'s overrides are ignored and the channel remains allowed by groupPolicy: "open"'
         : "messages from the channel are dropped";
     for (const channelKey of Object.keys(channels)) {
-      if (channelKey === "*" || looksLikeSlackChannelId(channelKey)) {
+      if (channelKey === "*") {
+        continue;
+      }
+      if (looksLikeSlackDmId(channelKey)) {
+        warnings.add(
+          `${channelsPrefix}.channels."${channelKey}" is a Slack DM conversation ID, but ${channelsPrefix}.channels only configures channel and group rooms. ` +
+            `Configure DM access with ${accountPrefix}.dmPolicy and ${accountPrefix}.allowFrom instead.`,
+        );
+        continue;
+      }
+      if (SLACK_AMBIGUOUS_LOWERCASE_DM_ID_RE.test(channelKey)) {
+        if (
+          account.dangerouslyAllowNameMatching === true &&
+          looksLikeSlackChannelNameKey(channelKey)
+        ) {
+          continue;
+        }
+        warnings.add(
+          `${channelsPrefix}.channels."${channelKey}" is ambiguous: it may be a lowercase Slack DM conversation ID or a channel name. ` +
+            `Configure DMs with ${accountPrefix}.dmPolicy and ${accountPrefix}.allowFrom; otherwise re-key the room with its stable C/G ID.`,
+        );
+        continue;
+      }
+      if (effectiveGroupPolicy === "disabled") {
         continue;
       }
       const channelConfig = asObjectRecord(channels[channelKey]);
       if (effectiveGroupPolicy === "open" && Object.keys(channelConfig ?? {}).length === 0) {
+        continue;
+      }
+      if (looksLikeSlackChannelId(channelKey)) {
         continue;
       }
       if (

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -2,8 +2,9 @@
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createDangerousNameMatchingMutableAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { type GroupPolicy, resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
+import type { GroupPolicy } from "openclaw/plugin-sdk/config-contracts";
 import { collectProviderDangerousNameMatchingScopes } from "openclaw/plugin-sdk/runtime-doctor";
+import { resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import {
   legacyConfigRules as SLACK_LEGACY_CONFIG_RULES,
   normalizeCompatibilityConfig as normalizeSlackCompatibilityConfig,

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -54,23 +54,26 @@ const collectSlackMutableAllowlistWarnings =
 // with a numeric second character; explicit `channel:` keys remain unambiguous.
 const SLACK_CANONICAL_CHANNEL_ID_RE = /^[CGD][A-Z0-9]{8,}$/;
 const SLACK_LOWERCASE_CHANNEL_ID_RE = /^[cgd][0-9][a-z0-9]{7,}$/;
-const SLACK_PREFIXED_CHANNEL_ID_RE = /^channel:[CGD][A-Z0-9]{8,}$/i;
+const SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE = /^channel:[CGD][A-Z0-9]{8,}$/;
+const SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE = /^channel:[cgd][a-z0-9]{8,}$/;
 
 function looksLikeSlackChannelId(channelKey: string): boolean {
   return (
     SLACK_CANONICAL_CHANNEL_ID_RE.test(channelKey) ||
     SLACK_LOWERCASE_CHANNEL_ID_RE.test(channelKey) ||
-    SLACK_PREFIXED_CHANNEL_ID_RE.test(channelKey)
+    SLACK_PREFIXED_CANONICAL_CHANNEL_ID_RE.test(channelKey) ||
+    SLACK_PREFIXED_LOWERCASE_CHANNEL_ID_RE.test(channelKey)
   );
 }
 
 function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
-  const warnings: string[] = [];
+  const warnings = new Set<string>();
   const slackCfg = asObjectRecord(asObjectRecord(cfg.channels)?.slack);
   const providerGroupPolicy =
     slackCfg && typeof slackCfg.groupPolicy === "string"
       ? (slackCfg.groupPolicy as GroupPolicy)
       : undefined;
+  const providerChannels = asObjectRecord(slackCfg?.channels);
   for (const scope of collectProviderDangerousNameMatchingScopes(cfg, "slack")) {
     if (scope.dangerousNameMatchingEnabled) {
       continue;
@@ -84,22 +87,24 @@ function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }):
     if (effectiveGroupPolicy !== "allowlist") {
       continue;
     }
-    const channels = asObjectRecord(scope.account.channels);
+    const accountChannels = asObjectRecord(scope.account.channels);
+    const channels = accountChannels ?? providerChannels;
     if (!channels) {
       continue;
     }
+    const channelsPrefix = accountChannels ? scope.prefix : "channels.slack";
     for (const channelKey of Object.keys(channels)) {
       if (channelKey === "*" || looksLikeSlackChannelId(channelKey)) {
         continue;
       }
-      warnings.push(
-        `${scope.prefix}.channels."${channelKey}" is keyed by a channel name, not a Slack channel ID; ` +
+      warnings.add(
+        `${channelsPrefix}.channels."${channelKey}" is keyed by a channel name or non-canonical ID form, not a routable Slack channel ID; ` +
           `under groupPolicy: "allowlist" this entry never matches and messages in that channel are silently dropped. ` +
           `Re-key it with the channel's ID (e.g. C0123ABCD, from the channel's About details or conversations.info).`,
       );
     }
   }
-  return warnings;
+  return [...warnings];
 }
 
 export const slackDoctor: ChannelDoctorAdapter = {

--- a/extensions/slack/src/doctor.ts
+++ b/extensions/slack/src/doctor.ts
@@ -67,6 +67,8 @@ function looksLikeSlackChannelId(channelKey: string): boolean {
   );
 }
 
+// Startup resolution updates ctx.channelsConfig, but inbound authorization captures the authored
+// channels map and key list when createSlackMonitorContext runs. Diagnose those authored keys.
 function collectSlackNameKeyedChannelWarnings({ cfg }: { cfg: OpenClawConfig }): string[] {
   const warnings = new Set<string>();
   const slackCfg = asObjectRecord(asObjectRecord(cfg.channels)?.slack);


### PR DESCRIPTION
## Summary

Fixes #81665.

Slack channel maps are authored as free-form records, but inbound room routing only consumes stable C/G conversation IDs unless dangerous name matching is explicitly enabled. Invalid keys could therefore be accepted while their allow/deny and per-channel overrides were silently ignored.

## What changed

- Audit effective enabled Slack accounts using the same account enumeration and merge rules as runtime.
- Warn for non-routable channel-name and target forms under allowlist policy.
- Warn when name-keyed overrides are ignored under open policy, including fail-open deny rules.
- Preserve supported lowercase IDs and valid international channel names when dangerous name matching is enabled.
- Diagnose misplaced D-prefixed DM IDs and point to the effective account's `dmPolicy` / `allowFrom` paths.
- Distinguish ambiguous lowercase ID/name forms without claiming valid lowercase IDs are broken.

Routing behavior is unchanged; this is a doctor diagnostic only.

## Real behavior proof

Behavior addressed: `openclaw doctor` now reports Slack channel-map keys that inbound routing cannot consume, including ignored open-policy overrides and misplaced DM IDs.

Real environment tested: Local source checkout at `f2ea6c6558aad3f816179c233f770274ff881589`.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs extensions/slack/src/doctor.test.ts extensions/slack/src/accounts.test.ts extensions/slack/src/monitor/monitor.test.ts extensions/slack/src/monitor/provider.allowlist.test.ts
pnpm tsgo:extensions
pnpm tsgo:extensions:test
pnpm test:extensions:package-boundary:compile
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix: 4 test files / 62 tests passed; both extension type lanes passed; all 114 plugin package-boundary compiles passed; final branch-wide autoreview reported no actionable findings.

Observed result after fix: Doctor warnings identify the authored provider/account path, explain wildcard/drop/open-policy outcomes, preserve valid name-matching forms, and route DM remediation to the effective account scope.

What was not tested: No live Slack workspace call. The change is static diagnostics over existing config and routing contracts.

## Verification

- `git diff --check`
- Post-rebase focused test rerun: 4 files / 62 tests passed
