### PR TITLE
refactor: add session entry lifecycle seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1358,6 +1358,8 @@ jobs:
           - check_name: check-additional-boundaries-bcd
             group: boundaries
             boundary_shard: 2/4,3/4,4/4
+          - check_name: check-session-accessor-boundary
+            group: session-accessor-boundary
           - check_name: check-additional-extension-channels
             group: extension-channels
           - check_name: check-additional-extension-bundled
@@ -1503,6 +1505,9 @@ jobs:
           case "$ADDITIONAL_CHECK_GROUP" in
             boundaries)
               node scripts/run-additional-boundary-checks.mjs
+              ;;
+            session-accessor-boundary)
+              run_check "lint:tmp:session-accessor-boundary" pnpm run lint:tmp:session-accessor-boundary
               ;;
             extension-channels)
               run_check "lint:extensions:channels" pnpm run lint:extensions:channels

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1fc413736b1320d11981317535e791cd40cb7b5ac14d6beef50cc032b4e28afb  plugin-sdk-api-baseline.json
-7a375996b95a8fd4fb4eade436497ea7153faf7061f65a4e4b16b54ed6690561  plugin-sdk-api-baseline.jsonl
+3783a464b7d054abbe393a6fc826cabcdf5468de8db2a1407e3d76f7badf059d  plugin-sdk-api-baseline.json
+26dcaaf21d56ab9d5ad801cd5133e617d6e6c3f6bb34fa13918eef66efd07609  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8a2769df428906990ee0d1bf8b0423f2a099b053c64c816d092ff84d61e11633  plugin-sdk-api-baseline.json
-28b798973f3fb2a5b33ccbb6e3c1ac0453fa234a3a1c6cdc27935c27639bd104  plugin-sdk-api-baseline.jsonl
+1fc413736b1320d11981317535e791cd40cb7b5ac14d6beef50cc032b4e28afb  plugin-sdk-api-baseline.json
+7a375996b95a8fd4fb4eade436497ea7153faf7061f65a4e4b16b54ed6690561  plugin-sdk-api-baseline.jsonl

--- a/package.json
+++ b/package.json
@@ -1592,6 +1592,7 @@
     "lint:tmp:no-random-messaging": "node scripts/check-no-random-messaging-tmp.mjs",
     "lint:tmp:no-raw-channel-fetch": "node scripts/check-no-raw-channel-fetch.mjs",
     "lint:tmp:no-raw-http2-imports": "node scripts/check-no-raw-http2-imports.mjs",
