### PR TITLE
Config: preserve implicit main route bindings

### DIFF
--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { runPluginSetupConfigMigrations } from "../../../plugins/setup-registry.js";
-import { normalizeAgentId } from "../../../routing/session-key.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../../routing/session-key.js";
 import { migrateLegacySecretRefEnvMarkers } from "../../../secrets/legacy-secretref-env-marker.js";
 import { applyChannelDoctorCompatibilityMigrations } from "./channel-legacy-config-migrate.js";
 import { normalizeBaseCompatibilityConfigValues } from "./legacy-config-compatibility-base.js";
@@ -23,7 +23,10 @@ function pruneBindingsForMissingAgents(cfg: OpenClawConfig, changes: string[]): 
     return cfg;
   }
 
-  const agentIds = new Set(validAgents.map((agent) => normalizeAgentId(agent.id)));
+  const agentIds = new Set([
+    normalizeAgentId(DEFAULT_AGENT_ID),
+    ...validAgents.map((agent) => normalizeAgentId(agent.id)),
+  ]);
   const nextBindings = bindings.filter((binding) => {
     const agentId = binding && typeof binding === "object" ? binding.agentId : undefined;
     return typeof agentId !== "string" || agentIds.has(normalizeAgentId(agentId));

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -44,6 +44,33 @@ describe("compatibility binding repair migrate", () => {
     expect(res.changes).toContain("Removed 1 binding that referenced missing agents.list ids.");
   });
 
+  it('preserves bindings for the implicit default agent "main" when agents.list is valid', () => {
+    const bindings = [
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "discord", accountId: "default" },
+      },
+      {
+        type: "route",
+        agentId: "main",
+        match: { channel: "telegram", accountId: "default" },
+      },
+    ];
+
+    const res = normalizeCompatibilityConfigValues({
+      agents: {
+        list: [{ id: "codex" }, { id: "claude" }],
+      },
+      bindings,
+    } as OpenClawConfig);
+
+    expect(res.config.bindings).toEqual(bindings);
+    expect(res.changes).not.toContain(
+      "Removed 2 bindings that referenced missing agents.list ids.",
+    );
+  });
+
   it("leaves bindings untouched when agents.list has malformed entries", () => {
     const cfg = {
       agents: {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -457,6 +457,31 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts route bindings to the implicit default agent "main" when agents.list is populated', () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          { id: "codex", model: "anthropic/claude-3-5-sonnet" },
+          { id: "claude", model: "anthropic/claude-3-5-sonnet" },
+        ],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "discord", accountId: "default" },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "telegram", accountId: "default" },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts bindings that match normalized agents.list ids", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -5,7 +5,7 @@ import {
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import {
   isValidControlUiChatMessageMaxWidth,
   normalizeControlUiChatMessageMaxWidth,
@@ -1283,7 +1283,10 @@ export const OpenClawSchema = z
       return;
     }
     const agentIds = new Set(agents.map((agent) => agent.id));
-    const effectiveAgentIds = new Set(agents.map((agent) => normalizeAgentId(agent.id)));
+    const effectiveAgentIds = new Set([
+      normalizeAgentId(DEFAULT_AGENT_ID),
+      ...agents.map((agent) => normalizeAgentId(agent.id)),
+    ]);
 
     // Bindings referencing a missing agent id silently misroute at gateway
     // load time. Match routing's normalized id semantics; otherwise valid


### PR DESCRIPTION
## Summary
- Treat the implicit default agent `main` as an allowed route binding target during config validation, even when `agents.list` is populated.
- Preserve `main` route bindings during doctor compatibility pruning while continuing to prune genuinely missing agent ids.
- Add regression coverage for the documented ACP multi-agent shape with `codex`/`claude` in `agents.list` and fallback bindings to `main`.

Fixes #89412

## Test plan
- RED: `node scripts/run-vitest.mjs src/config/config.schema-regressions.test.ts --run` failed on the new `main` binding validation regression.
- RED: `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts --run` failed on the new doctor preservation regression.
- GREEN: `node scripts/run-vitest.mjs src/config/config.schema-regressions.test.ts src/commands/doctor/shared/legacy-config-migrate.test.ts --run` passed: 2 Vitest shards, 137 tests.
- `pnpm check` passed.
- `pnpm build` passed.

— Seraphel
