### PR TITLE
fix(googlechat): deliver media as a text link when app-auth upload 403s

### DIFF
--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -308,4 +308,83 @@ describe("googlechat message actions", () => {
 
     expect(listGoogleChatReactions).not.toHaveBeenCalled();
   });
+
+  it("falls back to a text link when remote media upload hits an app-auth 403 (#89430)", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    const readRemoteMediaBuffer = vi.fn(async () => ({
+      buffer: Buffer.from("remote-bytes"),
+      fileName: "remote.png",
+      contentType: "image/png",
+    }));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: { media: { readRemoteMediaBuffer } },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(
+      new Error(
+        'Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes."}}',
+      ),
+    );
+    sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link" });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    const result = await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "caption",
+        media: "https://example.com/file.png",
+        threadId: "thread-1",
+      },
+      cfg: {},
+      accountId: "default",
+    } as never);
+
+    // The public URL is delivered as plain text instead of throwing, so the reply is not lost.
+    expect(sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.com/file.png",
+      thread: "thread-1",
+    });
+    expect(sendGoogleChatMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ attachments: expect.anything() }),
+    );
+    expectJsonResult(result, { ok: true, to: "spaces/AAA", mediaDelivery: "link-fallback" });
+  });
+
+  it("does not fall back for a local-file upload failure (no public URL to link) (#89430)", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/BBB");
+    const localRoot = "/tmp/googlechat-action-test";
+    const localPath = path.join(localRoot, "local.md");
+    const readFile = vi.fn(async () => Buffer.from("local-bytes"));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: { media: { readRemoteMediaBuffer: vi.fn() } },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    // A local file has no public URL to fall back to, so the auth failure must still surface.
+    await expect(
+      googlechatMessageActions.handleAction({
+        action: "upload-file",
+        params: { to: "spaces/BBB", path: localPath, message: "notes" },
+        cfg: {},
+        accountId: "default",
+        mediaLocalRoots: [localRoot],
+        mediaReadFile: readFile,
+      } as never),
+    ).rejects.toThrow("Google Chat upload 403");
+    expect(sendGoogleChatMessage).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -20,6 +20,11 @@ import {
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
+import {
+  buildMediaLinkFallbackText,
+  isAuthScopeUploadFailure,
+  isRemoteHttpMediaUrl,
+} from "./media-upload-fallback.js";
 import { getGoogleChatRuntime } from "./runtime.js";
 import { resolveGoogleChatOutboundSpace } from "./targets.js";
 
@@ -140,13 +145,30 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           readStringParam(params, "title") ??
           loaded.fileName ??
           "attachment";
-        const upload = await uploadGoogleChatAttachment({
-          account,
-          space,
-          filename: uploadFileName,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-        });
+        let upload: Awaited<ReturnType<typeof uploadGoogleChatAttachment>>;
+        try {
+          upload = await uploadGoogleChatAttachment({
+            account,
+            space,
+            filename: uploadFileName,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+          });
+        } catch (uploadErr) {
+          // App (bot) auth (chat.bot scope) can't upload attachments → 403. For remote http(s)
+          // media, deliver the URL as a text link instead of throwing; local files (no public
+          // URL) and non-auth failures still surface. #89430
+          if (isAuthScopeUploadFailure(uploadErr) && isRemoteHttpMediaUrl(mediaUrl)) {
+            await sendGoogleChatMessage({
+              account,
+              space,
+              text: buildMediaLinkFallbackText(content, mediaUrl),
+              thread: threadId ?? undefined,
+            });
+            return jsonResult({ ok: true, to: space, mediaDelivery: "link-fallback" });
+          }
+          throw uploadErr;
+        }
         await sendGoogleChatMessage({
           account,
           space,

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -37,6 +37,11 @@ import {
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
+import {
+  buildMediaLinkFallbackText,
+  isAuthScopeUploadFailure,
+  isRemoteHttpMediaUrl,
+} from "./media-upload-fallback.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -310,13 +315,39 @@ export const googlechatOutboundAdapter = {
           });
       const { sendGoogleChatMessage, uploadGoogleChatAttachment } =
         await loadGoogleChatChannelRuntime();
-      const upload = await uploadGoogleChatAttachment({
-        account,
-        space,
-        filename: loaded.fileName ?? "attachment",
-        buffer: loaded.buffer,
-        contentType: loaded.contentType,
-      });
+      let upload: Awaited<ReturnType<typeof uploadGoogleChatAttachment>>;
+      try {
+        upload = await uploadGoogleChatAttachment({
+          account,
+          space,
+          filename: loaded.fileName ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+      } catch (uploadErr) {
+        // App (bot) auth (chat.bot scope) can't upload attachments → 403. Deliver the public
+        // media URL as a text link instead of failing the send. Narrowly scoped to remote
+        // http(s) media and auth/scope failures; everything else rethrows. #89430
+        if (isAuthScopeUploadFailure(uploadErr) && isRemoteHttpMediaUrl(mediaUrl)) {
+          const fallback = await sendGoogleChatMessage({
+            account,
+            space,
+            text: buildMediaLinkFallbackText(text, mediaUrl),
+            thread,
+          });
+          const fallbackId = fallback?.messageName ?? "";
+          return {
+            messageId: fallbackId,
+            chatId: space,
+            receipt: createGoogleChatSendReceipt({
+              messageId: fallbackId,
+              chatId: space,
+              kind: "text",
+            }),
+          };
+        }
+        throw uploadErr;
+      }
       const result = await sendGoogleChatMessage({
         account,
         space,

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -406,6 +406,61 @@ describe("googlechatPlugin outbound sendMedia", () => {
     expect(result.chatId).toBe("spaces/AAA");
     expect(result.receipt.primaryPlatformMessageId).toBe("spaces/AAA/messages/msg-2");
   });
+
+  it("delivers the media URL as a text link when app-auth upload returns 403 (#89430)", async () => {
+    setupRuntimeMediaMocks({ loadFileName: "remote.png", loadBytes: "remote-bytes" });
+    uploadGoogleChatAttachmentMock.mockRejectedValue(
+      new Error(
+        'Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes."}}',
+      ),
+    );
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/link",
+    });
+
+    const cfg = createGoogleChatCfg();
+
+    const result = await googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+    });
+
+    // The remote URL is salvaged as a plain text message instead of being dropped.
+    const sendRequest = requireMockArg(sendGoogleChatMessageMock) as {
+      space?: string;
+      text?: string;
+      attachments?: unknown;
+    };
+    expect(sendRequest.space).toBe("spaces/AAA");
+    expect(sendRequest.text).toBe("caption\nhttps://example.com/image.png");
+    expect(sendRequest.attachments).toBeUndefined();
+    expect(result.messageId).toBe("spaces/AAA/messages/link");
+    expect(result.receipt.parts[0]?.kind).toBe("text");
+  });
+
+  it("rethrows non-auth upload failures instead of falling back (#89430)", async () => {
+    setupRuntimeMediaMocks({ loadFileName: "remote.png", loadBytes: "remote-bytes" });
+    uploadGoogleChatAttachmentMock.mockRejectedValue(
+      new Error("Google Chat upload 500: internal error"),
+    );
+
+    const cfg = createGoogleChatCfg();
+
+    // A 500 is not an auth/scope failure, so the error must surface (no silent text fallback).
+    await expect(
+      googlechatOutboundAdapter.attachedResults.sendMedia({
+        cfg,
+        to: "spaces/AAA",
+        text: "caption",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "default",
+      }),
+    ).rejects.toThrow("Google Chat upload 500");
+    expect(sendGoogleChatMessageMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("googlechatPlugin threading", () => {

--- a/extensions/googlechat/src/media-upload-fallback.test.ts
+++ b/extensions/googlechat/src/media-upload-fallback.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMediaLinkFallbackText,
+  isAuthScopeUploadFailure,
+  isRemoteHttpMediaUrl,
+} from "./media-upload-fallback.js";
+
+describe("media upload fallback predicates (#89430)", () => {
+  describe("isAuthScopeUploadFailure", () => {
+    it("matches the chat.bot insufficient-scope 403 from the upload endpoint", () => {
+      expect(
+        isAuthScopeUploadFailure(
+          new Error(
+            'Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes.","details":[{"reason":"ACCESS_TOKEN_SCOPE_INSUFFICIENT"}]}}',
+          ),
+        ),
+      ).toBe(true);
+      // The reason code alone (without the human message) also qualifies.
+      expect(
+        isAuthScopeUploadFailure(
+          new Error("Google Chat upload 403: ACCESS_TOKEN_SCOPE_INSUFFICIENT"),
+        ),
+      ).toBe(true);
+    });
+
+    it("does NOT match a non-scope 403 — quota, not-a-member, or generic PERMISSION_DENIED", () => {
+      // Real upload denials a text link cannot fix: they must surface unchanged, not degrade.
+      expect(
+        isAuthScopeUploadFailure(
+          new Error("Google Chat upload 403: RESOURCE_EXHAUSTED Quota exceeded"),
+        ),
+      ).toBe(false);
+      expect(
+        isAuthScopeUploadFailure(
+          new Error(
+            'Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"The caller does not have permission"}}',
+          ),
+        ),
+      ).toBe(false);
+      expect(isAuthScopeUploadFailure(new Error("Google Chat upload 403: Forbidden"))).toBe(false);
+    });
+
+    it("does NOT match non-403 upload errors — size, network, malformed", () => {
+      expect(isAuthScopeUploadFailure(new Error("Google Chat upload 500: internal error"))).toBe(
+        false,
+      );
+      expect(
+        isAuthScopeUploadFailure(new Error("Google Chat media exceeds max bytes (20971520)")),
+      ).toBe(false);
+      expect(isAuthScopeUploadFailure(new Error("fetch failed"))).toBe(false);
+    });
+
+    it("handles non-Error inputs without throwing", () => {
+      expect(isAuthScopeUploadFailure(undefined)).toBe(false);
+      expect(isAuthScopeUploadFailure(null)).toBe(false);
+      expect(isAuthScopeUploadFailure("Request had insufficient authentication scopes")).toBe(true);
+    });
+  });
+
+  describe("isRemoteHttpMediaUrl", () => {
+    it("accepts http(s) URLs and rejects local paths, file:// and data URIs", () => {
+      expect(isRemoteHttpMediaUrl("https://example.com/a.png")).toBe(true);
+      expect(isRemoteHttpMediaUrl("http://example.com/a.png")).toBe(true);
+      expect(isRemoteHttpMediaUrl("/tmp/a.png")).toBe(false);
+      expect(isRemoteHttpMediaUrl("file:///tmp/a.png")).toBe(false);
+      expect(isRemoteHttpMediaUrl("data:image/png;base64,AAAA")).toBe(false);
+      expect(isRemoteHttpMediaUrl(undefined)).toBe(false);
+      expect(isRemoteHttpMediaUrl(null)).toBe(false);
+    });
+  });
+
+  describe("buildMediaLinkFallbackText", () => {
+    it("appends the URL to a caption, or returns the URL alone when the caption is empty", () => {
+      expect(buildMediaLinkFallbackText("here you go", "https://x/a.png")).toBe(
+        "here you go\nhttps://x/a.png",
+      );
+      expect(buildMediaLinkFallbackText("   ", "https://x/a.png")).toBe("https://x/a.png");
+      expect(buildMediaLinkFallbackText(undefined, "https://x/a.png")).toBe("https://x/a.png");
+    });
+  });
+});

--- a/extensions/googlechat/src/media-upload-fallback.ts
+++ b/extensions/googlechat/src/media-upload-fallback.ts
@@ -1,0 +1,40 @@
+// Under Google Chat *app* (bot) authentication the granted scope is chat.bot (see auth.ts
+// CHAT_SCOPE), which is NOT authorized for the attachment upload endpoint. Google's OAuth
+// layer rejects the upload with a 403 whose body says "Request had insufficient authentication
+// scopes" (reason ACCESS_TOKEN_SCOPE_INSUFFICIENT). The media itself is reachable at a public
+// URL, so rather than silently dropping it (the prior behavior, which lost the message) we fall
+// back to delivering the URL as a text link.
+//
+// Keep this narrow on BOTH axes so a link never masks a failure it can't fix:
+//   - only this *scope* denial qualifies — a bare 403, quota (RESOURCE_EXHAUSTED), not-a-member
+//     or any other PERMISSION_DENIED upload error still surfaces (a text link wouldn't deliver
+//     to a space the bot can't post to, or fix a quota problem);
+//   - only remote http(s) media qualifies — a local file has no public URL to fall back to.
+// #89430
+
+export function isAuthScopeUploadFailure(err: unknown): boolean {
+  const message =
+    err instanceof Error ? err.message : typeof err === "string" ? err : String(err ?? "");
+  if (!message) {
+    return false;
+  }
+  // Match Google's documented OAuth scope-denial signals specifically, NOT a bare 403 or a
+  // generic PERMISSION_DENIED, so non-scope upload denials are not misclassified as scope
+  // failures and silently degraded to a link.
+  return (
+    /insufficient authentication scopes?/i.test(message) ||
+    /ACCESS_TOKEN_SCOPE_INSUFFICIENT/i.test(message)
+  );
+}
+
+export function isRemoteHttpMediaUrl(mediaUrl: string | null | undefined): mediaUrl is string {
+  return typeof mediaUrl === "string" && /^https?:\/\//i.test(mediaUrl);
+}
+
+export function buildMediaLinkFallbackText(
+  text: string | null | undefined,
+  mediaUrl: string,
+): string {
+  const trimmed = (text ?? "").trim();
+  return trimmed.length > 0 ? `${trimmed}\n${mediaUrl}` : mediaUrl;
+}

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -10,6 +10,11 @@ import {
   updateGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
+import {
+  buildMediaLinkFallbackText,
+  isAuthScopeUploadFailure,
+  isRemoteHttpMediaUrl,
+} from "./media-upload-fallback.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
 export async function deliverGoogleChatReply(params: {
@@ -111,13 +116,26 @@ export async function deliverGoogleChatReply(params: {
           url: mediaUrl,
           maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
         });
-        const upload = await uploadAttachmentForReply({
-          account,
-          spaceId,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-          filename: loaded.fileName ?? "attachment",
-        });
+        let upload: Awaited<ReturnType<typeof uploadAttachmentForReply>>;
+        try {
+          upload = await uploadAttachmentForReply({
+            account,
+            spaceId,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+            filename: loaded.fileName ?? "attachment",
+          });
+        } catch (uploadErr) {
+          // App (bot) auth carries only the chat.bot scope, which can't upload attachments and
+          // returns 403; the media is reachable at its public URL, so deliver it as a text link
+          // instead of silently dropping the reply. Non-auth/non-http failures still surface. #89430
+          if (isAuthScopeUploadFailure(uploadErr) && isRemoteHttpMediaUrl(mediaUrl)) {
+            await sendTextMessage(buildMediaLinkFallbackText(caption, mediaUrl));
+            statusSink?.({ lastOutboundAt: Date.now() });
+            return;
+          }
+          throw uploadErr;
+        }
         if (!upload.attachmentUploadToken) {
           throw new Error("missing attachment upload token");
         }

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -141,4 +141,76 @@ describe("Google Chat reply delivery", () => {
       attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
     });
   });
+
+  it("delivers the media URL as a text link when app-auth upload returns 403 (#89430)", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "shot.png" },
+    });
+    const runtime = createRuntime();
+    const statusSink = vi.fn();
+    mocks.uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error(
+        'Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes."}}',
+      ),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "here you go",
+        mediaUrl: "https://example.invalid/shot.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      statusSink,
+    });
+
+    // The reply is salvaged as a normal text message carrying the public URL instead of dropped.
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "here you go\nhttps://example.invalid/shot.png",
+      thread: "spaces/AAA/threads/root",
+    });
+    // No attachment send is attempted once the upload 403s.
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ attachments: expect.anything() }),
+    );
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back for non-auth upload failures (#89430)", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "shot.png" },
+    });
+    const runtime = createRuntime();
+    mocks.uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 500: internal error"),
+    );
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "here you go",
+        mediaUrl: "https://example.invalid/shot.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+    });
+
+    // A 500 is not an auth/scope failure, so no text-link fallback is sent and the error surfaces.
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Under Google Chat **app (bot)** authentication the OAuth scope is `chat.bot` (`extensions/googlechat/src/auth.ts:11`), which is **not authorized for the attachment upload endpoint** — Google's `media.upload` reference requires `chat.messages` / `chat.messages.create`, not the app `chat.bot` scope. `uploadGoogleChatAttachment` (`extensions/googlechat/src/api.ts:194`) therefore throws a 403 whose body is `... PERMISSION_DENIED ... Request had insufficient authentication scopes` (reason `ACCESS_TOKEN_SCOPE_INSUFFICIENT`).

