### PR TITLE
Propagate ClickClack tool policy through reply dispatch

### DIFF
--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -218,6 +218,38 @@ describe("handleClickClackInbound", () => {
     expect(dispatchReply.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(true);
   });
 
+  it("propagates account toolsAllow into agent reply dispatch", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4-mini",
+        },
+      },
+      tools: {
+        allow: ["*"],
+      },
+    } satisfies CoreConfig;
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        toolsAllow: ["message"],
+      }),
+      config: cfg,
+      message: createMessage(),
+    });
+
+    const dispatchReply = vi.mocked(runtime.channel.inbound.dispatchReply);
+    expect(dispatchReply).toHaveBeenCalledTimes(1);
+    const dispatchParams = dispatchReply.mock.calls[0]?.[0] as
+      | (Record<string, unknown> & {
+          toolsAllow?: unknown;
+        })
+      | undefined;
+    expect(dispatchParams?.toolsAllow).toEqual(["message"]);
+  });
+
   it("accepts ClickClack DM target syntax in allowFrom", async () => {
     const runtime = createRuntime();
     vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -174,6 +174,7 @@ export async function handleClickClackInbound(params: {
     recordInboundSession: runtime.channel.session.recordInboundSession,
     dispatchReplyWithBufferedBlockDispatcher:
       runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    toolsAllow: params.account.toolsAllow,
     delivery: {
       deliver: async (payload) => {
         const text =

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -269,6 +269,31 @@ describe("withReplyDispatcher", () => {
     expect(typing.markDispatchIdle).toHaveBeenCalledTimes(1);
   });
 
+  it("passes runtime toolsAllow from buffered dispatch into reply resolution", async () => {
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      toolsAllow: ["message"],
+      dispatcherOptions: {
+        deliver: async () => undefined,
+      },
+    });
+
+    const params = hoisted.dispatchReplyFromConfigMock.mock.calls[0]?.[0];
+    expect(params?.replyOptions?.toolsAllow).toEqual(["message"]);
+  });
+
   it("runs message_sending hooks before inbound dispatcher delivery", async () => {
     const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
     hoisted.getGlobalHookRunnerMock.mockReturnValue({

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -51,6 +51,19 @@ type ForegroundReplyFenceSnapshot = {
 const foregroundReplyFenceByKey = new Map<string, ForegroundReplyFenceState>();
 const replyPayloadSendingDispatchers = new WeakSet<ReplyDispatcher>();
 
+function applyRuntimeToolsAllow(
+  replyOptions: Omit<GetReplyOptions, "onBlockReply"> | undefined,
+  toolsAllow: string[] | undefined,
+): Omit<GetReplyOptions, "onBlockReply"> | undefined {
+  if (toolsAllow === undefined) {
+    return replyOptions;
+  }
+  return {
+    ...replyOptions,
+    toolsAllow,
+  };
+}
+
 function normalizeForegroundReplyFencePart(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -453,9 +466,11 @@ export async function dispatchInboundMessage(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
+  toolsAllow?: string[];
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
+  const replyOptions = applyRuntimeToolsAllow(params.replyOptions, params.toolsAllow);
   const finalized = measureDiagnosticsTimelineSpanSync(
     "auto_reply.finalize_context",
     () => finalizeInboundContext(params.ctx),
@@ -475,7 +490,7 @@ export async function dispatchInboundMessage(params: {
     });
   }
   installReplyPayloadSendingBeforeDeliver(params.dispatcher, finalized, {
-    runId: params.replyOptions?.runId,
+    runId: replyOptions?.runId,
   });
   const result = await withReplyDispatcher({
     dispatcher: params.dispatcher,
@@ -487,7 +502,7 @@ export async function dispatchInboundMessage(params: {
             ctx: finalized,
             cfg: params.cfg,
             dispatcher: params.dispatcher,
-            replyOptions: params.replyOptions,
+            replyOptions,
             replyResolver: params.replyResolver,
           }),
         {
@@ -504,6 +519,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherWithTypingOptions;
+  toolsAllow?: string[];
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
@@ -565,6 +581,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       ctx: finalized,
       cfg: params.cfg,
       dispatcher,
+      toolsAllow: params.toolsAllow,
       replyResolver: params.replyResolver,
       replyOptions: {
         ...params.replyOptions,
@@ -595,6 +612,7 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherOptions;
+  toolsAllow?: string[];
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
@@ -619,6 +637,7 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     ctx: params.ctx,
     cfg: params.cfg,
     dispatcher,
+    toolsAllow: params.toolsAllow,
     replyResolver: params.replyResolver,
     replyOptions: params.replyOptions,
   });

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -82,6 +82,8 @@ export type GetReplyOptions = {
   shouldSuppressToolErrorWarnings?: () => boolean | undefined;
   /** If true, run the model without OpenClaw tools for this turn. */
   disableTools?: boolean;
+  /** Runtime tool allow-list for this turn. Empty means no tools. */
+  toolsAllow?: string[];
   /** If true, include the heartbeat response tool for structured heartbeat outcomes. */
   enableHeartbeatTool?: boolean;
   /** If true, keep the heartbeat response tool available even under narrow tool profiles. */

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1160,6 +1160,26 @@ describe("runAgentTurnWithFallback", () => {
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
   });
 
+  it("passes runtime toolsAllow to embedded agent runs", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        opts: {
+          toolsAllow: ["message"],
+        },
+      }),
+    );
+
+    expectMockCallArgFields(state.runEmbeddedAgentMock, 0, "embedded run params", {
+      toolsAllow: ["message"],
+    });
+  });
+
   it("rechecks queued auto fallback primary probes before running", async () => {
     const { markAutoFallbackPrimaryProbe } = await import("../../agents/agent-scope.js");
     const probe = {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2204,6 +2204,7 @@ export async function runAgentTurnWithFallback(params: {
                     currentInboundAudio: hasInboundAudio(params.sessionCtx),
                     agentAccountId: params.followupRun.run.agentAccountId,
                     senderIsOwner: params.followupRun.run.senderIsOwner,
+                    toolsAllow: params.opts?.toolsAllow,
                     disableTools: params.opts?.disableTools,
                     abortSignal: runAbortSignal,
                     replyOperation: params.replyOperation,
@@ -2320,6 +2321,7 @@ export async function runAgentTurnWithFallback(params: {
                     suppressToolErrorWarnings:
                       params.opts?.shouldSuppressToolErrorWarnings ??
                       params.opts?.suppressToolErrorWarnings,
+                    toolsAllow: params.opts?.toolsAllow,
                     disableTools: params.opts?.disableTools,
                     enableHeartbeatTool: params.opts?.enableHeartbeatTool,
                     forceHeartbeatTool: params.opts?.forceHeartbeatTool,

--- a/src/auto-reply/reply/provider-dispatcher.test.ts
+++ b/src/auto-reply/reply/provider-dispatcher.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  ReplyDispatcherOptions,
+  ReplyDispatcherWithTypingOptions,
+} from "./reply-dispatcher.js";
+
+type BufferedDispatchFn =
+  typeof import("../dispatch.js").dispatchInboundMessageWithBufferedDispatcher;
+type PlainDispatchFn = typeof import("../dispatch.js").dispatchInboundMessageWithDispatcher;
+
+const hoisted = vi.hoisted(() => ({
+  bufferedDispatchMock: vi.fn(),
+  plainDispatchMock: vi.fn(),
+}));
+
+vi.mock("../dispatch.js", () => ({
+  dispatchInboundMessageWithBufferedDispatcher: (...args: Parameters<BufferedDispatchFn>) =>
+    hoisted.bufferedDispatchMock(...args),
+  dispatchInboundMessageWithDispatcher: (...args: Parameters<PlainDispatchFn>) =>
+    hoisted.plainDispatchMock(...args),
+}));
+
+const { dispatchReplyWithBufferedBlockDispatcher, dispatchReplyWithDispatcher } =
+  await import("./provider-dispatcher.js");
+
+const dispatchResult = {
+  queuedFinal: false,
+  counts: { tool: 0, block: 0, final: 0 },
+};
+
+describe("provider dispatcher wrappers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.bufferedDispatchMock.mockResolvedValue(dispatchResult);
+    hoisted.plainDispatchMock.mockResolvedValue(dispatchResult);
+  });
+
+  it("forwards runtime toolsAllow through the buffered wrapper", async () => {
+    const dispatcherOptions = {
+      deliver: async () => ({ visibleReplySent: false }),
+    } satisfies ReplyDispatcherWithTypingOptions;
+
+    await dispatchReplyWithBufferedBlockDispatcher({
+      ctx: { Body: "hello" },
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions,
+      toolsAllow: ["message"],
+    });
+
+    expect(hoisted.bufferedDispatchMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.bufferedDispatchMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        dispatcherOptions,
+        toolsAllow: ["message"],
+      }),
+    );
+  });
+
+  it("forwards runtime toolsAllow through the plain wrapper", async () => {
+    const dispatcherOptions = {
+      deliver: async () => ({ visibleReplySent: false }),
+    } satisfies ReplyDispatcherOptions;
+
+    await dispatchReplyWithDispatcher({
+      ctx: { Body: "hello" },
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions,
+      toolsAllow: ["message"],
+    });
+
+    expect(hoisted.plainDispatchMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.plainDispatchMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        dispatcherOptions,
+        toolsAllow: ["message"],
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/provider-dispatcher.ts
+++ b/src/auto-reply/reply/provider-dispatcher.ts
@@ -18,6 +18,7 @@ export const dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBuffered
       ctx: params.ctx,
       cfg: params.cfg,
       dispatcherOptions: params.dispatcherOptions,
+      toolsAllow: params.toolsAllow,
       replyResolver: params.replyResolver,
       replyOptions: params.replyOptions,
     });
@@ -28,6 +29,7 @@ export const dispatchReplyWithDispatcher: DispatchReplyWithDispatcher = async (p
     ctx: params.ctx,
     cfg: params.cfg,
     dispatcherOptions: params.dispatcherOptions,
+    toolsAllow: params.toolsAllow,
     replyResolver: params.replyResolver,
     replyOptions: params.replyOptions,
   });

--- a/src/auto-reply/reply/provider-dispatcher.types.ts
+++ b/src/auto-reply/reply/provider-dispatcher.types.ts
@@ -15,6 +15,7 @@ export type DispatchReplyWithBufferedBlockDispatcher = (params: {
   ctx: DispatchReplyContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherWithTypingOptions;
+  toolsAllow?: string[];
   replyOptions?: DispatchReplyOptions;
   replyResolver?: GetReplyFromConfig;
 }) => Promise<DispatchFromConfigResult>;
@@ -23,6 +24,7 @@ export type DispatchReplyWithDispatcher = (params: {
   ctx: DispatchReplyContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherOptions;
+  toolsAllow?: string[];
   replyOptions?: DispatchReplyOptions;
   replyResolver?: GetReplyFromConfig;
 }) => Promise<DispatchFromConfigResult>;

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -423,6 +423,7 @@ export async function dispatchAssembledChannelTurn(
             },
             onError: params.delivery.onError,
           },
+          toolsAllow: params.toolsAllow,
           replyOptions: replyPipeline.replyOptions,
           replyResolver: params.replyResolver,
         }),

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -380,6 +380,7 @@ export type AssembledChannelTurn = {
   delivery: ChannelEventDeliveryAdapter;
   replyPipeline?: ChannelTurnReplyPipelineOptions;
   dispatcherOptions?: ChannelTurnDispatcherOptions;
+  toolsAllow?: string[];
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
   record?: ChannelTurnRecordOptions;


### PR DESCRIPTION
## Summary
- Propagates ClickClack account tool policy through inbound agent reply dispatch
- Threads runtime tool restrictions through provider dispatchers, shared reply dispatch, and agent execution

## Changes
- Adds a runtime `toolsAllow` handoff on shared inbound dispatch params and exported provider-dispatcher wrappers
- Carries the policy through reply options into embedded and CLI agent execution
- Adds regression coverage for ClickClack dispatch, provider wrappers, shared dispatch, and embedded agent execution

## Real behavior proof
- Behavior or issue addressed: ClickClack account-level tool allowlists are carried through the exported provider dispatcher, shared reply dispatch, and agent reply runtime so the account policy remains the effective runtime tool set.
- Real environment tested: Local OpenClaw worktree `~/Worktrees/openclaw/openclaw/fix/fix-708` at commit `46a21f0323`, Node `v22.22.2`.
- Exact steps or command run after this patch: Ran targeted terminal probes from the PR worktree after the patch: provider wrapper dispatch coverage, shared dispatch to agent execution coverage, and the production embedded-agent tool-policy boundary probe.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied console output from the local OpenClaw run:

```text
$ node scripts/run-vitest.mjs run src/auto-reply/reply/provider-dispatcher.test.ts --reporter=verbose
✓ provider dispatcher wrappers > forwards runtime toolsAllow through the buffered wrapper
✓ provider dispatcher wrappers > forwards runtime toolsAllow through the plain wrapper
Test Files  1 passed (1)
Tests  2 passed (2)

$ node scripts/run-vitest.mjs run src/auto-reply/dispatch.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/provider-dispatcher.test.ts --reporter=verbose
✓ withReplyDispatcher > passes runtime toolsAllow from buffered dispatch into reply resolution
✓ runAgentTurnWithFallback > passes runtime toolsAllow to embedded agent runs
✓ provider dispatcher wrappers > forwards runtime toolsAllow through the buffered wrapper
✓ provider dispatcher wrappers > forwards runtime toolsAllow through the plain wrapper
Test Files  3 passed (3)
Tests  176 passed (176)

$ node --import tsx <production embedded-agent tool-policy boundary>
[proof-708] runtimeToolsAllow=["message"]
[proof-708] availableTools=["message","exec","read","web_search"]
[proof-708] allowedToolsAfterRuntimePolicy=["message"]
[proof-708] bundleMcpRuntimeCreated=false
[proof-708] result=pass
```

- Observed result after fix: The exported provider wrappers preserve `["message"]`; shared reply dispatch resolves that value into reply options; embedded agent execution receives it; and the production tool-policy boundary excludes `exec`, `read`, and `web_search` while leaving only `message` available.
- What was not tested: Live ClickClack service delivery and a real model-provider turn were not run locally; those require external service credentials.
- Proof limitations or environment constraints: The terminal proof uses focused local dispatch probes plus the production embedded-agent policy boundary rather than an external service account.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-clickclack.config.ts extensions/clickclack/src/inbound.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs run src/auto-reply/dispatch.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/provider-dispatcher.test.ts --reporter=verbose`
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- `pnpm tsgo:extensions`
- `pnpm tsgo:test:extensions`
- `git diff --check`
- `claude -p "/review 89500"` returned `approve`

## Notes
- CLI-backed agent runs fail closed when a runtime tool allowlist is requested, because that backend cannot enforce the runtime policy.
