### PR TITLE
fix(openai): harden Codex OAuth callback cleanup

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f6306d8082be6dcde00435a02db2a5cf46f0983fccb8ed6a39a60f1931546fce  plugin-sdk-api-baseline.json
-7c11aba346798e6db5be30a9b61141d1904a09764ea029656fd0fca79929df61  plugin-sdk-api-baseline.jsonl
+4440586f2797bc47ac5085d962feaab844d921acaba4e3b2f754c76f70a4f1a5  plugin-sdk-api-baseline.json
+88ab286e2484b5178a5447cd880372c773a11f3bf3a73a54759aa5bff55f5957  plugin-sdk-api-baseline.jsonl

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -1,5 +1,6 @@
 // Openai tests cover openai chatgpt oauth flow plugin behavior.
-import { createServer, type Server } from "node:http";
+import { Agent, createServer, get, type IncomingHttpHeaders, type Server } from "node:http";
+import type { ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ssrfMocks = vi.hoisted(() => ({
@@ -20,9 +21,34 @@ import {
   exchangeOpenAIAuthorizationCode,
   refreshOpenAIAccessToken,
 } from "./openai-chatgpt-oauth-token.runtime.js";
+import { loginOpenAICodexOAuth } from "./openai-chatgpt-oauth.runtime.js";
 
 function timeoutError(): Error {
   return new DOMException("timed out", "TimeoutError");
+}
+
+function fakeJwt(payload: unknown): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "test-signature",
+  ].join(".");
+}
+
+function requestCallback(
+  url: string,
+  agent: Agent,
+): Promise<{ headers: IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const request = get(url, { agent }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        resolve({ headers: response.headers, body: Buffer.concat(chunks).toString("utf8") });
+      });
+    });
+    request.on("error", reject);
+  });
 }
 
 function mockTokenResponse(body: unknown, status = 200): void {
@@ -41,6 +67,7 @@ function mockTokenResponseText(body: string, status = 200): void {
 
 afterEach(() => {
   ssrfMocks.fetchWithSsrFGuard.mockReset();
+  vi.unstubAllGlobals();
 });
 
 describe("OpenAI Codex OAuth flow", () => {
@@ -97,6 +124,88 @@ describe("OpenAI Codex OAuth flow", () => {
     expect(() => resolveOpenAICallbackHost({ OPENCLAW_OAUTH_CALLBACK_HOST: "0.0.0.0" })).toThrow(
       "callback host must be localhost, 127.0.0.1, or ::1",
     );
+  });
+
+  it("disconnects a keep-alive callback and cancels stale manual input", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 302 })),
+    );
+    const testJwt = fakeJwt({
+      "https://api.openai.com/auth": { chatgpt_account_id: "acct-test" },
+    });
+    mockTokenResponse({
+      access_token: testJwt,
+      refresh_token: "test-refresh-token",
+      expires_in: 3600,
+    });
+    const agent = new Agent({ keepAlive: true });
+    let callbackResponse: Promise<{ headers: IncomingHttpHeaders; body: string }> | undefined;
+    let manualPromptAborted = false;
+    let manualPrompt: Promise<string> | undefined;
+    const prompter = {
+      note: vi.fn(async () => undefined),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      text: vi.fn(
+        (params: { signal?: AbortSignal }) =>
+          new Promise<string>((_resolve, reject) => {
+            params.signal?.addEventListener(
+              "abort",
+              () => {
+                manualPromptAborted = true;
+                reject(new Error("manual prompt aborted"));
+              },
+              { once: true },
+            );
+          }),
+      ),
+    } as unknown as ProviderAuthContext["prompter"];
+    const oauth = {
+      createVpsAwareHandlers: vi.fn(
+        (params: Parameters<ProviderAuthContext["oauth"]["createVpsAwareHandlers"]>[0]) => ({
+          onAuth: async ({ url }: { url: string }) => {
+            const authUrl = new URL(url);
+            const redirectUri = authUrl.searchParams.get("redirect_uri");
+            const state = authUrl.searchParams.get("state");
+            if (!redirectUri || !state) {
+              throw new Error("OAuth URL missing callback parameters");
+            }
+            manualPrompt = params.prompter.text({
+              message: "Paste callback",
+              signal: params.manualPromptSignal,
+            });
+            callbackResponse = requestCallback(
+              `${redirectUri}?state=${state}&code=callback-code`,
+              agent,
+            );
+            await callbackResponse;
+          },
+          onPrompt: async () => await (manualPrompt ?? Promise.reject(new Error("no prompt"))),
+        }),
+      ),
+    } satisfies ProviderAuthContext["oauth"];
+
+    try {
+      await expect(
+        loginOpenAICodexOAuth({
+          prompter,
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          oauth,
+          isRemote: true,
+          openUrl: vi.fn(async () => undefined),
+        }),
+      ).resolves.toMatchObject({ access: testJwt, accountId: "acct-test" });
+      if (!callbackResponse) {
+        throw new Error("OAuth callback request was not started");
+      }
+      const response = await callbackResponse;
+      expect(response.headers.connection).toBe("close");
+      expect(response.body).toContain("OpenAI authentication completed");
+      await vi.waitFor(() => expect(manualPromptAborted).toBe(true));
+      expect(Object.keys(agent.freeSockets)).toHaveLength(0);
+    } finally {
+      agent.destroy();
+    }
   });
 
   it("times out token exchange requests", async () => {

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -92,6 +92,19 @@ type OAuthServerInfo = {
   waitForCode: () => Promise<{ code: string } | null>;
 };
 
+function sendOAuthHtmlResponse(
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  html: string,
+): void {
+  res.statusCode = statusCode;
+  // Callback browsers may reuse HTTP/1.1 connections. Force disconnect after
+  // the response so an accepted socket cannot keep the auth process alive.
+  res.setHeader("Connection", "close");
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.end(html);
+}
+
 async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
   const { http } = await loadNodeOAuthRuntime();
   let settleWait: ((value: { code: string } | null) => void) | undefined;
@@ -110,32 +123,30 @@ async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
     try {
       const url = new URL(req.url || "", "http://localhost");
       if (url.pathname !== "/auth/callback") {
-        res.statusCode = 404;
-        res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.end(oauthErrorHtml("Callback route not found."));
+        sendOAuthHtmlResponse(res, 404, oauthErrorHtml("Callback route not found."));
         return;
       }
       if (url.searchParams.get("state") !== state) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.end(oauthErrorHtml("State mismatch."));
+        sendOAuthHtmlResponse(res, 400, oauthErrorHtml("State mismatch."));
         return;
       }
       const code = url.searchParams.get("code");
       if (!code) {
-        res.statusCode = 400;
-        res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.end(oauthErrorHtml("Missing authorization code."));
+        sendOAuthHtmlResponse(res, 400, oauthErrorHtml("Missing authorization code."));
         return;
       }
-      res.statusCode = 200;
-      res.setHeader("Content-Type", "text/html; charset=utf-8");
-      res.end(oauthSuccessHtml("OpenAI authentication completed. You can close this window."));
+      sendOAuthHtmlResponse(
+        res,
+        200,
+        oauthSuccessHtml("OpenAI authentication completed. You can close this window."),
+      );
       settleWait?.({ code });
     } catch {
-      res.statusCode = 500;
-      res.setHeader("Content-Type", "text/html; charset=utf-8");
-      res.end(oauthErrorHtml("Internal error while processing OAuth callback."));
+      sendOAuthHtmlResponse(
+        res,
+        500,
+        oauthErrorHtml("Internal error while processing OAuth callback."),
+      );
     }
   });
 