All three outbound media paths swallowed that failure and dropped the media:

- `monitor-reply-delivery.ts` `sendMedia` only logged `Google Chat attachment send failed`
- `channel.adapters.ts` `attachedResults.sendMedia` had no `try`/`catch` (the error threw out)
- `actions.ts` `handleAction` had no `try`/`catch` (the error threw out)

so an agent replying with an image under app auth silently lost the message (impact:message-loss).

### Fix

A small shared module `media-upload-fallback.ts` adds a **narrow** fallback: when an upload fails with the OAuth **scope** denial **and** the media is a remote `http(s)` URL, deliver the URL as a text link instead of dropping it.

**Scoped to avoid over-matching** (addressing the review's `merge-risk: message-delivery` note): `isAuthScopeUploadFailure` now matches **only** Google's documented scope signals — `insufficient authentication scopes` / `ACCESS_TOKEN_SCOPE_INSUFFICIENT` — **not** a bare `403` or a generic `PERMISSION_DENIED`. A quota (`RESOURCE_EXHAUSTED`), not-a-member, or resource-forbidden 403 — none of which a text link can fix — still surfaces unchanged, as do non-403 errors (size / network / malformed) and local files (no public URL). No config flag, no cardsV2.

Fixes #89430

## Real behavior proof

**Behavior addressed**: Google Chat media replies under app (bot) auth were silently dropped because the `chat.bot` scope cannot upload attachments (403 `ACCESS_TOKEN_SCOPE_INSUFFICIENT`); they are now delivered as a text link, and **only** that scope denial triggers the fallback.

**Real environment tested**: vitest (the repo's `extension-messaging` config). A dedicated predicate suite (`media-upload-fallback.test.ts`) drives `isAuthScopeUploadFailure` / `isRemoteHttpMediaUrl` / `buildMediaLinkFallbackText` over the exact Google 403 error strings; three integration suites drive the real exported send paths (`deliverGoogleChatReply`, `googlechatOutboundAdapter.attachedResults.sendMedia`, `googlechatMessageActions.handleAction`) with `./api.js` mocked only at the HTTP boundary so `uploadGoogleChatAttachment` rejects with the real `Google Chat upload 403: {"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes."}}` string.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/googlechat/src/media-upload-fallback.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/channel.test.ts extensions/googlechat/src/actions.test.ts`

**Evidence after fix**: `Test Files  4 passed (4)` / `Tests  38 passed (38)`, including the predicate boundary suite and one fallback + one negative-control case per send path. Reverting only the three source-path edits (keeping the tests) flips exactly the three fallback cases to failing (`Tests  3 failed | 29 passed`), proving the tests bind the fix; the negative controls stay green either way.

**Observed result after fix**: On a scope-denial 403 with a remote `https` URL, each path calls `sendGoogleChatMessage` exactly once with `text` = caption + "\n" + URL and **no** attachments (reply receipt kind `text`); the message action returns `{ ok: true, mediaDelivery: "link-fallback" }`. A non-scope 403 (`RESOURCE_EXHAUSTED`, a bare `PERMISSION_DENIED`, `Forbidden`), a 500, and a local-file upload all surface their error with **no** fallback — confirmed directly by the predicate suite and the per-path negative controls.

**What was not tested**: A live Google Chat Workspace round-trip with a real service-account app-auth token — an external contributor has no access to such a workspace, so the upstream 403 is reproduced via the exact error string Google's OAuth layer returns (and that the upstream `media.upload` contract documents), not a live API call. cardsV2 image-widget delivery is intentionally out of scope per the issue's narrow-fallback direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
