### PR TITLE
fix(agents): cap runtime tool schema list scans

### DIFF
--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -99,6 +99,46 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     ]);
   });
 
+  it("quarantines oversized tool lists before provider schema normalization", () => {
+    const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
+    const tools = new Proxy([healthy] as AgentTool[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return 10_001;
+        }
+        if (property === "0") {
+          throw new Error("oversized sparse tool entry should not be read");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const diagnostics: RuntimeToolSchemaDiagnostic[][] = [];
+    mocks.normalizeProviderToolSchemas.mockImplementationOnce(({ tools: entries }) => entries);
+
+    expect(
+      normalizeAgentRuntimeTools({
+        tools,
+        provider: "openai",
+        onPreNormalizationSchemaDiagnostics: (entries) => diagnostics.push([...entries]),
+      }),
+    ).toEqual([]);
+    expect(mocks.normalizeProviderToolSchemas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: [],
+        provider: "openai",
+      }),
+    );
+    expect(diagnostics).toEqual([
+      [
+        {
+          toolName: "tool-list",
+          toolIndex: -1,
+          violations: ["runtime tool list length 10001 exceeds maximum 10000"],
+        },
+      ],
+    ]);
+  });
+
   it("quarantines non-object schemas before provider schema normalization", () => {
     const healthy = { ...createParameterFreeTool(), name: "healthy" } as AgentTool;
     const arraySchema = {

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -134,6 +134,54 @@ describe("runtime tool input schema projection", () => {
     });
   });
 
+  it("quarantines oversized runtime tool lists before walking sparse entries", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+    const tools = new Proxy([healthy] as Array<typeof healthy>, {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return 10_001;
+        }
+        if (property === "0") {
+          throw new Error("oversized sparse tool entry should not be read");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(filterRuntimeCompatibleTools(tools)).toEqual({
+      tools: [],
+      diagnostics: [
+        {
+          toolName: "tool-list",
+          toolIndex: -1,
+          violations: ["runtime tool list length 10001 exceeds maximum 10000"],
+        },
+      ],
+    });
+  });
+
+  it("quarantines invalid runtime tool list lengths", () => {
+    const tools = new Proxy([] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return Number.POSITIVE_INFINITY;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(inspectRuntimeToolInputSchemas(tools)).toEqual([
+      {
+        toolName: "tool-list",
+        toolIndex: -1,
+        violations: ["runtime tool list length must be a safe integer no greater than 10000"],
+      },
+    ]);
+  });
+
   it("quarantines unreadable runtime tool fields without dropping healthy siblings", () => {
     const unreadable = {
       name: "fuzzplugin_unreadable",

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -37,6 +37,13 @@ type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters"
 
 type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
 
+export const MAX_RUNTIME_TOOL_SCHEMA_ENTRIES = 10_000;
+const RUNTIME_TOOL_LIST_DIAGNOSTIC_INDEX = -1;
+
+export function isRuntimeToolListDiagnostic(diagnostic: RuntimeToolSchemaDiagnostic): boolean {
+  return diagnostic.toolIndex === RUNTIME_TOOL_LIST_DIAGNOSTIC_INDEX;
+}
+
 function unreadableRuntimeToolEntry(
   toolIndex: number,
 ): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
@@ -50,14 +57,50 @@ function unreadableRuntimeToolEntry(
   };
 }
 
+function invalidRuntimeToolListLength(): RuntimeToolEntryRead<
+  Pick<AnyAgentTool, "name" | "parameters">
+> {
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: "tool-list",
+      toolIndex: RUNTIME_TOOL_LIST_DIAGNOSTIC_INDEX,
+      violations: [
+        `runtime tool list length must be a safe integer no greater than ${MAX_RUNTIME_TOOL_SCHEMA_ENTRIES}`,
+      ],
+    },
+  };
+}
+
+function oversizedRuntimeToolList(
+  length: number,
+): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
+  return {
+    ok: false,
+    diagnostic: {
+      toolName: "tool-list",
+      toolIndex: RUNTIME_TOOL_LIST_DIAGNOSTIC_INDEX,
+      violations: [
+        `runtime tool list length ${length} exceeds maximum ${MAX_RUNTIME_TOOL_SCHEMA_ENTRIES}`,
+      ],
+    },
+  };
+}
+
 function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "parameters">>(
   tools: readonly TTool[],
 ): RuntimeToolEntryRead<TTool>[] {
-  let length: number;
+  let length: unknown;
   try {
     length = tools.length;
   } catch {
     return [unreadableRuntimeToolEntry(0) as RuntimeToolEntryRead<TTool>];
+  }
+  if (typeof length !== "number" || !Number.isSafeInteger(length) || length < 0) {
+    return [invalidRuntimeToolListLength() as RuntimeToolEntryRead<TTool>];
+  }
+  if (length > MAX_RUNTIME_TOOL_SCHEMA_ENTRIES) {
+    return [oversizedRuntimeToolList(length) as RuntimeToolEntryRead<TTool>];
   }
   const entries: RuntimeToolEntryRead<TTool>[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -1,7 +1,10 @@
 import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
+import {
+  isRuntimeToolListDiagnostic,
+  type RuntimeToolSchemaDiagnostic,
+} from "./tool-schema-projection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 const log = createSubsystemLogger("agents/tools");
@@ -10,6 +13,9 @@ function readDiagnosticPluginId(params: {
   tools: readonly AnyAgentTool[];
   diagnostic: RuntimeToolSchemaDiagnostic;
 }): string | undefined {
+  if (isRuntimeToolListDiagnostic(params.diagnostic)) {
+    return undefined;
+  }
   try {
     const tool = params.tools[params.diagnostic.toolIndex];
     return tool ? getPluginToolMeta(tool)?.pluginId : undefined;

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -13,6 +13,8 @@ import { resolveToolDisplay } from "./tool-display.js";
 import {
   filterProviderNormalizableTools,
   filterRuntimeCompatibleTools,
+  isRuntimeToolListDiagnostic,
+  MAX_RUNTIME_TOOL_SCHEMA_ENTRIES,
   type RuntimeToolSchemaDiagnostic,
 } from "./tool-schema-projection.js";
 import { buildEffectiveToolInventoryGroups } from "./tools-effective-inventory-groups.js";
@@ -75,6 +77,13 @@ function buildUnsupportedToolSchemaNotice(params: {
   tool: AnyAgentTool | undefined;
   fallbackTool: AnyAgentTool | undefined;
 }): EffectiveToolInventoryNotice {
+  if (isRuntimeToolListDiagnostic(params.diagnostic)) {
+    return {
+      id: `unsupported-tool-schema:${params.diagnostic.toolName}`,
+      severity: "warning",
+      message: `Runtime tool list has an unsupported shape (${params.diagnostic.violations.join(", ")}) and was quarantined before model projection. Reduce active tools, or disable/update the plugin/provider returning a malformed tool list.`,
+    };
+  }
   const sourceTool = params.tool ?? params.fallbackTool;
   const source = sourceTool
     ? resolveEffectiveToolSource(sourceTool, params.fallbackTool)
@@ -110,6 +119,9 @@ function readMatchingTool(
   tools: readonly AnyAgentTool[],
   diagnostic: RuntimeToolSchemaDiagnostic,
 ): AnyAgentTool | undefined {
+  if (isRuntimeToolListDiagnostic(diagnostic)) {
+    return undefined;
+  }
   try {
     const tool = tools[diagnostic.toolIndex];
     return tool?.name === diagnostic.toolName ? tool : undefined;
@@ -122,10 +134,16 @@ function buildReadableRawToolsByName(
   tools: readonly AnyAgentTool[],
 ): ReadonlyMap<string, AnyAgentTool> {
   const toolsByName = new Map<string, AnyAgentTool>();
-  let toolCount: number;
+  let toolCount: unknown;
   try {
     toolCount = tools.length;
   } catch {
+    return toolsByName;
+  }
+  if (typeof toolCount !== "number" || !Number.isSafeInteger(toolCount) || toolCount < 0) {
+    return toolsByName;
+  }
+  if (toolCount > MAX_RUNTIME_TOOL_SCHEMA_ENTRIES) {
     return toolsByName;
   }
   for (let index = 0; index < toolCount; index += 1) {

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -408,6 +408,39 @@ describe("resolveEffectiveToolInventory", () => {
     ]);
   });
 
+  it("reports oversized inventory tool lists without walking sparse entries", async () => {
+    const healthy = mockTool({ name: "exec", label: "Exec", description: "Run shell commands" });
+    const readSparseEntry = vi.fn(() => {
+      throw new Error("oversized sparse inventory entry should not be read");
+    });
+    const tools = new Proxy([healthy] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return 10_001;
+        }
+        if (property === "0") {
+          readSparseEntry();
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal14 } =
+      await loadHarness({ tools });
+
+    const result = resolveEffectiveToolInventoryLocal14({ cfg: {} });
+
+    expect(result.groups).toEqual([]);
+    expect(result.notices).toEqual([
+      {
+        id: "unsupported-tool-schema:tool-list",
+        severity: "warning",
+        message:
+          "Runtime tool list has an unsupported shape (runtime tool list length 10001 exceeds maximum 10000) and was quarantined before model projection. Reduce active tools, or disable/update the plugin/provider returning a malformed tool list.",
+      },
+    ]);
+    expect(readSparseEntry).not.toHaveBeenCalled();
+  });
+
   it("validates normalized runtime schemas before quarantining effective tools", async () => {
     const normalizeToolsMock = vi.fn((options: { tools: AnyAgentTool[] }) =>
       options.tools.map((entry) =>

--- a/src/flows/doctor-core-checks.runtime-errors.test.ts
+++ b/src/flows/doctor-core-checks.runtime-errors.test.ts
@@ -141,6 +141,35 @@ describe("doctor runtime tool schema error handling", () => {
     expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
   });
 
+  it("reports oversized agent runtime tool lists without blaming the first plugin", async () => {
+    const firstTool = tool("fuzzplugin_first", { type: "object", properties: {} });
+    setPluginToolMeta(firstTool, { pluginId: "fuzzplugin", optional: false });
+    const tools = new Proxy([firstTool] as AnyAgentTool[], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return 10_001;
+        }
+        if (property === "0") {
+          throw new Error("oversized sparse doctor entry should not be read");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    mocks.createOpenClawCodingTools.mockReturnValueOnce(tools);
+
+    await expect(collectRuntimeToolSchemaFindings({})).resolves.toContainEqual({
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: "Agent main runtime tool list has an unsupported shape for runtime projection.",
+      path: "agents.main.tools",
+      target: "tool-list",
+      requirement: "runtime tool list length 10001 exceeds maximum 10000",
+      fixHint:
+        "Reduce active tools or disable/update the plugin/provider returning a malformed tool list, then rerun doctor.",
+    });
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("reports bundle MCP runtime tool normalization failures without aborting doctor", async () => {
     mocks.createBundleMcpToolRuntime.mockResolvedValueOnce({
       tools: [bundleMcpTool("fuzzplugin__move_angles", { type: "object", properties: {} })],

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -25,6 +25,7 @@ import { supportsModelTools } from "../agents/model-tool-support.js";
 import { normalizeAgentRuntimeTools } from "../agents/runtime-plan/tools.js";
 import { collectExplicitAllowlist, normalizeToolName } from "../agents/tool-policy.js";
 import {
+  isRuntimeToolListDiagnostic,
   inspectRuntimeToolInputSchemas,
   type RuntimeToolSchemaDiagnostic,
 } from "../agents/tool-schema-projection.js";
@@ -547,6 +548,18 @@ function toolSchemaDiagnosticToFinding(params: {
   tools: readonly AnyAgentTool[];
   diagnostic: RuntimeToolSchemaDiagnostic;
 }): HealthFinding {
+  if (isRuntimeToolListDiagnostic(params.diagnostic)) {
+    return {
+      checkId: "core/doctor/runtime-tool-schemas",
+      severity: "error",
+      message: `Agent ${params.agentId} runtime tool list has an unsupported shape for runtime projection.`,
+      path: `agents.${params.agentId}.tools`,
+      target: params.diagnostic.toolName,
+      requirement: params.diagnostic.violations.join(", "),
+      fixHint:
+        "Reduce active tools or disable/update the plugin/provider returning a malformed tool list, then rerun doctor.",
+    };
+  }
   let tool: AnyAgentTool | undefined;
   try {
     tool = params.tools[params.diagnostic.toolIndex];


### PR DESCRIPTION
## Summary

- Cap runtime tool schema list inspection before reading entries so oversized sparse/proxy tool lists cannot stall assistant startup, doctor, or effective inventory.
- Add a list-level schema diagnostic sentinel so aggregate list failures are not attributed to the first tool/plugin.
- Surface clear doctor and inventory warnings for malformed/oversized active tool lists.

## Verification

- `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/agents/runtime-plan/tools.test.ts src/agents/tools-effective-inventory.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts src/agents/runtime-plan/tools.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/agents/tool-schema-quarantine.ts src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime-errors.test.ts`
- `./node_modules/.bin/oxlint src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts src/agents/runtime-plan/tools.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/agents/tool-schema-quarantine.ts src/flows/doctor-core-checks.runtime.ts src/flows/doctor-core-checks.runtime-errors.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_8e159198ecd3`, run `run_fc58fa0921d9`, exit 0

## Real behavior proof

Behavior addressed: A malformed plugin/provider/runtime tool source can no longer make schema projection, doctor, or tool inventory walk an oversized sparse/proxy tool list before quarantine.

Real environment tested: Local macOS sparse `gwt` worktree with shared repo dependencies; AWS Crabbox Linux fresh PR checkout at head `fd9cc118b3313ae868035d22c28939a5a48388cf`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-schema-projection.test.ts src/agents/runtime-plan/tools.test.ts src/agents/tools-effective-inventory.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts -- --reporter=dot`; AWS Crabbox `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: Regression tests now cover oversized runtime projection lists, invalid list lengths, runtime-plan pre-normalization quarantine, effective inventory aggregate warnings without sparse entry reads, and doctor findings that do not blame the first plugin; remote changed gate selected `core, coreTests` and completed all guard, typecheck, lint, and import-cycle checks.

Observed result after fix: Focused Vitest passed, formatter/lint/diff checks passed, autoreview reported no accepted/actionable findings, and remote `check:changed` passed in run `run_fc58fa0921d9`.

What was not tested: No live provider/Telegram turn; this is covered at the shared runtime schema projection, doctor, and inventory contracts.
