### PR TITLE
fix(ui): preserve visible chat stream text

### DIFF
--- a/src/chat/tool-content.ts
+++ b/src/chat/tool-content.ts
@@ -1,5 +1,16 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+
+const TOOL_USE_ID_FIELDS = [
+  "id",
+  "tool_call_id",
+  "toolCallId",
+  "tool_use_id",
+  "toolUseId",
+] as const;
+type ToolUseIdField = (typeof TOOL_USE_ID_FIELDS)[number];
+
 /** Provider-agnostic chat content block shape used before SDK-specific narrowing. */
-export type ToolContentBlock = Record<string, unknown>;
+export type ToolContentBlock = Record<string, unknown> & Partial<Record<ToolUseIdField, unknown>>;
 
 function normalizeToolContentType(value: unknown): string {
   return typeof value === "string" ? value.toLowerCase() : "";
@@ -34,11 +45,11 @@ export function resolveToolBlockArgs(block: ToolContentBlock): unknown {
 
 /** Reads the stable tool-use id across snake_case and camelCase provider field names. */
 export function resolveToolUseId(block: ToolContentBlock): string | undefined {
-  const id =
-    (typeof block.id === "string" && block.id.trim()) ||
-    (typeof block.tool_call_id === "string" && block.tool_call_id.trim()) ||
-    (typeof block.toolCallId === "string" && block.toolCallId.trim()) ||
-    (typeof block.tool_use_id === "string" && block.tool_use_id.trim()) ||
-    (typeof block.toolUseId === "string" && block.toolUseId.trim());
-  return id || undefined;
+  for (const field of TOOL_USE_ID_FIELDS) {
+    const id = normalizeOptionalString(block[field]);
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
 }

--- a/src/chat/tool-content.ts
+++ b/src/chat/tool-content.ts
@@ -36,6 +36,8 @@ export function resolveToolBlockArgs(block: ToolContentBlock): unknown {
 export function resolveToolUseId(block: ToolContentBlock): string | undefined {
   const id =
     (typeof block.id === "string" && block.id.trim()) ||
+    (typeof block.tool_call_id === "string" && block.tool_call_id.trim()) ||
+    (typeof block.toolCallId === "string" && block.toolCallId.trim()) ||
     (typeof block.tool_use_id === "string" && block.tool_use_id.trim()) ||
     (typeof block.toolUseId === "string" && block.toolUseId.trim());
   return id || undefined;

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -421,7 +421,7 @@ describe("refreshChat", () => {
     expect(requestUpdate).toHaveBeenCalled();
   });
 
-  it("records chat history timing when a reload resets active stream state", async () => {
+  it("records chat history timing when a reload keeps active stream state visible", async () => {
     const request = vi.fn((method: string) => {
       if (method === "chat.history") {
         return Promise.resolve({
@@ -440,20 +440,13 @@ describe("refreshChat", () => {
 
     await refreshChat(host, { awaitHistory: true, scheduleScroll: false });
 
-    expect(host.chatStream).toBeNull();
+    expect(host.chatStream).toBe("partial");
     expect(eventPayloads(host, "control-ui.chat.history")).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           phase: "start",
           sessionKey: "main",
           previousRunId: "run-main",
-        }),
-        expect.objectContaining({
-          phase: "stream-reset",
-          sessionKey: "main",
-          previousRunId: "run-main",
-          activeRunId: "run-main",
-          visibleMessageCount: 1,
         }),
         expect.objectContaining({
           phase: "applied",

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -286,6 +286,34 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.chatModelOverrides?.main).toBeNull();
   });
 
+  it("tags stream segments with the tool they precede", () => {
+    useToolStreamFakeTimers();
+    const host = createHost({
+      chatRunId: "run-1",
+      chatStream: "visible text before tool",
+      chatStreamStartedAt: TOOL_STREAM_TEST_NOW - 10,
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "exec",
+        toolCallId: "call_1",
+      },
+    });
+
+    expect(host.chatStreamSegments).toEqual([
+      { text: "visible text before tool", ts: TOOL_STREAM_TEST_NOW, toolCallId: "call_1" },
+    ]);
+    expect(host.chatStream).toBeNull();
+    vi.useRealTimers();
+  });
+
   it("records tool activity summaries without storing raw argument values", () => {
     useToolStreamFakeTimers();
     const host = createHost();

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -60,7 +60,7 @@ type ToolStreamHost = {
   chatRunId: string | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
-  chatStreamSegments: Array<{ text: string; ts: number }>;
+  chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
   toolStreamById: Map<string, ToolStreamEntry>;
   toolStreamOrder: string[];
   chatToolMessages: Record<string, unknown>[];
@@ -791,7 +791,10 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       host.chatStream &&
       host.chatStream.trim().length > 0
     ) {
-      host.chatStreamSegments = [...host.chatStreamSegments, { text: host.chatStream, ts: now }];
+      host.chatStreamSegments = [
+        ...host.chatStreamSegments,
+        { text: host.chatStream, ts: now, toolCallId },
+      ];
       host.chatStream = null;
       host.chatStreamStartedAt = null;
     }

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -494,6 +494,31 @@ describe("buildChatItems", () => {
     expect(messageRecord(requireGroup(items[1])).content).toBe("Missing timestamp.");
   });
 
+  it("renders an active stream after the persisted user turn it answers", () => {
+    const items = buildChatItems(
+      createProps({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Persisted prompt." }],
+            timestamp: 2_000,
+          },
+        ],
+        stream: "Visible partial answer.",
+        streamStartedAt: 1_000,
+      }),
+    );
+
+    expect(items).toHaveLength(2);
+    expect(requireGroup(items[0]).role).toBe("user");
+    expect(items[1]).toMatchObject({
+      kind: "stream",
+      text: "Visible partial answer.",
+      startedAt: 2_001,
+      isStreaming: true,
+    });
+  });
+
   it("renders submitted queued sends as user turns before chat.send ACK", () => {
     const groups = messageGroups({
       messages: [{ role: "assistant", content: "Ready.", timestamp: 1 }],

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -9,6 +9,7 @@ import { extractTextCached } from "./message-extract.ts";
 import { normalizeMessage, stripMessageDisplayMetadataText } from "./message-normalizer.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
 import { messageMatchesSearchQuery } from "./search-match.ts";
+import { trimAccumulatedStreamPrefix } from "./stream-text.ts";
 import { extractToolCardsCached, extractToolPreview } from "./tool-cards.ts";
 import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
@@ -298,13 +299,6 @@ function hasRenderableNormalizedMessage(message: unknown): boolean {
 function sanitizeStreamText(text: string): string {
   const stripped = stripMessageDisplayMetadataText(text);
   return stripped.trim().length > 0 ? stripped : "";
-}
-
-function trimAccumulatedStreamPrefix(text: string, previousText: string | null): string {
-  if (!previousText || !text.startsWith(previousText)) {
-    return text;
-  }
-  return text.slice(previousText.length).trimStart();
 }
 
 function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -356,6 +356,19 @@ function chatItemTimestamp(item: ChatItem): number | null {
   return null;
 }
 
+function timestampAfterVisibleItems(items: ChatItem[], desiredTimestamp: number): number {
+  const latestTimestamp = items.reduce<number | null>((latest, item) => {
+    const timestamp = chatItemTimestamp(item);
+    if (timestamp == null) {
+      return latest;
+    }
+    return latest == null || timestamp > latest ? timestamp : latest;
+  }, null);
+  return latestTimestamp != null && desiredTimestamp <= latestTimestamp
+    ? latestTimestamp + 1
+    : desiredTimestamp;
+}
+
 function sortChatItemsByVisibleTime(items: ChatItem[]): ChatItem[] {
   return items
     .map((item, index) => ({ item, index, timestamp: chatItemTimestamp(item) }))
@@ -667,13 +680,14 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
     const text = sanitizeStreamText(props.stream);
     const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
+    const startedAt = timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now());
     if (visibleText.length > 0) {
       if (!stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
         items.push({
           kind: "stream",
           key,
           text: visibleText,
-          startedAt: props.streamStartedAt ?? Date.now(),
+          startedAt,
           isStreaming: true,
         });
       }

--- a/ui/src/ui/chat/stream-reconciliation.ts
+++ b/ui/src/ui/chat/stream-reconciliation.ts
@@ -1,0 +1,460 @@
+import { resetToolStream } from "../app-tool-stream.ts";
+import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+import { extractText } from "./message-extract.ts";
+import { trimAccumulatedStreamPrefix } from "./stream-text.ts";
+import { extractToolMessageRefs } from "./tool-message-refs.ts";
+
+export type StreamReconciliationState = {
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+};
+
+type ToolStreamHost = StreamReconciliationState & {
+  chatStreamSegments?: Array<{ text?: unknown; ts?: unknown; toolCallId?: unknown }>;
+  chatToolMessages?: unknown[];
+  toolStreamById?: Map<string, unknown>;
+  toolStreamOrder?: unknown[];
+};
+
+type VisibleAssistantStreamPart = {
+  text: string;
+  replacementText: string;
+  source: "segment" | "current";
+  timestamp: number;
+  toolCallId?: string;
+};
+
+export type AssistantMessageVisibility = (message: unknown) => boolean;
+export type StreamVisibility = (stream: string) => boolean;
+
+export type MaterializeVisibleStreamOptions = {
+  includeCurrent?: boolean;
+  requirePersistedTool?: boolean;
+  replacementMessages?: unknown[];
+  isHiddenAssistantMessage: AssistantMessageVisibility;
+  isHiddenStreamText: StreamVisibility;
+};
+
+export function currentLiveToolCallIds(state: StreamReconciliationState): string[] {
+  const toolHost = state as ToolStreamHost;
+  return Array.isArray(toolHost.toolStreamOrder)
+    ? toolHost.toolStreamOrder.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+}
+
+export function lastUserMessageIndex(messages: unknown[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    if (role === "user") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function maybeResetToolStream(
+  state: StreamReconciliationState,
+  opts?: { preserveStreamSegments?: boolean },
+) {
+  const toolHost = state as ToolStreamHost & Partial<Parameters<typeof resetToolStream>[0]>;
+  if (
+    toolHost.toolStreamById instanceof Map &&
+    Array.isArray(toolHost.toolStreamOrder) &&
+    Array.isArray(toolHost.chatToolMessages) &&
+    Array.isArray(toolHost.chatStreamSegments)
+  ) {
+    const preservedStreamSegments = opts?.preserveStreamSegments
+      ? [...toolHost.chatStreamSegments]
+      : null;
+    resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
+    if (preservedStreamSegments) {
+      toolHost.chatStreamSegments = preservedStreamSegments;
+    }
+  }
+}
+
+export function clearToolStreamSegments(state: StreamReconciliationState) {
+  const toolHost = state as ToolStreamHost;
+  if (Array.isArray(toolHost.chatStreamSegments)) {
+    toolHost.chatStreamSegments = [];
+  }
+}
+
+export function persistedCurrentToolStreamIds(
+  messages: unknown[],
+  state: StreamReconciliationState,
+): Set<string> {
+  const liveToolIds = currentLiveToolCallIds(state);
+  const matchedToolIds = new Set<string>();
+  if (liveToolIds.length === 0) {
+    return matchedToolIds;
+  }
+  const liveToolIdSet = new Set(liveToolIds);
+  const persistedToolIds = new Set<string>();
+  for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
+    for (const ref of extractToolMessageRefs(message)) {
+      persistedToolIds.add(ref.id);
+    }
+  }
+  for (const id of persistedToolIds) {
+    if (liveToolIdSet.has(id)) {
+      matchedToolIds.add(id);
+    }
+  }
+  return matchedToolIds;
+}
+
+function buildAssistantStreamMessage(
+  stream: string,
+  replacementText = stream,
+  timestamp = Date.now(),
+): Record<string, unknown> {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: stream }],
+    timestamp,
+    openclawStreamFallback: {
+      replacementText,
+    },
+  };
+}
+
+function streamFallbackReplacementText(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const fallback = (message as { openclawStreamFallback?: unknown }).openclawStreamFallback;
+  if (!fallback || typeof fallback !== "object") {
+    return null;
+  }
+  const replacementText = (fallback as { replacementText?: unknown }).replacementText;
+  if (typeof replacementText === "string" && replacementText.trim()) {
+    return replacementText.trim();
+  }
+  return extractText(message)?.trim() ?? null;
+}
+
+function terminalMessageReplacesStreamFallback(message: unknown, fallback: unknown): boolean {
+  const fallbackText = streamFallbackReplacementText(fallback);
+  if (!fallbackText) {
+    return false;
+  }
+  const terminalText = extractText(message)?.trim();
+  return Boolean(
+    terminalText && (terminalText === fallbackText || terminalText.startsWith(fallbackText)),
+  );
+}
+
+export function appendTerminalAssistantMessage(messages: unknown[], message: unknown): unknown[] {
+  const retainedMessages = messages.filter((existing, index) => {
+    if (index <= lastUserMessageIndex(messages)) {
+      return true;
+    }
+    return !terminalMessageReplacesStreamFallback(message, existing);
+  });
+  return [...retainedMessages, message];
+}
+
+function visibleAssistantStreamText(
+  stream: string | null,
+  isHiddenStreamText: StreamVisibility,
+): string | null {
+  if (!stream?.trim() || isHiddenStreamText(stream)) {
+    return null;
+  }
+  return stream;
+}
+
+function hasAssistantStreamReplacement(
+  messages: unknown[],
+  stream: string,
+  isHiddenAssistantMessage: AssistantMessageVisibility,
+): boolean {
+  const expected = stream.trim();
+  if (!expected) {
+    return false;
+  }
+  const startIndex = lastUserMessageIndex(messages) + 1;
+  return messages.slice(startIndex).some((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    if (role && role !== "assistant") {
+      return false;
+    }
+    if (role === "assistant" && isHiddenAssistantMessage(message)) {
+      return false;
+    }
+    const text = extractText(message)?.trim();
+    return Boolean(text && (text === expected || text.startsWith(expected)));
+  });
+}
+
+function visibleAssistantStreamParts(
+  state: StreamReconciliationState,
+  opts: Pick<MaterializeVisibleStreamOptions, "includeCurrent" | "isHiddenStreamText">,
+): VisibleAssistantStreamPart[] {
+  const streamHost = state as ToolStreamHost;
+  const liveToolIds = currentLiveToolCallIds(state);
+  const parts: VisibleAssistantStreamPart[] = [];
+  let previousText: string | null = null;
+  const segments = Array.isArray(streamHost.chatStreamSegments)
+    ? streamHost.chatStreamSegments
+    : [];
+  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+    const segment = segments[segmentIndex];
+    if (!segment || typeof segment.text !== "string") {
+      continue;
+    }
+    const visible = visibleAssistantStreamText(
+      trimAccumulatedStreamPrefix(segment.text, previousText),
+      opts.isHiddenStreamText,
+    );
+    if (visible) {
+      parts.push({
+        text: visible,
+        replacementText: segment.text,
+        source: "segment",
+        timestamp:
+          typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
+        toolCallId:
+          typeof segment.toolCallId === "string" && segment.toolCallId.trim()
+            ? segment.toolCallId.trim()
+            : liveToolIds[segmentIndex],
+      });
+    }
+    if (segment.text.trim()) {
+      previousText = segment.text;
+    }
+  }
+  if (opts.includeCurrent !== false && typeof state.chatStream === "string") {
+    const visible = visibleAssistantStreamText(
+      trimAccumulatedStreamPrefix(state.chatStream, previousText),
+      opts.isHiddenStreamText,
+    );
+    if (visible) {
+      parts.push({
+        text: visible,
+        replacementText: state.chatStream,
+        source: "current",
+        timestamp: state.chatStreamStartedAt ?? Date.now(),
+      });
+    }
+  }
+  return parts;
+}
+
+export function visibleCurrentAssistantStreamTail(
+  state: StreamReconciliationState,
+  isHiddenStreamText: StreamVisibility,
+): string | null {
+  if (typeof state.chatStream !== "string") {
+    return null;
+  }
+  const streamHost = state as ToolStreamHost;
+  const segments = Array.isArray(streamHost.chatStreamSegments)
+    ? streamHost.chatStreamSegments
+    : [];
+  let previousText: string | null = null;
+  for (const segment of segments) {
+    if (typeof segment.text === "string" && segment.text.trim()) {
+      previousText = segment.text;
+    }
+  }
+  return visibleAssistantStreamText(
+    trimAccumulatedStreamPrefix(state.chatStream, previousText),
+    isHiddenStreamText,
+  );
+}
+
+function hasAssistantStreamPartReplacement(
+  messages: unknown[],
+  part: VisibleAssistantStreamPart,
+  isHiddenAssistantMessage: AssistantMessageVisibility,
+): boolean {
+  return (
+    hasAssistantStreamReplacement(messages, part.replacementText, isHiddenAssistantMessage) ||
+    hasAssistantStreamReplacement(messages, part.text, isHiddenAssistantMessage)
+  );
+}
+
+export function historyReplacedVisibleStream(
+  messages: unknown[],
+  state: StreamReconciliationState,
+  opts: Pick<
+    MaterializeVisibleStreamOptions,
+    "includeCurrent" | "isHiddenAssistantMessage" | "isHiddenStreamText"
+  >,
+): boolean {
+  const parts = visibleAssistantStreamParts(state, opts);
+  return (
+    parts.length > 0 &&
+    parts.every((part) =>
+      hasAssistantStreamPartReplacement(messages, part, opts.isHiddenAssistantMessage),
+    )
+  );
+}
+
+export function hasVisibleStreamParts(
+  state: StreamReconciliationState,
+  opts: Pick<MaterializeVisibleStreamOptions, "includeCurrent" | "isHiddenStreamText">,
+): boolean {
+  return visibleAssistantStreamParts(state, opts).length > 0;
+}
+
+function currentToolStreamMessageIndex(
+  messages: unknown[],
+  state: StreamReconciliationState,
+  toolCallId?: string,
+): number {
+  const liveToolIds = toolCallId ? new Set([toolCallId]) : new Set(currentLiveToolCallIds(state));
+  if (liveToolIds.size === 0) {
+    return -1;
+  }
+  const startIndex = lastUserMessageIndex(messages) + 1;
+  for (let index = startIndex; index < messages.length; index++) {
+    if (extractToolMessageRefs(messages[index]).some((ref) => liveToolIds.has(ref.id))) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function insertMessageAtIndex(messages: unknown[], message: unknown, index: number): unknown[] {
+  return [...messages.slice(0, index), message, ...messages.slice(index)];
+}
+
+function messageTimestampMs(message: unknown): number | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const timestamp = (message as { timestamp?: unknown; ts?: unknown }).timestamp;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return timestamp;
+  }
+  const ts = (message as { timestamp?: unknown; ts?: unknown }).ts;
+  return typeof ts === "number" && Number.isFinite(ts) ? ts : null;
+}
+
+function timestampForInsertedVisibleStream(
+  messages: unknown[],
+  index: number,
+  desiredTimestamp: number,
+): number {
+  const previousTimestamp = messages
+    .slice(0, index)
+    .toReversed()
+    .map(messageTimestampMs)
+    .find((timestamp): timestamp is number => timestamp != null);
+  const nextTimestamp = messages
+    .slice(index)
+    .map(messageTimestampMs)
+    .find((timestamp): timestamp is number => timestamp != null);
+  if (previousTimestamp != null && desiredTimestamp <= previousTimestamp) {
+    const afterPrevious = previousTimestamp + 1;
+    return nextTimestamp != null && afterPrevious >= nextTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : afterPrevious;
+  }
+  if (nextTimestamp != null && desiredTimestamp >= nextTimestamp) {
+    const beforeNext = nextTimestamp - 1;
+    return previousTimestamp != null && beforeNext <= previousTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : beforeNext;
+  }
+  return desiredTimestamp;
+}
+
+export function materializeVisibleStreamState(
+  messages: unknown[],
+  state: StreamReconciliationState,
+  opts: MaterializeVisibleStreamOptions,
+): unknown[] {
+  let nextMessages = messages;
+  for (const part of visibleAssistantStreamParts(state, opts)) {
+    const replacementMessages = opts.replacementMessages ?? [];
+    if (
+      hasAssistantStreamPartReplacement(
+        [...nextMessages, ...replacementMessages],
+        part,
+        opts.isHiddenAssistantMessage,
+      )
+    ) {
+      continue;
+    }
+    const toolIndex =
+      part.source === "segment"
+        ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
+        : -1;
+    if (opts.requirePersistedTool && toolIndex < 0) {
+      continue;
+    }
+    const insertIndex = toolIndex >= 0 ? toolIndex : nextMessages.length;
+    const streamMessage = buildAssistantStreamMessage(
+      part.text,
+      part.replacementText,
+      timestampForInsertedVisibleStream(nextMessages, insertIndex, part.timestamp),
+    );
+    nextMessages =
+      toolIndex >= 0
+        ? insertMessageAtIndex(nextMessages, streamMessage, toolIndex)
+        : [...nextMessages, streamMessage];
+  }
+  return nextMessages;
+}
+
+export function prunePersistedToolStreamMessages(
+  state: StreamReconciliationState,
+  persistedToolIds: Set<string>,
+) {
+  if (persistedToolIds.size === 0) {
+    return;
+  }
+  const toolHost = state as ToolStreamHost;
+  const liveToolIds = currentLiveToolCallIds(state);
+  if (toolHost.toolStreamById instanceof Map) {
+    for (const id of persistedToolIds) {
+      toolHost.toolStreamById.delete(id);
+    }
+  }
+  if (Array.isArray(toolHost.toolStreamOrder)) {
+    toolHost.toolStreamOrder = toolHost.toolStreamOrder.filter(
+      (id): id is string => typeof id === "string" && !persistedToolIds.has(id),
+    );
+  }
+  if (Array.isArray(toolHost.chatToolMessages)) {
+    toolHost.chatToolMessages = toolHost.chatToolMessages.filter((message) => {
+      const refs = extractToolMessageRefs(message);
+      return refs.every((ref) => !persistedToolIds.has(ref.id));
+    });
+  }
+  if (!Array.isArray(toolHost.chatStreamSegments)) {
+    return;
+  }
+  let lastPrunedAccumulatedText: string | null = null;
+  toolHost.chatStreamSegments = toolHost.chatStreamSegments.flatMap((segment, index) => {
+    const explicitToolCallId =
+      typeof segment.toolCallId === "string" && segment.toolCallId.trim()
+        ? segment.toolCallId.trim()
+        : null;
+    const toolCallId = explicitToolCallId ?? liveToolIds[index] ?? null;
+    const text = typeof segment.text === "string" ? segment.text : "";
+    if (toolCallId && persistedToolIds.has(toolCallId)) {
+      if (text.trim()) {
+        lastPrunedAccumulatedText = text;
+      }
+      return [];
+    }
+    const nextText = lastPrunedAccumulatedText
+      ? trimAccumulatedStreamPrefix(text, lastPrunedAccumulatedText)
+      : text;
+    return [{ ...segment, text: nextText }];
+  });
+}

--- a/ui/src/ui/chat/stream-text.ts
+++ b/ui/src/ui/chat/stream-text.ts
@@ -1,0 +1,6 @@
+export function trimAccumulatedStreamPrefix(text: string, previousText: string | null): string {
+  if (!previousText || !text.startsWith(previousText)) {
+    return text;
+  }
+  return text.slice(previousText.length).trimStart();
+}

--- a/ui/src/ui/chat/tool-message-refs.test.ts
+++ b/ui/src/ui/chat/tool-message-refs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { extractToolMessageRefs } from "./tool-message-refs.ts";
+
+describe("extractToolMessageRefs", () => {
+  it("extracts canonical toolResult ids", () => {
+    expect(
+      extractToolMessageRefs({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "shell",
+      }),
+    ).toEqual([{ id: "call_1" }]);
+  });
+
+  it("extracts snake-case tool ids from standalone tool messages", () => {
+    expect(
+      extractToolMessageRefs({
+        role: "tool",
+        tool_call_id: "call_2",
+        tool_name: "shell",
+      }),
+    ).toEqual([{ id: "call_2" }]);
+  });
+
+  it("extracts assistant tool-call block ids", () => {
+    expect(
+      extractToolMessageRefs({
+        role: "assistant",
+        content: [{ type: "toolcall", id: "call_3", name: "shell", arguments: {} }],
+      }),
+    ).toEqual([{ id: "call_3" }]);
+  });
+
+  it("extracts assistant tool-result block ids", () => {
+    expect(
+      extractToolMessageRefs({
+        role: "assistant",
+        content: [{ type: "tool_result", tool_use_id: "call_4", name: "shell", content: "ok" }],
+      }),
+    ).toEqual([{ id: "call_4" }]);
+  });
+
+  it("ignores plain assistant and user messages", () => {
+    expect(extractToolMessageRefs({ role: "assistant", content: "hello" })).toEqual([]);
+    expect(extractToolMessageRefs({ role: "user", content: "hello" })).toEqual([]);
+  });
+});

--- a/ui/src/ui/chat/tool-message-refs.ts
+++ b/ui/src/ui/chat/tool-message-refs.ts
@@ -1,0 +1,74 @@
+import {
+  isToolCallContentType,
+  isToolResultContentType,
+  resolveToolUseId,
+} from "../../../../src/chat/tool-content.js";
+import { normalizeRoleForGrouping } from "./role-normalizer.ts";
+
+export type ToolMessageRef = {
+  id: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function addToolRef(refs: ToolMessageRef[], seen: Set<string>, id: string | undefined) {
+  if (!id || seen.has(id)) {
+    return;
+  }
+  seen.add(id);
+  refs.push({ id });
+}
+
+function isToolLikeRole(role: unknown): boolean {
+  return typeof role === "string" && normalizeRoleForGrouping(role).toLowerCase() === "tool";
+}
+
+function hasToolName(message: Record<string, unknown>): boolean {
+  return typeof message.toolName === "string" || typeof message.tool_name === "string";
+}
+
+function toolContentBlocks(message: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(message.content)
+    ? message.content.filter(
+        (block): block is Record<string, unknown> => Boolean(block) && typeof block === "object",
+      )
+    : [];
+}
+
+function isToolContentBlock(block: Record<string, unknown>): boolean {
+  return isToolCallContentType(block.type) || isToolResultContentType(block.type);
+}
+
+export function extractToolMessageRefs(message: unknown): ToolMessageRef[] {
+  const record = asRecord(message);
+  if (!record) {
+    return [];
+  }
+
+  const refs: ToolMessageRef[] = [];
+  const seen = new Set<string>();
+  const blocks = toolContentBlocks(record);
+  const hasToolBlock = blocks.some(isToolContentBlock);
+  const topLevelToolId = resolveToolUseId(record);
+  const messageHasToolShape = isToolLikeRole(record.role) || hasToolName(record) || hasToolBlock;
+
+  // Long term, chat.history should expose canonical toolRefs on UI messages so
+  // WebChat never infers provider/transcript spellings here. Until then, keep
+  // raw compatibility isolated at this tool-message boundary.
+  if (messageHasToolShape) {
+    addToolRef(refs, seen, topLevelToolId);
+  }
+
+  for (const block of blocks) {
+    if (!isToolContentBlock(block)) {
+      continue;
+    }
+    addToolRef(refs, seen, resolveToolUseId(block) ?? topLevelToolId);
+  }
+
+  return refs;
+}

--- a/ui/src/ui/chat/tool-message-refs.ts
+++ b/ui/src/ui/chat/tool-message-refs.ts
@@ -3,15 +3,20 @@ import {
   isToolResultContentType,
   resolveToolUseId,
 } from "../../../../src/chat/tool-content.js";
+import { normalizeOptionalString } from "../string-coerce.ts";
 import { normalizeRoleForGrouping } from "./role-normalizer.ts";
+
+const TOOL_NAME_FIELDS = ["toolName", "tool_name"] as const;
+type ToolNameField = (typeof TOOL_NAME_FIELDS)[number];
+type ToolHistoryRecord = Record<string, unknown> & Partial<Record<ToolNameField, unknown>>;
 
 export type ToolMessageRef = {
   id: string;
 };
 
-function asRecord(value: unknown): Record<string, unknown> | null {
+function asRecord(value: unknown): ToolHistoryRecord | null {
   return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
+    ? (value as ToolHistoryRecord)
     : null;
 }
 
@@ -27,8 +32,8 @@ function isToolLikeRole(role: unknown): boolean {
   return typeof role === "string" && normalizeRoleForGrouping(role).toLowerCase() === "tool";
 }
 
-function hasToolName(message: Record<string, unknown>): boolean {
-  return typeof message.toolName === "string" || typeof message.tool_name === "string";
+function hasToolName(message: ToolHistoryRecord): boolean {
+  return TOOL_NAME_FIELDS.some((field) => Boolean(normalizeOptionalString(message[field])));
 }
 
 function toolContentBlocks(message: Record<string, unknown>): Record<string, unknown>[] {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1074,6 +1074,7 @@ describe("handleChatEvent", () => {
       role: "assistant",
       content: [{ type: "text", text: "Partial answer before gateway error." }],
       timestamp: 101,
+      metadata: { source: "gateway" },
     };
     const state = createState({
       sessionKey: "main",
@@ -1090,12 +1091,31 @@ describe("handleChatEvent", () => {
     };
 
     expect(handleChatEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toHaveLength(1);
-    expectTextChatMessage(
-      state.chatMessages[0],
-      "assistant",
-      "Partial answer before gateway error.",
-    );
+    expect(state.chatMessages).toEqual([message]);
+  });
+
+  it("does not keep partial stream when the error payload contains the fuller text", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Partial answer before gateway error. Final detail." }],
+      timestamp: 101,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial answer before gateway error.",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "gateway disconnected",
+      message,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages).toEqual([message]);
   });
 
   it("prefers server-provided assistant error messages", () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -884,6 +884,41 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([firstUser, firstAssistant, secondUser, secondAssistant]);
   });
 
+  it("keeps repeated assistant final text within the same turn", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "repeat" }],
+      timestamp: 1,
+    };
+    const firstAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "OK" }],
+      timestamp: 2,
+    };
+    const secondAssistant = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "OK" },
+        { type: "canvas", url: "/__openclaw__/canvas/documents/repeat/index.html" },
+      ],
+      timestamp: 3,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [user, firstAssistant],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: secondAssistant,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([user, firstAssistant, secondAssistant]);
+  });
+
   it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",
@@ -2555,8 +2590,8 @@ describe("loadChatHistory retry handling", () => {
 
     expect(state.chatMessages).toHaveLength(3);
     expect(state.chatMessages[0]).toEqual(persistedUser);
-    expect(state.chatMessages[1]).toEqual(persistedToolResult);
-    expectTextChatMessage(state.chatMessages[2], "assistant", "before tool");
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
     expect(state.chatToolMessages).toEqual([]);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -997,6 +997,70 @@ describe("handleChatEvent", () => {
     expect(state.lastError).toBe('No API key found for provider "openai".');
   });
 
+  it("keeps streamed assistant text visible when an error ends the run", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Ping" }],
+      timestamp: 1,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [existingMessage],
+      chatStream: "Partial answer before gateway error.",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "gateway disconnected",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(existingMessage);
+    expectTextChatMessage(
+      state.chatMessages[1],
+      "assistant",
+      "Partial answer before gateway error.",
+    );
+    expectTextChatMessage(state.chatMessages[2], "assistant", "Error: gateway disconnected");
+    expect(state.lastError).toBe("gateway disconnected");
+  });
+
+  it("does not duplicate streamed text when the error payload already carries it", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Partial answer before gateway error." }],
+      timestamp: 101,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial answer before gateway error.",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "gateway disconnected",
+      message,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages).toHaveLength(1);
+    expectTextChatMessage(
+      state.chatMessages[0],
+      "assistant",
+      "Partial answer before gateway error.",
+    );
+  });
+
   it("prefers server-provided assistant error messages", () => {
     const state = createState({
       sessionKey: "main",
@@ -1980,6 +2044,101 @@ describe("loadChatHistory retry handling", () => {
 
     expect(state.chatMessages).toEqual([persistedUser, optimisticUser, optimisticAssistant]);
     expect(state.chatStream).toBeNull();
+  });
+
+  it("keeps active streamed assistant text when history reload returns a stale snapshot", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+      __openclaw: { seq: 1 },
+    };
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      timestamp: 10,
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser, optimisticUser],
+      chatRunId: "run-1",
+      chatStream: "First visible stream text.",
+      chatStreamStartedAt: 100,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, optimisticUser]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("First visible stream text.");
+    expect(state.chatStreamStartedAt).toBe(100);
+  });
+
+  it("materializes orphaned streamed assistant text when history reload is stale", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+      __openclaw: { seq: 1 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: null,
+      chatStream: "Partial answer before history catch-up.",
+      chatStreamStartedAt: 100,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(2);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(
+      state.chatMessages[1],
+      "assistant",
+      "Partial answer before history catch-up.",
+    );
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+  });
+
+  it("clears streamed assistant text when history already contains the replacement", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const historyAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "First visible stream text. More final text." }],
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, historyAssistant],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "First visible stream text.",
+      chatStreamStartedAt: 100,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, historyAssistant]);
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
   });
 
   it("keeps local optimistic messages when history reload returns empty", async () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1118,6 +1118,60 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([message]);
   });
 
+  it("keeps stream segments visible when an error ends after a tool event", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Ping" }],
+      timestamp: 1,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [existingMessage],
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & { chatStreamSegments: Array<{ text: string; ts: number }> };
+    state.chatStreamSegments = [{ text: "Visible text before tool.", ts: 100 }];
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "gateway disconnected",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(existingMessage);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "Visible text before tool.");
+    expectTextChatMessage(state.chatMessages[2], "assistant", "Error: gateway disconnected");
+  });
+
+  it("does not treat substring matches as stream replacement", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Error: provider said NOT OK yet." }],
+      timestamp: 101,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "OK",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "provider said NOT OK yet",
+      message,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages).toHaveLength(2);
+    expectTextChatMessage(state.chatMessages[0], "assistant", "OK");
+    expect(state.chatMessages[1]).toEqual(message);
+  });
+
   it("prefers server-provided assistant error messages", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2258,7 +2258,56 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatStream).toBe("Still answering.");
     expect(state.chatStreamStartedAt).toBe(100);
     expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
