### PR TITLE
fix(provider): harden unsupported schema keyword stripping

### DIFF
--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -123,4 +123,121 @@ describe("stripXaiUnsupportedKeywords", () => {
     expect(stripXaiUnsupportedKeywords("string")).toBe("string");
     expect(stripXaiUnsupportedKeywords(42)).toBe(42);
   });
+
+  it("does not trust source array traversal methods", () => {
+    const anyOf = [{ type: "string", maxLength: 10 }, { type: "null" }];
+    Object.defineProperty(anyOf, "map", {
+      value() {
+        throw new Error("fuzzplugin schema array map exploded");
+      },
+    });
+    const result = stripXaiUnsupportedKeywords({ anyOf }) as {
+      anyOf: Array<Record<string, unknown>>;
+    };
+
+    expect(result.anyOf).toEqual([{ type: "string" }, { type: "null" }]);
+  });
+
+  it("snapshots schema array length before reading entries", () => {
+    let lengthReads = 0;
+    const anyOf = new Proxy([{ type: "string", maxLength: 10 }, { type: "null" }], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          lengthReads += 1;
+          if (lengthReads > 1) {
+            throw new Error("fuzzplugin schema array length exploded");
+          }
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const result = stripXaiUnsupportedKeywords({ anyOf }) as {
+      anyOf: Array<Record<string, unknown>>;
+    };
+
+    expect(result.anyOf).toEqual([{ type: "string" }, { type: "null" }]);
+  });
+
+  it("preserves readable properties when a sibling schema is unreadable", () => {
+    const unreadableChild = new Proxy(
+      { type: "string", maxLength: 10 },
+      {
+        ownKeys() {
+          throw new Error("fuzzplugin child schema ownKeys exploded");
+        },
+      },
+    );
+    const result = stripXaiUnsupportedKeywords({
+      type: "object",
+      properties: {
+        healthy: { type: "string", maxLength: 10 },
+        broken: unreadableChild,
+      },
+    }) as { properties: Record<string, unknown> };
+
+    expect(result.properties).toEqual({
+      healthy: { type: "string" },
+      broken: {},
+    });
+  });
+
+  it("preserves readable object fields when a sibling getter throws", () => {
+    const schema = {
+      type: "object",
+      maxLength: 10,
+      description: "A schema",
+    };
+    Object.defineProperty(schema, "broken", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin schema field getter exploded");
+      },
+    });
+
+    expect(stripXaiUnsupportedKeywords(schema)).toEqual({
+      type: "object",
+      description: "A schema",
+    });
+  });
+
+  it("omits unreadable scalar fields instead of replacing them with schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+    Object.defineProperty(schema, "required", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin required getter exploded");
+      },
+    });
+
+    expect(stripXaiUnsupportedKeywords(schema)).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    });
+  });
+
+  it("omits unreadable schema maps without throwing", () => {
+    const properties = new Proxy(
+      {
+        healthy: { type: "string", maxLength: 10 },
+      },
+      {
+        ownKeys() {
+          throw new Error("fuzzplugin properties ownKeys exploded");
+        },
+      },
+    );
+    const result = stripXaiUnsupportedKeywords({
+      type: "object",
+      properties,
+    }) as { properties: Record<string, unknown> };
+
+    expect(result.properties).toEqual({});
+  });
 });