+    "lint:tmp:session-accessor-boundary": "node scripts/check-session-accessor-boundary.mjs",
     "lint:tmp:tsgo-core-boundary": "node scripts/check-tsgo-core-boundary.mjs",
     "lint:ui:no-raw-window-open": "node scripts/check-no-raw-window-open.mjs",
     "lint:web-fetch-provider-boundaries": "node scripts/check-web-fetch-provider-boundaries.mjs",

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import ts from "typescript";
+import {
+  collectFileViolations,
+  resolveRepoRoot,
+  resolveSourceRoots,
+  runAsScript,
+  toLine,
+  unwrapExpression,
+} from "./lib/ts-guard-utils.mjs";
+
+const legacyReaderNames = new Set(["loadSessionStore", "readSessionEntries"]);
+
+export const migratedSessionAccessorFiles = new Set([
+  "src/config/sessions/combined-store-gateway.ts",
+  "src/gateway/session-utils.ts",
+  "src/gateway/sessions-resolve.ts",
+  "src/gateway/server-methods/sessions.ts",
+]);
+
+function normalizeRelativePath(filePath) {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+function propertyAccessName(expression) {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isIdentifier(unwrapped)) {
+    return unwrapped.text;
+  }
+  if (ts.isPropertyAccessExpression(unwrapped)) {
+    return unwrapped.name.text;
+  }
+  if (ts.isElementAccessExpression(unwrapped) && ts.isStringLiteral(unwrapped.argumentExpression)) {
+    return unwrapped.argumentExpression.text;
+  }
+  return null;
+}
+
+function bindingName(node) {
+  if (node.propertyName && ts.isIdentifier(node.propertyName)) {
+    return node.propertyName.text;
+  }
+  if (ts.isIdentifier(node.name)) {
+    return node.name.text;
+  }
+  return null;
+}
+
+export function findSessionAccessorBoundaryViolations(content, fileName = "source.ts") {
+  const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const violations = [];
+
+  const visit = (node) => {
+    if (ts.isImportDeclaration(node)) {
+      const namedBindings = node.importClause?.namedBindings;
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        for (const specifier of namedBindings.elements) {
+          const importedName = specifier.propertyName?.text ?? specifier.name.text;
+          if (legacyReaderNames.has(importedName)) {
+            violations.push({
+              line: toLine(sourceFile, specifier),
+              reason: `imports legacy session store reader "${importedName}"`,
+            });
+          }
+        }
+      }
+    }
+
+    if (ts.isBindingElement(node)) {
+      const name = bindingName(node);
+      if (name && legacyReaderNames.has(name)) {
+        violations.push({
+          line: toLine(sourceFile, node),
+          reason: `aliases legacy session store reader "${name}"`,
+        });
+      }
+    }
+
+    if (ts.isPropertyAccessExpression(node) && legacyReaderNames.has(node.name.text)) {
+      violations.push({
+        line: toLine(sourceFile, node.name),
+        reason: `references legacy session store reader "${node.name.text}"`,
+      });
+    }
+
+    if (
+      ts.isElementAccessExpression(node) &&
+      ts.isStringLiteral(node.argumentExpression) &&
+      legacyReaderNames.has(node.argumentExpression.text)
+    ) {
+      violations.push({
+        line: toLine(sourceFile, node.argumentExpression),
+        reason: `references legacy session store reader "${node.argumentExpression.text}"`,
+      });
+    }
+
+    if (ts.isCallExpression(node)) {
+      const calleeName = propertyAccessName(node.expression);
+      if (
+        calleeName &&
+        legacyReaderNames.has(calleeName) &&
+        ts.isIdentifier(unwrapExpression(node.expression))
+      ) {
+        violations.push({
+          line: toLine(sourceFile, node.expression),
+          reason: `calls legacy session store reader "${calleeName}"`,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+export async function main() {
+  const repoRoot = resolveRepoRoot(import.meta.url);
+  const sourceRoots = resolveSourceRoots(repoRoot, ["src/config/sessions", "src/gateway"]);
+  const violations = await collectFileViolations({
+    repoRoot,
+    sourceRoots,
+    skipFile: (filePath) =>
+      !migratedSessionAccessorFiles.has(normalizeRelativePath(path.relative(repoRoot, filePath))),
+    findViolations: findSessionAccessorBoundaryViolations,
+  });
+
+  if (violations.length === 0) {
+    console.log("session accessor boundary guard passed.");
+    return;
+  }
+
+  console.error("Found legacy session store reader usage in session-accessor migrated files:");
+  for (const violation of violations) {
+    console.error(`- ${violation.path}:${violation.line}: ${violation.reason}`);
+  }
+  console.error(
+    "Use src/config/sessions/session-accessor.ts helpers for migrated read/projection paths. Expand this ratchet only after a slice migrates more files.",
+  );
+  process.exit(1);
+}
+
+runAsScript(import.meta.url, main);

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -17,7 +17,6 @@ export const BOUNDARY_CHECKS = [
   ["lint:tmp:tsgo-core-boundary", "pnpm", ["run", "lint:tmp:tsgo-core-boundary"]],
   ["lint:tmp:no-raw-channel-fetch", "pnpm", ["run", "lint:tmp:no-raw-channel-fetch"]],
   ["lint:tmp:no-raw-http2-imports", "pnpm", ["run", "lint:tmp:no-raw-http2-imports"]],
-  ["lint:tmp:session-accessor-boundary", "pnpm", ["run", "lint:tmp:session-accessor-boundary"]],
   ["lint:agent:ingress-owner", "pnpm", ["run", "lint:agent:ingress-owner"]],
   [
     "lint:plugins:no-register-http-handler",

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -17,6 +17,7 @@ export const BOUNDARY_CHECKS = [
   ["lint:tmp:tsgo-core-boundary", "pnpm", ["run", "lint:tmp:tsgo-core-boundary"]],
   ["lint:tmp:no-raw-channel-fetch", "pnpm", ["run", "lint:tmp:no-raw-channel-fetch"]],
   ["lint:tmp:no-raw-http2-imports", "pnpm", ["run", "lint:tmp:no-raw-http2-imports"]],
+  ["lint:tmp:session-accessor-boundary", "pnpm", ["run", "lint:tmp:session-accessor-boundary"]],
   ["lint:agent:ingress-owner", "pnpm", ["run", "lint:agent:ingress-owner"]],
   [
     "lint:plugins:no-register-http-handler",

--- a/src/agents/command/attempt-execution.shared.ts
+++ b/src/agents/command/attempt-execution.shared.ts
@@ -2,7 +2,7 @@
  * Shared session persistence and prompt-body helpers for agent attempt
  * execution paths.
  */
-import { updateSessionStore } from "../../config/sessions/store.js";
+import { patchSessionLifecycleEntry } from "../../config/sessions/session-entry-lifecycle.js";
 import { mergeSessionEntry, type SessionEntry } from "../../config/sessions/types.js";
 import {
   formatAgentInternalEventsForPlainPrompt,
@@ -34,37 +34,41 @@ function normalizeTranscriptMarkerUpdatedAt(value: number | undefined): number |
 export async function persistSessionEntry(
   params: PersistSessionEntryParams,
 ): Promise<SessionEntry | undefined> {
-  const persisted = await updateSessionStore(
-    params.storePath,
-    (store) => {
-      const current = store[params.sessionKey];
-      if (params.shouldPersist && !params.shouldPersist(current)) {
-        return current;
-      }
-      const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
-      if (params.preserveTranscriptMarkerUpdatedAt) {
-        const currentUpdatedAt = normalizeTranscriptMarkerUpdatedAt(current?.updatedAt);
-        const markerUpdatedAt = normalizeTranscriptMarkerUpdatedAt(params.entry.updatedAt);
-        if (markerUpdatedAt !== undefined) {
-          merged.updatedAt = Math.max(currentUpdatedAt ?? 0, markerUpdatedAt);
+  const persisted =
+    (await patchSessionLifecycleEntry(
+      { sessionKey: params.sessionKey, storePath: params.storePath },
+      (current, context) => {
+        // shouldPersist=false maps to a null patch: the lifecycle seam skips
+        // persistence and returns the existing entry (or null when absent),
+        // matching the prior updateSessionStore early-return behavior.
+        if (params.shouldPersist && !params.shouldPersist(context.existingEntry)) {
+          return null;
         }
-      }
-      for (const field of params.clearedFields ?? []) {
-        // Cleared fields only apply when the replacement entry did not set the
-        // field again; this preserves explicit false/null updates.
-        if (!Object.hasOwn(params.entry, field)) {
-          Reflect.deleteProperty(merged, field);
+        const merged = mergeSessionEntry(current, params.entry);
+        if (params.preserveTranscriptMarkerUpdatedAt) {
+          const currentUpdatedAt = normalizeTranscriptMarkerUpdatedAt(
+            context.existingEntry?.updatedAt,
+          );
+          const markerUpdatedAt = normalizeTranscriptMarkerUpdatedAt(params.entry.updatedAt);
+          if (markerUpdatedAt !== undefined) {
+            merged.updatedAt = Math.max(currentUpdatedAt ?? 0, markerUpdatedAt);
+          }
         }
-      }
-      store[params.sessionKey] = merged;
-      return merged;
-    },
-    {
-      resolveSingleEntryPersistence: (entry) =>
-        entry ? { sessionKey: params.sessionKey, entry } : null,
-      takeCacheOwnership: true,
-    },
-  );
+        for (const field of params.clearedFields ?? []) {
+          // Cleared fields only apply when the replacement entry did not set the
+          // field again; this preserves explicit false/null updates.
+          if (!Object.hasOwn(params.entry, field)) {
+            Reflect.deleteProperty(merged, field);
+          }
+        }
+        return merged;
+      },
+      {
+        fallbackEntry: params.entry,
+        replaceEntry: true,
+        takeCacheOwnership: true,
+      },
+    )) ?? undefined;
   if (persisted) {
     params.sessionStore[params.sessionKey] = persisted;
   } else {

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -1,6 +1,6 @@
 // Shared session-store helpers for command handlers that mutate sessions.
 import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { patchSessionLifecycleEntry } from "../../config/sessions/session-entry-lifecycle.js";
 import { applyAbortCutoffToSessionEntry, type AbortCutoff } from "./abort-cutoff.js";
 import type { CommandHandler } from "./commands-types.js";
 
@@ -10,21 +10,19 @@ export async function persistSessionEntry(params: CommandParams): Promise<boolea
   if (!params.sessionEntry || !params.sessionStore || !params.sessionKey) {
     return false;
   }
-  params.sessionEntry.updatedAt = Date.now();
-  params.sessionStore[params.sessionKey] = params.sessionEntry;
+  const sessionEntry = params.sessionEntry;
+  sessionEntry.updatedAt = Date.now();
+  params.sessionStore[params.sessionKey] = sessionEntry;
   if (params.storePath) {
     // Slash commands mutate one known session entry; skipping global session
     // maintenance avoids scanning the whole sessions directory for simple
     // command-only writes.
-    await updateSessionStore(
-      params.storePath,
-      (store) => {
-        store[params.sessionKey] = params.sessionEntry as SessionEntry;
-        return params.sessionEntry as SessionEntry;
-      },
+    await patchSessionLifecycleEntry(
+      { sessionKey: params.sessionKey, storePath: params.storePath },
+      () => sessionEntry,
       {
-        resolveSingleEntryPersistence: (entry) =>
-          entry ? { sessionKey: params.sessionKey, entry } : null,
+        fallbackEntry: sessionEntry,
+        replaceEntry: true,
         skipMaintenance: true,
       },
     );
@@ -50,23 +48,15 @@ export async function persistAbortTargetEntry(params: {
   sessionStore[key] = entry;
 
   if (storePath) {
-    await updateSessionStore(
-      storePath,
-      (store) => {
-        const nextEntry = store[key] ?? entry;
-        if (!nextEntry) {
-          return undefined;
-        }
+    await patchSessionLifecycleEntry(
+      { sessionKey: key, storePath },
+      (nextEntry) => {
         nextEntry.abortedLastRun = true;
         applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
         nextEntry.updatedAt = Date.now();
-        store[key] = nextEntry;
         return nextEntry;
       },
-      {
-        resolveSingleEntryPersistence: (updated) =>
-          updated ? { sessionKey: key, entry: updated } : null,
-      },
+      { fallbackEntry: entry, replaceEntry: true },
     );
   }
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -10,9 +10,9 @@ import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   loadSessionStore,
+  deleteSessionEntries,
   pruneStaleEntries,
   resolveAllAgentSessionStoreTargetsSync,
-  updateSessionStore,
   type SessionEntry,
 } from "../config/sessions.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
@@ -197,23 +197,21 @@ async function runSessionRegistryMaintenance(params: {
     const beforeStore = loadSessionStore(target.storePath, { skipCache: true });
     const beforeCount = Object.keys(beforeStore).length;
     if (params.apply) {
-      // Apply mode mutates each store atomically through updateSessionStore.
-      const applied = await updateSessionStore(
-        target.storePath,
-        (store) => {
-          const { preserveKeys, preservedRunning } = buildSessionRegistryPreserveKeys({
-            store,
-            runningCronJobIds,
-          });
-          const pruned = pruneStaleEntries(store, SESSION_REGISTRY_RETENTION_MS, {
-            log: false,
-            preserveKeys,
-          });
-          return {
-            pruned,
-            afterCount: Object.keys(store).length,
-            preservedRunning,
-          };
+      // Apply mode mutates each store atomically through the entry lifecycle seam.
+      let preservedRunning = 0;
+      const cutoffMs = Date.now() - SESSION_REGISTRY_RETENTION_MS;
+      const deletion = await deleteSessionEntries(
+        { storePath: target.storePath },
+        (entry, { sessionKey }) => {
+          const jobId = parseCronRunSessionJobId(sessionKey);
+          if (!jobId) {
+            return false;
+          }
+          if (runningCronJobIds.has(jobId)) {
+            preservedRunning += 1;
+            return false;
+          }
+          return entry.updatedAt != null && entry.updatedAt < cutoffMs;
         },
         { skipMaintenance: true },
       );
@@ -221,9 +219,9 @@ async function runSessionRegistryMaintenance(params: {
         agentId: target.agentId,
         storePath: target.storePath,
         beforeCount,
-        afterCount: applied.afterCount,
-        pruned: applied.pruned,
-        preservedRunning: applied.preservedRunning,
+        afterCount: beforeCount - deletion.deleted.length,
+        pruned: deletion.deleted.length,
+        preservedRunning,
       });
       continue;
     }

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -14,6 +14,7 @@ export * from "./sessions/store.js";
 export * from "./sessions/types.js";
 export * from "./sessions/transcript.js";
 export * from "./sessions/session-file.js";
+export * from "./sessions/session-entry-lifecycle.js";
 export * from "./sessions/session-file-rotation.js";
 export * from "./sessions/delivery-info.js";
 export * from "./sessions/disk-budget.js";

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -9,7 +9,7 @@ import {
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveStorePath } from "./paths.js";
-import { loadSessionStore } from "./store-load.js";
+import { listSessionEntries } from "./session-accessor.js";
 import {
   resolveAgentSessionStoreTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
@@ -20,6 +20,15 @@ import type { SessionEntry } from "./types.js";
 // Template-backed stores need per-agent scans before they can be merged for Gateway views.
 function isStorePathTemplate(store?: string): boolean {
   return typeof store === "string" && store.includes("{agentId}");
+}
+
+function loadGatewayStoreEntries(storePath: string): Record<string, SessionEntry> {
+  return Object.fromEntries(
+    listSessionEntries({ clone: false, storePath }).map(({ sessionKey, entry }) => [
+      sessionKey,
+      entry,
+    ]),
+  );
 }
 
 function mergeSessionEntryIntoCombined(params: {
@@ -76,7 +85,7 @@ export function loadCombinedSessionStoreForGateway(
     // A single shared store still needs keys canonicalized as if owned by the default agent.
     const storePath = resolveStorePath(storeConfig);
     const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    const store = loadSessionStore(storePath, { clone: false });
+    const store = loadGatewayStoreEntries(storePath);
     const combined: Record<string, SessionEntry> = {};
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
@@ -108,7 +117,7 @@ export function loadCombinedSessionStoreForGateway(
   for (const target of targets) {
     const agentId = target.agentId;
     const storePath = target.storePath;
-    const store = loadSessionStore(storePath, { clone: false });
+    const store = loadGatewayStoreEntries(storePath);
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
         cfg,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -208,6 +208,34 @@ describe("session accessor file-backed seam", () => {
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
+  it("can patch metadata without refreshing session activity", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforePatch = loadSessionEntry(scope);
+
+    await patchSessionEntry(
+      scope,
+      () => ({
+        model: "gpt-5.5",
+        updatedAt: 20,
+      }),
+      { preserveActivity: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: beforePatch?.updatedAt,
+    });
+  });
+
   it("loads and appends transcript events through a session scope", async () => {
     const scope = {
       sessionFile: transcriptPath,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -159,13 +160,18 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    let missingContextEntry: SessionEntry | undefined;
+    let existingContextEntry: SessionEntry | undefined;
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: "gpt-5.5",
-      }),
+      (entry, context) => {
+        missingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: "gpt-5.5",
+        };
+      },
       {
         fallbackEntry: {
           sessionId: "session-1",
@@ -177,14 +183,19 @@ describe("session accessor file-backed seam", () => {
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: undefined,
-        providerOverride: "openai",
-      }),
+      (entry, context) => {
+        existingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: undefined,
+          providerOverride: "openai",
+        };
+      },
       { replaceEntry: true },
     );
 
+    expect(missingContextEntry).toBeUndefined();
+    expect(existingContextEntry).toMatchObject({ model: "gpt-5.5" });
     expect(loadSessionEntry(scope)).toMatchObject({
       providerOverride: "openai",
       sessionId: "session-1",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -124,6 +125,32 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("replaces entries so deleted fields stay removed", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      providerOverride: "openai",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    await replaceSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 20,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
+    expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
 
@@ -75,6 +76,34 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("updates existing entries without creating missing sessions", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(updateSessionEntry(scope, () => ({ model: "gpt-5.5" }))).resolves.toBeNull();
+    expect(listSessionEntries({ storePath })).toEqual([]);
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforeNullUpdate = loadSessionEntry(scope);
+    await expect(updateSessionEntry(scope, () => null)).resolves.toEqual(beforeNullUpdate);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: beforeNullUpdate?.updatedAt,
+    });
+    await expect(
+      updateSessionEntry(scope, () => ({ model: "gpt-5.5", updatedAt: 20 })),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+
+describe("session accessor file-backed seam", () => {
+  let tempDir: string;
+  let storePath: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    storePath = path.join(tempDir, "sessions.json");
+    transcriptPath = path.join(tempDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads, lists, and patches session entries without exposing the file store shape", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(listSessionEntries({ storePath })).toEqual([
+      {
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "session-1",
+          updatedAt: expect.any(Number),
+        }),
+      },
+    ]);
+
+    await upsertSessionEntry(scope, { model: "sonnet-4.6", updatedAt: 20 });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "sonnet-4.6",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("creates durable session ids for metadata-only inserts", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    const inserted = await upsertSessionEntry(scope, { model: "gpt-5.5" });
+
+    expect(inserted?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(inserted?.sessionId).not.toBe(scope.sessionKey);
+    expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("loads and appends transcript events through a session scope", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+    await appendTranscriptEvent(scope, event);
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", sessionId: "session-1" },
+      event,
+    ]);
+    expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors thread fallback paths when resolving transcript scope from the store", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:demo-channel:1234:thread:456",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, event);
+
+    const expectedTranscriptPath = path.join(tempDir, "session-1-topic-456.jsonl");
+    expect(fs.existsSync(expectedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "session-1.jsonl"))).toBe(false);
+    expect(fs.realpathSync(loadSessionEntry(scope)?.sessionFile ?? "")).toBe(
+      fs.realpathSync(expectedTranscriptPath),
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("persists transcript metadata under the normalized session key", async () => {
+    const canonicalScope = {
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(canonicalScope, {
+      sessionId: canonicalScope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: canonicalScope.sessionId,
+        sessionKey: "AGENT:MAIN:MAIN",
+        storePath,
+      },
+      { id: "msg-1", type: "message" },
+    );
+
+    expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([
+      canonicalScope.sessionKey,
+    ]);
+    expect(loadSessionEntry(canonicalScope)?.sessionFile).toBeTruthy();
+  });
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -10,6 +10,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { loadSessionStore } from "./store.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -76,6 +77,25 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("can borrow cached entry objects for read-only hot paths", async () => {
+    const scope = {
+      clone: false,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+
+    expect(loadSessionEntry(scope)).toBe(cachedStore["agent:main:main"]);
+    expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
+      cachedStore["agent:main:main"],
+    );
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,7 @@ import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
+  cleanupSessionLifecycleArtifacts,
   listSessionEntries,
   loadExactSessionEntry,
   loadSessionEntry,
@@ -264,6 +265,83 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: beforePatch?.updatedAt,
     });
+  });
+
+  it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
+    const nowMs = Date.now();
+    const oldDate = new Date(nowMs - 600_000);
+    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:lifecycle-cleanup-removed": {
+          sessionId: "removed-lifecycle",
+        },
+        "agent:main:lifecycle-cleanup-fresh": {
+          sessionId: "fresh-lifecycle",
+        },
+        "agent:main:lifecycle-cleanup-custom": {
+          sessionFile: "custom-lifecycle-old.jsonl",
+          sessionId: "custom-lifecycle",
+        },
+        "agent:main:telegram:group:lifecycle-cleanup-room": {
+          sessionId: "kept-by-segment",
+        },
+        "agent:main:regular": {
+          sessionId: "referenced",
+        },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(removedTranscriptPath, '{"runId":"lifecycle-marker-removed"}\n', "utf-8");
+    fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
+    fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
+    fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(
+      referencedTranscriptPath,
+      '{"runId":"lifecycle-marker-referenced"}\n',
+      "utf-8",
+    );
+    fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
+    fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(customTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
+
+    const result = await cleanupSessionLifecycleArtifacts({
+      storePath,
+      sessionKeySegmentPrefix: "lifecycle-cleanup-",
+      transcriptContentMarker: "lifecycle-marker-",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs,
+    });
+
+    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
+    expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
+    expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
+    expect(loaded).toHaveProperty("agent:main:regular");
+    const files = fs.readdirSync(tempDir);
+    expect(
+      files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted."))).toHaveLength(
+      1,
+    );
+    expect(
+      files.filter((file) => file.startsWith("custom-lifecycle-old.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files).toContain("custom-lifecycle.jsonl");
+    expect(files).toContain("fresh-lifecycle.jsonl");
+    expect(files).toContain("referenced.jsonl");
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -47,6 +51,7 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+    expect(readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
     expect(listSessionEntries({ storePath })).toEqual([
       {
         sessionKey: "agent:main:main",
@@ -225,6 +230,75 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends messages and publishes updates through a session scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    const appended = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    const replayed = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello again",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    await publishTranscriptUpdate(scope, {
+      agentId: "main",
+      message: appended.message,
+      messageId: appended.messageId,
+      sessionKey: scope.sessionKey,
+    });
+    unsubscribe();
+
+    expect(replayed).toMatchObject({
+      appended: false,
+      messageId: appended.messageId,
+      message: expect.objectContaining({
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      }),
+    });
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: appended.messageId,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        type: "message",
+      }),
+    ]);
+    expect(updates).toEqual([
+      {
+        agentId: "main",
+        message: appended.message,
+        messageId: appended.messageId,
+        sessionFile: transcriptPath,
+        sessionKey: scope.sessionKey,
+      },
+    ]);
   });
 
   it("honors thread fallback paths when resolving transcript scope from the store", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -270,18 +270,21 @@ describe("session accessor file-backed seam", () => {
   it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
     const nowMs = Date.now();
     const oldDate = new Date(nowMs - 600_000);
-    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
-    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
-    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
-    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
-    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
-    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
-    const siblingDir = `${tempDir}-sibling-sessions`;
+    const lifecycleSessionsDir = path.join(tempDir, "state", "agents", "main", "sessions");
+    const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
+    const removedTranscriptPath = path.join(lifecycleSessionsDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(lifecycleSessionsDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(lifecycleSessionsDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(lifecycleSessionsDir, "orphan-lifecycle.jsonl");
+    const siblingDir = path.join(tempDir, "state", "agents", "sibling", "sessions");
     const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
     fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
-      storePath,
+      lifecycleStorePath,
       JSON.stringify({
         "agent:main:lifecycle-cleanup-removed": {
           sessionId: "removed-lifecycle",
@@ -324,7 +327,7 @@ describe("session accessor file-backed seam", () => {
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
     const result = await cleanupSessionLifecycleArtifacts({
-      storePath,
+      storePath: lifecycleStorePath,
       sessionKeySegmentPrefix: "lifecycle-cleanup-",
       transcriptContentMarker: "lifecycle-marker-",
       orphanTranscriptMinAgeMs: 300_000,
@@ -332,14 +335,14 @@ describe("session accessor file-backed seam", () => {
     });
 
     expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
-    const loaded = loadSessionStore(storePath, { skipCache: true });
+    const loaded = loadSessionStore(lifecycleStorePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
-    const files = fs.readdirSync(tempDir);
+    const files = fs.readdirSync(lifecycleSessionsDir);
     expect(
       files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
     ).toHaveLength(1);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -104,6 +105,35 @@ describe("session accessor file-backed seam", () => {
     expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
       cachedStore["agent:main:main"],
     );
+  });
+
+  it("keeps exact persisted-key lookup separate from canonical entry reads", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-1",
+          updatedAt: 10,
+          model: "gpt-5.5",
+        },
+      }),
+      "utf8",
+    );
+
+    const mixedCaseScope = {
+      sessionKey: "AGENT:MAIN:MAIN",
+      storePath,
+    };
+
+    expect(loadSessionEntry(mixedCaseScope)?.sessionId).toBe("session-1");
+    expect(loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+    expect(loadExactSessionEntry({ sessionKey: "agent:main:main", storePath })).toEqual({
+      sessionKey: "agent:main:main",
+      entry: expect.objectContaining({
+        sessionId: "session-1",
+        model: "gpt-5.5",
+      }),
+    });
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -232,6 +232,48 @@ describe("session accessor file-backed seam", () => {
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
   });
 
+  it("loads transcript events without a session key when the read target is explicit", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(
+      {
+        ...scope,
+        sessionKey: "agent:main:main",
+        storePath,
+      },
+      event,
+    );
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("loads transcript events from a generated read target without a session key", async () => {
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    fs.writeFileSync(path.join(tempDir, "session-1.jsonl"), `${JSON.stringify(event)}\n`, "utf-8");
+
+    await expect(
+      loadTranscriptEvents({
+        sessionId: "session-1",
+        storePath,
+      }),
+    ).resolves.toEqual([event]);
+  });
+
   it("appends messages and publishes updates through a session scope", async () => {
     const scope = {
       agentId: "main",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  patchSessionEntry,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -151,6 +152,44 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
     expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
+  });
+
+  it("patches entries atomically with a fallback entry", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: "gpt-5.5",
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "session-1",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+      },
+    );
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: undefined,
+        providerOverride: "openai",
+      }),
+      { replaceEntry: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -367,10 +367,8 @@ describe("session accessor file-backed seam", () => {
       storePath,
     };
     const event = {
-      id: "msg-1",
-      message: { role: "user", content: "hello" },
-      parentId: null,
-      type: "message",
+      payload: { value: "hello" },
+      type: "metadata",
     };
 
     await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
@@ -383,16 +381,33 @@ describe("session accessor file-backed seam", () => {
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
   });
 
+  it("rejects raw message transcript events", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(
+      appendTranscriptEvent(scope, {
+        id: "msg-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      }),
+    ).rejects.toThrow(/appendTranscriptMessage/);
+    expect(fs.existsSync(transcriptPath)).toBe(false);
+  });
+
   it("loads transcript events without a session key when the read target is explicit", async () => {
     const scope = {
       sessionFile: transcriptPath,
       sessionId: "session-1",
     };
     const event = {
-      id: "msg-1",
-      message: { role: "user", content: "hello" },
-      parentId: null,
-      type: "message",
+      payload: { value: "hello" },
+      type: "metadata",
     };
 
     await appendTranscriptEvent(
@@ -409,10 +424,8 @@ describe("session accessor file-backed seam", () => {
 
   it("loads transcript events from a generated read target without a session key", async () => {
     const event = {
-      id: "msg-1",
-      message: { role: "user", content: "hello" },
-      parentId: null,
-      type: "message",
+      payload: { value: "hello" },
+      type: "metadata",
     };
 
     fs.writeFileSync(path.join(tempDir, "session-1.jsonl"), `${JSON.stringify(event)}\n`, "utf-8");
@@ -502,10 +515,8 @@ describe("session accessor file-backed seam", () => {
       storePath,
     };
     const event = {
-      id: "msg-1",
-      message: { role: "user", content: "hello" },
-      parentId: null,
-      type: "message",
+      payload: { value: "hello" },
+      type: "metadata",
     };
 
     await upsertSessionEntry(scope, {
@@ -541,7 +552,7 @@ describe("session accessor file-backed seam", () => {
         sessionKey: "AGENT:MAIN:MAIN",
         storePath,
       },
-      { id: "msg-1", type: "message" },
+      { id: "event-1", type: "metadata" },
     );
 
     expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -276,6 +276,9 @@ describe("session accessor file-backed seam", () => {
     const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
     const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
     const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+    const siblingDir = `${tempDir}-sibling-sessions`;
+    const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
       storePath,
@@ -290,6 +293,10 @@ describe("session accessor file-backed seam", () => {
           sessionFile: "custom-lifecycle-old.jsonl",
           sessionId: "custom-lifecycle",
         },
+        "agent:main:lifecycle-cleanup-sibling": {
+          sessionFile: siblingTranscriptPath,
+          sessionId: "sibling-lifecycle",
+        },
         "agent:main:telegram:group:lifecycle-cleanup-room": {
           sessionId: "kept-by-segment",
         },
@@ -303,6 +310,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
     fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
     fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(siblingTranscriptPath, '{"runId":"lifecycle-marker-sibling"}\n', "utf-8");
     fs.writeFileSync(
       referencedTranscriptPath,
       '{"runId":"lifecycle-marker-referenced"}\n',
@@ -311,6 +319,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
     fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(customTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(siblingTranscriptPath, oldDate, oldDate);
     fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
@@ -322,10 +331,11 @@ describe("session accessor file-backed seam", () => {
       nowMs,
     });
 
-    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
+    expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
     const loaded = loadSessionStore(storePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
@@ -342,6 +352,8 @@ describe("session accessor file-backed seam", () => {
     expect(files).toContain("custom-lifecycle.jsonl");
     expect(files).toContain("fresh-lifecycle.jsonl");
     expect(files).toContain("referenced.jsonl");
+    expect(fs.existsSync(siblingTranscriptPath)).toBe(true);
+    expect(fs.readdirSync(siblingDir)).toEqual(["sibling-lifecycle.jsonl"]);
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveAndPersistSessionFile } from "./session-file.js";
+import {
+  getSessionEntry,
+  listSessionEntries as listFileSessionEntries,
+  loadSessionStore,
+  patchSessionEntry as patchFileSessionEntry,
+  resolveSessionStoreEntry,
+} from "./store.js";
+import { parseSessionThreadInfo } from "./thread-info.js";
+import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import { resolveSessionTranscriptFile } from "./transcript.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionAccessScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionKey: string;
+  storePath?: string;
+};
+
+export type SessionTranscriptAccessScope = SessionAccessScope & {
+  sessionFile?: string;
+  sessionId: string;
+  threadId?: string | number;
+};
+
+export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type TranscriptEvent = unknown;
+
+/** Loads one session entry through the storage-neutral accessor seam. */
+export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  return getSessionEntry(scope);
+}
+
+/** Lists session entries through the storage-neutral accessor seam. */
+export function listSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  return listFileSessionEntries(scope);
+}
+
+/** Applies a partial entry update through the storage-neutral accessor seam. */
+export async function upsertSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: createFallbackSessionEntry(patch),
+    update: () => patch,
+  });
+}
+
+/** Loads raw transcript events through the storage-neutral accessor seam. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const transcript = await resolveTranscriptAccess(scope);
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
+
+/** Appends one raw transcript event through the storage-neutral accessor seam. */
+export async function appendTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  await appendSessionTranscriptEvent({
+    event,
+    transcriptPath: transcript.sessionFile,
+  });
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    return await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+  }
+  return await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -13,12 +13,15 @@ import {
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
+  cleanupSessionLifecycleArtifacts as cleanupFileSessionLifecycleArtifacts,
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
+  type SessionLifecycleArtifactCleanupParams,
+  type SessionLifecycleArtifactCleanupResult,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import {
@@ -98,6 +101,8 @@ export type SessionEntryPatchOptions = {
 export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
+
+export type { SessionLifecycleArtifactCleanupParams, SessionLifecycleArtifactCleanupResult };
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
@@ -212,6 +217,13 @@ export async function updateSessionEntry(
     takeCacheOwnership: options.takeCacheOwnership,
     update,
   });
+}
+
+/** Cleans scoped session lifecycle entries and transcript artifacts through the accessor seam. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  return await cleanupFileSessionLifecycleArtifacts(params);
 }
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -9,6 +10,7 @@ import {
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptEvent } from "./transcript-append.js";
@@ -37,6 +39,11 @@ export type SessionEntrySummary = {
 
 export type TranscriptEvent = unknown;
 
+export type SessionEntryUpdateOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   return getSessionEntry(scope);
@@ -58,6 +65,23 @@ export async function upsertSessionEntry(
     ...scope,
     fallbackEntry: createFallbackSessionEntry(patch),
     update: () => patch,
+  });
+}
+
+/** Updates an existing session entry through the storage-neutral accessor seam. */
+export async function updateSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  return await updateFileSessionStoreEntry({
+    storePath: resolveAccessStorePath(scope),
+    sessionKey: scope.sessionKey,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
   });
 }
 
@@ -92,6 +116,17 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
     updatedAt: patch.updatedAt ?? now,
     ...patch,
   };
+}
+
+function resolveAccessStorePath(scope: SessionAccessScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -84,6 +84,19 @@ export async function upsertSessionEntry(
   });
 }
 
+/** Replaces one entry through the storage-neutral accessor seam. */
+export async function replaceSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: entry,
+    replaceEntry: true,
+    update: () => entry,
+  });
+}
+
 /** Updates an existing session entry through the storage-neutral accessor seam. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -32,32 +32,55 @@ import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
+/**
+ * Session access API for callers that need entries or transcripts without
+ * depending on the persisted store layout. Callers provide stable session
+ * identity, and this module resolves the current entry/transcript target while
+ * preserving canonical-key, transcript-linking, and update-notification rules.
+ */
 export type SessionAccessScope = {
+  /** Agent owner used when the session key does not already encode one. */
   agentId?: string;
+  /**
+   * Set false only for internal read-only hot paths that will not retain or
+   * mutate the returned entry.
+   */
   clone?: boolean;
+  /** Environment override used when resolving agent-scoped store paths in tests/tools. */
   env?: NodeJS.ProcessEnv;
+  /** Set false for metadata-only reads that do not need hydrated prompt refs. */
   hydrateSkillPromptRefs?: boolean;
+  /** Canonical or alias session key for the entry being read or written. */
   sessionKey: string;
+  /** Explicit store path for callers that already resolved the owning store. */
   storePath?: string;
 };
 
 export type SessionTranscriptReadScope = Omit<SessionAccessScope, "sessionKey"> & {
+  /** Explicit transcript file path; bypasses store lookup when already known. */
   sessionFile?: string;
+  /** Runtime session id used to derive a transcript file when no explicit file is provided. */
   sessionId: string;
+  /** Optional key for read callers that can resolve via the session entry. */
   sessionKey?: string;
+  /** Channel thread suffix used when deriving topic transcript paths. */
   threadId?: string | number;
 };
 
 export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
+  /** Required for writes because write paths may update entry metadata. */
   sessionKey: string;
 };
 
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  /** Optional for appenders that can operate on an existing explicit transcript target. */
   sessionId?: string;
 };
 
 export type SessionEntrySummary = {
+  /** Persisted key for the entry. */
   sessionKey: string;
+  /** Entry value cloned from the backing store unless the caller requested borrowed reads. */
   entry: SessionEntry;
 };
 
@@ -67,44 +90,62 @@ export type ExactSessionEntry = {
   entry: SessionEntry;
 };
 
+/** Raw transcript record for non-message events; message records use appendTranscriptMessage. */
 export type TranscriptEvent = unknown;
 
 export type TranscriptMessageAppendOptions<TMessage> = {
+  /** Runtime config used for message redaction and transcript header metadata. */
   config?: OpenClawConfig;
+  /** Working directory recorded in a newly created transcript header. */
   cwd?: string;
+  /** How duplicate message idempotency keys are detected before append. */
   idempotencyLookup?: "scan" | "caller-checked";
+  /** Provider/channel message payload to persist. */
   message: TMessage;
+  /** Testable timestamp override for the generated transcript entry. */
   now?: number;
+  /** Optional finalizer that runs after duplicate detection but before persistence. */
   prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  /** Allow append without parent-link migration for large legacy linear transcripts. */
   useRawWhenLinear?: boolean;
 };
 
 export type TranscriptMessageAppendResult<TMessage> = {
+  /** False when idempotency lookup found an existing transcript message. */
   appended: boolean;
+  /** Redacted message payload as persisted or replayed from the transcript. */
   message: TMessage;
+  /** Existing or newly generated transcript message id. */
   messageId: string;
 };
 
+/** Transcript update fields supplied by callers; sessionFile is resolved here. */
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
+  /** Skip prune/cap/rotation maintenance for specialized internal updates. */
   skipMaintenance?: boolean;
+  /** Let the writer cache retain the updated object without cloning. */
   takeCacheOwnership?: boolean;
 };
 
 export type SessionEntryPatchOptions = {
+  /** Entry to synthesize when a patch operation is allowed to create. */
   fallbackEntry?: SessionEntry;
+  /** Keep the previous updatedAt value when the patch should not count as activity. */
   preserveActivity?: boolean;
+  /** Replace the whole entry instead of merging the returned patch. */
   replaceEntry?: boolean;
 };
 
 export type SessionEntryPatchContext = {
+  /** Present when the patched entry already existed before fallback synthesis. */
   existingEntry?: SessionEntry;
 };
 
 export type { SessionLifecycleArtifactCleanupParams, SessionLifecycleArtifactCleanupResult };
 
-/** Loads one session entry through the storage-neutral accessor seam. */
+/** Returns the entry for a canonical or alias session key, if one exists. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
     const store = loadSessionStore(resolveAccessStorePath(scope), {
@@ -117,8 +158,9 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 }
 
 /**
- * Loads one entry only when the persisted key exactly matches the requested key.
- * Approval routing uses this to avoid canonical alias lookup crossing accounts.
+ * Returns only the row persisted under the exact key provided.
+ * Use this for authorization-sensitive routing where alias canonicalization
+ * could cross an account or agent boundary.
  */
 export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
   const sessionKey = scope.sessionKey.trim();
@@ -133,7 +175,7 @@ export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEn
   return entry ? { sessionKey, entry } : undefined;
 }
 
-/** Lists session entries through the storage-neutral accessor seam. */
+/** Lists entries from the resolved store, preserving the persisted key for each row. */
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
@@ -148,7 +190,7 @@ export function listSessionEntries(
   return listFileSessionEntries(scope);
 }
 
-/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+/** Reads the last activity timestamp for one session entry, or undefined when absent. */
 export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
   if (scope.storePath) {
     return readFileSessionUpdatedAt({
@@ -159,7 +201,7 @@ export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefi
   return loadSessionEntry(scope)?.updatedAt;
 }
 
-/** Applies a partial entry update through the storage-neutral accessor seam. */
+/** Creates or updates one entry from a partial patch and returns the persisted entry. */
 export async function upsertSessionEntry(
   scope: SessionAccessScope,
   patch: Partial<SessionEntry>,
@@ -171,7 +213,7 @@ export async function upsertSessionEntry(
   });
 }
 
-/** Replaces one entry through the storage-neutral accessor seam. */
+/** Replaces one entry with the supplied value and returns the persisted entry. */
 export async function replaceSessionEntry(
   scope: SessionAccessScope,
   entry: SessionEntry,
@@ -184,7 +226,11 @@ export async function replaceSessionEntry(
   });
 }
 
-/** Patches one entry atomically through the storage-neutral accessor seam. */
+/**
+ * Applies an atomic patch to one entry.
+ * The updater sees the current entry plus whether it was synthesized from a
+ * fallback; returning null skips persistence.
+ */
 export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
@@ -202,7 +248,7 @@ export async function patchSessionEntry(
   });
 }
 
-/** Updates an existing session entry through the storage-neutral accessor seam. */
+/** Updates an existing entry only; returns null when the session is absent. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,
   update: (
@@ -219,14 +265,14 @@ export async function updateSessionEntry(
   });
 }
 
-/** Cleans scoped session lifecycle entries and transcript artifacts through the accessor seam. */
+/** Removes entries and orphan transcript artifacts owned by a named session lifecycle. */
 export async function cleanupSessionLifecycleArtifacts(
   params: SessionLifecycleArtifactCleanupParams,
 ): Promise<SessionLifecycleArtifactCleanupResult> {
   return await cleanupFileSessionLifecycleArtifacts(params);
 }
 
-/** Loads raw transcript events through the storage-neutral accessor seam. */
+/** Reads parsed transcript records from an explicit or derived transcript target. */
 export async function loadTranscriptEvents(
   scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
@@ -238,7 +284,11 @@ export async function loadTranscriptEvents(
   return events;
 }
 
-/** Appends one raw transcript event through the storage-neutral accessor seam. */
+/**
+ * Appends a non-message transcript record such as session or metadata events.
+ * Message records must use appendTranscriptMessage so parent links, idempotency,
+ * and redaction are preserved.
+ */
 export async function appendTranscriptEvent(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
@@ -264,7 +314,10 @@ function assertNonMessageTranscriptEvent(event: TranscriptEvent): void {
   }
 }
 
-/** Appends one transcript message through the storage-neutral writer seam. */
+/**
+ * Appends one transcript message with message-id generation and optional
+ * idempotency lookup. The returned message is the redacted persisted value.
+ */
 export async function appendTranscriptMessage<TMessage>(
   scope: SessionTranscriptWriteScope,
   options: TranscriptMessageAppendOptions<TMessage> & {
@@ -297,7 +350,7 @@ export async function appendTranscriptMessage<TMessage>(
   });
 }
 
-/** Publishes a transcript update after resolving the current storage target. */
+/** Emits a transcript update after resolving the current transcript target. */
 export async function publishTranscriptUpdate(
   scope: SessionTranscriptWriteScope,
   update: TranscriptUpdatePayload = {},

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
@@ -9,11 +12,15 @@ import {
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
+  readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
-import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
@@ -33,12 +40,34 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  sessionId?: string;
+};
+
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
 export type TranscriptEvent = unknown;
+
+export type TranscriptMessageAppendOptions<TMessage> = {
+  config?: OpenClawConfig;
+  cwd?: string;
+  idempotencyLookup?: "scan" | "caller-checked";
+  message: TMessage;
+  now?: number;
+  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  useRawWhenLinear?: boolean;
+};
+
+export type TranscriptMessageAppendResult<TMessage> = {
+  appended: boolean;
+  message: TMessage;
+  messageId: string;
+};
+
+export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -79,6 +108,17 @@ export function listSessionEntries(
     ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
   }
   return listFileSessionEntries(scope);
+}
+
+/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  if (scope.storePath) {
+    return readFileSessionUpdatedAt({
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+    });
+  }
+  return loadSessionEntry(scope)?.updatedAt;
 }
 
 /** Applies a partial entry update through the storage-neutral accessor seam. */
@@ -164,6 +204,51 @@ export async function appendTranscriptEvent(
   });
 }
 
+/** Appends one transcript message through the storage-neutral writer seam. */
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return await appendSessionTranscriptMessage({
+    transcriptPath: transcript.sessionFile,
+    message: options.message,
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.config ? { config: options.config } : {}),
+    ...(options.idempotencyLookup ? { idempotencyLookup: options.idempotencyLookup } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.prepareMessageAfterIdempotencyCheck
+      ? { prepareMessageAfterIdempotencyCheck: options.prepareMessageAfterIdempotencyCheck }
+      : {}),
+    ...(options.useRawWhenLinear !== undefined
+      ? { useRawWhenLinear: options.useRawWhenLinear }
+      : {}),
+  });
+}
+
+/** Publishes a transcript update after resolving the current storage target. */
+export async function publishTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: transcript.sessionFile,
+  });
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -184,11 +269,14 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
   sessionFile: string;
 }> {
   if (scope.sessionFile?.trim()) {
     return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionAccessScope = {
   agentId?: string;
+  clone?: boolean;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -46,6 +47,13 @@ export type SessionEntryUpdateOptions = {
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  if (scope.clone === false) {
+    const store = loadSessionStore(resolveAccessStorePath(scope), {
+      clone: false,
+      ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+    });
+    return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
+  }
   return getSessionEntry(scope);
 }
 
@@ -53,6 +61,14 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
+  if (scope.clone === false) {
+    return Object.entries(
+      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+        clone: false,
+        ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+      }),
+    ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  }
   return listFileSessionEntries(scope);
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -50,6 +50,10 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
 };
 
+export type SessionEntryPatchContext = {
+  existingEntry?: SessionEntry;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -107,6 +111,7 @@ export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
     entry: SessionEntry,
+    context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -85,6 +85,7 @@ export type SessionEntryUpdateOptions = {
 
 export type SessionEntryPatchOptions = {
   fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
   replaceEntry?: boolean;
 };
 
@@ -167,6 +168,7 @@ export async function patchSessionEntry(
   return await patchFileSessionEntry({
     ...scope,
     fallbackEntry: options.fallbackEntry,
+    preserveActivity: options.preserveActivity,
     replaceEntry: options.replaceEntry,
     update,
   });

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -58,6 +58,12 @@ export type SessionEntrySummary = {
   entry: SessionEntry;
 };
 
+/** Session entry read by the exact persisted session key, without alias resolution. */
+export type ExactSessionEntry = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
 export type TranscriptEvent = unknown;
 
 export type TranscriptMessageAppendOptions<TMessage> = {
@@ -103,6 +109,23 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
     return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
   }
   return getSessionEntry(scope);
+}
+
+/**
+ * Loads one entry only when the persisted key exactly matches the requested key.
+ * Approval routing uses this to avoid canonical alias lookup crossing accounts.
+ */
+export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const store = loadSessionStore(resolveAccessStorePath(scope), {
+    ...(scope.clone === false ? { clone: false } : {}),
+    ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+  });
+  const entry = Object.hasOwn(store, sessionKey) ? store[sessionKey] : undefined;
+  return entry ? { sessionKey, entry } : undefined;
 }
 
 /** Lists session entries through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -243,11 +243,25 @@ export async function appendTranscriptEvent(
   scope: SessionTranscriptAccessScope,
   event: TranscriptEvent,
 ): Promise<void> {
+  assertNonMessageTranscriptEvent(event);
   const transcript = await resolveTranscriptAccess(scope);
   await appendSessionTranscriptEvent({
     event,
     transcriptPath: transcript.sessionFile,
   });
+}
+
+function assertNonMessageTranscriptEvent(event: TranscriptEvent): void {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return;
+  }
+  // Message records require parent-link, idempotency, and redaction handling
+  // from appendTranscriptMessage; raw event writes would bypass those invariants.
+  if ((event as { type?: unknown }).type === "message") {
+    throw new Error(
+      "appendTranscriptEvent cannot write message transcript records; use appendTranscriptMessage instead.",
+    );
+  }
 }
 
 /** Appends one transcript message through the storage-neutral writer seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -45,6 +45,11 @@ export type SessionEntryUpdateOptions = {
   takeCacheOwnership?: boolean;
 };
 
+export type SessionEntryPatchOptions = {
+  fallbackEntry?: SessionEntry;
+  replaceEntry?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -94,6 +99,22 @@ export async function replaceSessionEntry(
     fallbackEntry: entry,
     replaceEntry: true,
     update: () => entry,
+  });
+}
+
+/** Patches one entry atomically through the storage-neutral accessor seam. */
+export async function patchSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    replaceEntry: options.replaceEntry,
+    update,
   });
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -5,7 +5,11 @@ import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
+import {
+  resolveSessionTranscriptPath,
+  resolveSessionTranscriptPathInDir,
+  resolveStorePath,
+} from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -34,10 +38,15 @@ export type SessionAccessScope = {
   storePath?: string;
 };
 
-export type SessionTranscriptAccessScope = SessionAccessScope & {
+export type SessionTranscriptReadScope = Omit<SessionAccessScope, "sessionKey"> & {
   sessionFile?: string;
   sessionId: string;
+  sessionKey?: string;
   threadId?: string | number;
+};
+
+export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
+  sessionKey: string;
 };
 
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
@@ -182,9 +191,9 @@ export async function updateSessionEntry(
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */
 export async function loadTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const transcript = await resolveTranscriptAccess(scope);
+  const transcript = await resolveTranscriptReadAccess(scope);
   const events: TranscriptEvent[] = [];
   for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
     events.push(JSON.parse(line) as TranscriptEvent);
@@ -267,6 +276,32 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
     agentId,
     env: scope.env,
   });
+}
+
+async function resolveTranscriptReadAccess(scope: SessionTranscriptReadScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  if (scope.sessionKey) {
+    return await resolveTranscriptAccess({ ...scope, sessionKey: scope.sessionKey });
+  }
+  if (scope.storePath) {
+    return {
+      sessionFile: resolveSessionTranscriptPathInDir(
+        scope.sessionId,
+        path.dirname(path.resolve(scope.storePath)),
+        scope.threadId,
+      ),
+    };
+  }
+  if (scope.agentId) {
+    return {
+      sessionFile: resolveSessionTranscriptPath(scope.sessionId, scope.agentId, scope.threadId),
+    };
+  }
+  throw new Error(`Cannot resolve transcript read scope without a session target`);
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{

--- a/src/config/sessions/session-entry-lifecycle.test.ts
+++ b/src/config/sessions/session-entry-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { upsertSessionEntry } from "./session-accessor.js";
+import {
+  deleteSessionEntries,
+  patchSessionEntries,
+  patchSessionLifecycleEntry,
+} from "./session-entry-lifecycle.js";
+import { loadSessionStore } from "./store.js";
+
+describe("session entry lifecycle seam", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-lifecycle-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("patches one entry with replacement semantics", async () => {
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:main", storePath },
+      {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      },
+    );
+
+    const patched = await patchSessionLifecycleEntry(
+      { sessionKey: "agent:main:main", storePath },
+      (entry) => {
+        delete entry.model;
+        entry.providerOverride = "openai";
+        return entry;
+      },
+      { replaceEntry: true, skipMaintenance: true },
+    );
+
+    expect(patched).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(
+      loadSessionStore(storePath, { skipCache: true })["agent:main:main"]?.model,
+    ).toBeUndefined();
+  });
+
+  it("patches multiple entries without exposing a mutable store", async () => {
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:one", storePath },
+      { sessionId: "session-1", updatedAt: 10 },
+    );
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:two", storePath },
+      { sessionId: "session-2", updatedAt: 20 },
+    );
+
+    const result = await patchSessionEntries(
+      { storePath },
+      (entry, { sessionKey }) =>
+        sessionKey.endsWith(":two")
+          ? {
+              ...entry,
+              model: "gpt-5.5",
+            }
+          : null,
+      { replaceEntry: true, skipMaintenance: true },
+    );
+
+    expect(result.patched).toHaveLength(1);
+    expect(loadSessionStore(storePath, { skipCache: true })["agent:main:two"]?.model).toBe(
+      "gpt-5.5",
+    );
+  });
+
+  it("deletes selected entries and returns cleanup metadata", async () => {
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:keep", storePath },
+      { sessionFile: path.join(tempDir, "keep.jsonl"), sessionId: "keep", updatedAt: 20 },
+    );
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:delete", storePath },
+      { sessionFile: path.join(tempDir, "delete.jsonl"), sessionId: "delete", updatedAt: 10 },
+    );
+
+    const deletion = await deleteSessionEntries(
+      { storePath },
+      (entry) => entry.sessionId === "delete",
+      {
+        skipMaintenance: true,
+      },
+    );
+
+    expect(deletion.deleted.map((entry) => entry.sessionKey)).toEqual(["agent:main:delete"]);
+    expect(deletion.referencedSessionIds).toEqual(new Set(["keep"]));
+    expect(deletion.removedSessionFiles).toEqual(
+      new Map([["delete", path.join(tempDir, "delete.jsonl")]]),
+    );
+    expect(loadSessionStore(storePath, { skipCache: true })["agent:main:delete"]).toBeUndefined();
+  });
+});

--- a/src/config/sessions/session-entry-lifecycle.test.ts
+++ b/src/config/sessions/session-entry-lifecycle.test.ts
@@ -52,6 +52,88 @@ describe("session entry lifecycle seam", () => {
     ).toBeUndefined();
   });
 
+  it("preserves an existing raw row key while exposing normalized context", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        GLOBAL: {
+          sessionId: "session-raw",
+          updatedAt: 10,
+        },
+      }),
+    );
+    let contextKey: string | undefined;
+
+    await patchSessionLifecycleEntry(
+      { sessionKey: "GLOBAL", storePath },
+      (entry, context) => {
+        contextKey = context.sessionKey;
+        entry.fastMode = true;
+        return entry;
+      },
+      { replaceEntry: true, skipMaintenance: true },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(contextKey).toBe("global");
+    expect(store.GLOBAL?.fastMode).toBe(true);
+    expect(store.global).toBeUndefined();
+  });
+
+  it("collapses legacy aliases when a usable canonical row exists", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-canonical",
+          updatedAt: 10,
+          fastMode: false,
+        },
+        "Agent:Main:Main": {
+          sessionId: "session-legacy",
+          updatedAt: 20,
+          fastMode: false,
+        },
+      }),
+    );
+
+    await patchSessionLifecycleEntry(
+      { sessionKey: "Agent:Main:Main", storePath },
+      (entry) => {
+        entry.fastMode = true;
+        return entry;
+      },
+      { replaceEntry: true, skipMaintenance: true },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:main:main"]?.sessionId).toBe("session-legacy");
+    expect(store["agent:main:main"]?.fastMode).toBe(true);
+    expect(store["Agent:Main:Main"]).toBeUndefined();
+  });
+
+  it("preserves a fallback raw row key", async () => {
+    await patchSessionLifecycleEntry(
+      { sessionKey: "UNKNOWN", storePath },
+      (entry) => {
+        entry.fastMode = true;
+        return entry;
+      },
+      {
+        fallbackEntry: {
+          sessionId: "session-fallback",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store.UNKNOWN?.fastMode).toBe(true);
+    expect(store.unknown).toBeUndefined();
+  });
+
   it("patches multiple entries without exposing a mutable store", async () => {
     await upsertSessionEntry(
       { sessionKey: "agent:main:one", storePath },

--- a/src/config/sessions/session-entry-lifecycle.ts
+++ b/src/config/sessions/session-entry-lifecycle.ts
@@ -1,5 +1,6 @@
 import { getRuntimeConfig } from "../io.js";
 import { resolveStorePath } from "./paths.js";
+import { hasMismatchedCaseSensitiveDeliveryProof } from "./store-entry.js";
 import {
   archiveRemovedSessionTranscripts,
   loadSessionStore,
@@ -63,6 +64,11 @@ export async function patchSessionLifecycleEntry(
       if (!existing) {
         return { changed: false, entry: null };
       }
+      const storageKey = resolveLifecyclePatchStorageKey({
+        store,
+        resolved,
+        requestedKey: scope.sessionKey,
+      });
       const patch = await update(structuredClone(existing), {
         existingEntry: resolved.existing ? structuredClone(resolved.existing) : undefined,
         sessionKey: resolved.normalizedKey,
@@ -78,8 +84,11 @@ export async function patchSessionLifecycleEntry(
         : options.preserveActivity
           ? mergeSessionEntryPreserveActivity(existing, patch)
           : mergeSessionEntry(existing, patch);
-      store[resolved.normalizedKey] = next;
+      store[storageKey] = next;
       for (const legacyKey of resolved.legacyKeys) {
+        if (legacyKey === storageKey) {
+          continue;
+        }
         delete store[legacyKey];
       }
       return { changed: true, entry: next };
@@ -217,6 +226,35 @@ function collectReferencedSessionIds(store: Record<string, SessionEntry>): Set<s
       .map((entry) => entry?.sessionId)
       .filter((sessionId): sessionId is string => Boolean(sessionId)),
   );
+}
+
+// Preserve the concrete row key for behavior-neutral file-backed updates. Callers
+// still receive the normalized key in context for canonical decisions.
+function resolveLifecyclePatchStorageKey(params: {
+  store: Record<string, SessionEntry>;
+  requestedKey: string;
+  resolved: ReturnType<typeof resolveSessionStoreEntry>;
+}): string {
+  if (
+    params.resolved.existing &&
+    params.store[params.resolved.normalizedKey] === params.resolved.existing
+  ) {
+    return params.resolved.normalizedKey;
+  }
+  const canonicalEntry = params.store[params.resolved.normalizedKey];
+  if (
+    canonicalEntry &&
+    !hasMismatchedCaseSensitiveDeliveryProof(canonicalEntry, params.resolved.normalizedKey)
+  ) {
+    return params.resolved.normalizedKey;
+  }
+  const existingLegacyKey = params.resolved.legacyKeys.find(
+    (legacyKey) => params.store[legacyKey] === params.resolved.existing,
+  );
+  if (existingLegacyKey) {
+    return existingLegacyKey;
+  }
+  return params.requestedKey.trim() || params.resolved.normalizedKey;
 }
 
 function rememberRemovedSessionFile(

--- a/src/config/sessions/session-entry-lifecycle.ts
+++ b/src/config/sessions/session-entry-lifecycle.ts
@@ -1,0 +1,229 @@
+import { getRuntimeConfig } from "../io.js";
+import { resolveStorePath } from "./paths.js";
+import {
+  archiveRemovedSessionTranscripts,
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "./store.js";
+import {
+  mergeSessionEntry,
+  mergeSessionEntryPreserveActivity,
+  type SessionEntry,
+} from "./types.js";
+
+export type SessionEntryLifecycleScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+};
+
+export type SessionEntryLifecycleContext = {
+  entry: SessionEntry;
+  sessionKey: string;
+};
+
+export type SessionEntryLifecyclePatchOptions = {
+  fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
+  replaceEntry?: boolean;
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
+export type SessionEntryLifecycleDeleteOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
+export type SessionEntriesPatchResult = {
+  patched: Array<{ sessionKey: string; entry: SessionEntry }>;
+};
+
+export type SessionEntriesDeleteResult = {
+  deleted: Array<{ sessionKey: string; entry: SessionEntry }>;
+  referencedSessionIds: Set<string>;
+  removedSessionFiles: Map<string, string | undefined>;
+};
+
+/** Patches one session entry through the lifecycle mutation seam. */
+export async function patchSessionLifecycleEntry(
+  scope: SessionEntryLifecycleScope & { sessionKey: string },
+  update: (
+    entry: SessionEntry,
+    context: { existingEntry?: SessionEntry; sessionKey: string },
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryLifecyclePatchOptions = {},
+): Promise<SessionEntry | null> {
+  const result = await updateSessionStore(
+    resolveLifecycleStorePath(scope),
+    async (store) => {
+      const resolved = resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey });
+      const existing = resolved.existing ?? options.fallbackEntry;
+      if (!existing) {
+        return { changed: false, entry: null };
+      }
+      const patch = await update(structuredClone(existing), {
+        existingEntry: resolved.existing ? structuredClone(resolved.existing) : undefined,
+        sessionKey: resolved.normalizedKey,
+      });
+      if (!patch) {
+        return {
+          changed: false,
+          entry: resolved.existing ? structuredClone(resolved.existing) : null,
+        };
+      }
+      const next = options.replaceEntry
+        ? structuredClone(patch as SessionEntry)
+        : options.preserveActivity
+          ? mergeSessionEntryPreserveActivity(existing, patch)
+          : mergeSessionEntry(existing, patch);
+      store[resolved.normalizedKey] = next;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
+      return { changed: true, entry: next };
+    },
+    {
+      skipMaintenance: options.skipMaintenance,
+      skipSaveWhenResult: (entry) => !entry.changed,
+      takeCacheOwnership: options.takeCacheOwnership,
+    },
+  );
+  return result.entry;
+}
+
+/** Patches zero or more session entries through the lifecycle mutation seam. */
+export async function patchSessionEntries(
+  scope: SessionEntryLifecycleScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryLifecycleContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryLifecyclePatchOptions = {},
+): Promise<SessionEntriesPatchResult> {
+  return await updateSessionStore(
+    resolveLifecycleStorePath(scope),
+    async (store) => {
+      const patched: SessionEntriesPatchResult["patched"] = [];
+      for (const [sessionKey, entry] of Object.entries(store)) {
+        if (!entry) {
+          continue;
+        }
+        const entrySnapshot = structuredClone(entry);
+        const patch = await update(structuredClone(entry), {
+          entry: entrySnapshot,
+          sessionKey,
+        });
+        if (!patch) {
+          continue;
+        }
+        const next = options.replaceEntry
+          ? structuredClone(patch as SessionEntry)
+          : options.preserveActivity
+            ? mergeSessionEntryPreserveActivity(entry, patch)
+            : mergeSessionEntry(entry, patch);
+        store[sessionKey] = next;
+        patched.push({ sessionKey, entry: next });
+      }
+      return { patched };
+    },
+    {
+      skipMaintenance: options.skipMaintenance,
+      skipSaveWhenResult: (result) => result.patched.length === 0,
+      takeCacheOwnership: options.takeCacheOwnership,
+    },
+  );
+}
+
+/** Deletes session entries through the lifecycle mutation seam. */
+export async function deleteSessionEntries(
+  scope: SessionEntryLifecycleScope,
+  shouldDelete: (
+    entry: SessionEntry,
+    context: SessionEntryLifecycleContext,
+  ) => Promise<boolean> | boolean,
+  options: SessionEntryLifecycleDeleteOptions = {},
+): Promise<SessionEntriesDeleteResult> {
+  const storePath = resolveLifecycleStorePath(scope);
+  const deletion = await updateSessionStore(
+    storePath,
+    async (store) => {
+      const deleted: SessionEntriesDeleteResult["deleted"] = [];
+      const removedSessionFiles = new Map<string, string | undefined>();
+      for (const [sessionKey, entry] of Object.entries(store)) {
+        if (!entry) {
+          continue;
+        }
+        const entrySnapshot = structuredClone(entry);
+        if (!(await shouldDelete(entrySnapshot, { entry: entrySnapshot, sessionKey }))) {
+          continue;
+        }
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+        deleted.push({ sessionKey, entry });
+        delete store[sessionKey];
+      }
+      return {
+        deleted,
+        referencedSessionIds: collectReferencedSessionIds(store),
+        removedSessionFiles,
+      };
+    },
+    {
+      skipMaintenance: options.skipMaintenance,
+      skipSaveWhenResult: (result) => result.deleted.length === 0,
+      takeCacheOwnership: options.takeCacheOwnership,
+    },
+  );
+  if (deletion.deleted.length === 0) {
+    return deletion;
+  }
+  const persistedStore = loadSessionStore(storePath, { skipCache: true });
+  return {
+    ...deletion,
+    referencedSessionIds: collectReferencedSessionIds(persistedStore),
+  };
+}
+
+/** Archives transcript artifacts for entries removed by deleteSessionEntries. */
+export async function archiveDeletedSessionEntryArtifacts(params: {
+  deletion: SessionEntriesDeleteResult;
+  reason: "deleted" | "reset";
+  restrictToStoreDir?: boolean;
+  storePath: string;
+}): Promise<Set<string>> {
+  return await archiveRemovedSessionTranscripts({
+    removedSessionFiles: params.deletion.removedSessionFiles,
+    referencedSessionIds: params.deletion.referencedSessionIds,
+    storePath: params.storePath,
+    reason: params.reason,
+    restrictToStoreDir: params.restrictToStoreDir,
+  });
+}
+
+function resolveLifecycleStorePath(scope: SessionEntryLifecycleScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId: scope.agentId,
+    env: scope.env,
+  });
+}
+
+function collectReferencedSessionIds(store: Record<string, SessionEntry>): Set<string> {
+  return new Set(
+    Object.values(store)
+      .map((entry) => entry?.sessionId)
+      .filter((sessionId): sessionId is string => Boolean(sessionId)),
+  );
+}
+
+function rememberRemovedSessionFile(
+  removedSessionFiles: Map<string, string | undefined>,
+  entry: SessionEntry,
+): void {
+  if (!removedSessionFiles.has(entry.sessionId) || entry.sessionFile) {
+    removedSessionFiles.set(entry.sessionId, entry.sessionFile);
+  }
+}

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,6 +1,11 @@
 // Runtime facade for session store mutation helpers.
 export {
   applySessionStoreEntryPatch,
+  cleanupSessionLifecycleArtifacts,
   updateSessionStore,
   updateSessionStoreEntry,
+} from "./store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "./store.js";

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -5,6 +5,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   deliveryContextFromChannelRoute,
   deliveryContextFromSession,
@@ -15,9 +16,10 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
+import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import { resolveStorePath } from "./paths.js";
+import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,
@@ -189,6 +191,24 @@ type SessionEntryWorkflowOptions = {
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   storePath?: string;
+};
+
+export type SessionLifecycleArtifactCleanupParams = {
+  /** Session store to clean. */
+  storePath: string;
+  /** Matches the persisted session-key segment after `agent:<id>:`. */
+  sessionKeySegmentPrefix: string;
+  /** Marker that identifies transcript artifacts owned by this lifecycle. */
+  transcriptContentMarker: string;
+  /** Minimum age before a present transcript can be reclaimed or archived. */
+  orphanTranscriptMinAgeMs: number;
+  /** Testable clock override. */
+  nowMs?: number;
+};
+
+export type SessionLifecycleArtifactCleanupResult = {
+  removedEntries: number;
+  archivedTranscriptArtifacts: number;
 };
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -501,6 +521,66 @@ function sessionEntriesHaveSameSerializedForm(
   next: SessionEntry,
 ): boolean {
   return previous !== undefined && JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function normalizePathForLifecycleComparison(filePath: string): string {
+  try {
+    return path.normalize(fs.realpathSync(filePath));
+  } catch {
+    return path.normalize(path.resolve(filePath));
+  }
+}
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function resolveLifecycleTranscriptPath(params: {
+  entry: SessionEntry | undefined;
+  sessionsDir: string;
+}): string | null {
+  const sessionId = params.entry?.sessionId?.trim();
+  if (!sessionId) {
+    return null;
+  }
+  try {
+    return resolveSessionFilePath(sessionId, params.entry, { sessionsDir: params.sessionsDir });
+  } catch {
+    return null;
+  }
+}
+
+function lifecycleTranscriptIsReclaimable(params: {
+  transcriptPath: string | null;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  if (!params.transcriptPath || !fs.existsSync(params.transcriptPath)) {
+    return true;
+  }
+  try {
+    const stat = fs.statSync(params.transcriptPath);
+    return params.nowMs - stat.mtimeMs >= params.orphanTranscriptMinAgeMs;
+  } catch {
+    return true;
+  }
+}
+
+function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
+  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+  try {
+    fs.renameSync(transcriptPath, archivedPath);
+    emitSessionTranscriptUpdate({ sessionFile: archivedPath });
+    return 1;
+  } catch {
+    return 0;
+  }
 }
 
 async function saveSessionStoreUnlocked(
@@ -816,6 +896,158 @@ export async function updateSessionStore<T>(
     });
     return result;
   });
+}
+
+async function archiveUnreferencedLifecycleTranscriptArtifacts(params: {
+  storePath: string;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+}): Promise<number> {
+  const sessionsDir = path.dirname(path.resolve(params.storePath));
+  return await runExclusiveSessionStoreWrite(params.storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(params.storePath);
+    const referencedTranscriptPaths = new Set<string>();
+    for (const entry of Object.values(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      if (transcriptPath) {
+        referencedTranscriptPaths.add(normalizePathForLifecycleComparison(transcriptPath));
+      }
+    }
+    restoreUnchangedSessionStoreCache(params.storePath, store);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+
+    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+    let archived = 0;
+    // Only archive primary transcripts that are no longer referenced by the
+    // current store and still carry the lifecycle marker supplied by the caller.
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+        continue;
+      }
+      const transcriptPath = path.join(sessionsDir, entry.name);
+      if (referencedTranscriptPaths.has(normalizePathForLifecycleComparison(transcriptPath))) {
+        continue;
+      }
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.stat(transcriptPath);
+      } catch {
+        continue;
+      }
+      if (params.nowMs - stat.mtimeMs < params.orphanTranscriptMinAgeMs) {
+        continue;
+      }
+      let content: string;
+      try {
+        content = await fs.promises.readFile(transcriptPath, "utf-8");
+      } catch {
+        continue;
+      }
+      if (!content.includes(params.transcriptContentMarker)) {
+        continue;
+      }
+      const sessionId = entry.name.slice(0, -".jsonl".length);
+      archived += archiveSessionTranscripts({
+        sessionId,
+        storePath: params.storePath,
+        sessionFile: transcriptPath,
+        reason: "deleted",
+        restrictToStoreDir: true,
+      }).length;
+    }
+    return archived;
+  });
+}
+
+/** Cleans scoped session lifecycle entries and their unreferenced transcript artifacts. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  const sessionKeySegmentPrefix = params.sessionKeySegmentPrefix.trim();
+  const transcriptContentMarker = params.transcriptContentMarker;
+  if (!sessionKeySegmentPrefix || !transcriptContentMarker) {
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const storePath = path.resolve(params.storePath);
+  const sessionsDir = path.dirname(storePath);
+  const removedSessionFiles = new Map<string, string | undefined>();
+  const removedTranscriptPaths: Array<{ sessionId: string; transcriptPath: string }> = [];
+  let removedEntries = 0;
+  let archivedTranscriptArtifacts = 0;
+
+  await runExclusiveSessionStoreWrite(storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(storePath);
+    // Delete only rows owned by the named lifecycle. Orphan transcript cleanup
+    // reacquires this writer lock later so its reference set cannot go stale.
+    for (const [sessionKey, entry] of Object.entries(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      const matchesLifecycle = sessionKeySegmentStartsWith(sessionKey, sessionKeySegmentPrefix);
+      if (
+        matchesLifecycle &&
+        lifecycleTranscriptIsReclaimable({
+          transcriptPath,
+          nowMs,
+          orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        })
+      ) {
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+        if (entry.sessionId && transcriptPath && fs.existsSync(transcriptPath)) {
+          removedTranscriptPaths.push({ sessionId: entry.sessionId, transcriptPath });
+        }
+        delete store[sessionKey];
+        removedEntries += 1;
+        continue;
+      }
+    }
+
+    if (removedEntries === 0) {
+      restoreUnchangedSessionStoreCache(storePath, store);
+      return;
+    }
+
+    const referencedSessionIds = new Set(
+      Object.values(store)
+        .map((entry) => entry?.sessionId)
+        .filter((sessionId): sessionId is string => Boolean(sessionId)),
+    );
+    // Archive only the exact transcript path that passed the age/missing guard.
+    // Broader session-id candidate scans can include fresh sibling transcripts.
+    for (const { sessionId: removedSessionId, transcriptPath } of removedTranscriptPaths) {
+      if (referencedSessionIds.has(removedSessionId)) {
+        continue;
+      }
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
+    }
+    const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+    await removeRemovedSessionTrajectoryArtifacts({
+      removedSessionFiles,
+      referencedSessionIds,
+      storePath,
+      restrictToStoreDir: true,
+    });
+    await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
+  });
+
+  return {
+    removedEntries,
+    archivedTranscriptArtifacts:
+      archivedTranscriptArtifacts +
+      (await archiveUnreferencedLifecycleTranscriptArtifacts({
+        storePath,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs,
+      })),
+  };
 }
 
 export async function runQuotaSuspensionMaintenance(params: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1016,6 +1016,7 @@ export async function patchSessionEntry(
     replaceEntry?: boolean;
     update: (
       entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   },
 ): Promise<SessionEntry | null> {
@@ -1027,7 +1028,9 @@ export async function patchSessionEntry(
     if (!existing) {
       return null;
     }
-    const patch = await params.update(cloneSessionEntry(existing));
+    const patch = await params.update(cloneSessionEntry(existing), {
+      existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
+    });
     if (!patch) {
       return existing;
     }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -572,10 +572,19 @@ function lifecycleTranscriptIsReclaimable(params: {
   }
 }
 
-function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
-  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+function archiveExactLifecycleTranscriptPath(params: {
+  sessionsDir: string;
+  transcriptPath: string;
+}): number {
+  const resolvedSessionsDir = normalizePathForLifecycleComparison(params.sessionsDir);
+  const resolvedTranscriptPath = normalizePathForLifecycleComparison(params.transcriptPath);
+  const relative = path.relative(resolvedSessionsDir, resolvedTranscriptPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return 0;
+  }
+  const archivedPath = `${resolvedTranscriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
   try {
-    fs.renameSync(transcriptPath, archivedPath);
+    fs.renameSync(resolvedTranscriptPath, archivedPath);
     emitSessionTranscriptUpdate({ sessionFile: archivedPath });
     return 1;
   } catch {
@@ -1025,7 +1034,10 @@ export async function cleanupSessionLifecycleArtifacts(
       if (referencedSessionIds.has(removedSessionId)) {
         continue;
       }
-      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath({
+        sessionsDir,
+        transcriptPath,
+      });
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
     await removeRemovedSessionTrajectoryArtifacts({

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -15,6 +15,7 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -289,6 +290,31 @@ export async function appendSessionTranscriptMessage<TMessage>(
   );
 }
 
+export type AppendSessionTranscriptEventParams = {
+  config?: OpenClawConfig;
+  event: unknown;
+  transcriptPath: string;
+};
+
+/** Appends a raw transcript event using the same write lock and FIFO as message appends. */
+export async function appendSessionTranscriptEvent(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
+    sessionFile: params.transcriptPath,
+  });
+  if (activeLockRunner) {
+    return await activeLockRunner(() =>
+      withTranscriptAppendQueue(params.transcriptPath, () =>
+        appendSessionTranscriptEventLocked(params),
+      ),
+    );
+  }
+  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+    withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
+  );
+}
+
 async function withSessionTranscriptWriteLock<T>(
   params: Pick<AppendSessionTranscriptMessageParams, "transcriptPath" | "config">,
   run: () => Promise<T> | T,
@@ -302,6 +328,18 @@ async function withSessionTranscriptWriteLock<T>(
     return await run();
   } finally {
     await lock.release();
+  }
+}
+
+async function appendSessionTranscriptEventLocked(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
+  const handle = await fs.open(params.transcriptPath, "a", 0o600);
+  try {
+    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,7 +1,10 @@
 /** Prunes expired per-run cron sessions and archives unreferenced transcripts. */
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { loadSessionStore } from "../config/sessions/store-load.js";
-import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
+import {
+  archiveDeletedSessionEntryArtifacts,
+  deleteSessionEntries,
+  type SessionEntriesDeleteResult,
+} from "../config/sessions/session-entry-lifecycle.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
@@ -38,8 +41,9 @@ type ReaperResult = {
 /**
  * Sweeps completed isolated cron run sessions while preserving base cron sessions.
  *
- * Must run outside the cron service `locked()` section because this acquires
- * the session-store file lock; reversing that order can deadlock timer ticks.
+ * Lock ordering: this function acquires the session-entry lifecycle lock. It
+ * must run outside the cron service's own `locked()` section to avoid
+ * lock-order inversions. The cron timer calls this after those sections exit.
  */
 export async function sweepCronRunSessions(params: {
   cronConfig?: CronConfig;
@@ -66,49 +70,26 @@ export async function sweepCronRunSessions(params: {
     return { swept: false, pruned: 0 };
   }
 
-  let pruned = 0;
-  const prunedSessions = new Map<string, string | undefined>();
+  let deletion: SessionEntriesDeleteResult;
   try {
-    await updateSessionStore(storePath, (store) => {
-      const cutoff = now - retentionMs;
-      for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
-          continue;
-        }
-        const entry = store[key];
-        if (!entry) {
-          continue;
-        }
-        const updatedAt = entry.updatedAt ?? 0;
-        if (updatedAt < cutoff) {
-          if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
-            prunedSessions.set(entry.sessionId, entry.sessionFile);
-          }
-          delete store[key];
-          pruned++;
-        }
-      }
+    const cutoff = now - retentionMs;
+    deletion = await deleteSessionEntries({ storePath }, (entry, { sessionKey }) => {
+      return isCronRunSessionKey(sessionKey) && (entry.updatedAt ?? 0) < cutoff;
     });
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
     return { swept: false, pruned: 0 };
   }
+  const pruned = deletion.deleted.length;
 
   lastSweepAtMsByStore.set(storePath, now);
 
-  if (prunedSessions.size > 0) {
+  if (deletion.removedSessionFiles.size > 0) {
     try {
-      const store = loadSessionStore(storePath, { skipCache: true });
       // Archive only transcripts that no remaining session references; base
       // cron sessions intentionally keep their transcript history.
-      const referencedSessionIds = new Set(
-        Object.values(store)
-          .map((entry) => entry?.sessionId)
-          .filter((id): id is string => Boolean(id)),
-      );
-      const archivedDirs = await archiveRemovedSessionTranscripts({
-        removedSessionFiles: prunedSessions,
-        referencedSessionIds,
+      const archivedDirs = await archiveDeletedSessionEntryArtifacts({
+        deletion,
         storePath,
         reason: "deleted",
         restrictToStoreDir: true,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -49,7 +49,6 @@ import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import {
-  loadSessionStore,
   runSessionsCleanup,
   serializeSessionCleanupResult,
   resolveMainSessionKey,
@@ -259,6 +258,22 @@ function resolveGatewaySessionTargetFromKey(
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
   });
   return { cfg, target, storePath: target.storePath };
+}
+
+function loadSessionEntriesForTarget(params: {
+  key: string;
+  cfg: OpenClawConfig;
+  agentId?: string;
+}) {
+  const target = resolveGatewaySessionStoreTargetWithStore({
+    cfg: params.cfg,
+    key: params.key,
+    clone: false,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+  });
+  const store = target.store;
+  const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
+  return { target, storePath: target.storePath, store, entry };
 }
 
 function resolveOptionalInitialSessionMessage(params: {
@@ -1215,9 +1230,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const cfg = context.getRuntimeConfig();
-    const { target, storePath } = resolveGatewaySessionTargetFromKey(key, cfg);
-    const store = loadSessionStore(storePath);
-    const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
+    const { target, storePath, store, entry } = loadSessionEntriesForTarget({ key, cfg });
     if (!entry) {
       respond(true, { session: null }, undefined);
       return;
@@ -2420,11 +2433,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, requestedAgent.error);
       return;
     }
-    const { target, storePath } = resolveGatewaySessionTargetFromKey(key, cfg, {
+    const { storePath, entry } = loadSessionEntriesForTarget({
+      key,
+      cfg,
       agentId: requestedAgent.agentId,
     });
-    const store = loadSessionStore(storePath);
-    const entry = resolveFreshestSessionEntryFromStoreKeys(store, target.storeKeys);
     if (!entry?.sessionId) {
       respond(true, { messages: [] }, undefined);
       return;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -116,7 +116,7 @@ import {
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
 } from "../session-utils.js";
-import { applySessionsPatchToStore } from "../sessions-patch.js";
+import { applySessionsPatchToStore, patchGatewaySessionEntry } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
@@ -2112,21 +2112,13 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const { target, storePath } = resolveGatewaySessionTargetFromKey(key, cfg, {
       agentId: requestedAgentId,
     });
-    const applied = await updateSessionStore(storePath, async (store) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
-        cfg,
-        key,
-        store,
-        agentId: requestedAgentId,
-      });
-      return await applySessionsPatchToStore({
-        cfg,
-        store,
-        storeKey: primaryKey,
-        agentId: requestedAgentId,
-        patch: p,
-        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-      });
+    const applied = await patchGatewaySessionEntry({
+      cfg,
+      storePath,
+      key,
+      agentId: requestedAgentId,
+      patch: p,
+      loadGatewayModelCatalog: context.loadGatewayModelCatalog,
     });
     if (!applied.ok) {
       respond(false, undefined, applied.error);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -61,7 +61,6 @@ import { resolveStateDir } from "../config/paths.js";
 import {
   buildGroupDisplayName,
   getSessionStoreCacheVersion,
-  loadSessionStore,
   resolveAllAgentSessionStoreTargetsSync,
   resolveAgentMainSessionKey,
   resolveFreshSessionTotalTokens,
@@ -71,6 +70,7 @@ import {
   type SessionStoreTarget,
   type SessionScope,
 } from "../config/sessions.js";
+import { listSessionEntries as listAccessorSessionEntries } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
@@ -1410,6 +1410,18 @@ function resolveGatewaySessionStoreCandidates(
   return [...targets.values()];
 }
 
+function loadGatewaySessionLookupStore(
+  storePath: string,
+  clone: boolean | undefined,
+): Record<string, SessionEntry> {
+  return Object.fromEntries(
+    listAccessorSessionEntries({
+      ...(clone === false ? { clone: false } : {}),
+      storePath,
+    }).map(({ sessionKey, entry }) => [sessionKey, entry]),
+  );
+}
+
 function resolveGatewaySessionStoreLookup(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -1428,9 +1440,9 @@ function resolveGatewaySessionStoreLookup(params: {
     agentId: params.agentId,
     storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
   };
-  const loadOptions = params.clone === false ? { clone: false } : undefined;
+  const loadStore = (storePath: string) => loadGatewaySessionLookupStore(storePath, params.clone);
   let selectedStorePath = fallback.storePath;
-  let selectedStore = params.initialStore ?? loadSessionStore(fallback.storePath, loadOptions);
+  let selectedStore = params.initialStore ?? loadStore(fallback.storePath);
   let selectedMatch = findFreshestStoreMatch(selectedStore, ...scanTargets);
   let selectedUpdatedAt = selectedMatch?.entry.updatedAt ?? Number.NEGATIVE_INFINITY;
 
@@ -1439,7 +1451,7 @@ function resolveGatewaySessionStoreLookup(params: {
     if (!candidate) {
       continue;
     }
-    const store = loadSessionStore(candidate.storePath, loadOptions);
+    const store = loadStore(candidate.storePath);
     const match = findFreshestStoreMatch(store, ...scanTargets);
     if (!match) {
       continue;
@@ -1497,12 +1509,11 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
         match: { entry: SessionEntry; key: string };
       }
     | undefined;
-  const loadOptions = params.clone === false ? { clone: false } : undefined;
   for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg)) {
     if (target.agentId !== legacyAgentId) {
       continue;
     }
-    const store = loadSessionStore(target.storePath, loadOptions);
+    const store = loadGatewaySessionLookupStore(target.storePath, params.clone);
     const match = findFreshestStoreMatch(store, ...lookupSeeds);
     if (!match) {
       continue;

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,12 +1,19 @@
 // Session patch tests cover model/provider edits, subagent patching, provider
 // aliases, model catalog validation, and rejected invalid patch payloads.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { applySessionsPatchToStore } from "./sessions-patch.js";
+import {
+  applySessionsPatchProjection,
+  applySessionsPatchToStore,
+  patchGatewaySessionEntry,
+} from "./sessions-patch.js";
 
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.5";
 const KIMI_SUBAGENT_KEY = "agent:kimi:subagent:child";
@@ -19,6 +26,7 @@ const OPENAI_GPT_ID = "gpt-5.4";
 const EMPTY_CFG = {} as OpenClawConfig;
 
 type ApplySessionsPatchArgs = Parameters<typeof applySessionsPatchToStore>[0];
+const tempDirs: string[] = [];
 
 async function runPatch(params: {
   patch: ApplySessionsPatchArgs["patch"];
@@ -153,6 +161,14 @@ function expectAuthOverride(
   }
 }
 
+async function createTempStorePath(store: Record<string, SessionEntry> = {}) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-patch-"));
+  tempDirs.push(dir);
+  const storePath = path.join(dir, "sessions.json");
+  await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf8");
+  return storePath;
+}
+
 async function applySubagentModelPatch(cfg: OpenClawConfig) {
   return expectPatchOk(
     await runPatch({
@@ -211,9 +227,12 @@ function createAllowlistedAnthropicModelCfg(): OpenClawConfig {
 }
 
 describe("gateway sessions patch", () => {
-  afterEach(() => {
+  afterEach(async () => {
     resetProviderAuthAliasMapCacheForTest();
     resetPluginRuntimeStateForTest();
+    for (const dir of tempDirs.splice(0)) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   test("persists thinkingLevel=off (does not clear)", async () => {
@@ -307,6 +326,72 @@ describe("gateway sessions patch", () => {
     expect(entry.responseUsage).toBe("tokens");
     expect(entry.parentSessionKey).toBe("agent:main:main");
     expect(entry.fastMode).toBe(true);
+  });
+
+  test("projects patches without mutating the source entry", async () => {
+    const sourceEntry = {
+      sessionId: "source-session",
+      updatedAt: 1,
+      fastMode: false,
+    } as SessionEntry;
+    const entry = expectPatchOk(
+      await applySessionsPatchProjection({
+        cfg: EMPTY_CFG,
+        entry: sourceEntry,
+        entries: [{ sessionKey: MAIN_SESSION_KEY, entry: sourceEntry }],
+        storeKey: MAIN_SESSION_KEY,
+        patch: { key: MAIN_SESSION_KEY, fastMode: true },
+      }),
+    );
+
+    expect(entry.fastMode).toBe(true);
+    expect(sourceEntry.fastMode).toBe(false);
+  });
+
+  test("applies gateway patches through the file-backed projection seam", async () => {
+    const storePath = await createTempStorePath({
+      [MAIN_SESSION_KEY]: {
+        sessionId: "main-session",
+        updatedAt: 1,
+        fastMode: false,
+      } as SessionEntry,
+    });
+
+    const entry = expectPatchOk(
+      await patchGatewaySessionEntry({
+        cfg: EMPTY_CFG,
+        storePath,
+        key: MAIN_SESSION_KEY,
+        patch: { key: MAIN_SESSION_KEY, fastMode: true },
+      }),
+    );
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+      string,
+      SessionEntry
+    >;
+
+    expect(entry.fastMode).toBe(true);
+    expect(persisted[MAIN_SESSION_KEY]?.fastMode).toBe(true);
+  });
+
+  test("rejects duplicate labels through the gateway patch seam", async () => {
+    const storePath = await createTempStorePath({
+      [MAIN_SESSION_KEY]: { sessionId: "main-session", updatedAt: 1 } as SessionEntry,
+      "agent:main:other": {
+        sessionId: "other-session",
+        updatedAt: 1,
+        label: "taken",
+      } as SessionEntry,
+    });
+
+    const result = await patchGatewaySessionEntry({
+      cfg: EMPTY_CFG,
+      storePath,
+      key: MAIN_SESSION_KEY,
+      patch: { key: MAIN_SESSION_KEY, label: "taken" },
+    });
+
+    expectPatchError(result, "label already in use: taken");
   });
 
   test("clears fastMode when patch sets null", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -35,6 +35,7 @@ import {
   resolveSupportedThinkingLevel,
 } from "../auto-reply/thinking.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { updateSessionStore } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeExecTarget } from "../infra/exec-approvals.js";
 import {
@@ -52,6 +53,12 @@ import {
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { normalizeSendPolicy } from "../sessions/send-policy.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
+import { migrateAndPruneGatewaySessionStoreKey } from "./session-utils.js";
+
+export type SessionPatchProjectionEntry = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
 
 function invalid(message: string): { ok: false; error: ErrorShape } {
   return { ok: false, error: errorShape(ErrorCodes.INVALID_REQUEST, message) };
@@ -139,7 +146,33 @@ export async function applySessionsPatchToStore(params: {
   patch: SessionsPatchParams;
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
-  const { cfg, store, storeKey, patch } = params;
+  const projected = await applySessionsPatchProjection({
+    cfg: params.cfg,
+    entry: params.store[params.storeKey],
+    entries: Object.entries(params.store).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+    storeKey: params.storeKey,
+    agentId: params.agentId,
+    patch: params.patch,
+    loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+  });
+  if (!projected.ok) {
+    return projected;
+  }
+  params.store[params.storeKey] = projected.entry;
+  return projected;
+}
+
+/** Projects a sessions.patch payload onto one entry without assuming a storage backend. */
+export async function applySessionsPatchProjection(params: {
+  cfg: OpenClawConfig;
+  entry?: SessionEntry;
+  entries: Iterable<SessionPatchProjectionEntry>;
+  storeKey: string;
+  agentId?: string;
+  patch: SessionsPatchParams;
+  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+}): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
+  const { cfg, storeKey, patch } = params;
   const now = Date.now();
   const parsedAgent = parseAgentSessionKey(storeKey);
   const sessionAgentId = normalizeAgentId(
@@ -162,7 +195,7 @@ export async function applySessionsPatchToStore(params: {
     return loadedModelCatalog;
   };
 
-  const existing = store[storeKey];
+  const existing = params.entry;
   // Existing entries without session ids are placeholder aliases; assigning an id makes them real.
   const next: SessionEntry = existing?.sessionId
     ? {
@@ -356,8 +389,8 @@ export async function applySessionsPatchToStore(params: {
       if (!parsed.ok) {
         return invalid(parsed.error);
       }
-      for (const [key, entry] of Object.entries(store)) {
-        if (key === storeKey) {
+      for (const { sessionKey, entry } of params.entries) {
+        if (sessionKey === storeKey) {
           continue;
         }
         if (entry?.label === parsed.label) {
@@ -642,6 +675,38 @@ export async function applySessionsPatchToStore(params: {
     }
   }
 
-  store[storeKey] = next;
   return { ok: true, entry: next };
+}
+
+/** Applies a gateway/TUI session patch through the current file-backed patch seam. */
+export async function patchGatewaySessionEntry(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  key: string;
+  agentId?: string;
+  patch: SessionsPatchParams;
+  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+}): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
+  return await updateSessionStore(params.storePath, async (store) => {
+    const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+      cfg: params.cfg,
+      key: params.key,
+      store,
+      agentId: params.agentId,
+    });
+    const projected = await applySessionsPatchProjection({
+      cfg: params.cfg,
+      entry: store[primaryKey],
+      entries: Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+      storeKey: primaryKey,
+      agentId: params.agentId,
+      patch: params.patch,
+      loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+    });
+    if (!projected.ok) {
+      return projected;
+    }
+    store[primaryKey] = projected.entry;
+    return projected;
+  });
 }

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -5,11 +5,10 @@ import { ErrorCodes } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 
 const hoisted = vi.hoisted(() => ({
-  loadSessionStoreMock: vi.fn(),
   updateSessionStoreMock: vi.fn(),
   listSessionsFromStoreMock: vi.fn(),
   migrateAndPruneGatewaySessionStoreKeyMock: vi.fn(),
-  resolveGatewaySessionStoreTargetMock: vi.fn(),
+  resolveGatewaySessionStoreTargetWithStoreMock: vi.fn(),
   loadCombinedSessionStoreForGatewayMock: vi.fn(),
   listAgentIdsMock: vi.fn(),
 }));
@@ -29,7 +28,6 @@ vi.mock("../config/sessions.js", async () => {
     await vi.importActual<typeof import("../config/sessions.js")>("../config/sessions.js");
   return {
     ...actual,
-    loadSessionStore: hoisted.loadSessionStoreMock,
     updateSessionStore: hoisted.updateSessionStoreMock,
   };
 });
@@ -40,7 +38,8 @@ vi.mock("./session-utils.js", async () => {
     ...actual,
     listSessionsFromStore: hoisted.listSessionsFromStoreMock,
     migrateAndPruneGatewaySessionStoreKey: hoisted.migrateAndPruneGatewaySessionStoreKeyMock,
-    resolveGatewaySessionStoreTarget: hoisted.resolveGatewaySessionStoreTargetMock,
+    resolveGatewaySessionStoreTargetWithStore:
+      hoisted.resolveGatewaySessionStoreTargetWithStoreMock,
     loadCombinedSessionStoreForGateway: hoisted.loadCombinedSessionStoreForGatewayMock,
   };
 });
@@ -51,6 +50,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
   const canonicalKey = "agent:main:canon";
   const legacyKey = "agent:main:legacy";
   const storePath = "/tmp/sessions.json";
+  let targetStore: Record<string, SessionEntry>;
 
   const expectResolveToCanonicalKey = async (
     p: Parameters<typeof resolveSessionKeyFromResolveParams>[0]["p"],
@@ -68,37 +68,33 @@ describe("resolveSessionKeyFromResolveParams", () => {
   };
 
   beforeEach(() => {
-    hoisted.loadSessionStoreMock.mockReset();
     hoisted.updateSessionStoreMock.mockReset();
     hoisted.listSessionsFromStoreMock.mockReset();
     hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReset();
-    hoisted.resolveGatewaySessionStoreTargetMock.mockReset();
+    hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReset();
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReset();
     hoisted.listAgentIdsMock.mockReset();
+    targetStore = {};
     // Default: all agents are known (main is always present).
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
-    hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({
+    hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockImplementation(() => ({
       canonicalKey,
       storeKeys: [canonicalKey, legacyKey],
       storePath,
-    });
+      store: targetStore,
+    }));
     hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReturnValue({ primaryKey: canonicalKey });
     hoisted.updateSessionStoreMock.mockImplementation(
       async (_path: string, updater: (store: Record<string, SessionEntry>) => void) => {
-        const store = hoisted.loadSessionStoreMock.mock.results[0]?.value as
-          | Record<string, SessionEntry>
-          | undefined;
-        if (store) {
-          updater(store);
-        }
+        updater(targetStore);
       },
     );
   });
 
   it("hides canonical keys that fail the spawnedBy visibility filter", async () => {
-    hoisted.loadSessionStoreMock.mockReturnValue({
+    targetStore = {
       [canonicalKey]: { sessionId: "sess-1", updatedAt: 1 },
-    });
+    };
     hoisted.listSessionsFromStoreMock.mockReturnValue({ sessions: [] });
 
     await expect(
@@ -131,7 +127,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
         updatedAt: now - i,
       };
     }
-    hoisted.loadSessionStoreMock.mockReturnValue(store);
+    targetStore = store;
 
     await expectResolveToCanonicalKey({ key: canonicalKey, spawnedBy: "controller-1" });
   });
@@ -140,7 +136,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
     const store = {
       [legacyKey]: { sessionId: "sess-legacy", spawnedBy: "controller-1", updatedAt: Date.now() },
     } satisfies Record<string, SessionEntry>;
-    hoisted.loadSessionStoreMock.mockImplementation(() => store);
+    targetStore = store;
 
     await expectResolveToCanonicalKey({ key: canonicalKey, spawnedBy: "controller-1" });
 
@@ -152,13 +148,14 @@ describe("resolveSessionKeyFromResolveParams", () => {
 
   it("rejects sessions belonging to a deleted agent (key-based lookup)", async () => {
     const deletedAgentKey = "agent:deleted-agent:main";
-    hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({
+    targetStore = {
+      [deletedAgentKey]: { sessionId: "sess-orphan", updatedAt: 1 },
+    };
+    hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReturnValue({
       canonicalKey: deletedAgentKey,
       storeKeys: [deletedAgentKey],
       storePath,
-    });
-    hoisted.loadSessionStoreMock.mockReturnValue({
-      [deletedAgentKey]: { sessionId: "sess-orphan", updatedAt: 1 },
+      store: targetStore,
     });
     // "deleted-agent" is not in the known agents list.
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
@@ -214,13 +211,14 @@ describe("resolveSessionKeyFromResolveParams", () => {
 
   it("rejects non-alias agent:main sessions when main is no longer configured", async () => {
     const staleMainKey = "agent:main:guildchat:direct:u1";
-    hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({
+    targetStore = {
+      [staleMainKey]: { sessionId: "sess-stale-main", updatedAt: 1 },
+    };
+    hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReturnValue({
       canonicalKey: staleMainKey,
       storeKeys: [staleMainKey],
       storePath,
-    });
-    hoisted.loadSessionStoreMock.mockReturnValue({
-      [staleMainKey]: { sessionId: "sess-stale-main", updatedAt: 1 },
+      store: targetStore,
     });
     hoisted.listAgentIdsMock.mockReturnValue(["ops"]);
 

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -176,12 +176,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
 
   it("resolves ACP harness session keys even when harness id is not in agents.list", async () => {
     const acpKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
-    hoisted.resolveGatewaySessionStoreTargetMock.mockReturnValue({
-      canonicalKey: acpKey,
-      storeKeys: [acpKey],
-      storePath,
-    });
-    hoisted.loadSessionStoreMock.mockReturnValue({
+    targetStore = {
       [acpKey]: {
         sessionId: "sess-acp",
         updatedAt: 1,
@@ -195,6 +190,12 @@ describe("resolveSessionKeyFromResolveParams", () => {
           lastActivityAt: 1,
         },
       },
+    };
+    hoisted.resolveGatewaySessionStoreTargetWithStoreMock.mockReturnValue({
+      canonicalKey: acpKey,
+      storeKeys: [acpKey],
+      storePath,
+      store: targetStore,
     });
     hoisted.listAgentIdsMock.mockReturnValue(["main"]);
 

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -7,7 +7,7 @@ import {
   errorShape,
   type SessionsResolveParams,
 } from "../../packages/gateway-protocol/src/index.js";
-import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
+import { updateSessionStore, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
@@ -17,7 +17,7 @@ import {
   loadCombinedSessionStoreForGateway,
   migrateAndPruneGatewaySessionStoreKey,
   resolveDeletedAgentIdFromSessionKey,
-  resolveGatewaySessionStoreTarget,
+  resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils.js";
 
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
@@ -61,8 +61,7 @@ function validateSessionAgentExists(
 function isResolvedSessionKeyVisible(params: {
   cfg: OpenClawConfig;
   p: SessionsResolveParams;
-  storePath: string;
-  store: ReturnType<typeof loadSessionStore>;
+  store: Record<string, SessionEntry>;
   key: string;
 }) {
   if (typeof params.p.spawnedBy !== "string" || params.p.spawnedBy.trim().length === 0) {
@@ -125,14 +124,13 @@ export async function resolveSessionKeyFromResolveParams(params: {
   if (hasKey) {
     // Key lookups may hit legacy store aliases. Migrate/prune before returning
     // the canonical key so later calls operate on one store identity.
-    const target = resolveGatewaySessionStoreTarget({ cfg, key });
-    const store = loadSessionStore(target.storePath);
+    const target = resolveGatewaySessionStoreTargetWithStore({ cfg, key, clone: false });
+    const store = target.store;
     if (store[target.canonicalKey]) {
       if (
         !isResolvedSessionKeyVisible({
           cfg,
           p,
-          storePath: target.storePath,
           store,
           key: target.canonicalKey,
         })
@@ -160,28 +158,31 @@ export async function resolveSessionKeyFromResolveParams(params: {
         s[primaryKey] = s[legacyKey];
       }
     });
-    const migratedStore = loadSessionStore(target.storePath);
+    const refreshedTarget = resolveGatewaySessionStoreTargetWithStore({
+      cfg,
+      key: target.canonicalKey,
+      clone: false,
+    });
     if (
       !isResolvedSessionKeyVisible({
         cfg,
         p,
-        storePath: target.storePath,
-        store: migratedStore,
-        key: target.canonicalKey,
+        store: refreshedTarget.store,
+        key: refreshedTarget.canonicalKey,
       })
     ) {
       return noSessionFoundResult(key);
     }
     const agentCheckLegacy = validateSessionAgentExists(
       cfg,
-      target.canonicalKey,
-      migratedStore[target.canonicalKey],
-      { acpMetadataSessionKey: target.canonicalKey },
+      refreshedTarget.canonicalKey,
+      refreshedTarget.store[refreshedTarget.canonicalKey],
+      { acpMetadataSessionKey: refreshedTarget.canonicalKey },
     );
     if (agentCheckLegacy) {
       return agentCheckLegacy;
     }
-    return { ok: true, key: target.canonicalKey };
+    return { ok: true, key: refreshedTarget.canonicalKey };
   }
 
   if (hasSessionId) {

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -22,6 +22,7 @@ export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 export {
   clearSessionStoreCacheForTest,
+  cleanupSessionLifecycleArtifacts,
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
@@ -32,6 +33,10 @@ export {
   updateSessionStore,
   updateSessionStoreEntry,
   upsertSessionEntry,
+} from "../config/sessions/store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "../config/sessions/store.js";
 export {
   evaluateSessionFreshness,

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -22,7 +22,6 @@ export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 export {
   clearSessionStoreCacheForTest,
-  cleanupSessionLifecycleArtifacts,
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
@@ -33,10 +32,6 @@ export {
   updateSessionStore,
   updateSessionStoreEntry,
   upsertSessionEntry,
-} from "../config/sessions/store.js";
-export type {
-  SessionLifecycleArtifactCleanupParams,
-  SessionLifecycleArtifactCleanupResult,
 } from "../config/sessions/store.js";
 export {
   evaluateSessionFreshness,

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/config.js";
-import { updateSessionStore } from "../config/sessions/store.js";
+import { patchSessionEntries } from "../config/sessions/session-entry-lifecycle.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -253,29 +253,23 @@ async function clearPluginOwnedSessionStores(params: {
   const storePaths = resolveCleanupSessionStorePaths(params);
   let cleared = 0;
   for (const storePath of storePaths) {
-    cleared += await updateSessionStore(
-      storePath,
-      (store) => {
-        let clearedInStore = 0;
-        const now = Date.now();
-        for (const [entryKey, entry] of Object.entries(store)) {
-          if (
-            !matchesCleanupSession(entryKey, entry, params.sessionKey) ||
-            !hasPluginOwnedSessionState(entry, params.pluginId, params.sessionEntrySlotKeys)
-          ) {
-            continue;
-          }
-          clearPluginOwnedSessionState(entry, params.pluginId, params.sessionEntrySlotKeys);
-          entry.updatedAt = now;
-          clearedInStore += 1;
+    const now = Date.now();
+    const result = await patchSessionEntries(
+      { storePath },
+      (entry, { sessionKey }) => {
+        if (
+          !matchesCleanupSession(sessionKey, entry, params.sessionKey) ||
+          !hasPluginOwnedSessionState(entry, params.pluginId, params.sessionEntrySlotKeys)
+        ) {
+          return null;
         }
-        return clearedInStore;
+        clearPluginOwnedSessionState(entry, params.pluginId, params.sessionEntrySlotKeys);
+        entry.updatedAt = now;
+        return entry;
       },
-      {
-        skipSaveWhenResult: (clearedInStore) => clearedInStore === 0,
-        takeCacheOwnership: true,
-      },
+      { replaceEntry: true, takeCacheOwnership: true },
     );
+    cleared += result.patched.length;
   }
   return cleared;
 }
@@ -294,32 +288,26 @@ async function clearPromotedSessionEntrySlotStores(params: {
   const storePaths = resolveCleanupSessionStorePaths(params);
   let cleared = 0;
   for (const storePath of storePaths) {
-    cleared += await updateSessionStore(
-      storePath,
-      (store) => {
-        let clearedInStore = 0;
-        const now = Date.now();
-        for (const [entryKey, entry] of Object.entries(store)) {
-          if (
-            !matchesCleanupSession(entryKey, entry, params.sessionKey) ||
-            !hasPromotedSessionEntrySlot(entry, params.pluginId, params.sessionEntrySlotKeys)
-          ) {
-            continue;
-          }
-          clearPromotedSessionEntrySlots(entry, params.pluginId, params.sessionEntrySlotKeys, {
-            includeStoredSlotKeys: false,
-            pruneSlotOwnership: true,
-          });
-          entry.updatedAt = now;
-          clearedInStore += 1;
+    const now = Date.now();
+    const result = await patchSessionEntries(
+      { storePath },
+      (entry, { sessionKey }) => {
+        if (
+          !matchesCleanupSession(sessionKey, entry, params.sessionKey) ||
+          !hasPromotedSessionEntrySlot(entry, params.pluginId, params.sessionEntrySlotKeys)
+        ) {
+          return null;
         }
-        return clearedInStore;
+        clearPromotedSessionEntrySlots(entry, params.pluginId, params.sessionEntrySlotKeys, {
+          includeStoredSlotKeys: false,
+          pruneSlotOwnership: true,
+        });
+        entry.updatedAt = now;
+        return entry;
       },
-      {
-        skipSaveWhenResult: (clearedInStore) => clearedInStore === 0,
-        takeCacheOwnership: true,
-      },
+      { replaceEntry: true, takeCacheOwnership: true },
     );
+    cleared += result.patched.length;
   }
   return cleared;
 }

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -4,9 +4,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { loadSessionStore, updateSessionStore, type SessionEntry } from "../config/sessions.js";
+import { loadSessionStore, type SessionEntry } from "../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { patchSessionLifecycleEntry } from "../config/sessions/session-entry-lifecycle.js";
 import {
   resolveAllAgentSessionStoreTargetsSync,
   type SessionStoreTarget,
@@ -292,37 +293,38 @@ export async function enqueuePluginNextTurnInjection(params: {
   });
   let enqueued = false;
   let resultId = record.id;
-  await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
-      return;
-    }
-    const injections = { ...entry.pluginNextTurnInjections };
-    // Guard against malformed/hand-edited persisted state — a non-array value
-    // here would crash the spread/filter and break the whole session's enqueue.
-    const rawExisting = injections[params.pluginId];
-    const existing = (Array.isArray(rawExisting) ? [...rawExisting] : []).filter(
-      (candidate): candidate is PluginNextTurnInjectionRecord => !isExpired(candidate, now),
-    );
-    const duplicate = record.idempotencyKey
-      ? existing.find((candidate) => candidate.idempotencyKey === record.idempotencyKey)
-      : undefined;
-    if (duplicate) {
-      resultId = duplicate.id;
-      injections[params.pluginId] = existing;
+  await patchSessionLifecycleEntry(
+    { sessionKey: loaded.storeKey, storePath: loaded.storePath },
+    (entry) => {
+      const injections = { ...entry.pluginNextTurnInjections };
+      // Guard against malformed/hand-edited persisted state — a non-array value
+      // here would crash the spread/filter and break the whole session's enqueue.
+      const rawExisting = injections[params.pluginId];
+      const existing = (Array.isArray(rawExisting) ? [...rawExisting] : []).filter(
+        (candidate): candidate is PluginNextTurnInjectionRecord => !isExpired(candidate, now),
+      );
+      const duplicate = record.idempotencyKey
+        ? existing.find((candidate) => candidate.idempotencyKey === record.idempotencyKey)
+        : undefined;
+      if (duplicate) {
+        resultId = duplicate.id;
+        injections[params.pluginId] = existing;
+        entry.pluginNextTurnInjections = injections;
+        return entry;
+      }
+      if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
+        injections[params.pluginId] = existing;
+        entry.pluginNextTurnInjections = injections;
+        return entry;
+      }
+      injections[params.pluginId] = [...existing, record];
       entry.pluginNextTurnInjections = injections;
-      return;
-    }
-    if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
-      injections[params.pluginId] = existing;
-      entry.pluginNextTurnInjections = injections;
-      return;
-    }
-    injections[params.pluginId] = [...existing, record];
-    entry.pluginNextTurnInjections = injections;
-    entry.updatedAt = now;
-    enqueued = true;
-  });
+      entry.updatedAt = now;
+      enqueued = true;
+      return entry;
+    },
+    { replaceEntry: true },
+  );
   return { enqueued, id: resultId, sessionKey: canonicalKey };
 }
 
@@ -339,7 +341,7 @@ export async function drainPluginNextTurnInjections(params: {
   if (!loaded.entry) {
     return [];
   }
-  // Avoid the locked re-save in updateSessionStore when there is nothing queued.
+  // Avoid the locked lifecycle write when there is nothing queued.
   // Drain runs once per prompt build; the common case is no injections, so a
   // pre-flight read keeps prompt-build off the session-store write path.
   // (Concurrently-enqueued injections during this gap land on the next turn.)
@@ -350,40 +352,48 @@ export async function drainPluginNextTurnInjections(params: {
     return [];
   }
   const now = params.now ?? Date.now();
-  return await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry?.pluginNextTurnInjections) {
-      return [];
-    }
-    const activePluginIds = new Set(
-      (getActivePluginRegistry()?.plugins ?? [])
-        .filter((plugin) => plugin.status === "loaded")
-        .map((plugin) => plugin.id),
-    );
-    const drained: PluginNextTurnInjectionRecord[] = [];
-    for (const [pluginId, entries] of Object.entries(entry.pluginNextTurnInjections)) {
-      if (!activePluginIds.has(pluginId) || !isPluginPromptInjectionEnabled(params.cfg, pluginId)) {
-        continue;
+  let drained: PluginNextTurnInjectionRecord[] = [];
+  await patchSessionLifecycleEntry(
+    { sessionKey: loaded.storeKey, storePath: loaded.storePath },
+    (entry) => {
+      if (!entry.pluginNextTurnInjections) {
+        return null;
       }
-      // Guard against malformed/hand-edited persisted state — a non-array value
-      // here would crash .filter and break prompt-building for the session.
-      if (!Array.isArray(entries)) {
-        continue;
-      }
-      const liveEntries = entries.filter(
-        (candidate): candidate is PluginNextTurnInjectionRecord => !isExpired(candidate, now),
+      const activePluginIds = new Set(
+        (getActivePluginRegistry()?.plugins ?? [])
+          .filter((plugin) => plugin.status === "loaded")
+          .map((plugin) => plugin.id),
       );
-      drained.push(...liveEntries);
-    }
-    drained.sort((left, right) => left.createdAt - right.createdAt);
-    // A drain is the consume boundary for this session queue. Inactive plugin
-    // records are stale owner state and are discarded with expired records.
-    delete entry.pluginNextTurnInjections;
-    if (drained.length > 0) {
-      entry.updatedAt = now;
-    }
-    return drained;
-  });
+      drained = [];
+      for (const [pluginId, entries] of Object.entries(entry.pluginNextTurnInjections)) {
+        if (
+          !activePluginIds.has(pluginId) ||
+          !isPluginPromptInjectionEnabled(params.cfg, pluginId)
+        ) {
+          continue;
+        }
+        // Guard against malformed/hand-edited persisted state — a non-array value
+        // here would crash .filter and break prompt-building for the session.
+        if (!Array.isArray(entries)) {
+          continue;
+        }
+        const liveEntries = entries.filter(
+          (candidate): candidate is PluginNextTurnInjectionRecord => !isExpired(candidate, now),
+        );
+        drained.push(...liveEntries);
+      }
+      drained.sort((left, right) => left.createdAt - right.createdAt);
+      // A drain is the consume boundary for this session queue. Inactive plugin
+      // records are stale owner state and are discarded with expired records.
+      delete entry.pluginNextTurnInjections;
+      if (drained.length > 0) {
+        entry.updatedAt = now;
+      }
+      return entry;
+    },
+    { replaceEntry: true },
+  );
+  return drained;
 }
 
 export async function drainPluginNextTurnInjectionContext(params: {
@@ -482,66 +492,68 @@ export async function patchPluginSessionExtension(params: {
     );
   }
   const slotKey = normalizedSlotKey?.ok === true ? normalizedSlotKey.key : undefined;
-  const nextValue = await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
-      return undefined;
-    }
-    const entryRecord = entry as Record<string, unknown>;
-    const pluginExtensions = { ...entry.pluginExtensions };
-    const pluginState = { ...pluginExtensions[pluginId] };
-    if (params.unset === true) {
-      delete pluginState[namespace];
-    } else {
-      pluginState[namespace] = copyJsonValue(nextPluginValue);
-    }
-    if (Object.keys(pluginState).length > 0) {
-      pluginExtensions[pluginId] = pluginState;
-    } else {
-      delete pluginExtensions[pluginId];
-    }
-    if (Object.keys(pluginExtensions).length > 0) {
-      entry.pluginExtensions = pluginExtensions;
-    } else {
-      delete entry.pluginExtensions;
-    }
-    const storedSlotKeys = { ...entry.pluginExtensionSlotKeys };
-    const pluginSlotKeys = { ...storedSlotKeys[pluginId] };
-    const previousSlotKey = normalizeSessionEntrySlotKey(pluginSlotKeys[namespace]);
-    if (previousSlotKey.ok && previousSlotKey.key !== slotKey) {
-      delete entryRecord[previousSlotKey.key];
-    }
-    if (slotKey && params.unset !== true) {
-      pluginSlotKeys[namespace] = slotKey;
-    } else {
-      delete pluginSlotKeys[namespace];
-    }
-    if (Object.keys(pluginSlotKeys).length > 0) {
-      storedSlotKeys[pluginId] = pluginSlotKeys;
-    } else {
-      delete storedSlotKeys[pluginId];
-    }
-    if (Object.keys(storedSlotKeys).length > 0) {
-      entry.pluginExtensionSlotKeys = storedSlotKeys;
-    } else {
-      delete entry.pluginExtensionSlotKeys;
-    }
-    if (slotKey) {
-      const projected = projectSessionExtensionValueForSlot({
-        registration,
-        sessionKey: canonicalKey,
-        sessionId: entry.sessionId,
-        nextValue: params.unset === true ? undefined : nextPluginValue,
-      });
-      if (projected === undefined) {
-        delete entryRecord[slotKey];
+  let nextValue: PluginJsonValue | undefined;
+  await patchSessionLifecycleEntry(
+    { sessionKey: loaded.storeKey, storePath: loaded.storePath },
+    (entry) => {
+      const entryRecord = entry as Record<string, unknown>;
+      const pluginExtensions = { ...entry.pluginExtensions };
+      const pluginState = { ...pluginExtensions[pluginId] };
+      if (params.unset === true) {
+        delete pluginState[namespace];
       } else {
-        entryRecord[slotKey] = projected;
+        pluginState[namespace] = copyJsonValue(nextPluginValue);
       }
-    }
-    entry.updatedAt = Date.now();
-    return pluginState[namespace] as PluginJsonValue | undefined;
-  });
+      if (Object.keys(pluginState).length > 0) {
+        pluginExtensions[pluginId] = pluginState;
+      } else {
+        delete pluginExtensions[pluginId];
+      }
+      if (Object.keys(pluginExtensions).length > 0) {
+        entry.pluginExtensions = pluginExtensions;
+      } else {
+        delete entry.pluginExtensions;
+      }
+      const storedSlotKeys = { ...entry.pluginExtensionSlotKeys };
+      const pluginSlotKeys = { ...storedSlotKeys[pluginId] };
+      const previousSlotKey = normalizeSessionEntrySlotKey(pluginSlotKeys[namespace]);
+      if (previousSlotKey.ok && previousSlotKey.key !== slotKey) {
+        delete entryRecord[previousSlotKey.key];
+      }
+      if (slotKey && params.unset !== true) {
+        pluginSlotKeys[namespace] = slotKey;
+      } else {
+        delete pluginSlotKeys[namespace];
+      }
+      if (Object.keys(pluginSlotKeys).length > 0) {
+        storedSlotKeys[pluginId] = pluginSlotKeys;
+      } else {
+        delete storedSlotKeys[pluginId];
+      }
+      if (Object.keys(storedSlotKeys).length > 0) {
+        entry.pluginExtensionSlotKeys = storedSlotKeys;
+      } else {
+        delete entry.pluginExtensionSlotKeys;
+      }
+      if (slotKey) {
+        const projected = projectSessionExtensionValueForSlot({
+          registration,
+          sessionKey: canonicalKey,
+          sessionId: entry.sessionId,
+          nextValue: params.unset === true ? undefined : nextPluginValue,
+        });
+        if (projected === undefined) {
+          delete entryRecord[slotKey];
+        } else {
+          entryRecord[slotKey] = projected;
+        }
+      }
+      entry.updatedAt = Date.now();
+      nextValue = pluginState[namespace] as PluginJsonValue | undefined;
+      return entry;
+    },
+    { replaceEntry: true },
+  );
   return { ok: true, key: canonicalKey, value: nextValue };
 }
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -6,7 +6,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 
 const agentCommandFromIngressMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
-const applySessionsPatchToStoreMock = vi.fn();
+const patchGatewaySessionEntryMock = vi.fn();
 const createSessionGoalMock = vi.fn();
 const clearSessionGoalMock = vi.fn();
 const getSessionGoalMock = vi.fn();
@@ -178,7 +178,7 @@ vi.mock("../gateway/session-utils.fs.js", () => ({
 }));
 
 vi.mock("../gateway/sessions-patch.js", () => ({
-  applySessionsPatchToStore: (...args: unknown[]) => applySessionsPatchToStoreMock(...args),
+  patchGatewaySessionEntry: (...args: unknown[]) => patchGatewaySessionEntryMock(...args),
 }));
 
 vi.mock("../gateway/server-methods/agent-timestamp.js", () => ({
@@ -244,8 +244,8 @@ describe("EmbeddedTuiBackend", () => {
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
     });
-    applySessionsPatchToStoreMock.mockReset();
-    applySessionsPatchToStoreMock.mockResolvedValue({ ok: true, entry: {} });
+    patchGatewaySessionEntryMock.mockReset();
+    patchGatewaySessionEntryMock.mockResolvedValue({ ok: true, entry: {} });
     getRuntimeConfigMock.mockReset();
     getRuntimeConfigMock.mockReturnValue({});
     loadGatewayModelCatalogMock.mockReset();
@@ -469,7 +469,7 @@ describe("EmbeddedTuiBackend", () => {
         provider: "tui-pty-mock",
       },
     ]);
-    applySessionsPatchToStoreMock.mockImplementation(
+    patchGatewaySessionEntryMock.mockImplementation(
       async ({
         loadGatewayModelCatalog,
       }: {
@@ -1291,9 +1291,9 @@ describe("EmbeddedTuiBackend", () => {
       fastMode: true,
     });
 
-    expect(applySessionsPatchToStoreMock).toHaveBeenCalledWith(
+    expect(patchGatewaySessionEntryMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        storeKey: "global",
+        key: "global",
         agentId: "work",
         patch: expect.objectContaining({
           key: "global",

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -24,7 +24,6 @@ import {
   formatSessionGoalStatus,
   getSessionGoal,
   updateSessionGoalStatus,
-  updateSessionStore,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
@@ -56,12 +55,11 @@ import {
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
-  migrateAndPruneGatewaySessionStoreKey,
   resolveGatewaySessionStoreTarget,
   resolveSessionModelRef,
   readSessionMessagesAsync,
 } from "../gateway/session-utils.js";
-import { applySessionsPatchToStore } from "../gateway/sessions-patch.js";
+import { patchGatewaySessionEntry } from "../gateway/sessions-patch.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -533,21 +531,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
       key: opts.key,
       agentId: opts.agentId,
     });
-    const applied = await updateSessionStore(target.storePath, async (store) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
-        cfg,
-        key: opts.key,
-        store,
-        agentId: opts.agentId,
-      });
-      return await applySessionsPatchToStore({
-        cfg,
-        store,
-        storeKey: primaryKey,
-        agentId: opts.agentId,
-        patch: opts,
-        loadGatewayModelCatalog: () => loadEmbeddedTuiModelCatalog(cfg),
-      });
+    const applied = await patchGatewaySessionEntry({
+      cfg,
+      storePath: target.storePath,
+      key: opts.key,
+      agentId: opts.agentId,
+      patch: opts,
+      loadGatewayModelCatalog: () => loadEmbeddedTuiModelCatalog(cfg),
     });
     if (!applied.ok) {
       throw new Error(applied.error.message);

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  findSessionAccessorBoundaryViolations,
+  migratedSessionAccessorFiles,
+} from "../../scripts/check-session-accessor-boundary.mjs";
+
+describe("session accessor boundary guard", () => {
+  it("ratchets only the files migrated by the session accessor gateway slice", () => {
+    expect(migratedSessionAccessorFiles).toEqual(
+      new Set([
+        "src/config/sessions/combined-store-gateway.ts",
+        "src/gateway/session-utils.ts",
+        "src/gateway/sessions-resolve.ts",
+        "src/gateway/server-methods/sessions.ts",
+      ]),
+    );
+  });
+
+  it("flags legacy reader imports", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        import { loadSessionStore, readSessionEntries as readEntries } from "../config/sessions.js";
+      `),
+    ).toEqual([
+      { line: 2, reason: 'imports legacy session store reader "loadSessionStore"' },
+      { line: 2, reason: 'imports legacy session store reader "readSessionEntries"' },
+    ]);
+  });
+
+  it("flags direct and namespace legacy reader calls", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        loadSessionStore(storePath);
+        sessions.readSessionEntries(storePath);
+        sessions["loadSessionStore"](storePath);
+      `),
+    ).toEqual([
+      { line: 2, reason: 'calls legacy session store reader "loadSessionStore"' },
+      { line: 3, reason: 'references legacy session store reader "readSessionEntries"' },
+      { line: 4, reason: 'references legacy session store reader "loadSessionStore"' },
+    ]);
+  });
+
+  it("flags aliased namespace reader references", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        const load = sessions.loadSessionStore;
+        const { readSessionEntries: readEntries } = sessions;
+        const { loadSessionStore } = sessions;
+      `),
+    ).toEqual([
+      { line: 2, reason: 'references legacy session store reader "loadSessionStore"' },
+      { line: 3, reason: 'aliases legacy session store reader "readSessionEntries"' },
+      { line: 4, reason: 'aliases legacy session store reader "loadSessionStore"' },
+    ]);
+  });
+
+  it("allows migrated accessor reads", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        import { listSessionEntries } from "../config/sessions/session-accessor.js";
+        listSessionEntries({ storePath });
+      `),
+    ).toEqual([]);
+  });
+
+  it("ignores comments and strings that describe legacy readers", () => {
+    expect(
+      findSessionAccessorBoundaryViolations(`
+        // loadSessionStore and readSessionEntries used to be called here.
+        const description = "loadSessionStore";
+      `),
+    ).toEqual([]);
+  });
+});

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -16,6 +16,22 @@ function readCriticalQualityWorkflow() {
 }
 
 describe("ci workflow guards", () => {
+  it("runs the session accessor ratchet as a visible additional check", () => {
+    const workflow = readCiWorkflow();
+    const additionalJob = workflow.jobs["check-additional-shard"];
+    const matrixRows = additionalJob.strategy.matrix.include;
+    expect(matrixRows).toContainEqual({
+      check_name: "check-session-accessor-boundary",
+      group: "session-accessor-boundary",
+    });
+
+    const runStep = additionalJob.steps.find((step) => step.name === "Run additional check shard");
+    expect(runStep.run).toContain("session-accessor-boundary)");
+    expect(runStep.run).toContain(
+      'run_check "lint:tmp:session-accessor-boundary" pnpm run lint:tmp:session-accessor-boundary',
+    );
+  });
+
   it("kills timed manual checkout fetches after the grace period", () => {
     const workflowPaths = [
       ".github/workflows/ci.yml",

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -93,16 +93,11 @@ describe("run-additional-boundary-checks", () => {
     expect(() => parseShardSpec("5/4")).toThrow("Invalid shard spec");
   });
 
-  it("keeps the temporary ratchet guards in source boundary checks", () => {
+  it("keeps the raw HTTP/2 import guard in source boundary checks", () => {
     expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:tmp:no-raw-http2-imports",
       command: "pnpm",
       args: ["run", "lint:tmp:no-raw-http2-imports"],
-    });
-    expect(BOUNDARY_CHECKS).toContainEqual({
-      label: "lint:tmp:session-accessor-boundary",
-      command: "pnpm",
-      args: ["run", "lint:tmp:session-accessor-boundary"],
     });
   });
 

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -93,11 +93,16 @@ describe("run-additional-boundary-checks", () => {
     expect(() => parseShardSpec("5/4")).toThrow("Invalid shard spec");
   });
 
-  it("keeps the raw HTTP/2 import guard in source boundary checks", () => {
-    expect(BOUNDARY_CHECKS[6]).toEqual({
+  it("keeps the temporary ratchet guards in source boundary checks", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:tmp:no-raw-http2-imports",
       command: "pnpm",
       args: ["run", "lint:tmp:no-raw-http2-imports"],
+    });
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "lint:tmp:session-accessor-boundary",
+      command: "pnpm",
+      args: ["run", "lint:tmp:session-accessor-boundary"],
     });
   });
 


### PR DESCRIPTION
## What
Adds storage-neutral session entry lifecycle operations over the current file-backed store and routes representative lifecycle mutation callers through those operations instead of mutable whole-store callbacks.

## Why
Path 3 needs delete, replace, scoped patch/delete, deleted-artifact archiving, and TUI/Gateway patch projection to be explicit domain operations before the SQLite storage flip. Arbitrary `updateSessionStore(store => ...)` callbacks do not map cleanly to SQLite row operations and would keep the old JSON-store shape as the hidden runtime contract.

Refs #88838.

## Changes
- Add lifecycle seam
- Route cleanup callers
- Route command writes
- Route plugin cleanup
- Add patch projection
- Cover lifecycle regressions

| File | Change |
|------|--------|
| `src/config/sessions/session-entry-lifecycle.ts` | Adds lifecycle operation helpers |
| `src/config/sessions/session-entry-lifecycle.test.ts` | Covers lifecycle semantics |
| `src/cron/session-reaper.ts` | Uses lifecycle deletes/archive handling |
| `src/commands/tasks.ts` | Uses lifecycle pruning |
| `src/plugins/host-hook-cleanup.ts` | Uses scoped lifecycle cleanup |
| `src/plugins/host-hook-state.ts` | Uses lifecycle patching |
| `src/agents/command/attempt-execution.shared.ts` | Persists cleared fields through seam |
| `src/auto-reply/reply/commands-session-store.ts` | Routes command store writes |
| `src/gateway/sessions-patch.ts` | Adds storage-neutral patch projection |
| `src/tui/embedded-backend.ts` | Uses patch projection seam |

## Testing
- `node scripts/run-vitest.mjs src/config/sessions/session-entry-lifecycle.test.ts src/cron/session-reaper.test.ts src/commands/tasks.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/agents/command/attempt-execution.shared.test.ts`
- `node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts src/tui/embedded-backend.test.ts`
- `node scripts/run-oxlint.mjs <touched files>`
- `pnpm tsgo:core`
- `git diff --check`
- Autoreview completed with no accepted/actionable findings after review-driven fixes

This is file-backed and behavior-neutral. It does not add SQLite schema/store modules, production storage flip, runtime dual-read/fallback, doctor migration code, or a generic mutable whole-store runtime seam. Public SDK whole-store compatibility remains tracked separately in `clawdbot-d02.1.9.1.18`.
