### PR TITLE
docs(exec): correct host=node auto-routing under an active sandbox

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -170,7 +170,7 @@ Or per session:
 Once set, any `exec` call with `host=node` runs on the node host (subject to the
 node allowlist/approvals).
 
-`host=auto` will not implicitly choose the node on its own, but an explicit per-call `host=node` request is allowed from `auto`. If you want node exec to be the default for the session, set `tools.exec.host=node` or `/exec host=node ...` explicitly.
+`host=auto` will not implicitly choose the node on its own. An explicit per-call `host=node` request is only allowed from `auto` when no sandbox runtime is active (the same rule as `host=gateway`); while a sandbox runtime is active, `auto` keeps exec inside the sandbox. If you want node exec to be the default for the session, set `tools.exec.host=node` or `/exec host=node ...` explicitly.
 
 Related:
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -219,7 +219,7 @@ YOLO is the default host behavior unless you tighten it explicitly:
 - `tools.exec.host=auto` chooses **where** exec runs: sandbox when available, otherwise gateway.
 - YOLO chooses **how** host exec is approved: `security=full` plus `ask=off`.
 - In YOLO mode, OpenClaw does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy.
-- `auto` does not make gateway routing a free override from a sandboxed session. A per-call `host=node` request is allowed from `auto`; `host=gateway` is only allowed from `auto` when no sandbox runtime is active. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
+- `auto` does not make gateway or node routing a free override from a sandboxed session. A per-call `host=node` or `host=gateway` request is only allowed from `auto` when no sandbox runtime is active. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
 
 </Warning>
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -67,7 +67,7 @@ Notes:
 
 - `host` defaults to `auto`: sandbox when sandbox runtime is active for the session, otherwise gateway.
 - `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector; hostname-like values are rejected before the command runs.
-- `auto` is the default routing strategy, not a wildcard. Per-call `host=node` is allowed from `auto`; per-call `host=gateway` is only allowed when no sandbox runtime is active.
+- `auto` is the default routing strategy, not a wildcard. Per-call `host=node` and `host=gateway` are only allowed from `auto` when no sandbox runtime is active; while a sandbox runtime is active, `auto` keeps exec inside the sandbox and rejects both overrides.
 - `tools.exec.mode` is the normalized policy knob. Values are `deny`, `allowlist`, `ask`, `auto`, and `full`. `auto` runs deterministic allowlist/safe-bin matches directly and routes every remaining exec approval case through OpenClaw's native auto reviewer before asking a human. `ask` / `ask=always` still asks a human every time.
 - With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`; a live sandbox means it stays in the sandbox.
 - `elevated` escapes the sandbox onto the configured host path: `gateway` by default, or `node` when `tools.exec.host=node` (or the session default is `host=node`). It is only available when elevated access is enabled for the current session/provider.


### PR DESCRIPTION
## Summary

Fixes #61009.

`docs/tools/exec.md`, `docs/tools/exec-approvals.md`, and `docs/nodes/index.md` all stated that a per-call `host=node` override is allowed from `auto` (while only `host=gateway` was gated on no active sandbox). The runtime disagrees: `isRequestedExecTargetAllowed` rejects **both** `host=node` and `host=gateway` from `auto` while a sandbox runtime is active, and allows both only when no sandbox is active. The asymmetric docs were wrong — node and gateway are treated identically.

## What changed

Docs-only. Aligned the three pages with the test-locked runtime behavior (`src/agents/bash-tools.exec-runtime.ts` `isRequestedExecTargetAllowed`, pinned by `bash-tools.exec-runtime.test.ts`): a per-call `host=node` or `host=gateway` request is only allowed from `auto` when no sandbox runtime is active; while a sandbox is active, `auto` keeps exec inside the sandbox and rejects both overrides.

## Real behavior proof

**Behavior addressed:** the docs now match the runtime — from `auto`, both `host=node` and `host=gateway` per-call overrides are rejected while a sandbox is active, and allowed only when no sandbox is active (previously the docs claimed `host=node` was unconditionally allowed from `auto`).

**Real environment tested:** Local checkout at HEAD `0cbda2b94b7f9a1a07a25a91bd72990ca4a3e504` (a worktree of `origin/main`), Node v22.22.0. Drove the real exported `isRequestedExecTargetAllowed` — the function the docs describe — with `node --import tsx` (no mocks).

**Exact steps or command run after this patch:**
```
node --import tsx ./harness.mts   # isRequestedExecTargetAllowed across {auto} × {node,gateway} × {sandbox on/off}
node scripts/check-docs-mdx.mjs docs/tools/exec.md docs/tools/exec-approvals.md docs/nodes/index.md
```

**Evidence after fix:** Real console output from `node --import tsx` driving the production `isRequestedExecTargetAllowed` (the runtime the docs now describe):
```
=== auto + sandbox ACTIVE (runtime rejects BOTH) ===
auto sandbox node      -> false
auto sandbox gateway   -> false
=== auto + NO sandbox (both overrides allowed) ===
auto nosandbox node    -> true
auto nosandbox gateway -> true
```

**Observed result after fix:** From `auto`, `host=node` and `host=gateway` are both rejected when a sandbox is active and both allowed when no sandbox is active — exactly what the three updated doc pages now say. The previous docs claimed `host=node` was allowed unconditionally from `auto`, which contradicted the runtime.

**What was not tested:** No runtime/code change — this is a docs-only correction; the behavior is unchanged and already enforced and test-locked by `bash-tools.exec-runtime.test.ts`.

## Validation (supplemental)

- `node scripts/check-docs-mdx.mjs` (3 files) → passed. `format-docs --check` and `docs:check-i18n-glossary` → clean. `git diff --check` clean.
