### PR TITLE
memory-wiki: make native generated links source-relative

### DIFF
--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -199,6 +199,6 @@ keep this note
     expect(parsed.body).toContain("<!-- openclaw:human:start -->");
     await expect(
       fs.readFile(path.join(rootDir, "entities", "index.md"), "utf8"),
-    ).resolves.toContain("[Alpha](entities/alpha.md)");
+    ).resolves.toContain("[Alpha](alpha.md)");
   });
 });

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -91,7 +91,7 @@ describe("compileMemoryWikiVault", () => {
       "- Claims: 1",
     );
     await expect(fs.readFile(path.join(rootDir, "sources", "index.md"), "utf8")).resolves.toContain(
-      "[Alpha](sources/alpha.md)",
+      "[Alpha](alpha.md)",
     );
     const agentDigest = JSON.parse(
       await fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "agent-digest.json"), "utf8"),
@@ -108,6 +108,50 @@ describe("compileMemoryWikiVault", () => {
     await expect(
       fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "claims.jsonl"), "utf8"),
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
+  });
+
+  it("renders native directory index links relative to each generated index", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    await fs.writeFile(
+      path.join(rootDir, "concepts", "alpha-concept.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "concept", id: "concept.alpha", title: "Alpha Concept" },
+        body: "# Alpha Concept\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "alpha-entity.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "entity", id: "entity.alpha", title: "Alpha Entity" },
+        body: "# Alpha Entity\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "alpha-synthesis.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "synthesis", id: "synthesis.alpha", title: "Alpha Synthesis" },
+        body: "# Alpha Synthesis\n",
+      }),
+      "utf8",
+    );
+
+    await compileMemoryWikiVault(config);
+
+    await expect(
+      fs.readFile(path.join(rootDir, "concepts", "index.md"), "utf8"),
+    ).resolves.toContain("[Alpha Concept](alpha-concept.md)");
+    await expect(
+      fs.readFile(path.join(rootDir, "entities", "index.md"), "utf8"),
+    ).resolves.toContain("[Alpha Entity](alpha-entity.md)");
+    await expect(
+      fs.readFile(path.join(rootDir, "syntheses", "index.md"), "utf8"),
+    ).resolves.toContain("[Alpha Synthesis](alpha-synthesis.md)");
   });
 
   it("bounds concurrent page reads while compiling", async () => {
@@ -239,16 +283,69 @@ describe("compileMemoryWikiVault", () => {
       "## Related",
     );
     await expect(fs.readFile(path.join(rootDir, "entities", "beta.md"), "utf8")).resolves.toContain(
-      "[Alpha](sources/alpha.md)",
+      "[Alpha](../sources/alpha.md)",
     );
     await expect(fs.readFile(path.join(rootDir, "entities", "beta.md"), "utf8")).resolves.toContain(
-      "[Gamma](concepts/gamma.md)",
+      "[Gamma](../concepts/gamma.md)",
     );
     await expect(fs.readFile(path.join(rootDir, "sources", "alpha.md"), "utf8")).resolves.toContain(
-      "[Beta](entities/beta.md)",
+      "[Beta](../entities/beta.md)",
     );
     await expect(fs.readFile(path.join(rootDir, "sources", "alpha.md"), "utf8")).resolves.toContain(
-      "[Gamma](concepts/gamma.md)",
+      "[Gamma](../concepts/gamma.md)",
+    );
+  });
+
+  it("renders native synthesis related and source links relative to the synthesis page", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
+        body: "# Alpha Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "concepts", "alpha-concept.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "concept",
+          id: "concept.alpha",
+          title: "Alpha Concept",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Alpha Concept\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "alpha-synthesis.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.alpha",
+          title: "Alpha Synthesis",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Alpha Synthesis\n",
+      }),
+      "utf8",
+    );
+
+    await compileMemoryWikiVault(config);
+
+    const synthesis = await fs.readFile(
+      path.join(rootDir, "syntheses", "alpha-synthesis.md"),
+      "utf8",
+    );
+    expect(synthesis).toContain("### Sources\n\n- [Alpha Source](../sources/alpha.md)");
+    expect(synthesis).toContain(
+      "### Related Pages\n\n- [Alpha Concept](../concepts/alpha-concept.md)",
     );
   });
 
@@ -305,7 +402,7 @@ describe("compileMemoryWikiVault", () => {
 
     const firstEntity = await fs.readFile(path.join(rootDir, "entities", "entity-0.md"), "utf8");
     const sourcePage = await fs.readFile(path.join(rootDir, "sources", "alpha.md"), "utf8");
-    expect(firstEntity).toContain("[Alpha](sources/alpha.md)");
+    expect(firstEntity).toContain("[Alpha](../sources/alpha.md)");
     expect(firstEntity).not.toContain("### Related Pages");
     expect(sourcePage).not.toContain("### Referenced By");
   });