+  it("keeps segment-only streamed text when history catches up with tools", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "tool output" }],
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
+    state.chatToolMessages = [persistedToolResult];
+    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
+    state.toolStreamOrder = ["call_1"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedToolResult]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
     expect(state.toolStreamById.size).toBe(0);
     expect(state.toolStreamOrder).toEqual([]);
   });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1172,6 +1172,31 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages[1]).toEqual(message);
   });
 
+  it("does not duplicate post-tool stream tail when error payload has full text", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "First thought. After tool. Final detail." }],
+      timestamp: 101,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "First thought. After tool.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & { chatStreamSegments: Array<{ text: string; ts: number }> };
+    state.chatStreamSegments = [{ text: "First thought.", ts: 90 }];
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "gateway disconnected",
+      message,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages).toEqual([message]);
+  });
+
   it("prefers server-provided assistant error messages", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2352,6 +2352,74 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual([]);
   });
 
+  it("inserts multiple recovered stream segments before their matching persisted tools", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const firstToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "first output" }],
+      timestamp: 2,
+      __openclaw: { seq: 2 },
+    };
+    const secondToolResult = {
+      role: "toolResult",
+      toolCallId: "call_2",
+      toolName: "shell",
+      content: [{ type: "text", text: "second output" }],
+      timestamp: 4,
+      __openclaw: { seq: 3 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, firstToolResult, secondToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "Still answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [
+      { text: "before first tool", ts: 1 },
+      { text: "before first tool\nbefore second tool", ts: 3 },
+    ];
+    state.chatToolMessages = [firstToolResult, secondToolResult];
+    state.toolStreamById = new Map([
+      ["call_1", { message: firstToolResult }],
+      ["call_2", { message: secondToolResult }],
+    ]);
+    state.toolStreamOrder = ["call_1", "call_2"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(5);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before first tool");
+    expect(state.chatMessages[2]).toEqual(firstToolResult);
+    expectTextChatMessage(state.chatMessages[3], "assistant", "before second tool");
+    expect(state.chatMessages[4]).toEqual(secondToolResult);
+    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
+    expect(requireRecord(state.chatMessages[3]).timestamp).toBe(3);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("keeps live tool cards when only older history has a persisted tool result", async () => {
     const olderUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2747,6 +2747,40 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatStreamStartedAt).toBeNull();
   });
 
+  it("timestamps materialized streamed text after the persisted user prompt", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+      timestamp: 200,
+      __openclaw: { seq: 1 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: null,
+      chatStream: "Partial answer before history catch-up.",
+      chatStreamStartedAt: 100,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(2);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(
+      state.chatMessages[1],
+      "assistant",
+      "Partial answer before history catch-up.",
+    );
+    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(201);
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+  });
+
   it("materializes orphaned segment-only assistant text before clearing caught-up tools", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -911,6 +911,32 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(null);
   });
 
