### PR TITLE
fix(codex): quarantine unreadable dynamic tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -36,6 +36,25 @@ function createTool(overrides: Partial<AnyAgentTool>): AnyAgentTool {
   } as unknown as AnyAgentTool;
 }
 
+function createToolWithUnreadableField(
+  field: "description" | "parameters",
+  params: { name: string; execute: ReturnType<typeof vi.fn> },
+): AnyAgentTool {
+  const base = {
+    name: params.name,
+    description: "Unreadable descriptor tool.",
+    parameters: { type: "object", properties: {} },
+    execute: params.execute,
+  };
+  Object.defineProperty(base, field, {
+    enumerable: true,
+    get() {
+      throw new Error(`${field} getter exploded`);
+    },
+  });
+  return base as unknown as AnyAgentTool;
+}
+
 function mediaResult(mediaUrl: string, audioAsVoice?: boolean): AgentToolResult<unknown> {
   return {
     content: [{ type: "text", text: "Generated media reply." }],
@@ -369,6 +388,141 @@ describe("createCodexDynamicToolBridge", () => {
       contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: fuzzplugin_move_angles" }],
     });
     expect(badExecute).not.toHaveBeenCalled();
+  });
+
+  it("quarantines unreadable dynamic tool descriptors before wrapping", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const unsubscribeDiagnostics = onInternalDiagnosticEvent((event) =>
+      diagnosticEvents.push(event),
+    );
+    const unreadableParametersExecute = vi.fn();
+    const unreadableDescriptionExecute = vi.fn();
+    let bridge!: ReturnType<typeof createCodexDynamicToolBridge>;
+    try {
+      bridge = createCodexDynamicToolBridge({
+        tools: [
+          createTool({
+            name: "message",
+            execute: vi.fn(async () => textToolResult("healthy reply")),
+          }),
+          createToolWithUnreadableField("parameters", {
+            name: "fuzzplugin_unreadable_parameters",
+            execute: unreadableParametersExecute,
+          }),
+          createToolWithUnreadableField("description", {
+            name: "fuzzplugin_unreadable_description",
+            execute: unreadableDescriptionExecute,
+          }),
+        ],
+        signal: new AbortController().signal,
+        hookContext: {
+          runId: "run-unreadable",
+          sessionId: "session-unreadable",
+          sessionKey: "agent:main:session-unreadable",
+        },
+      });
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribeDiagnostics();
+    }
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "fuzzplugin_unreadable_parameters",
+        violations: ["fuzzplugin_unreadable_parameters.parameters is unreadable"],
+      },
+      {
+        tool: "fuzzplugin_unreadable_description",
+        violations: ["fuzzplugin_unreadable_description.description is unreadable"],
+      },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("fuzzplugin_unreadable_parameters"),
+      expect.objectContaining({
+        tools: expect.arrayContaining([
+          {
+            tool: "fuzzplugin_unreadable_parameters",
+            violations: ["fuzzplugin_unreadable_parameters.parameters is unreadable"],
+          },
+          {
+            tool: "fuzzplugin_unreadable_description",
+            violations: ["fuzzplugin_unreadable_description.description is unreadable"],
+          },
+        ]),
+      }),
+    );
+    const blockedToolNames = diagnosticEvents
+      .filter(
+        (event): event is Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }> =>
+          event.type === "tool.execution.blocked",
+      )
+      .map((event) => event.toolName)
+      .toSorted();
+    expect(blockedToolNames).toEqual([
+      "fuzzplugin_unreadable_description",
+      "fuzzplugin_unreadable_parameters",
+    ]);
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "message",
+      arguments: {},
+    });
+
+    expect(result).toEqual(expectInputText("healthy reply"));
+    expect(unreadableParametersExecute).not.toHaveBeenCalled();
+    expect(unreadableDescriptionExecute).not.toHaveBeenCalled();
+  });
+
+  it("quarantines unreadable dynamic tool entries while keeping healthy siblings", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const hiddenExecute = vi.fn();
+    const tools = [
+      createTool({ name: "message" }),
+      createTool({
+        name: "hidden_bad_tool",
+        execute: hiddenExecute,
+      }),
+      createTool({ name: "web_search" }),
+    ];
+    Object.defineProperty(tools, "1", {
+      configurable: true,
+      get() {
+        throw new Error("tool entry getter exploded");
+      },
+    });
+
+    const bridge = createCodexDynamicToolBridge({
+      tools,
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message", "web_search"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual(["message", "web_search"]);
+    expect(bridge.telemetry.quarantinedTools).toEqual([
+      {
+        tool: "tool[1]",
+        violations: ["tool[1] is unreadable"],
+      },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("tool[1]"),
+      expect.objectContaining({
+        tools: [
+          {
+            tool: "tool[1]",
+            violations: ["tool[1] is unreadable"],
+          },
+        ],
+      }),
+    );
+    expect(hiddenExecute).not.toHaveBeenCalled();
   });
 
   it("can expose all dynamic tools directly for compatibility", () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -51,6 +51,8 @@ type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 type ProjectedCodexDynamicTool = {
   tool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
 };
 
@@ -58,6 +60,25 @@ type CodexDynamicToolSchemaQuarantine = {
   tool: string;
   violations: readonly string[];
 };
+
+type CodexDynamicToolDescriptor = {
+  tool: AnyAgentTool;
+  name: string;
+  description: string;
+  parameters: unknown;
+};
+
+type CodexDynamicToolEntryRead =
+  | {
+      readable: true;
+      tool: AnyAgentTool;
+      toolIndex: number;
+    }
+  | {
+      readable: false;
+      toolName: string;
+      violations: readonly string[];
+    };
 
 export type CodexDynamicToolBridge = {
   availableSpecs: CodexDynamicToolSpec[];
@@ -101,19 +122,22 @@ export function createCodexDynamicToolBridge(params: {
   const registeredProjection = params.registeredTools
     ? projectCodexDynamicTools(params.registeredTools)
     : availableProjection;
-  const availableTools = availableProjection.tools.map(({ tool, inputSchema }) => {
-    if (isToolWrappedWithBeforeToolCallHook(tool)) {
-      setBeforeToolCallDiagnosticsEnabled(tool, false);
-      return { tool, inputSchema };
-    }
-    return {
-      tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
-      inputSchema,
-    };
-  });
-  const toolMap = new Map(availableTools.map(({ tool }) => [tool.name, tool]));
-  const registeredTools = registeredProjection.tools.map(({ tool }) => tool);
-  const registeredToolNames = new Set(registeredTools.map((tool) => tool.name));
+  const availableTools = availableProjection.tools.map(
+    ({ tool, name, description, inputSchema }) => {
+      if (isToolWrappedWithBeforeToolCallHook(tool)) {
+        setBeforeToolCallDiagnosticsEnabled(tool, false);
+        return { tool, name, description, inputSchema };
+      }
+      return {
+        tool: wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false }),
+        name,
+        description,
+        inputSchema,
+      };
+    },
+  );
+  const toolMap = new Map(availableTools.map((tool) => [tool.name, tool]));
+  const registeredToolNames = new Set(registeredProjection.tools.map((tool) => tool.name));
   const quarantinedTools = dedupeQuarantinedDynamicTools([
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
@@ -142,17 +166,19 @@ export function createCodexDynamicToolBridge(params: {
   ]);
 
   return {
-    availableSpecs: availableTools.map(({ tool, inputSchema }) =>
+    availableSpecs: availableTools.map(({ name, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        name,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
       }),
     ),
-    specs: registeredProjection.tools.map(({ tool, inputSchema }) =>
+    specs: registeredProjection.tools.map(({ name, description, inputSchema }) =>
       createCodexDynamicToolSpec({
-        tool,
+        name,
+        description,
         inputSchema,
         loading: params.loading ?? "searchable",
         directToolNames,
@@ -160,8 +186,8 @@ export function createCodexDynamicToolBridge(params: {
     ),
     telemetry,
     handleToolCall: async (call, options) => {
-      const tool = toolMap.get(call.tool);
-      if (!tool) {
+      const toolEntry = toolMap.get(call.tool);
+      if (!toolEntry) {
         if (registeredToolNames.has(call.tool)) {
           return {
             contentItems: [
@@ -178,6 +204,7 @@ export function createCodexDynamicToolBridge(params: {
           success: false,
         };
       }
+      const { tool, name: toolName } = toolEntry;
       const args = jsonObjectToRecord(call.arguments);
       const startedAt = Date.now();
       const signal = composeAbortSignals(params.signal, options?.signal);
@@ -191,7 +218,7 @@ export function createCodexDynamicToolBridge(params: {
           threadId: call.threadId,
           turnId: call.turnId,
           toolCallId: call.callId,
-          toolName: tool.name,
+          toolName,
           args,
           isError: rawIsError,
           result: rawResult,
@@ -200,13 +227,13 @@ export function createCodexDynamicToolBridge(params: {
           threadId: call.threadId,
           turnId: call.turnId,
           toolCallId: call.callId,
-          toolName: tool.name,
+          toolName,
           args,
           result: middlewareResult,
         });
         const resultIsError = rawIsError || isToolResultError(result);
         collectToolTelemetry({
-          toolName: tool.name,
+          toolName,
           args,
           result,
           mediaTrustResult: rawResult,
@@ -214,7 +241,7 @@ export function createCodexDynamicToolBridge(params: {
           isError: resultIsError,
         });
         void runAgentHarnessAfterToolCallHook({
-          toolName: tool.name,
+          toolName,
           toolCallId: call.callId,
           runId: toolResultHookContext.runId,
           agentId: toolResultHookContext.agentId,
@@ -247,14 +274,14 @@ export function createCodexDynamicToolBridge(params: {
         return withSideEffectEvidence(response, terminalType !== "blocked");
       } catch (error) {
         collectToolTelemetry({
-          toolName: tool.name,
+          toolName,
           args,
           result: undefined,
           telemetry,
           isError: true,
         });
         void runAgentHarnessAfterToolCallHook({
-          toolName: tool.name,
+          toolName,
           toolCallId: call.callId,
           runId: toolResultHookContext.runId,
           agentId: toolResultHookContext.agentId,
@@ -286,17 +313,18 @@ export function createCodexDynamicToolBridge(params: {
 }
 
 function createCodexDynamicToolSpec(params: {
-  tool: AnyAgentTool;
+  name: string;
+  description: string;
   inputSchema: JsonValue;
   loading: CodexDynamicToolsLoading;
   directToolNames: ReadonlySet<string>;
 }): CodexDynamicToolSpec {
   const base = {
-    name: params.tool.name,
-    description: params.tool.description,
+    name: params.name,
+    description: params.description,
     inputSchema: params.inputSchema,
   };
-  if (params.loading === "direct" || params.directToolNames.has(params.tool.name)) {
+  if (params.loading === "direct" || params.directToolNames.has(params.name)) {
     return base;
   }
   return {
@@ -312,15 +340,127 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
 } {
   const projectedTools: ProjectedCodexDynamicTool[] = [];
   const quarantinedTools: CodexDynamicToolSchemaQuarantine[] = [];
-  for (const tool of tools) {
-    const projection = projectRuntimeToolInputSchema(tool.parameters, `${tool.name}.inputSchema`);
-    if (projection.violations.length > 0) {
-      quarantinedTools.push({ tool: tool.name, violations: projection.violations });
+  for (const entry of readCodexDynamicToolEntries(tools)) {
+    if (!entry.readable) {
+      quarantinedTools.push({
+        tool: entry.toolName,
+        violations: entry.violations,
+      });
       continue;
     }
-    projectedTools.push({ tool, inputSchema: projection.schema as JsonValue });
+    const descriptor = snapshotCodexDynamicToolDescriptor(entry.tool, entry.toolIndex);
+    if (!descriptor.readable) {
+      quarantinedTools.push({
+        tool: descriptor.toolName,
+        violations: descriptor.violations,
+      });
+      continue;
+    }
+    const projection = projectRuntimeToolInputSchema(
+      descriptor.parameters,
+      `${descriptor.name}.inputSchema`,
+    );
+    if (projection.violations.length > 0) {
+      quarantinedTools.push({ tool: descriptor.name, violations: projection.violations });
+      continue;
+    }
+    projectedTools.push({
+      tool: descriptor.tool,
+      name: descriptor.name,
+      description: descriptor.description,
+      inputSchema: projection.schema as JsonValue,
+    });
   }
   return { tools: projectedTools, quarantinedTools };
+}
+
+function readCodexDynamicToolEntries(tools: readonly AnyAgentTool[]): CodexDynamicToolEntryRead[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [
+      {
+        readable: false,
+        toolName: "tool[0]",
+        violations: ["tool[0] is unreadable"],
+      },
+    ];
+  }
+  const entries: CodexDynamicToolEntryRead[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      const tool = tools[toolIndex];
+      if (!tool) {
+        entries.push(unreadableCodexDynamicToolEntry(toolIndex));
+        continue;
+      }
+      entries.push({ readable: true, tool, toolIndex });
+    } catch {
+      entries.push(unreadableCodexDynamicToolEntry(toolIndex));
+    }
+  }
+  return entries;
+}
+
+function unreadableCodexDynamicToolEntry(toolIndex: number): CodexDynamicToolEntryRead {
+  const toolName = `tool[${toolIndex}]`;
+  return {
+    readable: false,
+    toolName,
+    violations: [`${toolName} is unreadable`],
+  };
+}
+
+function snapshotCodexDynamicToolDescriptor(
+  tool: AnyAgentTool,
+  toolIndex: number,
+):
+  | ({ readable: true } & CodexDynamicToolDescriptor)
+  | { readable: false; toolName: string; violations: readonly string[] } {
+  const fallbackName = `tool[${toolIndex}]`;
+  const nameRead = readCodexDynamicToolField(tool, "name");
+  const hasValidName =
+    nameRead.readable && typeof nameRead.value === "string" && nameRead.value.length > 0;
+  const name = hasValidName && typeof nameRead.value === "string" ? nameRead.value : fallbackName;
+  const violations: string[] = [];
+  if (!nameRead.readable) {
+    violations.push(`${name}.name is unreadable`);
+  } else if (!hasValidName) {
+    violations.push(`${name}.name must be a non-empty string`);
+  }
+
+  const descriptionRead = readCodexDynamicToolField(tool, "description");
+  if (!descriptionRead.readable) {
+    violations.push(`${name}.description is unreadable`);
+  }
+
+  const parametersRead = readCodexDynamicToolField(tool, "parameters");
+  if (!parametersRead.readable) {
+    violations.push(`${name}.parameters is unreadable`);
+  }
+
+  if (!descriptionRead.readable || !parametersRead.readable || violations.length > 0) {
+    return { readable: false, toolName: name, violations };
+  }
+  return {
+    readable: true,
+    tool,
+    name,
+    description: typeof descriptionRead.value === "string" ? descriptionRead.value : "",
+    parameters: parametersRead.value,
+  };
+}
+
+function readCodexDynamicToolField(
+  tool: AnyAgentTool,
+  field: "description" | "name" | "parameters",
+): { readable: true; value: unknown } | { readable: false } {
+  try {
+    return { readable: true, value: (tool as unknown as Record<string, unknown>)[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 function warnQuarantinedDynamicTools(tools: readonly CodexDynamicToolSchemaQuarantine[]): void {


### PR DESCRIPTION
## Summary
- Snapshot Codex dynamic tool names, descriptions, and schemas before wrapping or emitting specs.
- Quarantine unreadable dynamic tool entries/descriptors instead of aborting Codex bridge construction.
- Keep healthy sibling dynamic tools available when one plugin tool has a hostile descriptor or list entry.

## Verification
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts`
- `./node_modules/.bin/oxlint extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`
- AWS Crabbox fresh-PR changed gate: `run_8adb0867537d`, lease `cbx_5a28a16938b0`, provider `aws`, command `corepack pnpm check:changed`, exit 0

## Real behavior proof
Behavior addressed: Codex app-server dynamic tool bridge no longer crashes before content when a dynamic tool list entry or descriptor field is unreadable.
Real environment tested: local macOS checkout with Node 24 via repo Vitest wrapper; AWS Crabbox fresh PR checkout on Linux Node 24.15.0.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -- --reporter=dot`; AWS Crabbox `corepack pnpm check:changed` on PR #89481.
Evidence after fix: focused Codex dynamic-tools suite passed 38 tests; AWS Crabbox run `run_8adb0867537d` passed changed lanes `extensions, extensionTests`.
Observed result after fix: malformed dynamic tools are quarantined, warnings/diagnostics name the offending tool or index, healthy sibling specs remain available, and healthy tool calls still execute.
What was not tested: full repository test suite.
