### PR TITLE
fix(agents): skip unreadable tool-search entries

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -44,6 +44,29 @@ function pluginTool(name: string, description: string, pluginId = "fake-catalog"
   return tool;
 }
 
+function unreadableParametersTool(name: string, description: string): AnyAgentTool {
+  const tool = Object.defineProperties(
+    {
+      name,
+      label: name,
+      description,
+      execute: vi.fn(async (_toolCallId, input) => jsonResult({ name, input })),
+    },
+    {
+      parameters: {
+        get() {
+          throw new Error("parameters getter exploded");
+        },
+      },
+    },
+  ) as unknown as AnyAgentTool;
+  setPluginToolMeta(tool, {
+    pluginId: "fake-catalog",
+    optional: true,
+  });
+  return tool;
+}
+
 function resultDetails(result: { details?: unknown }): Record<string, unknown> {
   if (!result.details || typeof result.details !== "object") {
     throw new Error("Expected result details");
@@ -156,6 +179,44 @@ describe("Tool Search", () => {
     expect(telemetry.searchCount).toBe(1);
     expect(telemetry.describeCount).toBe(1);
     expect(telemetry.callCount).toBe(1);
+  });
+
+  it("skips unreadable target tool schemas while keeping healthy catalog siblings", async () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const broken = unreadableParametersTool("fake_broken_schema", "Broken schema");
+    const valid = pluginTool("fake_valid_schema", "Valid schema");
+
+    const compacted = applyToolSearchCatalog({
+      tools: [codeTool, broken, valid],
+      config: {
+        tools: {
+          toolSearch: true,
+        },
+      } as never,
+      sessionId: "session-unreadable-schema",
+      sessionKey: "agent:main:main",
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+    expect(compacted.catalogToolCount).toBe(1);
+
+    const [runtimeCodeTool] = createToolSearchTools({
+      sessionId: "session-unreadable-schema",
+      sessionKey: "agent:main:main",
+    });
+    const result = await runtimeCodeTool.execute("call-unreadable-schema", {
+      code: `
+        const hits = await openclaw.tools.search("schema", { limit: 10 });
+        return hits.map((hit) => hit.name);
+      `,
+    });
+
+    expect(vi.mocked(broken.execute)).not.toHaveBeenCalled();
+    expect(resultDetails(result)).toMatchObject({
+      ok: true,
+      value: ["fake_valid_schema"],
+      telemetry: { catalogSize: 1 },
+    });
   });
 
   it("scopes catalogs by run id when attempts share a session", async () => {
@@ -327,6 +388,35 @@ describe("Tool Search", () => {
       .get("session:session-client")
       ?.entries.find((entry) => entry.id === "client:client:client_pick_file");
     expect(clientEntry?.source).toBe("client");
+  });
+
+  it("quarantines unreadable client tool schemas instead of exposing them directly", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = {
+      tools: {
+        toolSearch: true,
+      },
+    } as never;
+    applyToolSearchCatalog({
+      tools: [codeTool],
+      config,
+      sessionId: "session-client-unreadable-schema",
+    });
+
+    const broken = unreadableParametersTool("client_broken_schema", "Broken client schema");
+    const valid = fakeTool("client_valid_schema", "Valid client schema");
+    const compacted = addClientToolsToToolSearchCatalog({
+      tools: [broken, valid],
+      config,
+      sessionId: "session-client-unreadable-schema",
+    });
+
+    expect(compacted.tools).toEqual([]);
+    expect(compacted.compacted).toBe(true);
+    expect(compacted.catalogToolCount).toBe(1);
+    const catalogEntries =
+      testing.sessionCatalogs.get("session:session-client-unreadable-schema")?.entries ?? [];
+    expect(catalogEntries.map((entry) => entry.name)).toEqual(["client_valid_schema"]);
   });
 
   it("wraps cataloged OpenClaw tools with before_tool_call hooks", async () => {

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -42,6 +42,12 @@ type CatalogTool = AnyAgentTool | ToolDefinition;
 type CatalogVisibilityOptions = {
   includeMcp?: boolean;
 };
+type CatalogToolSnapshot = {
+  name: string;
+  label?: string;
+  description: string;
+  parameters?: unknown;
+};
 
 type ReusableCatalogSnapshot = {
   entries: ToolSearchCatalogEntry[];
@@ -628,9 +634,9 @@ function classifyTool(tool: CatalogTool): {
   return { source: "openclaw", sourceName: "core" };
 }
 
-function makeCatalogId(tool: CatalogTool, source: CatalogSource, sourceName?: string): string {
+function makeCatalogId(name: string, source: CatalogSource, sourceName?: string): string {
   const owner = sourceName?.trim() || "core";
-  return `${source}:${owner}:${tool.name}`;
+  return `${source}:${owner}:${name}`;
 }
 
 function wrapCatalogTool(tool: AnyAgentTool, hookContext?: HookContext): AnyAgentTool {
@@ -644,27 +650,96 @@ function toCatalogEntry(
   tool: CatalogTool,
   sourceOverride?: CatalogSource,
   hookContext?: HookContext,
-): ToolSearchCatalogEntry {
+): ToolSearchCatalogEntry | undefined {
+  const snapshot = snapshotCatalogTool(tool);
+  if (!snapshot) {
+    return undefined;
+  }
   const classified = classifyTool(tool);
   const source = sourceOverride ?? classified.source;
   const sourceName = sourceOverride === "client" ? "client" : classified.sourceName;
   const catalogTool =
     source === "client" ? tool : wrapCatalogTool(tool as AnyAgentTool, hookContext);
   return {
-    id: makeCatalogId(tool, source, sourceName),
+    id: makeCatalogId(snapshot.name, source, sourceName),
     source,
     sourceName,
     ...(source === "mcp" && classified.mcp ? { mcp: classified.mcp } : {}),
-    name: tool.name,
-    label: tool.label,
-    description: tool.description ?? "",
-    parameters: tool.parameters,
+    name: snapshot.name,
+    ...(snapshot.label ? { label: snapshot.label } : {}),
+    description: snapshot.description,
+    parameters: snapshot.parameters,
     tool: catalogTool,
   };
 }
 
+function readCatalogToolField(
+  tool: CatalogTool,
+  field: "description" | "label" | "name" | "parameters",
+): { readable: boolean; value?: unknown } {
+  try {
+    return { readable: true, value: (tool as unknown as Record<string, unknown>)[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function readCatalogToolStringField(
+  tool: CatalogTool,
+  field: "description" | "label" | "name",
+): string | undefined {
+  const fieldValue = readCatalogToolField(tool, field);
+  return typeof fieldValue.value === "string" ? fieldValue.value : undefined;
+}
+
+function readCatalogToolName(tool: CatalogTool): string | undefined {
+  const name = readCatalogToolStringField(tool, "name")?.trim();
+  return name || undefined;
+}
+
+function snapshotCatalogTool(tool: CatalogTool): CatalogToolSnapshot | undefined {
+  const name = readCatalogToolName(tool);
+  const parameters = readCatalogToolField(tool, "parameters");
+  if (!name || !parameters.readable) {
+    return undefined;
+  }
+  const label = readCatalogToolStringField(tool, "label");
+  return {
+    name,
+    ...(label ? { label } : {}),
+    description: readCatalogToolStringField(tool, "description") ?? "",
+    parameters: parameters.value,
+  };
+}
+
+function isControlToolName(name: string | undefined): boolean {
+  return name !== undefined && TOOL_SEARCH_CONTROL_TOOL_NAMES.has(name);
+}
+
+function isVisibleControlTool(
+  isVisible: (tool: AnyAgentTool) => boolean,
+  tool: AnyAgentTool,
+): boolean {
+  try {
+    return isVisible(tool);
+  } catch {
+    return false;
+  }
+}
+
+function shouldCatalogCatalogTool(
+  shouldCatalog: (tool: AnyAgentTool) => boolean,
+  tool: AnyAgentTool,
+): boolean {
+  try {
+    return shouldCatalog(tool);
+  } catch {
+    return false;
+  }
+}
+
 function shouldCatalogTool(tool: AnyAgentTool): boolean {
-  if (TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)) {
+  if (isControlToolName(readCatalogToolName(tool))) {
     return false;
   }
   return true;
@@ -1252,11 +1327,13 @@ export function applyToolCatalogCompaction(params: {
       catalogReused: false,
     };
   }
-  const hasControlTool = params.tools.some((tool) => params.isVisibleControlTool(tool));
+  const hasControlTool = params.tools.some((tool) =>
+    isVisibleControlTool(params.isVisibleControlTool, tool),
+  );
   const key = sessionCatalogKey(params);
   if (!hasControlTool || (!key && !params.catalogRef)) {
     return {
-      tools: params.tools.filter((tool) => !TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)),
+      tools: params.tools.filter((tool) => !isControlToolName(readCatalogToolName(tool))),
       compacted: false,
       catalogToolCount: 0,
       catalogRegistered: false,
@@ -1268,15 +1345,18 @@ export function applyToolCatalogCompaction(params: {
   const catalog: ToolSearchCatalogEntry[] = [];
   const shouldCatalog = params.shouldCatalogTool ?? shouldCatalogTool;
   for (const tool of params.tools) {
-    if (params.isVisibleControlTool(tool)) {
+    if (isVisibleControlTool(params.isVisibleControlTool, tool)) {
       visible.push(tool);
       continue;
     }
-    if (TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)) {
+    if (isControlToolName(readCatalogToolName(tool))) {
       continue;
     }
-    if (shouldCatalog(tool)) {
-      catalog.push(toCatalogEntry(tool, undefined, params.toolHookContext));
+    if (shouldCatalogCatalogTool(shouldCatalog, tool)) {
+      const entry = toCatalogEntry(tool, undefined, params.toolHookContext);
+      if (entry) {
+        catalog.push(entry);
+      }
       continue;
     }
     visible.push(tool);
@@ -1365,16 +1445,23 @@ export function addClientToolsToToolCatalog(params: {
   if (!existing) {
     return { tools: params.tools, compacted: false, catalogToolCount: 0 };
   }
+  const entries: ToolSearchCatalogEntry[] = [];
+  for (const tool of params.tools) {
+    const entry = toCatalogEntry(tool, "client");
+    if (entry) {
+      entries.push(entry);
+    }
+  }
   registerToolSearchCatalog({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     runId: params.runId,
     catalogRef: params.catalogRef,
-    entries: params.tools.map((tool) => toCatalogEntry(tool, "client")),
+    entries,
     append: true,
   });
-  return { tools: [], compacted: params.tools.length > 0, catalogToolCount: params.tools.length };
+  return { tools: [], compacted: params.tools.length > 0, catalogToolCount: entries.length };
 }
 
 function toJsonSafe(value: unknown): unknown {


### PR DESCRIPTION
## Summary
- Skip tool-search catalog entries whose descriptor fields cannot be safely read.
- Keep healthy sibling tools cataloged when one plugin/client tool has an unreadable schema accessor.
- Quarantine unreadable client tool schemas by omission instead of exposing them directly after catalog compaction.

## Verification
- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tool-search.ts src/agents/tool-search.test.ts`
- `git diff --check`
- `./node_modules/.bin/oxlint src/agents/tool-search.ts src/agents/tool-search.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`
- AWS Crabbox fresh-PR changed gate: `run_e45b3f723b8a`, lease `cbx_79a653491806`, provider `aws`, command `corepack pnpm check:changed`, exit 0

## Real behavior proof
Behavior addressed: tool-search catalog construction no longer aborts when one target or client tool exposes an unreadable `parameters` accessor.
Real environment tested: local macOS checkout with Node 24 via repo Vitest wrapper; AWS Crabbox fresh PR checkout on Linux Node 24.15.0.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`; AWS Crabbox `corepack pnpm check:changed` on PR #89468.
Evidence after fix: focused tool-search suite passed 27 tests; AWS Crabbox run `run_e45b3f723b8a` passed changed lanes `core, coreTests`.
Observed result after fix: malformed target tools are skipped from the catalog, valid siblings remain searchable, control tools stay visible, and malformed client tools are omitted instead of re-exposed directly.
What was not tested: full repository test suite.
