### PR TITLE
fix(agents): sanitize tool schema quarantine diagnostics

### DIFF
--- a/src/agents/tool-schema-quarantine.test.ts
+++ b/src/agents/tool-schema-quarantine.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import { logRuntimeToolSchemaQuarantine } from "./tool-schema-quarantine.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 describe("runtime tool schema quarantine logging", () => {
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
   it("does not re-read unreadable tool entries while logging diagnostics", () => {
     const tools = new Proxy([] as AnyAgentTool[], {
       get(target, property, receiver) {
@@ -26,5 +37,55 @@ describe("runtime tool schema quarantine logging", () => {
         runId: "run-fuzzplugin-unreadable-tool",
       }),
     ).not.toThrow();
+  });
+
+  it("sanitizes unsupported schema diagnostics before logging trusted quarantine events", async () => {
+    const capture = createWarnLogCapture("tool-schema-quarantine");
+    const blockedEvents: Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }>[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "tool.execution.blocked") {
+        blockedEvents.push(event);
+      }
+    });
+    try {
+      const toolName = "bad_tool\n\u001b]0;pwned\u0007";
+
+      logRuntimeToolSchemaQuarantine({
+        diagnostics: [
+          {
+            toolName,
+            toolIndex: 0,
+            violations: [`${toolName}.parameters.type must be "object"`],
+          },
+        ],
+        tools: [
+          {
+            name: toolName,
+            parameters: { type: "array", items: { type: "number" } },
+            execute: async () => ({ text: "never" }),
+          } as unknown as AnyAgentTool,
+        ],
+        runId: "run-fuzzplugin-terminal-control",
+      });
+
+      await waitForDiagnosticEventsDrained();
+      const warning = await capture.findText("quarantined 1 unsupported tool schema");
+      expect(warning).toBeDefined();
+      expect(warning).not.toContain("\n");
+      expect(warning).not.toContain("\u001b");
+      expect(warning).not.toContain("\u0007");
+      expect(warning).toContain("bad_tool");
+      expect(warning).toContain('bad_tool.parameters.type must be "object"');
+      expect(blockedEvents).toEqual([
+        expect.objectContaining({
+          toolName: "bad_tool",
+          deniedReason: "unsupported_tool_schema",
+          reason: 'bad_tool.parameters.type must be "object"',
+        }),
+      ]);
+    } finally {
+      unsubscribe();
+      capture.cleanup();
+    }
   });
 });

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -1,3 +1,4 @@
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -18,6 +19,11 @@ function readDiagnosticPluginId(params: {
   }
 }
 
+function sanitizeQuarantineDiagnosticText(value: string, fallback: string): string {
+  const sanitized = sanitizeForLog(value);
+  return sanitized.length > 0 ? sanitized : fallback;
+}
+
 export function logRuntimeToolSchemaQuarantine(params: {
   diagnostics: readonly RuntimeToolSchemaDiagnostic[];
   tools: readonly AnyAgentTool[];
@@ -31,19 +37,26 @@ export function logRuntimeToolSchemaQuarantine(params: {
   const summary = params.diagnostics
     .map((diagnostic) => {
       const pluginId = readDiagnosticPluginId({ tools: params.tools, diagnostic });
-      const owner = pluginId ? ` plugin=${pluginId}` : "";
+      const safeToolName = sanitizeQuarantineDiagnosticText(diagnostic.toolName, "unknown-tool");
+      const safePluginId = pluginId
+        ? sanitizeQuarantineDiagnosticText(pluginId, "unknown-plugin")
+        : undefined;
+      const reason = diagnostic.violations
+        .map((violation) => sanitizeQuarantineDiagnosticText(violation, "unsupported schema"))
+        .join(", ");
+      const owner = safePluginId ? ` plugin=${safePluginId}` : "";
       emitTrustedDiagnosticEvent({
         type: "tool.execution.blocked",
         runId: params.runId,
         ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
         ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-        toolName: diagnostic.toolName,
-        toolSource: pluginId ? "plugin" : "core",
-        ...(pluginId ? { toolOwner: pluginId } : {}),
+        toolName: safeToolName,
+        toolSource: safePluginId ? "plugin" : "core",
+        ...(safePluginId ? { toolOwner: safePluginId } : {}),
         deniedReason: "unsupported_tool_schema",
-        reason: diagnostic.violations.join(", "),
+        reason,
       });
-      return `${diagnostic.toolName}${owner}: ${diagnostic.violations.join(", ")}`;
+      return `${safeToolName}${owner}: ${reason}`;
     })
     .join("; ");
   log.warn(


### PR DESCRIPTION
## Summary
- sanitize unsupported tool-schema quarantine diagnostic text before warning logs
- emit sanitized `tool.execution.blocked` payloads for quarantined runtime schemas
- cover hostile newline/OSC tool names and violations in the quarantine regression

## Verification
- `node scripts/run-vitest.mjs src/agents/tool-schema-quarantine.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tool-schema-quarantine.ts src/agents/tool-schema-quarantine.test.ts`
- `./node_modules/.bin/oxlint src/agents/tool-schema-quarantine.ts src/agents/tool-schema-quarantine.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `crabbox run --provider aws --fresh-pr openclaw/openclaw#89499 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` - provider `aws`, run `run_835130de1930`, lease `cbx_ae57d76af3bb`, exit 0

## Real behavior proof
Behavior addressed: when runtime tool-schema projection quarantines a bad active tool, plugin-controlled tool names and schema violation text can no longer inject newlines or terminal escapes into the warning log or trusted blocked-tool diagnostic payload.
Real environment tested: local macOS focused quarantine test plus direct AWS Crabbox fresh-PR changed gate on Linux for openclaw/openclaw#89499.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-schema-quarantine.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89499 ... corepack pnpm check:changed`
Evidence after fix: local focused proof passed 1 file / 2 tests; autoreview returned no accepted/actionable findings; AWS Crabbox `run_835130de1930` on lease `cbx_ae57d76af3bb` passed `pnpm check:changed` with exit 0.
Observed result after fix: the quarantined tool still emits a runtime warning and `tool.execution.blocked`, but hostile newline/OSC control text is stripped from both surfaces, and the changed core/coreTests lanes pass remotely.
What was not tested: a live assistant turn with a third-party plugin; the focused test exercises the runtime quarantine logger directly.
