### PR TITLE
fix(agents): harden OpenAI strict schema inspection

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearOpenAIToolSchemaCacheForTest,
+  findOpenAIStrictToolSchemaDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
@@ -90,5 +91,163 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("reports circular strict schemas without recursing forever", () => {
+    const schema: {
+      type: "object";
+      properties: Record<string, unknown>;
+      required: string[];
+      additionalProperties: false;
+    } = {
+      type: "object",
+      properties: {},
+      required: ["self"],
+      additionalProperties: false,
+    };
+    schema.properties.self = schema;
+
+    expect(() => normalizeStrictOpenAIJsonSchema(schema)).not.toThrow();
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(false);
+    expect(findOpenAIStrictToolSchemaDiagnostics([{ name: "cycle", parameters: schema }])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "cycle",
+        violations: ["cycle.parameters is not inspectable for OpenAI strict schema compatibility"],
+      },
+    ]);
+    expect(
+      resolveOpenAIStrictToolFlagForInventory([{ name: "cycle", parameters: schema }], true),
+    ).toBe(false);
+  });
+
+  it("reports hostile properties maps without throwing", () => {
+    const hostileProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("strict schema properties ownKeys exploded");
+        },
+      },
+    );
+    const schema = {
+      type: "object",
+      properties: hostileProperties,
+      required: [],
+      additionalProperties: false,
+    };
+
+    expect(() => normalizeStrictOpenAIJsonSchema(schema)).not.toThrow();
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(false);
+    expect(
+      findOpenAIStrictToolSchemaDiagnostics([{ name: "hostile", parameters: schema }]),
+    ).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "hostile",
+        violations: [
+          "hostile.parameters is not inspectable for OpenAI strict schema compatibility",
+        ],
+      },
+    ]);
+  });
+
+  it("reports circular schema arrays without recursing forever", () => {
+    const enumValues: unknown[] = [];
+    enumValues.push(enumValues);
+    const schema = {
+      type: "object",
+      properties: {
+        choice: { type: "string", enum: enumValues },
+      },
+      required: ["choice"],
+      additionalProperties: false,
+    };
+
+    expect(() => normalizeStrictOpenAIJsonSchema(schema)).not.toThrow();
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(false);
+    expect(
+      findOpenAIStrictToolSchemaDiagnostics([{ name: "circular_enum", parameters: schema }]),
+    ).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "circular_enum",
+        violations: [
+          "circular_enum.parameters is not inspectable for OpenAI strict schema compatibility",
+        ],
+      },
+    ]);
+  });
+
+  it("normalizes schema arrays before strict compatibility walkers inspect them", () => {
+    const required = new Proxy(["path"], {
+      get(target, property, receiver) {
+        if (property === "filter") {
+          throw new Error("source required.filter should not be used");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const schema = {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required,
+      additionalProperties: false,
+    };
+
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(true);
+    expect(findOpenAIStrictToolSchemaDiagnostics([{ name: "read", parameters: schema }])).toEqual(
+      [],
+    );
+  });
+
+  it("does not trust source tool array traversal methods", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const tools = new Proxy([healthy], {
+      get(target, property, receiver) {
+        if (property === "every" || property === "flatMap") {
+          throw new Error(`source ${property} should not be used`);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(resolveOpenAIStrictToolFlagForInventory(tools, true)).toBe(true);
+    expect(findOpenAIStrictToolSchemaDiagnostics(tools)).toEqual([]);
+  });
+
+  it("reports unreadable tool schemas before strict compatibility checks", () => {
+    const tool = {
+      name: "fuzzplugin_unreadable",
+      parameters: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    Object.defineProperty(tool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("strict schema parameters getter exploded");
+      },
+    });
+
+    expect(resolveOpenAIStrictToolFlagForInventory([tool], true)).toBe(false);
+    expect(findOpenAIStrictToolSchemaDiagnostics([tool])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "fuzzplugin_unreadable",
+        violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+      },
+    ]);
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -13,7 +13,15 @@ type ToolWithParameters = {
 };
 
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
+const MAX_OPENAI_STRICT_SCHEMA_ARRAY_ENTRIES = 10_000;
+const OPENAI_STRICT_SCHEMA_INSPECTION_ERROR =
+  "is not inspectable for OpenAI strict schema compatibility";
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
+
+type StrictOpenAINormalizationResult = {
+  readonly schema: unknown;
+  readonly ok: boolean;
+};
 
 function resolveToolSchemaModelCompat(
   compat: ToolSchemaCompatInput | null | undefined,
@@ -69,56 +77,128 @@ export function normalizeStrictOpenAIJsonSchema(
   schema: unknown,
   modelCompat?: ToolSchemaCompatInput | null,
 ): unknown {
+  return normalizeStrictOpenAIJsonSchemaSafely(schema, modelCompat).schema;
+}
+
+function normalizeStrictOpenAIJsonSchemaSafely(
+  schema: unknown,
+  modelCompat?: ToolSchemaCompatInput | null,
+): StrictOpenAINormalizationResult {
   const schemaInput = schema ?? {};
   if (!schemaInput || typeof schemaInput !== "object") {
-    return normalizeStrictOpenAIJsonSchemaRecursive(
-      normalizeToolParameterSchema(schemaInput, {
-        modelCompat: resolveToolSchemaModelCompat(modelCompat),
-      }),
+    const normalizedInput = normalizeToolParameterSchemaSafely(schemaInput, modelCompat);
+    const result = normalizeStrictOpenAIJsonSchemaRecursiveSafely(
+      normalizedInput.schema,
       0,
+      new WeakSet(),
     );
+    return { schema: result.schema, ok: normalizedInput.ok && result.ok };
   }
   const cacheKey = resolveStrictOpenAISchemaCacheKey(modelCompat);
   const cached = readCachedStrictOpenAISchema(schemaInput, cacheKey);
   if (cached !== undefined) {
-    return cached;
+    return { schema: cached, ok: true };
   }
-  return rememberStrictOpenAISchema(
-    schemaInput,
-    cacheKey,
-    normalizeStrictOpenAIJsonSchemaRecursive(
-      normalizeToolParameterSchema(schemaInput, {
-        modelCompat: resolveToolSchemaModelCompat(modelCompat),
-      }),
-      0,
-    ),
+  const normalizedInput = normalizeToolParameterSchemaSafely(schemaInput, modelCompat);
+  const result = normalizeStrictOpenAIJsonSchemaRecursiveSafely(
+    normalizedInput.schema,
+    0,
+    new WeakSet(),
   );
+  const safeResult = { schema: result.schema, ok: normalizedInput.ok && result.ok };
+  if (safeResult.ok) {
+    rememberStrictOpenAISchema(schemaInput, cacheKey, safeResult.schema);
+  }
+  return safeResult;
 }
 
-function normalizeStrictOpenAIJsonSchemaRecursive(schema: unknown, depth: number): unknown {
+function normalizeToolParameterSchemaSafely(
+  schema: unknown,
+  modelCompat?: ToolSchemaCompatInput | null,
+): StrictOpenAINormalizationResult {
+  try {
+    return {
+      schema: normalizeToolParameterSchema(schema, {
+        modelCompat: resolveToolSchemaModelCompat(modelCompat),
+      }),
+      ok: true,
+    };
+  } catch {
+    return { schema: {}, ok: false };
+  }
+}
+
+function normalizeStrictOpenAIJsonSchemaRecursiveSafely(
+  schema: unknown,
+  depth: number,
+  activeObjects: WeakSet<object>,
+): StrictOpenAINormalizationResult {
   if (Array.isArray(schema)) {
-    let changed = false;
-    const normalized = schema.map((entry) => {
-      const next = normalizeStrictOpenAIJsonSchemaRecursive(entry, depth);
-      changed ||= next !== entry;
-      return next;
-    });
-    return changed ? normalized : schema;
+    if (activeObjects.has(schema)) {
+      return { schema: [], ok: false };
+    }
+    activeObjects.add(schema);
+    let length: number;
+    try {
+      length = schema.length;
+    } catch {
+      activeObjects.delete(schema);
+      return { schema: [], ok: false };
+    }
+    if (
+      !Number.isSafeInteger(length) ||
+      length < 0 ||
+      length > MAX_OPENAI_STRICT_SCHEMA_ARRAY_ENTRIES
+    ) {
+      activeObjects.delete(schema);
+      return { schema: [], ok: false };
+    }
+    let ok = true;
+    const normalized: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      let entry: unknown;
+      try {
+        entry = schema[index];
+      } catch {
+        normalized.push({});
+        ok = false;
+        continue;
+      }
+      const next = normalizeStrictOpenAIJsonSchemaRecursiveSafely(entry, depth, activeObjects);
+      normalized.push(next.schema);
+      ok &&= next.ok;
+    }
+    activeObjects.delete(schema);
+    return { schema: normalized, ok };
   }
   if (!schema || typeof schema !== "object") {
-    return schema;
+    return { schema, ok: true };
+  }
+  if (activeObjects.has(schema)) {
+    return { schema: {}, ok: false };
   }
 
   const record = schema as Record<string, unknown>;
+  activeObjects.add(schema);
   let changed = false;
+  let ok = true;
   const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    const next = normalizeStrictOpenAIJsonSchemaRecursive(
+  let entries: Array<[string, unknown]>;
+  try {
+    entries = Object.entries(record);
+  } catch {
+    activeObjects.delete(schema);
+    return { schema: {}, ok: false };
+  }
+  for (const [key, value] of entries) {
+    const next = normalizeStrictOpenAIJsonSchemaRecursiveSafely(
       value,
       key === "properties" ? depth : depth + 1,
+      activeObjects,
     );
-    normalized[key] = next;
-    changed ||= next !== value;
+    normalized[key] = next.schema;
+    changed ||= next.schema !== value;
+    ok &&= next.ok;
   }
 
   if (normalized.type === "object") {
@@ -128,8 +208,13 @@ function normalizeStrictOpenAIJsonSchemaRecursive(schema: unknown, depth: number
       !Array.isArray(normalized.properties)
         ? (normalized.properties as Record<string, unknown>)
         : undefined;
-    if (properties && Object.keys(properties).length === 0 && !Array.isArray(normalized.required)) {
+    const propertyKeys = properties ? readOpenAIStrictObjectKeys(properties) : undefined;
+    if (propertyKeys && propertyKeys.length === 0 && !Array.isArray(normalized.required)) {
       normalized.required = [];
+      changed = true;
+    } else if (properties && !propertyKeys) {
+      normalized.properties = {};
+      ok = false;
       changed = true;
     }
     if (depth === 0 && !("additionalProperties" in normalized)) {
@@ -138,7 +223,16 @@ function normalizeStrictOpenAIJsonSchemaRecursive(schema: unknown, depth: number
     }
   }
 
-  return changed ? normalized : schema;
+  activeObjects.delete(schema);
+  return { schema: changed ? normalized : schema, ok };
+}
+
+function readOpenAIStrictObjectKeys(value: Record<string, unknown>): string[] | undefined {
+  try {
+    return Object.keys(value);
+  } catch {
+    return undefined;
+  }
 }
 
 export function normalizeOpenAIStrictToolParameters<T>(
@@ -154,7 +248,8 @@ export function normalizeOpenAIStrictToolParameters<T>(
 }
 
 export function isStrictOpenAIJsonSchemaCompatible(schema: unknown): boolean {
-  return isStrictOpenAIJsonSchemaCompatibleRecursive(normalizeStrictOpenAIJsonSchema(schema));
+  const normalized = normalizeStrictOpenAIJsonSchemaSafely(schema);
+  return normalized.ok && isStrictOpenAIJsonSchemaCompatibleRecursive(normalized.schema);
 }
 
 type OpenAIStrictToolSchemaDiagnostic = {
@@ -166,22 +261,97 @@ type OpenAIStrictToolSchemaDiagnostic = {
 export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
-  return tools.flatMap((tool, toolIndex) => {
-    const violations = findStrictOpenAIJsonSchemaViolations(
-      normalizeStrictOpenAIJsonSchema(tool.parameters),
-      `${typeof tool.name === "string" && tool.name ? tool.name : `tool[${toolIndex}]`}.parameters`,
-    );
+  return readOpenAIStrictToolEntries(tools).flatMap((entry) => {
+    if (!entry.readable) {
+      return [
+        {
+          toolIndex: entry.toolIndex,
+          violations: [`tool[${entry.toolIndex}] is unreadable`],
+        },
+      ];
+    }
+    const nameRead = readOpenAIStrictToolField(entry.tool, "name");
+    const toolName =
+      nameRead.readable && typeof nameRead.value === "string" && nameRead.value
+        ? nameRead.value
+        : `tool[${entry.toolIndex}]`;
+    const descriptorViolations = nameRead.readable ? [] : [`${toolName}.name is unreadable`];
+    const parametersRead = readOpenAIStrictToolField(entry.tool, "parameters");
+    if (!parametersRead.readable) {
+      return [
+        {
+          toolIndex: entry.toolIndex,
+          ...(toolName ? { toolName } : {}),
+          violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+        },
+      ];
+    }
+    const schemaPath = `${toolName}.parameters`;
+    const normalized = normalizeStrictOpenAIJsonSchemaSafely(parametersRead.value);
+    const violations = [
+      ...descriptorViolations,
+      ...(normalized.ok ? [] : [`${schemaPath} ${OPENAI_STRICT_SCHEMA_INSPECTION_ERROR}`]),
+      ...findStrictOpenAIJsonSchemaViolations(normalized.schema, schemaPath),
+    ];
     if (violations.length === 0) {
       return [];
     }
     return [
       {
-        toolIndex,
-        ...(typeof tool.name === "string" && tool.name ? { toolName: tool.name } : {}),
+        toolIndex: entry.toolIndex,
+        ...(toolName ? { toolName } : {}),
         violations,
       },
     ];
   });
+}
+
+function readOpenAIStrictToolEntries(
+  tools: readonly ToolWithParameters[],
+): Array<
+  | { readonly readable: true; readonly tool: ToolWithParameters; readonly toolIndex: number }
+  | { readonly readable: false; readonly toolIndex: number }
+> {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [{ readable: false, toolIndex: 0 }];
+  }
+  if (
+    !Number.isSafeInteger(length) ||
+    length < 0 ||
+    length > MAX_OPENAI_STRICT_SCHEMA_ARRAY_ENTRIES
+  ) {
+    return [{ readable: false, toolIndex: 0 }];
+  }
+  const entries: Array<
+    | { readonly readable: true; readonly tool: ToolWithParameters; readonly toolIndex: number }
+    | { readonly readable: false; readonly toolIndex: number }
+  > = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      entries.push({ readable: true, tool: tools[toolIndex], toolIndex });
+    } catch {
+      entries.push({ readable: false, toolIndex });
+    }
+  }
+  return entries;
+}
+
+function readOpenAIStrictToolField<TField extends keyof ToolWithParameters>(
+  tool: ToolWithParameters,
+  field: TField,
+):
+  | { readonly readable: true; readonly value: ToolWithParameters[TField] }
+  | {
+      readonly readable: false;
+    } {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
 }
 
 function isStrictOpenAIJsonSchemaCompatibleRecursive(schema: unknown): boolean {
@@ -304,5 +474,5 @@ export function resolveOpenAIStrictToolFlagForInventory(
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
-  return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
+  return findOpenAIStrictToolSchemaDiagnostics(tools).length === 0;
 }


### PR DESCRIPTION
## Summary

- Harden OpenAI strict tool-schema inspection against circular schemas, hostile schema maps, hostile schema arrays, and unreadable tool schema fields.
- Avoid trusting source array traversal helpers while deciding strict compatibility and building downgrade diagnostics.
- Keep strict mode disabled when schemas cannot be safely inspected instead of crashing during provider payload preparation.

## Verification

- `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
- `./node_modules/.bin/oxlint src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_baa8e0d3c672`, run `run_80da162f785c`, exit 0

## Real behavior proof

Behavior addressed: OpenAI strict tool-schema compatibility checks and downgrade diagnostics no longer crash when a plugin/provider-owned schema contains circular structures, hostile object maps, hostile array methods, or unreadable `parameters`.

Real environment tested: Local macOS sparse `gwt` worktree with shared repo dependencies; AWS Crabbox Linux fresh PR checkout at head `a7999274f4fb778c38f742796520cd433ca84fd0`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-tool-schema.test.ts -- --reporter=dot`; AWS Crabbox `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: Regressions cover circular object schemas, circular schema arrays, hostile `properties` maps, hostile `required.filter`, hostile source tool `every`/`flatMap`, and unreadable tool `parameters` getters; remote changed gate selected `core, coreTests` and completed all guard, typecheck, lint, and import-cycle checks.

Observed result after fix: Focused Vitest passed, formatter/lint/diff checks passed, autoreview reported no accepted/actionable findings after fixing its two array findings, and remote `check:changed` passed in run `run_80da162f785c`.

What was not tested: No live OpenAI request; this is covered at the strict schema inspection and downgrade decision contract.
