### PR TITLE
fix(agents): guard system prompt tool reports

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -216,4 +216,110 @@ describe("buildSystemPromptReport", () => {
     });
     expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
   });
+
+  it("keeps reporting when tool descriptor getters throw", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const unreadableTool = Object.defineProperties(
+      {},
+      {
+        name: {
+          get() {
+            throw new Error("name unavailable");
+          },
+        },
+        description: {
+          get() {
+            throw new Error("description unavailable");
+          },
+        },
+        label: {
+          get() {
+            throw new Error("label unavailable");
+          },
+        },
+        parameters: {
+          get() {
+            throw new Error("parameters unavailable");
+          },
+        },
+      },
+    );
+    const hostileSchema = Object.defineProperty({ type: "object" }, "properties", {
+      get() {
+        throw new Error("properties unavailable");
+      },
+    });
+    const hostileSchemaJsonChars = JSON.stringify({ type: "object" }).length;
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        unreadableTool,
+        {
+          name: "hostile_schema",
+          description: "Hostile schema",
+          parameters: hostileSchema,
+        },
+      ] as never,
+    });
+
+    expect(report.tools.schemaChars).toBe(hostileSchemaJsonChars);
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "(unknown)",
+      summaryChars: 0,
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[1]).toMatchObject({
+      name: "hostile_schema",
+      summaryChars: "Hostile schema".length,
+      schemaChars: hostileSchemaJsonChars,
+      propertiesCount: null,
+    });
+  });
+
+  it("keeps reporting when schema properties cannot be enumerated", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const hostileProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("properties unavailable");
+        },
+      },
+    );
+    const schema = {
+      type: "object",
+      properties: hostileProperties,
+    };
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        {
+          name: "hostile_properties",
+          description: "Hostile properties",
+          parameters: schema,
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "hostile_properties",
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -23,6 +23,13 @@ function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
+const EMPTY_SCHEMA_STATS: Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> =
+  {
+    schemaChars: 0,
+    schemaHash: sha256(""),
+    propertiesCount: null,
+  };
+
 function extractBetween(input: string, startMarker: string, endMarker: string): string {
   const start = input.indexOf(startMarker);
   if (start === -1) {
@@ -48,13 +55,87 @@ function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChar
     .filter((b) => b.blockChars > 0);
 }
 
+function readToolStringField(
+  tool: AgentTool,
+  field: "description" | "label" | "name",
+): string | undefined {
+  try {
+    const value = (tool as unknown as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolParameters(tool: AgentTool): AgentTool["parameters"] | undefined {
+  try {
+    return tool.parameters;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCachedToolEntry(tool: AgentTool): ToolReportEntry | undefined {
+  try {
+    return toolReportEntryCache.get(tool);
+  } catch {
+    return undefined;
+  }
+}
+
+function cacheToolEntry(tool: AgentTool, entry: ToolReportEntry): void {
+  try {
+    toolReportEntryCache.set(tool, entry);
+  } catch {
+    // Prompt reports are diagnostics; malformed tool descriptors should not block a turn.
+  }
+}
+
+function getCachedSchemaStats(
+  parameters: object,
+): Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> | undefined {
+  try {
+    return toolSchemaStatsCache.get(parameters);
+  } catch {
+    return undefined;
+  }
+}
+
+function cacheSchemaStats(
+  parameters: object,
+  stats: Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash">,
+): void {
+  try {
+    toolSchemaStatsCache.set(parameters, stats);
+  } catch {
+    // Schema stat caching is an optimization only.
+  }
+}
+
+function countSchemaProperties(parameters: object): number | null {
+  let properties: unknown;
+  try {
+    properties = (parameters as Record<string, unknown>).properties;
+  } catch {
+    return null;
+  }
+  if (!properties || typeof properties !== "object") {
+    return null;
+  }
+  try {
+    return Object.keys(properties as Record<string, unknown>).length;
+  } catch {
+    return null;
+  }
+}
+
 function buildToolSchemaStats(
-  parameters: AgentTool["parameters"],
+  parameters: AgentTool["parameters"] | undefined,
 ): Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> {
   if (!parameters || typeof parameters !== "object") {
-    return { schemaChars: 0, schemaHash: sha256(""), propertiesCount: null };
+    return EMPTY_SCHEMA_STATS;
   }
-  const cached = toolSchemaStatsCache.get(parameters);
+  const cached = getCachedSchemaStats(parameters);
   if (cached) {
     return cached;
   }
@@ -67,33 +148,27 @@ function buildToolSchemaStats(
   const stats = {
     schemaChars: schemaJson.length,
     schemaHash: sha256(schemaJson),
-    propertiesCount: (() => {
-      const schema = parameters as Record<string, unknown>;
-      const props = typeof schema.properties === "object" ? schema.properties : null;
-      if (!props || typeof props !== "object") {
-        return null;
-      }
-      return Object.keys(props as Record<string, unknown>).length;
-    })(),
+    propertiesCount: countSchemaProperties(parameters),
   };
-  // Tool parameter objects are reused across runs; cache their stable size/hash
-  // so report generation stays cheap during frequent prompt rebuilds.
-  toolSchemaStatsCache.set(parameters, stats);
+  cacheSchemaStats(parameters, stats);
   return stats;
 }
 
 function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools"]["entries"] {
   return tools.map((tool) => {
-    const cached = toolReportEntryCache.get(tool);
+    const cached = getCachedToolEntry(tool);
     if (cached) {
       return cached;
     }
-    const name = tool.name;
-    const summary = tool.description?.trim() || tool.label?.trim() || "";
+    const name = readToolStringField(tool, "name") ?? "(unknown)";
+    const summary =
+      readToolStringField(tool, "description")?.trim() ||
+      readToolStringField(tool, "label")?.trim() ||
+      "";
     const summaryChars = summary.length;
-    const schemaStats = buildToolSchemaStats(tool.parameters);
+    const schemaStats = buildToolSchemaStats(readToolParameters(tool));
     const entry = { name, summaryChars, summaryHash: sha256(summary), ...schemaStats };
-    toolReportEntryCache.set(tool, entry);
+    cacheToolEntry(tool, entry);
     return entry;
   });
 }


### PR DESCRIPTION
## Summary

- Hardens `buildSystemPromptReport` so diagnostic tool reporting cannot throw when a tool descriptor exposes throwing `name`, `description`, `label`, `parameters`, or hostile schema `properties` accessors/traps.
- Preserves existing hashes, schema char counts, and property counts for valid tools while reporting stable empty stats for unreadable descriptors.
- Adds focused regression coverage for throwing descriptor getters, throwing schema `properties` getters, and `properties` objects that cannot be enumerated.
- Out of scope: provider payload projection and runtime tool execution paths.

Transcript note: agent transcript finder returned candidate local sessions; no transcript excerpt is included because approval is required before adding session logs.

## Linked context

Closes: none.
Related: ongoing tool-schema fuzzing hardening workstream.
Was this requested by a maintainer or owner? Maintainer fuzzing sweep.

## Real behavior proof

Behavior addressed: system prompt report generation no longer crashes when diagnostic tool metadata accessors or property enumeration traps throw.
Real environment tested: local macOS linked gwt worktree on `origin/main` plus current remote-runner auth probes.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `node_modules/.bin/oxfmt --check --threads=1 src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`; `node scripts/run-oxlint.mjs src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`; `git diff --check origin/main...HEAD -- src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`; `git diff --check -- src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"`.
Evidence after fix: focused Vitest passed 1 file / 12 tests; oxfmt passed; oxlint passed; both diff whitespace checks passed; autoreview returned `autoreview clean: no accepted/actionable findings reported` with `overall: patch is correct (0.86)`.
Observed result after fix: the regression tests build reports for unreadable tool descriptors, schemas whose `properties` getter throws, and schema property maps whose enumeration throws; report generation completes with `(unknown)`/empty stats for unreadable descriptors and `propertiesCount: null` for hostile schema maps.
What was not tested: provider payload projection and runtime tool execution paths, which are outside this diagnostic reporting surface.
Proof limitations or environment constraints: Blacksmith Testbox is unavailable because `blacksmith testbox list --all` reports `not authenticated`; AWS Crabbox probe is currently blocked by coordinator 401 on run-history/lease creation, so no fresh remote changed gate was available for this refresh.
Before evidence: previous implementation read `tool.name`, `tool.description`, `tool.label`, `tool.parameters`, and `parameters.properties` directly in `src/agents/system-prompt-report.ts`, so throwing accessors could abort diagnostic report generation before the assistant turn produced content.

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `node scripts/run-oxlint.mjs src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check origin/main...HEAD -- src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check -- src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Remote proof attempted:
- `blacksmith testbox list --all` -> blocked: not authenticated.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"` -> blocked: coordinator 401 creating run history/lease.

Regression coverage added: `src/agents/system-prompt-report.test.ts` now covers throwing tool descriptor getters, throwing schema `properties` getters, and throwing property enumeration traps.

What failed before this fix: hostile descriptor accessors or property enumeration traps could throw before diagnostic reporting reached its existing JSON stringify guard.

## Risk checklist

Did user-visible behavior change? No, except report generation is more resilient and less likely to block a turn.
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
What is the highest-risk area? Diagnostic context accounting for malformed tools.
How is that risk mitigated? Valid tool reporting semantics are preserved; unreadable metadata falls back to stable empty stats instead of fabricating schema details or throwing.

## Current review state

What is the next action? Maintainer review and CI once remote runner auth is available.
What is still waiting on author, maintainer, CI, or external proof? GitHub CI/remote changed gate; current local runner auth blocks Testbox and Crabbox proof.
Which bot or reviewer comments were addressed? Local autoreview found no accepted/actionable findings.
