### PR TITLE
fix(google): quarantine invalid extension tool schemas

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -301,6 +301,140 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(declarations[1]?.behavior).toBe("NON_BLOCKING");
   });
 
+  it("quarantines invalid realtime tools before connecting Google Live", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const unreadable = { type: "function", name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "gemini-key",
+      },
+      instructions: "Speak briefly.",
+      tools: [
+        unreadable,
+        {
+          type: "function",
+          name: "dynamic_schema",
+          description: "dynamic",
+          parameters: {
+            type: "object",
+            properties: {
+              target: { $dynamicRef: "#target" },
+            },
+          },
+        },
+        {
+          type: "function",
+          name: "openclaw_agent_consult",
+          description: "Ask OpenClaw",
+          parameters: {
+            type: "object",
+            properties: {
+              question: { type: "string" },
+            },
+            required: ["question"],
+          },
+        },
+      ] as never,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    const config = lastConnectParams().config as {
+      tools?: Array<{
+        functionDeclarations?: Array<{
+          behavior?: string;
+          description?: string;
+          name?: string;
+          parametersJsonSchema?: unknown;
+        }>;
+      }>;
+    };
+    expect(config.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "openclaw_agent_consult",
+            description: "Ask OpenClaw",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                question: { type: "string" },
+              },
+              required: ["question"],
+            },
+            behavior: "NON_BLOCKING",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("omits realtime tools when the tool list length is unreadable", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const tools = new Proxy([] as unknown[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "gemini-key",
+      },
+      tools: tools as never,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    expect(lastConnectParams().config).not.toHaveProperty("tools");
+  });
+
+  it("keeps parameter-free realtime tools", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "gemini-key",
+      },
+      tools: [
+        {
+          type: "function",
+          name: "ping",
+          description: "Ping",
+        },
+      ] as never,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    const config = lastConnectParams().config as {
+      tools?: Array<{ functionDeclarations?: Array<Record<string, unknown>> }>;
+    };
+    expect(config.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "ping",
+            description: "Ping",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("omits zero temperature for native audio responses", async () => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type {
   ActivityHandling,
-  Behavior,
   EndSensitivity,
   FunctionDeclaration,
   FunctionResponse,
@@ -47,6 +46,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createGoogleGenAI } from "./google-genai-runtime.js";
+import { buildGoogleFunctionDeclarations } from "./tool-schema.js";
 
 const GOOGLE_REALTIME_DEFAULT_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025";
 const GOOGLE_REALTIME_DEFAULT_VOICE = "Kore";
@@ -338,17 +338,9 @@ function buildRealtimeInputConfig(
 }
 
 function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): FunctionDeclaration[] {
-  return (tools ?? []).map((tool) => {
-    const declaration: FunctionDeclaration = {
-      name: tool.name,
-      description: tool.description,
-      parametersJsonSchema: tool.parameters,
-    };
-    if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      declaration.behavior = "NON_BLOCKING" as Behavior;
-    }
-    return declaration;
-  });
+  return buildGoogleFunctionDeclarations(tools, {
+    nonBlockingToolName: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  }) as FunctionDeclaration[];
 }
 
 function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveConnectConfig {

--- a/extensions/google/tool-schema.ts
+++ b/extensions/google/tool-schema.ts
@@ -1,0 +1,93 @@
+import { projectRuntimeToolInputSchema } from "openclaw/plugin-sdk/agent-harness-runtime";
+
+type GoogleToolDeclaration = {
+  name: string;
+  description?: string;
+  parametersJsonSchema?: Record<string, unknown>;
+  behavior?: "NON_BLOCKING";
+};
+
+type GoogleToolDescriptor = {
+  name: string;
+  description?: string;
+  parameters: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readToolField(
+  tool: object,
+  field: "name" | "description" | "parameters",
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: Reflect.get(tool, field) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readToolEntry(
+  tools: readonly GoogleToolDescriptor[],
+  toolIndex: number,
+): { ok: true; tool: unknown } | { ok: false } {
+  try {
+    return { ok: true, tool: Reflect.get(tools, String(toolIndex)) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function buildGoogleFunctionDeclarations(
+  tools: readonly GoogleToolDescriptor[] | undefined,
+  options: { nonBlockingToolName?: string } = {},
+): GoogleToolDeclaration[] {
+  let length: number;
+  try {
+    length = tools?.length ?? 0;
+  } catch {
+    return [];
+  }
+
+  const declarations: GoogleToolDeclaration[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    const entry = readToolEntry(tools ?? [], toolIndex);
+    if (!entry.ok || !isRecord(entry.tool)) {
+      continue;
+    }
+
+    const name = readToolField(entry.tool, "name");
+    if (!name.ok || typeof name.value !== "string" || !name.value) {
+      continue;
+    }
+
+    const parameters = readToolField(entry.tool, "parameters");
+    if (!parameters.ok) {
+      continue;
+    }
+
+    const description = readToolField(entry.tool, "description");
+    const declaration: GoogleToolDeclaration = {
+      name: name.value,
+    };
+    if (parameters.value !== undefined) {
+      const projection = projectRuntimeToolInputSchema(
+        parameters.value,
+        `${name.value}.parameters`,
+      );
+      if (projection.violations.length > 0 || !isRecord(projection.schema)) {
+        continue;
+      }
+      declaration.parametersJsonSchema = projection.schema;
+    }
+    if (description.ok && typeof description.value === "string") {
+      declaration.description = description.value;
+    }
+    if (name.value === options.nonBlockingToolName) {
+      declaration.behavior = "NON_BLOCKING";
+    }
+    declarations.push(declaration);
+  }
+  return declarations;
+}

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1797,6 +1797,154 @@ describe("google transport stream", () => {
     expect(params.toolConfig).toBeUndefined();
   });
 
+  it("quarantines invalid Google transport tools before building request params", () => {
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          unreadable,
+          {
+            name: "dynamic_schema",
+            description: "dynamic",
+            parameters: {
+              type: "object",
+              properties: {
+                target: { $dynamicRef: "#target" },
+              },
+            },
+          },
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parameters: {
+              type: "object",
+              properties: { q: { type: "string" } },
+              required: ["q"],
+            },
+          },
+        ],
+      } as never,
+      { toolChoice: "auto" },
+    );
+
+    expect(params.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { q: { type: "string" } },
+              required: ["q"],
+            },
+          },
+        ],
+      },
+    ]);
+    expect(params.toolConfig).toEqual({
+      functionCallingConfig: { mode: "AUTO" },
+    });
+  });
+
+  it("omits tools and tool config when the Google transport tool list length is unreadable", () => {
+    const tools = new Proxy([] as unknown[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          throw new Error("length getter exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools,
+      } as never,
+      { toolChoice: "auto" },
+    );
+
+    expect(params.tools).toBeUndefined();
+    expect(params.toolConfig).toBeUndefined();
+  });
+
+  it("throws a local error when the forced Google transport tool is quarantined", () => {
+    const unreadable = { name: "bad_parameters", description: "bad" };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    expect(() =>
+      buildGoogleGenerativeAiParams(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          tools: [
+            unreadable,
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parameters: {
+                type: "object",
+                properties: { q: { type: "string" } },
+              },
+            },
+          ],
+        } as never,
+        {
+          toolChoice: {
+            type: "function",
+            function: { name: "bad_parameters" },
+          },
+        },
+      ),
+    ).toThrow('forced Google tool choice "bad_parameters" is unavailable');
+  });
+
+  it("keeps parameter-free Google transport tools", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "ping",
+            description: "Ping",
+          },
+        ],
+      } as never,
+      { toolChoice: "auto" },
+    );
+
+    expect(params.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "ping",
+            description: "Ping",
+          },
+        ],
+      },
+    ]);
+    expect(params.toolConfig).toEqual({
+      functionCallingConfig: { mode: "AUTO" },
+    });
+  });
+
   it("uses a non-empty text placeholder for empty user text", () => {
     const params = buildGoogleGenerativeAiParams(buildGeminiModel(), {
       messages: [

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -37,6 +37,7 @@ import {
   type GoogleThinkingInputLevel,
   type GoogleThinkingLevel,
 } from "./thinking-api.js";
+import { buildGoogleFunctionDeclarations } from "./tool-schema.js";
 import {
   isGoogleVertexCredentialsMarker,
   resolveGoogleVertexAuthorizedUserHeaders,
@@ -301,6 +302,12 @@ function mapToolChoice(
     default:
       return { mode: "AUTO" };
   }
+}
+
+function getForcedToolChoiceName(choice: GoogleTransportOptions["toolChoice"]): string | undefined {
+  return typeof choice === "object" && choice.type === "function"
+    ? choice.function.name
+    : undefined;
 }
 
 function mapStopReasonString(reason: string): "stop" | "length" | "error" {
@@ -676,21 +683,6 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   return contents;
 }
 
-function convertGoogleTools(tools: NonNullable<Context["tools"]>) {
-  if (tools.length === 0) {
-    return undefined;
-  }
-  return [
-    {
-      functionDeclarations: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        parametersJsonSchema: tool.parameters,
-      })),
-    },
-  ];
-}
-
 export function buildGoogleGenerativeAiParams(
   model: GoogleTransportModel,
   context: Context,
@@ -728,8 +720,16 @@ export function buildGoogleGenerativeAiParams(
       ],
     };
   }
-  if (!cachedContent && context.tools?.length) {
-    params.tools = convertGoogleTools(context.tools);
+  const functionDeclarations = !cachedContent ? buildGoogleFunctionDeclarations(context.tools) : [];
+  const availableToolNames = new Set(functionDeclarations.map((tool) => tool.name));
+  const forcedToolChoiceName = !cachedContent
+    ? getForcedToolChoiceName(options?.toolChoice)
+    : undefined;
+  if (forcedToolChoiceName && !availableToolNames.has(forcedToolChoiceName)) {
+    throw new Error(`forced Google tool choice "${forcedToolChoiceName}" is unavailable`);
+  }
+  if (functionDeclarations.length > 0) {
+    params.tools = [{ functionDeclarations }];
     const toolChoice = mapToolChoice(options?.toolChoice);
     if (toolChoice) {
       params.toolConfig = {


### PR DESCRIPTION
## Summary

- Quarantines unreadable or runtime-invalid tool declarations in the Google extension before text transport and realtime Live request construction.
- Centralizes Google extension function declaration projection so transport-stream and realtime voice use the same guarded runtime schema projection.
- Preserves valid parameter-free tools and `openclaw_agent_consult` non-blocking behavior.
- Preserves forced tool-choice semantics: if a caller forces a tool that was quarantined or is unavailable, OpenClaw throws a clear local error instead of emitting a contradictory Google request.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #89437

Was this requested by a maintainer or owner?

Maintainer fuzzing sweep for tool-schema ingress hardening.

## Real behavior proof (required for external PRs)

- Behavior addressed: malformed Google extension tool descriptors with throwing getters or unsupported dynamic input schemas no longer crash normal Google transport/realtime request construction or produce invalid function declarations.
- Real environment tested: local OpenClaw checkout on current `origin/main` after rebasing this branch; AWS Crabbox fresh PR checkout for `openclaw/openclaw#89451`.
- Exact steps or command run after this patch: `node --import tsx - <<'TS' ... buildGoogleGenerativeAiParams(... badGetterTool ...) ... TS`; `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts extensions/google/realtime-voice-provider.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 extensions/google/tool-schema.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts`; `git diff --check origin/main..HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`; AWS Crabbox `corepack pnpm check:changed` on the fresh PR checkout.
- Evidence after fix: the direct bad-getter repro prints `{}` for `{ tools, toolConfig }` instead of throwing `parameters getter exploded`; focused Vitest passed 91 tests; oxfmt exited 0; diff whitespace check exited 0; autoreview reported `autoreview clean: no accepted/actionable findings reported`; AWS Crabbox `run_9856f74d63c7` / `cbx_b8d2440fe483` exited 0.
- Observed result after fix: invalid Google extension tools are dropped, healthy sibling tools remain, parameter-free tools remain valid, realtime consult tools keep `NON_BLOCKING`, forced choices for quarantined tools fail locally with a clear unavailable-tool error, and `pnpm check:changed` passes on Linux for `extensions, extensionTests` lanes.
- What was not tested: live Google API / realtime Live calls with real credentials.
- Proof limitations or environment constraints: this is schema-ingress hardening covered with targeted extension tests, a local crash repro, and Linux changed-gate proof; no external provider request was sent.
- Before evidence (optional but encouraged): the old Google extension mappers read `tool.parameters` directly, so a getter-backed descriptor could throw before the provider request was built.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts extensions/google/realtime-voice-provider.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/google/tool-schema.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`
- AWS Crabbox `run_9856f74d63c7` / `cbx_b8d2440fe483`: `corepack pnpm check:changed` on fresh PR checkout, exit 0

What regression coverage was added or updated?

- Google transport tests now cover unreadable `parameters`, dynamic schema quarantine, unreadable tool-list length, forced quarantined tool-choice failure, and parameter-free tools.
- Google realtime voice tests now cover unreadable `parameters`, dynamic schema quarantine, unreadable tool-list length, consult tool `NON_BLOCKING` preservation, and parameter-free tools.

What failed before this fix, if known?

- Direct descriptor mapping read `tool.parameters` and `tools.length` before any guarded projection, so getter/proxy-backed tools could crash request construction.

If no test was added, why not?

- Tests were added for both changed runtime paths.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed Google extension tool descriptors are now omitted instead of crashing normal request construction.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This hardens provider tool schema ingestion and preserves forced tool-choice constraints after quarantine; no auth or secret handling changed.

What is the highest-risk area?

Dropping a malformed tool can reduce available Google tools for that turn, and forced choices for dropped tools now fail locally.

How is that risk mitigated?

Only unreadable or runtime-projection-invalid schemas are dropped; healthy sibling tools and parameter-free tools are preserved, and forced choices get a named local error instead of silently changing tool-call semantics.

## Current review state

What is the next action?

Ready for maintainer review once normal PR CI settles.

What is still waiting on author, maintainer, CI, or external proof?

Normal PR CI may still be running; remote changed-gate proof is complete.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed: forced tool-choice handling was aligned with surviving declarations, explicit forced unavailable tools now error locally, and parameter-free Google tools are preserved.
