### PR TITLE
refactor(gateway): share duplicated test helpers

### DIFF
--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -22,7 +22,10 @@ import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { sleep } from "../utils.js";
 import type { GatewayClient } from "./client.js";
-import { connectTestGatewayClient } from "./gateway-cli-backend.live-helpers.js";
+import {
+  connectTestGatewayClient,
+  getFreeGatewayPort,
+} from "./gateway-cli-backend.live-helpers.js";
 import { startGatewayServer } from "./server.js";
 
 const LIVE = isLiveTestEnabled();
@@ -93,14 +96,6 @@ function createSlackCurrentConversationBindingRegistry(outboundReplies: Captured
       },
     },
   ]);
-}
-
-async function getFreeGatewayPort(): Promise<number> {
-  const { getFreePortBlockWithPermissionFallback } = await import("../test-utils/ports.js");
-  return await getFreePortBlockWithPermissionFallback({
-    offsets: [0, 1, 2, 4],
-    fallbackBase: 42_000,
-  });
 }
 
 function extractAssistantTexts(messages: unknown[]): string[] {

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -61,6 +61,32 @@ describe("gateway hooks helpers", () => {
       },
     }) as OpenClawConfig;
 
+  const buildStaticShadowingMappingConfig = (params: {
+    firstMatch?: Partial<{ path: string; source: string }>;
+    firstMessageTemplate?: string;
+    secondMatch?: Partial<{ path: string; source: string }>;
+  }) =>
+    ({
+      hooks: {
+        enabled: true,
+        token: "secret",
+        mappings: [
+          {
+            ...(params.firstMatch ? { match: params.firstMatch } : {}),
+            action: "agent",
+            messageTemplate: params.firstMessageTemplate ?? "catch-all",
+            sessionKey: "hook:static",
+          },
+          {
+            match: params.secondMatch ?? { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            sessionKey: "hook:gmail:{{messages[0].id}}",
+          },
+        ],
+      },
+    }) as OpenClawConfig;
+
   beforeEach(() => {
     setActivePluginRegistry(emptyRegistry);
   });
@@ -428,25 +454,7 @@ describe("gateway hooks helpers", () => {
   });
 
   test("resolveHooksConfig allows a static catch-all mapping to shadow a later templated mapping", () => {
-    const resolved = resolveHooksConfigOrThrow({
-      hooks: {
-        enabled: true,
-        token: "secret",
-        mappings: [
-          {
-            action: "agent",
-            messageTemplate: "catch-all",
-            sessionKey: "hook:static",
-          },
-          {
-            match: { path: "gmail" },
-            action: "agent",
-            messageTemplate: "Subject: {{messages[0].subject}}",
-            sessionKey: "hook:gmail:{{messages[0].id}}",
-          },
-        ],
-      },
-    } as OpenClawConfig);
+    const resolved = resolveHooksConfigOrThrow(buildStaticShadowingMappingConfig({}));
 
     expect(resolved.mappings.map((mapping) => mapping.sessionKey)).toEqual([
       "hook:static",
@@ -479,52 +487,22 @@ describe("gateway hooks helpers", () => {
   });
 
   test("resolveHooksConfig treats '/' match.path as a catch-all for shadowing", () => {
-    const resolved = resolveHooksConfigOrThrow({
-      hooks: {
-        enabled: true,
-        token: "secret",
-        mappings: [
-          {
-            match: { path: "/" },
-            action: "agent",
-            messageTemplate: "catch-all",
-            sessionKey: "hook:static",
-          },
-          {
-            match: { path: "gmail" },
-            action: "agent",
-            messageTemplate: "Subject: {{messages[0].subject}}",
-            sessionKey: "hook:gmail:{{messages[0].id}}",
-          },
-        ],
-      },
-    } as OpenClawConfig);
+    const resolved = resolveHooksConfigOrThrow(
+      buildStaticShadowingMappingConfig({ firstMatch: { path: "/" } }),
+    );
 
     expect(resolved.mappings.map((mapping) => mapping.matchPath)).toEqual(["", "gmail"]);
     expect(resolved.sessionPolicy.allowedSessionKeyPrefixes).toBeUndefined();
   });
 
   test("resolveHooksConfig treats empty match.source as a wildcard for shadowing", () => {
-    const resolved = resolveHooksConfigOrThrow({
-      hooks: {
-        enabled: true,
-        token: "secret",
-        mappings: [
-          {
-            match: { path: "gmail", source: "" },
-            action: "agent",
-            messageTemplate: "catch-all source",
-            sessionKey: "hook:static",
-          },
-          {
-            match: { path: "gmail", source: "gmail" },
-            action: "agent",
-            messageTemplate: "Subject: {{messages[0].subject}}",
-            sessionKey: "hook:gmail:{{messages[0].id}}",
-          },
-        ],
-      },
-    } as OpenClawConfig);
+    const resolved = resolveHooksConfigOrThrow(
+      buildStaticShadowingMappingConfig({
+        firstMatch: { path: "gmail", source: "" },
+        firstMessageTemplate: "catch-all source",
+        secondMatch: { path: "gmail", source: "gmail" },
+      }),
+    );
 
     expect(resolved.mappings.map((mapping) => mapping.matchSource)).toEqual(["", "gmail"]);
     expect(resolved.sessionPolicy.allowedSessionKeyPrefixes).toBeUndefined();

--- a/src/gateway/http-common.fuzz.test.ts
+++ b/src/gateway/http-common.fuzz.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAuthResult } from "./auth.js";
 import {
@@ -16,7 +16,7 @@ import {
   watchClientDisconnect,
   writeDone,
 } from "./http-common.js";
-import { makeMockHttpResponse } from "./test-http-response.js";
+import { makeMockHttpReqRes, makeMockHttpResponse } from "./test-http-response.js";
 
 /**
  * Seeded property-based / fuzz coverage for http-common.
@@ -369,16 +369,6 @@ describe("fuzz: setSseHeaders", () => {
 });
 
 describe("fuzz: watchClientDisconnect", () => {
-  function buildReqRes(
-    reqSocket: EventEmitter | null,
-    resSocket: EventEmitter | null,
-  ): { req: IncomingMessage; res: ServerResponse } {
-    return {
-      req: { socket: reqSocket } as unknown as IncomingMessage,
-      res: { socket: resSocket } as unknown as ServerResponse,
-    };
-  }
-
   it("invariants hold for arbitrary socket/controller/callback combinations", () => {
     const rng = makeRng(0xc105e);
     for (let i = 0; i < ITERATIONS; i += 1) {
@@ -408,7 +398,7 @@ describe("fuzz: watchClientDisconnect", () => {
       }
       const onDisconnect = hasCallback ? vi.fn() : undefined;
 
-      const { req, res } = buildReqRes(reqSocket, resSocket);
+      const { req, res } = makeMockHttpReqRes(reqSocket, resSocket);
       const cleanup = watchClientDisconnect(req, res, controller, onDisconnect);
 
       const uniqueSockets = new Set<EventEmitter>();

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -21,7 +21,7 @@ import {
   watchClientDisconnect,
   writeDone,
 } from "./http-common.js";
-import { makeMockHttpResponse } from "./test-http-response.js";
+import { makeMockHttpReqRes, makeMockHttpResponse } from "./test-http-response.js";
 
 const readJsonBodyMock = vi.hoisted(() => vi.fn());
 
@@ -314,18 +314,8 @@ describe("setSseHeaders", () => {
 });
 
 describe("watchClientDisconnect", () => {
-  function buildReqRes(
-    reqSocket: EventEmitter | null,
-    resSocket: EventEmitter | null,
-  ): { req: IncomingMessage; res: ServerResponse } {
-    return {
-      req: { socket: reqSocket } as unknown as IncomingMessage,
-      res: { socket: resSocket } as unknown as ServerResponse,
-    };
-  }
-
   it("returns a no-op cleanup when no sockets are available", () => {
-    const { req, res } = buildReqRes(null, null);
+    const { req, res } = makeMockHttpReqRes(null, null);
     const controller = new AbortController();
     const cleanup = watchClientDisconnect(req, res, controller);
     cleanup();
@@ -334,7 +324,7 @@ describe("watchClientDisconnect", () => {
 
   it("aborts the controller and calls onDisconnect when a socket closes", () => {
     const socket = new EventEmitter();
-    const { req, res } = buildReqRes(socket, socket);
+    const { req, res } = makeMockHttpReqRes(socket, socket);
     const controller = new AbortController();
     const onDisconnect = vi.fn();
     watchClientDisconnect(req, res, controller, onDisconnect);
@@ -345,7 +335,7 @@ describe("watchClientDisconnect", () => {
 
   it("does not double-abort when the controller is already aborted", () => {
     const socket = new EventEmitter();
-    const { req, res } = buildReqRes(socket, null);
+    const { req, res } = makeMockHttpReqRes(socket, null);
     const controller = new AbortController();
     controller.abort();
     const abortSpy = vi.spyOn(controller, "abort");
@@ -358,7 +348,7 @@ describe("watchClientDisconnect", () => {
 
   it("works without an onDisconnect callback", () => {
     const socket = new EventEmitter();
-    const { req, res } = buildReqRes(null, socket);
+    const { req, res } = makeMockHttpReqRes(null, socket);
     const controller = new AbortController();
     watchClientDisconnect(req, res, controller);
     socket.emit("close");
@@ -368,7 +358,7 @@ describe("watchClientDisconnect", () => {
   it("deduplicates identical request and response sockets", () => {
     const socket = new EventEmitter();
     const onSpy = vi.spyOn(socket, "on");
-    const { req, res } = buildReqRes(socket, socket);
+    const { req, res } = makeMockHttpReqRes(socket, socket);
     const controller = new AbortController();
     watchClientDisconnect(req, res, controller);
     expect(onSpy).toHaveBeenCalledTimes(1);
@@ -379,7 +369,7 @@ describe("watchClientDisconnect", () => {
     const resSocket = new EventEmitter();
     const reqOn = vi.spyOn(reqSocket, "on");
     const resOn = vi.spyOn(resSocket, "on");
-    const { req, res } = buildReqRes(reqSocket, resSocket);
+    const { req, res } = makeMockHttpReqRes(reqSocket, resSocket);
     const controller = new AbortController();
     watchClientDisconnect(req, res, controller);
     const reqOnCall = mockCallRecord(reqOn, 0);
@@ -392,7 +382,7 @@ describe("watchClientDisconnect", () => {
 
   it("cleanup detaches the close listener from each socket", () => {
     const socket = new EventEmitter();
-    const { req, res } = buildReqRes(socket, null);
+    const { req, res } = makeMockHttpReqRes(socket, null);
     const controller = new AbortController();
     const cleanup = watchClientDisconnect(req, res, controller);
     expect(socket.listenerCount("close")).toBe(1);

--- a/src/gateway/node-invoke-system-run-approval-match.test.ts
+++ b/src/gateway/node-invoke-system-run-approval-match.test.ts
@@ -19,6 +19,26 @@ function expectMismatch(
   expect(result.code).toBe(code);
 }
 
+function createBoundSystemRunRequest(params: {
+  argv: string[];
+  command?: string;
+  commandArgv?: string[];
+  env?: Record<string, string>;
+}) {
+  return {
+    host: "node",
+    command: params.command ?? params.argv.join(" "),
+    ...(params.commandArgv ? { commandArgv: params.commandArgv } : {}),
+    systemRunBinding: buildSystemRunApprovalBinding({
+      argv: params.argv,
+      cwd: null,
+      agentId: null,
+      sessionKey: null,
+      ...(params.env ? { env: params.env } : {}),
+    }).binding,
+  };
+}
+
 function expectV1BindingMatch(params: {
   argv: string[];
   requestCommand: string;
@@ -26,17 +46,11 @@ function expectV1BindingMatch(params: {
 }) {
   const result = evaluateSystemRunApprovalMatch({
     argv: params.argv,
-    request: {
-      host: "node",
+    request: createBoundSystemRunRequest({
+      argv: params.argv,
       command: params.requestCommand,
       commandArgv: params.commandArgv,
-      systemRunBinding: buildSystemRunApprovalBinding({
-        argv: params.argv,
-        cwd: null,
-        agentId: null,
-        sessionKey: null,
-      }).binding,
-    },
+    }),
     binding: defaultBinding,
   });
   expect(result).toEqual({ ok: true });
@@ -65,16 +79,7 @@ describe("evaluateSystemRunApprovalMatch", () => {
   test("rejects argv mismatch in v1 object", () => {
     const result = evaluateSystemRunApprovalMatch({
       argv: ["echo", "SAFE"],
-      request: {
-        host: "node",
-        command: "echo SAFE",
-        systemRunBinding: buildSystemRunApprovalBinding({
-          argv: ["echo SAFE"],
-          cwd: null,
-          agentId: null,
-          sessionKey: null,
-        }).binding,
-      },
+      request: createBoundSystemRunRequest({ argv: ["echo SAFE"] }),
       binding: defaultBinding,
     });
     expectMismatch(result, "APPROVAL_REQUEST_MISMATCH");
@@ -83,16 +88,7 @@ describe("evaluateSystemRunApprovalMatch", () => {
   test("rejects env overrides when v1 binding has no env hash", () => {
     const result = evaluateSystemRunApprovalMatch({
       argv: ["git", "diff"],
-      request: {
-        host: "node",
-        command: "git diff",
-        systemRunBinding: buildSystemRunApprovalBinding({
-          argv: ["git", "diff"],
-          cwd: null,
-          agentId: null,
-          sessionKey: null,
-        }).binding,
-      },
+      request: createBoundSystemRunRequest({ argv: ["git", "diff"] }),
       binding: {
         ...defaultBinding,
         env: { GIT_EXTERNAL_DIFF: "/tmp/pwn.sh" },
@@ -104,17 +100,10 @@ describe("evaluateSystemRunApprovalMatch", () => {
   test("accepts matching env hash with reordered keys", () => {
     const result = evaluateSystemRunApprovalMatch({
       argv: ["git", "diff"],
-      request: {
-        host: "node",
-        command: "git diff",
-        systemRunBinding: buildSystemRunApprovalBinding({
-          argv: ["git", "diff"],
-          cwd: null,
-          agentId: null,
-          sessionKey: null,
-          env: { SAFE_A: "1", SAFE_B: "2" },
-        }).binding,
-      },
+      request: createBoundSystemRunRequest({
+        argv: ["git", "diff"],
+        env: { SAFE_A: "1", SAFE_B: "2" },
+      }),
       binding: {
         ...defaultBinding,
         env: { SAFE_B: "2", SAFE_A: "1" },

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HealthSummary } from "../commands/health.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
-import { createChatRunState } from "./server-chat-state.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "./server-constants.js";
+import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
 
 const cleanOldMediaMock = vi.fn(async () => {});
 
@@ -33,24 +33,7 @@ function createActiveRun(
 }
 
 function createMaintenanceTimerDeps() {
-  const chatRunState = createChatRunState();
-  return {
-    broadcast: () => {},
-    nodeSendToAllSubscribed: () => {},
-    getPresenceVersion: () => 1,
-    getHealthVersion: () => 1,
-    refreshGatewayHealthSnapshot: async () => ({ ok: true }) as HealthSummary,
-    logHealth: { error: () => {} },
-    dedupe: new Map(),
-    chatAbortControllers: new Map(),
-    chatRunState,
-    chatRunBuffers: chatRunState.buffers,
-    chatDeltaSentAt: chatRunState.deltaSentAt,
-    chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
-    removeChatRun: () => undefined,
-    agentRunSeq: new Map(),
-    nodeSendToSession: () => {},
-  };
+  return createGatewayMaintenanceStateForTest();
 }
 
 type MaintenanceTimerDeps = ReturnType<typeof createMaintenanceTimerDeps>;

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireRecord } from "../test-helpers.assertions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 type ChannelTestPlugin = {
@@ -126,9 +127,9 @@ function channelAccounts(
   payload: Record<string, unknown>,
   channel: string,
 ): Record<string, unknown>[] {
-  const accounts = requireRecord(payload.channelAccounts)[channel] as unknown[];
+  const accounts = requireRecord(payload.channelAccounts, "channel accounts")[channel] as unknown[];
   expect(Array.isArray(accounts)).toBe(true);
-  return accounts.map((account) => requireRecord(account));
+  return accounts.map((account) => requireRecord(account, "channel account"));
 }
 
 function firstChannelAccount(
@@ -136,13 +137,6 @@ function firstChannelAccount(
   channel: string,
 ): Record<string, unknown> {
   return channelAccounts(payload, channel)[0];
-}
-
-function requireRecord(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Expected record");
-  }
-  return value as Record<string, unknown>;
 }
 
 function requireFirstCallArg(mock: { mock: { calls: readonly (readonly unknown[])[] } }) {
@@ -160,7 +154,7 @@ function requireRespondPayload(respond: ReturnType<typeof vi.fn>): Record<string
   }
   expect(call[0]).toBe(true);
   expect(call[2]).toBeUndefined();
-  return requireRecord(call[1]);
+  return requireRecord(call[1], "respond payload");
 }
 
 describe("channelsHandlers channels.status", () => {
@@ -195,11 +189,14 @@ describe("channelsHandlers channels.status", () => {
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
       config: {},
     });
-    const snapshotArgs = requireRecord(requireFirstCallArg(mocks.buildChannelAccountSnapshot));
+    const snapshotArgs = requireRecord(
+      requireFirstCallArg(mocks.buildChannelAccountSnapshot),
+      "snapshot args",
+    );
     expect(snapshotArgs.cfg).toBe(autoEnabledConfig);
     expect(snapshotArgs.accountId).toBe("default");
-    const channels = requireRecord(payload.channels);
-    const whatsapp = requireRecord(channels.whatsapp);
+    const channels = requireRecord(payload.channels, "channels payload");
+    const whatsapp = requireRecord(channels.whatsapp, "whatsapp channel");
     expect(whatsapp.configured).toBe(true);
   });
 
@@ -211,7 +208,7 @@ describe("channelsHandlers channels.status", () => {
 
     await channelsHandlers["channels.status"](createOptions({ probe: true, timeoutMs: 999_999 }));
 
-    const probeArgs = requireRecord(requireFirstCallArg(probeAccount));
+    const probeArgs = requireRecord(requireFirstCallArg(probeAccount), "probe args");
     expect(probeArgs.timeoutMs).toBe(30_000);
     expect(probeArgs.cfg).toBe(autoEnabledConfig);
   });
@@ -276,7 +273,7 @@ describe("channelsHandlers channels.status", () => {
     expect(account.accountId).toBe("default");
     expect(String(account.lastError)).toContain("probe failed");
     expect(typeof account.lastProbeAt).toBe("number");
-    const accountProbe = requireRecord(account.probe);
+    const accountProbe = requireRecord(account.probe, "account probe");
     expect(accountProbe.ok).toBe(false);
     expect(String(accountProbe.error)).toContain("probe failed");
   });
@@ -296,8 +293,11 @@ describe("channelsHandlers channels.status", () => {
       await vi.advanceTimersByTimeAsync(1000);
       await run;
 
-      const snapshotArgs = requireRecord(requireFirstCallArg(mocks.buildChannelAccountSnapshot));
-      const probe = requireRecord(snapshotArgs.probe);
+      const snapshotArgs = requireRecord(
+        requireFirstCallArg(mocks.buildChannelAccountSnapshot),
+        "snapshot args",
+      );
+      const probe = requireRecord(snapshotArgs.probe, "snapshot probe");
       expect(probe.timedOut).toBe(true);
       const payload = requireRespondPayload(respond);
       expect(payload.partial).toBe(true);
@@ -323,8 +323,8 @@ describe("channelsHandlers channels.status", () => {
     ]);
 
     const payload = await runChannelsStatus({ probe: false, timeoutMs: 1000 });
-    const channels = requireRecord(payload.channels);
-    const whatsapp = requireRecord(channels.whatsapp);
+    const channels = requireRecord(payload.channels, "channels payload");
+    const whatsapp = requireRecord(channels.whatsapp, "whatsapp channel");
     expect(whatsapp.configured).toBe(true);
     expect(String(whatsapp.lastError)).toContain("summary failed");
 

--- a/src/gateway/server-session-key.test.ts
+++ b/src/gateway/server-session-key.test.ts
@@ -25,6 +25,14 @@ vi.mock("./session-utils.js", async () => {
 const { resolveSessionKeyForRun, resetResolvedSessionKeyForRunCacheForTest } =
   await import("./server-session-key.js");
 
+function mockCombinedSessionStore(cfg: OpenClawConfig, store: Record<string, unknown>) {
+  hoisted.loadConfigMock.mockReturnValue(cfg);
+  hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
+    storePath: "(multiple)",
+    store,
+  });
+}
+
 describe("resolveSessionKeyForRun", () => {
   beforeEach(() => {
     hoisted.loadConfigMock.mockReset();
@@ -45,12 +53,8 @@ describe("resolveSessionKeyForRun", () => {
         store: "/custom/root/agents/{agentId}/sessions/sessions.json",
       },
     };
-    hoisted.loadConfigMock.mockReturnValue(cfg);
-    hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
-      storePath: "(multiple)",
-      store: {
-        "agent:main:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
-      },
+    mockCombinedSessionStore(cfg, {
+      "agent:main:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
     });
 
     expect(resolveSessionKeyForRun("run-1")).toBe("acp:run-1");
@@ -67,12 +71,8 @@ describe("resolveSessionKeyForRun", () => {
         store: "/custom/root/agents/{agentId}/sessions/sessions.json",
       },
     };
-    hoisted.loadConfigMock.mockReturnValue(cfg);
-    hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
-      storePath: "(multiple)",
-      store: {
-        "agent:retired:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
-      },
+    mockCombinedSessionStore(cfg, {
+      "agent:retired:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
     });
 
     expect(resolveSessionKeyForRun("run-1", { agentId: "retired" })).toBe("acp:run-1");
@@ -87,12 +87,8 @@ describe("resolveSessionKeyForRun", () => {
         store: "/custom/root/agents/{agentId}/sessions/sessions.json",
       },
     };
-    hoisted.loadConfigMock.mockReturnValue(cfg);
-    hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
-      storePath: "(multiple)",
-      store: {
-        "agent:retired:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
-      },
+    mockCombinedSessionStore(cfg, {
+      "agent:retired:acp:run-1": { sessionId: "run-1", updatedAt: 123 },
     });
 
     expect(resolveSessionKeyForRun("run-1")).toBeUndefined();
@@ -127,12 +123,8 @@ describe("resolveSessionKeyForRun", () => {
         scope: "global",
       },
     };
-    hoisted.loadConfigMock.mockReturnValue(cfg);
-    hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
-      storePath: "(multiple)",
-      store: {
-        global: { sessionId: "run-global", updatedAt: 123 },
-      },
+    mockCombinedSessionStore(cfg, {
+      global: { sessionId: "run-global", updatedAt: 123 },
     });
 
     expect(resolveSessionKeyForRun("run-global", { agentId: "work" })).toBe("global");

--- a/src/gateway/server-startup-early.test.ts
+++ b/src/gateway/server-startup-early.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
 
 type StartGatewayDiscovery = typeof import("./server-discovery-runtime.js").startGatewayDiscovery;
 
@@ -39,7 +40,6 @@ vi.mock("../tasks/task-registry.maintenance.js", () => ({
   getInspectableActiveTaskRestartBlockers: mocks.getInspectableActiveTaskRestartBlockers,
 }));
 
-import { createChatRunState } from "./server-chat-state.js";
 import { startGatewayEarlyRuntime, startGatewayPluginDiscovery } from "./server-startup-early.js";
 
 type StartGatewayEarlyRuntimeInput = Parameters<typeof startGatewayEarlyRuntime>[0];
@@ -52,7 +52,11 @@ const log = {
 function earlyRuntimeInput(
   overrides: Partial<StartGatewayEarlyRuntimeInput> = {},
 ): StartGatewayEarlyRuntimeInput {
-  const chatRunState = createChatRunState();
+  const maintenanceState = createGatewayMaintenanceStateForTest({
+    healthSummary: {} as never,
+    healthVersion: 0,
+    presenceVersion: 0,
+  });
   return {
     minimalTestGateway: true,
     cfgAtStart: {} as never,
@@ -63,21 +67,7 @@ function earlyRuntimeInput(
     log,
     logDiscovery: log,
     nodeRegistry: {} as never,
-    broadcast: () => {},
-    nodeSendToAllSubscribed: () => {},
-    getPresenceVersion: () => 0,
-    getHealthVersion: () => 0,
-    refreshGatewayHealthSnapshot: async () => ({}) as never,
-    logHealth: { error: () => {} },
-    dedupe: new Map(),
-    chatAbortControllers: new Map(),
-    chatRunState,
-    chatRunBuffers: chatRunState.buffers,
-    chatDeltaSentAt: chatRunState.deltaSentAt,
-    chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
-    removeChatRun: () => undefined,
-    agentRunSeq: new Map(),
-    nodeSendToSession: () => {},
+    ...maintenanceState,
     skillsRefreshDelayMs: 30_000,
     getSkillsRefreshTimer: () => null,
     setSkillsRefreshTimer: () => {},

--- a/src/gateway/server-startup-web-fetch-bind.test.ts
+++ b/src/gateway/server-startup-web-fetch-bind.test.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
+import { readClientResponseBody } from "./test-http-response.js";
 
 const webFetchProviderDiscovery = vi.hoisted(() => ({
   resolveBundledWebFetchProvidersFromPublicArtifactsMock: vi.fn(() => {
@@ -51,16 +52,7 @@ async function requestHealthz(port: number): Promise<{ status: number; body: str
         port,
         path: "/healthz",
       },
-      (res) => {
-        let body = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk) => {
-          body += chunk;
-        });
-        res.once("end", () => {
-          resolve({ status: res.statusCode ?? 0, body });
-        });
-      },
+      (res) => void readClientResponseBody(res).then(resolve, reject),
     );
     req.once("error", reject);
     req.setTimeout(5_000, () => {

--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -149,24 +149,12 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
     expect(mocks.disableTailscaleServe).not.toHaveBeenCalled();
   });
 
-  it("does not derive a Service URL when Tailscale only reports an IP", async () => {
+  it.each([
+    ["only reports an IP", "100.64.0.8"],
+    ["omits the DNS suffix", "node"],
+  ])("does not derive a Service URL when Tailscale %s", async (_name, hostname) => {
     const logTailscale = createLogger();
-    mocks.getTailnetHostname.mockResolvedValue("100.64.0.8");
-
-    await startGatewayTailscaleExposure({
-      tailscaleMode: "serve",
-      port: 18789,
-      serviceName: "svc:openclaw",
-      logTailscale,
-    });
-
-    expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789, undefined, "svc:openclaw");
-    expect(logTailscale.info).toHaveBeenCalledWith("serve enabled");
-  });
-
-  it("does not derive a Service URL when Tailscale omits the DNS suffix", async () => {
-    const logTailscale = createLogger();
-    mocks.getTailnetHostname.mockResolvedValue("node");
+    mocks.getTailnetHostname.mockResolvedValue(hostname);
 
     await startGatewayTailscaleExposure({
       tailscaleMode: "serve",

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -1,45 +1,27 @@
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
-import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createDirectOutboundTestAdapter,
+} from "../test-utils/channel-plugins.js";
 import { waitForAgentCommandCall } from "./agent-command.test-helpers.js";
 import { resetModelCatalogCacheForTest as resetGatewayModelCatalogCacheForTest } from "./server-model-catalog.js";
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
+import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
 import {
   agentCommand,
-  connectOk,
   installGatewayTestHooks,
   agentDiscoveryMock,
   rpcReq,
-  startServerWithClient,
   testState,
   writeSessionStore,
 } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
-let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
-let ws: Awaited<ReturnType<typeof startServerWithClient>>["ws"];
-let sharedSessionStoreDir: string;
-let sharedSessionStorePath: string;
-
-beforeAll(async () => {
-  const started = await startServerWithClient();
-  server = started.server;
-  ws = started.ws;
-  await connectOk(ws);
-  sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-session-"));
-  sharedSessionStorePath = path.join(sharedSessionStoreDir, "sessions.json");
-});
-
-afterAll(async () => {
-  ws.close();
-  await server.close();
-  await fs.rm(sharedSessionStoreDir, { recursive: true, force: true });
-});
+const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-session-");
 
 const BASE_IMAGE_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X3mIAAAAASUVORK5CYII=";
@@ -69,7 +51,7 @@ async function setTestSessionStore(params: {
   entries: Record<string, Record<string, unknown>>;
   agentId?: string;
 }) {
-  testState.sessionStorePath = sharedSessionStorePath;
+  testState.sessionStorePath = gatewaySuite.sessionStorePath;
   await writeSessionStore({
     entries: params.entries,
     agentId: params.agentId,
@@ -92,7 +74,7 @@ async function runMainAgentDeliveryWithSession(params: {
         },
       },
     });
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "main",
       deliver: true,
@@ -136,7 +118,7 @@ async function runAgentImageRequest(params: {
     },
   });
 
-  const res = await rpcReq(ws, "agent", {
+  const res = await rpcReq(gatewaySuite.ws, "agent", {
     message: "what is in the image?",
     sessionKey: params.sessionKey ?? "main",
     attachments: [baseImageAttachment()],
@@ -169,8 +151,8 @@ const createStubChannelPlugin = (params: {
         : undefined,
     },
   }),
-  outbound: {
-    deliveryMode: "direct",
+  outbound: createDirectOutboundTestAdapter({
+    channel: params.id,
     resolveTarget: ({ to, allowFrom }) => {
       const trimmed = to?.trim() ?? "";
       if (trimmed) {
@@ -185,9 +167,7 @@ const createStubChannelPlugin = (params: {
         error: new Error(`missing target for ${params.id}`),
       };
     },
-    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
-  },
+  }),
 });
 
 const defaultDirectChannelEntries = [
@@ -244,7 +224,7 @@ describe("gateway server agent", () => {
         },
       },
     });
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "main",
       channel: "last",
@@ -270,7 +250,7 @@ describe("gateway server agent", () => {
         },
       },
     });
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "agent:main:subagent:abc",
       idempotencyKey: "idem-agent-subkey",
@@ -286,7 +266,7 @@ describe("gateway server agent", () => {
   });
 
   test("agent forwards sourceReplyDeliveryMode to agentCommand", async () => {
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "main",
       sourceReplyDeliveryMode: "message_tool_only",
@@ -310,7 +290,7 @@ describe("gateway server agent", () => {
       },
     });
 
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "agent:main:subagent:depth",
       idempotencyKey: "idem-agent-subdepth",
@@ -318,7 +298,7 @@ describe("gateway server agent", () => {
     expect(res.ok).toBe(true);
     await waitForAgentCommandCall("idem-agent-subdepth");
 
-    const raw = await fs.readFile(sharedSessionStorePath, "utf-8");
+    const raw = await fs.readFile(gatewaySuite.sessionStorePath, "utf-8");
     const persisted = JSON.parse(raw) as Record<
       string,
       { spawnDepth?: number; spawnedBy?: string }
@@ -338,7 +318,7 @@ describe("gateway server agent", () => {
       },
     });
     testState.agentsConfig = { list: [{ id: "ops" }] };
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       agentId: "ops",
       idempotencyKey: "idem-agent-id",
@@ -351,7 +331,7 @@ describe("gateway server agent", () => {
   });
 
   test("agent rejects unknown reply channel", async () => {
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       replyChannel: "unknown-channel",
       idempotencyKey: "idem-agent-reply-unknown",
@@ -365,7 +345,7 @@ describe("gateway server agent", () => {
 
   test("agent rejects mismatched agentId and sessionKey", async () => {
     testState.agentsConfig = { list: [{ id: "ops" }] };
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       agentId: "ops",
       sessionKey: "agent:main:main",
@@ -379,7 +359,7 @@ describe("gateway server agent", () => {
   });
 
   test("agent rejects malformed agent-prefixed session keys", async () => {
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "agent:main",
       idempotencyKey: "idem-agent-malformed-key",
@@ -518,7 +498,7 @@ describe("gateway server agent", () => {
           },
         },
       });
-      const res = await rpcReq(ws, "agent", {
+      const res = await rpcReq(gatewaySuite.ws, "agent", {
         message: "hi",
         sessionKey: "main",
         deliver: true,
@@ -581,7 +561,7 @@ describe("gateway server agent", () => {
         },
       },
     });
-    const res = await rpcReq(ws, "agent", {
+    const res = await rpcReq(gatewaySuite.ws, "agent", {
       message: "hi",
       sessionKey: "main",
       channel: "last",

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -6,7 +6,10 @@ import { WebSocket } from "ws";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
-import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createDirectOutboundTestAdapter,
+} from "../test-utils/channel-plugins.js";
 import { readAgentCommandCall } from "./agent-command.test-helpers.js";
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
@@ -72,11 +75,7 @@ const createStubChannelPlugin = (params: {
       resolveAccount: () => ({}),
     },
   }),
-  outbound: {
-    deliveryMode: "direct",
-    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
-  },
+  outbound: createDirectOutboundTestAdapter({ channel: params.id }),
 });
 
 const createConfiguredChannelPlugin = (params: {
@@ -92,11 +91,7 @@ const createConfiguredChannelPlugin = (params: {
       isConfigured: async () => true,
     },
   }),
-  outbound: {
-    deliveryMode: "direct",
-    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
-  },
+  outbound: createDirectOutboundTestAdapter({ channel: params.id }),
 });
 
 const emptyRegistry = createRegistry([]);

--- a/src/gateway/server.agent.subagent-delivery-context.test.ts
+++ b/src/gateway/server.agent.subagent-delivery-context.test.ts
@@ -1,26 +1,18 @@
 import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
-import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createDirectOutboundTestAdapter,
+} from "../test-utils/channel-plugins.js";
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
-import {
-  connectOk,
-  installGatewayTestHooks,
-  rpcReq,
-  startServerWithClient,
-  testState,
-  writeSessionStore,
-} from "./test-helpers.js";
+import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
+import { installGatewayTestHooks, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
-let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
-let ws: Awaited<ReturnType<typeof startServerWithClient>>["ws"];
-let sessionStoreDir: string;
-let sessionStorePath: string;
+const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-subagent-delivery-ctx-");
 
 const createStubChannelPlugin = (params: {
   id: ChannelPlugin["id"];
@@ -30,8 +22,8 @@ const createStubChannelPlugin = (params: {
     id: params.id,
     label: params.label,
   }),
-  outbound: {
-    deliveryMode: "direct",
+  outbound: createDirectOutboundTestAdapter({
+    channel: params.id,
     resolveTarget: ({ to }) => {
       const trimmed = to?.trim() ?? "";
       if (trimmed) {
@@ -39,9 +31,7 @@ const createStubChannelPlugin = (params: {
       }
       return { ok: false, error: new Error(`missing target for ${params.id}`) };
     },
-    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
-    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
-  },
+  }),
 });
 
 const defaultRegistry = createRegistry([
@@ -51,21 +41,6 @@ const defaultRegistry = createRegistry([
     plugin: createStubChannelPlugin({ id: "slack", label: "Slack" }),
   },
 ]);
-
-beforeAll(async () => {
-  const started = await startServerWithClient();
-  server = started.server;
-  ws = started.ws;
-  await connectOk(ws);
-  sessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-subagent-delivery-ctx-"));
-  sessionStorePath = path.join(sessionStoreDir, "sessions.json");
-});
-
-afterAll(async () => {
-  ws.close();
-  await server.close();
-  await fs.rm(sessionStoreDir, { recursive: true, force: true });
-});
 
 type StoredEntry = {
   route?: {
@@ -85,7 +60,7 @@ type StoreEntries = Parameters<typeof writeSessionStore>[0]["entries"];
 
 async function prepareSessionStore(entries: StoreEntries = {}): Promise<void> {
   setRegistry(defaultRegistry);
-  testState.sessionStorePath = sessionStorePath;
+  testState.sessionStorePath = gatewaySuite.sessionStorePath;
   await writeSessionStore({ entries });
 }
 
@@ -105,7 +80,7 @@ function readDeliveryContext(entry: StoredEntry): NonNullable<StoredEntry["deliv
 }
 
 async function readStoredSessionEntry(key: string): Promise<StoredEntry> {
-  const stored = JSON.parse(await fs.readFile(sessionStorePath, "utf-8")) as Record<
+  const stored = JSON.parse(await fs.readFile(gatewaySuite.sessionStorePath, "utf-8")) as Record<
     string,
     StoredEntry
   >;
@@ -113,7 +88,7 @@ async function readStoredSessionEntry(key: string): Promise<StoredEntry> {
 }
 
 async function sendAgentRequest(params: Record<string, unknown>): Promise<void> {
-  const res = await rpcReq(ws, "agent", {
+  const res = await rpcReq(gatewaySuite.ws, "agent", {
     deliver: false,
     ...params,
   });

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../infra/device-identity.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
+import { CONTROL_UI_CLIENT, TEST_OPERATOR_CLIENT } from "./server.auth.shared.js";
 import {
   connectReq,
   connectOk,
@@ -24,18 +25,6 @@ import {
 
 installGatewayTestHooks({ scope: "suite" });
 
-const TEST_OPERATOR_CLIENT = {
-  id: GATEWAY_CLIENT_NAMES.TEST,
-  version: "1.0.0",
-  platform: "test",
-  mode: GATEWAY_CLIENT_MODES.TEST,
-};
-const CONTROL_UI_CLIENT = {
-  id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
-  version: "1.0.0",
-  platform: "web",
-  mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-};
 const ALLOWED_BROWSER_ORIGIN = "https://control.example.com";
 const TRUSTED_PROXY_BROWSER_HEADERS = {
   "x-forwarded-for": "203.0.113.50",

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -80,6 +80,26 @@ export function registerDefaultAuthTokenSuite(): void {
       expect(health.ok).toBe(true);
     }
 
+    function readHelloOkAuth(payload: unknown):
+      | {
+          role?: unknown;
+          scopes?: unknown;
+          deviceToken?: unknown;
+        }
+      | undefined {
+      return (
+        payload as
+          | {
+              auth?: {
+                role?: unknown;
+                scopes?: unknown;
+                deviceToken?: unknown;
+              };
+            }
+          | undefined
+      )?.auth;
+    }
+
     test("closes silent handshakes after timeout", async () => {
       vi.useRealTimers();
       const prevHandshakeTimeout = process.env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS;
@@ -250,18 +270,10 @@ export function registerDefaultAuthTokenSuite(): void {
       try {
         const res = await connectReq(ws, { scopes: ["operator.read"], device: null });
         expect(res.ok).toBe(true);
-        const helloOk = res.payload as
-          | {
-              auth?: {
-                role?: unknown;
-                scopes?: unknown;
-                deviceToken?: unknown;
-              };
-            }
-          | undefined;
-        expect(helloOk?.auth?.role).toBe("operator");
-        expect(helloOk?.auth?.scopes).toEqual([]);
-        expect(helloOk?.auth?.deviceToken).toBeUndefined();
+        const auth = readHelloOkAuth(res.payload);
+        expect(auth?.role).toBe("operator");
+        expect(auth?.scopes).toEqual([]);
+        expect(auth?.deviceToken).toBeUndefined();
       } finally {
         ws.close();
       }
@@ -286,20 +298,12 @@ export function registerDefaultAuthTokenSuite(): void {
           deviceIdentityPath,
         });
         expect(initial.ok).toBe(true);
-        const helloOk = initial.payload as
-          | {
-              auth?: {
-                role?: unknown;
-                scopes?: unknown;
-                deviceToken?: unknown;
-              };
-            }
-          | undefined;
-        expect(helloOk?.auth?.role).toBe("operator");
-        expect(Array.isArray(helloOk?.auth?.scopes)).toBe(true);
-        expect(typeof helloOk?.auth?.deviceToken).toBe("string");
-        pairedDeviceToken = helloOk?.auth?.deviceToken as string | undefined;
-        pairedDeviceScopes = helloOk?.auth?.scopes;
+        const auth = readHelloOkAuth(initial.payload);
+        expect(auth?.role).toBe("operator");
+        expect(Array.isArray(auth?.scopes)).toBe(true);
+        expect(typeof auth?.deviceToken).toBe("string");
+        pairedDeviceToken = auth?.deviceToken as string | undefined;
+        pairedDeviceScopes = auth?.scopes;
       } finally {
         wsInitial.close();
       }
@@ -312,19 +316,11 @@ export function registerDefaultAuthTokenSuite(): void {
           deviceIdentityPath,
         });
         expect(reconnect.ok).toBe(true);
-        const helloOk = reconnect.payload as
-          | {
-              auth?: {
-                role?: unknown;
-                scopes?: unknown;
-                deviceToken?: unknown;
-              };
-            }
-          | undefined;
-        expect(helloOk?.auth?.role).toBe("operator");
-        expect(helloOk?.auth?.deviceToken).toBe(pairedDeviceToken);
-        expect(helloOk?.auth?.scopes).toEqual(pairedDeviceScopes);
-        expect(helloOk?.auth?.scopes).not.toEqual(["operator.read"]);
+        const auth = readHelloOkAuth(reconnect.payload);
+        expect(auth?.role).toBe("operator");
+        expect(auth?.deviceToken).toBe(pairedDeviceToken);
+        expect(auth?.scopes).toEqual(pairedDeviceScopes);
+        expect(auth?.scopes).not.toEqual(["operator.read"]);
       } finally {
         wsReconnect.close();
       }

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -27,7 +27,10 @@ import {
   startServer,
   startServerWithClient,
 } from "./test-helpers.js";
-import { acknowledgeNodeInvokeRequestForTest } from "./test-helpers.node-invoke.js";
+import {
+  acknowledgeNodeInvokeRequestForTest,
+  getConnectedNodeIdForTest,
+} from "./test-helpers.node-invoke.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -99,20 +102,6 @@ async function connectApprovedNode(params: {
     }
   }
   return client;
-}
-
-async function getConnectedNodeId(ws: WebSocket): Promise<string> {
-  const nodes = await rpcReq<{ nodes?: Array<{ nodeId: string; connected?: boolean }> }>(
-    ws,
-    "node.list",
-    {},
-  );
-  expect(nodes.ok).toBe(true);
-  const nodeId = nodes.payload?.nodes?.find((node) => node.connected)?.nodeId ?? "";
-  if (!nodeId) {
-    throw new Error("expected connected node id");
-  }
-  return nodeId;
 }
 
 async function waitForMacrotasks(): Promise<void> {
@@ -677,7 +666,7 @@ describe("gateway device.token.rotate/revoke caller scope guard", () => {
           sawInvoke = true;
         },
       });
-      await getConnectedNodeId(started.ws);
+      await getConnectedNodeIdForTest(started.ws);
 
       pairingWs = await connectPairingScopedIssuedOperator(started.port, attacker);
 

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -19,7 +19,10 @@ import {
   startServerWithClient,
   trackConnectChallengeNonce,
 } from "./test-helpers.js";
-import { acknowledgeNodeInvokeRequestForTest } from "./test-helpers.node-invoke.js";
+import {
+  acknowledgeNodeInvokeRequestForTest,
+  getConnectedNodeIdForTest,
+} from "./test-helpers.node-invoke.js";
 
 installGatewayTestHooks({ scope: "suite" });
 const NODE_CONNECT_TIMEOUT_MS = 10_000;
@@ -111,19 +114,6 @@ function requireRecord(
     throw new Error(`expected ${label}`);
   }
   return value;
-}
-
-async function getConnectedNodeId(ws: WebSocket): Promise<string> {
-  const nodes = await rpcReq<{ nodes?: Array<{ nodeId: string; connected?: boolean }> }>(
-    ws,
-    "node.list",
-    {},
-  );
-  expect(nodes.ok).toBe(true);
-  return requireNonEmptyString(
-    nodes.payload?.nodes?.find((n) => n.connected)?.nodeId,
-    "connected node id",
-  );
 }
 
 async function getConnectedNodeIds(ws: WebSocket): Promise<string[]> {
@@ -471,7 +461,7 @@ describe("node.invoke approval bypass", () => {
     });
     const ws = await connectOperator(["operator.write"]);
     try {
-      const nodeId = await getConnectedNodeId(ws);
+      const nodeId = await getConnectedNodeIdForTest(ws);
       const cases = [
         {
           name: "rawCommand mismatch",
@@ -536,7 +526,7 @@ describe("node.invoke approval bypass", () => {
     );
     const ws = await connectOperator(["operator.write"]);
     try {
-      const nodeId = await getConnectedNodeId(ws);
+      const nodeId = await getConnectedNodeIdForTest(ws);
       const res = await rpcReq(ws, "node.invoke", {
         nodeId,
         command: "browser.proxy",
@@ -567,7 +557,7 @@ describe("node.invoke approval bypass", () => {
     const wsOtherDevice = await connectOperatorWithNewDevice(["operator.write"]);
 
     try {
-      const nodeId = await getConnectedNodeId(wsApprover);
+      const nodeId = await getConnectedNodeIdForTest(wsApprover);
 
       const approvalId = await requestAllowOnceApproval(wsApprover, "echo hi", nodeId);
       // Separate caller connection simulates per-call clients.
@@ -610,7 +600,7 @@ describe("node.invoke approval bypass", () => {
     const wsReplay = await connectTrustedBackend(["operator.write", "operator.approvals"]);
 
     try {
-      const nodeId = await getConnectedNodeId(wsRequest);
+      const nodeId = await getConnectedNodeIdForTest(wsRequest);
       const context: ChatApprovalContext = {
         agentId: "main",
         sessionKey: "agent:main:telegram:direct:12345",

--- a/src/gateway/server.node-pairing-auto-approve.test.ts
+++ b/src/gateway/server.node-pairing-auto-approve.test.ts
@@ -85,80 +85,82 @@ async function canUseLanSelfConnect(host: string): Promise<boolean> {
   });
 }
 
+async function withLanNodePairingAttempt(
+  identityName: string,
+  beforeStart: (lanIp: string) => Promise<void>,
+  run: (params: {
+    res: Awaited<ReturnType<typeof connectReq>>;
+    loaded: ReturnType<typeof loadDeviceIdentity>;
+  }) => Promise<void>,
+): Promise<void> {
+  const lanIp = pickPrimaryLanIPv4();
+  if (!lanIp || !(await canUseLanSelfConnect(lanIp))) {
+    return;
+  }
+  await beforeStart(lanIp);
+  const started = await startServer(TOKEN, { bind: "lan", controlUiEnabled: false });
+  let ws: WebSocket | undefined;
+  try {
+    const loaded = loadDeviceIdentity(identityName);
+    ws = await openLanGatewayWs({ host: lanIp, port: started.port });
+    const res = await connectReq(ws, {
+      token: TOKEN,
+      role: "node",
+      scopes: [],
+      client: NODE_CLIENT,
+      deviceIdentityPath: loaded.identityPath,
+    });
+    await run({ res, loaded });
+  } finally {
+    ws?.close();
+    await started.server.close();
+    started.envSnapshot.restore();
+  }
+}
+
 describe("gateway trusted CIDR node pairing auto-approve", () => {
   test("stays disabled by default for a direct non-loopback node", async () => {
-    const lanIp = pickPrimaryLanIPv4();
-    if (!lanIp || !(await canUseLanSelfConnect(lanIp))) {
-      return;
-    }
-    const started = await startServer(TOKEN, { bind: "lan", controlUiEnabled: false });
-    let ws: WebSocket | undefined;
-    try {
-      const loaded = loadDeviceIdentity("trusted-cidr-default-off");
-      ws = await openLanGatewayWs({ host: lanIp, port: started.port });
-      const res = await connectReq(ws, {
-        token: TOKEN,
-        role: "node",
-        scopes: [],
-        client: NODE_CLIENT,
-        deviceIdentityPath: loaded.identityPath,
-      });
-
-      expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("pairing required");
-      const pending = (await listDevicePairing()).pending.filter(
-        (entry) => entry.deviceId === loaded.identity.deviceId,
-      );
-      expect(pending).toHaveLength(1);
-      expect(pending[0]?.silent).toBe(false);
-      expect(await getPairedDevice(loaded.identity.deviceId)).toBeNull();
-    } finally {
-      ws?.close();
-      await started.server.close();
-      started.envSnapshot.restore();
-    }
+    await withLanNodePairingAttempt(
+      "trusted-cidr-default-off",
+      async () => {},
+      async ({ res, loaded }) => {
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("pairing required");
+        const pending = (await listDevicePairing()).pending.filter(
+          (entry) => entry.deviceId === loaded.identity.deviceId,
+        );
+        expect(pending).toHaveLength(1);
+        expect(pending[0]?.silent).toBe(false);
+        expect(await getPairedDevice(loaded.identity.deviceId)).toBeNull();
+      },
+    );
   });
 
   test("auto-approves first-time node pairing from a matching direct non-loopback CIDR", async () => {
-    const lanIp = pickPrimaryLanIPv4();
-    if (!lanIp || !(await canUseLanSelfConnect(lanIp))) {
-      return;
-    }
-    await writeConfigFile({
-      gateway: {
-        nodes: {
-          pairing: {
-            autoApproveCidrs: [`${lanIp}/32`],
+    await withLanNodePairingAttempt(
+      "trusted-cidr-direct-lan-auto-approve",
+      async (lanIp) => {
+        await writeConfigFile({
+          gateway: {
+            nodes: {
+              pairing: {
+                autoApproveCidrs: [`${lanIp}/32`],
+              },
+            },
           },
-        },
+        });
       },
-    });
-    const started = await startServer(TOKEN, { bind: "lan", controlUiEnabled: false });
-    let ws: WebSocket | undefined;
-    try {
-      const loaded = loadDeviceIdentity("trusted-cidr-direct-lan-auto-approve");
-      ws = await openLanGatewayWs({ host: lanIp, port: started.port });
-      const res = await connectReq(ws, {
-        token: TOKEN,
-        role: "node",
-        scopes: [],
-        client: NODE_CLIENT,
-        deviceIdentityPath: loaded.identityPath,
-      });
-
-      expect(res.ok).toBe(true);
-      expect((res.payload as { type?: unknown } | undefined)?.type).toBe("hello-ok");
-      const pending = (await listDevicePairing()).pending.filter(
-        (entry) => entry.deviceId === loaded.identity.deviceId,
-      );
-      expect(pending).toHaveLength(0);
-      const paired = await getPairedDevice(loaded.identity.deviceId);
-      expect(paired?.role).toBe("node");
-      expect(paired?.approvedScopes ?? []).toStrictEqual([]);
-    } finally {
-      ws?.close();
-      await started.server.close();
-      started.envSnapshot.restore();
-    }
+      async ({ res, loaded }) => {
+        expect(res.ok).toBe(true);
+        expect((res.payload as { type?: unknown } | undefined)?.type).toBe("hello-ok");
+        const pending = (await listDevicePairing()).pending.filter(
+          (entry) => entry.deviceId === loaded.identity.deviceId,
+        );
+        expect(pending).toHaveLength(0);
+        const paired = await getPairedDevice(loaded.identity.deviceId);
+        expect(paired?.role).toBe("node");
+        expect(paired?.approvedScopes ?? []).toStrictEqual([]);
+      },
+    );
   });
 });

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -18,6 +18,7 @@ import {
   installGatewayTestHooks,
   readConnectChallengeNonce,
 } from "./test-helpers.server.js";
+import { readClientResponseBody } from "./test-http-response.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -72,14 +73,7 @@ async function requestUpgradeRejection(port: number): Promise<{ status: number; 
       reject(new Error("expected websocket upgrade to be rejected"));
     });
     req.once("response", (res) => {
-      let body = "";
-      res.setEncoding("utf8");
-      res.on("data", (chunk) => {
-        body += chunk;
-      });
-      res.once("end", () => {
-        resolve({ status: res.statusCode ?? 0, body });
-      });
+      void readClientResponseBody(res).then(resolve, reject);
     });
     req.once("error", reject);
     req.end();
@@ -120,7 +114,7 @@ describe("gateway pre-auth hardening", () => {
       handleHooksRequest: async () => false,
       resolvedAuth,
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ maxPayload: 1024, noServer: true });
     attachGatewayUpgradeHandler({
       httpServer,
       wss,

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -7,6 +7,7 @@ import {
   GATEWAY_CLIENT_MODES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { isSessionPatchEvent } from "../hooks/internal-hooks.js";
+import { requireRecord } from "./test-helpers.assertions.js";
 import { connectWebchatClient, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -29,13 +30,6 @@ async function openPermissionClient(client: Pick<PermissionClient, "id" | "mode"
       mode: client.mode,
     },
   });
-}
-
-function requireRecord(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Expected record");
-  }
-  return value as Record<string, unknown>;
 }
 
 function requireFirstCallArg(mock: { mock: { calls: readonly (readonly unknown[])[] } }) {
@@ -144,16 +138,19 @@ test("session:patch hook fires with correct context", async () => {
   });
 
   expect(patched.ok).toBe(true);
-  const event = requireRecord(requireFirstCallArg(sessionHookMocks.triggerInternalHook));
+  const event = requireRecord(
+    requireFirstCallArg(sessionHookMocks.triggerInternalHook),
+    "internal hook event",
+  );
   expect(event.type).toBe("session");
   expect(event.action).toBe("patch");
   expect(event.sessionKey).toBe("agent:main:main");
-  const context = requireRecord(event.context);
-  const sessionEntry = requireRecord(context.sessionEntry);
+  const context = requireRecord(event.context, "internal hook context");
+  const sessionEntry = requireRecord(context.sessionEntry, "session entry");
   expect(sessionEntry.sessionId).toBe("sess-hook-test");
   expect(sessionEntry.label).toBe("updated-label");
-  expect(requireRecord(context.patch).label).toBe("updated-label");
-  requireRecord(context.cfg);
+  expect(requireRecord(context.patch, "session patch").label).toBe("updated-label");
+  requireRecord(context.cfg, "config");
 
   ws.close();
 });
@@ -218,7 +215,10 @@ test("session:patch hook only fires after successful patch", async () => {
   });
 
   expect(validPatch.ok).toBe(true);
-  const event = requireRecord(requireFirstCallArg(sessionHookMocks.triggerInternalHook));
+  const event = requireRecord(
+    requireFirstCallArg(sessionHookMocks.triggerInternalHook),
+    "internal hook event",
+  );
   expect(event.type).toBe("session");
   expect(event.action).toBe("patch");
 

--- a/src/gateway/test-helpers.connected-session-store.ts
+++ b/src/gateway/test-helpers.connected-session-store.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll } from "vitest";
+import { startConnectedServerWithClient } from "./test-helpers.js";
+
+type ConnectedGateway = Awaited<ReturnType<typeof startConnectedServerWithClient>>;
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`${label} is not ready`);
+  }
+  return value;
+}
+
+export function installConnectedSessionStoreGatewaySuite(prefix: string) {
+  let started: ConnectedGateway | undefined;
+  let sessionStoreDir: string | undefined;
+  let sessionStorePath: string | undefined;
+
+  beforeAll(async () => {
+    started = await startConnectedServerWithClient();
+    sessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+    sessionStorePath = path.join(sessionStoreDir, "sessions.json");
+  });
+
+  afterAll(async () => {
+    started?.ws.close();
+    await started?.server.close();
+    if (sessionStoreDir) {
+      await fs.rm(sessionStoreDir, { recursive: true, force: true });
+    }
+  });
+
+  return {
+    get sessionStorePath() {
+      return requireValue(sessionStorePath, "session store path");
+    },
+    get ws() {
+      return requireValue(started, "gateway client").ws;
+    },
+  };
+}

--- a/src/gateway/test-helpers.maintenance-state.ts
+++ b/src/gateway/test-helpers.maintenance-state.ts
@@ -1,0 +1,28 @@
+import type { HealthSummary } from "../commands/health.js";
+import { createChatRunState } from "./server-chat-state.js";
+
+export function createGatewayMaintenanceStateForTest(params?: {
+  healthSummary?: HealthSummary;
+  healthVersion?: number;
+  presenceVersion?: number;
+}) {
+  const chatRunState = createChatRunState();
+  return {
+    broadcast: () => {},
+    nodeSendToAllSubscribed: () => {},
+    getPresenceVersion: () => params?.presenceVersion ?? 1,
+    getHealthVersion: () => params?.healthVersion ?? 1,
+    refreshGatewayHealthSnapshot: async () =>
+      params?.healthSummary ?? ({ ok: true } as HealthSummary),
+    logHealth: { error: () => {} },
+    dedupe: new Map(),
+    chatAbortControllers: new Map(),
+    chatRunState,
+    chatRunBuffers: chatRunState.buffers,
+    chatDeltaSentAt: chatRunState.deltaSentAt,
+    chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
+    removeChatRun: () => undefined,
+    agentRunSeq: new Map(),
+    nodeSendToSession: () => {},
+  };
+}

--- a/src/gateway/test-helpers.node-invoke.ts
+++ b/src/gateway/test-helpers.node-invoke.ts
@@ -1,4 +1,7 @@
+import { expect } from "vitest";
+import type { WebSocket } from "ws";
 import type { GatewayClient } from "./client.js";
+import { rpcReq } from "./test-helpers.js";
 
 export function acknowledgeNodeInvokeRequestForTest(params: {
   client: GatewayClient;
@@ -21,4 +24,18 @@ export function acknowledgeNodeInvokeRequestForTest(params: {
     ok: true,
     payloadJSON: JSON.stringify({ ok: true }),
   });
+}
+
+export async function getConnectedNodeIdForTest(ws: WebSocket): Promise<string> {
+  const nodes = await rpcReq<{ nodes?: Array<{ nodeId?: string; connected?: boolean }> }>(
+    ws,
+    "node.list",
+    {},
+  );
+  expect(nodes.ok).toBe(true);
+  const nodeId = nodes.payload?.nodes?.find((node) => node.connected)?.nodeId;
+  if (!nodeId) {
+    throw new Error("expected connected node id");
+  }
+  return nodeId;
 }

--- a/src/gateway/test-http-response.ts
+++ b/src/gateway/test-http-response.ts
@@ -1,4 +1,5 @@
-import type { ServerResponse } from "node:http";
+import type { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { PassThrough } from "node:stream";
 import { vi } from "vitest";
 
@@ -23,4 +24,28 @@ export function makeMockHttpResponse(): {
     end,
   }) as unknown as ServerResponse;
   return { res, setHeader, end };
+}
+
+export function makeMockHttpReqRes(
+  reqSocket: EventEmitter | null,
+  resSocket: EventEmitter | null,
+): { req: IncomingMessage; res: ServerResponse } {
+  return {
+    req: { socket: reqSocket } as unknown as IncomingMessage,
+    res: { socket: resSocket } as unknown as ServerResponse,
+  };
+}
+
+export async function readClientResponseBody(
+  res: IncomingMessage,
+): Promise<{ status: number; body: string }> {
+  let body = "";
+  res.setEncoding("utf8");
+  res.on("data", (chunk) => {
+    body += chunk;
+  });
+  await new Promise<void>((resolve) => {
+    res.once("end", resolve);
+  });
+  return { status: res.statusCode ?? 0, body };
 }

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -84,6 +84,17 @@ export const createChannelTestPluginBase = (params: {
   },
 });
 
+export const createDirectOutboundTestAdapter = (params: {
+  channel: ChannelId;
+  messageId?: string;
+  resolveTarget?: ChannelOutboundAdapter["resolveTarget"];
+}): ChannelOutboundAdapter => ({
+  deliveryMode: "direct",
+  ...(params.resolveTarget ? { resolveTarget: params.resolveTarget } : {}),
+  sendText: async () => ({ channel: params.channel, messageId: params.messageId ?? "msg-test" }),
+  sendMedia: async () => ({ channel: params.channel, messageId: params.messageId ?? "msg-test" }),
+});
+
 export const createMSTeamsTestPluginBase = (): Pick<
   ChannelPlugin,
   "id" | "meta" | "capabilities" | "config"


### PR DESCRIPTION
## Summary

- Consolidates repeated gateway test setup into focused helpers for connected session-store state, maintenance-state fixtures, HTTP response reads, node-invoke requests, and channel plugin mocks.
- Reduces local duplication across gateway tests while keeping behavior unchanged; final `jscpd` scan is down to two TypeScript clones in `src/gateway` plus the intentional `AGENTS.md` / `CLAUDE.md` mirror.
- Leaves the remaining TypeScript clones alone intentionally: one is `vi.hoisted` metadata fixture setup, and the other is a production option-forwarding boundary where extraction would add a weak adapter.
- Intentionally out of scope: runtime behavior, config, protocol, docs, and changelog changes.
- Review focus: helper boundaries, test readability, and whether the two remaining TypeScript duplicate regions should stay explicit.

AI-assisted: yes. No agent transcript is included in this draft because transcript insertion requires explicit approval.

## Linked context

Closes #

Related #

Was this requested by a maintainer or owner?

Maintainer-requested local cleanup of gateway test duplication; no public issue link.

## Real behavior proof (required for external PRs)

- Behavior addressed: Gateway test duplication reduced without changing runtime behavior.
- Real environment tested: Local OpenClaw checkout for focused Vitest, duplicate scan, diff sanity, and autoreview; Crabbox AWS remote environment for `pnpm check:changed`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/gateway/server-maintenance.test.ts src/gateway/server-startup-early.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server.agent.subagent-delivery-context.test.ts src/gateway/server-startup-web-fetch-bind.test.ts src/gateway/server.preauth-hardening.test.ts`; `node_modules/.bin/jscpd src/gateway --min-lines 10 --min-tokens 50`; `git diff --check origin/main...HEAD`; `node scripts/crabbox-wrapper.mjs run --provider aws --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.
- Evidence after fix: Focused post-rebase sanity passed 6 files / 53 tests; final duplicate scan reports 2 TypeScript clones and 1 intentional Markdown mirror; remote changed gate passed on AWS with run `run_e0a6a5651aba`, lease `cbx_b5669a4e05b9`.
- Observed result after fix: Gateway tests continue to pass, the changed gate passes remotely, and the patch is net smaller by 79 lines.
- What was not tested: Full repo `pnpm check` and unrelated runtime/live gateway scenarios.
- Proof limitations or environment constraints: The successful remote changed gate ran before a final clean rebase onto moving `origin/main`; after that rebase, focused local Vitest, `git diff --check`, and the duplicate scan were rerun instead of chasing another full remote gate.
- Before evidence (optional but encouraged): Earlier duplicate scans found substantially more gateway test duplication; this draft records the final after-fix `jscpd` result as the durable comparison point.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run src/gateway/hooks.test.ts src/gateway/http-common.fuzz.test.ts src/gateway/http-common.test.ts src/gateway/node-invoke-system-run-approval-match.test.ts src/gateway/server-methods/channels.status.test.ts src/gateway/server-session-key.test.ts src/gateway/server-tailscale.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/gateway/server.agent.subagent-delivery-context.test.ts src/gateway/server.auth.browser-hardening.test.ts src/gateway/server.auth.default-token.test.ts src/gateway/server.device-token-rotate-authz.test.ts src/gateway/server.node-invoke-approval-bypass.test.ts src/gateway/server.node-pairing-auto-approve.test.ts src/gateway/server.sessions.permissions-hooks.test.ts src/gateway/server-startup-web-fetch-bind.test.ts src/gateway/server.preauth-hardening.test.ts src/gateway/server-maintenance.test.ts src/gateway/server-startup-early.test.ts` passed 20 files / 239 tests.
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` returned clean with no accepted/actionable findings.
- `node scripts/crabbox-wrapper.mjs run --provider aws --timing-json --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` passed, AWS run `run_e0a6a5651aba`, lease `cbx_b5669a4e05b9`.
- After the final rebase onto latest `origin/main`: `node scripts/run-vitest.mjs run src/gateway/server-maintenance.test.ts src/gateway/server-startup-early.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server.agent.subagent-delivery-context.test.ts src/gateway/server-startup-web-fetch-bind.test.ts src/gateway/server.preauth-hardening.test.ts` passed 6 files / 53 tests.
- After the final rebase: `git diff --check origin/main...HEAD` passed.
- After the final rebase: `node_modules/.bin/jscpd src/gateway --min-lines 10 --min-tokens 50` reported 2 TypeScript clones plus the intentional `AGENTS.md` / `CLAUDE.md` mirror.

What regression coverage was added or updated?

No new behavioral coverage; this refactors existing tests to reuse shared setup and assertion helpers.

What failed before this fix, if known?

The remote changed gate initially caught a missing type-only import in `src/gateway/server-maintenance.test.ts`; the import was restored and the gate passed afterward.

If no test was added, why not?

This change is test-helper consolidation only. Existing focused gateway tests are the regression coverage.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally weakening tests by over-generalizing shared helpers.

How is that risk mitigated?

Helpers stay narrow, callers still assert scenario-specific behavior, focused gateway tests passed, autoreview was clean, and `pnpm check:changed` passed remotely.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer judgment on whether the two remaining TypeScript duplicate regions should stay explicit.

Which bot or reviewer comments were addressed?

None yet.