@@ -572,7 +669,7 @@ describe("compileMemoryWikiVault", () => {
 
     expect(second.updatedFiles).toStrictEqual([]);
     await expect(fs.readFile(path.join(rootDir, "entities", "beta.md"), "utf8")).resolves.toContain(
-      "[Gamma](concepts/gamma.md)",
+      "[Gamma](../concepts/gamma.md)",
     );
     await expect(
       fs.readFile(path.join(rootDir, "concepts", "gamma.md"), "utf8"),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -660,6 +660,7 @@ function buildPageLookupKeys(page: WikiPageSummary): Set<string> {
 function renderWikiPageLinks(params: {
   config: ResolvedMemoryWikiConfig;
   pages: WikiPageSummary[];
+  sourceRelativeTo?: string;
 }): string {
   return params.pages
     .map(
@@ -667,6 +668,7 @@ function renderWikiPageLinks(params: {
         `- ${formatWikiLink({
           renderMode: params.config.vault.renderMode,
           relativePath: page.relativePath,
+          sourceRelativeTo: params.sourceRelativeTo,
           title: page.title,
         })}`,
     )
@@ -755,19 +757,31 @@ function buildRelatedBlockBody(params: {
   if (sourcePages.length > 0) {
     sections.push(
       "### Sources",
-      renderWikiPageLinks({ config: params.config, pages: sourcePages }),
+      renderWikiPageLinks({
+        config: params.config,
+        pages: sourcePages,
+        sourceRelativeTo: params.page.relativePath,
+      }),
     );
   }
   if (backlinkPages.length > 0) {
     sections.push(
       "### Referenced By",
-      renderWikiPageLinks({ config: params.config, pages: backlinkPages }),
+      renderWikiPageLinks({
+        config: params.config,
+        pages: backlinkPages,
+        sourceRelativeTo: params.page.relativePath,
+      }),
     );
   }
   if (relatedPages.length > 0) {
     sections.push(
       "### Related Pages",
-      renderWikiPageLinks({ config: params.config, pages: relatedPages }),
+      renderWikiPageLinks({
+        config: params.config,
+        pages: relatedPages,
+        sourceRelativeTo: params.page.relativePath,
+      }),
     );
   }
   if (sections.length === 0) {
@@ -819,6 +833,7 @@ function renderSectionList(params: {
   config: ResolvedMemoryWikiConfig;
   pages: WikiPageSummary[];
   emptyText: string;
+  sourceRelativeTo?: string;
 }): string {
   if (params.pages.length === 0) {
     return `- ${params.emptyText}`;
@@ -829,6 +844,7 @@ function renderSectionList(params: {
         `- ${formatWikiLink({
           renderMode: params.config.vault.renderMode,
           relativePath: page.relativePath,
+          sourceRelativeTo: params.sourceRelativeTo,
           title: page.title,
         })}`,
     )
@@ -1002,6 +1018,7 @@ function buildDirectoryIndexBody(params: {
     config: params.config,
     pages: params.pages.filter((page) => page.kind === params.group.kind),
     emptyText: `No ${normalizeLowercaseStringOrEmpty(params.group.heading)} yet.`,
+    sourceRelativeTo: `${params.group.dir}/index.md`,
   });
 }
 

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -396,12 +396,20 @@ function extractWikiLinks(markdown: string): string[] {
 export function formatWikiLink(params: {
   renderMode: "native" | "obsidian";
   relativePath: string;
+  sourceRelativeTo?: string;
   title: string;
 }): string {
   const withoutExtension = params.relativePath.replace(/\.md$/i, "");
-  return params.renderMode === "obsidian"
-    ? `[[${withoutExtension}|${params.title}]]`
-    : `[${params.title}](${params.relativePath})`;
+  if (params.renderMode === "obsidian") {
+    return `[[${withoutExtension}|${params.title}]]`;
+  }
+  const linkTarget = params.sourceRelativeTo
+    ? path
+        .relative(path.dirname(params.sourceRelativeTo), params.relativePath)
+        .split(path.sep)
+        .join("/")
+    : params.relativePath;
+  return `[${params.title}](${linkTarget})`;
 }
 
 export function renderMarkdownFence(content: string, infoString = "text"): string {


### PR DESCRIPTION
## Summary
- make native Markdown link targets source-relative for generated memory-wiki directory indexes
- make generated Related/Sources/Referenced By blocks source-relative from each page
- preserve Obsidian wikilink output by only adjusting native link targets

## Test Plan
- pnpm test extensions/memory-wiki/src/compile.test.ts extensions/memory-wiki/src/apply.test.ts
- pnpm check

Fixes #89424

— Seraphel
