### PR TITLE
fix(agents): ignore unreadable session tool metadata

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -93,7 +93,10 @@ import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-promp
 import type { BashOperations } from "./tools/bash-operations.js";
 import { createLocalBashOperations } from "./tools/bash.js";
 import { createAllToolDefinitions } from "./tools/index.js";
-import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.js";
+import {
+  createToolDefinitionFromAgentTool,
+  snapshotReadableToolDefinition,
+} from "./tools/tool-definition-wrapper.js";
 
 function unwrapCoreResult<T>(result: { ok: true; value: T } | { ok: false; error: Error }): T {
   if (result.ok) {
@@ -281,6 +284,10 @@ export interface SessionStats {
 interface ToolDefinitionEntry {
   definition: ToolDefinition;
   sourceInfo: SourceInfo;
+}
+
+function createSyntheticToolSourcePath(kind: "builtin" | "sdk", toolName: string): string {
+  return `<${kind}:${toolName.replace(/[\r\n]/g, " ")}>`;
 }
 
 type ActiveToolPromptMetadata = {
@@ -2389,13 +2396,26 @@ export class AgentSession {
     const isAllowedTool = (name: string): boolean =>
       !isDisabledBuiltInToolName(name) && (!allowedToolNames || allowedToolNames.has(name));
 
-    const registeredTools = this.currentExtensionRunner.getAllRegisteredTools();
+    const registeredTools = this.currentExtensionRunner.getAllRegisteredTools().flatMap((tool) => {
+      const definition = snapshotReadableToolDefinition(tool.definition);
+      return definition ? [{ definition, sourceInfo: tool.sourceInfo }] : [];
+    });
     const allCustomTools = [
       ...registeredTools,
-      ...this.customTools.map((definition) => ({
-        definition,
-        sourceInfo: createSyntheticSourceInfo(`<sdk:${definition.name}>`, { source: "sdk" }),
-      })),
+      ...this.customTools.flatMap((toolDefinition) => {
+        const definition = snapshotReadableToolDefinition(toolDefinition);
+        return definition
+          ? [
+              {
+                definition,
+                sourceInfo: createSyntheticSourceInfo(
+                  createSyntheticToolSourcePath("sdk", definition.name),
+                  { source: "sdk" },
+                ),
+              },
+            ]
+          : [];
+      }),
     ].filter((tool) => isAllowedTool(tool.definition.name));
     const definitionRegistry = new Map<string, ToolDefinitionEntry>(
       Array.from(this.baseToolDefinitions.entries())
@@ -2404,7 +2424,9 @@ export class AgentSession {
           name,
           {
             definition,
-            sourceInfo: createSyntheticSourceInfo(`<builtin:${name}>`, { source: "builtin" }),
+            sourceInfo: createSyntheticSourceInfo(createSyntheticToolSourcePath("builtin", name), {
+              source: "builtin",
+            }),
           },
         ]),
     );
@@ -2438,9 +2460,12 @@ export class AgentSession {
         .filter((definition) => isAllowedTool(definition.name))
         .map((definition) => ({
           definition,
-          sourceInfo: createSyntheticSourceInfo(`<builtin:${definition.name}>`, {
-            source: "builtin",
-          }),
+          sourceInfo: createSyntheticSourceInfo(
+            createSyntheticToolSourcePath("builtin", definition.name),
+            {
+              source: "builtin",
+            },
+          ),
         })),
       runner,
     );

--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -11,6 +11,49 @@ afterEach(async () => {
 });
 
 describe("loadExtensions", () => {
+  it("ignores extension tools with unreadable names during registration", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-tool-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+export default async function(api) {
+  const badTool = {
+    label: "Broken Name",
+    description: "Should be ignored.",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "bad" }], details: {} };
+    },
+  };
+  Object.defineProperty(badTool, "name", {
+    get() {
+      throw new Error("bad\\nname");
+    },
+  });
+
+  api.registerTool(badTool);
+  api.registerTool({
+    name: "extension_lookup",
+    label: "Extension Lookup",
+    description: "Looks up a test value.",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }], details: {} };
+    },
+  });
+}
+`,
+    );
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+    expect(Array.from(result.extensions[0]?.tools.keys() ?? [])).toEqual(["extension_lookup"]);
+  });
+
   it("resolves plugin SDK subpaths in jiti-loaded extensions", async () => {
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-sdk-"));
     tempDirs.push(dir);

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -29,6 +29,7 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import * as bundledAgentSessions from "../extension-sdk.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
+import { readToolDefinitionName } from "../tools/tool-definition-wrapper.js";
 import type {
   Extension,
   ExtensionAPI,
@@ -226,7 +227,11 @@ function createExtensionAPI(
 
     registerTool(tool: ToolDefinition): void {
       runtime.assertActive();
-      extension.tools.set(tool.name, {
+      const name = readToolDefinitionName(tool);
+      if (name === undefined) {
+        return;
+      }
+      extension.tools.set(name, {
         definition: tool,
         sourceInfo: extension.sourceInfo,
       });

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -11,6 +11,7 @@ import type { KeybindingsConfig } from "../keybindings.js";
 import type { ModelRegistry } from "../model-registry.js";
 import type { SessionManager } from "../session-manager.js";
 import type { BuildSystemPromptOptions } from "../system-prompt.js";
+import { readToolDefinitionName } from "../tools/tool-definition-wrapper.js";
 import type {
   BeforeAgentStartEvent,
   BeforeAgentStartEventResult,
@@ -400,8 +401,9 @@ export class ExtensionRunner {
     const toolsByName = new Map<string, RegisteredTool>();
     for (const ext of this.extensions) {
       for (const tool of ext.tools.values()) {
-        if (!toolsByName.has(tool.definition.name)) {
-          toolsByName.set(tool.definition.name, tool);
+        const name = readToolDefinitionName(tool.definition);
+        if (name !== undefined && !toolsByName.has(name)) {
+          toolsByName.set(name, tool);
         }
       }
     }

--- a/src/agents/sessions/extensions/wrapper.ts
+++ b/src/agents/sessions/extensions/wrapper.ts
@@ -6,7 +6,11 @@
  */
 
 import type { AgentTool } from "../../runtime/index.js";
-import { wrapToolDefinition, wrapToolDefinitions } from "../tools/tool-definition-wrapper.js";
+import {
+  snapshotReadableToolDefinition,
+  wrapToolDefinition,
+  wrapToolDefinitions,
+} from "../tools/tool-definition-wrapper.js";
 import type { ExtensionRunner } from "./runner.js";
 import type { RegisteredTool } from "./types.js";
 
@@ -30,7 +34,10 @@ export function wrapRegisteredTools(
   runner: ExtensionRunner,
 ): AgentTool[] {
   return wrapToolDefinitions(
-    registeredTools.map((registeredTool) => registeredTool.definition),
+    registeredTools.flatMap((registeredTool) => {
+      const definition = snapshotReadableToolDefinition(registeredTool.definition);
+      return definition ? [definition] : [];
+    }),
     () => runner.createContext(),
   );
 }

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { AuthStorage } from "./auth-storage.js";
 import { createExtensionRuntime } from "./extensions/loader.js";
-import type { LoadExtensionsResult, ToolDefinition } from "./extensions/types.js";
+import type { LoadExtensionsResult, RegisteredTool, ToolDefinition } from "./extensions/types.js";
 import { ModelRegistry } from "./model-registry.js";
 import type { ResourceLoader } from "./resource-loader.js";
 import { createAgentSession } from "./sdk.js";
@@ -30,17 +30,18 @@ function createEmptyResourceLoader(): ResourceLoader {
 
 function createResourceLoaderWithHandlers(
   handlers: Map<string, Array<(...args: unknown[]) => Promise<unknown>>>,
+  tools: Map<string, RegisteredTool> = new Map(),
 ): ResourceLoader {
   const extensionsResult: LoadExtensionsResult = {
     extensions:
-      handlers.size > 0
+      handlers.size > 0 || tools.size > 0
         ? [
             {
               path: "<test-extension>",
               resolvedPath: "<test-extension>",
               sourceInfo: createSyntheticSourceInfo("<test-extension>", { source: "temporary" }),
               handlers,
-              tools: new Map(),
+              tools,
               messageRenderers: new Map(),
               commands: new Map(),
               flags: new Map(),
@@ -62,6 +63,52 @@ function createResourceLoaderWithHandlers(
     extendResources: () => {},
     reload: async () => {},
   };
+}
+
+function createTextTool(name: string): ToolDefinition {
+  return {
+    name,
+    label: "Test Tool",
+    description: "Looks up a test value.",
+    parameters: Type.Object({}),
+    execute: async () => ({
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+    }),
+  };
+}
+
+function createUnreadableNameTool(): ToolDefinition {
+  const tool = {
+    label: "Broken Name",
+    description: "Should be ignored.",
+    parameters: Type.Object({}),
+    execute: async () => ({
+      content: [{ type: "text", text: "bad" }],
+      details: {},
+    }),
+  } as unknown as ToolDefinition;
+  Object.defineProperty(tool, "name", {
+    get() {
+      throw new Error("bad\nname");
+    },
+  });
+  return tool;
+}
+
+function createUnreadableParametersTool(): ToolDefinition {
+  return {
+    name: "broken_params",
+    label: "Broken Params",
+    description: "Should be ignored.",
+    get parameters() {
+      throw new Error("bad\nparameters");
+    },
+    execute: async () => ({
+      content: [{ type: "text", text: "bad" }],
+      details: {},
+    }),
+  } as unknown as ToolDefinition;
 }
 
 describe("createAgentSession tool defaults", () => {
@@ -115,6 +162,46 @@ describe("createAgentSession tool defaults", () => {
     session.setActiveToolsByName(["bash", "custom_lookup"]);
 
     expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
+  });
+
+  it("ignores custom tools with unreadable registry metadata", async () => {
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      customTools: [
+        createUnreadableNameTool(),
+        createUnreadableParametersTool(),
+        createTextTool("custom_lookup"),
+      ],
+      resourceLoader: createEmptyResourceLoader(),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["custom_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["custom_lookup"]);
+  });
+
+  it("ignores extension tools with unreadable registry metadata", async () => {
+    const sourceInfo = createSyntheticSourceInfo("<test-extension>", { source: "temporary" });
+    const tools = new Map<string, RegisteredTool>([
+      ["unreadable_name", { definition: createUnreadableNameTool(), sourceInfo }],
+      ["broken_params", { definition: createUnreadableParametersTool(), sourceInfo }],
+      ["extension_lookup", { definition: createTextTool("extension_lookup"), sourceInfo }],
+    ]);
+
+    const { session } = await createAgentSession({
+      model: testModel,
+      noTools: "builtin",
+      resourceLoader: createResourceLoaderWithHandlers(new Map(), tools),
+      sessionManager: SessionManager.inMemory(),
+      settingsManager: SettingsManager.inMemory(),
+      modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+    });
+
+    expect(session.getActiveToolNames()).toEqual(["extension_lookup"]);
+    expect(session.getAllTools().map((tool) => tool.name)).toEqual(["extension_lookup"]);
   });
 
   it("preserves an exact base system prompt when active tools change", async () => {

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -32,6 +32,7 @@ import {
   createReadOnlyTools,
   createReadTool,
   createWriteTool,
+  readToolDefinitionName,
   type ToolName,
   withFileMutationQueue,
 } from "./tools/index.js";
@@ -283,7 +284,11 @@ export async function createAgentSession(
   }
 
   const defaultActiveToolNames: ToolName[] = ["read", "bash", "edit", "write"];
-  const customToolNames = options.customTools?.map((tool) => tool.name) ?? [];
+  const customToolNames =
+    options.customTools?.flatMap((tool) => {
+      const name = readToolDefinitionName(tool);
+      return name === undefined ? [] : [name];
+    }) ?? [];
   const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
   const disableBuiltInTools = !options.tools && options.noTools === "builtin";
   const initialActiveToolNames: string[] = options.tools

--- a/src/agents/sessions/tools/index.ts
+++ b/src/agents/sessions/tools/index.ts
@@ -69,6 +69,13 @@ export {
   type WriteOperations,
   type WriteToolOptions,
 } from "./write.js";
+export {
+  createToolDefinitionFromAgentTool,
+  readToolDefinitionName,
+  snapshotReadableToolDefinition,
+  wrapToolDefinition,
+  wrapToolDefinitions,
+} from "./tool-definition-wrapper.js";
 
 import type { AgentTool } from "../../runtime/index.js";
 import type { ToolDefinition } from "../extensions/types.js";

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -2,6 +2,68 @@ import type { TSchema } from "typebox";
 import type { AgentTool } from "../../runtime/index.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 
+export function readToolDefinitionName(definition: ToolDefinition): string | undefined {
+  try {
+    const name = definition.name as unknown;
+    return typeof name === "string" ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function snapshotReadableToolDefinition<
+  TParams extends TSchema = TSchema,
+  TDetails = unknown,
+  TState = unknown,
+>(
+  definition: ToolDefinition<TParams, TDetails, TState>,
+): ToolDefinition<TParams, TDetails, TState> | undefined {
+  try {
+    const name = definition.name as unknown;
+    const label = definition.label as unknown;
+    const description = definition.description as unknown;
+    const parameters = definition.parameters;
+    const execute = Reflect.get(definition, "execute") as unknown;
+
+    if (
+      typeof name !== "string" ||
+      typeof label !== "string" ||
+      typeof description !== "string" ||
+      parameters === undefined ||
+      typeof execute !== "function"
+    ) {
+      return undefined;
+    }
+
+    const executeTool = execute as ToolDefinition<TParams, TDetails, TState>["execute"];
+    const promptSnippet = definition.promptSnippet;
+    const promptGuidelines = definition.promptGuidelines;
+    const renderShell = definition.renderShell;
+    const prepareArguments = definition.prepareArguments;
+    const executionMode = definition.executionMode;
+    const renderCall = definition.renderCall;
+    const renderResult = definition.renderResult;
+
+    return {
+      name,
+      label,
+      description,
+      promptSnippet,
+      promptGuidelines,
+      parameters,
+      renderShell,
+      prepareArguments,
+      executionMode,
+      execute: (toolCallId, params, signal, onUpdate, ctx) =>
+        executeTool.call(definition, toolCallId, params, signal, onUpdate, ctx),
+      renderCall,
+      renderResult,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /** Wrap a ToolDefinition into an AgentTool for the core runtime. */
 export function wrapToolDefinition<
   TParams extends TSchema = TSchema,
@@ -11,15 +73,20 @@ export function wrapToolDefinition<
   definition: ToolDefinition<TParams, TDetails, TState>,
   ctxFactory?: () => ExtensionContext,
 ): AgentTool<TParams, TDetails> {
+  const snapshot = snapshotReadableToolDefinition(definition);
+  if (!snapshot) {
+    throw new Error("Cannot wrap unreadable tool definition");
+  }
+
   return {
-    name: definition.name,
-    label: definition.label,
-    description: definition.description,
-    parameters: definition.parameters,
-    prepareArguments: definition.prepareArguments,
-    executionMode: definition.executionMode,
+    name: snapshot.name,
+    label: snapshot.label,
+    description: snapshot.description,
+    parameters: snapshot.parameters,
+    prepareArguments: snapshot.prepareArguments,
+    executionMode: snapshot.executionMode,
     execute: (toolCallId, params, signal, onUpdate) =>
-      definition.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext),
+      snapshot.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext),
   };
 }
 


### PR DESCRIPTION
## Summary

- Guard SDK custom-tool and extension-tool metadata reads so unreadable `name` / schema metadata skips the malformed tool instead of crashing session startup or refresh.
- Snapshot readable tool definitions before wrapping while preserving the original execution path for valid tools.
- Sanitize synthetic SDK/builtin tool source labels used in session tool metadata.

## Verification

- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/sessions/extensions/loader.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/extensions/runner.ts src/agents/sessions/extensions/wrapper.ts src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/sdk.test.ts src/agents/sessions/tools/index.ts`
- `./node_modules/.bin/oxlint src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/extensions/runner.ts src/agents/sessions/extensions/wrapper.ts src/agents/sessions/sdk.ts src/agents/sessions/agent-session.ts src/agents/sessions/sdk.test.ts src/agents/sessions/tools/index.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_bebed30ed07e`, run `run_b3a68dec96fd`, exit 0

## Real behavior proof

Behavior addressed: Session startup and tool-registry refresh skip malformed SDK custom tools or extension tools with unreadable registry metadata instead of throwing before a valid tool registry can be built.

Real environment tested: Local macOS sparse `gwt` worktree with shared repo dependencies; AWS Crabbox Linux `c7a.8xlarge` fresh PR checkout at head `b74a7ed8d7c`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/sessions/extensions/loader.test.ts -- --reporter=dot`; `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` on AWS Crabbox.

Evidence after fix: `sdk.test.ts` covers SDK custom tools and already-registered extension tools with throwing `name` / `parameters` getters; `loader.test.ts` covers production `api.registerTool` registration with a throwing `name` getter; remote `check:changed` selected `core, coreTests` and completed successfully.

Observed result after fix: Focused Vitest shards passed, formatter/lint/diff checks passed, autoreview reported no accepted/actionable findings, and AWS Crabbox `check:changed` exited 0.

What was not tested: No live extension package was installed; coverage uses session/loader regression tests around the registration and registry paths.
