### PR TITLE
fix(discord): ignore stale ACP bindings when acpx is disabled

### DIFF
--- a/extensions/discord/src/monitor/message-handler.routing-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.routing-preflight.ts
@@ -61,6 +61,7 @@ export async function resolveDiscordPreflightRoute(params: {
     shouldIgnoreStaleDiscordRouteBinding({
       bindingRecord: runtimeRoute.bindingRecord,
       route,
+      cfg: params.preflight.cfg,
     })
   ) {
     logVerbose(

--- a/extensions/discord/src/monitor/route-resolution.test.ts
+++ b/extensions/discord/src/monitor/route-resolution.test.ts
@@ -210,4 +210,106 @@ describe("discord route resolution helpers", () => {
       }),
     ).toBe(false);
   });
+
+  it("ignores ACP bindings when ACP dispatch is disabled", () => {
+    const route: ResolvedAgentRoute = {
+      agentId: "engineering",
+      channel: "discord",
+      accountId: "default",
+      sessionKey: "agent:engineering:discord:channel:c1",
+      mainSessionKey: "agent:engineering:main",
+      lastRoutePolicy: "session",
+      matchedBy: "binding.peer",
+    };
+
+    expect(
+      shouldIgnoreStaleDiscordRouteBinding({
+        route,
+        cfg: {
+          acp: { enabled: false, dispatch: { enabled: false } },
+          plugins: { entries: { acpx: { enabled: false } }, deny: ["acpx"] },
+        } as any,
+        bindingRecord: {
+          bindingId: "acp-binding",
+          targetSessionKey: "agent:codex:acp:session-1",
+          targetKind: "acp",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "c1",
+          },
+          status: "active",
+          boundAt: 1,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores ACP bindings when plugins.allow omits acpx", () => {
+    const route: ResolvedAgentRoute = {
+      agentId: "engineering",
+      channel: "discord",
+      accountId: "default",
+      sessionKey: "agent:engineering:discord:channel:c1",
+      mainSessionKey: "agent:engineering:main",
+      lastRoutePolicy: "session",
+      matchedBy: "binding.peer",
+    };
+
+    expect(
+      shouldIgnoreStaleDiscordRouteBinding({
+        route,
+        cfg: {
+          acp: { enabled: true, dispatch: { enabled: true } },
+          plugins: { allow: ["discord", "codex"], entries: { acpx: { enabled: true } } },
+        } as any,
+        bindingRecord: {
+          bindingId: "acp-binding",
+          targetSessionKey: "agent:codex:acp:session-1",
+          targetKind: "acp",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "c1",
+          },
+          status: "active",
+          boundAt: 1,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps ACP bindings when ACP dispatch is enabled", () => {
+    const route: ResolvedAgentRoute = {
+      agentId: "engineering",
+      channel: "discord",
+      accountId: "default",
+      sessionKey: "agent:engineering:discord:channel:c1",
+      mainSessionKey: "agent:engineering:main",
+      lastRoutePolicy: "session",
+      matchedBy: "binding.peer",
+    };
+
+    expect(
+      shouldIgnoreStaleDiscordRouteBinding({
+        route,
+        cfg: {
+          acp: { enabled: true, dispatch: { enabled: true } },
+          plugins: { entries: { acpx: { enabled: true } }, deny: [] },
+        } as any,
+        bindingRecord: {
+          bindingId: "acp-binding",
+          targetSessionKey: "agent:codex:acp:session-1",
+          targetKind: "acp",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "c1",
+          },
+          status: "active",
+          boundAt: 1,
+        },
+      }),
+    ).toBe(false);
+  });
 });

--- a/extensions/discord/src/monitor/route-resolution.ts
+++ b/extensions/discord/src/monitor/route-resolution.ts
@@ -123,13 +123,39 @@ function hasExplicitRuntimeBindingIntent(record: SessionBindingRecord): boolean 
   );
 }
 
+function isAcpRuntimeDisabledForDiscordBinding(cfg?: OpenClawConfig | null): boolean {
+  if (!cfg) {
+    return false;
+  }
+  const acpxEntryEnabled = cfg.plugins?.entries?.acpx?.enabled !== false;
+  const acpxDenied = Array.isArray(cfg.plugins?.deny) && cfg.plugins.deny.includes("acpx");
+  const acpxAllowed =
+    !Array.isArray(cfg.plugins?.allow) ||
+    cfg.plugins.allow.length === 0 ||
+    cfg.plugins.allow.includes("acpx");
+  return (
+    cfg.acp?.enabled === false ||
+    cfg.acp?.dispatch?.enabled === false ||
+    !acpxEntryEnabled ||
+    acpxDenied ||
+    !acpxAllowed
+  );
+}
+
 export function shouldIgnoreStaleDiscordRouteBinding(params: {
   bindingRecord?: SessionBindingRecord | null;
   route: ResolvedAgentRoute;
+  cfg?: OpenClawConfig | null;
 }): boolean {
   const bindingRecord = params.bindingRecord;
   const boundSessionKey = bindingRecord?.targetSessionKey?.trim();
-  if (!bindingRecord || !boundSessionKey || hasExplicitRuntimeBindingIntent(bindingRecord)) {
+  if (!bindingRecord || !boundSessionKey) {
+    return false;
+  }
+  if (isAcpSessionKey(boundSessionKey) && isAcpRuntimeDisabledForDiscordBinding(params.cfg)) {
+    return true;
+  }
+  if (hasExplicitRuntimeBindingIntent(bindingRecord)) {
     return false;
   }
   const bound = parseAgentSessionKey(boundSessionKey);


### PR DESCRIPTION
## Summary
- ignore Discord ACP session bindings when ACP is effectively unavailable so stale ACP routes cannot override the configured native Discord route
- treat restrictive `plugins.allow` configs that omit `acpx` as ACPX-disabled for Discord stale-binding recovery
- keep the fix scoped to Discord route preflight on current `main`; this version intentionally does **not** change generic ACP dispatch error suppression or session unbinding behavior

## Root cause
Discord conversation bindings treated ACP session keys as explicit focus bindings forever. After ACP/acpx was disabled, stale ACP bindings could still override the configured native Discord route. In the affected deployment, ACP was disabled and `plugins.allow` excluded `acpx`, but Discord could still try to follow a stale ACP session binding instead of routing natively.

## Real behavior proof
- Behavior or issue addressed: stale Discord ACP bindings no longer keep routing turns through ACP when ACP is disabled and `plugins.allow` excludes `acpx`
- Real environment tested: Jeremy's live OpenClaw gateway on macOS via the LaunchAgent-backed installed runtime (`/Users/tmfprettybot/.nvm/versions/node/v22.22.1/lib/node_modules/openclaw/dist/index.js`) with Discord `#engineering`
- Exact steps or command run after this patch:
  - updated the Discord stale-binding recovery logic on the live gateway to honor restrictive `plugins.allow` without `acpx`
  - verified live config state: `acp.enabled=false`, `acp.dispatch.enabled=false`, and restrictive `plugins.allow` excluding `acpx`
  - restarted the live gateway LaunchAgent
  - sent a fresh human-authored Discord message in `#engineering`
- Evidence after fix:
  - live restart window: `2026-06-06 09:27:48 CDT` shutdown start through `2026-06-06 09:27:51 CDT` ready
  - restarted process PID: `48364`
  - startup log after restart: `http server listening (12 plugins: bonjour, brave, browser, canvas, codex, device-pair, discord, file-transfer, memory-core, phone-control, talk-voice, telegram; 1.9s)` showing no `acpx`
  - post-fix fresh Discord turn: human-authored `#engineering` message at `2026-06-06 10:20:27 CDT`
  - after that turn, gateway/std err logs show normal agent activity and no new `ACP_TURN_FAILED: acpx exited with code 1`
- Observed result after fix: the live gateway stayed on native Discord routing in the disabled-backend state that originally reproduced the problem, and the fresh real Discord turn did not emit the recurring ACP error
- What was not tested: I did not capture screenshot/video artifacts and did not force-create a brand-new synthetic stale binding after deploy; proof is from the real affected deployment state and a fresh human Discord turn
- Proof limitations or environment constraints: this proof comes from one live deployment and one fresh real Discord turn after restart; it proves the reported user-visible failure path is no longer reproducing in the affected environment
- Before evidence: before the fix, the affected deployment repeatedly emitted `ACP_TURN_FAILED: acpx exited with code 1` on Discord turns while ACP was disabled; see the original incident notes and prior PR discussion

## Tests
- `pnpm exec vitest run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/route-resolution.test.ts`

## Current review state
- This branch has been rebuilt on current `main` and now only changes Discord route preflight logic plus focused regression coverage
- The earlier broad `dispatch-acp.ts` suppression/unbind shape is intentionally gone from this version
- Next action: re-review this narrowed patch against the existing live proof
