### PR TITLE
fix(ui): guard WebRTC addTrack against null peer after stop() during getUserMedia

### DIFF
--- a/ui/src/ui/chat/realtime-talk-webrtc.ts
+++ b/ui/src/ui/chat/realtime-talk-webrtc.ts
@@ -68,6 +68,11 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       }
     });
     this.media = await navigator.mediaDevices.getUserMedia({ audio: true });
+    // stop() may have been called during the getUserMedia await (e.g. user denied permission
+    // or cancelled the session), which nullifies this.peer — guard before addTrack.
+    if (!this.peer) {
+      throw new Error("Realtime Talk session was closed during microphone setup");
+    }
     for (const track of this.media.getAudioTracks()) {
       this.peer.addTrack(track, this.media);
     }

--- a/ui/src/ui/realtime-talk-webrtc.test.ts
+++ b/ui/src/ui/realtime-talk-webrtc.test.ts
@@ -717,4 +717,44 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     });
     transport.stop();
   });
+
+  it("throws a clear error when stop() is called during getUserMedia", async () => {
+    let resolveGetUserMedia: (stream: MediaStream) => void;
+    const getUserMediaPromise = new Promise<MediaStream>((resolve) => {
+      resolveGetUserMedia = resolve;
+    });
+    const track = { stop: vi.fn() } as unknown as MediaStreamTrack;
+    const stream = {
+      getAudioTracks: () => [track],
+      getTracks: () => [track],
+    } as unknown as MediaStream;
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => getUserMediaPromise),
+      },
+    });
+
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "client-secret-123",
+      },
+      {
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: {},
+      },
+    );
+
+    const startPromise = transport.start();
+    // Simulate stop() being called during the getUserMedia await
+    transport.stop();
+    // Now resolve getUserMedia — start() should throw
+    resolveGetUserMedia!(stream);
+    await expect(startPromise).rejects.toThrow(
+      "Realtime Talk session was closed during microphone setup",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

When `stop()` is called during the async `getUserMedia` await in `start()` (e.g. user denies microphone permission or cancels the session), `this.peer` is set to `null`, causing a `TypeError: this.peer is null` on the subsequent `addTrack` call.

This is a race condition that affects all users of the Control UI Dashboard Realtime Talk (voice input) feature.

## Root Cause

In `ui/src/ui/chat/realtime-talk-webrtc.ts`:
1. `start()` creates `this.peer = new RTCPeerConnection()`
2. `await navigator.mediaDevices.getUserMedia({ audio: true })` — user permission dialog can take arbitrary time
3. If `stop()` is called during the await, `this.peer = null`
4. After getUserMedia resolves, `this.peer.addTrack(...)` crashes

## Fix

Added a null guard after the getUserMedia await that throws a clear error message instead of crashing:

```ts
this.media = await navigator.mediaDevices.getUserMedia({ audio: true });
if (!this.peer) {
  throw new Error("Realtime Talk session was closed during microphone setup");
}
for (const track of this.media.getAudioTracks()) {
  this.peer.addTrack(track, this.media);
}
```

## Test

Added test case `throws a clear error when stop() is called during getUserMedia` that simulates the race condition by:
1. Making getUserMedia return a deferred promise
2. Calling stop() before resolving the promise
3. Resolving the promise and asserting the expected error

## Checklist
- [x] Issue linked: #89434
- [x] Tests added
- [x] No CHANGELOG update (minor bug fix, no user-facing config change)