+  it("does not materialize stream segments when final payload is renderable", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & { chatStreamSegments: Array<{ text: string; ts: number }> };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "source reply final" }],
+        timestamp: 101,
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([payload.message]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+  });
+
   it("processes aborted from own run and keeps partial assistant message", () => {
     const existingMessage = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2372,6 +2372,67 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual(["call_current"]);
   });
 
+  it("clears live tool cards when history catches up with content-block tool ids", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedToolCall = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "shell",
+          arguments: {},
+        },
+      ],
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedToolCall],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "Still answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
+    state.chatToolMessages = [
+      {
+        role: "assistant",
+        toolCallId: "call_1",
+        runId: "run-1",
+        content: [{ type: "toolcall", name: "shell", arguments: {} }],
+      },
+    ];
+    state.toolStreamById = new Map([["call_1", { message: state.chatToolMessages[0] }]]);
+    state.toolStreamOrder = ["call_1"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedToolCall]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("Still answering.");
+    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("keeps segment-only streamed text when history catches up with tools", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -439,6 +439,29 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(null);
   });
 
+  it("does not duplicate streamed text when final payload has no role", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Live reply",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        text: "Live reply",
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([payload.message]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+
   it("reconciles cached run and indicator state on terminal events", () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2420,6 +2420,121 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual([]);
   });
 
+  it("uses segment tool ids when a tool starts before any stream text", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const firstToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "first output" }],
+      timestamp: 2,
+      __openclaw: { seq: 2 },
+    };
+    const secondToolResult = {
+      role: "toolResult",
+      toolCallId: "call_2",
+      toolName: "shell",
+      content: [{ type: "text", text: "second output" }],
+      timestamp: 4,
+      __openclaw: { seq: 3 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, firstToolResult, secondToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "Still answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before second tool", ts: 3, toolCallId: "call_2" }];
+    state.chatToolMessages = [firstToolResult, secondToolResult];
+    state.toolStreamById = new Map([
+      ["call_1", { message: firstToolResult }],
+      ["call_2", { message: secondToolResult }],
+    ]);
+    state.toolStreamOrder = ["call_1", "call_2"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(4);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expect(state.chatMessages[1]).toEqual(firstToolResult);
+    expectTextChatMessage(state.chatMessages[2], "assistant", "before second tool");
+    expect(state.chatMessages[3]).toEqual(secondToolResult);
+    expect(requireRecord(state.chatMessages[2]).timestamp).toBe(3);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
+  it("trims accumulated current stream after materializing caught-up tool segments", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "tool output" }],
+      timestamp: 2,
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "before tool\nafter tool",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1, toolCallId: "call_1" }];
+    state.chatToolMessages = [persistedToolResult];
+    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
+    state.toolStreamOrder = ["call_1"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(state.chatMessages[2]).toEqual(persistedToolResult);
+    expect(state.chatStream).toBe("after tool");
+    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("keeps live tool cards when only older history has a persisted tool result", async () => {
     const olderUser = {
       role: "user",
@@ -2593,7 +2708,7 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBeNull();
-    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatStreamStartedAt).toBeNull();
     expect(state.chatToolMessages).toEqual([]);
     expect(state.chatStreamSegments).toEqual([]);
     expect(state.toolStreamById.size).toBe(0);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -824,7 +824,44 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
   });
 
-  it("appends final payload message from own run after clearing stream state", () => {
+  it("keeps repeated assistant final text from a later turn", () => {
+    const firstUser = {
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+      timestamp: 1,
+    };
+    const firstAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "OK" }],
+      timestamp: 2,
+    };
+    const secondUser = {
+      role: "user",
+      content: [{ type: "text", text: "second" }],
+      timestamp: 3,
+    };
+    const secondAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "OK" }],
+      timestamp: 4,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-2",
+      chatMessages: [firstUser, firstAssistant, secondUser],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-2",
+      sessionKey: "main",
+      state: "final",
+      message: secondAssistant,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([firstUser, firstAssistant, secondUser, secondAssistant]);
+  });
+
+  it("appends final payload message from own run before clearing stream state", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
@@ -844,7 +881,7 @@ describe("handleChatEvent", () => {
     const assignments = trackChatMessagesAssignments(state);
 
     expect(handleChatEvent(state, payload)).toBe("final");
-    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
+    expect(assignments).toMatchObject([{ chatRunId: "run-1", chatStream: "Reply" }]);
     expect(state.chatMessages).toEqual([payload.message]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2420,6 +2420,80 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual([]);
   });
 
+  it("prunes only the live tool cards that history has caught up with", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const firstToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "first output" }],
+      timestamp: 2,
+      __openclaw: { seq: 2 },
+    };
+    const secondLiveToolResult = {
+      role: "assistant",
+      toolCallId: "call_2",
+      runId: "run-1",
+      content: [
+        { type: "toolcall", name: "shell", arguments: {} },
+        { type: "toolresult", name: "shell", text: "second output" },
+      ],
+      timestamp: 4,
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, firstToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "before first tool\nbefore second tool\nStill answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; toolCallId?: string }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [
+      { text: "before first tool", ts: 1, toolCallId: "call_1" },
+      {
+        text: "before first tool\nbefore second tool",
+        ts: 3,
+        toolCallId: "call_2",
+      },
+    ];
+    state.chatToolMessages = [firstToolResult, secondLiveToolResult];
+    state.toolStreamById = new Map([
+      ["call_1", { message: firstToolResult }],
+      ["call_2", { message: secondLiveToolResult }],
+    ]);
+    state.toolStreamOrder = ["call_1", "call_2"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before first tool");
+    expect(state.chatMessages[2]).toEqual(firstToolResult);
+    expect(state.chatToolMessages).toEqual([secondLiveToolResult]);
+    expect(state.chatStreamSegments).toEqual([
+      { text: "before second tool", ts: 3, toolCallId: "call_2" },
+    ]);
+    expect(state.chatStream).toBe("Still answering.");
+    expect(state.toolStreamById.size).toBe(1);
+    expect(state.toolStreamById.has("call_2")).toBe(true);
+    expect(state.toolStreamOrder).toEqual(["call_2"]);
+  });
+
   it("uses segment tool ids when a tool starts before any stream text", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2309,6 +2309,7 @@ describe("loadChatHistory retry handling", () => {
       toolCallId: "call_1",
       toolName: "shell",
       content: [{ type: "text", text: "tool output" }],
+      timestamp: 2,
       __openclaw: { seq: 2 },
     };
     const request = vi.fn().mockResolvedValue({
@@ -2340,6 +2341,7 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toHaveLength(3);
     expect(state.chatMessages[0]).toEqual(persistedUser);
     expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
     expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBe("Still answering.");
@@ -2426,6 +2428,7 @@ describe("loadChatHistory retry handling", () => {
           arguments: {},
         },
       ],
+      timestamp: 2,
       __openclaw: { seq: 2 },
     };
     const request = vi.fn().mockResolvedValue({
@@ -2464,6 +2467,7 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toHaveLength(3);
     expect(state.chatMessages[0]).toEqual(persistedUser);
     expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
     expect(state.chatMessages[2]).toEqual(persistedToolCall);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBe("Still answering.");
@@ -2485,6 +2489,7 @@ describe("loadChatHistory retry handling", () => {
       toolCallId: "call_1",
       toolName: "shell",
       content: [{ type: "text", text: "tool output" }],
+      timestamp: 2,
       __openclaw: { seq: 2 },
     };
     const request = vi.fn().mockResolvedValue({
@@ -2516,6 +2521,7 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toHaveLength(3);
     expect(state.chatMessages[0]).toEqual(persistedUser);
     expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(requireRecord(state.chatMessages[1]).timestamp).toBe(1);
     expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBeNull();
@@ -2638,6 +2644,58 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatMessages).toEqual([persistedUser, historyAssistant]);
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
+  });
+
+  it("keeps live tool cards when history only replaces streamed text", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const historyAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "First visible stream text. More final text." }],
+      __openclaw: { seq: 2 },
+    };
+    const liveToolMessage = {
+      role: "assistant",
+      toolCallId: "call_current",
+      runId: "run-1",
+      content: [{ type: "toolcall", name: "shell", arguments: {} }],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, historyAssistant],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "First visible stream text.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "First visible stream text.", ts: 90 }];
+    state.chatToolMessages = [liveToolMessage];
+    state.toolStreamById = new Map([["call_current", { message: liveToolMessage }]]);
+    state.toolStreamOrder = ["call_current"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, historyAssistant]);
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatToolMessages).toEqual([liveToolMessage]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(1);
+    expect(state.toolStreamOrder).toEqual(["call_current"]);
   });
 
   it("keeps local optimistic messages when history reload returns empty", async () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2367,6 +2367,57 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatStreamStartedAt).toBeNull();
   });
 
