### PR TITLE
fix(agents): guard prompt cache tool names

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -17,6 +17,24 @@ describe("prompt cache observability", () => {
     ).toEqual(["read", "write"]);
   });
 
+  it("skips unreadable tool names when collecting prompt-cache diagnostics", () => {
+    const unreadable = {};
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin name getter exploded");
+      },
+    });
+
+    expect(
+      collectPromptCacheToolNames([
+        { name: "read" },
+        unreadable as { name?: string },
+        { name: " write " },
+      ]),
+    ).toEqual(["read", "write"]);
+  });
+
   it("tracks cache-relevant changes and reports a real cache-read drop", () => {
     const first = beginPromptCacheObservation({
       sessionId: "session-1",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -137,8 +137,20 @@ function diffSnapshots(
   return changes.length > 0 ? changes : null;
 }
 
+function readPromptCacheToolName(tool: { name?: string }): string | undefined {
+  try {
+    const name = tool.name?.trim();
+    return name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): string[] {
-  return tools.map((tool) => tool.name?.trim()).filter((name): name is string => Boolean(name));
+  return tools.flatMap((tool) => {
+    const name = readPromptCacheToolName(tool);
+    return name ? [name] : [];
+  });
 }
 
 export function beginPromptCacheObservation(params: {


### PR DESCRIPTION
## Summary

- Keep prompt-cache observability from crashing when a tool descriptor exposes an unreadable `name` getter.
- Treat tool names used for cache-break diagnostics as best-effort metadata: readable names are trimmed and kept, unreadable/empty names are skipped.
- Intentionally out of scope: changing runtime tool registration, schema projection, prompt-cache eligibility, or provider payload construction.

## Linked context

Related to the ongoing tool-schema fuzzing hardening sweep.

## Real behavior proof

Behavior addressed: a hostile tool descriptor should not be able to abort an assistant turn through prompt-cache diagnostics while collecting tool names.

Real environment tested: local OpenClaw checkout on the PR branch with the repo Node/Vitest wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-observability.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`; `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`; `git diff --check HEAD~1..HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89507 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.

Evidence after fix: focused Vitest reported `1 passed (1)` and `8 passed (8)`; oxfmt, oxlint, and `git diff --check` exited 0; autoreview reported `autoreview clean: no accepted/actionable findings reported`; AWS Crabbox fresh-PR changed gate reported provider `aws`, lease `cbx_76f581b1fdbe`, slug `silver-hermit`, run `run_76885f3175be`, lanes `core, coreTests`, exit `0`, total `4m20.429s`.

Observed result after fix: `collectPromptCacheToolNames` returns readable names and skips a descriptor whose `name` getter throws.

What was not tested: full suite and live model/provider calls.

Proof limitations or environment constraints: local proof directly exercises the observability helper; remote proof covers the changed gate, not a full release suite.

## Tests and validation

- Added a regression in `src/agents/embedded-agent-runner/prompt-cache-observability.test.ts` for a throwing tool-name getter.
- Re-ran focused Vitest, oxfmt check, oxlint, whitespace check, and local autoreview.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
No. This only hardens observability metadata collection.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?
Prompt-cache break diagnostics could omit an unreadable tool name.

How is that risk mitigated?
The helper already filters empty names, and this metadata is diagnostic-only; readable tool names preserve existing behavior.

## Current review state

What is the next action?
Wait for maintainer review and GitHub CI.

What is still waiting on author, maintainer, CI, or external proof?
Maintainer review and any GitHub CI that runs for the draft PR.

Which bot or reviewer comments were addressed?
Local autoreview was clean; no bot comments yet.

AI-assisted: yes; sanitized transcript logs were found locally but are not included without explicit maintainer approval.
