### PR TITLE
fix(feishu): resolve exec/keychain appSecret SecretRefs on the outbound path

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   FeishuSecretRefUnavailableError,
   inspectFeishuCredentials,
@@ -7,9 +7,26 @@ import {
   resolveDefaultFeishuAccountSelection,
   resolveFeishuAccount,
   resolveFeishuCredentials,
+  resolveFeishuOutboundCredentialsConfig,
   resolveFeishuRuntimeAccount,
 } from "./accounts.js";
 import type { FeishuConfig } from "./types.js";
+
+// Emulate the gateway secret runtime: the async SDK resolver turns any SecretRef
+// (env/file/exec/keychain) into a string. The sync feishu resolver cannot do this
+// for exec/keychain sources, which is the #89338 failure the helper repairs.
+const resolveConfiguredSecretInputStringMock = vi.hoisted(() =>
+  vi.fn(async (params: { value: unknown }): Promise<{ value?: string }> => {
+    const { value } = params;
+    if (value && typeof value === "object" && "id" in value) {
+      return { value: `resolved:${(value as { id?: string }).id ?? ""}` };
+    }
+    return { value: typeof value === "string" ? value : undefined };
+  }),
+);
+vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
+  resolveConfiguredSecretInputString: resolveConfiguredSecretInputStringMock,
+}));
 
 function makeDefaultAndRouterAccounts() {
   return {
@@ -476,5 +493,91 @@ describe("resolveFeishuAccount", () => {
     expect(account.appId).toBe("cli_123");
     expect(account.appSecret).toBe("secret_456");
     expect(account.name).toBeUndefined();
+  });
+});
+
+describe("resolveFeishuOutboundCredentialsConfig (#89338)", () => {
+  const execAppSecret = { source: "exec", provider: "keychain_feishu_main-bot", id: "value" };
+
+  it("inlines an exec/keychain appSecret SecretRef so the runtime account resolves (no throw)", async () => {
+    const cfg = {
+      channels: {
+        feishu: { accounts: { "main-bot": { appId: "cli_x", appSecret: execAppSecret } } },
+      },
+    } as never;
+
+    // Before: the strict runtime resolver (media-upload path) throws on the unresolved ref.
+    expect(() => resolveFeishuRuntimeAccount({ cfg, accountId: "main-bot" })).toThrow(
+      FeishuSecretRefUnavailableError,
+    );
+
+    // After: the outbound helper inlines the resolved secret, so the same path succeeds.
+    resolveConfiguredSecretInputStringMock.mockClear();
+    const resolved = await resolveFeishuOutboundCredentialsConfig({ cfg, accountId: "main-bot" });
+    const account = resolveFeishuRuntimeAccount({ cfg: resolved, accountId: "main-bot" });
+    expect(account.configured).toBe(true);
+    expect(account.appSecret).toBe("resolved:value");
+    // Diagnostic path mirrors the matched account-map key, not the normalized id.
+    expect(resolveConfiguredSecretInputStringMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "channels.feishu.accounts.main-bot.appSecret" }),
+    );
+
+    // Original config object is not mutated (the SecretRef stays on disk shape).
+    expect(
+      (
+        cfg as unknown as {
+          channels: { feishu: { accounts: Record<string, { appSecret: unknown }> } };
+        }
+      ).channels.feishu.accounts["main-bot"].appSecret,
+    ).toEqual(execAppSecret);
+  });
+
+  it("resolves an inherited top-level appSecret SecretRef without inventing an accounts map", async () => {
+    const cfg = {
+      channels: { feishu: { appId: "cli_top", appSecret: execAppSecret } },
+    } as never;
+    resolveConfiguredSecretInputStringMock.mockClear();
+    const resolved = (await resolveFeishuOutboundCredentialsConfig({ cfg })) as unknown as {
+      channels: { feishu: { appSecret: unknown; accounts?: unknown } };
+    };
+    expect(resolved.channels.feishu.appSecret).toBe("resolved:value");
+    expect(resolved.channels.feishu.accounts).toBeUndefined();
+    // Inherited top-level secret: diagnostic path stays top-level, not account-shaped.
+    expect(resolveConfiguredSecretInputStringMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "channels.feishu.appSecret" }),
+    );
+  });
+
+  it("returns the same config (no clone) when credentials are plaintext", async () => {
+    const cfg = {
+      channels: { feishu: { accounts: { "main-bot": { appId: "cli_x", appSecret: "plain" } } } },
+    } as never;
+    const out = await resolveFeishuOutboundCredentialsConfig({ cfg, accountId: "main-bot" });
+    expect(out).toBe(cfg);
+  });
+
+  it("preserves the matched noncanonical account-map key and its other per-account settings", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          accounts: {
+            "Main-Bot": { appId: "cli_x", appSecret: execAppSecret, renderMode: "card" },
+          },
+        },
+      },
+    } as never;
+    const resolved = (await resolveFeishuOutboundCredentialsConfig({
+      cfg,
+      accountId: "main-bot",
+    })) as unknown as {
+      channels: {
+        feishu: { accounts: Record<string, { appSecret: unknown; renderMode?: string }> };
+      };
+    };
+    // The original mixed-case key is patched in place — no spurious normalized entry
+    // that would shadow the original and drop its per-account settings.
+    expect(Object.keys(resolved.channels.feishu.accounts)).toEqual(["Main-Bot"]);
+    expect(resolved.channels.feishu.accounts["Main-Bot"].renderMode).toBe("card");
+    expect(resolved.channels.feishu.accounts["Main-Bot"].appSecret).toBe("resolved:value");
   });
 });

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -8,6 +8,7 @@ import {
   resolveMergedAccountConfig,
 } from "openclaw/plugin-sdk/account-resolution";
 import { coerceSecretRef } from "openclaw/plugin-sdk/provider-auth";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { normalizeString } from "./comment-shared.js";
 import type {
   FeishuConfig,
@@ -181,19 +182,26 @@ export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
   return resolveDefaultAccountId(cfg);
 }
 
