### PR TITLE
fix: stabilize Anthropic cache marker through tool loops

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -90,12 +90,112 @@ describe("anthropic payload policy", () => {
     expect(payload.messages[1]).toEqual({
       role: "user",
       content: [
-        { type: "text", text: "Hello" },
+        { type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } },
         {
           type: "tool_result",
           tool_use_id: "tool_1",
           content: "done",
-          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+    });
+  });
+
+  it("keeps the conversation cache marker on user text through trailing tool results", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+      cacheRetention: "short",
+      enableCacheControl: true,
+    });
+    const payload: TestPayload = {
+      system: [{ type: "text", text: "Follow policy." }],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Investigate the cache writes." }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I'll inspect the logs." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_1", content: "log chunk" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I'll inspect the next log." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_2", content: "next chunk" }],
+        },
+      ],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Investigate the cache writes.",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    });
+    expect(payload.messages[2]).toEqual({
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tool_1", content: "log chunk" }],
+    });
+    expect(payload.messages[4]).toEqual({
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tool_2", content: "next chunk" }],
+    });
+  });
+
+  it("falls back to the latest tool result when no user text or image exists", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+      cacheRetention: "short",
+      enableCacheControl: true,
+    });
+    const payload: TestPayload = {
+      system: [{ type: "text", text: "Follow policy." }],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_1", content: "first" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Continue." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_2", content: "second" }],
+        },
+      ],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tool_1", content: "first" }],
+    });
+    expect(payload.messages[2]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool_2",
+          content: "second",
+          cache_control: { type: "ephemeral" },
         },
       ],
     });

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -95,12 +95,13 @@ describe("anthropic payload policy", () => {
           type: "tool_result",
           tool_use_id: "tool_1",
           content: "done",
+          cache_control: { type: "ephemeral", ttl: "1h" },
         },
       ],
     });
   });
 
-  it("keeps the conversation cache marker on user text through trailing tool results", () => {
+  it("keeps a stable user marker while advancing through trailing tool results", () => {
     const policy = resolveAnthropicPayloadPolicy({
       provider: "anthropic",
       api: "anthropic-messages",
@@ -152,7 +153,14 @@ describe("anthropic payload policy", () => {
     });
     expect(payload.messages[4]).toEqual({
       role: "user",
-      content: [{ type: "tool_result", tool_use_id: "tool_2", content: "next chunk" }],
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool_2",
+          content: "next chunk",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
     });
   });
 

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -9,6 +9,7 @@ type TestPayload = {
   messages: Array<{ role: string; content: unknown }>;
   service_tier?: string;
   system?: unknown;
+  tools?: unknown;
 };
 
 function textBlock(text: string, cache_control?: { type: "ephemeral"; ttl?: "1h" }) {
@@ -203,6 +204,55 @@ describe("anthropic payload policy", () => {
           type: "tool_result",
           tool_use_id: "tool_2",
           content: "second",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    });
+  });
+
+  it("uses the latest tool result when only one message cache marker remains", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+      cacheRetention: "short",
+      enableCacheControl: true,
+    });
+    const payload: TestPayload = {
+      system: [
+        { type: "text", text: "Claude Code identity." },
+        { type: "text", text: "Follow policy." },
+      ],
+      tools: [{ name: "Read", cache_control: { type: "ephemeral" } }],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Investigate the cache writes." }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I'll inspect the logs." }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_1", content: "log chunk" }],
+        },
+      ],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "Investigate the cache writes." }],
+    });
+    expect(payload.messages[2]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool_1",
+          content: "log chunk",
           cache_control: { type: "ephemeral" },
         },
       ],

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -237,7 +237,6 @@ export function applyAnthropicPayloadPolicyToParams(
     return;
   }
 
-  // Preserve Anthropic cache-write scope by only tagging the trailing user turn.
   applyAnthropicCacheControlToMessages(payloadObj.messages, policy.cacheControl);
 }
 

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -22,6 +22,8 @@ type AnthropicPayloadPolicyInput = {
   serviceTier?: AnthropicServiceTier;
 };
 