+  it("materializes orphaned segment-only assistant text before clearing caught-up tools", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "tool output" }],
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
+    state.chatToolMessages = [persistedToolResult];
+    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
+    state.toolStreamOrder = ["call_1"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expect(state.chatMessages[1]).toEqual(persistedToolResult);
+    expectTextChatMessage(state.chatMessages[2], "assistant", "before tool");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("clears streamed assistant text when history already contains the replacement", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2337,12 +2337,15 @@ describe("loadChatHistory retry handling", () => {
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toEqual([persistedUser, persistedToolResult]);
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBe("Still answering.");
     expect(state.chatStreamStartedAt).toBe(100);
     expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+    expect(state.chatStreamSegments).toEqual([]);
     expect(state.toolStreamById.size).toBe(0);
     expect(state.toolStreamOrder).toEqual([]);
   });
@@ -2458,12 +2461,15 @@ describe("loadChatHistory retry handling", () => {
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toEqual([persistedUser, persistedToolCall]);
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(state.chatMessages[2]).toEqual(persistedToolCall);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBe("Still answering.");
     expect(state.chatStreamStartedAt).toBe(100);
     expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+    expect(state.chatStreamSegments).toEqual([]);
     expect(state.toolStreamById.size).toBe(0);
     expect(state.toolStreamOrder).toEqual([]);
   });
@@ -2507,12 +2513,15 @@ describe("loadChatHistory retry handling", () => {
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toEqual([persistedUser, persistedToolResult]);
+    expect(state.chatMessages).toHaveLength(3);
+    expect(state.chatMessages[0]).toEqual(persistedUser);
+    expectTextChatMessage(state.chatMessages[1], "assistant", "before tool");
+    expect(state.chatMessages[2]).toEqual(persistedToolResult);
     expect(state.chatRunId).toBe("run-1");
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBe(100);
     expect(state.chatToolMessages).toEqual([]);
-    expect(state.chatStreamSegments).toEqual([{ text: "before tool", ts: 1 }]);
+    expect(state.chatStreamSegments).toEqual([]);
     expect(state.toolStreamById.size).toBe(0);
     expect(state.toolStreamOrder).toEqual([]);
   });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2312,6 +2312,66 @@ describe("loadChatHistory retry handling", () => {
     expect(state.toolStreamOrder).toEqual([]);
   });
 
+  it("keeps live tool cards when only older history has a persisted tool result", async () => {
+    const olderUser = {
+      role: "user",
+      content: [{ type: "text", text: "older ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const olderToolResult = {
+      role: "toolResult",
+      toolCallId: "call_old",
+      toolName: "shell",
+      content: [{ type: "text", text: "old tool output" }],
+      __openclaw: { seq: 2 },
+    };
+    const latestUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 3 },
+    };
+    const liveToolMessage = {
+      role: "assistant",
+      toolCallId: "call_current",
+      runId: "run-1",
+      content: [{ type: "toolcall", name: "shell", arguments: {} }],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [olderUser, olderToolResult, latestUser],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [olderUser, olderToolResult, latestUser],
+      chatRunId: "run-1",
+      chatStream: "Still answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before current tool", ts: 1 }];
+    state.chatToolMessages = [liveToolMessage];
+    state.toolStreamById = new Map([["call_current", { message: liveToolMessage }]]);
+    state.toolStreamOrder = ["call_current"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([olderUser, olderToolResult, latestUser]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("Still answering.");
+    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual([liveToolMessage]);
+    expect(state.chatStreamSegments).toEqual([{ text: "before current tool", ts: 1 }]);
+    expect(state.toolStreamById.size).toBe(1);
+    expect(state.toolStreamOrder).toEqual(["call_current"]);
+  });
+
   it("keeps segment-only streamed text when history catches up with tools", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2115,6 +2115,55 @@ describe("loadChatHistory retry handling", () => {
     expect(state.chatStreamStartedAt).toBe(100);
   });
 
+  it("clears live tool cards when history catches up before assistant text", async () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const persistedToolResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "shell",
+      content: [{ type: "text", text: "tool output" }],
+      __openclaw: { seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [persistedUser, persistedToolResult],
+      thinkingLevel: "low",
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [persistedUser],
+      chatRunId: "run-1",
+      chatStream: "Still answering.",
+      chatStreamStartedAt: 100,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number }>;
+      chatToolMessages: Record<string, unknown>[];
+      toolStreamById: Map<string, unknown>;
+      toolStreamOrder: string[];
+      toolStreamSyncTimer: number | null;
+    };
+    state.chatStreamSegments = [{ text: "before tool", ts: 1 }];
+    state.chatToolMessages = [persistedToolResult];
+    state.toolStreamById = new Map([["call_1", { message: persistedToolResult }]]);
+    state.toolStreamOrder = ["call_1"];
+    state.toolStreamSyncTimer = null;
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedUser, persistedToolResult]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("Still answering.");
+    expect(state.chatStreamStartedAt).toBe(100);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamById.size).toBe(0);
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("materializes orphaned streamed assistant text when history reload is stale", async () => {
     const persistedUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -781,7 +781,7 @@ describe("handleChatEvent", () => {
     const assignments = trackChatMessagesAssignments(state);
 
     expect(handleChatEvent(state, payload)).toBe("final");
-    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
+    expect(assignments).toMatchObject([{ chatRunId: "run-1", chatStream: "Here is my reply" }]);
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);
@@ -999,7 +999,10 @@ describe("handleChatEvent", () => {
     const assignments = trackChatMessagesAssignments(state);
 
     expect(handleChatEvent(state, payload)).toBe("aborted");
-    expect(assignments).toMatchObject([{ chatRunId: null, chatStream: null }]);
+    expect(assignments.at(-1)).toMatchObject({
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+    });
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -197,6 +197,72 @@ function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
+function appendDisplayMessageIfMissing(messages: unknown[], message: unknown): unknown[] {
+  const signature = messageDisplaySignature(message);
+  if (!signature) {
+    return [...messages, message];
+  }
+  return messages.some((existing) => messageDisplaySignature(existing) === signature)
+    ? messages
+    : [...messages, message];
+}
+
+function visibleAssistantStreamText(stream: string | null): string | null {
+  if (!stream?.trim() || isSilentReplyStream(stream) || isHeartbeatAckStream(stream)) {
+    return null;
+  }
+  return stream;
+}
+
+function buildAssistantStreamMessage(stream: string): Record<string, unknown> {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: stream }],
+    timestamp: Date.now(),
+  };
+}
+
+function lastUserMessageIndex(messages: unknown[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    if (role === "user") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function hasAssistantStreamReplacement(messages: unknown[], stream: string): boolean {
+  const expected = stream.trim();
+  if (!expected) {
+    return false;
+  }
+  const startIndex = lastUserMessageIndex(messages) + 1;
+  return messages.slice(startIndex).some((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
+    if (role !== "assistant" || shouldHideAssistantChatMessage(message)) {
+      return false;
+    }
+    const text = extractText(message)?.trim();
+    return Boolean(text && (text === expected || text.includes(expected)));
+  });
+}
+
+function appendVisibleStreamMessage(messages: unknown[], stream: string | null): unknown[] {
+  const text = visibleAssistantStreamText(stream);
+  if (!text || hasAssistantStreamReplacement(messages, text)) {
+    return messages;
+  }
+  return appendDisplayMessageIfMissing(messages, buildAssistantStreamMessage(text));
+}
+
 function messageTimestampMs(message: unknown): number | null {
   if (!message || typeof message !== "object") {
     return null;
@@ -709,18 +775,28 @@ async function loadChatHistoryUncached(
     state.chatThinkingLevel = res.sessionInfo?.thinkingLevel ?? res.thinkingLevel ?? null;
     const resetStream = !state.chatRunId || state.chatRunId === previousRunId;
     if (resetStream) {
-      // Clear all streaming state — history includes tool results and text
-      // inline, so keeping streaming artifacts would cause duplicates.
-      maybeResetToolStream(state);
-      state.chatStream = null;
-      state.chatStreamStartedAt = null;
-      recordChatHistoryTiming(state, "stream-reset", startedAtMs, {
-        requestSessionKey: sessionKey,
-        requestAgentId,
-        previousRunId,
-        messageCount: messages.length,
-        visibleMessageCount: visibleMessages.length,
-      });
+      const visibleStream = visibleAssistantStreamText(state.chatStream);
+      const historyReplacedStream =
+        visibleStream !== null && hasAssistantStreamReplacement(state.chatMessages, visibleStream);
+      if (!visibleStream || historyReplacedStream) {
+        // Clear all streaming state — history includes tool results and text
+        // inline, so keeping streaming artifacts would cause duplicates.
+        maybeResetToolStream(state);
+        state.chatStream = null;
+        state.chatStreamStartedAt = null;
+        recordChatHistoryTiming(state, "stream-reset", startedAtMs, {
+          requestSessionKey: sessionKey,
+          requestAgentId,
+          previousRunId,
+          messageCount: messages.length,
+          visibleMessageCount: visibleMessages.length,
+        });
+      } else if (!state.chatRunId) {
+        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, visibleStream);
+        maybeResetToolStream(state);
+        state.chatStream = null;
+        state.chatStreamStartedAt = null;
+      }
     }
     recordChatHistoryTiming(state, "applied", startedAtMs, {
       requestSessionKey: sessionKey,
@@ -1138,54 +1214,27 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    const visibleFinalMessage =
-      finalMessage && !shouldHideAssistantChatMessage(finalMessage) ? finalMessage : null;
-    const streamedText = state.chatStream ?? "";
-    const fallbackMessage =
-      !visibleFinalMessage &&
-      streamedText.trim() &&
-      !isSilentReplyStream(streamedText) &&
-      !isHeartbeatAckStream(streamedText)
-        ? {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          }
-        : null;
-    reconcileTerminalRun("done", "done");
-    if (visibleFinalMessage) {
-      state.chatMessages = [...state.chatMessages, visibleFinalMessage];
-    } else if (fallbackMessage) {
-      state.chatMessages = [...state.chatMessages, fallbackMessage];
+    if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
+      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, finalMessage);
+    } else {
+      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
     }
+    reconcileTerminalRun("done", "done");
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    const visibleAbortedMessage =
-      normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)
-        ? normalizedMessage
-        : null;
-    const streamedText = state.chatStream ?? "";
-    const fallbackMessage =
-      !visibleAbortedMessage &&
-      streamedText.trim() &&
-      !isSilentReplyStream(streamedText) &&
-      !isHeartbeatAckStream(streamedText)
-        ? {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          }
-        : null;
-    reconcileTerminalRun("interrupted", "killed");
-    if (visibleAbortedMessage) {
-      state.chatMessages = [...state.chatMessages, visibleAbortedMessage];
-    } else if (fallbackMessage) {
-      state.chatMessages = [...state.chatMessages, fallbackMessage];
+    if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
+      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, normalizedMessage);
+    } else {
+      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
     }
+    reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {
     const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
+    if (hadActiveRunBeforeEvent) {
+      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+    }
     if (errorMessage) {
-      state.chatMessages = [...state.chatMessages, errorMessage];
+      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, errorMessage);
     }
     reconcileTerminalRun("interrupted", "failed");
     setChatError(state, payload.errorMessage ?? "chat error");

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1275,12 +1275,31 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
     reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {
-    const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
-    if (hadActiveRunBeforeEvent) {
-      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
-    }
-    if (errorMessage) {
-      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, errorMessage);
+    const payloadMessage = hadActiveRunBeforeEvent
+      ? normalizeFinalAssistantMessage(payload.message)
+      : null;
+    const visiblePayloadMessage =
+      payloadMessage && !shouldHideAssistantChatMessage(payloadMessage) ? payloadMessage : null;
+    if (visiblePayloadMessage) {
+      const visibleStream = visibleAssistantStreamText(state.chatStream);
+      const payloadReplacesStream =
+        visibleStream !== null &&
+        hasAssistantStreamReplacement(
+          [...state.chatMessages, visiblePayloadMessage],
+          visibleStream,
+        );
+      if (!payloadReplacesStream) {
+        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+      }
+      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, visiblePayloadMessage);
+    } else {
+      const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
+      if (hadActiveRunBeforeEvent) {
+        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+      }
+      if (errorMessage) {
+        state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, errorMessage);
+      }
     }
     reconcileTerminalRun("interrupted", "failed");
     setChatError(state, payload.errorMessage ?? "chat error");

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -290,18 +290,6 @@ function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
-function appendDisplayMessageIfMissing(messages: unknown[], message: unknown): unknown[] {
-  const signature = messageDisplaySignature(message);
-  if (!signature) {
-    return [...messages, message];
-  }
-  return messages
-    .slice(lastUserMessageIndex(messages) + 1)
-    .some((existing) => messageDisplaySignature(existing) === signature)
-    ? messages
-    : [...messages, message];
-}
-
 function visibleAssistantStreamText(stream: string | null): string | null {
   if (!stream?.trim() || isSilentReplyStream(stream) || isHeartbeatAckStream(stream)) {
     return null;
@@ -363,6 +351,7 @@ function trimAccumulatedVisibleStreamText(text: string, previousText: string | n
 type VisibleAssistantStreamPart = {
   text: string;
   replacementText: string;
+  source: "segment" | "current";
 };
 
 function visibleAssistantStreamParts(
@@ -384,7 +373,7 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(segment.text, previousText),
     );
     if (visible) {
-      parts.push({ text: visible, replacementText: segment.text });
+      parts.push({ text: visible, replacementText: segment.text, source: "segment" });
     }
     if (segment.text.trim()) {
       previousText = segment.text;
@@ -395,7 +384,7 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(state.chatStream, previousText),
     );
     if (visible) {
-      parts.push({ text: visible, replacementText: state.chatStream });
+      parts.push({ text: visible, replacementText: state.chatStream, source: "current" });
     }
   }
   return parts;
@@ -411,6 +400,28 @@ function hasAssistantStreamPartReplacement(
   );
 }
 
+function firstCurrentToolStreamMessageIndex(messages: unknown[], state: ChatState): number {
+  const liveToolIds = new Set(currentLiveToolCallIds(state));
+  if (liveToolIds.size === 0) {
+    return -1;
+  }
+  const startIndex = lastUserMessageIndex(messages) + 1;
+  for (let index = startIndex; index < messages.length; index++) {
+    const message = messages[index];
+    if (!isPersistedToolHistoryMessage(message)) {
+      continue;
+    }
+    if (collectToolCallIds(message).some((id) => liveToolIds.has(id))) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function insertMessageAtIndex(messages: unknown[], message: unknown, index: number): unknown[] {
+  return [...messages.slice(0, index), message, ...messages.slice(index)];
+}
+
 function appendVisibleStreamStateMessages(
   messages: unknown[],
   state: ChatState,
@@ -422,10 +433,13 @@ function appendVisibleStreamStateMessages(
     if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
       continue;
     }
-    nextMessages = appendDisplayMessageIfMissing(
-      nextMessages,
-      buildAssistantStreamMessage(part.text),
-    );
+    const streamMessage = buildAssistantStreamMessage(part.text);
+    const toolIndex =
+      part.source === "segment" ? firstCurrentToolStreamMessageIndex(nextMessages, state) : -1;
+    nextMessages =
+      toolIndex >= 0
+        ? insertMessageAtIndex(nextMessages, streamMessage, toolIndex)
+        : [...nextMessages, streamMessage];
   }
   return nextMessages;
 }
@@ -1397,7 +1411,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, finalMessage);
+      state.chatMessages = [...state.chatMessages, finalMessage];
     } else {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
@@ -1411,7 +1425,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         [normalizedMessage],
         { includeCurrent: false },
       );
-      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, normalizedMessage);
+      state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
@@ -1426,14 +1440,14 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [
         visiblePayloadMessage,
       ]);
-      state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, visiblePayloadMessage);
+      state.chatMessages = [...state.chatMessages, visiblePayloadMessage];
     } else {
       const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
       if (hadActiveRunBeforeEvent) {
         state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
       }
       if (errorMessage) {
-        state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, errorMessage);
+        state.chatMessages = [...state.chatMessages, errorMessage];
       }
     }
     reconcileTerminalRun("interrupted", "failed");

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -293,16 +293,67 @@ function hasAssistantStreamReplacement(messages: unknown[], stream: string): boo
       return false;
     }
     const text = extractText(message)?.trim();
-    return Boolean(text && (text === expected || text.includes(expected)));
+    return Boolean(text && (text === expected || text.startsWith(expected)));
   });
 }
 
-function appendVisibleStreamMessage(messages: unknown[], stream: string | null): unknown[] {
-  const text = visibleAssistantStreamText(stream);
-  if (!text || hasAssistantStreamReplacement(messages, text)) {
-    return messages;
+function trimAccumulatedVisibleStreamText(text: string, previousText: string | null): string {
+  if (!previousText || !text.startsWith(previousText)) {
+    return text;
   }
-  return appendDisplayMessageIfMissing(messages, buildAssistantStreamMessage(text));
+  return text.slice(previousText.length).trimStart();
+}
+
+function visibleAssistantStreamParts(
+  state: ChatState,
+  opts?: { includeCurrent?: boolean },
+): string[] {
+  const streamHost = state as ChatState & {
+    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown }>;
+  };
+  const parts: string[] = [];
+  let previousText: string | null = null;
+  for (const segment of Array.isArray(streamHost.chatStreamSegments)
+    ? streamHost.chatStreamSegments
+    : []) {
+    if (typeof segment.text !== "string") {
+      continue;
+    }
+    const visible = visibleAssistantStreamText(
+      trimAccumulatedVisibleStreamText(segment.text, previousText),
+    );
+    if (visible) {
+      parts.push(visible);
+    }
+    if (segment.text.trim()) {
+      previousText = segment.text;
+    }
+  }
+  if (opts?.includeCurrent !== false && typeof state.chatStream === "string") {
+    const visible = visibleAssistantStreamText(
+      trimAccumulatedVisibleStreamText(state.chatStream, previousText),
+    );
+    if (visible) {
+      parts.push(visible);
+    }
+  }
+  return parts;
+}
+
+function appendVisibleStreamStateMessages(
+  messages: unknown[],
+  state: ChatState,
+  replacementMessages: unknown[] = [],
+  opts?: { includeCurrent?: boolean },
+): unknown[] {
+  let nextMessages = messages;
+  for (const part of visibleAssistantStreamParts(state, opts)) {
+    if (hasAssistantStreamReplacement([...nextMessages, ...replacementMessages], part)) {
+      continue;
+    }
+    nextMessages = appendDisplayMessageIfMissing(nextMessages, buildAssistantStreamMessage(part));
+  }
+  return nextMessages;
 }
 
 function messageTimestampMs(message: unknown): number | null {
@@ -838,7 +889,7 @@ async function loadChatHistoryUncached(
           visibleMessageCount: visibleMessages.length,
         });
       } else if (!state.chatRunId) {
-        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, visibleStream);
+        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
         maybeResetToolStream(state);
         state.chatStream = null;
         state.chatStreamStartedAt = null;
