### PR TITLE
test(codex): cover binds without model overrides

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -296,6 +296,33 @@ describe("codex conversation binding", () => {
     expect(bindingAfterStart.networkProxyConfigFingerprint).toBe(NETWORK_PROXY_CONFIG_FINGERPRINT);
   });
 
+  it("starts a new bind thread when no model override is provided", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        return {
+          thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+          model: "gpt-5.5",
+        };
+      }),
+    });
+
+    await startCodexConversationThread({
+      sessionFile,
+      workspaceDir: tempDir,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("thread/start");
+    expect(requests[0]?.params).not.toHaveProperty("model");
+    expect(requests[0]?.params).not.toHaveProperty("modelProvider");
+    await expect(fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8")).resolves.toContain(
+      '"model": "gpt-5.5"',
+    );
+  });
+
   it("preserves Codex auth and omits the public OpenAI provider for native bind threads", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Adds regression coverage for `/codex bind` when the user does not pass `--model`.
- Covers the command path behind openclaw/openclaw#89534, where a released bundle returned `Codex command failed: defaultModel is not defined` instead of binding a Codex app-server thread.

Why does this matter now?

- The default bind flow is the ergonomic path shown by `/codex bind [thread-id] [--cwd <path>] [--model <model>] [--provider <provider>]`.
- A no-model bind should either let Codex app-server use its configured default or persist the model returned by app-server, not fail before the thread is created.

What is the intended outcome?

- Current and future Codex binding changes keep the no-model `thread/start` path working.
- The binding sidecar persists the app-server-returned model after a successful no-override bind.

What is intentionally out of scope?

- This PR does not change Codex model selection behavior on current `main`.
- It does not backport the local release hot patch; current `main` has already refactored the exact released bundle shape.

What does success look like?

- The focused Codex conversation binding test passes.
- `/codex bind --cwd <path>` remains covered when neither `model` nor `modelProvider` is supplied by the command.

What should reviewers focus on?

- Whether the regression assertion matches the intended no-override behavior: no `model` or public `modelProvider` is sent, and the returned app-server model is persisted.

## Linked context

Which issue does this close?

Closes #89534

Which issues, PRs, or discussions are related?

Related #89534

Was this requested by a maintainer or owner?

No. This is contributor-submitted after observing the failure in a live AlphaClaw/OpenClaw deployment.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/codex bind --cwd /home/art/projects/lobster-workflows/` failed when no `--model` was provided.
- Real environment tested: OpenClaw `2026.5.28 (e932160)` through AlphaClaw Docker on NixOS, from a Telegram topic using `openai/gpt-5.5` with the OpenAI Codex runtime.
- Exact steps or command run after this patch: Sent `/codex bind --cwd /home/art/projects/lobster-workflows/` in the same Telegram topic after applying the local runtime patch and restarting AlphaClaw.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
> Art Kessler:
/codex bind --cwd /home/art/projects/lobster-workflows/

> Niemand:
Bound this conversation to Codex thread 019e8922-a66f-7dd0-9e22-ac67a383a648 in /home/art/projects/lobster-workflows/.
```

- Observed result after fix: The conversation bound to a Codex app-server thread instead of returning the `defaultModel` ReferenceError.
- What was not tested: Full OpenClaw suite, broad changed checks, and a clean current-main live gateway reproduction. Current `main` has already refactored the exact release-bundle shape, so this PR adds regression coverage rather than changing production code.
- Proof limitations or environment constraints: The before/after proof came from a private Telegram topic; the copied output is the redacted durable evidence. The PR itself is test-only because current `main` no longer contains the exact generated release-bundle ReferenceError shape.
- Before evidence (optional but encouraged):

```text
> Art Kessler:
/codex bind --cwd /home/art/projects/lobster-workflows/

> Niemand:
Codex command failed: defaultModel is not defined

> Art Kessler:
/codex status

> Niemand:
Codex app-server: connected
Models: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark
Account: subs@kessler.io
Rate limits: Codex: primary 85% left ...
```

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts
/home/art/projects/ai-dotfiles/skills/autoreview/scripts/autoreview --mode local --reviewers agy:gemini-3.5-flash:high --prompt 'Review the local regression-test patch before opening an upstream OpenClaw PR. Focus on whether the test accurately covers /codex bind without --model after the observed release failure: Codex command failed: defaultModel is not defined.'
```

What regression coverage was added or updated?

- Added `starts a new bind thread when no model override is provided` in `extensions/codex/src/conversation-binding.test.ts`.
- The test asserts `thread/start` is called without `model` or `modelProvider`, then verifies the model returned by app-server is written into the Codex app-server binding file.

What failed before this fix, if known?

- Live OpenClaw `2026.5.28 (e932160)` returned `Codex command failed: defaultModel is not defined` for `/codex bind --cwd /home/art/projects/lobster-workflows/`.

If no test was added, why not?

- A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No. Test-only change.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Low risk. The test documents existing no-override behavior and does not alter runtime code.

How is that risk mitigated?

The focused Codex conversation binding test passed locally, and `agy` high-thinking autoreview reported no accepted/actionable findings.

## Current review state

What is the next action?

Maintainer review of the regression-test scope.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review.

Which bot or reviewer comments were addressed?

None yet.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex_gpt--5.5_(high)](https://img.shields.io/badge/Codex_gpt--5.5_(high)-000000)
![Antigravity_Gemini_3.5_Flash_(high)](https://img.shields.io/badge/Antigravity_Gemini_3.5_Flash_(high)-4285F4?logo=googlegemini&logoColor=white)
