### PR TITLE
fix(models): clarify provider model registration hint

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2277,7 +2277,7 @@ describe("resolveModel", () => {
     });
 
     expect(result.error).toBe(
-      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model.',
+      'Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models["microsoft-foundry/Kimi-K2.6-1"], but no matching models.providers["microsoft-foundry"].models[] entry. Add { "id": "Kimi-K2.6-1", "name": "Kimi-K2.6-1" } to models.providers["microsoft-foundry"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.',
     );
   });
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1691,5 +1691,5 @@ function buildMissingProviderModelRegistrationHint(params: {
   if (hasProviderModel) {
     return undefined;
   }
-  return `Found agents.defaults.models["${agentModelKey}"], but no matching models.providers["${params.provider}"].models[] entry. Add { "id": "${params.modelId}" } to models.providers["${params.provider}"].models[] to register this provider model.`;
+  return `Found agents.defaults.models["${agentModelKey}"], but no matching models.providers["${params.provider}"].models[] entry. Add { "id": "${params.modelId}", "name": "${params.modelId}" } to models.providers["${params.provider}"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.`;
 }


### PR DESCRIPTION
## Summary

Fixes #89192.

- Include the required `name` field in the missing provider model registration hint.
- Warn custom/proxy provider users to set `api` and `baseUrl` so traffic routes to the intended endpoint.
- Link the model provider docs from the remediation message and update the regression test.

## Real behavior proof

Behavior addressed: The missing provider model registration hint now suggests a schema-valid model entry with both `id` and `name`, warns custom/proxy provider users to set `api` and `baseUrl`, and links the model provider docs.

Real environment tested: Local OpenClaw checkout on branch `fix/89192-model-remediation-message` at commit `4f757038ac72fade9a84d01ea39bfb2c97dad084`, using Node with `--import tsx`. The one-off run imports the production `resolveModelAsync` from `src/agents/embedded-agent-runner/model.ts`.

Exact steps or command run after this patch: I ran a one-off Node script with `node --import tsx --input-type=module`, imported `resolveModelAsync` from `./src/agents/embedded-agent-runner/model.ts`, then called `resolveModelAsync("microsoft-foundry", "Kimi-K2.6-1", "/tmp/agent", cfg, { skipAgentDiscovery: true, skipProviderRuntimeHooks: true })` where `cfg.agents.defaults.models` contains `microsoft-foundry/Kimi-K2.6-1` but `models.providers["microsoft-foundry"].models[]` is absent.

Evidence after fix: Copied live console output from the production resolver run:

```json
{
  "behavior": "missing provider model registration hint",
  "error": "Unknown model: microsoft-foundry/Kimi-K2.6-1. Found agents.defaults.models[\"microsoft-foundry/Kimi-K2.6-1\"], but no matching models.providers[\"microsoft-foundry\"].models[] entry. Add { \"id\": \"Kimi-K2.6-1\", \"name\": \"Kimi-K2.6-1\" } to models.providers[\"microsoft-foundry\"].models[] to register this provider model. For custom or proxy providers, also set api and baseUrl so requests route to the intended endpoint. See https://docs.openclaw.ai/concepts/model-providers.",
  "assertions": {
    "hasNameInSnippet": true,
    "mentionsApiAndBaseUrl": true,
    "linksDocs": true,
    "noIdOnlySnippet": true
  }
}
```

Observed result after fix: The production resolver returned the updated remediation text; the output includes the `id` plus `name` snippet, mentions `api and baseUrl`, links the model provider docs, and confirms the old id-only snippet is absent.

What was not tested: I did not run a live Microsoft Foundry/OpenCode provider request or test credential routing to external endpoints. This PR only corrects the local remediation copy and regression test; the broader routing/fail-closed policy remains tracked by #85042.

## Tests

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts`
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/model.ts src/agents/embedded-agent-runner/model.test.ts`
- `npx oxfmt --check src/agents/embedded-agent-runner/model.ts src/agents/embedded-agent-runner/model.test.ts`
- `git diff --check`