@@ -1261,17 +1312,29 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
+      state.chatMessages = appendVisibleStreamStateMessages(
+        state.chatMessages,
+        state,
+        [finalMessage],
+        { includeCurrent: false },
+      );
       state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, finalMessage);
     } else {
-      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
     reconcileTerminalRun("done", "done");
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
+      state.chatMessages = appendVisibleStreamStateMessages(
+        state.chatMessages,
+        state,
+        [normalizedMessage],
+        { includeCurrent: false },
+      );
       state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, normalizedMessage);
     } else {
-      state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
     reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {
@@ -1281,21 +1344,14 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     const visiblePayloadMessage =
       payloadMessage && !shouldHideAssistantChatMessage(payloadMessage) ? payloadMessage : null;
     if (visiblePayloadMessage) {
-      const visibleStream = visibleAssistantStreamText(state.chatStream);
-      const payloadReplacesStream =
-        visibleStream !== null &&
-        hasAssistantStreamReplacement(
-          [...state.chatMessages, visiblePayloadMessage],
-          visibleStream,
-        );
-      if (!payloadReplacesStream) {
-        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
-      }
+      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [
+        visiblePayloadMessage,
+      ]);
       state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, visiblePayloadMessage);
     } else {
       const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
       if (hadActiveRunBeforeEvent) {
-        state.chatMessages = appendVisibleStreamMessage(state.chatMessages, state.chatStream);
+        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
       }
       if (errorMessage) {
         state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, errorMessage);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -289,7 +289,10 @@ function hasAssistantStreamReplacement(messages: unknown[], stream: string): boo
       return false;
     }
     const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-    if (role !== "assistant" || shouldHideAssistantChatMessage(message)) {
+    if (role && role !== "assistant") {
+      return false;
+    }
+    if (role === "assistant" && shouldHideAssistantChatMessage(message)) {
       return false;
     }
     const text = extractText(message)?.trim();

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -131,8 +131,55 @@ function isPersistedToolHistoryMessage(message: unknown): boolean {
   );
 }
 
