### PR TITLE
fix(cron): reject durations that overflow to a non-finite value

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -7,6 +7,7 @@ import {
   getCronChannelOptions,
   parseAt,
   parseCronToolsAllow,
+  parseDurationMs,
   printCronList,
 } from "./shared.js";
 
@@ -312,5 +313,28 @@ describe("coerceCronDeliveryPreviews", () => {
         },
       }).size,
     ).toBe(0);
+  });
+});
+
+describe("parseDurationMs", () => {
+  it("parses valid positive durations", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("1.5h")).toBe(5_400_000);
+    expect(parseDurationMs("1d")).toBe(86_400_000);
+  });
+
+  it("rejects non-positive and malformed durations", () => {
+    expect(parseDurationMs("0s")).toBeNull();
+    expect(parseDurationMs("-5s")).toBeNull();
+    expect(parseDurationMs("abc")).toBeNull();
+    expect(parseDurationMs("")).toBeNull();
+  });
+
+  it("rejects durations that overflow to a non-finite millisecond value (#83906)", () => {
+    // A finite mantissa can still overflow once multiplied by a large unit factor.
+    expect(parseDurationMs(`1${"0".repeat(302)}d`)).toBeNull();
+    // A large-but-finite result is still accepted.
+    expect(parseDurationMs(`9${"0".repeat(15)}ms`)).toBe(9_000_000_000_000_000);
   });
 });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -219,7 +219,13 @@ export function parseDurationMs(input: string): number | null {
           : unit === "h"
             ? 3_600_000
             : 86_400_000;
-  return Math.floor(n * factor);
+  const result = Math.floor(n * factor);
+  if (!Number.isFinite(result)) {
+    // A finite mantissa can still overflow to Infinity for a large unit (e.g. a long
+    // pure-digit string with "d"); reject it instead of returning Infinity ms.
+    return null;
+  }
+  return result;
 }
 
 export function parseCronStaggerMs(params: {


### PR DESCRIPTION
## Summary

Fixes #83906.

`parseDurationMs` (`src/cli/cron-cli/shared.ts`) guards the parsed mantissa (`if (!Number.isFinite(n) || n <= 0) return null`) but returns `Math.floor(n * factor)` with no finite check on the product. A finite mantissa from the regex (`/^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/i`) times a large unit factor — e.g. `1e302` with `d` (factor `86_400_000`) — overflows to `Infinity`, and `Math.floor(Infinity)` is returned as the millisecond value instead of being rejected.

## What changed

**`src/cli/cron-cli/shared.ts`** — `parseDurationMs` now checks the multiplied result with `Number.isFinite` and returns `null` for a non-finite product, matching the existing contract (it already rejects non-finite / non-positive mantissas). Large-but-finite results are still accepted.

**`src/cli/cron-cli/shared.test.ts`** — regression tests for the overflow case plus valid / invalid durations.

## Real behavior proof

**Behavior addressed:** `parseDurationMs` now returns `null` for a duration whose `value * unitFactor` overflows to a non-finite number (previously it returned `Infinity` ms); valid finite durations are unchanged.

**Real environment tested:** Local checkout at HEAD `eefd296fb913f76a6e68a222c43df84e0731050c` (a worktree of `origin/main`), Node v22.22.0. Drove the real exported `parseDurationMs` with `node --import tsx` — no mocks/stubs.

**Exact steps or command run after this patch:**
```
node --import tsx ./harness.mts   # parseDurationMs across overflow + valid + invalid inputs
node scripts/run-vitest.mjs run src/cli/cron-cli/shared.test.ts
```

**Evidence after fix:** Real console output from `node --import tsx` driving the production `parseDurationMs`:
```
overflow (1e302 d):       null               (want null)
big-but-finite 9e15 ms:   9000000000000000   (finite ok)
30s:                      30000              (want 30000)
1d:                       86400000           (want 86400000)
1.5h:                     5400000            (want 5400000)
0s:                       null               (want null)
garbage:                  null               (want null)
```

**Observed result after fix:** The overflowing `1e302d` input now returns `null` instead of `Infinity`; large-but-finite, normal, zero, and malformed inputs all behave as before (finite values preserved, non-positive / garbage rejected).

**What was not tested:** No end-to-end cron scheduling run — the change is a single guard in the pure `parseDurationMs` function, exercised directly with the real export; callers already treat `null` as "invalid duration".

## Validation (supplemental)

- `node scripts/run-vitest.mjs run src/cli/cron-cli/shared.test.ts` → `Test Files 1 passed (1)`, `Tests 28 passed (28)`
- `tsgo:core` and `tsgo:core:test` → exit 0. `oxlint` clean. `git diff --check` clean.