+const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
 export type AnthropicPayloadPolicy = {
   allowsServiceTier: boolean;
@@ -136,8 +138,9 @@ function stripAnthropicSystemPromptBoundary(system: unknown): void {
 function applyAnthropicCacheControlToMessages(
   messages: unknown,
   cacheControl: AnthropicEphemeralCacheControl,
+  markerLimit: number,
 ): void {
-  if (!Array.isArray(messages) || messages.length === 0) {
+  if (!Array.isArray(messages) || messages.length === 0 || markerLimit <= 0) {
     return;
   }
 
@@ -156,6 +159,10 @@ function applyAnthropicCacheControlToMessages(
 
     const content = record.content;
     if (typeof content === "string") {
+      if (fallbackToolResult && markerLimit === 1) {
+        fallbackToolResult.cache_control = cacheControl;
+        return;
+      }
       record.content = [
         {
           type: "text",
@@ -163,6 +170,9 @@ function applyAnthropicCacheControlToMessages(
           cache_control: cacheControl,
         },
       ];
+      if (fallbackToolResult && markerLimit > 1) {
+        fallbackToolResult.cache_control = cacheControl;
+      }
       return;
     }
 
@@ -178,8 +188,12 @@ function applyAnthropicCacheControlToMessages(
 
       const blockRecord = block as Record<string, unknown>;
       if (blockRecord.type === "text" || blockRecord.type === "image") {
+        if (fallbackToolResult && markerLimit === 1) {
+          fallbackToolResult.cache_control = cacheControl;
+          return;
+        }
         blockRecord.cache_control = cacheControl;
-        if (fallbackToolResult) {
+        if (fallbackToolResult && markerLimit > 1) {
           fallbackToolResult.cache_control = cacheControl;
         }
         return;
@@ -193,6 +207,20 @@ function applyAnthropicCacheControlToMessages(
   if (fallbackToolResult) {
     fallbackToolResult.cache_control = cacheControl;
   }
+}
+
+function countAnthropicCacheControlMarkers(blocks: unknown): number {
+  if (!Array.isArray(blocks)) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const block of blocks) {
+    if (block && typeof block === "object" && "cache_control" in block) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */
@@ -240,7 +268,14 @@ export function applyAnthropicPayloadPolicyToParams(
     return;
   }
 
-  applyAnthropicCacheControlToMessages(payloadObj.messages, policy.cacheControl);
+  const usedMarkers =
+    countAnthropicCacheControlMarkers(payloadObj.system) +
+    countAnthropicCacheControlMarkers(payloadObj.tools);
+  applyAnthropicCacheControlToMessages(
+    payloadObj.messages,
+    policy.cacheControl,
+    ANTHROPIC_CACHE_CONTROL_LIMIT - usedMarkers,
+  );
 }
 
 /** @deprecated Anthropic-family provider payload helper; do not use from third-party plugins. */

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -179,6 +179,9 @@ function applyAnthropicCacheControlToMessages(
       const blockRecord = block as Record<string, unknown>;
       if (blockRecord.type === "text" || blockRecord.type === "image") {
         blockRecord.cache_control = cacheControl;
+        if (fallbackToolResult) {
+          fallbackToolResult.cache_control = cacheControl;
+        }
         return;
       }
       if (blockRecord.type === "tool_result" && fallbackToolResult === undefined) {

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -141,41 +141,54 @@ function applyAnthropicCacheControlToMessages(
     return;
   }
 
-  const lastMessage = messages[messages.length - 1];
-  if (!lastMessage || typeof lastMessage !== "object") {
-    return;
-  }
+  let fallbackToolResult: Record<string, unknown> | undefined;
 
-  const record = lastMessage as Record<string, unknown>;
-  if (record.role !== "user") {
-    return;
-  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
 
-  const content = record.content;
-  if (Array.isArray(content)) {
-    const lastBlock = content[content.length - 1];
-    if (!lastBlock || typeof lastBlock !== "object") {
+    const record = message as Record<string, unknown>;
+    if (record.role !== "user") {
+      continue;
+    }
+
+    const content = record.content;
+    if (typeof content === "string") {
+      record.content = [
+        {
+          type: "text",
+          text: content,
+          cache_control: cacheControl,
+        },
+      ];
       return;
     }
-    const lastBlockRecord = lastBlock as Record<string, unknown>;
-    if (
-      lastBlockRecord.type === "text" ||
-      lastBlockRecord.type === "image" ||
-      lastBlockRecord.type === "tool_result"
-    ) {
-      lastBlockRecord.cache_control = cacheControl;
+
+    if (!Array.isArray(content)) {
+      continue;
     }
-    return;
+
+    for (let j = content.length - 1; j >= 0; j--) {
+      const block = content[j];
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+
+      const blockRecord = block as Record<string, unknown>;
+      if (blockRecord.type === "text" || blockRecord.type === "image") {
+        blockRecord.cache_control = cacheControl;
+        return;
+      }
+      if (blockRecord.type === "tool_result" && fallbackToolResult === undefined) {
+        fallbackToolResult = blockRecord;
+      }
+    }
   }
 
-  if (typeof content === "string") {
-    record.content = [
-      {
-        type: "text",
-        text: content,
-        cache_control: cacheControl,
-      },
-    ];
+  if (fallbackToolResult) {
+    fallbackToolResult.cache_control = cacheControl;
   }
 }
 

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -41,6 +41,8 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
+const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+
 /**
  * Resolve cache retention preference.
  * Defaults to "short" and uses OPENCLAW_CACHE_RETENTION for backward compatibility.
@@ -939,9 +941,27 @@ function buildParams(
   options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
+  const systemCacheControlCount = !cacheControl
+    ? 0
+    : isOAuthTokenResult
+      ? 1 + (context.systemPrompt ? 1 : 0)
+      : context.systemPrompt
+        ? 1
+        : 0;
+  const toolCacheControlCount = cacheControl && context.tools?.length ? 1 : 0;
+  const messageCacheControlLimit = Math.max(
+    0,
+    ANTHROPIC_CACHE_CONTROL_LIMIT - systemCacheControlCount - toolCacheControlCount,
+  );
   const params: MessageCreateParamsStreaming = {
     model: model.id,
-    messages: convertMessages(context.messages, model, isOAuthTokenResult, cacheControl),
+    messages: convertMessages(
+      context.messages,
+      model,
+      isOAuthTokenResult,
+      cacheControl,
+      messageCacheControlLimit,
+    ),
     max_tokens: options?.maxTokens ?? model.maxTokens,
     stream: true,
   };
@@ -1041,6 +1061,7 @@ function convertMessages(
   model: Model<"anthropic-messages">,
   isOAuthTokenValue: boolean,
   cacheControl?: CacheControlEphemeral,
+  messageCacheControlLimit = 4,
 ): MessageParam[] {
   const params: MessageParam[] = [];
 
@@ -1178,7 +1199,7 @@ function convertMessages(
     }
   }
 
-  if (cacheControl && params.length > 0) {
+  if (cacheControl && params.length > 0 && messageCacheControlLimit > 0) {
     let fallbackToolResult: ContentBlockParam | undefined;
 
     for (let i = params.length - 1; i >= 0; i--) {
@@ -1191,14 +1212,13 @@ function convertMessages(
         for (let j = message.content.length - 1; j >= 0; j--) {
           const block = message.content[j];
           if (block.type === "text" || block.type === "image") {
-            (block as typeof block & { cache_control?: typeof cacheControl }).cache_control =
-              cacheControl;
-            if (fallbackToolResult) {
-              (
-                fallbackToolResult as typeof fallbackToolResult & {
-                  cache_control?: typeof cacheControl;
-                }
-              ).cache_control = cacheControl;
+            if (fallbackToolResult && messageCacheControlLimit === 1) {
+              applyContentBlockCacheControl(fallbackToolResult, cacheControl);
+              return params;
+            }
+            applyContentBlockCacheControl(block, cacheControl);
+            if (fallbackToolResult && messageCacheControlLimit > 1) {
+              applyContentBlockCacheControl(fallbackToolResult, cacheControl);
             }
             return params;
           }
@@ -1210,6 +1230,10 @@ function convertMessages(
       }
 
       if (typeof message.content === "string") {
+        if (fallbackToolResult && messageCacheControlLimit === 1) {
+          applyContentBlockCacheControl(fallbackToolResult, cacheControl);
+          return params;
+        }
         message.content = [
           {
             type: "text",
@@ -1217,16 +1241,15 @@ function convertMessages(
             cache_control: cacheControl,
           },
         ] as ContentBlockParam[];
+        if (fallbackToolResult && messageCacheControlLimit > 1) {
+          applyContentBlockCacheControl(fallbackToolResult, cacheControl);
+        }
         return params;
       }
     }
 
     if (fallbackToolResult) {
-      (
-        fallbackToolResult as typeof fallbackToolResult & {
-          cache_control?: typeof cacheControl;
-        }
-      ).cache_control = cacheControl;
+      applyContentBlockCacheControl(fallbackToolResult, cacheControl);
     }
   }
 
@@ -1266,6 +1289,14 @@ function buildSystemPromptBlocks(
     blocks.push({ type: "text", text: sanitizeSurrogates(split.dynamicSuffix) });
   }
   return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
+}
+
+function applyContentBlockCacheControl(
+  block: ContentBlockParam,
+  cacheControl: CacheControlEphemeral,
+): void {
+  (block as ContentBlockParam & { cache_control?: CacheControlEphemeral }).cache_control =
+    cacheControl;
 }
 
 function shouldUseFineGrainedToolStreamingBeta(

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -941,14 +941,19 @@ function buildParams(
   options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
-  const systemCacheControlCount = !cacheControl
-    ? 0
-    : isOAuthTokenResult
-      ? 1 + (context.systemPrompt ? 1 : 0)
-      : context.systemPrompt
-        ? 1
-        : 0;
-  const toolCacheControlCount = cacheControl && context.tools?.length ? 1 : 0;
+  const system = buildAnthropicSystemBlocks(context.systemPrompt, isOAuthTokenResult, cacheControl);
+  const compat = context.tools?.length ? getAnthropicCompat(model) : undefined;
+  const tools =
+    context.tools && compat
+      ? convertTools(
+          context.tools,
+          isOAuthTokenResult,
+          compat.supportsEagerToolInputStreaming,
+          compat.supportsCacheControlOnTools ? cacheControl : undefined,
+        )
+      : undefined;
+  const systemCacheControlCount = countNativeCacheControlMarkers(system);
+  const toolCacheControlCount = countNativeCacheControlMarkers(tools);
   const messageCacheControlLimit = Math.max(
     0,
     ANTHROPIC_CACHE_CONTROL_LIMIT - systemCacheControlCount - toolCacheControlCount,
@@ -966,20 +971,8 @@ function buildParams(
     stream: true,
   };
 
-  // For OAuth tokens, we MUST include Claude Code identity
-  if (isOAuthTokenResult) {
-    params.system = [
-      {
-        type: "text",
-        text: "You are Claude Code, Anthropic's official CLI for Claude.",
-        ...(cacheControl ? { cache_control: cacheControl } : {}),
-      },
-    ];
-    if (context.systemPrompt) {
-      params.system.push(...buildSystemPromptBlocks(context.systemPrompt, cacheControl));
-    }
-  } else if (context.systemPrompt) {
-    params.system = buildSystemPromptBlocks(context.systemPrompt, cacheControl);
+  if (system) {
+    params.system = system;
   }
 
   // Temperature is incompatible with extended thinking (adaptive or budget-based).
@@ -991,14 +984,8 @@ function buildParams(
     params.stop_sequences = options.stop;
   }
 
-  if (context.tools && context.tools.length > 0) {
-    const compat = getAnthropicCompat(model);
-    params.tools = convertTools(
-      context.tools,
-      isOAuthTokenResult,
-      compat.supportsEagerToolInputStreaming,
-      compat.supportsCacheControlOnTools ? cacheControl : undefined,
-    );
+  if (tools && tools.length > 0) {
+    params.tools = tools;
   }
 
   // Configure thinking mode: adaptive (Opus 4.6+ and Sonnet 4.6),
@@ -1256,6 +1243,33 @@ function convertMessages(
   return params;
 }
 
+function applyContentBlockCacheControl(
+  block: ContentBlockParam,
+  cacheControl: CacheControlEphemeral,
+): void {
+  (block as ContentBlockParam & { cache_control?: CacheControlEphemeral }).cache_control =
+    cacheControl;
+}
+
+function buildAnthropicSystemBlocks(
+  systemPrompt: string | undefined,
+  isOAuthTokenResult: boolean,
+  cacheControl: CacheControlEphemeral | undefined,
+): TextBlockParam[] | undefined {
+  const blocks: TextBlockParam[] = [];
+  if (isOAuthTokenResult) {
+    blocks.push({
+      type: "text",
+      text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      ...(cacheControl ? { cache_control: cacheControl } : {}),
+    });
+  }
+  if (systemPrompt) {
+    blocks.push(...buildSystemPromptBlocks(systemPrompt, cacheControl));
+  }
+  return blocks.length > 0 ? blocks : undefined;
+}
+
 function buildSystemPromptBlocks(
   systemPrompt: string,
   cacheControl: CacheControlEphemeral | undefined,
@@ -1291,12 +1305,18 @@ function buildSystemPromptBlocks(
   return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
 }
 
-function applyContentBlockCacheControl(
-  block: ContentBlockParam,
-  cacheControl: CacheControlEphemeral,
-): void {
-  (block as ContentBlockParam & { cache_control?: CacheControlEphemeral }).cache_control =
-    cacheControl;
+function countNativeCacheControlMarkers(blocks: unknown): number {
+  if (!Array.isArray(blocks)) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const block of blocks) {
+    if (block && typeof block === "object" && "cache_control" in block) {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function shouldUseFineGrainedToolStreamingBeta(

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1193,6 +1193,13 @@ function convertMessages(
           if (block.type === "text" || block.type === "image") {
             (block as typeof block & { cache_control?: typeof cacheControl }).cache_control =
               cacheControl;
+            if (fallbackToolResult) {
+              (
+                fallbackToolResult as typeof fallbackToolResult & {
+                  cache_control?: typeof cacheControl;
+                }
+              ).cache_control = cacheControl;
+            }
             return params;
           }
           if (block.type === "tool_result" && fallbackToolResult === undefined) {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1151,8 +1151,6 @@ function convertMessages(
     } else if (msg.role === "toolResult") {
       // Collect all consecutive toolResult messages, needed for z.ai Anthropic endpoint
       const toolResults: ContentBlockParam[] = [];
-
-      // Add the current tool result
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
@@ -1160,10 +1158,9 @@ function convertMessages(
         is_error: msg.isError,
       });
 
-      // Look ahead for consecutive toolResult messages
       let j = i + 1;
       while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
-        const nextMsg = transformedMessages[j] as ToolResultMessage; // We know it's a toolResult
+        const nextMsg = transformedMessages[j] as ToolResultMessage;
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
@@ -1173,10 +1170,7 @@ function convertMessages(
         j++;
       }
 
-      // Skip the messages we've already processed
       i = j - 1;
-
-      // Add a single user message with all tool results
       params.push({
         role: "user",
         content: toolResults,
@@ -1184,13 +1178,10 @@ function convertMessages(
     }
   }
 
-  // Prefer the latest real user content over trailing tool-result carriers so
-  // tool loops do not move the conversation cache marker on every request.
   if (cacheControl && params.length > 0) {
     let fallbackToolResult: ContentBlockParam | undefined;
-    let applied = false;
 
-    for (let i = params.length - 1; i >= 0 && !applied; i--) {
+    for (let i = params.length - 1; i >= 0; i--) {
       const message = params[i];
       if (message.role !== "user") {
         continue;
@@ -1202,9 +1193,7 @@ function convertMessages(
           if (block.type === "text" || block.type === "image") {
             (block as typeof block & { cache_control?: typeof cacheControl }).cache_control =
               cacheControl;
-            fallbackToolResult = undefined;
-            applied = true;
-            break;
+            return params;
           }
           if (block.type === "tool_result" && fallbackToolResult === undefined) {
             fallbackToolResult = block;
@@ -1221,8 +1210,7 @@ function convertMessages(
             cache_control: cacheControl,
           },
         ] as ContentBlockParam[];
-        fallbackToolResult = undefined;
-        break;
+        return params;
       }
     }
 

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1184,30 +1184,54 @@ function convertMessages(
     }
   }
 
-  // Add cache_control to the last user message to cache conversation history
+  // Prefer the latest real user content over trailing tool-result carriers so
+  // tool loops do not move the conversation cache marker on every request.
   if (cacheControl && params.length > 0) {
-    const lastMessage = params[params.length - 1];
-    if (lastMessage.role === "user") {
-      if (Array.isArray(lastMessage.content)) {
-        const lastBlock = lastMessage.content[lastMessage.content.length - 1];
-        if (
-          lastBlock &&
-          (lastBlock.type === "text" ||
-            lastBlock.type === "image" ||
-            lastBlock.type === "tool_result")
-        ) {
-          (lastBlock as typeof lastBlock & { cache_control?: typeof cacheControl }).cache_control =
-            cacheControl;
+    let fallbackToolResult: ContentBlockParam | undefined;
+    let applied = false;
+
+    for (let i = params.length - 1; i >= 0 && !applied; i--) {
+      const message = params[i];
+      if (message.role !== "user") {
+        continue;
+      }
+
+      if (Array.isArray(message.content)) {
+        for (let j = message.content.length - 1; j >= 0; j--) {
+          const block = message.content[j];
+          if (block.type === "text" || block.type === "image") {
+            (block as typeof block & { cache_control?: typeof cacheControl }).cache_control =
+              cacheControl;
+            fallbackToolResult = undefined;
+            applied = true;
+            break;
+          }
+          if (block.type === "tool_result" && fallbackToolResult === undefined) {
+            fallbackToolResult = block;
+          }
         }
-      } else if (typeof lastMessage.content === "string") {
-        lastMessage.content = [
+        continue;
+      }
+
+      if (typeof message.content === "string") {
+        message.content = [
           {
             type: "text",
-            text: lastMessage.content,
+            text: message.content,
             cache_control: cacheControl,
           },
         ] as ContentBlockParam[];
+        fallbackToolResult = undefined;
+        break;
       }
+    }
+
+    if (fallbackToolResult) {
+      (
+        fallbackToolResult as typeof fallbackToolResult & {
+          cache_control?: typeof cacheControl;
+        }
+      ).cache_control = cacheControl;
     }
   }
 


### PR DESCRIPTION
## Summary

- Stabilizes Anthropic conversation cache marker placement during tool loops.
- Prefers the latest real user text/image block over trailing user-role `tool_result` carriers.
- Keeps the previous fallback behavior for degenerate histories that contain only tool results.
- Applies the same rule to the shared Anthropic payload policy and the native Anthropic message conversion path.

Fixes part of #86063.

## Why

In tool-heavy sessions, OpenClaw currently attaches the conversation cache marker to the newest user-role `tool_result`. That marker moves on every tool call, so the historical prefix changes even when the actual conversation content is stable. This causes repeated large cache writes instead of cache reads.

A live current-version evidence comment with sanitized payload/cost data is here:
https://github.com/openclaw/openclaw/issues/86063#issuecomment-4602637983

## Real behavior proof

- Behavior or issue addressed: Anthropic conversation-history cache control no longer moves from stable user text onto each trailing synthetic `tool_result` during tool loops.
- Real environment tested: MarvinMBP, macOS Sequoia 15.7.3, local OpenClaw `2026.6.1-beta.1 (13dd4e3)`, installed OpenClaw dist hotpatched from this PR, gateway restarted and running locally against a real Anthropic-compatible/Pioneer session payload captured from the affected setup.
- Exact steps or command run after this patch: Applied the patch to the installed OpenClaw dist, restarted/checked the gateway with `openclaw gateway status`, syntax-checked the patched provider bundles with `node --check`, then replayed the captured 102-message real provider payload through the installed patched Anthropic cache policy to compare marker placement before and after the fix.
- Evidence after fix: Terminal transcript from the local patched setup:

```text
$ openclaw gateway status
Runtime: running pid 38894
Connectivity probe: ok
Version: 2026.6.1-beta.1 (13dd4e3)
Gateway: listening on 127.0.0.1:18789

$ node --check /usr/local/lib/node_modules/openclaw/dist/anthropic-payload-policy-D0z5Wqp1.js
$ node --check /usr/local/lib/node_modules/openclaw/dist/anthropic-CeIct-Vo.js

$ node replay-installed-anthropic-cache-policy.mjs
sample: 2026-06-02T09:30:05.130Z provider=pioneer model=claude-opus-4-8 messages=102
before patch marker locations:
  system[0]
  tool[33]
  msg[101] user block[0] tool_result
after patched installed policy:
  system[0]
  tool[33]
  msg[63] user block[0] text
```

- Observed result after fix: The conversation cache marker stays on the latest real user text block instead of following the newest tool-result carrier, so a tool loop no longer invalidates the stable conversation prefix on every tool call. Existing tool-definition and system cache markers remain unchanged.
- What was not tested: I did not force a fresh paid live provider call solely for this proof because the sanitized captured payload already came from the affected real setup and reproduces the marker movement deterministically. The broad local `pnpm tsgo:test:src` command hung with no output after several minutes and was stopped.

## Tests

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts -- src/agents/anthropic-payload-policy.test.ts

Test Files  1 passed (1)
Tests       10 passed (10)
```

Also run:

```text
git diff --check
```

`pnpm tsgo:test:src` was attempted locally but hung with no output after several minutes and was stopped, so I am not claiming that check passed.

## AI assistance

This PR was prepared with AI assistance on a human-operated OpenClaw instance, using sanitized payload-location/counter evidence only. No user message contents, account identifiers, API keys, or private session transcript text are included.
