### PR TITLE
docs: add third-party UIs page

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1116,6 +1116,22 @@
     "target": "Control UI"
   },
   {
+    "source": "Third-party UIs",
+    "target": "第三方 UI"
+  },
+  {
+    "source": "Gateway protocol",
+    "target": "Gateway 协议"
+  },
+  {
+    "source": "Bridge protocol",
+    "target": "Bridge 协议"
+  },
+  {
+    "source": "WebChat",
+    "target": "WebChat"
+  },
+  {
     "source": "Z.AI (GLM)",
     "target": "Z.AI (GLM)"
   }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1632,7 +1632,14 @@
               },
               {
                 "group": "Web interfaces",
-                "pages": ["web/index", "web/control-ui", "web/dashboard", "web/webchat", "web/tui"]
+                "pages": [
+                  "web/index",
+                  "web/control-ui",
+                  "web/third-party-uis",
+                  "web/dashboard",
+                  "web/webchat",
+                  "web/tui"
+                ]
               }
             ]
           },

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -12,7 +12,7 @@ The Gateway serves a small **browser Control UI** (Vite + Lit) from the same por
 - with `gateway.tls.enabled: true`: `https://<host>:18789/`
 - optional prefix: set `gateway.controlUi.basePath` (e.g. `/openclaw`)
 
-Capabilities live in [Control UI](/web/control-ui). The rest of this page focuses on bind modes, security, and web-facing surfaces.
+Capabilities live in [Control UI](/web/control-ui). Community alternatives are listed in [Third-party UIs](/web/third-party-uis). The rest of this page focuses on bind modes, security, and web-facing surfaces.
 
 ## Webhooks
 

--- a/docs/web/third-party-uis.md
+++ b/docs/web/third-party-uis.md
@@ -1,0 +1,61 @@
+---
+summary: "Community web dashboards and other third-party interfaces for the OpenClaw Gateway"
+read_when:
+  - You want a community dashboard instead of the built-in Control UI
+  - You are building an external web interface for the OpenClaw Gateway
+  - You need security guidance before exposing a third-party UI
+sidebarTitle: "Third-party UIs"
+title: "Third-party UIs"
+---
+
+OpenClaw ships the built-in [Control UI](/web/control-ui), but the Gateway protocol also lets community projects build alternate dashboards, event viewers, and operator consoles.
+
+Third-party UIs are separate projects. Review their source, release process, and security model before giving them access to a Gateway token, password, workspace, or public network route.
+
+## Available UIs
+
+<CardGroup cols={2}>
+  <Card title="DeepClaw UI" href="https://github.com/c0hm/deepclaw-ui" icon="monitor">
+    Community dashboard for live Gateway sessions, event visibility, tool-call inspection, token usage, chat, and file sharing.
+  </Card>
+</CardGroup>
+
+## Connecting a third-party UI
+
+Most external UIs connect to the Gateway WebSocket and authenticate the same way other Gateway clients do:
+
+- local Gateway: `ws://127.0.0.1:18789`
+- TLS Gateway: `wss://<host>:18789`
+- optional Control UI base path: set `gateway.controlUi.basePath` only for the built-in static UI route; WebSocket clients should follow the UI project documentation for its Gateway URL setting
+
+Use the least-privileged auth mode that fits your deployment:
+
+- local loopback while testing
+- Tailscale Serve or another identity-aware private proxy for remote access
+- explicit Gateway token or password only when the UI needs it
+
+See [Web](/web), [Gateway remote access](/gateway/remote), and [Tailscale](/gateway/tailscale) for the supported Gateway network patterns.
+
+## Security checklist
+
+Before running a third-party UI against a real Gateway:
+
+- Keep the Gateway itself protected by Gateway auth, Tailscale, or a trusted private network.
+- Do not put a Gateway token or password into a public static site, browser bundle, screenshot, log, or issue report.
+- Prefer environment variables, local config files, or server-side secret storage when the UI supports them.
+- Rotate any Gateway credential that was pasted into a tool you do not fully control.
+- If the UI exposes its own HTTP server, enable its password, TLS, or reverse-proxy auth before exposing it beyond loopback.
+- Treat file-sharing and transcript export features as sensitive because they may reveal workspace paths, tool output, prompts, or private conversation history.
+
+## Building your own UI
+
+Use the Gateway WebSocket protocol rather than scraping the built-in Control UI. The Gateway protocol is the stable integration surface for external dashboards and clients.
+
+Relevant references:
+
+- [Gateway protocol](/gateway/protocol)
+- [Bridge protocol](/gateway/bridge-protocol)
+- [Control UI](/web/control-ui)
+- [WebChat](/web/webchat)
+
+If your UI is open source and broadly useful, open a docs PR adding it to this page with a short description, repository link, supported auth mode, and any important security notes.


### PR DESCRIPTION
## Summary

- Add a Third-party UIs docs page under Web interfaces
- List DeepClaw UI as a community dashboard for OpenClaw Gateway
- Add connection guidance and a security checklist for external UIs
- Link the new page from the Web docs overview

Closes #88920

## Test Plan

- `pnpm format:docs:check`
- `pnpm docs:check-mdx docs/web/third-party-uis.md docs/web/index.md`
- `pnpm docs:check-links`
- `pnpm docs:check-i18n-glossary`
- `pnpm lint:docs -- docs/web/third-party-uis.md docs/web/index.md`

## Real behavior proof

- **Behavior or issue addressed:** Added documentation for third-party/community UIs so users can find non-built-in interfaces for OpenClaw Gateway, with DeepClaw UI listed as the initial community dashboard example.
- **Real environment tested:** Local OpenClaw checkout at commit `357a1c8d` on branch `docs/third-party-uis`.
- **Exact steps or command run after this patch:**

  ```bash
  git status --short
  test -f docs/web/third-party-uis.md && printf 'docs/web/third-party-uis.md present
'
  python3 - <<'PY'
  from pathlib import Path
  assert 'web/third-party-uis' in Path('docs/docs.json').read_text()
  assert '/web/third-party-uis' in Path('docs/web/index.md').read_text()
  print('third-party UI docs page is present, linked from docs nav, and linked from web overview')
  PY
  pnpm format:docs:check
  pnpm docs:check-mdx docs/web/third-party-uis.md docs/web/index.md
  pnpm docs:check-links
  pnpm docs:check-i18n-glossary
  pnpm lint:docs -- docs/web/third-party-uis.md docs/web/index.md
  ```

- **Evidence after fix:** Terminal output from the local OpenClaw checkout showed the live documentation files and links are present:

  ```text
  docs/web/third-party-uis.md present
  third-party UI docs page is present, linked from docs nav, and linked from web overview
  pnpm format:docs:check exited 0
  pnpm docs:check-mdx docs/web/third-party-uis.md docs/web/index.md exited 0
  pnpm docs:check-links exited 0
  pnpm docs:check-i18n-glossary exited 0
  pnpm lint:docs -- docs/web/third-party-uis.md docs/web/index.md exited 0
  ```

- **Observed result after fix:** The local checkout contains the new `docs/web/third-party-uis.md` page, `docs/docs.json` includes it in the Web interfaces navigation, and `docs/web/index.md` links readers to `/web/third-party-uis`. The docs validation commands completed successfully.
- **What was not tested:** No browser rendering or deployed docs preview was tested; this PR only changes Markdown/docs navigation.