--- a/src/shared/schema-keyword-strip.ts
+++ b/src/shared/schema-keyword-strip.ts
@@ -1,3 +1,96 @@
+type ReadableSchemaEntry = { readonly readable: true; readonly value: unknown };
+type UnreadableSchemaEntry = { readonly readable: false };
+type ReadableSchemaObjectEntry = ReadableSchemaEntry & { readonly key: string };
+type UnreadableSchemaObjectEntry = UnreadableSchemaEntry & { readonly key: string };
+
+const MAX_SCHEMA_ARRAY_ENTRIES = 10_000;
+const SCHEMA_VALUE_KEYS = new Set([
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "oneOf",
+  "propertyNames",
+  "then",
+]);
+
+function unreadableSchemaFieldFallback(key: string): unknown {
+  if (key === "properties") {
+    return {};
+  }
+  if (key === "anyOf" || key === "oneOf" || key === "allOf") {
+    return [];
+  }
+  return SCHEMA_VALUE_KEYS.has(key) ? {} : undefined;
+}
+
+function readArrayEntries(
+  array: readonly unknown[],
+): Array<ReadableSchemaEntry | UnreadableSchemaEntry> | undefined {
+  try {
+    const length = array.length;
+    if (!Number.isSafeInteger(length) || length < 0 || length > MAX_SCHEMA_ARRAY_ENTRIES) {
+      return undefined;
+    }
+    const entries: Array<ReadableSchemaEntry | UnreadableSchemaEntry> = [];
+    let index = 0;
+    while (index < length) {
+      try {
+        entries.push({ readable: true, value: array[index] });
+      } catch {
+        entries.push({ readable: false });
+      }
+      index += 1;
+    }
+    return entries;
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectEntries(
+  value: object,
+): Array<ReadableSchemaObjectEntry | UnreadableSchemaObjectEntry> | undefined {
+  try {
+    return Object.keys(value as Record<string, unknown>).map((key) => {
+      try {
+        return { key, readable: true, value: (value as Record<string, unknown>)[key] };
+      } catch {
+        return { key, readable: false };
+      }
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function stripUnsupportedSchemaKeywordArray(
+  schema: readonly unknown[],
+  unsupportedKeywords: ReadonlySet<string>,
+): unknown[] {
+  return (
+    readArrayEntries(schema)?.map((entry) =>
+      entry.readable ? stripUnsupportedSchemaKeywords(entry.value, unsupportedKeywords) : {},
+    ) ?? []
+  );
+}
+
+function stripUnsupportedSchemaKeywordMap(
+  value: object,
+  unsupportedKeywords: ReadonlySet<string>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    readObjectEntries(value)?.map((entry) => [
+      entry.key,
+      entry.readable ? stripUnsupportedSchemaKeywords(entry.value, unsupportedKeywords) : {},
+    ]) ?? [],
+  );
+}
+
 export function stripUnsupportedSchemaKeywords(
   schema: unknown,
   unsupportedKeywords: ReadonlySet<string>,
@@ -6,33 +99,38 @@ export function stripUnsupportedSchemaKeywords(
     return schema;
   }
   if (Array.isArray(schema)) {
-    return schema.map((entry) => stripUnsupportedSchemaKeywords(entry, unsupportedKeywords));
+    return stripUnsupportedSchemaKeywordArray(schema, unsupportedKeywords);
   }
-  const obj = schema as Record<string, unknown>;
+  const entries = readObjectEntries(schema);
+  if (!entries) {
+    return {};
+  }
   const cleaned: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
+  for (const entry of entries) {
+    const key = entry.key;
     if (unsupportedKeywords.has(key)) {
       continue;
     }
+    if (!entry.readable) {
+      const fallback = unreadableSchemaFieldFallback(key);
+      if (fallback !== undefined) {
+        cleaned[key] = fallback;
+      }
+      continue;
+    }
+    const value = entry.value;
     if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
-      cleaned[key] = Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
-          childKey,
-          stripUnsupportedSchemaKeywords(childValue, unsupportedKeywords),
-        ]),
-      );
+      cleaned[key] = stripUnsupportedSchemaKeywordMap(value, unsupportedKeywords);
       continue;
     }
     if (key === "items" && value && typeof value === "object") {
       cleaned[key] = Array.isArray(value)
-        ? value.map((entry) => stripUnsupportedSchemaKeywords(entry, unsupportedKeywords))
+        ? stripUnsupportedSchemaKeywordArray(value, unsupportedKeywords)
         : stripUnsupportedSchemaKeywords(value, unsupportedKeywords);
       continue;
     }
     if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      cleaned[key] = value.map((entry) =>
-        stripUnsupportedSchemaKeywords(entry, unsupportedKeywords),
-      );
+      cleaned[key] = stripUnsupportedSchemaKeywordArray(value, unsupportedKeywords);
       continue;
     }
     cleaned[key] = value;


### PR DESCRIPTION
## Summary

- Harden shared unsupported schema keyword stripping against hostile schema arrays and objects from provider/plugin compatibility paths.
- Avoid source array traversal methods, snapshot array length once, and collapse only schema-valued unreadable branches.
- Add xAI/provider compatibility regressions for hostile `map`, length, getter, and `ownKeys` traps.

## Verification

- `node scripts/run-vitest.mjs src/agents/schema/clean-for-xai.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/shared/schema-keyword-strip.ts src/agents/schema/clean-for-xai.test.ts`
- `./node_modules/.bin/oxlint src/shared/schema-keyword-strip.ts src/agents/schema/clean-for-xai.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_4e60beabda1f`, run `run_660867ae7225`, exit 0

## Real behavior proof

Behavior addressed: Provider compatibility schema keyword stripping no longer trusts plugin-owned schema array methods or object traversal when removing model-unsupported JSON Schema keywords.

Real environment tested: Local macOS sparse `gwt` worktree with shared repo dependencies; AWS Crabbox Linux fresh PR checkout at head `28193f55bbfb5533cf2e5726f3c0fd6e709a413e`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/schema/clean-for-xai.test.ts -- --reporter=dot`; AWS Crabbox `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: xAI compatibility tests now cover hostile schema array `map`, hostile array `length`, unreadable child schema objects, unreadable scalar getters, and unreadable schema maps; remote changed gate selected `core, coreTests` and completed all guard, typecheck, lint, and import-cycle checks.

Observed result after fix: Focused Vitest passed, formatter/lint/diff checks passed, autoreview reported no accepted/actionable findings, and remote `check:changed` passed in run `run_660867ae7225`.

What was not tested: No live provider call; this is covered at the shared schema sanitizer contract level.
