### PR TITLE
fix(discord): clean migrated thread binding state

### DIFF
--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
@@ -193,7 +193,7 @@ describe("Discord model picker preference migration", () => {
     expect(plan.pluginId).toBe("discord");
     expect(plan.namespace).toBe("thread-bindings");
     const entries = await plan.readEntries();
-    expect(entries).toEqual([
+    expect(entries).toStrictEqual([
       {
         key: "default:legacy-thread",
         value: {

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -197,7 +197,7 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
           if (normalized) {
             out.push({
               key: toBindingRecordKey(normalized),
-              value: JSON.parse(JSON.stringify(normalized)) as unknown,
+              value: normalized,
             });
           }
         }

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -195,7 +195,10 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
         )) {
           const normalized = normalizePersistedBinding(rawKey, rawEntry);
           if (normalized) {
-            out.push({ key: toBindingRecordKey(normalized), value: normalized });
+            out.push({
+              key: toBindingRecordKey(normalized),
+              value: JSON.parse(JSON.stringify(normalized)) as unknown,
+            });
           }
         }
         return out;

--- a/extensions/discord/src/monitor/thread-bindings.state.ts
+++ b/extensions/discord/src/monitor/thread-bindings.state.ts
@@ -215,23 +215,36 @@ export function normalizePersistedBinding(
     }
   }
 
-  return {
+  const record: ThreadBindingRecord = {
     accountId,
     channelId,
     threadId,
     targetKind,
     targetSessionKey,
     agentId,
-    label,
-    webhookId,
-    webhookToken,
     boundBy,
     boundAt,
     lastActivityAt,
-    idleTimeoutMs: migratedIdleTimeoutMs,
-    maxAgeMs: migratedMaxAgeMs,
-    metadata,
   };
+  if (label !== undefined) {
+    record.label = label;
+  }
+  if (webhookId !== undefined) {
+    record.webhookId = webhookId;
+  }
+  if (webhookToken !== undefined) {
+    record.webhookToken = webhookToken;
+  }
+  if (migratedIdleTimeoutMs !== undefined) {
+    record.idleTimeoutMs = migratedIdleTimeoutMs;
+  }
+  if (migratedMaxAgeMs !== undefined) {
+    record.maxAgeMs = migratedMaxAgeMs;
+  }
+  if (metadata !== undefined) {
+    record.metadata = metadata;
+  }
+  return record;
 }
 
 export function normalizeThreadBindingDurationMs(raw: unknown, defaultsTo: number): number {


### PR DESCRIPTION
## Summary

- Clean Discord legacy thread-binding records before importing them into plugin state.
- Prevent omitted optional fields from being imported as enumerable `undefined` values.
- Tighten the migration regression test so JSON-unsafe undefined fields fail.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts`
- `pnpm run lint:extensions:bundled`
- `pnpm lint --threads=8`
- `git diff --check`
- Real behavior proof below: `pnpm openclaw doctor --fix --yes --non-interactive` against an isolated legacy Discord state directory.

## Real behavior proof

- Behavior addressed: Discord legacy thread-binding migration no longer passes enumerable `undefined` optional fields to plugin state, avoiding `PluginStateStoreError` during doctor/gateway legacy-state migration.
- Real environment tested: Real OpenClaw CLI doctor repair run from this PR head (`521539890b`) against an isolated temp `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`; no mocked migration helper or unit-test harness was used.
- Exact steps or command run after this patch: Created a temp `openclaw.json` and legacy `discord/thread-bindings.json` with one version 1 binding using legacy `expiresAt`, then ran `HOME=<proof-root>/home OPENCLAW_STATE_DIR=<proof-root>/state OPENCLAW_CONFIG_PATH=<proof-root>/state/openclaw.json pnpm openclaw doctor --fix --yes --non-interactive`.
- Evidence after fix (terminal capture):

```text
Proof setup: legacy Discord thread-bindings.json created
$ node scripts/run-node.mjs doctor --fix --yes --non-interactive
[state-migrations] Auto-migrated legacy state:
- Migrated 1 Discord thread bindings entry -> plugin state
- Archived Discord thread bindings legacy source -> <proof-root>/state/discord/thread-bindings.json.migrated

Doctor changes
- Migrated 1 Discord thread bindings entry -> plugin state
- Archived Discord thread bindings legacy source -> <proof-root>/state/discord/thread-bindings.json.migrated

Doctor complete.
Proof inspect: legacy source present? no
Proof inspect: archived source present? yes
```

- Observed result after fix: Doctor completed the Discord thread-binding plugin-state import without `PluginStateStoreError`; the legacy source was renamed to `.migrated`, proving all entries were accepted by plugin state.
- What was not tested: Full repository test suite and a live gateway restart with real Discord credentials were not run.
- Proof limitations or environment constraints: The proof uses a local isolated OpenClaw source checkout and temp state, which is enough for this bug because the failing path is the doctor/gateway legacy-state migration before Discord network auth is needed.
