### PR TITLE
fix: guard WebRTC Talk startup teardown race

### DIFF
--- a/ui/src/ui/chat/realtime-talk-webrtc.ts
+++ b/ui/src/ui/chat/realtime-talk-webrtc.ts
@@ -57,27 +57,38 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       throw new Error("Realtime Talk requires browser WebRTC and microphone access");
     }
     this.closed = false;
-    this.peer = new RTCPeerConnection();
+    const peer = new RTCPeerConnection();
+    this.peer = peer;
     this.audio = document.createElement("audio");
     this.audio.autoplay = true;
     this.audio.style.display = "none";
     document.body.append(this.audio);
-    this.peer.addEventListener("track", (event) => {
+    peer.addEventListener("track", (event) => {
       if (this.audio) {
         this.audio.srcObject = event.streams[0];
       }
     });
-    this.media = await navigator.mediaDevices.getUserMedia({ audio: true });
-    for (const track of this.media.getAudioTracks()) {
-      this.peer.addTrack(track, this.media);
+    const media = await navigator.mediaDevices.getUserMedia({ audio: true });
+    if (!this.isCurrentPeer(peer)) {
+      media.getTracks().forEach((track) => track.stop());
+      return;
     }
-    this.channel = this.peer.createDataChannel("oai-events");
-    this.channel.addEventListener("open", () => {
+    this.media = media;
+    for (const track of media.getAudioTracks()) {
+      peer.addTrack(track, media);
+    }
+    const channel = peer.createDataChannel("oai-events");
+    if (!this.isCurrentPeer(peer)) {
+      channel.close();
+      return;
+    }
+    this.channel = channel;
+    channel.addEventListener("open", () => {
       this.ctx.callbacks.onStatus?.("listening");
       this.emitTalkEvent({ type: "session.ready" });
     });
-    this.channel.addEventListener("message", (event) => this.handleRealtimeEvent(event.data));
-    this.peer.addEventListener("connectionstatechange", () => {
+    channel.addEventListener("message", (event) => this.handleRealtimeEvent(event.data));
+    peer.addEventListener("connectionstatechange", () => {
       if (this.closed) {
         return;
       }
@@ -86,8 +97,14 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       }
     });
 
-    const offer = await this.peer.createOffer();
-    await this.peer.setLocalDescription(offer);
+    const offer = await peer.createOffer();
+    if (!this.isCurrentPeer(peer)) {
+      return;
+    }
+    await peer.setLocalDescription(offer);
+    if (!this.isCurrentPeer(peer)) {
+      return;
+    }
     const sdp = await fetch(this.session.offerUrl ?? "https://api.openai.com/v1/realtime/calls", {
       method: "POST",
       body: offer.sdp,
@@ -97,13 +114,24 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         "Content-Type": "application/sdp",
       },
     });
+    if (!this.isCurrentPeer(peer)) {
+      return;
+    }
     if (!sdp.ok) {
       throw new Error(`Realtime WebRTC setup failed (${sdp.status})`);
     }
-    await this.peer.setRemoteDescription({
+    const answerSdp = await sdp.text();
+    if (!this.isCurrentPeer(peer)) {
+      return;
+    }
+    await peer.setRemoteDescription({
       type: "answer",
-      sdp: await sdp.text(),
+      sdp: answerSdp,
     });
+  }
+
+  private isCurrentPeer(peer: RTCPeerConnection): boolean {
+    return !this.closed && this.peer === peer;
   }
 
   stop(): void {

--- a/ui/src/ui/realtime-talk-webrtc.test.ts
+++ b/ui/src/ui/realtime-talk-webrtc.test.ts
@@ -188,6 +188,40 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     vi.stubGlobal("RTCPeerConnection", FakePeerConnection as unknown as typeof RTCPeerConnection);
   });
 
+  it("does not continue WebRTC setup when stopped while microphone access is pending", async () => {
+    const fetchMock = vi.fn(async () => new Response("answer-sdp"));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const stopTrack = vi.fn();
+    const track = { stop: stopTrack } as unknown as MediaStreamTrack;
+    const stream = {
+      getAudioTracks: () => [track],
+      getTracks: () => [track],
+    } as unknown as MediaStream;
+    let resolveMedia: (stream: MediaStream) => void = () => undefined;
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(
+          () =>
+            new Promise<MediaStream>((resolve) => {
+              resolveMedia = resolve;
+            }),
+        ),
+      },
+    });
+    const transport = createOpenAiTransport();
+
+    const startPromise = transport.start();
+    const peer = FakePeerConnection.instances[0];
+    transport.stop();
+    resolveMedia(stream);
+
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(peer?.addTrack).not.toHaveBeenCalled();
+    expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("sends provider offer headers with the WebRTC SDP request", async () => {
     const fetchMock = vi.fn(async () => new Response("answer-sdp"));
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);


### PR DESCRIPTION
## Summary
- Guards WebRTC Talk startup against stop/start teardown races by continuing async setup only while the original RTCPeerConnection is still live.
- Stops microphone tracks obtained after cancellation and avoids addTrack/fetch/SDP setup after the transport has been stopped.
- Adds a regression test for stopping while microphone access is pending.

## Test Plan
- node scripts/run-vitest.mjs ui/src/ui/realtime-talk-webrtc.test.ts
- pnpm check

Fixes #89434

— Seraphel
