### PR TITLE
fix(agents): classify read-only shell commands as non-mutating

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -26,11 +26,61 @@ describe("tool mutation helpers", () => {
     );
     expect(writeFingerprint).toBe("tool=write|path=/tmp/demo.txt|id=42");
 
-    const metaOnlyFingerprint = buildToolActionFingerprint("exec", { command: "ls -la" }, "ls -la");
-    expect(metaOnlyFingerprint).toBe("tool=exec|meta=ls -la");
+    const metaOnlyFingerprint = buildToolActionFingerprint(
+      "exec",
+      { command: "npm start" },
+      "npm start",
+    );
+    expect(metaOnlyFingerprint).toBe("tool=exec|meta=npm start");
 
     const readFingerprint = buildToolActionFingerprint("read", { path: "/tmp/demo.txt" });
     expect(readFingerprint).toBeUndefined();
+  });
+
+  it.each([
+    ["exec", "sed -n '1,220p' src/agents/tool-mutation.ts"],
+    ["bash", "cat package.json"],
+    ["exec", "rg -n tool-mutation src/agents"],
+    ["bash", "git status --short"],
+    ["exec", "git diff -- src/agents/tool-mutation.ts"],
+    ["exec", "gh search prs --repo openclaw/openclaw tool-mutation --json number,title,state"],
+    ["bash", "gh pr view 123 --repo openclaw/openclaw --json title,state"],
+  ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
+    expect(isMutatingToolCall(toolName, { command })).toBe(false);
+    expect(buildToolMutationState(toolName, { command }).mutatingAction).toBe(false);
+    expect(buildToolActionFingerprint(toolName, { command }, command)).toBeUndefined();
+  });
+
+  it.each([
+    ["exec", "sed -i 's/a/b/' file.txt"],
+    ["exec", "sed --in-place 's/a/b/' file.txt"],
+    ["exec", "sed -n '1p' -i file.txt"],
+    ["exec", "sed -n -e '1p' -e 'w /tmp/out' file.txt"],
+    ["bash", "cat package.json > /tmp/package.json"],
+    ["bash", "rg foo src | wc -l"],
+    ["bash", "rg --pre touch pattern file"],
+    ["exec", "python3 <<'PY'\nprint('hello')\nPY"],
+    ["exec", "npm start"],
+    ["exec", "git checkout feature-branch"],
+    ["exec", "git branch -D old-branch"],
+    ["exec", "git diff --output=/tmp/patch.diff"],
+    ["exec", "git diff --ext-diff"],
+    ["exec", "git grep -O pattern"],
+    ["exec", "git grep -Ovim pattern"],
+    ["exec", "git grep --open-files-in-pager=vim pattern"],
+    ["exec", "gh pr create --title fix --body body"],
+    ["exec", "gh pr view 123 --web"],
+    ["exec", "gh pr view 123 -w"],
+    ["exec", "gh issue comment 123 --body fixed"],
+    ["exec", "gh search prs bug --web"],
+    ["exec", "gh search prs bug -w"],
+    ["exec", "gh api --method POST repos/openclaw/openclaw/issues"],
+  ])("keeps ambiguous or mutating shell command mutating: %s %s", (toolName, command) => {
+    expect(isMutatingToolCall(toolName, { command })).toBe(true);
+    expect(buildToolMutationState(toolName, { command }, command).mutatingAction).toBe(true);
+    expect(buildToolActionFingerprint(toolName, { command }, command)).toBe(
+      `tool=${toolName}|meta=${command.toLowerCase().replace(/\s+/g, " ")}`,
+    );
   });
 
   it("treats coding-tool path aliases as the same stable target", () => {

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -70,10 +70,16 @@ describe("tool mutation helpers", () => {
     ["exec", "git grep --open-files-in-pager=vim pattern"],
     ["exec", "gh pr create --title fix --body body"],
     ["exec", "gh pr view 123 --web"],
+    ["exec", "gh pr view 123 --web=true"],
+    ["exec", "gh pr view 123 --web=false"],
     ["exec", "gh pr view 123 -w"],
+    ["exec", "gh pr view 123 -w=true"],
+    ["exec", "gh pr view 123 -w=false"],
     ["exec", "gh issue comment 123 --body fixed"],
     ["exec", "gh search prs bug --web"],
+    ["exec", "gh search prs bug --web=true"],
     ["exec", "gh search prs bug -w"],
+    ["exec", "gh search prs bug -w=true"],
     ["exec", "gh api --method POST repos/openclaw/openclaw/issues"],
   ])("keeps ambiguous or mutating shell command mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(true);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -250,7 +250,11 @@ function isReadOnlyGhCommand(tokens: readonly string[]): boolean {
   if (
     tokens.some((token) => {
       const normalized = normalizeLowercaseStringOrEmpty(token);
-      return normalized === "--web" || /^-[a-z]*w[a-z]*$/.test(normalized);
+      return (
+        normalized === "--web" ||
+        normalized.startsWith("--web=") ||
+        /^-[a-z]*w[a-z]*(?:=.*)?$/.test(normalized)
+      );
     })
   ) {
     return false;

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -69,6 +69,35 @@ const MESSAGE_MUTATING_ACTIONS = new Set([
   "unpin",
 ]);
 
+const READ_ONLY_SHELL_COMMANDS = new Set([
+  "cat",
+  "file",
+  "grep",
+  "head",
+  "ls",
+  "pwd",
+  "rg",
+  "stat",
+  "tail",
+  "wc",
+]);
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  "diff",
+  "grep",
+  "log",
+  "ls-files",
+  "rev-parse",
+  "show",
+  "status",
+]);
+
+const READ_ONLY_GH_PR_SUBCOMMANDS = new Set(["checks", "diff", "list", "status", "view"]);
+const READ_ONLY_GH_ISSUE_SUBCOMMANDS = new Set(["list", "status", "view"]);
+
+const UNSAFE_RG_FLAGS = new Set(["--pre", "--pre-glob"]);
+const UNSAFE_GIT_FLAGS = new Set(["--ext-diff", "--output", "-o", "--open-files-in-pager"]);
+
 // Structured file-target identity for cross-tool same-target recovery.
 // Carried alongside `actionFingerprint` so comparison does not have to
 // re-parse the joined fingerprint string. Re-parsing was unsafe because
@@ -96,6 +125,175 @@ type ToolActionRef = {
 function normalizeActionName(value: unknown): string | undefined {
   const normalized = normalizeOptionalLowercaseString(value)?.replace(/[\s-]+/g, "_");
   return normalized || undefined;
+}
+
+function readShellCommand(record: Record<string, unknown> | undefined): string | undefined {
+  const command = record?.command ?? record?.cmd;
+  if (typeof command !== "string") {
+    return undefined;
+  }
+  const trimmed = command.trim();
+  return trimmed || undefined;
+}
+
+function tokenizeSimpleShellCommand(command: string): string[] | undefined {
+  if (/[;&|<>\n\r`]/.test(command) || command.includes("$(") || command.includes("\\")) {
+    return undefined;
+  }
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  for (const char of command) {
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (quote) {
+    return undefined;
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens.length > 0 ? tokens : undefined;
+}
+
+function isReadOnlySedCommand(tokens: readonly string[]): boolean {
+  const args = tokens.slice(1);
+  if (args.some((token) => token === "--in-place" || token.startsWith("--in-place="))) {
+    return false;
+  }
+  if (args.some((token) => token.startsWith("-") && token !== "-" && token.includes("i"))) {
+    return false;
+  }
+  // `sed -e 'w /tmp/out'` and mixed scripts are easy to misclassify. Only
+  // allow the simple line-print shape that agents use for file inspection.
+  if (args.some((token) => token === "-e" || token === "--expression")) {
+    return false;
+  }
+  let sawSuppressAutoPrint = false;
+  let expression: string | undefined;
+  for (const token of args) {
+    if (token === "--in-place" || token.startsWith("--in-place=")) {
+      return false;
+    }
+    if (token === "--quiet" || token === "--silent") {
+      sawSuppressAutoPrint = true;
+      continue;
+    }
+    if (token.startsWith("-") && token !== "-") {
+      if (token.includes("i")) {
+        return false;
+      }
+      if (token.includes("n")) {
+        sawSuppressAutoPrint = true;
+      }
+      continue;
+    }
+    expression ??= token;
+    break;
+  }
+  return sawSuppressAutoPrint && expression != null && /^(\d+|\$)(,(\d+|\$))?p$/.test(expression);
+}
+
+function hasUnsafeRipgrepFlag(tokens: readonly string[]): boolean {
+  return tokens.some((token) => {
+    const normalized = normalizeLowercaseStringOrEmpty(token);
+    return (
+      UNSAFE_RG_FLAGS.has(normalized) ||
+      normalized.startsWith("--pre=") ||
+      normalized.startsWith("--pre-glob=")
+    );
+  });
+}
+
+function hasUnsafeGitFlag(tokens: readonly string[]): boolean {
+  return tokens.some((token) => {
+    const normalized = normalizeLowercaseStringOrEmpty(token);
+    return (
+      UNSAFE_GIT_FLAGS.has(normalized) ||
+      token.startsWith("-O") ||
+      normalized.startsWith("--output=") ||
+      normalized.startsWith("--open-files-in-pager=")
+    );
+  });
+}
+
+function isReadOnlyGitCommand(tokens: readonly string[]): boolean {
+  const subcommand = normalizeLowercaseStringOrEmpty(tokens[1]);
+  if (hasUnsafeGitFlag(tokens)) {
+    return false;
+  }
+  if (READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) {
+    return true;
+  }
+  return subcommand === "remote" && tokens.length === 3 && tokens[2] === "-v";
+}
+
+function isReadOnlyGhCommand(tokens: readonly string[]): boolean {
+  if (
+    tokens.some((token) => {
+      const normalized = normalizeLowercaseStringOrEmpty(token);
+      return normalized === "--web" || /^-[a-z]*w[a-z]*$/.test(normalized);
+    })
+  ) {
+    return false;
+  }
+  const area = normalizeLowercaseStringOrEmpty(tokens[1]);
+  const action = normalizeLowercaseStringOrEmpty(tokens[2]);
+  if (area === "search") {
+    return action.length > 0;
+  }
+  if (area === "pr") {
+    return READ_ONLY_GH_PR_SUBCOMMANDS.has(action);
+  }
+  if (area === "issue") {
+    return READ_ONLY_GH_ISSUE_SUBCOMMANDS.has(action);
+  }
+  return false;
+}
+
+function isPlainReadOnlyShellCommand(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  const tokens = tokenizeSimpleShellCommand(command);
+  if (!tokens) {
+    return false;
+  }
+  const executable = normalizeLowercaseStringOrEmpty(tokens[0]);
+  if (executable === "rg" && hasUnsafeRipgrepFlag(tokens)) {
+    return false;
+  }
+  if (READ_ONLY_SHELL_COMMANDS.has(executable)) {
+    return true;
+  }
+  if (executable === "sed") {
+    return isReadOnlySedCommand(tokens);
+  }
+  if (executable === "git") {
+    return isReadOnlyGitCommand(tokens);
+  }
+  if (executable === "gh") {
+    return isReadOnlyGhCommand(tokens);
+  }
+  return false;
 }
 
 function normalizeFingerprintValue(value: unknown): string | undefined {
@@ -148,12 +346,13 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "write":
     case "edit":
     case "apply_patch":
-    case "exec":
-    case "bash":
     case "sessions_send":
     case "create_goal":
     case "update_goal":
       return true;
+    case "exec":
+    case "bash":
+      return !isPlainReadOnlyShellCommand(readShellCommand(record));
     case "process":
       return action != null && PROCESS_MUTATING_ACTIONS.has(action);
     case "message":


### PR DESCRIPTION
## Summary

- classify only simple, clearly read-only `exec`/`bash` shell commands as non-mutating
- keep ambiguous shell commands fail-closed as mutating, including heredocs, redirection, pipes, app starts, and mutating `git`/`gh` subcommands
- cover the regression with focused classifier tests for `sed -n`, `rg`, `git status/diff`, read-only `gh` queries, and unsafe lookalikes found during review

## Context

This restores the intent of `6b05916c14` (`fix: gate Telegram exec tool warnings behind verbose mode`) without reverting `658a30b42f` (`fix(agents): surface exec failures after claimed success`).

`exec` and `bash` currently fall through as always-mutating, so read-only investigation failures like `sed -n ...` or `gh search prs ...` can surface as final tool warnings even when the assistant already produced a useful response. This patch keeps the claimed-success protection for mutating or ambiguous commands while letting obviously read-only probes use the existing non-mutating warning policy.

The allowlist is intentionally narrow and subcommand-aware. Examples that remain mutating:

- `python3 <<'PY' ...`
- `npm start`
- `cat file > out`
- `rg foo | wc -l`
- `rg --pre ...`
- `sed -i ...`
- `sed -n '1p' -i file.txt`
- `git checkout ...`
- `git branch -D ...`
- `git diff --output=...`
- `git diff --ext-diff`
- `git grep -O`
- `gh pr create ...`
- `gh pr view ... --web`
- `gh pr view ... --web=true`
- `gh pr view ... -w=true`
- `gh issue comment ...`
- `gh api --method POST ...`

## Real behavior proof

- Behavior or issue addressed: failed read-only `exec`/`bash` probes could be surfaced as final tool warnings because `exec`/`bash` were classified as mutating regardless of the command.
- Real environment tested: local OpenClaw source worktree at PR head `346853fb0702872b8f04599906b759420592bc05`, Node `v24.15.0`, using the production `buildToolMutationState` and `buildEmbeddedRunPayloads` code paths.
- Exact steps or command run after this patch: `node --import tsx --eval '<script that builds failed read-only, failed mutating, and assigned gh web-flag exec cases through buildEmbeddedRunPayloads>'`
- Evidence after fix:

```text
{
  "label": "failed read-only probe after useful answer",
  "command": "sed -n '1,220p' /tmp/missing-openclaw-proof-file.md",
  "mutatingAction": false,
  "payloadCount": 1,
  "payloadTexts": [
    "I found the likely cause and the PR narrows read-only exec classification."
  ],
  "warningEmitted": false
}
{
  "label": "failed mutating command after claimed success",
  "command": "npm start",
  "mutatingAction": true,
  "payloadCount": 2,
  "payloadTexts": [
    "I found the likely cause and the PR narrows read-only exec classification.",
    "⚠️ 🛠️ npm start failed"
  ],
  "warningEmitted": true
}
{
  "label": "assigned gh web flag remains fail-closed",
  "command": "gh pr view 123 --web=true",
  "mutatingAction": true,
  "payloadCount": 2,
  "payloadTexts": [
    "I found the likely cause and the PR narrows read-only exec classification.",
    "⚠️ 🛠️ gh pr view 123 --web=true failed"
  ],
  "warningEmitted": true
}
PROOF RESULT: read-only exec warning suppressed; mutating exec warning retained; assigned gh web flags remain fail-closed.
```

- Observed result after fix: the failed read-only `sed -n` probe keeps only the assistant reply and emits no final warning; the failed mutating `npm start` command still emits the tool warning after the assistant claims success; assigned `gh --web=true` remains fail-closed and still emits the warning.
- What was not tested: a live Telegram/Mantis transcript was not captured locally, and Vitest did not complete in this environment.
- Proof limitations or environment constraints: this is terminal-captured proof through the production payload builder rather than a live Telegram conversation. It exercises the same mutation classification and warning policy path used by the embedded runner.
- Before evidence: the current published behavior classifies `exec`/`bash` as mutating by default, which makes read-only command failures take the mutating warning path.

## Test plan

- `pnpm exec oxfmt --check src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts`
- `pnpm exec oxlint src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts`
- `node --import tsx --eval '<real behavior proof script above>'`
- targeted classifier smoke test covering read-only commands plus unsafe `gh --web`, `gh --web=true`, `gh --web=false`, `gh -w`, `gh -w=true`, `gh -w=false`, `git grep -O`, and attached `git grep -O<pager>` forms

I also attempted:

- `pnpm vitest run src/agents/tool-mutation.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- `pnpm vitest run src/agents/tool-mutation.test.ts`

Both Vitest runs stalled locally during the Rolldown build phase with repeated `PLUGIN_TIMINGS` warnings before reaching test execution, so I stopped them and used the targeted formatter/linter/smoke/proof checks above.