### PR TITLE
Clean up partial downloads on failure

### DIFF
--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -162,6 +162,9 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 
     const fileStream = createWriteStream(dest);
     await pipeline(Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>), fileStream);
+  } catch (err) {
+    rmSync(dest, { force: true });
+    throw err;
   } finally {
     await guarded.release();
   }


### PR DESCRIPTION
## Summary

When downloadFile() fails during a network error, a partially downloaded archive may be left on disk.

This change adds cleanup logic directly inside downloadFile() so that failed downloads automatically remove the incomplete destination file before re-throwing the error.

## Why

The downloaded archives are temporary artifacts and are not intended to be preserved. Cleaning them up inside downloadFile() ensures the function either:

- succeeds and produces a valid file, or
- fails without leaving partial files behind.

This also protects any future callers of downloadFile() without requiring additional cleanup logic at each call site.

## Testing

- Verified TypeScript build passes.
- Verified cleanup logic only runs on download failure.
- Existing successful download behavior is unchanged.