### PR TITLE
fix(agents): snapshot tool inventory display fields

### DIFF
--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -5,8 +5,12 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.js";
-import { getChannelAgentToolMeta } from "./channel-tools.js";
+import {
+  buildPluginToolMetadataKey,
+  copyPluginToolMeta,
+  getPluginToolMeta,
+} from "../plugins/tools.js";
+import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { summarizeToolDescriptionText } from "./tool-description-summary.js";
 import { resolveToolDisplay } from "./tool-display.js";
@@ -23,25 +27,85 @@ import type {
 } from "./tools-effective-inventory.types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
-function resolveEffectiveToolLabel(tool: AnyAgentTool): string {
-  const rawLabel = normalizeOptionalString(tool.label) ?? "";
+type ToolInventoryDisplaySnapshot = {
+  name: string;
+  label: string;
+  rawDescription: string;
+  displaySummary?: string;
+};
+
+function readToolInventoryStringField(
+  tool: AnyAgentTool,
+  field: "description" | "displaySummary" | "label" | "name",
+): string | undefined {
+  try {
+    return normalizeOptionalString((tool as unknown as Record<string, unknown>)[field]);
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolInventoryUnknownField(tool: AnyAgentTool, field: "parameters"): unknown {
+  try {
+    return (tool as unknown as Record<string, unknown>)[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotToolInventoryDisplay(
+  tool: AnyAgentTool,
+): ToolInventoryDisplaySnapshot | undefined {
+  const name = readToolInventoryStringField(tool, "name");
+  if (!name) {
+    return undefined;
+  }
+  const displaySummary = readToolInventoryStringField(tool, "displaySummary");
+  return {
+    name,
+    label: readToolInventoryStringField(tool, "label") ?? "",
+    rawDescription: readToolInventoryStringField(tool, "description") ?? "",
+    ...(displaySummary ? { displaySummary } : {}),
+  };
+}
+
+function copyInventoryToolMetadata(source: AnyAgentTool, target: AnyAgentTool): void {
+  copyPluginToolMeta(source, target);
+  copyChannelAgentToolMeta(source as never, target as never);
+}
+
+function snapshotToolForInventoryNormalization(tool: AnyAgentTool): AnyAgentTool | undefined {
+  const snapshot = snapshotToolInventoryDisplay(tool);
+  if (!snapshot) {
+    return undefined;
+  }
+  const safeTool = {
+    name: snapshot.name,
+    label: snapshot.label,
+    description: snapshot.rawDescription,
+    parameters: readToolInventoryUnknownField(tool, "parameters"),
+    execute: async () => ({ text: "" }),
+    ...(snapshot.displaySummary ? { displaySummary: snapshot.displaySummary } : {}),
+  } as unknown as AnyAgentTool;
+  copyInventoryToolMetadata(tool, safeTool);
+  return safeTool;
+}
+
+function resolveEffectiveToolLabel(snapshot: ToolInventoryDisplaySnapshot): string {
+  const rawLabel = snapshot.label;
   if (
     rawLabel &&
-    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(tool.name)
+    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(snapshot.name)
   ) {
     return rawLabel;
   }
-  return resolveToolDisplay({ name: tool.name }).title;
+  return resolveToolDisplay({ name: snapshot.name }).title;
 }
 
-function resolveRawToolDescription(tool: AnyAgentTool): string {
-  return normalizeOptionalString(tool.description) ?? "";
-}
-
-function summarizeToolDescription(tool: AnyAgentTool): string {
+function summarizeToolDescription(snapshot: ToolInventoryDisplaySnapshot): string {
   return summarizeToolDescriptionText({
-    rawDescription: resolveRawToolDescription(tool),
-    displaySummary: tool.displaySummary,
+    rawDescription: snapshot.rawDescription,
+    displaySummary: snapshot.displaySummary,
   });
 }
 
@@ -131,7 +195,10 @@ function buildReadableRawToolsByName(
   for (let index = 0; index < toolCount; index += 1) {
     try {
       const tool = tools[index];
-      toolsByName.set(tool.name, tool);
+      const name = tool ? readToolInventoryStringField(tool, "name") : undefined;
+      if (name) {
+        toolsByName.set(name, tool);
+      }
     } catch {
       // Unreadable entries are reported by the schema projection diagnostics.
     }
@@ -168,27 +235,34 @@ export function buildEffectiveToolInventoryEntries(
 
   return disambiguateLabels(
     tools
-      .map((tool) => {
-        const source = resolveEffectiveToolSource(tool, rawToolsByName.get(tool.name));
+      .flatMap((tool) => {
+        const snapshot = snapshotToolInventoryDisplay(tool);
+        if (!snapshot) {
+          return [];
+        }
+        const source = resolveEffectiveToolSource(tool, rawToolsByName.get(snapshot.name));
         const metadata = source.pluginId
-          ? pluginToolMetadata.get(buildPluginToolMetadataKey(source.pluginId, tool.name))
+          ? pluginToolMetadata.get(buildPluginToolMetadataKey(source.pluginId, snapshot.name))
           : undefined;
-        return Object.assign(
-          {
-            id: tool.name,
-            label:
-              normalizeOptionalString(metadata?.displayName) ?? resolveEffectiveToolLabel(tool),
-            description:
-              normalizeOptionalString(metadata?.description) ?? summarizeToolDescription(tool),
-            rawDescription:
-              normalizeOptionalString(metadata?.description) ??
-              resolveRawToolDescription(tool) ??
-              summarizeToolDescription(tool),
-            ...(metadata?.risk ? { risk: metadata.risk } : {}),
-            ...(metadata?.tags ? { tags: metadata.tags } : {}),
-          },
-          source,
-        ) satisfies EffectiveToolInventoryEntry;
+        const description =
+          normalizeOptionalString(metadata?.description) ?? summarizeToolDescription(snapshot);
+        return [
+          Object.assign(
+            {
+              id: snapshot.name,
+              label:
+                normalizeOptionalString(metadata?.displayName) ??
+                resolveEffectiveToolLabel(snapshot),
+              description,
+              rawDescription:
+                normalizeOptionalString(metadata?.description) ??
+                (snapshot.rawDescription || description),
+              ...(metadata?.risk ? { risk: metadata.risk } : {}),
+              ...(metadata?.tags ? { tags: metadata.tags } : {}),
+            },
+            source,
+          ) satisfies EffectiveToolInventoryEntry,
+        ];
       })
       .toSorted((a, b) => a.label.localeCompare(b.label)),
   );
@@ -214,7 +288,10 @@ export function buildRuntimeCompatibleToolInventory(params: {
   const normalizedTools = normalizeAgentRuntimeTools({
     // Schema normalization can replace tool definitions, so hand the runtime
     // policy a mutable copy while keeping this inventory API readonly.
-    tools: [...preNormalizationProjection.tools],
+    tools: preNormalizationProjection.tools.flatMap((tool) => {
+      const safeTool = snapshotToolForInventoryNormalization(tool);
+      return safeTool ? [safeTool] : [];
+    }),
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -20,6 +20,27 @@ function mockTool(params: {
   } as unknown as AnyAgentTool;
 }
 
+function mockToolWithUnreadableDisplayFields(
+  params: {
+    name: string;
+    label: string;
+    description: string;
+  },
+  fields: Array<"description" | "displaySummary" | "label">,
+): AnyAgentTool {
+  const entry = mockTool(params);
+  for (const field of fields) {
+    Object.defineProperty(entry, field, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        throw new Error(`${field} getter exploded`);
+      },
+    });
+  }
+  return entry;
+}
+
 const effectiveInventoryState = vi.hoisted(() => ({
   tools: [
     mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
@@ -60,11 +81,13 @@ vi.mock("../plugins/tools.js", () => ({
   getPluginToolMeta: (tool: { name: string }) => effectiveInventoryState.pluginMeta[tool.name],
   buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
     JSON.stringify([pluginId, toolName]),
+  copyPluginToolMeta: () => undefined,
 }));
 
 vi.mock("./channel-tools.js", () => ({
   getChannelAgentToolMeta: (tool: { name: string }) =>
     effectiveInventoryState.channelMeta[tool.name],
+  copyChannelAgentToolMeta: () => undefined,
 }));
 
 vi.mock("./agent-tools.policy.js", () => ({
@@ -106,6 +129,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 }));
 
 let resolveEffectiveToolInventory: typeof import("./tools-effective-inventory.js").resolveEffectiveToolInventory;
+let buildRuntimeCompatibleMcpToolInventory: typeof import("./tools-effective-mcp-inventory.js").buildRuntimeCompatibleMcpToolInventory;
 
 async function loadHarness(options?: {
   tools?: AnyAgentTool[];
@@ -139,6 +163,8 @@ async function loadHarness(options?: {
 describe("resolveEffectiveToolInventory", () => {
   beforeAll(async () => {
     ({ resolveEffectiveToolInventory } = await import("./tools-effective-inventory.js"));
+    ({ buildRuntimeCompatibleMcpToolInventory } =
+      await import("./tools-effective-mcp-inventory.js"));
   });
 
   beforeEach(() => {
@@ -406,6 +432,84 @@ describe("resolveEffectiveToolInventory", () => {
           'Tool "tool[0]" has an unsupported runtime input schema (tool[0] is unreadable) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
       },
     ]);
+  });
+
+  it("keeps effective inventory available when compatible plugin tool display fields throw", async () => {
+    const normalizeToolsMock = vi.fn((options: { tools: AnyAgentTool[] }) =>
+      options.tools.map((entry) => ({ ...entry }) as AnyAgentTool),
+    );
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal14 } =
+      await loadHarness({
+        tools: [
+          mockToolWithUnreadableDisplayFields(
+            {
+              name: "fuzzplugin_move_angles",
+              label: "Fuzzplugin Move Angles",
+              description: "Move fixture joints",
+            },
+            ["description", "displaySummary", "label"],
+          ),
+        ],
+        pluginMeta: { fuzzplugin_move_angles: { pluginId: "fuzzplugin" } },
+        normalizeToolsMock,
+      });
+
+    const result = resolveEffectiveToolInventoryLocal14({ cfg: {} });
+
+    expect(normalizeToolsMock).toHaveBeenCalled();
+    expect(result.groups).toEqual([
+      {
+        id: "plugin",
+        label: "Connected tools",
+        source: "plugin",
+        tools: [
+          {
+            id: "fuzzplugin_move_angles",
+            label: "Fuzzplugin Move Angles",
+            description: "Tool",
+            rawDescription: "Tool",
+            source: "plugin",
+            pluginId: "fuzzplugin",
+          },
+        ],
+      },
+    ]);
+    expect(result.notices).toBeUndefined();
+  });
+
+  it("keeps MCP tool inventory available when compatible tool display fields throw", async () => {
+    effectiveInventoryState.normalizeToolsMock = vi.fn((options: { tools: AnyAgentTool[] }) =>
+      options.tools.map((entry) => ({ ...entry }) as AnyAgentTool),
+    );
+
+    const result = buildRuntimeCompatibleMcpToolInventory({
+      tools: [
+        mockToolWithUnreadableDisplayFields(
+          {
+            name: "probe_mcp_tool",
+            label: "Probe MCP Tool",
+            description: "Probe MCP server",
+          },
+          ["description", "displaySummary", "label"],
+        ),
+      ],
+      cfg: {},
+    });
+
+    expect(effectiveInventoryState.normalizeToolsMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      entries: [
+        {
+          id: "probe_mcp_tool",
+          label: "Probe Mcp Tool",
+          description: "Tool",
+          rawDescription: "Tool",
+          source: "mcp",
+          pluginId: "bundle-mcp",
+        },
+      ],
+      notices: [],
+    });
   });
 
   it("validates normalized runtime schemas before quarantining effective tools", async () => {

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -18,27 +18,80 @@ import type {
 } from "./tools-effective-inventory.types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
+type McpToolInventoryDisplaySnapshot = {
+  name: string;
+  label: string;
+  rawDescription: string;
+  displaySummary?: string;
+};
+
 const BUNDLE_MCP_PLUGIN_ID = "bundle-mcp";
 
-function resolveMcpToolLabel(tool: AnyAgentTool): string {
-  const rawLabel = normalizeOptionalString(tool.label) ?? "";
+function readMcpToolInventoryStringField(
+  tool: AnyAgentTool,
+  field: "description" | "displaySummary" | "label" | "name",
+): string | undefined {
+  try {
+    return normalizeOptionalString((tool as unknown as Record<string, unknown>)[field]);
+  } catch {
+    return undefined;
+  }
+}
+
+function readMcpToolInventoryUnknownField(tool: AnyAgentTool, field: "parameters"): unknown {
+  try {
+    return (tool as unknown as Record<string, unknown>)[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotMcpToolInventoryDisplay(
+  tool: AnyAgentTool,
+): McpToolInventoryDisplaySnapshot | undefined {
+  const name = readMcpToolInventoryStringField(tool, "name");
+  if (!name) {
+    return undefined;
+  }
+  const displaySummary = readMcpToolInventoryStringField(tool, "displaySummary");
+  return {
+    name,
+    label: readMcpToolInventoryStringField(tool, "label") ?? "",
+    rawDescription: readMcpToolInventoryStringField(tool, "description") ?? "",
+    ...(displaySummary ? { displaySummary } : {}),
+  };
+}
+
+function snapshotMcpToolForInventoryNormalization(tool: AnyAgentTool): AnyAgentTool | undefined {
+  const snapshot = snapshotMcpToolInventoryDisplay(tool);
+  if (!snapshot) {
+    return undefined;
+  }
+  return {
+    name: snapshot.name,
+    label: snapshot.label,
+    description: snapshot.rawDescription,
+    parameters: readMcpToolInventoryUnknownField(tool, "parameters"),
+    execute: async () => ({ text: "" }),
+    ...(snapshot.displaySummary ? { displaySummary: snapshot.displaySummary } : {}),
+  } as unknown as AnyAgentTool;
+}
+
+function resolveMcpToolLabel(snapshot: McpToolInventoryDisplaySnapshot): string {
+  const rawLabel = snapshot.label;
   if (
     rawLabel &&
-    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(tool.name)
+    normalizeLowercaseStringOrEmpty(rawLabel) !== normalizeLowercaseStringOrEmpty(snapshot.name)
   ) {
     return rawLabel;
   }
-  return resolveToolDisplay({ name: tool.name }).title;
+  return resolveToolDisplay({ name: snapshot.name }).title;
 }
 
-function resolveRawToolDescription(tool: AnyAgentTool): string {
-  return normalizeOptionalString(tool.description) ?? "";
-}
-
-function summarizeToolDescription(tool: AnyAgentTool): string {
+function summarizeToolDescription(snapshot: McpToolInventoryDisplaySnapshot): string {
   return summarizeToolDescriptionText({
-    rawDescription: resolveRawToolDescription(tool),
-    displaySummary: tool.displaySummary,
+    rawDescription: snapshot.rawDescription,
+    displaySummary: snapshot.displaySummary,
   });
 }
 
@@ -70,17 +123,23 @@ function buildMcpToolInventoryEntries(
 ): EffectiveToolInventoryEntry[] {
   return disambiguateLabels(
     tools
-      .map(
-        (tool) =>
-          ({
-            id: tool.name,
-            label: resolveMcpToolLabel(tool),
-            description: summarizeToolDescription(tool),
-            rawDescription: resolveRawToolDescription(tool) || summarizeToolDescription(tool),
+      .flatMap((tool) => {
+        const snapshot = snapshotMcpToolInventoryDisplay(tool);
+        if (!snapshot) {
+          return [];
+        }
+        const description = summarizeToolDescription(snapshot);
+        return [
+          {
+            id: snapshot.name,
+            label: resolveMcpToolLabel(snapshot),
+            description,
+            rawDescription: snapshot.rawDescription || description,
             source: "mcp",
             pluginId: BUNDLE_MCP_PLUGIN_ID,
-          }) satisfies EffectiveToolInventoryEntry,
-      )
+          } satisfies EffectiveToolInventoryEntry,
+        ];
+      })
       .toSorted((a, b) => a.label.localeCompare(b.label)),
   );
 }
@@ -102,7 +161,10 @@ export function buildRuntimeCompatibleMcpToolInventory(params: {
     ...preNormalizationProjection.diagnostics,
   ];
   const normalizedTools = normalizeAgentRuntimeTools({
-    tools: [...preNormalizationProjection.tools],
+    tools: preNormalizationProjection.tools.flatMap((tool) => {
+      const safeTool = snapshotMcpToolForInventoryNormalization(tool);
+      return safeTool ? [safeTool] : [];
+    }),
     provider: params.modelProvider ?? "",
     config: params.cfg,
     workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary

- Prevent effective tool inventory/status rendering from crashing when compatible plugin or MCP tools expose throwing display-field getters.
- Snapshot `name`, `label`, `description`, `displaySummary`, and `parameters` into safe inventory-only tool objects before provider normalization can clone or spread hostile tool descriptors.
- Preserve plugin/channel ownership metadata across the safe clone path so quarantine notices and inventory grouping keep pointing at the right owner.
- Intentionally out of scope: changing provider runtime normalization, shipped tool execution semantics, or unsupported-schema quarantine policy.

## Linked context

Related to the ongoing tool-schema fuzzing hardening sweep.

## Real behavior proof

Behavior addressed: effective tool inventory and bundled MCP inventory stay available when a valid tool's display getters throw during inventory rendering or provider normalization.

Real environment tested: local OpenClaw checkout on the PR branch with the repo Node/Vitest wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-mcp-inventory.ts src/agents/tools-effective-inventory.test.ts`; `./node_modules/.bin/oxlint src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-mcp-inventory.ts src/agents/tools-effective-inventory.test.ts`; `git diff --check HEAD~1..HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89504 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.

Evidence after fix: focused Vitest reported `1 passed (1)` and `22 passed (22)`; oxfmt, oxlint, and `git diff --check` exited 0; autoreview reported `autoreview clean: no accepted/actionable findings reported`; AWS Crabbox fresh-PR changed gate reported provider `aws`, lease `cbx_092da60cf90e`, slug `amber-prawn`, run `run_f78ccc2237a0`, lanes `core, coreTests`, exit `0`, total `4m10.695s`.

Observed result after fix: both new regressions pass while forcing normalization to spread the safe inventory clone; the original throwing display getters are no longer read after the guarded snapshot boundary.

What was not tested: full suite, live provider calls, and external MCP server process.

Proof limitations or environment constraints: local proof uses mocked inventory/runtime normalization to exercise the crash path deterministically; remote proof covers the changed gate, not a full release suite.

## Tests and validation

- Added regressions in `src/agents/tools-effective-inventory.test.ts` for plugin and MCP inventory with unreadable display fields.
- Re-ran focused Vitest, oxfmt check, oxlint, whitespace check, and local autoreview.
- A prior autoreview P2 found that provider normalization could spread hostile descriptors before the snapshot path; this version passes safe clones into normalization first.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Inventory/status surfaces now degrade display metadata instead of crashing on hostile compatible tool descriptors.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?
Tool ownership metadata after cloning.

How is that risk mitigated?
The plugin/channel metadata copy path is preserved for effective inventory clones, and existing plus new tests cover owner grouping and quarantine notices.

## Current review state

What is the next action?
Wait for maintainer review and GitHub CI.

What is still waiting on author, maintainer, CI, or external proof?
Maintainer review and any GitHub CI that runs for the draft PR.

Which bot or reviewer comments were addressed?
Local autoreview P2 about pre-snapshot provider normalization spread was addressed; rerun is clean.

AI-assisted: yes; sanitized transcript logs were found locally but are not included without explicit maintainer approval.