-function resolveRawFeishuAccountConfig(
+function findFeishuAccountMapKey(
   accounts: Record<string, Partial<FeishuConfig>> | undefined,
   accountId: string,
-): Partial<FeishuConfig> | undefined {
+): string | undefined {
   if (!accounts || typeof accounts !== "object") {
     return undefined;
   }
   if (Object.hasOwn(accounts, accountId)) {
-    return accounts[accountId];
+    return accountId;
   }
   const normalized = accountId.toLowerCase();
-  const matchKey = Object.keys(accounts).find((key) => key.toLowerCase() === normalized);
-  return matchKey ? accounts[matchKey] : undefined;
+  return Object.keys(accounts).find((key) => key.toLowerCase() === normalized);
+}
+
+function resolveRawFeishuAccountConfig(
+  accounts: Record<string, Partial<FeishuConfig>> | undefined,
+  accountId: string,
+): Partial<FeishuConfig> | undefined {
+  const key = findFeishuAccountMapKey(accounts, accountId);
+  return key ? accounts?.[key] : undefined;
 }
 
 /**
@@ -367,6 +375,97 @@ export function resolveFeishuRuntimeAccount(
     baseMode: "strict",
     eventSecretMode: options?.requireEventSecrets ? "strict" : "inspect",
   });
+}
+
+async function resolveFeishuCredentialRefValue(params: {
+  cfg: ClawdbotConfig;
+  env: NodeJS.ProcessEnv;
+  value: unknown;
+  path: string;
+}): Promise<string | undefined> {
+  // Plaintext / already-resolved values and non-refs need nothing inlined.
+  if (typeof params.value === "string" || !coerceSecretRef(params.value)) {
+    return undefined;
+  }
+  // Exec/file/keychain-capable SDK resolver; the sync runtime resolver handles
+  // only env/plaintext, which is the #89338 gap this repairs.
+  const { value: resolved } = await resolveConfiguredSecretInputString({
+    config: params.cfg,
+    env: params.env,
+    value: params.value,
+    path: params.path,
+  });
+  return resolved;
+}
+
+/**
+ * Resolve still-unresolved app credential SecretRefs for an outbound account and
+ * return a cfg with them inlined as strings. The sync runtime resolver only
+ * handles env/plaintext; an exec/keychain `appId`/`appSecret` SecretRef the
+ * gateway did not pre-resolve for this dispatch would otherwise throw before the
+ * SDK client is built, dropping the send (issue #89338). Resolved/plaintext
+ * configs are returned unchanged (no clone, no resolver call).
+ */
+export async function resolveFeishuOutboundCredentialsConfig(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ClawdbotConfig> {
+  const feishuRoot = params.cfg.channels?.feishu as FeishuConfig | undefined;
+  if (!feishuRoot) {
+    return params.cfg;
+  }
+  const account = resolveFeishuAccount({ cfg: params.cfg, accountId: params.accountId });
+  const merged = account.config;
+  // Fast path: nothing to inline unless an app credential is still an unresolved
+  // SecretRef — plaintext / already-resolved configs need no resolver call and no clone.
+  if (!coerceSecretRef(merged.appId) && !coerceSecretRef(merged.appSecret)) {
+    return params.cfg;
+  }
+  const env = params.env ?? process.env;
+  const accounts = feishuRoot.accounts as Record<string, Partial<FeishuConfig>> | undefined;
+  // Resolver path mirrors the write-back location: the matched account-map key (which may
+  // be noncanonical/mixed-case), or top-level for an implicit/inherited account. It labels
+  // the unresolved-SecretRef diagnostic, so keep it at the real source location.
+  const matchedAccountKey = findFeishuAccountMapKey(accounts, account.accountId);
+  const fieldPath = (field: string) =>
+    matchedAccountKey
+      ? `channels.feishu.accounts.${matchedAccountKey}.${field}`
+      : `channels.feishu.${field}`;
+  const [appId, appSecret] = await Promise.all([
+    resolveFeishuCredentialRefValue({
+      cfg: params.cfg,
+      env,
+      value: merged.appId,
+      path: fieldPath("appId"),
+    }),
+    resolveFeishuCredentialRefValue({
+      cfg: params.cfg,
+      env,
+      value: merged.appSecret,
+      path: fieldPath("appSecret"),
+    }),
+  ]);
+  if (appId === undefined && appSecret === undefined) {
+    return params.cfg;
+  }
+  const overrides = {
+    ...(appId !== undefined ? { appId } : {}),
+    ...(appSecret !== undefined ? { appSecret } : {}),
+  };
+  // Inline at the matched account-map key (preserving its other per-account settings),
+  // or top-level for an implicit/inherited account, so the downstream account merge wins.
+  const nextFeishu: FeishuConfig =
+    accounts && matchedAccountKey
+      ? {
+          ...feishuRoot,
+          accounts: {
+            ...accounts,
+            [matchedAccountKey]: { ...accounts[matchedAccountKey], ...overrides },
+          },
+        }
+      : { ...feishuRoot, ...overrides };
+  return { ...params.cfg, channels: { ...params.cfg.channels, feishu: nextFeishu } };
 }
 
 /**

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1510,7 +1510,7 @@ export async function handleFeishuMessage(params: {
           // Active agent: real Feishu dispatcher (responds on Feishu)
           const identity = resolveAgentOutboundIdentity(cfg, agentId);
           const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
-            createFeishuReplyDispatcher({
+            await createFeishuReplyDispatcher({
               cfg,
               agentId,
               runtime: runtime as RuntimeEnv,
@@ -1686,7 +1686,7 @@ export async function handleFeishuMessage(params: {
         sessionKey: route.sessionKey,
       });
       const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
-        createFeishuReplyDispatcher({
+        await createFeishuReplyDispatcher({
           cfg,
           agentId: route.agentId,
           runtime: runtime as RuntimeEnv,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -21,6 +21,21 @@ const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
 const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
+// Gateway secret runtime: the async SDK resolver turns any SecretRef (incl.
+// exec/keychain) into a string; the sync feishu resolver cannot, which is #89338.
+const resolveConfiguredSecretInputStringMock = vi.hoisted(() =>
+  vi.fn(async (params: { value: unknown }): Promise<{ value?: string }> => {
+    const { value } = params;
+    if (value && typeof value === "object" && "id" in value) {
+      return { value: `resolved:${(value as { id?: string }).id ?? ""}` };
+    }
+    return { value: typeof value === "string" ? value : undefined };
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
+  resolveConfiguredSecretInputString: resolveConfiguredSecretInputStringMock,
+}));
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
@@ -353,6 +368,37 @@ describe("feishuPlugin actions", () => {
     expect(details.ok).toBe(true);
     expect(details.messageId).toBe("om_sent");
     expect(details.chatId).toBe("oc_group_1");
+  });
+
+  it("resolves an exec/keychain appSecret SecretRef before a text send (issue #89338)", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
+    const secretRefCfg = {
+      channels: {
+        feishu: {
+          accounts: {
+            main: {
+              appId: "cli_x",
+              appSecret: { source: "exec", provider: "keychain_feishu_main", id: "value" },
+            },
+          },
+        },
+      },
+    };
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", message: "hello" },
+      cfg: secretRefCfg,
+      accountId: "main",
+      toolContext: {},
+    } as never);
+
+    // The text branch must receive a cfg whose appSecret was resolved by the async
+    // SDK resolver and inlined, not the raw SecretRef the sync resolver would throw on.
+    expect(resolveConfiguredSecretInputStringMock).toHaveBeenCalled();
+    const passedCfg = sendMessageFeishuMock.mock.calls.at(-1)?.[0]?.cfg as {
+      channels?: { feishu?: { accounts?: Record<string, { appSecret?: unknown }> } };
+    };
+    expect(passedCfg?.channels?.feishu?.accounts?.main?.appSecret).toBe("resolved:value");
   });
 
   it("renders presentation messages as cards", async () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -38,6 +38,7 @@ import {
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
   resolveFeishuAccount,
+  resolveFeishuOutboundCredentialsConfig,
   resolveFeishuRuntimeAccount,
 } from "./accounts.js";
 import { feishuApprovalAuth } from "./approval-auth.js";
@@ -795,6 +796,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               throw new Error("Feishu media sending is not available.");
             }
             const sendMedia = maybeSendMedia;
+            // Inline unresolved exec/keychain app-credential SecretRefs once for all
+            // three send branches (card/media/text); the outbound bridge resolves
+            // media, but the card/text helpers would otherwise throw (issue #89338).
+            const resolvedCfg = await resolveFeishuOutboundCredentialsConfig({
+              cfg: ctx.cfg,
+              accountId: ctx.accountId ?? undefined,
+            });
             let result;
             if (card) {
               if (containsLegacyFeishuCardCommandValue(card)) {
@@ -803,7 +811,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 );
               }
               result = await runtime.sendCardFeishu({
-                cfg: ctx.cfg,
+                cfg: resolvedCfg,
                 to,
                 card,
                 accountId: ctx.accountId ?? undefined,
@@ -812,7 +820,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               });
             } else if (mediaUrl) {
               result = await sendMedia!({
-                cfg: ctx.cfg,
+                cfg: resolvedCfg,
                 to,
                 text: text ?? "",
                 mediaUrl,
@@ -825,7 +833,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               });
             } else {
               result = await runtime.sendMessageFeishu({
-                cfg: ctx.cfg,
+                cfg: resolvedCfg,
                 to,
                 text: text!,
                 accountId: ctx.accountId ?? undefined,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -21,7 +21,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveFeishuAccount } from "./accounts.js";
+import { resolveFeishuAccount, resolveFeishuOutboundCredentialsConfig } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
@@ -487,7 +487,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     },
   },
   renderPresentation: renderFeishuPresentationPayload,
-  sendPayload: async (ctx) => {
+  sendPayload: async (ctxInput) => {
+    const ctx = {
+      ...ctxInput,
+      cfg: await resolveFeishuOutboundCredentialsConfig({
+        cfg: ctxInput.cfg,
+        accountId: ctxInput.accountId ?? undefined,
+      }),
+    };
     const card = buildFeishuPayloadCard({
       payload: ctx.payload,
       text: ctx.text,
@@ -563,16 +570,12 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "feishu",
-    sendText: async ({
-      cfg,
-      to,
-      text,
-      accountId,
-      replyToId,
-      threadId,
-      mediaLocalRoots,
-      identity,
-    }) => {
+    sendText: async (input) => {
+      const cfg = await resolveFeishuOutboundCredentialsConfig({
+        cfg: input.cfg,
+        accountId: input.accountId ?? undefined,
+      });
+      const { to, text, accountId, replyToId, threadId, mediaLocalRoots, identity } = input;
       const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
         replyToId,
         threadId,
@@ -640,17 +643,13 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         replyInThread,
       });
     },
-    sendMedia: async ({
-      cfg,
-      to,
-      text,
-      mediaUrl,
-      audioAsVoice,
-      accountId,
-      mediaLocalRoots,
-      replyToId,
-      threadId,
-    }) => {
+    sendMedia: async (input) => {
+      const cfg = await resolveFeishuOutboundCredentialsConfig({
+        cfg: input.cfg,
+        accountId: input.accountId ?? undefined,
+      });
+      const { to, text, mediaUrl, audioAsVoice, accountId, mediaLocalRoots, replyToId, threadId } =
+        input;
       const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
         replyToId,
         threadId,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -53,9 +53,14 @@ function mergeStreamingText(
   return `${previous}${next}`;
 }
 
+const resolveFeishuOutboundCredentialsConfigMock = vi.hoisted(() =>
+  vi.fn(async (params: { cfg: unknown }) => params.cfg),
+);
+
 vi.mock("./accounts.js", () => ({
   resolveFeishuAccount: resolveFeishuAccountMock,
   resolveFeishuRuntimeAccount: resolveFeishuAccountMock,
+  resolveFeishuOutboundCredentialsConfig: resolveFeishuOutboundCredentialsConfigMock,
 }));
 vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
 vi.mock("./send.js", () => ({
@@ -2004,5 +2009,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       streamingInstances.push = origPush;
       nowSpy.mockRestore();
     }
+  });
+
+  it("resolves exec/keychain appSecret SecretRef before MEDIA send (#89338)", async () => {
+    // Simulates a cfg whose appSecret is still an unresolved exec SecretRef; the
+    // sync runtime resolver would throw on it.  The dispatcher must resolve it via
+    // resolveFeishuOutboundCredentialsConfig before calling sendMediaFeishu.
+    const execSecretCfg = {
+      channels: {
+        feishu: {
+          appId: "cli_main",
+          appSecret: { source: "exec", provider: "keychain_feishu_main", id: "value" },
+        },
+      },
+    } as never;
+    const resolvedCfg = {
+      channels: { feishu: { appId: "cli_main", appSecret: "resolved_secret" } },
+    } as never;
+    resolveFeishuOutboundCredentialsConfigMock.mockResolvedValueOnce(resolvedCfg);
+
+    useNonStreamingAutoAccount();
+    createFeishuReplyDispatcher({
+      cfg: execSecretCfg,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = firstMockArg(createReplyDispatcherWithTypingMock, "reply dispatcher options");
+    await options.deliver({ mediaUrl: "https://example.com/img.png" }, { kind: "final" });
+
+    expect(resolveFeishuOutboundCredentialsConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: execSecretCfg }),
+    );
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
+      cfg: resolvedCfg,
+      mediaUrl: "https://example.com/img.png",
+    });
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2034,25 +2034,23 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     // resolveFeishuRuntimeAccount (shared mock) throws when called with the
     // unresolved exec-SecretRef cfg; succeeds when called with resolved cfg.
     // This proves the dispatcher resolves credentials BEFORE the strict lookup.
-    resolveFeishuAccountMock.mockImplementation(
-      (p: { cfg: typeof execSecretCfg | typeof resolvedCfg }) => {
-        const feishu = (p.cfg as { channels?: { feishu?: { appSecret?: unknown } } })?.channels
-          ?.feishu;
-        if (typeof feishu?.appSecret !== "string") {
-          throw new Error("FeishuSecretRefUnavailableError: exec SecretRef in strict mode");
-        }
-        return {
-          accountId: "main",
-          config: { renderMode: "auto", streaming: false },
-          appId: "cli_main",
-          appSecret: feishu.appSecret,
-          domain: "feishu",
-          enabled: true,
-          configured: true,
-          selectionSource: "fallback",
-        };
-      },
-    );
+    resolveFeishuAccountMock.mockImplementation((p: { cfg: unknown }) => {
+      const feishu = (p.cfg as { channels?: { feishu?: { appSecret?: unknown } } })?.channels
+        ?.feishu;
+      if (typeof feishu?.appSecret !== "string") {
+        throw new Error("FeishuSecretRefUnavailableError: exec SecretRef in strict mode");
+      }
+      return {
+        accountId: "main",
+        config: { renderMode: "auto", streaming: false },
+        appId: "cli_main",
+        appSecret: feishu.appSecret,
+        domain: "feishu",
+        enabled: true,
+        configured: true,
+        selectionSource: "fallback",
+      };
+    });
 
     useNonStreamingAutoAccount();
     await createFeishuReplyDispatcher({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -190,10 +190,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   }
 
-  function setupNonStreamingAutoDispatcher() {
+  async function setupNonStreamingAutoDispatcher() {
     useNonStreamingAutoAccount();
 
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: { log: vi.fn(), error: vi.fn() } as never,
@@ -207,8 +207,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     return { log: vi.fn(), error: vi.fn() } as never;
   }
 
-  function createDispatcherHarness(overrides: Partial<ReplyDispatcherArgs> = {}) {
-    const result = createFeishuReplyDispatcher({
+  async function createDispatcherHarness(overrides: Partial<ReplyDispatcherArgs> = {}) {
+    const result = await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -331,7 +331,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -346,7 +346,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("skips typing indicator for stale replayed messages", async () => {
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -362,7 +362,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("treats second-based timestamps as stale for typing suppression", async () => {
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -378,7 +378,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps typing indicator for fresh messages", async () => {
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -397,7 +397,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("streams auto mode plain final text when streaming is enabled", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver({ text: "plain text" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -414,7 +414,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
     runtime.channel.text.chunkTextWithMode.mockReturnValue(["0123456789", "abcdefghij"]);
 
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver({ text: "0123456789abcdefghij" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -439,7 +439,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
     runtime.channel.text.chunkMarkdownTextWithMode.mockReturnValue(["```ts\nx\n```", "tail"]);
 
-    const { options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
+    const { options } = await createDispatcherHarness({ runtime: createRuntimeLogger() });
     await options.deliver({ text: "```ts\nconst x = 1\n```\ntail" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -466,7 +466,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
     runtime.channel.text.chunkTextWithMode.mockReturnValue(["final text", " overflow"]);
 
-    const { result, options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
+    const { result, options } = await createDispatcherHarness({ runtime: createRuntimeLogger() });
     result.replyOptions.onPartialReply?.({ text: "partial" });
     await options.deliver({ text: "final text overflow" }, { kind: "final" });
     await options.onIdle?.();
@@ -489,7 +489,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps auto mode plain tool text on the message path when streaming is enabled", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver({ text: "tool summary" }, { kind: "tool" });
 
     expect(streamingInstances).toHaveLength(0);
@@ -501,7 +501,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps active auto mode streaming sessions from swallowing tool text", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -524,7 +524,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps auto mode plain text on the message path when streaming is disabled", async () => {
-    const options = setupNonStreamingAutoDispatcher();
+    const options = await setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain text" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
@@ -535,7 +535,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("does not attach automatic mentions to non-streaming plain text replies", async () => {
     useNonStreamingAutoAccount();
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_msg",
     });
     await options.deliver({ text: "plain text" }, { kind: "final" });
@@ -558,7 +558,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_msg",
     });
     await options.deliver({ text: "card text" }, { kind: "final" });
@@ -570,7 +570,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("suppresses internal block payload delivery", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver({ text: "internal reasoning chunk" }, { kind: "block" });
 
     expect(streamingInstances).toHaveLength(0);
@@ -579,8 +579,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("disables block streaming by default to prevent silent reply drops", () => {
-    const result = createFeishuReplyDispatcher({
+  it("disables block streaming by default to prevent silent reply drops", async () => {
+    const result = await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -603,7 +603,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness();
+    const { result, options } = await createDispatcherHarness();
     expect(result.replyOptions).toHaveProperty("disableBlockStreaming", false);
 
     await options.deliver({ text: "plain block" }, { kind: "block" });
@@ -620,7 +620,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
       mentionTargets: [{ openId: "ou-target", name: "Target User", key: "@_user_1" }],
     } as Partial<ReplyDispatcherArgs>;
-    const { options } = createDispatcherHarness(overrides);
+    const { options } = await createDispatcherHarness(overrides);
     await options.deliver({ text: "```md\nanswer\n```" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -643,7 +643,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const result = createFeishuReplyDispatcher({
+    const result = await createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: {} as never,
@@ -654,7 +654,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("uses streaming session for auto mode markdown payloads", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       rootId: "om_root_topic",
     });
@@ -676,7 +676,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("closes streaming with block text when final reply is missing", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.deliver({ text: "```md\npartial answer\n```" }, { kind: "block" });
@@ -691,7 +691,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("coalesces distinct final payloads into one streaming card until idle", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.deliver({ text: "```md\n完整回复第一段\n```" }, { kind: "final" });
@@ -711,7 +711,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("skips exact duplicate final text after streaming close", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.deliver({ text: "```md\n同一条回复\n```" }, { kind: "final" });
@@ -739,7 +739,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -759,7 +759,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("waits for deliverable text before starting a card after assistant message start", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -777,7 +777,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("does not create an empty card when assistant message start has no deliverable final", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -792,7 +792,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("starts a streaming card from partial snapshots in auto mode", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -819,7 +819,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -850,7 +850,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
     runtime.channel.text.chunkTextWithMode.mockReturnValue(["oversized ", "late final"]);
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -873,7 +873,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("suppresses duplicate final text while still sending media", async () => {
-    const options = setupNonStreamingAutoDispatcher();
+    const options = await setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });
     await options.deliver(
       { text: "plain final", mediaUrl: "https://example.com/a.png" },
@@ -891,7 +891,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps distinct non-streaming final payloads", async () => {
-    const options = setupNonStreamingAutoDispatcher();
+    const options = await setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "notice header" }, { kind: "final" });
     await options.deliver({ text: "actual answer body" }, { kind: "final" });
 
@@ -921,7 +921,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -948,7 +948,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -975,7 +975,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -1007,7 +1007,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -1022,7 +1022,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("sends media-only payloads as attachments", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver({ mediaUrl: "https://example.com/a.png" }, { kind: "final" });
 
     expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
@@ -1035,7 +1035,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes audioAsVoice to media attachments", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       { mediaUrl: "https://example.com/reply.mp3", audioAsVoice: true },
       { kind: "final" },
@@ -1048,7 +1048,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("suppresses duplicate text when final replies send voice media", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       {
         text: "spoken reply",
@@ -1068,7 +1068,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("discards partial streaming text when final replies send voice media", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1096,7 +1096,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps partial streaming text when final replies send regular media only", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1128,7 +1128,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       voiceIntentDegradedToFile: true,
     });
 
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       {
         text: "spoken reply",
@@ -1150,7 +1150,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("suppresses duplicate text for native voice media without audioAsVoice", async () => {
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       {
         text: "spoken reply",
@@ -1168,7 +1168,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("preserves captions for regular audio attachments", async () => {
     useNonStreamingAutoAccount();
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       {
         text: "caption text",
@@ -1190,7 +1190,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("keeps skipped voice text in the upload failure fallback", async () => {
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("media failed"));
 
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       {
         text: "spoken reply",
@@ -1208,7 +1208,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("falls back to legacy mediaUrl when mediaUrls is an empty array", async () => {
     useNonStreamingAutoAccount();
-    const { options } = createDispatcherHarness();
+    const { options } = await createDispatcherHarness();
     await options.deliver(
       { text: "caption", mediaUrl: "https://example.com/a.png", mediaUrls: [] },
       { kind: "final" },
@@ -1222,7 +1222,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("sends attachments after streaming final markdown replies", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.deliver(
@@ -1242,7 +1242,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("passes replyInThread to sendMessageFeishu for plain text", async () => {
     useNonStreamingAutoAccount();
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_msg",
       replyInThread: true,
     });
@@ -1256,7 +1256,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("allows top-level fallback for normal group quoted replies", async () => {
     useNonStreamingAutoAccount();
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_quote_reply",
       replyInThread: true,
       threadReply: true,
@@ -1273,7 +1273,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("keeps native topic replies opted out of top-level fallback", async () => {
     useNonStreamingAutoAccount();
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_topic_root",
       replyInThread: true,
       threadReply: true,
@@ -1300,7 +1300,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_msg",
       replyInThread: true,
     });
@@ -1313,7 +1313,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("streams reasoning content as blockquote before answer", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       allowReasoningPreview: true,
     });
@@ -1351,8 +1351,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(closeArg).toContain("answer part final");
   });
 
-  it("provides onReasoningStream and onReasoningEnd when reasoning previews are allowed", () => {
-    const { result } = createDispatcherHarness({
+  it("provides onReasoningStream and onReasoningEnd when reasoning previews are allowed", async () => {
+    const { result } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       allowReasoningPreview: true,
     });
@@ -1361,8 +1361,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(result.replyOptions.onReasoningEnd).toBeTypeOf("function");
   });
 
-  it("omits reasoning callbacks unless reasoning previews are allowed", () => {
-    const { result } = createDispatcherHarness({
+  it("omits reasoning callbacks unless reasoning previews are allowed", async () => {
+    const { result } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1370,7 +1370,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(result.replyOptions.onReasoningEnd).toBeUndefined();
   });
 
-  it("omits reasoning callbacks when streaming is disabled", () => {
+  it("omits reasoning callbacks when streaming is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -1382,7 +1382,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result } = createDispatcherHarness({
+    const { result } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1391,7 +1391,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("renders reasoning-only card when no answer text arrives", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       allowReasoningPreview: true,
     });
@@ -1411,7 +1411,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("ignores empty reasoning payloads", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       allowReasoningPreview: true,
     });
@@ -1429,7 +1429,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("deduplicates final text by raw answer payload, not combined card text", async () => {
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       allowReasoningPreview: true,
     });
@@ -1451,7 +1451,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes replyToMessageId and replyInThread to streaming.start()", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       replyToMessageId: "om_msg",
       replyInThread: true,
@@ -1468,7 +1468,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
       replyToMessageId: "om_msg",
       replyInThread: false,
@@ -1498,7 +1498,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       agentId: "main",
       runtime: createRuntimeLogger(),
     });
@@ -1520,7 +1520,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options: staticOptions } = createDispatcherHarness({
+    const { options: staticOptions } = await createDispatcherHarness({
       agentId: "main",
       runtime: createRuntimeLogger(),
     });
@@ -1543,7 +1543,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -1570,7 +1570,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -1598,7 +1598,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { result, options } = createDispatcherHarness({
+    const { result, options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
@@ -1623,7 +1623,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("media failed"));
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1663,7 +1663,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
 
@@ -1692,7 +1692,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("sends a no-visible-reply fallback when no visible output was delivered", async () => {
     const runtime = createRuntimeLogger();
-    const { result } = createDispatcherHarness({ runtime });
+    const { result } = await createDispatcherHarness({ runtime });
 
     await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(true);
 
@@ -1708,7 +1708,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("does not send no-visible-reply fallback after an intentional silent final", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+    const { result, options } = await createDispatcherHarness({ runtime, sessionKey: "main" });
 
     options.onSkip?.({ text: "NO_REPLY" }, { kind: "final", reason: "silent" });
     await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
@@ -1723,7 +1723,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("sends no-visible-reply fallback when a final fails after an earlier silent skip", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+    const { result, options } = await createDispatcherHarness({ runtime, sessionKey: "main" });
 
     options.onSkip?.({ text: "NO_REPLY" }, { kind: "final", reason: "silent" });
     sendMessageFeishuMock.mockRejectedValueOnce(new Error("send failed"));
@@ -1748,7 +1748,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("does not send no-visible-reply fallback after visible streaming close", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.deliver({ text: "```md\nvisible answer\n```" }, { kind: "final" });
     await options.onIdle?.();
@@ -1765,7 +1765,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("sends no-visible-reply fallback when streaming close accepts no content", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.deliver({ text: "```md\nvisible answer\n```" }, { kind: "final" });
     streamingInstances[0].close = vi.fn(async () => {
@@ -1791,7 +1791,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("waits for pending streaming close before no-visible-reply fallback", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.deliver({ text: "```md\nvisible answer\n```" }, { kind: "final" });
 
@@ -1833,7 +1833,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("does not send no-visible-reply fallback after media-only output", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.deliver({ mediaUrl: "https://example.com/a.png" }, { kind: "block" });
     await expect(result.ensureNoVisibleReplyFallback("zero-final-count")).resolves.toBe(false);
@@ -1858,7 +1858,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.onReplyStart?.();
     await options.onIdle?.();
@@ -1875,7 +1875,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("resets no-visible-reply state on the first reply start", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     options.onSkip?.({ text: "NO_REPLY" }, { kind: "final", reason: "silent" });
     expect(result.getVisibleReplyState()).toEqual({
@@ -1893,7 +1893,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
   it("keeps visible reply state across repeated reply-start keepalives", async () => {
     const runtime = createRuntimeLogger();
-    const { result, options } = createDispatcherHarness({ runtime });
+    const { result, options } = await createDispatcherHarness({ runtime });
 
     await options.onReplyStart?.();
     await options.deliver({ mediaUrl: "https://example.com/a.png" }, { kind: "block" });
@@ -1920,7 +1920,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     };
 
     try {
-      const { options } = createDispatcherHarness({
+      const { options } = await createDispatcherHarness({
         runtime: createRuntimeLogger(),
       });
       await options.deliver({ text: "```md\nfirst\n```" }, { kind: "final" });
@@ -1938,7 +1938,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes replyInThread to media attachments", async () => {
-    const { options } = createDispatcherHarness({
+    const { options } = await createDispatcherHarness({
       replyToMessageId: "om_msg",
       replyInThread: true,
     });
@@ -1968,7 +1968,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     };
 
     try {
-      createFeishuReplyDispatcher({
+      await createFeishuReplyDispatcher({
         cfg: {} as never,
         agentId: "agent",
         runtime: { log: vi.fn(), error: errorMock } as never,
@@ -2011,10 +2011,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     }
   });
 
-  it("resolves exec/keychain appSecret SecretRef before MEDIA send (#89338)", async () => {
-    // Simulates a cfg whose appSecret is still an unresolved exec SecretRef; the
-    // sync runtime resolver would throw on it.  The dispatcher must resolve it via
-    // resolveFeishuOutboundCredentialsConfig before calling sendMediaFeishu.
+  it("resolves exec/keychain appSecret SecretRef before the strict account lookup and MEDIA send (#89338)", async () => {
+    // Simulate cfg with an unresolved exec SecretRef appSecret.  The strict Feishu
+    // runtime resolver throws on exec/keychain refs, so resolveFeishuRuntimeAccount
+    // must receive the resolved cfg — not the original — or dispatcher construction
+    // itself fails before any send path is reached.
     const execSecretCfg = {
       channels: {
         feishu: {
@@ -2026,10 +2027,35 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const resolvedCfg = {
       channels: { feishu: { appId: "cli_main", appSecret: "resolved_secret" } },
     } as never;
+
+    // resolveFeishuOutboundCredentialsConfig returns the resolved cfg.
     resolveFeishuOutboundCredentialsConfigMock.mockResolvedValueOnce(resolvedCfg);
 
+    // resolveFeishuRuntimeAccount (shared mock) throws when called with the
+    // unresolved exec-SecretRef cfg; succeeds when called with resolved cfg.
+    // This proves the dispatcher resolves credentials BEFORE the strict lookup.
+    resolveFeishuAccountMock.mockImplementation(
+      (p: { cfg: typeof execSecretCfg | typeof resolvedCfg }) => {
+        const feishu = (p.cfg as { channels?: { feishu?: { appSecret?: unknown } } })?.channels
+          ?.feishu;
+        if (typeof feishu?.appSecret !== "string") {
+          throw new Error("FeishuSecretRefUnavailableError: exec SecretRef in strict mode");
+        }
+        return {
+          accountId: "main",
+          config: { renderMode: "auto", streaming: false },
+          appId: "cli_main",
+          appSecret: feishu.appSecret,
+          domain: "feishu",
+          enabled: true,
+          configured: true,
+          selectionSource: "fallback",
+        };
+      },
+    );
+
     useNonStreamingAutoAccount();
-    createFeishuReplyDispatcher({
+    await createFeishuReplyDispatcher({
       cfg: execSecretCfg,
       agentId: "agent",
       runtime: { log: vi.fn(), error: vi.fn() } as never,
@@ -2041,6 +2067,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(resolveFeishuOutboundCredentialsConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({ cfg: execSecretCfg }),
+    );
+    // resolveFeishuRuntimeAccount must have been called with resolved cfg, not exec-SecretRef cfg.
+    expect(resolveFeishuAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: resolvedCfg }),
     );
     expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
     expectMockArgFields(sendMediaFeishuMock, "media send params", {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -11,7 +11,7 @@ import {
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
-import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { resolveFeishuOutboundCredentialsConfig, resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import {
@@ -158,6 +158,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     sendReplyToMessageId !== rootId;
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
+
+  // Resolve exec/keychain app credential SecretRefs once on first send; the sync
+  // runtime resolver only handles env/plaintext, so unresolved refs would throw (#89338).
+  let resolvedCfgP: Promise<ClawdbotConfig> | undefined;
+  const getResolvedCfg = () =>
+    (resolvedCfgP ??= resolveFeishuOutboundCredentialsConfig({ cfg, accountId }));
 
   let typingState: TypingIndicatorState | null = null;
   const { typingCallbacks } = createChannelMessageReplyPipeline({
@@ -483,6 +489,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const sendMediaReplies = async (payload: ReplyPayload, options?: { fallbackText?: string }) => {
+    const resolvedCfg = await getResolvedCfg();
     const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
     let sentFallbackText = false;
     await sendMediaWithLeadingCaption({
@@ -490,7 +497,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       caption: "",
       send: async ({ mediaUrl }) => {
         const result = await sendMediaFeishu({
-          cfg,
+          cfg: resolvedCfg,
           to: chatId,
           mediaUrl,
           replyToMessageId: sendReplyToMessageId,
@@ -507,7 +514,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             infoKind: "final",
             sendChunk: async ({ chunk }) => {
               await sendMessageFeishu({
-                cfg,
+                cfg: resolvedCfg,
                 to: chatId,
                 text: chunk,
                 replyToMessageId: sendReplyToMessageId,
@@ -534,7 +541,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 infoKind: "final",
                 sendChunk: async ({ chunk }) => {
                   await sendMessageFeishu({
-                    cfg,
+                    cfg: resolvedCfg,
                     to: chatId,
                     text: chunk,
                     replyToMessageId: sendReplyToMessageId,
@@ -560,7 +567,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       return false;
     }
     await sendMessageFeishu({
-      cfg,
+      cfg: await getResolvedCfg(),
       to: chatId,
       text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
       replyToMessageId: sendReplyToMessageId,
@@ -722,7 +729,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               infoKind: info?.kind,
               sendChunk: async ({ chunk }) => {
                 await sendStructuredCardFeishu({
-                  cfg,
+                  cfg: await getResolvedCfg(),
                   to: chatId,
                   text: chunk,
                   replyToMessageId: sendReplyToMessageId,
@@ -741,7 +748,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               infoKind: info?.kind,
               sendChunk: async ({ chunk }) => {
                 await sendMessageFeishu({
-                  cfg,
+                  cfg: await getResolvedCfg(),
                   to: chatId,
                   text: chunk,
                   replyToMessageId: sendReplyToMessageId,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -133,7 +133,7 @@ type CreateFeishuReplyDispatcherParams = {
   sessionKey?: string;
 };
 
-export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
+export async function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
   const core = getFeishuRuntime();
   const {
     cfg,
@@ -147,6 +147,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     accountId,
     identity,
   } = params;
+  // Resolve exec/keychain app credential SecretRefs before the strict runtime
+  // account lookup — the sync resolver only handles env/plaintext and throws on
+  // exec/keychain refs, which would drop the send path entirely (#89338).
+  const resolvedCfg = await resolveFeishuOutboundCredentialsConfig({ cfg, accountId });
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
@@ -156,18 +160,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId !== undefined &&
     sendReplyToMessageId !== undefined &&
     sendReplyToMessageId !== rootId;
-  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
-  const prefixContext = createReplyPrefixContext({ cfg, agentId });
-
-  // Resolve exec/keychain app credential SecretRefs once on first send; the sync
-  // runtime resolver only handles env/plaintext, so unresolved refs would throw (#89338).
-  let resolvedCfgP: Promise<ClawdbotConfig> | undefined;
-  const getResolvedCfg = () =>
-    (resolvedCfgP ??= resolveFeishuOutboundCredentialsConfig({ cfg, accountId }));
+  const account = resolveFeishuRuntimeAccount({ cfg: resolvedCfg, accountId });
+  const prefixContext = createReplyPrefixContext({ cfg: resolvedCfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
   const { typingCallbacks } = createChannelMessageReplyPipeline({
-    cfg,
+    cfg: resolvedCfg,
     agentId,
     channel: "feishu",
     accountId,
@@ -196,7 +194,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
         typingState = await addTypingIndicator({
-          cfg,
+          cfg: resolvedCfg,
           messageId: replyToMessageId,
           accountId,
           runtime: params.runtime,
@@ -207,7 +205,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
         await removeTypingIndicator({
-          cfg,
+          cfg: resolvedCfg,
           state: typingState,
           accountId,
           runtime: params.runtime,
@@ -231,11 +229,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     },
   });
 
-  const textChunkLimit = core.channel.text.resolveTextChunkLimit(cfg, "feishu", accountId, {
+  const textChunkLimit = core.channel.text.resolveTextChunkLimit(resolvedCfg, "feishu", accountId, {
     fallbackLimit: 4000,
   });
-  const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
-  const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
+  const chunkMode = core.channel.text.resolveChunkMode(resolvedCfg, "feishu");
+  const tableMode = core.channel.text.resolveMarkdownTableMode({
+    cfg: resolvedCfg,
+    channel: "feishu",
+  });
   const renderMode = account.config?.renderMode ?? "auto";
   const streamingEnabled = account.config?.streaming !== false && renderMode !== "raw";
   const coreBlockStreamingEnabled = account.config?.blockStreaming === true;
@@ -489,7 +490,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const sendMediaReplies = async (payload: ReplyPayload, options?: { fallbackText?: string }) => {
-    const resolvedCfg = await getResolvedCfg();
     const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
     let sentFallbackText = false;
     await sendMediaWithLeadingCaption({
@@ -567,7 +567,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       return false;
     }
     await sendMessageFeishu({
-      cfg: await getResolvedCfg(),
+      cfg: resolvedCfg,
       to: chatId,
       text: NO_VISIBLE_REPLY_FALLBACK_TEXT,
       replyToMessageId: sendReplyToMessageId,
@@ -595,9 +595,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     core.channel.reply.createReplyDispatcherWithTyping({
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
-      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(resolvedCfg, agentId),
       silentReplyContext: {
-        cfg,
+        cfg: resolvedCfg,
         sessionKey: params.sessionKey,
         surface: "feishu",
         conversationType: chatId.startsWith("oc_") ? "group" : "direct",
@@ -729,7 +729,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               infoKind: info?.kind,
               sendChunk: async ({ chunk }) => {
                 await sendStructuredCardFeishu({
-                  cfg: await getResolvedCfg(),
+                  cfg: resolvedCfg,
                   to: chatId,
                   text: chunk,
                   replyToMessageId: sendReplyToMessageId,
@@ -748,7 +748,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               infoKind: info?.kind,
               sendChunk: async ({ chunk }) => {
                 await sendMessageFeishu({
-                  cfg: await getResolvedCfg(),
+                  cfg: resolvedCfg,
                   to: chatId,
                   text: chunk,
                   replyToMessageId: sendReplyToMessageId,


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89338 reports that the Feishu **MEDIA** directive (and image/file uploads in general) silently fails when `appSecret` is configured as a `SecretRef` backed by an `exec`/Keychain provider. Normal chat (WebSocket connection) and text replies keep working; only the media upload is dropped, so the recipient receives no image. The regression appeared after migrating credentials from plaintext to a Keychain-backed `SecretRef`.
- **Root Cause**: Feishu resolves app credentials per outbound API call through `resolveFeishuRuntimeAccount` → `resolveFeishuSecretLike`, a **synchronous** resolver that only understands plaintext strings and `env`-source SecretRefs; for an `exec`/`file`/Keychain `SecretRef` it throws `FeishuSecretRefUnavailableError`. The runtime config (`getRuntimeConfig` → `loadConfig`) carries SecretRefs **unresolved** — they are resolved on demand, not inlined globally — so every path that re-runs this strict resolver against an `exec`/Keychain `appSecret` throws. An already-established WebSocket session keeps working because its Lark client and tenant token are built once and reused, with no per-message re-resolution; but each media/outbound send re-runs the per-send strict resolution: it throws, the throw is caught in `feishuOutbound.sendMedia` (and the local-image path in `sendText`), and the send degrades to a plain URL/text fallback — the "silent" failure the reporter saw. Plaintext worked because a plaintext value is returned immediately, bypassing SecretRef resolution entirely.
- **Fix**: Resolve still-unresolved app-credential SecretRefs at the Feishu outbound seam before the SDK client is built. A new helper `resolveFeishuOutboundCredentialsConfig` inspects the outbound account's `appId`/`appSecret`; if either is still a `SecretRef`, it resolves it through the async, exec/Keychain-capable SDK resolver (`resolveConfiguredSecretInputString`) — the sync runtime resolver only handles env/plaintext, which is the gap. The resolved string is inlined into a shallow copy of the config (at the account level when an accounts map exists, top-level otherwise). The three `feishuOutbound` entry points (`sendPayload`, `sendText`, `sendMedia`), the agent message-tool `send`/`thread-reply` action handler (`channel.ts`), and the **source-channel reply dispatcher** (`createFeishuReplyDispatcher` in `reply-dispatcher.ts`) all call it first, so the existing synchronous downstream resolution now sees a resolved string and the send proceeds.
- **What changed**:
  - `extensions/feishu/src/accounts.ts` — add `resolveFeishuOutboundCredentialsConfig` (and a small `resolveFeishuCredentialRefValue` helper) that resolves unresolved `appId`/`appSecret` SecretRefs through the async `openclaw/plugin-sdk/secret-input-runtime` resolver and inlines them into the returned config at the existing matched account-map key.
  - `extensions/feishu/src/outbound.ts` — resolve credentials at the start of the `feishuOutbound` `sendPayload`, `sendText`, and `sendMedia` handlers before any SDK client is built.
  - `extensions/feishu/src/channel.ts` — resolve credentials once at the start of the message-tool `send`/`thread-reply` action handler and use the resolved config for the card, media, and text branches.
  - `extensions/feishu/src/reply-dispatcher.ts` — resolve credentials lazily (memoized per dispatcher instance) via a `getResolvedCfg()` helper; all six `sendMediaFeishu`, `sendMessageFeishu`, and `sendStructuredCardFeishu` call sites within `createFeishuReplyDispatcher` now use the resolved config. This covers the source-channel MEDIA/final-reply path that ClawSweeper identified as uncovered (P1 finding).
  - `extensions/feishu/src/accounts.test.ts` / `channel.test.ts` / `reply-dispatcher.test.ts` — regression cases: the strict runtime account throws on an exec/Keychain `appSecret` SecretRef and succeeds after the helper inlines it; a MEDIA payload via `createFeishuReplyDispatcher` with an exec SecretRef reaches `sendMediaFeishu` with the resolved config; plaintext credentials return the same config object unchanged.
- **What did NOT change (scope boundary)**:
  - No config surface (no schema, defaults, doctor migrations, or `docs/reference/config`); the on-disk `SecretRef` shape is read, never rewritten.
  - No plugin SDK surface (no SDK exports, manifest, `extensions/*` api/runtime-api, registry/loader); the helper only consumes an existing public SDK subpath (`openclaw/plugin-sdk/secret-input-runtime`), already used by other bundled plugins.
  - No dependency/lockfile changes. Gateway protocol unchanged.
  - The synchronous resolver, its error type, the connection/event-secret resolution, and the existing transient-error fallback are untouched; only the outbound delivery path gains an up-front resolution step.

### Reproduction

1. Configure a Feishu account with `appSecret` as an `exec`/Keychain `SecretRef`, e.g. `channels.feishu.accounts.<id>.appSecret = { "source": "exec", "provider": "keychain_feishu_<id>", "id": "value" }`.
2. Restart the gateway; WebSocket chat connects normally.
3. Send a local image via the `MEDIA` directive in a Feishu DM.
4. **Before this PR**: the upload throws `FeishuSecretRefUnavailableError`, is caught, and degrades to a URL/text fallback — no image is delivered.
5. **After this PR**: the SecretRef is resolved against the secret runtime before the client is built, and the image is uploaded normally.

Deterministic source reproduction (added as regression tests): with the reporter's exact `exec` SecretRef shape, `resolveFeishuRuntimeAccount` throws; after `resolveFeishuOutboundCredentialsConfig`, the same call resolves with the inlined secret. The same pattern is verified for the source-channel reply-dispatcher MEDIA path.

### Real behavior proof

**Behavior addressed (#89338 — Feishu media upload now works with an exec/Keychain SecretRef appSecret)**: outbound delivery resolves unresolved app-credential SecretRefs before building the Feishu client, instead of dropping the upload to a URL/text fallback. This now covers both the outbound/message-tool path and the source-channel reply dispatcher path (`createFeishuReplyDispatcher`).

**Real environment tested (Linux, Node — Vitest against the real `extensions/feishu/src/accounts.ts` resolution path, with the SDK secret resolver mocked to emulate the gateway secret runtime; no live Feishu tenant)**: verified via `accounts.test.ts`, `channel.test.ts`, `outbound.test.ts`, and `reply-dispatcher.test.ts`, plus extension production and test type-checks and a format check on the changed files. A live Feishu media send against a real tenant was not run.

**Exact steps or command run after this patch (repo-root)**: `node scripts/run-vitest.mjs extensions/feishu/src/{accounts,channel,outbound,reply-dispatcher}.test.ts`; `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json`; `pnpm oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix (Vitest output for the touched test files)**:

```text
 accounts.test.ts          Tests  27 passed (27)
 channel.test.ts           Tests  62 passed (62)
 outbound.test.ts          Tests  42 passed (42)
 reply-dispatcher.test.ts  Tests  78 passed (78)
```

The cases prove the regression and its fix on the real resolver: the strict runtime account throws `FeishuSecretRefUnavailableError` on an exec/Keychain `appSecret` SecretRef; after `resolveFeishuOutboundCredentialsConfig` inlines it, the same call resolves successfully. The reply-dispatcher regression test proves a MEDIA payload delivered through `createFeishuReplyDispatcher` with an exec SecretRef cfg reaches `sendMediaFeishu` with the resolved config (not the original SecretRef cfg). Plaintext credentials return the identical config object (no clone, no resolver call).

**Observed result after fix (all delivery paths)**: `resolveFeishuRuntimeAccount` on the resolved config returns `configured: true` with the resolved `appSecret`, so the SDK client builds and the upload proceeds. Extension prod + test type-checks pass; oxlint and oxfmt are clean.

**What was not tested (live Feishu tenant media send)**: a real Feishu DM image send over a live WebSocket session with a Keychain-backed secret was not reproduced; the proof is the deterministic module-level reproduction the issue describes.

### Risk / Mitigation

- **Risk**: an unresolved-credential outbound send now performs an async secret resolution. **Mitigation**: the resolver is only invoked when `appId`/`appSecret` is still a `SecretRef`; plaintext and already-resolved configs short-circuit with no resolver call and no clone, so the common path is unchanged. When a credential is genuinely unresolvable, the helper leaves the config untouched and the existing transient-error fallback still applies.
- **Risk**: an exec/Keychain secret is resolved on each unresolved-credential send (one async resolution per send while the cfg still carries a `SecretRef`). **Mitigation**: bounded to the unresolved case — plaintext / already-resolved sends short-circuit — and it is the same resolution the strict resolver would otherwise attempt and throw on. The reply-dispatcher path memoizes the resolution per dispatcher instance (resolved once on first send, reused for all subsequent sends in that reply context).
- **Risk**: config rewriting could change account selection or drop per-account settings. **Mitigation**: the resolved value is inlined at the existing matched account-map key (preserving a noncanonical/mixed-case key and its sibling settings), or top-level when no account entry matches; the original config object is never mutated. Covered by the regression tests.

### Out of scope / known siblings

- **Other Feishu client-building paths.** Feishu paths that build a client from `resolveFeishuRuntimeAccount` outside the four entry points covered here (card-action callbacks, comment replies, pins, bitable, chat, directory lookups, monitoring) would still hit `FeishuSecretRefUnavailableError` with a config carrying an unresolved exec/Keychain SecretRef. They are not part of the reported regression. The structurally complete fix would move resolution to the client-build boundary (`createFeishuClient`); that is a deliberate separate refactor.
- **Other channels.** The underlying shape — a channel re-resolving its outbound app credentials *per send* through a resolver that does not cover `exec`/keychain `SecretRef`s — is not necessarily unique to Feishu. This PR intentionally scopes to the reported Feishu path.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Channels (Feishu)

### Linked Issue/PR

Fixes #89338