### PR TITLE
fix(mcp): quarantine invalid plugin tool schemas

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -1,8 +1,10 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
   rewrapToolWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "../agents/agent-tools.before-tool-call.js";
+import { projectRuntimeToolInputSchema } from "../agents/tool-schema-projection.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
@@ -12,34 +14,44 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
-function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
-  const params = tool.parameters;
-  if (params && typeof params === "object" && "type" in params) {
-    return params as Record<string, unknown>;
-  }
-  return { type: "object", properties: {} };
-}
+type McpPluginToolSnapshot = {
+  tool: AnyAgentTool;
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+type McpPluginToolEntryRead =
+  | {
+      readable: true;
+      tool: AnyAgentTool;
+      toolIndex: number;
+    }
+  | {
+      readable: false;
+      toolName: string;
+      violations: readonly string[];
+    };
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
-  const wrappedTools = tools.map((tool) => {
-    if (isToolWrappedWithBeforeToolCallHook(tool)) {
-      return rewrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
-    }
-    // The ACPX MCP bridge should enforce the same pre-execution hook boundary
-    // as the agent and HTTP tool execution paths.
-    return wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
+  const snapshots = snapshotMcpPluginTools(tools);
+  const wrappedTools = snapshots.map(({ tool, name, description, inputSchema }) => {
+    const wrapped = isToolWrappedWithBeforeToolCallHook(tool)
+      ? rewrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" })
+      : wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
+    return { tool: wrapped, name, description, inputSchema };
   });
   const toolMap = new Map<string, AnyAgentTool>();
-  for (const tool of wrappedTools) {
-    toolMap.set(tool.name, tool);
+  for (const entry of wrappedTools) {
+    toolMap.set(entry.name, entry.tool);
   }
 
   return {
     listTools: async () => ({
-      tools: wrappedTools.map((tool) => ({
-        name: tool.name,
-        description: tool.description ?? "",
-        inputSchema: resolveJsonSchemaForTool(tool),
+      tools: wrappedTools.map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
       })),
     }),
     callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {
@@ -69,4 +81,121 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
       }
     },
   };
+}
+
+function snapshotMcpPluginTools(tools: readonly AnyAgentTool[]): McpPluginToolSnapshot[] {
+  const snapshots: McpPluginToolSnapshot[] = [];
+  for (const entry of readMcpPluginToolEntries(tools)) {
+    if (!entry.readable) {
+      warnSkippedMcpPluginTool(entry.toolName, entry.violations);
+      continue;
+    }
+    const snapshot = snapshotMcpPluginTool(entry.tool, entry.toolIndex);
+    if (!snapshot.readable) {
+      warnSkippedMcpPluginTool(snapshot.toolName, snapshot.violations);
+      continue;
+    }
+    snapshots.push(snapshot);
+  }
+  return snapshots;
+}
+
+function readMcpPluginToolEntries(tools: readonly AnyAgentTool[]): McpPluginToolEntryRead[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [unreadableMcpPluginToolEntry(0)];
+  }
+  const entries: McpPluginToolEntryRead[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      const tool = tools[toolIndex];
+      if (!tool) {
+        entries.push(unreadableMcpPluginToolEntry(toolIndex));
+        continue;
+      }
+      entries.push({ readable: true, tool, toolIndex });
+    } catch {
+      entries.push(unreadableMcpPluginToolEntry(toolIndex));
+    }
+  }
+  return entries;
+}
+
+function unreadableMcpPluginToolEntry(toolIndex: number): McpPluginToolEntryRead {
+  const toolName = `tool[${toolIndex}]`;
+  return {
+    readable: false,
+    toolName,
+    violations: [`${toolName} is unreadable`],
+  };
+}
+
+function snapshotMcpPluginTool(
+  tool: AnyAgentTool,
+  toolIndex: number,
+):
+  | ({ readable: true } & McpPluginToolSnapshot)
+  | { readable: false; toolName: string; violations: readonly string[] } {
+  const fallbackName = `tool[${toolIndex}]`;
+  const nameRead = readMcpPluginToolField(tool, "name");
+  const hasValidName =
+    nameRead.readable && typeof nameRead.value === "string" && nameRead.value.length > 0;
+  const name = hasValidName && typeof nameRead.value === "string" ? nameRead.value : fallbackName;
+  const violations: string[] = [];
+  if (!nameRead.readable) {
+    violations.push(`${name}.name is unreadable`);
+  } else if (!hasValidName) {
+    violations.push(`${name}.name must be a non-empty string`);
+  }
+
+  const descriptionRead = readMcpPluginToolField(tool, "description");
+  if (!descriptionRead.readable) {
+    violations.push(`${name}.description is unreadable`);
+  }
+
+  const parametersRead = readMcpPluginToolField(tool, "parameters");
+  if (!parametersRead.readable) {
+    violations.push(`${name}.parameters is unreadable`);
+  }
+
+  if (!descriptionRead.readable || !parametersRead.readable || violations.length > 0) {
+    return { readable: false, toolName: name, violations };
+  }
+  const parameters = parametersRead.value ?? { type: "object", properties: {} };
+  const projection = projectRuntimeToolInputSchema(parameters, `${name}.parameters`);
+  if (projection.violations.length > 0) {
+    return { readable: false, toolName: name, violations: projection.violations };
+  }
+  return {
+    readable: true,
+    tool,
+    name,
+    description: typeof descriptionRead.value === "string" ? descriptionRead.value : "",
+    inputSchema: normalizeMcpInputSchema(projection.schema as Record<string, unknown>),
+  };
+}
+
+function normalizeMcpInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  return schema.type === undefined ? { ...schema, type: "object" } : schema;
+}
+
+function readMcpPluginToolField(
+  tool: AnyAgentTool,
+  field: "description" | "name" | "parameters",
+): { readable: true; value: unknown } | { readable: false } {
+  try {
+    return { readable: true, value: (tool as unknown as Record<string, unknown>)[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function warnSkippedMcpPluginTool(toolName: string, violations: readonly string[]): void {
+  const safeToolName = sanitizeForLog(toolName);
+  const safeViolations = violations.map((violation) => sanitizeForLog(violation)).join(", ");
+  process.stderr.write(
+    `plugin-tools-serve: skipped unsupported plugin tool ${safeToolName}: ${safeViolations}\n`,
+  );
 }

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -81,6 +81,25 @@ function requireToolPolicyParams(mock: ReturnType<typeof vi.fn>) {
   return params;
 }
 
+function createPluginToolWithUnreadableField(
+  field: "description" | "parameters",
+  params: { name: string; execute: ReturnType<typeof vi.fn> },
+): AnyAgentTool {
+  const tool = {
+    name: params.name,
+    description: "Unreadable plugin tool.",
+    parameters: { type: "object", properties: {} },
+    execute: params.execute,
+  };
+  Object.defineProperty(tool, field, {
+    enumerable: true,
+    get() {
+      throw new Error(`${field} getter exploded`);
+    },
+  });
+  return tool as unknown as AnyAgentTool;
+}
+
 describe("plugin tools MCP server", () => {
   it("routes logs to stderr before resolving tools for stdio", async () => {
     const { servePluginToolsMcp } = await import("./plugin-tools-serve.js");
@@ -172,6 +191,173 @@ describe("plugin tools MCP server", () => {
     expect(executeCall[2]).toBeUndefined();
     expect(executeCall[3]).toBeUndefined();
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
+  });
+
+  it("quarantines unreadable plugin tool descriptors before MCP listing and wrapping", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const healthyExecute = vi.fn().mockResolvedValue({ content: "healthy" });
+    const unreadableParametersExecute = vi.fn();
+    const unreadableDescriptionExecute = vi.fn();
+    const handlers = createPluginToolsMcpHandlers([
+      {
+        name: "memory_recall",
+        description: "Recall stored memory",
+        parameters: { type: "object", properties: {} },
+        execute: healthyExecute,
+      } as unknown as AnyAgentTool,
+      createPluginToolWithUnreadableField("parameters", {
+        name: "bad_parameters",
+        execute: unreadableParametersExecute,
+      }),
+      createPluginToolWithUnreadableField("description", {
+        name: "bad_description",
+        execute: unreadableDescriptionExecute,
+      }),
+    ]);
+
+    const listed = await handlers.listTools();
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["memory_recall"]);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("bad_parameters.parameters is unreadable"),
+    );
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("bad_description.description is unreadable"),
+    );
+
+    const healthy = await handlers.callTool({ name: "memory_recall", arguments: {} });
+    expect(healthy.content).toEqual([{ type: "text", text: "healthy" }]);
+    expect(healthyExecute).toHaveBeenCalledTimes(1);
+    expect(unreadableParametersExecute).not.toHaveBeenCalled();
+    expect(unreadableDescriptionExecute).not.toHaveBeenCalled();
+  });
+
+  it("quarantines unreadable plugin tool entries while keeping healthy siblings", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const hiddenExecute = vi.fn();
+    const tools = [
+      {
+        name: "memory_recall",
+        description: "Recall stored memory",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(),
+      } as unknown as AnyAgentTool,
+      {
+        name: "hidden_bad_tool",
+        description: "Hidden bad tool",
+        parameters: { type: "object", properties: {} },
+        execute: hiddenExecute,
+      } as unknown as AnyAgentTool,
+    ];
+    Object.defineProperty(tools, "1", {
+      configurable: true,
+      get() {
+        throw new Error("tool entry getter exploded");
+      },
+    });
+
+    const handlers = createPluginToolsMcpHandlers(tools);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["memory_recall"]);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("tool[1] is unreadable"));
+    expect(hiddenExecute).not.toHaveBeenCalled();
+  });
+
+  it("quarantines runtime-incompatible plugin tool schemas before MCP listing", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const badExecute = vi.fn();
+    const handlers = createPluginToolsMcpHandlers([
+      {
+        name: "memory_recall",
+        description: "Recall stored memory",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(),
+      } as unknown as AnyAgentTool,
+      {
+        name: "dofbot_move_angles",
+        description: "Move Dofbot angles",
+        parameters: { type: "array", items: { type: "number" } },
+        execute: badExecute,
+      } as unknown as AnyAgentTool,
+    ]);
+
+    const listed = await handlers.listTools();
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["memory_recall"]);
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining('dofbot_move_angles.parameters.type must be "object"'),
+    );
+
+    const result = await handlers.callTool({ name: "dofbot_move_angles", arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: "Unknown tool: dofbot_move_angles" }]);
+    expect(badExecute).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes quarantined plugin tool diagnostics before writing stderr", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const badName = "bad_tool\n\u001b]0;pwned\u0007";
+
+    createPluginToolsMcpHandlers([
+      {
+        name: badName,
+        description: "Terminal escape fixture",
+        parameters: { type: "array", items: { type: "string" } },
+        execute: vi.fn(),
+      } as unknown as AnyAgentTool,
+    ]);
+
+    const rawMessage = String(stderr.mock.calls[0]?.[0] ?? "");
+    expect(rawMessage.endsWith("\n")).toBe(true);
+    const body = rawMessage.slice(0, -1);
+    expect(body).not.toContain("\n");
+    expect(body).not.toContain("\u001b");
+    expect(body).not.toContain("\u0007");
+    expect(body).toContain("bad_tool");
+    expect(body).toContain('bad_tool.parameters.type must be "object"');
+  });
+
+  it("keeps parameter-free plugin tools as empty-object MCP schemas", async () => {
+    const tool = {
+      name: "memory_ping",
+      description: "Ping memory",
+      execute: vi.fn(),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools).toEqual([
+      {
+        name: "memory_ping",
+        description: "Ping memory",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]);
+  });
+
+  it("adds the MCP-required object root type to accepted typeless schemas", async () => {
+    const tool = {
+      name: "memory_search",
+      description: "Search memory",
+      parameters: {
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+      execute: vi.fn(),
+    } as unknown as AnyAgentTool;
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const listed = await handlers.listTools();
+
+    expect(listed.tools[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
   });
 
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {


### PR DESCRIPTION
## Summary
- guard plugin MCP tool entries and descriptors before listing or wrapping them
- project plugin MCP input schemas through the runtime tool-schema contract and quarantine unsupported schemas
- normalize accepted MCP input schemas to include the MCP-required object root type
- sanitize quarantine diagnostics before writing plugin-controlled values to stderr

## Verification
- `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts`
- `./node_modules/.bin/oxlint src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `crabbox run --provider aws --fresh-pr openclaw/openclaw#89493 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` - provider `aws`, run `run_c2772ba9a57a`, lease `cbx_e66dab7253f6`, exit 0

## Real behavior proof
Behavior addressed: the plugin-tools MCP bridge now skips unreadable plugin tool entries/descriptors and schemas that cannot be represented by the runtime tool-schema contract instead of crashing or exposing unsupported MCP tool schemas.
Real environment tested: local macOS focused handler tests plus direct AWS Crabbox fresh-PR changed gate on Linux for openclaw/openclaw#89493.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89493 ... corepack pnpm check:changed`
Evidence after fix: local focused proof passed 2 files / 14 tests; autoreview returned no accepted/actionable findings; AWS Crabbox `run_c2772ba9a57a` on lease `cbx_e66dab7253f6` passed `pnpm check:changed` with exit 0.
Observed result after fix: healthy plugin tools remain listed/callable, quarantined plugin tools return unknown-tool errors without executing, accepted typeless schemas gain `type: "object"`, stderr diagnostics strip terminal-control input, and the changed core/coreTests lanes pass remotely.
What was not tested: a live third-party MCP client session; the focused tests cover the handler/list/call behavior directly.