--- a/extensions/openai/openai-chatgpt-oauth.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.ts
@@ -231,6 +231,7 @@ export async function loginOpenAICodexOAuth(params: {
   const waitForLoginToSettle = new Promise<void>((resolve) => {
     markLoginSettled = resolve;
   });
+  const manualPromptAbort = new AbortController();
   try {
     const { onAuth: baseOnAuth, onPrompt } = params.oauth.createVpsAwareHandlers({
       isRemote,
@@ -240,6 +241,7 @@ export async function loginOpenAICodexOAuth(params: {
       openUrl,
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser...",
       manualPromptMessage: manualInputPromptMessage,
+      manualPromptSignal: manualPromptAbort.signal,
     });
     const onAuth = async (event: Parameters<typeof baseOnAuth>[0]) => {
       browserAuthStarted = true;
@@ -273,6 +275,7 @@ export async function loginOpenAICodexOAuth(params: {
     await prompter.note("Trouble with OAuth? See https://docs.openclaw.ai/start/faq", "OAuth help");
     throw rewrittenError;
   } finally {
+    manualPromptAbort.abort();
     markLoginSettled();
   }
 }

--- a/src/plugins/provider-oauth-flow.test.ts
+++ b/src/plugins/provider-oauth-flow.test.ts
@@ -27,4 +27,35 @@ describe("createVpsAwareOAuthHandlers", () => {
     );
     await expect(handlers.onPrompt({ message: "Paste callback" })).resolves.toBe("callback-value");
   });
+
+  it("forwards prompt cancellation to remote manual entry", async () => {
+    const controller = new AbortController();
+    const text = vi.fn(
+      (params: { signal?: AbortSignal }) =>
+        new Promise<string>((_resolve, reject) => {
+          params.signal?.addEventListener("abort", () => reject(new Error("prompt aborted")), {
+            once: true,
+          });
+        }),
+    );
+    const handlers = createVpsAwareOAuthHandlers({
+      isRemote: true,
+      prompter: {
+        note: vi.fn(async () => undefined),
+        text,
+      } as unknown as WizardPrompter,
+      runtime: { log: vi.fn() } as unknown as RuntimeEnv,
+      spin: { update: vi.fn(), stop: vi.fn() } as ReturnType<WizardPrompter["progress"]>,
+      openUrl: vi.fn(async () => undefined),
+      localBrowserMessage: "Opening browser",
+      manualPromptSignal: controller.signal,
+    });
+
+    await handlers.onAuth({ url: "https://provider.example/oauth?state=state-1" });
+    const prompt = handlers.onPrompt({ message: "Paste callback" });
+    controller.abort();
+
+    await expect(prompt).rejects.toThrow("prompt aborted");
+    expect(text).toHaveBeenCalledWith(expect.objectContaining({ signal: controller.signal }));
+  });
 });

--- a/src/plugins/provider-oauth-flow.ts
+++ b/src/plugins/provider-oauth-flow.ts
@@ -16,6 +16,7 @@ export function createVpsAwareOAuthHandlers(params: {
   openUrl: (url: string) => Promise<unknown>;
   localBrowserMessage: string;
   manualPromptMessage?: string;
+  manualPromptSignal?: AbortSignal;
 }): {
   onAuth: (event: { url: string }) => Promise<void>;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
@@ -36,6 +37,7 @@ export function createVpsAwareOAuthHandlers(params: {
         );
         manualCodePromise = params.prompter.text({
           message: manualPromptMessage,
+          signal: params.manualPromptSignal,
           validate: validateRequiredInput,
         });
         return;
@@ -52,6 +54,7 @@ export function createVpsAwareOAuthHandlers(params: {
       const code = await params.prompter.text({
         message: prompt.message,
         placeholder: prompt.placeholder,
+        signal: params.manualPromptSignal,
         validate: validateRequiredInput,
       });
       return code;

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -80,7 +80,7 @@ vi.mock("./clack-navigation-prompts.js", () => ({
 
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { createClackPrompter, tokenizedOptionFilter } from "./clack-prompter.js";
-import { WizardNavigationError } from "./prompts.js";
+import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -258,6 +258,27 @@ describe("createClackPrompter", () => {
         navigation: { canGoBack: true, canGoForward: true },
         signal: expect.any(AbortSignal),
       }),
+    );
+  });
+
+  it("cancels text prompts silently when their owner aborts them", async () => {
+    const controller = new AbortController();
+    clackMocks.isCancel.mockReturnValueOnce(true);
+    clackMocks.text.mockImplementation(
+      async ({ signal }: { signal?: AbortSignal }) =>
+        await new Promise<symbol>((resolve) => {
+          signal?.addEventListener("abort", () => resolve(Symbol("clack:cancel")), { once: true });
+        }),
+    );
+    const prompter = createClackPrompter();
+
+    const prompt = prompter.text({ message: "Paste callback", signal: controller.signal });
+    controller.abort();
+
+    await expect(prompt).rejects.toBeInstanceOf(WizardCancelledError);
+    expect(clackMocks.cancel).not.toHaveBeenCalled();
+    expect(clackMocks.text).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
     );
   });
 

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -43,9 +43,11 @@ const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
 
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
 // converts the generic wizard prompt contract into styled Clack prompts.
-function guardCancel<T>(value: T | symbol): T {
+function guardCancel<T>(value: T | symbol, signal?: AbortSignal): T {
   if (isCancel(value)) {
-    cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    if (!signal?.aborted) {
+      cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    }
     throw new WizardCancelledError();
   }
   return value;
@@ -99,12 +101,16 @@ async function withHorizontalCursorActionsDisabled<T>(
 async function runPromptWithNavigation<T>(
   navigation: WizardPromptNavigation | undefined,
   work: (signal: AbortSignal | undefined) => Promise<T | symbol>,
+  externalSignal?: AbortSignal,
 ): Promise<T> {
   if (!hasPromptNavigation(navigation)) {
-    return guardCancel(await work(undefined));
+    return guardCancel(await work(externalSignal), externalSignal);
   }
 
   const controller = new AbortController();
+  const signal = externalSignal
+    ? AbortSignal.any([controller.signal, externalSignal])
+    : controller.signal;
   let navigationDirection: "back" | "forward" | undefined;
   const onKeypress = (_input: string | undefined, key: KeypressInfo | undefined) => {
     const nextDirection = resolveNavigationDirection(navigation, key);
@@ -117,11 +123,11 @@ async function runPromptWithNavigation<T>(
 
   try {
     process.stdin.on("keypress", onKeypress);
-    const value = await work(controller.signal);
+    const value = await work(signal);
     if (navigationDirection) {
       throw new WizardNavigationError(navigationDirection);
     }
-    return guardCancel(value);
+    return guardCancel(value, externalSignal);
   } finally {
     process.stdin.off("keypress", onKeypress);
   }
@@ -257,38 +263,42 @@ export function createClackPrompter(): WizardPrompter {
       return await withHorizontalCursorActionsDisabled(
         hasPromptNavigation(params.navigation),
         async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) => {
-            const message = stylePromptMessage(params.message);
-            const validateInput = validate
-              ? (value: string | undefined) => validate(value ?? "")
-              : undefined;
-            if (params.sensitive) {
+          await runPromptWithNavigation(
+            params.navigation,
+            async (signal) => {
+              const message = stylePromptMessage(params.message);
+              const validateInput = validate
+                ? (value: string | undefined) => validate(value ?? "")
+                : undefined;
+              if (params.sensitive) {
+                return params.navigation
+                  ? await passwordWithNavigationFooter({
+                      message,
+                      validate: validateInput,
+                      navigation: params.navigation,
+                      signal,
+                    })
+                  : await password({ message, validate: validateInput, signal });
+              }
               return params.navigation
-                ? await passwordWithNavigationFooter({
+                ? await textWithNavigationFooter({
                     message,
+                    initialValue: params.initialValue,
+                    placeholder: params.placeholder,
                     validate: validateInput,
                     navigation: params.navigation,
                     signal,
                   })
-                : await password({ message, validate: validateInput, signal });
-            }
-            return params.navigation
-              ? await textWithNavigationFooter({
-                  message,
-                  initialValue: params.initialValue,
-                  placeholder: params.placeholder,
-                  validate: validateInput,
-                  navigation: params.navigation,
-                  signal,
-                })
-              : await text({
-                  message,
-                  initialValue: params.initialValue,
-                  placeholder: params.placeholder,
-                  validate: validateInput,
-                  signal,
-                });
-          }),
+                : await text({
+                    message,
+                    initialValue: params.initialValue,
+                    placeholder: params.placeholder,
+                    validate: validateInput,
+                    signal,
+                  });
+            },
+            params.signal,
+          ),
       );
     },
     confirm: async (params) =>

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -31,6 +31,7 @@ type WizardTextParams = {
   initialValue?: string;
   placeholder?: string;
   validate?: (value: string) => string | undefined;
+  signal?: AbortSignal;
   // Render as a masked input. The entered value is never echoed to the
   // terminal — keeps secrets out of scrollback, transcripts, and screenshots.
   sensitive?: boolean;


### PR DESCRIPTION
## Summary

Closes #81865.

Successful OpenAI OAuth callbacks could leave the local callback connection or the already-started manual-entry prompt alive after login had otherwise finished. This made the CLI appear hung.

This change:

- sends every local callback response with an explicit `Connection: close`
- gives the owner flow an abort signal for the manual-entry prompt
- aborts that prompt when browser login settles
- preserves navigation cancellation semantics while keeping owner-driven cleanup silent

The original fake-IP/SSRF-policy and token-parsing changes are intentionally excluded. They need a separate maintainer and security decision with a current proxy reproduction.

Contributor credit preserved with `Co-authored-by: abnershang <abner.shang@gmail.com>`.

## Verification

- `node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts extensions/openai/openai-chatgpt-oauth.runtime.test.ts src/plugins/provider-oauth-flow.test.ts src/wizard/clack-prompter.test.ts`
  - Passed: 4 files, 31 tests.
- `node scripts/check-changed.mjs -- docs/.generated/plugin-sdk-api-baseline.sha256 extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts extensions/openai/openai-chatgpt-oauth-flow.runtime.ts extensions/openai/openai-chatgpt-oauth.runtime.test.ts extensions/openai/openai-chatgpt-oauth.runtime.ts src/plugins/provider-oauth-flow.test.ts src/plugins/provider-oauth-flow.ts src/wizard/clack-prompter.test.ts src/wizard/clack-prompter.ts src/wizard/prompts.ts`
  - Passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29559652147
- `git diff --check`
  - Passed.
- Fresh autoreview
  - No accepted or actionable findings.

## Real behavior proof

The deterministic loopback regression uses a real Node HTTP server and keep-alive client. It completes a successful callback, verifies the response body and `Connection: close` header, and proves the client has no reusable free socket afterward. A separate regression starts the fallback manual prompt and proves browser success aborts it and allows the OAuth flow to settle.

Upstream Codex carries the same explicit callback-disconnect contract in `codex-rs/login/src/server.rs`: its callback server bypasses normal response machinery to write `Connection: close`, flush, and terminate the accepted socket.

No OpenAI live-test credential or configured `CODEX_HOME` was available in this environment, so a real credentialed browser login was not rerun on this rewritten head.