-function hasPersistedToolHistoryMessages(messages: unknown[]): boolean {
-  return messages.some(isPersistedToolHistoryMessage);
+function collectToolCallIds(message: unknown): string[] {
+  if (!message || typeof message !== "object") {
+    return [];
+  }
+  const entry = message as Record<string, unknown>;
+  const ids = [entry.toolCallId, entry.tool_call_id]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => value.trim());
+  if (!Array.isArray(entry.content)) {
+    return ids;
+  }
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const contentEntry = block as Record<string, unknown>;
+    for (const value of [contentEntry.toolCallId, contentEntry.tool_call_id]) {
+      if (typeof value === "string" && value.trim()) {
+        ids.push(value.trim());
+      }
+    }
+  }
+  return ids;
+}
+
+function currentLiveToolCallIds(state: ChatState): string[] {
+  const toolHost = state as ChatState & { toolStreamOrder?: unknown };
+  return Array.isArray(toolHost.toolStreamOrder)
+    ? toolHost.toolStreamOrder.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+}
+
+function hasPersistedCurrentToolStreamMessages(messages: unknown[], state: ChatState): boolean {
+  const liveToolIds = currentLiveToolCallIds(state);
+  if (liveToolIds.length === 0) {
+    return false;
+  }
+  const persistedToolIds = new Set<string>();
+  for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
+    if (!isPersistedToolHistoryMessage(message)) {
+      continue;
+    }
+    for (const id of collectToolCallIds(message)) {
+      persistedToolIds.add(id);
+    }
+  }
+  return liveToolIds.every((id) => persistedToolIds.has(id));
 }
 
 function isTextOnlyContent(content: unknown): boolean {
@@ -901,7 +948,10 @@ async function loadChatHistoryUncached(
         visibleStreamParts.every((part) =>
           hasAssistantStreamPartReplacement(state.chatMessages, part),
         );
-      const historyReplacedToolStream = hasPersistedToolHistoryMessages(state.chatMessages);
+      const historyReplacedToolStream = hasPersistedCurrentToolStreamMessages(
+        state.chatMessages,
+        state,
+      );
       if (visibleStreamParts.length === 0 || historyReplacedStream) {
         // Clear all streaming state — history includes tool results and text
         // inline, so keeping streaming artifacts would cause duplicates.

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -902,12 +902,6 @@ async function loadChatHistoryUncached(
           hasAssistantStreamPartReplacement(state.chatMessages, part),
         );
       const historyReplacedToolStream = hasPersistedToolHistoryMessages(state.chatMessages);
-      if (historyReplacedToolStream) {
-        maybeResetToolStream(state, {
-          preserveStreamSegments:
-            Boolean(state.chatRunId) && visibleStreamParts.length > 0 && !historyReplacedStream,
-        });
-      }
       if (visibleStreamParts.length === 0 || historyReplacedStream) {
         // Clear all streaming state — history includes tool results and text
         // inline, so keeping streaming artifacts would cause duplicates.
@@ -926,6 +920,8 @@ async function loadChatHistoryUncached(
         maybeResetToolStream(state);
         state.chatStream = null;
         state.chatStreamStartedAt = null;
+      } else if (historyReplacedToolStream) {
+        maybeResetToolStream(state, { preserveStreamSegments: true });
       }
     }
     recordChatHistoryTiming(state, "applied", startedAtMs, {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -396,6 +396,7 @@ type VisibleAssistantStreamPart = {
   replacementText: string;
   source: "segment" | "current";
   timestamp: number;
+  toolCallId?: string;
 };
 
 function visibleAssistantStreamParts(
@@ -405,11 +406,17 @@ function visibleAssistantStreamParts(
   const streamHost = state as ChatState & {
     chatStreamSegments?: Array<{ text?: unknown; ts?: unknown }>;
   };
+  const liveToolIds = currentLiveToolCallIds(state);
   const parts: VisibleAssistantStreamPart[] = [];
   let previousText: string | null = null;
-  for (const segment of Array.isArray(streamHost.chatStreamSegments)
+  const segments = Array.isArray(streamHost.chatStreamSegments)
     ? streamHost.chatStreamSegments
-    : []) {
+    : [];
+  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+    const segment = segments[segmentIndex];
+    if (!segment) {
+      continue;
+    }
     if (typeof segment.text !== "string") {
       continue;
     }
@@ -423,6 +430,7 @@ function visibleAssistantStreamParts(
         source: "segment",
         timestamp:
           typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
+        toolCallId: liveToolIds[segmentIndex],
       });
     }
     if (segment.text.trim()) {
@@ -455,8 +463,12 @@ function hasAssistantStreamPartReplacement(
   );
 }
 
-function firstCurrentToolStreamMessageIndex(messages: unknown[], state: ChatState): number {
-  const liveToolIds = new Set(currentLiveToolCallIds(state));
+function currentToolStreamMessageIndex(
+  messages: unknown[],
+  state: ChatState,
+  toolCallId?: string,
+): number {
+  const liveToolIds = toolCallId ? new Set([toolCallId]) : new Set(currentLiveToolCallIds(state));
   if (liveToolIds.size === 0) {
     return -1;
   }
@@ -494,7 +506,9 @@ function appendVisibleStreamStateMessages(
       part.timestamp,
     );
     const toolIndex =
-      part.source === "segment" ? firstCurrentToolStreamMessageIndex(nextMessages, state) : -1;
+      part.source === "segment"
+        ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
+        : -1;
     nextMessages =
       toolIndex >= 0
         ? insertMessageAtIndex(nextMessages, streamMessage, toolIndex)

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -202,7 +202,9 @@ function appendDisplayMessageIfMissing(messages: unknown[], message: unknown): u
   if (!signature) {
     return [...messages, message];
   }
-  return messages.some((existing) => messageDisplaySignature(existing) === signature)
+  return messages
+    .slice(lastUserMessageIndex(messages) + 1)
+    .some((existing) => messageDisplaySignature(existing) === signature)
     ? messages
     : [...messages, message];
 }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -661,7 +661,7 @@ function chatEventSessionMatches(state: ChatState, payload: ChatEventPayload): b
   );
 }
 
-function maybeResetToolStream(state: ChatState) {
+function maybeResetToolStream(state: ChatState, opts?: { preserveStreamSegments?: boolean }) {
   const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
   if (
     toolHost.toolStreamById instanceof Map &&
@@ -669,7 +669,13 @@ function maybeResetToolStream(state: ChatState) {
     Array.isArray(toolHost.chatToolMessages) &&
     Array.isArray(toolHost.chatStreamSegments)
   ) {
+    const preservedStreamSegments = opts?.preserveStreamSegments
+      ? [...toolHost.chatStreamSegments]
+      : null;
     resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
+    if (preservedStreamSegments) {
+      toolHost.chatStreamSegments = preservedStreamSegments;
+    }
   }
 }
 
@@ -886,14 +892,20 @@ async function loadChatHistoryUncached(
     state.chatThinkingLevel = res.sessionInfo?.thinkingLevel ?? res.thinkingLevel ?? null;
     const resetStream = !state.chatRunId || state.chatRunId === previousRunId;
     if (resetStream) {
-      const visibleStream = visibleAssistantStreamText(state.chatStream);
+      const visibleStreamParts = visibleAssistantStreamParts(state);
       const historyReplacedStream =
-        visibleStream !== null && hasAssistantStreamReplacement(state.chatMessages, visibleStream);
+        visibleStreamParts.length > 0 &&
+        visibleStreamParts.every((part) =>
+          hasAssistantStreamPartReplacement(state.chatMessages, part),
+        );
       const historyReplacedToolStream = hasPersistedToolHistoryMessages(state.chatMessages);
       if (historyReplacedToolStream) {
-        maybeResetToolStream(state);
+        maybeResetToolStream(state, {
+          preserveStreamSegments:
+            Boolean(state.chatRunId) && visibleStreamParts.length > 0 && !historyReplacedStream,
+        });
       }
-      if (!visibleStream || historyReplacedStream) {
+      if (visibleStreamParts.length === 0 || historyReplacedStream) {
         // Clear all streaming state — history includes tool results and text
         // inline, so keeping streaming artifacts would cause duplicates.
         maybeResetToolStream(state);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -136,7 +136,7 @@ function collectToolCallIds(message: unknown): string[] {
     return [];
   }
   const entry = message as Record<string, unknown>;
-  const ids = [entry.toolCallId, entry.tool_call_id]
+  const ids = [entry.toolCallId, entry.tool_call_id, entry.toolUseId, entry.tool_use_id, entry.id]
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
     .map((value) => value.trim());
   if (!Array.isArray(entry.content)) {
@@ -147,7 +147,13 @@ function collectToolCallIds(message: unknown): string[] {
       continue;
     }
     const contentEntry = block as Record<string, unknown>;
-    for (const value of [contentEntry.toolCallId, contentEntry.tool_call_id]) {
+    for (const value of [
+      contentEntry.toolCallId,
+      contentEntry.tool_call_id,
+      contentEntry.toolUseId,
+      contentEntry.tool_use_id,
+      contentEntry.id,
+    ]) {
       if (typeof value === "string" && value.trim()) {
         ids.push(value.trim());
       }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -171,11 +171,13 @@ function currentLiveToolCallIds(state: ChatState): string[] {
     : [];
 }
 
-function hasPersistedCurrentToolStreamMessages(messages: unknown[], state: ChatState): boolean {
+function persistedCurrentToolStreamIds(messages: unknown[], state: ChatState): Set<string> {
   const liveToolIds = currentLiveToolCallIds(state);
+  const matchedToolIds = new Set<string>();
   if (liveToolIds.length === 0) {
-    return false;
+    return matchedToolIds;
   }
+  const liveToolIdSet = new Set(liveToolIds);
   const persistedToolIds = new Set<string>();
   for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
     if (!isPersistedToolHistoryMessage(message)) {
@@ -185,7 +187,12 @@ function hasPersistedCurrentToolStreamMessages(messages: unknown[], state: ChatS
       persistedToolIds.add(id);
     }
   }
-  return liveToolIds.every((id) => persistedToolIds.has(id));
+  for (const id of persistedToolIds) {
+    if (liveToolIdSet.has(id)) {
+      matchedToolIds.add(id);
+    }
+  }
+  return matchedToolIds;
 }
 
 function isTextOnlyContent(content: unknown): boolean {
@@ -546,7 +553,7 @@ function appendVisibleStreamStateMessages(
   messages: unknown[],
   state: ChatState,
   replacementMessages: unknown[] = [],
-  opts?: { includeCurrent?: boolean },
+  opts?: { includeCurrent?: boolean; requirePersistedTool?: boolean },
 ): unknown[] {
   let nextMessages = messages;
   for (const part of visibleAssistantStreamParts(state, opts)) {
@@ -557,6 +564,9 @@ function appendVisibleStreamStateMessages(
       part.source === "segment"
         ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
         : -1;
+    if (opts?.requirePersistedTool && toolIndex < 0) {
+      continue;
+    }
     const insertIndex = toolIndex >= 0 ? toolIndex : nextMessages.length;
     const streamMessage = buildAssistantStreamMessage(
       part.text,
@@ -883,6 +893,57 @@ function clearToolStreamSegments(state: ChatState) {
   }
 }
 
+function prunePersistedToolStreamMessages(state: ChatState, persistedToolIds: Set<string>) {
+  if (persistedToolIds.size === 0) {
+    return;
+  }
+  const toolHost = state as ChatState & {
+    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown; toolCallId?: unknown }>;
+    chatToolMessages?: unknown[];
+    toolStreamById?: Map<string, unknown>;
+    toolStreamOrder?: unknown[];
+  };
+  const liveToolIds = currentLiveToolCallIds(state);
+  if (toolHost.toolStreamById instanceof Map) {
+    for (const id of persistedToolIds) {
+      toolHost.toolStreamById.delete(id);
+    }
+  }
+  if (Array.isArray(toolHost.toolStreamOrder)) {
+    toolHost.toolStreamOrder = toolHost.toolStreamOrder.filter(
+      (id): id is string => typeof id === "string" && !persistedToolIds.has(id),
+    );
+  }
+  if (Array.isArray(toolHost.chatToolMessages)) {
+    toolHost.chatToolMessages = toolHost.chatToolMessages.filter((message) => {
+      const ids = collectToolCallIds(message);
+      return ids.every((id) => !persistedToolIds.has(id));
+    });
+  }
+  if (!Array.isArray(toolHost.chatStreamSegments)) {
+    return;
+  }
+  let lastPrunedAccumulatedText: string | null = null;
+  toolHost.chatStreamSegments = toolHost.chatStreamSegments.flatMap((segment, index) => {
+    const explicitToolCallId =
+      typeof segment.toolCallId === "string" && segment.toolCallId.trim()
+        ? segment.toolCallId.trim()
+        : null;
+    const toolCallId = explicitToolCallId ?? liveToolIds[index] ?? null;
+    const text = typeof segment.text === "string" ? segment.text : "";
+    if (toolCallId && persistedToolIds.has(toolCallId)) {
+      if (text.trim()) {
+        lastPrunedAccumulatedText = text;
+      }
+      return [];
+    }
+    const nextText = lastPrunedAccumulatedText
+      ? trimAccumulatedVisibleStreamText(text, lastPrunedAccumulatedText)
+      : text;
+    return [{ ...segment, text: nextText }];
+  });
+}
+
 function resolveDeltaChatStreamText(
   currentStream: string | null,
   payload: ChatEventPayload,
@@ -1102,18 +1163,19 @@ async function loadChatHistoryUncached(
         visibleStreamParts.every((part) =>
           hasAssistantStreamPartReplacement(state.chatMessages, part),
         );
-      const historyReplacedToolStream = hasPersistedCurrentToolStreamMessages(
-        state.chatMessages,
-        state,
-      );
-      const liveToolStreamReplaced =
-        currentLiveToolCallIds(state).length === 0 || historyReplacedToolStream;
+      const liveToolIds = currentLiveToolCallIds(state);
+      const persistedToolStreamIds = persistedCurrentToolStreamIds(state.chatMessages, state);
+      const historyReplacedToolStream =
+        liveToolIds.length > 0 && liveToolIds.every((id) => persistedToolStreamIds.has(id));
+      const historyReplacedSomeToolStream = persistedToolStreamIds.size > 0;
+      const liveToolStreamReplaced = liveToolIds.length === 0 || historyReplacedToolStream;
       if (visibleStreamParts.length === 0 || historyReplacedStream) {
         if (liveToolStreamReplaced) {
           // Clear all streaming state — history includes tool results and text
           // inline, so keeping streaming artifacts would cause duplicates.
           maybeResetToolStream(state);
         } else {
+          prunePersistedToolStreamMessages(state, persistedToolStreamIds);
           clearToolStreamSegments(state);
         }
         state.chatStream = null;
@@ -1139,6 +1201,17 @@ async function loadChatHistoryUncached(
           state.chatStreamStartedAt = null;
         }
         maybeResetToolStream(state);
+      } else if (historyReplacedSomeToolStream) {
+        const visibleCurrentTail = visibleCurrentAssistantStreamTail(state);
+        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [], {
+          includeCurrent: false,
+          requirePersistedTool: true,
+        });
+        state.chatStream = visibleCurrentTail;
+        if (state.chatStream === null) {
+          state.chatStreamStartedAt = null;
+        }
+        prunePersistedToolStreamMessages(state, persistedToolStreamIds);
       }
     }
     recordChatHistoryTiming(state, "applied", startedAtMs, {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -304,14 +304,19 @@ function trimAccumulatedVisibleStreamText(text: string, previousText: string | n
   return text.slice(previousText.length).trimStart();
 }
 
+type VisibleAssistantStreamPart = {
+  text: string;
+  replacementText: string;
+};
+
 function visibleAssistantStreamParts(
   state: ChatState,
   opts?: { includeCurrent?: boolean },
-): string[] {
+): VisibleAssistantStreamPart[] {
   const streamHost = state as ChatState & {
     chatStreamSegments?: Array<{ text?: unknown; ts?: unknown }>;
   };
-  const parts: string[] = [];
+  const parts: VisibleAssistantStreamPart[] = [];
   let previousText: string | null = null;
   for (const segment of Array.isArray(streamHost.chatStreamSegments)
     ? streamHost.chatStreamSegments
@@ -323,7 +328,7 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(segment.text, previousText),
     );
     if (visible) {
-      parts.push(visible);
+      parts.push({ text: visible, replacementText: segment.text });
     }
     if (segment.text.trim()) {
       previousText = segment.text;
@@ -334,10 +339,20 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(state.chatStream, previousText),
     );
     if (visible) {
-      parts.push(visible);
+      parts.push({ text: visible, replacementText: state.chatStream });
     }
   }
   return parts;
+}
+
+function hasAssistantStreamPartReplacement(
+  messages: unknown[],
+  part: VisibleAssistantStreamPart,
+): boolean {
+  return (
+    hasAssistantStreamReplacement(messages, part.replacementText) ||
+    hasAssistantStreamReplacement(messages, part.text)
+  );
 }
 
 function appendVisibleStreamStateMessages(
@@ -348,10 +363,13 @@ function appendVisibleStreamStateMessages(
 ): unknown[] {
   let nextMessages = messages;
   for (const part of visibleAssistantStreamParts(state, opts)) {
-    if (hasAssistantStreamReplacement([...nextMessages, ...replacementMessages], part)) {
+    if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
       continue;
     }
-    nextMessages = appendDisplayMessageIfMissing(nextMessages, buildAssistantStreamMessage(part));
+    nextMessages = appendDisplayMessageIfMissing(
+      nextMessages,
+      buildAssistantStreamMessage(part.text),
+    );
   }
   return nextMessages;
 }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -513,6 +513,35 @@ function insertMessageAtIndex(messages: unknown[], message: unknown, index: numb
   return [...messages.slice(0, index), message, ...messages.slice(index)];
 }
 
+function timestampForInsertedVisibleStream(
+  messages: unknown[],
+  index: number,
+  desiredTimestamp: number,
+): number {
+  const previousTimestamp = messages
+    .slice(0, index)
+    .toReversed()
+    .map(messageTimestampMs)
+    .find((timestamp): timestamp is number => timestamp != null);
+  const nextTimestamp = messages
+    .slice(index)
+    .map(messageTimestampMs)
+    .find((timestamp): timestamp is number => timestamp != null);
+  if (previousTimestamp != null && desiredTimestamp <= previousTimestamp) {
+    const afterPrevious = previousTimestamp + 1;
+    return nextTimestamp != null && afterPrevious >= nextTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : afterPrevious;
+  }
+  if (nextTimestamp != null && desiredTimestamp >= nextTimestamp) {
+    const beforeNext = nextTimestamp - 1;
+    return previousTimestamp != null && beforeNext <= previousTimestamp
+      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
+      : beforeNext;
+  }
+  return desiredTimestamp;
+}
+
 function appendVisibleStreamStateMessages(
   messages: unknown[],
   state: ChatState,
@@ -524,15 +553,16 @@ function appendVisibleStreamStateMessages(
     if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
       continue;
     }
-    const streamMessage = buildAssistantStreamMessage(
-      part.text,
-      part.replacementText,
-      part.timestamp,
-    );
     const toolIndex =
       part.source === "segment"
         ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
         : -1;
+    const insertIndex = toolIndex >= 0 ? toolIndex : nextMessages.length;
+    const streamMessage = buildAssistantStreamMessage(
+      part.text,
+      part.replacementText,
+      timestampForInsertedVisibleStream(nextMessages, insertIndex, part.timestamp),
+    );
     nextMessages =
       toolIndex >= 0
         ? insertMessageAtIndex(nextMessages, streamMessage, toolIndex)

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -404,7 +404,7 @@ function visibleAssistantStreamParts(
   opts?: { includeCurrent?: boolean },
 ): VisibleAssistantStreamPart[] {
   const streamHost = state as ChatState & {
-    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown }>;
+    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown; toolCallId?: unknown }>;
   };
   const liveToolIds = currentLiveToolCallIds(state);
   const parts: VisibleAssistantStreamPart[] = [];
@@ -430,7 +430,10 @@ function visibleAssistantStreamParts(
         source: "segment",
         timestamp:
           typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
-        toolCallId: liveToolIds[segmentIndex],
+        toolCallId:
+          typeof segment.toolCallId === "string" && segment.toolCallId.trim()
+            ? segment.toolCallId.trim()
+            : liveToolIds[segmentIndex],
       });
     }
     if (segment.text.trim()) {
@@ -451,6 +454,27 @@ function visibleAssistantStreamParts(
     }
   }
   return parts;
+}
+
+function visibleCurrentAssistantStreamTail(state: ChatState): string | null {
+  if (typeof state.chatStream !== "string") {
+    return null;
+  }
+  const streamHost = state as ChatState & {
+    chatStreamSegments?: Array<{ text?: unknown }>;
+  };
+  const segments = Array.isArray(streamHost.chatStreamSegments)
+    ? streamHost.chatStreamSegments
+    : [];
+  let previousText: string | null = null;
+  for (const segment of segments) {
+    if (typeof segment.text === "string" && segment.text.trim()) {
+      previousText = segment.text;
+    }
+  }
+  return visibleAssistantStreamText(
+    trimAccumulatedVisibleStreamText(state.chatStream, previousText),
+  );
 }
 
 function hasAssistantStreamPartReplacement(
@@ -1080,6 +1104,10 @@ async function loadChatHistoryUncached(
         state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [], {
           includeCurrent: false,
         });
+        state.chatStream = visibleCurrentAssistantStreamTail(state);
+        if (state.chatStream === null) {
+          state.chatStreamStartedAt = null;
+        }
         maybeResetToolStream(state);
       }
     }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,4 +1,3 @@
-import { resetToolStream } from "../app-tool-stream.ts";
 import { getChatAttachmentDataUrl } from "../chat/attachment-payload-store.ts";
 import {
   isAssistantHeartbeatAckForDisplay,
@@ -6,7 +5,18 @@ import {
 } from "../chat/heartbeat-display.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
-import { extractToolMessageRefs } from "../chat/tool-message-refs.ts";
+import {
+  appendTerminalAssistantMessage,
+  clearToolStreamSegments,
+  currentLiveToolCallIds,
+  hasVisibleStreamParts,
+  historyReplacedVisibleStream,
+  materializeVisibleStreamState,
+  maybeResetToolStream,
+  persistedCurrentToolStreamIds,
+  prunePersistedToolStreamMessages,
+  visibleCurrentAssistantStreamTail,
+} from "../chat/stream-reconciliation.ts";
 import { buildUserChatMessageContentBlocks } from "../chat/user-message-content.ts";
 import { formatConnectError } from "../connect-error.ts";
 import {
@@ -96,36 +106,6 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
   return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
 }
 
-function currentLiveToolCallIds(state: ChatState): string[] {
-  const toolHost = state as ChatState & { toolStreamOrder?: unknown };
-  return Array.isArray(toolHost.toolStreamOrder)
-    ? toolHost.toolStreamOrder.filter(
-        (value): value is string => typeof value === "string" && value.trim().length > 0,
-      )
-    : [];
-}
-
-function persistedCurrentToolStreamIds(messages: unknown[], state: ChatState): Set<string> {
-  const liveToolIds = currentLiveToolCallIds(state);
-  const matchedToolIds = new Set<string>();
-  if (liveToolIds.length === 0) {
-    return matchedToolIds;
-  }
-  const liveToolIdSet = new Set(liveToolIds);
-  const persistedToolIds = new Set<string>();
-  for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
-    for (const ref of extractToolMessageRefs(message)) {
-      persistedToolIds.add(ref.id);
-    }
-  }
-  for (const id of persistedToolIds) {
-    if (liveToolIdSet.has(id)) {
-      matchedToolIds.add(id);
-    }
-  }
-  return matchedToolIds;
-}
-
 function isTextOnlyContent(content: unknown): boolean {
   if (typeof content === "string") {
     return true;
@@ -179,6 +159,10 @@ function isHeartbeatAckStream(text: string): boolean {
   return stripHeartbeatTokenForDisplay(text).shouldSkip;
 }
 
+function isHiddenAssistantStreamText(text: string): boolean {
+  return isSilentReplyStream(text) || isHeartbeatAckStream(text);
+}
+
 function shouldHideAssistantChatMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isAssistantHeartbeatAckForDisplay(message);
 }
@@ -189,6 +173,22 @@ function shouldHideHistoryMessage(message: unknown): boolean {
     isSyntheticTranscriptRepairToolResult(message) ||
     isEmptyUserTextOnlyMessage(message)
   );
+}
+
+function materializeVisibleAssistantStreamMessages(
+  messages: unknown[],
+  state: ChatState,
+  opts: {
+    includeCurrent?: boolean;
+    requirePersistedTool?: boolean;
+    replacementMessages?: unknown[];
+  } = {},
+): unknown[] {
+  return materializeVisibleStreamState(messages, state, {
+    ...opts,
+    isHiddenAssistantMessage: shouldHideAssistantChatMessage,
+    isHiddenStreamText: isHiddenAssistantStreamText,
+  });
 }
 
 function hasTranscriptMeta(message: unknown): boolean {
@@ -226,286 +226,6 @@ function messageDisplaySignature(message: unknown): string | null {
   } catch {
     return null;
   }
-}
-
-function visibleAssistantStreamText(stream: string | null): string | null {
-  if (!stream?.trim() || isSilentReplyStream(stream) || isHeartbeatAckStream(stream)) {
-    return null;
-  }
-  return stream;
-}
-
-function buildAssistantStreamMessage(
-  stream: string,
-  replacementText = stream,
-  timestamp = Date.now(),
-): Record<string, unknown> {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text: stream }],
-    timestamp,
-    openclawStreamFallback: {
-      replacementText,
-    },
-  };
-}
-
-function streamFallbackReplacementText(message: unknown): string | null {
-  if (!message || typeof message !== "object") {
-    return null;
-  }
-  const fallback = (message as { openclawStreamFallback?: unknown }).openclawStreamFallback;
-  if (!fallback || typeof fallback !== "object") {
-    return null;
-  }
-  const replacementText = (fallback as { replacementText?: unknown }).replacementText;
-  if (typeof replacementText === "string" && replacementText.trim()) {
-    return replacementText.trim();
-  }
-  return extractText(message)?.trim() ?? null;
-}
-
-function terminalMessageReplacesStreamFallback(message: unknown, fallback: unknown): boolean {
-  const fallbackText = streamFallbackReplacementText(fallback);
-  if (!fallbackText) {
-    return false;
-  }
-  const terminalText = extractText(message)?.trim();
-  return Boolean(
-    terminalText && (terminalText === fallbackText || terminalText.startsWith(fallbackText)),
-  );
-}
-
-function appendTerminalAssistantMessage(messages: unknown[], message: unknown): unknown[] {
-  const retainedMessages = messages.filter((existing, index) => {
-    if (index <= lastUserMessageIndex(messages)) {
-      return true;
-    }
-    return !terminalMessageReplacesStreamFallback(message, existing);
-  });
-  return [...retainedMessages, message];
-}
-
-function lastUserMessageIndex(messages: unknown[]): number {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-    if (role === "user") {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function hasAssistantStreamReplacement(messages: unknown[], stream: string): boolean {
-  const expected = stream.trim();
-  if (!expected) {
-    return false;
-  }
-  const startIndex = lastUserMessageIndex(messages) + 1;
-  return messages.slice(startIndex).some((message) => {
-    if (!message || typeof message !== "object") {
-      return false;
-    }
-    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-    if (role && role !== "assistant") {
-      return false;
-    }
-    if (role === "assistant" && shouldHideAssistantChatMessage(message)) {
-      return false;
-    }
-    const text = extractText(message)?.trim();
-    return Boolean(text && (text === expected || text.startsWith(expected)));
-  });
-}
-
-function trimAccumulatedVisibleStreamText(text: string, previousText: string | null): string {
-  if (!previousText || !text.startsWith(previousText)) {
-    return text;
-  }
-  return text.slice(previousText.length).trimStart();
-}
-
-type VisibleAssistantStreamPart = {
-  text: string;
-  replacementText: string;
-  source: "segment" | "current";
-  timestamp: number;
-  toolCallId?: string;
-};
-
-function visibleAssistantStreamParts(
-  state: ChatState,
-  opts?: { includeCurrent?: boolean },
-): VisibleAssistantStreamPart[] {
-  const streamHost = state as ChatState & {
-    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown; toolCallId?: unknown }>;
-  };
-  const liveToolIds = currentLiveToolCallIds(state);
-  const parts: VisibleAssistantStreamPart[] = [];
-  let previousText: string | null = null;
-  const segments = Array.isArray(streamHost.chatStreamSegments)
-    ? streamHost.chatStreamSegments
-    : [];
-  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
-    const segment = segments[segmentIndex];
-    if (!segment) {
-      continue;
-    }
-    if (typeof segment.text !== "string") {
-      continue;
-    }
-    const visible = visibleAssistantStreamText(
-      trimAccumulatedVisibleStreamText(segment.text, previousText),
-    );
-    if (visible) {
-      parts.push({
-        text: visible,
-        replacementText: segment.text,
-        source: "segment",
-        timestamp:
-          typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
-        toolCallId:
-          typeof segment.toolCallId === "string" && segment.toolCallId.trim()
-            ? segment.toolCallId.trim()
-            : liveToolIds[segmentIndex],
-      });
-    }
-    if (segment.text.trim()) {
-      previousText = segment.text;
-    }
-  }
-  if (opts?.includeCurrent !== false && typeof state.chatStream === "string") {
-    const visible = visibleAssistantStreamText(
-      trimAccumulatedVisibleStreamText(state.chatStream, previousText),
-    );
-    if (visible) {
-      parts.push({
-        text: visible,
-        replacementText: state.chatStream,
-        source: "current",
-        timestamp: state.chatStreamStartedAt ?? Date.now(),
-      });
-    }
-  }
-  return parts;
-}
-
-function visibleCurrentAssistantStreamTail(state: ChatState): string | null {
-  if (typeof state.chatStream !== "string") {
-    return null;
-  }
-  const streamHost = state as ChatState & {
-    chatStreamSegments?: Array<{ text?: unknown }>;
-  };
-  const segments = Array.isArray(streamHost.chatStreamSegments)
-    ? streamHost.chatStreamSegments
-    : [];
-  let previousText: string | null = null;
-  for (const segment of segments) {
-    if (typeof segment.text === "string" && segment.text.trim()) {
-      previousText = segment.text;
-    }
-  }
-  return visibleAssistantStreamText(
-    trimAccumulatedVisibleStreamText(state.chatStream, previousText),
-  );
-}
-
-function hasAssistantStreamPartReplacement(
-  messages: unknown[],
-  part: VisibleAssistantStreamPart,
-): boolean {
-  return (
-    hasAssistantStreamReplacement(messages, part.replacementText) ||
-    hasAssistantStreamReplacement(messages, part.text)
-  );
-}
-
-function currentToolStreamMessageIndex(
-  messages: unknown[],
-  state: ChatState,
-  toolCallId?: string,
-): number {
-  const liveToolIds = toolCallId ? new Set([toolCallId]) : new Set(currentLiveToolCallIds(state));
-  if (liveToolIds.size === 0) {
-    return -1;
-  }
-  const startIndex = lastUserMessageIndex(messages) + 1;
-  for (let index = startIndex; index < messages.length; index++) {
-    if (extractToolMessageRefs(messages[index]).some((ref) => liveToolIds.has(ref.id))) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function insertMessageAtIndex(messages: unknown[], message: unknown, index: number): unknown[] {
-  return [...messages.slice(0, index), message, ...messages.slice(index)];
-}
-
-function timestampForInsertedVisibleStream(
-  messages: unknown[],
-  index: number,
-  desiredTimestamp: number,
-): number {
-  const previousTimestamp = messages
-    .slice(0, index)
-    .toReversed()
-    .map(messageTimestampMs)
-    .find((timestamp): timestamp is number => timestamp != null);
-  const nextTimestamp = messages
-    .slice(index)
-    .map(messageTimestampMs)
-    .find((timestamp): timestamp is number => timestamp != null);
-  if (previousTimestamp != null && desiredTimestamp <= previousTimestamp) {
-    const afterPrevious = previousTimestamp + 1;
-    return nextTimestamp != null && afterPrevious >= nextTimestamp
-      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
-      : afterPrevious;
-  }
-  if (nextTimestamp != null && desiredTimestamp >= nextTimestamp) {
-    const beforeNext = nextTimestamp - 1;
-    return previousTimestamp != null && beforeNext <= previousTimestamp
-      ? previousTimestamp + (nextTimestamp - previousTimestamp) / 2
-      : beforeNext;
-  }
-  return desiredTimestamp;
-}
-
-function appendVisibleStreamStateMessages(
-  messages: unknown[],
-  state: ChatState,
-  replacementMessages: unknown[] = [],
-  opts?: { includeCurrent?: boolean; requirePersistedTool?: boolean },
-): unknown[] {
-  let nextMessages = messages;
-  for (const part of visibleAssistantStreamParts(state, opts)) {
-    if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
-      continue;
-    }
-    const toolIndex =
-      part.source === "segment"
-        ? currentToolStreamMessageIndex(nextMessages, state, part.toolCallId)
-        : -1;
-    if (opts?.requirePersistedTool && toolIndex < 0) {
-      continue;
-    }
-    const insertIndex = toolIndex >= 0 ? toolIndex : nextMessages.length;
-    const streamMessage = buildAssistantStreamMessage(
-      part.text,
-      part.replacementText,
-      timestampForInsertedVisibleStream(nextMessages, insertIndex, part.timestamp),
-    );
-    nextMessages =
-      toolIndex >= 0
-        ? insertMessageAtIndex(nextMessages, streamMessage, toolIndex)
-        : [...nextMessages, streamMessage];
-  }
-  return nextMessages;
 }
 
 function messageTimestampMs(message: unknown): number | null {
@@ -795,82 +515,6 @@ function chatEventSessionMatches(state: ChatState, payload: ChatEventPayload): b
   );
 }
 
-function maybeResetToolStream(state: ChatState, opts?: { preserveStreamSegments?: boolean }) {
-  const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
-  if (
-    toolHost.toolStreamById instanceof Map &&
-    Array.isArray(toolHost.toolStreamOrder) &&
-    Array.isArray(toolHost.chatToolMessages) &&
-    Array.isArray(toolHost.chatStreamSegments)
-  ) {
-    const preservedStreamSegments = opts?.preserveStreamSegments
-      ? [...toolHost.chatStreamSegments]
-      : null;
-    resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
-    if (preservedStreamSegments) {
-      toolHost.chatStreamSegments = preservedStreamSegments;
-    }
-  }
-}
-
-function clearToolStreamSegments(state: ChatState) {
-  const toolHost = state as ChatState & { chatStreamSegments?: unknown };
-  if (Array.isArray(toolHost.chatStreamSegments)) {
-    toolHost.chatStreamSegments = [];
-  }
-}
-
-function prunePersistedToolStreamMessages(state: ChatState, persistedToolIds: Set<string>) {
-  if (persistedToolIds.size === 0) {
-    return;
-  }
-  const toolHost = state as ChatState & {
-    chatStreamSegments?: Array<{ text?: unknown; ts?: unknown; toolCallId?: unknown }>;
-    chatToolMessages?: unknown[];
-    toolStreamById?: Map<string, unknown>;
-    toolStreamOrder?: unknown[];
-  };
-  const liveToolIds = currentLiveToolCallIds(state);
-  if (toolHost.toolStreamById instanceof Map) {
-    for (const id of persistedToolIds) {
-      toolHost.toolStreamById.delete(id);
-    }
-  }
-  if (Array.isArray(toolHost.toolStreamOrder)) {
-    toolHost.toolStreamOrder = toolHost.toolStreamOrder.filter(
-      (id): id is string => typeof id === "string" && !persistedToolIds.has(id),
-    );
-  }
-  if (Array.isArray(toolHost.chatToolMessages)) {
-    toolHost.chatToolMessages = toolHost.chatToolMessages.filter((message) => {
-      const refs = extractToolMessageRefs(message);
-      return refs.every((ref) => !persistedToolIds.has(ref.id));
-    });
-  }
-  if (!Array.isArray(toolHost.chatStreamSegments)) {
-    return;
-  }
-  let lastPrunedAccumulatedText: string | null = null;
-  toolHost.chatStreamSegments = toolHost.chatStreamSegments.flatMap((segment, index) => {
-    const explicitToolCallId =
-      typeof segment.toolCallId === "string" && segment.toolCallId.trim()
-        ? segment.toolCallId.trim()
-        : null;
-    const toolCallId = explicitToolCallId ?? liveToolIds[index] ?? null;
-    const text = typeof segment.text === "string" ? segment.text : "";
-    if (toolCallId && persistedToolIds.has(toolCallId)) {
-      if (text.trim()) {
-        lastPrunedAccumulatedText = text;
-      }
-      return [];
-    }
-    const nextText = lastPrunedAccumulatedText
-      ? trimAccumulatedVisibleStreamText(text, lastPrunedAccumulatedText)
-      : text;
-    return [{ ...segment, text: nextText }];
-  });
-}
-
 function resolveDeltaChatStreamText(
   currentStream: string | null,
   payload: ChatEventPayload,
@@ -1084,19 +728,23 @@ async function loadChatHistoryUncached(
     state.chatThinkingLevel = res.sessionInfo?.thinkingLevel ?? res.thinkingLevel ?? null;
     const resetStream = !state.chatRunId || state.chatRunId === previousRunId;
     if (resetStream) {
-      const visibleStreamParts = visibleAssistantStreamParts(state);
-      const historyReplacedStream =
-        visibleStreamParts.length > 0 &&
-        visibleStreamParts.every((part) =>
-          hasAssistantStreamPartReplacement(state.chatMessages, part),
-        );
+      const streamReconciliation = {
+        isHiddenAssistantMessage: shouldHideAssistantChatMessage,
+        isHiddenStreamText: isHiddenAssistantStreamText,
+      };
+      const hasVisibleStream = hasVisibleStreamParts(state, streamReconciliation);
+      const historyReplacedStream = historyReplacedVisibleStream(
+        state.chatMessages,
+        state,
+        streamReconciliation,
+      );
       const liveToolIds = currentLiveToolCallIds(state);
       const persistedToolStreamIds = persistedCurrentToolStreamIds(state.chatMessages, state);
       const historyReplacedToolStream =
         liveToolIds.length > 0 && liveToolIds.every((id) => persistedToolStreamIds.has(id));
       const historyReplacedSomeToolStream = persistedToolStreamIds.size > 0;
       const liveToolStreamReplaced = liveToolIds.length === 0 || historyReplacedToolStream;
-      if (visibleStreamParts.length === 0 || historyReplacedStream) {
+      if (!hasVisibleStream || historyReplacedStream) {
         if (liveToolStreamReplaced) {
           // Clear all streaming state — history includes tool results and text
           // inline, so keeping streaming artifacts would cause duplicates.
@@ -1115,22 +763,28 @@ async function loadChatHistoryUncached(
           visibleMessageCount: visibleMessages.length,
         });
       } else if (!state.chatRunId) {
-        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
+        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
         maybeResetToolStream(state);
         state.chatStream = null;
         state.chatStreamStartedAt = null;
       } else if (historyReplacedToolStream) {
-        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [], {
+        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
           includeCurrent: false,
         });
-        state.chatStream = visibleCurrentAssistantStreamTail(state);
+        state.chatStream = visibleCurrentAssistantStreamTail(
+          state,
+          streamReconciliation.isHiddenStreamText,
+        );
         if (state.chatStream === null) {
           state.chatStreamStartedAt = null;
         }
         maybeResetToolStream(state);
       } else if (historyReplacedSomeToolStream) {
-        const visibleCurrentTail = visibleCurrentAssistantStreamTail(state);
-        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [], {
+        const visibleCurrentTail = visibleCurrentAssistantStreamTail(
+          state,
+          streamReconciliation.isHiddenStreamText,
+        );
+        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
           includeCurrent: false,
           requirePersistedTool: true,
         });
@@ -1560,21 +1214,19 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
       state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, finalMessage);
     } else {
-      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
+      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
     }
     reconcileTerminalRun("done", "done");
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !shouldHideAssistantChatMessage(normalizedMessage)) {
-      state.chatMessages = appendVisibleStreamStateMessages(
-        state.chatMessages,
-        state,
-        [normalizedMessage],
-        { includeCurrent: false },
-      );
+      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
+        replacementMessages: [normalizedMessage],
+        includeCurrent: false,
+      });
       state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, normalizedMessage);
     } else {
-      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
+      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
     }
     reconcileTerminalRun("interrupted", "killed");
   } else if (payload.state === "error") {
@@ -1584,9 +1236,9 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     const visiblePayloadMessage =
       payloadMessage && !shouldHideAssistantChatMessage(payloadMessage) ? payloadMessage : null;
     if (visiblePayloadMessage) {
-      state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [
-        visiblePayloadMessage,
-      ]);
+      state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state, {
+        replacementMessages: [visiblePayloadMessage],
+      });
       state.chatMessages = appendTerminalAssistantMessage(
         state.chatMessages,
         visiblePayloadMessage,
@@ -1594,7 +1246,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     } else {
       const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
       if (hadActiveRunBeforeEvent) {
-        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
+        state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
       }
       if (errorMessage) {
         state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, errorMessage);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -297,12 +297,54 @@ function visibleAssistantStreamText(stream: string | null): string | null {
   return stream;
 }
 
-function buildAssistantStreamMessage(stream: string): Record<string, unknown> {
+function buildAssistantStreamMessage(
+  stream: string,
+  replacementText = stream,
+): Record<string, unknown> {
   return {
     role: "assistant",
     content: [{ type: "text", text: stream }],
     timestamp: Date.now(),
+    openclawStreamFallback: {
+      replacementText,
+    },
   };
+}
+
+function streamFallbackReplacementText(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const fallback = (message as { openclawStreamFallback?: unknown }).openclawStreamFallback;
+  if (!fallback || typeof fallback !== "object") {
+    return null;
+  }
+  const replacementText = (fallback as { replacementText?: unknown }).replacementText;
+  if (typeof replacementText === "string" && replacementText.trim()) {
+    return replacementText.trim();
+  }
+  return extractText(message)?.trim() ?? null;
+}
+
+function terminalMessageReplacesStreamFallback(message: unknown, fallback: unknown): boolean {
+  const fallbackText = streamFallbackReplacementText(fallback);
+  if (!fallbackText) {
+    return false;
+  }
+  const terminalText = extractText(message)?.trim();
+  return Boolean(
+    terminalText && (terminalText === fallbackText || terminalText.startsWith(fallbackText)),
+  );
+}
+
+function appendTerminalAssistantMessage(messages: unknown[], message: unknown): unknown[] {
+  const retainedMessages = messages.filter((existing, index) => {
+    if (index <= lastUserMessageIndex(messages)) {
+      return true;
+    }
+    return !terminalMessageReplacesStreamFallback(message, existing);
+  });
+  return [...retainedMessages, message];
 }
 
 function lastUserMessageIndex(messages: unknown[]): number {
@@ -433,7 +475,7 @@ function appendVisibleStreamStateMessages(
     if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
       continue;
     }
-    const streamMessage = buildAssistantStreamMessage(part.text);
+    const streamMessage = buildAssistantStreamMessage(part.text, part.replacementText);
     const toolIndex =
       part.source === "segment" ? firstCurrentToolStreamMessageIndex(nextMessages, state) : -1;
     nextMessages =
@@ -991,7 +1033,10 @@ async function loadChatHistoryUncached(
         state.chatStream = null;
         state.chatStreamStartedAt = null;
       } else if (historyReplacedToolStream) {
-        maybeResetToolStream(state, { preserveStreamSegments: true });
+        state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [], {
+          includeCurrent: false,
+        });
+        maybeResetToolStream(state);
       }
     }
     recordChatHistoryTiming(state, "applied", startedAtMs, {
@@ -1411,7 +1456,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
+      state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, finalMessage);
     } else {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
@@ -1425,7 +1470,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         [normalizedMessage],
         { includeCurrent: false },
       );
-      state.chatMessages = [...state.chatMessages, normalizedMessage];
+      state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, normalizedMessage);
     } else {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
     }
@@ -1440,14 +1485,17 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state, [
         visiblePayloadMessage,
       ]);
-      state.chatMessages = [...state.chatMessages, visiblePayloadMessage];
+      state.chatMessages = appendTerminalAssistantMessage(
+        state.chatMessages,
+        visiblePayloadMessage,
+      );
     } else {
       const errorMessage = hadActiveRunBeforeEvent ? buildErrorAssistantMessage(payload) : null;
       if (hadActiveRunBeforeEvent) {
         state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);
       }
       if (errorMessage) {
-        state.chatMessages = [...state.chatMessages, errorMessage];
+        state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, errorMessage);
       }
     }
     reconcileTerminalRun("interrupted", "failed");

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -95,6 +95,46 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
   return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
 }
 
+function isPersistedToolHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role === "toolresult" || role === "tool_result" || role === "tool" || role === "function") {
+    return true;
+  }
+  if (
+    typeof entry.toolCallId === "string" ||
+    typeof entry.tool_call_id === "string" ||
+    typeof entry.toolName === "string" ||
+    typeof entry.tool_name === "string"
+  ) {
+    return true;
+  }
+  return (
+    Array.isArray(entry.content) &&
+    entry.content.some((block) => {
+      if (!block || typeof block !== "object") {
+        return false;
+      }
+      const type = normalizeLowercaseStringOrEmpty((block as Record<string, unknown>).type);
+      return (
+        type === "toolresult" ||
+        type === "tool_result" ||
+        type === "toolcall" ||
+        type === "tool_call" ||
+        type === "tooluse" ||
+        type === "tool_use"
+      );
+    })
+  );
+}
+
+function hasPersistedToolHistoryMessages(messages: unknown[]): boolean {
+  return messages.some(isPersistedToolHistoryMessage);
+}
+
 function isTextOnlyContent(content: unknown): boolean {
   if (typeof content === "string") {
     return true;
@@ -780,6 +820,10 @@ async function loadChatHistoryUncached(
       const visibleStream = visibleAssistantStreamText(state.chatStream);
       const historyReplacedStream =
         visibleStream !== null && hasAssistantStreamReplacement(state.chatMessages, visibleStream);
+      const historyReplacedToolStream = hasPersistedToolHistoryMessages(state.chatMessages);
+      if (historyReplacedToolStream) {
+        maybeResetToolStream(state);
+      }
       if (!visibleStream || historyReplacedStream) {
         // Clear all streaming state — history includes tool results and text
         // inline, so keeping streaming artifacts would cause duplicates.

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -6,6 +6,7 @@ import {
 } from "../chat/heartbeat-display.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
+import { extractToolMessageRefs } from "../chat/tool-message-refs.ts";
 import { buildUserChatMessageContentBlocks } from "../chat/user-message-content.ts";
 import { formatConnectError } from "../connect-error.ts";
 import {
@@ -95,73 +96,6 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
   return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
 }
 
-function isPersistedToolHistoryMessage(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const entry = message as Record<string, unknown>;
-  const role = normalizeLowercaseStringOrEmpty(entry.role);
-  if (role === "toolresult" || role === "tool_result" || role === "tool" || role === "function") {
-    return true;
-  }
-  if (
-    typeof entry.toolCallId === "string" ||
-    typeof entry.tool_call_id === "string" ||
-    typeof entry.toolName === "string" ||
-    typeof entry.tool_name === "string"
-  ) {
-    return true;
-  }
-  return (
-    Array.isArray(entry.content) &&
-    entry.content.some((block) => {
-      if (!block || typeof block !== "object") {
-        return false;
-      }
-      const type = normalizeLowercaseStringOrEmpty((block as Record<string, unknown>).type);
-      return (
-        type === "toolresult" ||
-        type === "tool_result" ||
-        type === "toolcall" ||
-        type === "tool_call" ||
-        type === "tooluse" ||
-        type === "tool_use"
-      );
-    })
-  );
-}
-
-function collectToolCallIds(message: unknown): string[] {
-  if (!message || typeof message !== "object") {
-    return [];
-  }
-  const entry = message as Record<string, unknown>;
-  const ids = [entry.toolCallId, entry.tool_call_id, entry.toolUseId, entry.tool_use_id, entry.id]
-    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-    .map((value) => value.trim());
-  if (!Array.isArray(entry.content)) {
-    return ids;
-  }
-  for (const block of entry.content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const contentEntry = block as Record<string, unknown>;
-    for (const value of [
-      contentEntry.toolCallId,
-      contentEntry.tool_call_id,
-      contentEntry.toolUseId,
-      contentEntry.tool_use_id,
-      contentEntry.id,
-    ]) {
-      if (typeof value === "string" && value.trim()) {
-        ids.push(value.trim());
-      }
-    }
-  }
-  return ids;
-}
-
 function currentLiveToolCallIds(state: ChatState): string[] {
   const toolHost = state as ChatState & { toolStreamOrder?: unknown };
   return Array.isArray(toolHost.toolStreamOrder)
@@ -180,11 +114,8 @@ function persistedCurrentToolStreamIds(messages: unknown[], state: ChatState): S
   const liveToolIdSet = new Set(liveToolIds);
   const persistedToolIds = new Set<string>();
   for (const message of messages.slice(lastUserMessageIndex(messages) + 1)) {
-    if (!isPersistedToolHistoryMessage(message)) {
-      continue;
-    }
-    for (const id of collectToolCallIds(message)) {
-      persistedToolIds.add(id);
+    for (const ref of extractToolMessageRefs(message)) {
+      persistedToolIds.add(ref.id);
     }
   }
   for (const id of persistedToolIds) {
@@ -505,11 +436,7 @@ function currentToolStreamMessageIndex(
   }
   const startIndex = lastUserMessageIndex(messages) + 1;
   for (let index = startIndex; index < messages.length; index++) {
-    const message = messages[index];
-    if (!isPersistedToolHistoryMessage(message)) {
-      continue;
-    }
-    if (collectToolCallIds(message).some((id) => liveToolIds.has(id))) {
+    if (extractToolMessageRefs(messages[index]).some((ref) => liveToolIds.has(ref.id))) {
       return index;
     }
   }
@@ -916,8 +843,8 @@ function prunePersistedToolStreamMessages(state: ChatState, persistedToolIds: Se
   }
   if (Array.isArray(toolHost.chatToolMessages)) {
     toolHost.chatToolMessages = toolHost.chatToolMessages.filter((message) => {
-      const ids = collectToolCallIds(message);
-      return ids.every((id) => !persistedToolIds.has(id));
+      const refs = extractToolMessageRefs(message);
+      return refs.every((ref) => !persistedToolIds.has(ref.id));
     });
   }
   if (!Array.isArray(toolHost.chatStreamSegments)) {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1341,12 +1341,6 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = appendVisibleStreamStateMessages(
-        state.chatMessages,
-        state,
-        [finalMessage],
-        { includeCurrent: false },
-      );
       state.chatMessages = appendDisplayMessageIfMissing(state.chatMessages, finalMessage);
     } else {
       state.chatMessages = appendVisibleStreamStateMessages(state.chatMessages, state);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -300,11 +300,12 @@ function visibleAssistantStreamText(stream: string | null): string | null {
 function buildAssistantStreamMessage(
   stream: string,
   replacementText = stream,
+  timestamp = Date.now(),
 ): Record<string, unknown> {
   return {
     role: "assistant",
     content: [{ type: "text", text: stream }],
-    timestamp: Date.now(),
+    timestamp,
     openclawStreamFallback: {
       replacementText,
     },
@@ -394,6 +395,7 @@ type VisibleAssistantStreamPart = {
   text: string;
   replacementText: string;
   source: "segment" | "current";
+  timestamp: number;
 };
 
 function visibleAssistantStreamParts(
@@ -415,7 +417,13 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(segment.text, previousText),
     );
     if (visible) {
-      parts.push({ text: visible, replacementText: segment.text, source: "segment" });
+      parts.push({
+        text: visible,
+        replacementText: segment.text,
+        source: "segment",
+        timestamp:
+          typeof segment.ts === "number" && Number.isFinite(segment.ts) ? segment.ts : Date.now(),
+      });
     }
     if (segment.text.trim()) {
       previousText = segment.text;
@@ -426,7 +434,12 @@ function visibleAssistantStreamParts(
       trimAccumulatedVisibleStreamText(state.chatStream, previousText),
     );
     if (visible) {
-      parts.push({ text: visible, replacementText: state.chatStream, source: "current" });
+      parts.push({
+        text: visible,
+        replacementText: state.chatStream,
+        source: "current",
+        timestamp: state.chatStreamStartedAt ?? Date.now(),
+      });
     }
   }
   return parts;
@@ -475,7 +488,11 @@ function appendVisibleStreamStateMessages(
     if (hasAssistantStreamPartReplacement([...nextMessages, ...replacementMessages], part)) {
       continue;
     }
-    const streamMessage = buildAssistantStreamMessage(part.text, part.replacementText);
+    const streamMessage = buildAssistantStreamMessage(
+      part.text,
+      part.replacementText,
+      part.timestamp,
+    );
     const toolIndex =
       part.source === "segment" ? firstCurrentToolStreamMessageIndex(nextMessages, state) : -1;
     nextMessages =
@@ -791,6 +808,13 @@ function maybeResetToolStream(state: ChatState, opts?: { preserveStreamSegments?
   }
 }
 
+function clearToolStreamSegments(state: ChatState) {
+  const toolHost = state as ChatState & { chatStreamSegments?: unknown };
+  if (Array.isArray(toolHost.chatStreamSegments)) {
+    toolHost.chatStreamSegments = [];
+  }
+}
+
 function resolveDeltaChatStreamText(
   currentStream: string | null,
   payload: ChatEventPayload,
@@ -1014,10 +1038,16 @@ async function loadChatHistoryUncached(
         state.chatMessages,
         state,
       );
+      const liveToolStreamReplaced =
+        currentLiveToolCallIds(state).length === 0 || historyReplacedToolStream;
       if (visibleStreamParts.length === 0 || historyReplacedStream) {
-        // Clear all streaming state — history includes tool results and text
-        // inline, so keeping streaming artifacts would cause duplicates.
-        maybeResetToolStream(state);
+        if (liveToolStreamReplaced) {
+          // Clear all streaming state — history includes tool results and text
+          // inline, so keeping streaming artifacts would cause duplicates.
+          maybeResetToolStream(state);
+        } else {
+          clearToolStreamSegments(state);
+        }
         state.chatStream = null;
         state.chatStreamStartedAt = null;
         recordChatHistoryTiming(state, "stream-reset", startedAtMs, {

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -363,9 +363,57 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         models: [],
       });
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
+      await page.getByText("First token visible.").waitFor({ timeout: 10_000 });
       await gateway.emitChatFinal({ runId, text: "History race stayed visible." });
       await page.getByText("History race stayed visible.").waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("agents.list")).toHaveLength(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps streamed text visible when a chat error terminates the turn", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const prompt = "stream before terminal error";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+      const partialText = "Partial answer before gateway error.";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: partialText,
+        message: {
+          content: [{ text: partialText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await page.getByText(partialText).waitFor({ timeout: 10_000 });
+
+      await gateway.emitGatewayEvent("chat", {
+        errorMessage: "gateway disconnected",
+        runId,
+        sessionKey: "main",
+        state: "error",
+      });
+
+      await page.getByText(partialText).waitFor({ timeout: 10_000 });
+      await page.getByText("Error: gateway disconnected").waitFor({ timeout: 10_000 });
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

AI-assisted: yes.

## Summary

WebChat could show assistant text, then make it disappear.
This keeps visible streamed assistant text on screen when stale history, tool-history catch-up, or terminal run events arrive.
The confirmed bug is in WebChat state reconciliation, not in local-model latency itself.

## What Changed

The chat UI now has one place for deciding whether visible stream text should stay, be materialized into history, or be replaced by persisted messages.
That makes stale history reloads, terminal final/error/abort events, and tool-result catch-up follow the same rule.

- Added `ui/src/ui/chat/stream-reconciliation.ts` for stream/history/tool reconciliation.
- Added `ui/src/ui/chat/stream-text.ts` for shared stream text normalization and matching.
- Added `ui/src/ui/chat/tool-message-refs.ts` so tool message ids/names are read through one typed helper instead of scattered field checks.
- Kept visible `chatStream` when a stale history reload does not contain replacement assistant text.
- Materialized visible streamed assistant text before terminal final, aborted, or error cleanup.
- Pruned live tool cards only after persisted history includes the same tool ids.
- Reworked `build-chat-items` so persisted tool-history rows and live tool-stream rows do not double-render.
- Replaced the earlier controller-local patch with smaller helpers and focused tests around each rule.

## Linked Context

Closes #67035.

Related PR: #77418.

This follows the narrowed maintainer repro from `run_e7fc89b73ec0`, where composer preservation passed but stale refresh and terminal-error stream retention failed.

## Real Behavior Proof

I tested the real WebChat path and the focused mocked browser paths.
The live smoke used the built Control UI from this branch with a real local OpenClaw gateway and the `testbob` Codex/OpenAI agent config.

- Behavior addressed: visible WebChat assistant stream text disappearing after stale history refreshes, tool-history catch-up, or terminal chat events.
- Real environment tested: macOS local OpenClaw checkout, built Control UI, real local gateway on `127.0.0.1:18790`, WebChat session `main`, Codex/OpenAI agent runtime.
- Live smoke after the refactors:
  - Built current UI with `pnpm ui:build`.
  - Started gateway from this checkout with the `testbob` config.
  - Opened `http://127.0.0.1:18790/chat?session=main`.
  - Sent `Live smoke on PR 89530: reply with exactly "live smoke ok 89530".`
  - Verified the assistant reply `live smoke ok 89530` appeared under the user prompt.
  - Reloaded the page and verified the user prompt and assistant reply rehydrated correctly.
  - Sent a longer 12-line response using `SMOKE89530-LINE-* OK` markers.
  - Reloaded again and verified all 12 assistant lines rehydrated correctly.
- Before evidence: Crabbox AWS browser repro `provider=aws`, lease `cbx_126c45468a1a`, run `run_e7fc89b73ec0` failed 2 of 3 checks before this patch.
- What was not tested: true Windows IME input and live LM Studio/local-model streaming timing.
- Proof limitation: the live model completed quickly, so the live smoke proves completed-output/history rehydration. The mid-token stream interruption case is covered by the mocked browser/controller tests.

## Tests and Validation

The regression tests cover the state rules directly, and the browser tests cover the visible WebChat behavior.
Current-head CI is also green.

- `node scripts/run-vitest.mjs ui/src/ui/chat/tool-message-refs.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/app-chat.test.ts --reporter=dot`
- `pnpm exec oxfmt --check ui/src/ui/chat/stream-reconciliation.ts ui/src/ui/chat/stream-text.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/controllers/chat.ts`
- `pnpm lint:core -- ui/src/ui/chat/stream-reconciliation.ts ui/src/ui/chat/stream-text.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/controllers/chat.ts`
- `git diff --check`
- `pnpm ui:build`
- Live WebChat smoke through `http://127.0.0.1:18790/chat?session=main`

Regression coverage added or updated:

- Error events preserve partial streamed assistant text before clearing stream state.
- Error events avoid duplicating streamed text when the server already supplied the same assistant message.
- Stale history reloads keep active visible streamed text.
- Stale history reloads materialize orphaned streamed text when no active run remains.
- Caught-up history clears streamed text when it contains the replacement assistant message.
- Tool-history catch-up clears live tool cards only when matching persisted tool ids exist.
- Mocked browser E2E verifies visible stream text survives stale startup history and terminal error.

## Risks

The main risk is message ordering or duplication in WebChat.
The refactor reduces that risk by centralizing the matching and materialization rules instead of keeping separate controller-only checks.

- User-visible behavior changed: Yes.
- Config, environment, or migration behavior changed: No.
- Security, auth, secrets, network, or tool execution behavior changed: No.
- Highest-risk area: WebChat message reconciliation around stream/history/tool ordering.
- Risk mitigation: focused controller tests, tool-message tests, build-chat-items tests, mocked browser E2E, green CI, and live WebChat smoke.

## Current Review State

ClawSweeper has no concrete blocker on current head `9999d6dde242cdc4d9053fcfb0fd4ae211f7b707`.
GitHub reports the PR as mergeable and clean.
Current-head checks are green: 133 success, 25 skipped, 1 neutral, 0 failing, 0 pending.
