### PR TITLE
Sandbox/Docker: add opt-in sandbox.docker.capAdd passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sandbox/Docker: add opt-in `sandbox.docker.capAdd` passthrough for Docker sandbox containers so workloads that need elevated Linux capabilities (e.g. `NET_ADMIN`, `SYS_PTRACE`) can run inside sandboxed agents. Each capability is emitted as a separate `--cap-add` argument.
 - Docs: add a dedicated Skill Workshop guide covering governed skill creation, reviewable proposals, CLI, Gateway, agent tool behavior, approval policy, support files, and recovery. Thanks @shakkernerd.
 - Skills: let the `skill_workshop` agent tool apply, reject, and quarantine explicit proposals through the guarded review flow. Thanks @shakkernerd.
 - Skills: let proposals carry approved support files under standard skill folders, with scanner, hash, and rollback safeguards. Thanks @shakkernerd.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -91,6 +91,8 @@ Sandboxing is off by default. If you enable sandboxing and do not choose a backe
 
 To expose host GPUs to Docker sandboxes, set `agents.defaults.sandbox.docker.gpus` or the per-agent `agents.list[].sandbox.docker.gpus` override. The value is passed to Docker's `--gpus` flag as a separate argument, for example `"all"` or `"device=GPU-uuid"`, and requires a compatible host runtime such as NVIDIA Container Toolkit.
 
+To grant specific Linux capabilities to Docker sandbox containers, set `agents.defaults.sandbox.docker.capAdd` (or the per-agent override `agents.list[].sandbox.docker.capAdd`) to an array of capability names, for example `["NET_ADMIN", "SYS_PTRACE"]`. Each entry is passed to Docker as a separate `--cap-add` argument. Adding capabilities weakens sandbox isolation, so prefer the minimum set required for the workload.
+
 <Warning>
 **Docker-out-of-Docker (DooD) constraints**
 

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -204,6 +204,22 @@ describe("buildSandboxCreateArgs", () => {
     expectFlagValues(args, "--gpus", ["device=GPU-123"]);
   });
 
+  it("emits Docker --cap-add entries as separate arguments", () => {
+    const cfg = createSandboxConfig({
+      capAdd: ["NET_ADMIN", "SYS_PTRACE"],
+    });
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-cap-add",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    expectFlagValues(args, "--cap-add", ["NET_ADMIN", "SYS_PTRACE"]);
+    expect(valuesForFlag(args, "--cap-add")).toEqual(["NET_ADMIN", "SYS_PTRACE"]);
+  });
+
   it("emits -v flags for safe custom binds", () => {
     const cfg: SandboxDockerConfig = {
       image: "openclaw-sandbox:bookworm-slim",

--- a/src/agents/sandbox-merge.test.ts
+++ b/src/agents/sandbox-merge.test.ts
@@ -59,6 +59,29 @@ describe("sandbox config merges", () => {
     expect(sharedScope.gpus).toBe("all");
   });
 
+  it("resolves sandbox docker capAdd with agent precedence", () => {
+    const inherited = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { capAdd: ["NET_ADMIN"] },
+      agentDocker: {},
+    });
+    expect(inherited.capAdd).toEqual(["NET_ADMIN"]);
+
+    const overridden = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { capAdd: ["NET_ADMIN"] },
+      agentDocker: { capAdd: ["SYS_PTRACE"] },
+    });
+    expect(overridden.capAdd).toEqual(["SYS_PTRACE"]);
+
+    const sharedScope = resolveSandboxDockerConfig({
+      scope: "shared",
+      globalDocker: { capAdd: ["NET_ADMIN"] },
+      agentDocker: { capAdd: ["SYS_PTRACE"] },
+    });
+    expect(sharedScope.capAdd).toEqual(["NET_ADMIN"]);
+  });
+
   it("resolves docker binds and shared-scope override behavior", () => {
     for (const scenario of [
       {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -121,6 +121,7 @@ export function resolveSandboxDockerConfig(params: {
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,
     cpus: agentDocker?.cpus ?? globalDocker?.cpus,
+    capAdd: agentDocker?.capAdd ?? globalDocker?.capAdd,
     gpus: normalizeOptionalString(agentDocker?.gpus ?? globalDocker?.gpus),
     ulimits,
     seccompProfile: agentDocker?.seccompProfile ?? globalDocker?.seccompProfile,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -530,6 +530,10 @@ export function buildSandboxCreateArgs(params: {
   if (gpus) {
     args.push("--gpus", gpus);
   }
+  for (const cap of params.cfg.capAdd ?? []) {
+    const trimmed = cap.trim();
+    if (trimmed) args.push("--cap-add", trimmed);
+  }
   for (const [name, value] of Object.entries(params.cfg.ulimits ?? {})) {
     const formatted = formatUlimitValue(name, value);
     if (formatted) {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -131,6 +131,42 @@ describe("sandbox docker config", () => {
     expect(res.ok).toBe(false);
   });
 
+  it("accepts Docker --cap-add list in sandbox.docker config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              capAdd: ["NET_ADMIN", "SYS_PTRACE"],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.docker?.capAdd).toEqual([
+        "NET_ADMIN",
+        "SYS_PTRACE",
+      ]);
+    }
+  });
+
+  it("rejects Docker --cap-add list containing an empty string entry", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              capAdd: ["NET_ADMIN", ""],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
   it("rejects network host mode via Zod schema validation", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -527,6 +527,10 @@ export const FIELD_HELP: Record<string, string> = {
     'Optional Docker GPU passthrough value passed to --gpus, for example "all" or "device=GPU-uuid". Requires a compatible host runtime such as NVIDIA Container Toolkit.',
   "agents.list[].sandbox.docker.gpus":
     "Per-agent Docker GPU passthrough override for sandbox containers.",
+  "agents.defaults.sandbox.docker.capAdd":
+    'Optional Linux capabilities to grant via Docker --cap-add (e.g. ["NET_ADMIN", "SYS_PTRACE"]). Each entry is emitted as a separate --cap-add argument. Granting capabilities weakens sandbox isolation; use with care.',
+  "agents.list[].sandbox.docker.capAdd":
+    "Per-agent Docker --cap-add override for sandbox containers.",
   "agents.defaults.sandbox.browser.cdpSourceRange":
     "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",
   "agents.list[].sandbox.browser.cdpSourceRange":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -734,6 +734,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Sandbox Docker Allow Container Namespace Join",
   "agents.defaults.sandbox.docker.gpus": "Sandbox Docker GPUs",
+  "agents.defaults.sandbox.docker.capAdd": "Sandbox Docker Cap Add",
   commands: "Commands",
   "commands.native": "Native Commands",
   "commands.nativeSkills": "Native Skill Commands",
@@ -1044,6 +1045,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",
   "agents.list[].sandbox.docker.gpus": "Agent Sandbox Docker GPUs",
+  "agents.list[].sandbox.docker.capAdd": "Agent Sandbox Docker Cap Add",
   "discovery.mdns.mode": "mDNS Discovery Mode",
   plugins: "Plugins",
   "plugins.enabled": "Enable Plugins",

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -29,6 +29,8 @@ export type SandboxDockerSettings = {
   memorySwap?: string | number;
   /** Limit container CPU shares (e.g. 0.5, 1, 2). */
   cpus?: number;
+  /** Linux capabilities to grant via Docker --cap-add (e.g. ["NET_ADMIN"]). */
+  capAdd?: string[];
   /** GPU devices to expose via Docker --gpus (e.g. "all", "device=GPU-uuid"). */
   gpus?: string;
   /**

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -183,6 +183,7 @@ const SandboxDockerSchema = z
     memory: z.union([z.string(), z.number()]).optional(),
     memorySwap: z.union([z.string(), z.number()]).optional(),
     cpus: z.number().positive().optional(),
+    capAdd: z.array(z.string().min(1)).optional(),
     gpus: z.string().min(1).optional(),
     ulimits: z
       .record(


### PR DESCRIPTION
## Summary

Adds an opt-in `sandbox.docker.capAdd` field for the Docker sandbox backend so workloads that need elevated Linux capabilities (for example `NET_ADMIN`, `SYS_PTRACE`) can run inside sandboxed agents. Each entry is emitted as a separate `--cap-add` argument when building the Docker create command.

The change mirrors the existing `sandbox.docker.gpus` passthrough (PR #57976) in shape, merge semantics, Zod validation, FIELD_LABELS, FIELD_HELP, docs, and test coverage.

## Motivation

Some sandboxed workloads need narrowly-scoped Linux capabilities at runtime — common cases include packet-capture tooling that needs `NET_ADMIN`, debuggers/tracers that need `SYS_PTRACE`, and certain low-level networking tasks. Today the Docker sandbox surface exposes `capDrop` but no `capAdd`, so users either keep capabilities permanently denied or bypass the sandbox layer with hand-rolled Docker flags out-of-band.

This change keeps the policy decision explicit (opt-in, per-defaults or per-agent override) and routes the value through the same merge layer the rest of `sandbox.docker.*` already uses, so behavior stays predictable next to `gpus`, `cpus`, `memory`, `capDrop`, `ulimits`, etc.

## Behavior

| Layer | Before | After |
|---|---|---|
| `SandboxDockerSettings` type | no `capAdd` | `capAdd?: string[]` |
| Zod schema | rejected as unknown key | `z.array(z.string().min(1)).optional()` (rejects empty-string entries) |
| `resolveSandboxDockerConfig` | n/a | `agentDocker?.capAdd ?? globalDocker?.capAdd` (agent-precedence on `agent` scope, global wins on `shared` scope — matches `gpus`) |
| `buildSandboxCreateArgs` | no `--cap-add` ever emitted | one `--cap-add <cap>` per entry, trimmed |
| `agents.defaults.sandbox.docker.capAdd` | no FIELD_LABEL / FIELD_HELP | "Sandbox Docker Cap Add" + help text warning about isolation impact |
| `agents.list[].sandbox.docker.capAdd` | no per-agent override | symmetric per-agent override label + help |

Default behavior is unchanged: with no `capAdd` configured, no `--cap-add` arguments are produced. Sandbox isolation defaults stay as-is.

## Safety notes

- The field is opt-in. Empty/undefined → no `--cap-add` emitted.
- Empty-string entries are rejected at validation time (`z.string().min(1)`).
- Each capability becomes a separate `--cap-add` argument — Docker handles unknown capability names by failing the create, not by silently dropping them.
- The help text explicitly notes that adding capabilities weakens sandbox isolation and recommends granting the minimum required set.
- The behavior is fully analogous to `gpus`, including the shared-scope rule where the global setting wins over per-agent overrides to keep shared scopes deterministic.

## Test plan

Three test files updated with capAdd-specific cases that mirror the existing `gpus` cases:

1. **`src/agents/sandbox-create-args.test.ts`** — `it("emits Docker --cap-add entries as separate arguments")`
   - Verifies that for `capAdd: ["NET_ADMIN", "SYS_PTRACE"]` the create-args build path emits `--cap-add NET_ADMIN --cap-add SYS_PTRACE` as two separate flag occurrences (uses `expectFlagValues` + strict `valuesForFlag(args, "--cap-add").toEqual([...])`).

2. **`src/agents/sandbox-merge.test.ts`** — `it("resolves sandbox docker capAdd with agent precedence")`
   - Three scenarios mirroring the `gpus` test:
     - `agent` scope, only `globalDocker.capAdd` set → inherited.
     - `agent` scope, both `globalDocker.capAdd` and `agentDocker.capAdd` set → agent override wins.
     - `shared` scope, both set → global wins (per the existing precedence rule for shared scope).

3. **`src/config/config.sandbox-docker.test.ts`**
   - `it("accepts Docker --cap-add list in sandbox.docker config")` — validates a non-empty `["NET_ADMIN", "SYS_PTRACE"]` array through `validateConfigObject`.
   - `it("rejects Docker --cap-add list containing an empty string entry")` — confirms `z.string().min(1)` rejects `["NET_ADMIN", ""]`.

### Local verification

Verified locally against a clean clone of `v2026.5.12` with the patch applied via `git am`:

```
pnpm install --frozen-lockfile         # OK in 77s on Node 24.16.0 + pnpm 11.1.0
pnpm exec vitest run \
  src/agents/sandbox-create-args.test.ts \
  src/agents/sandbox-merge.test.ts \
  src/config/config.sandbox-docker.test.ts \
  --reporter=verbose

Test Files  3 passed (3)
     Tests  52 passed (52)
  Duration  1.85s
```

All four new capAdd tests pass, and no existing test in the three target files regressed (52/52 PASS).

## Files changed

- `src/config/types.sandbox.ts` — `+capAdd?: string[]` on `SandboxDockerSettings`.
- `src/config/zod-schema.agent-runtime.ts` — `+capAdd: z.array(z.string().min(1)).optional()` on the Docker sandbox schema.
- `src/agents/sandbox/config.ts` — `+capAdd: agentDocker?.capAdd ?? globalDocker?.capAdd` in `resolveSandboxDockerConfig`.
- `src/agents/sandbox/docker.ts` — emit one `--cap-add` per entry in `buildSandboxCreateArgs` (immediately after the existing `--gpus` block, trimmed and empty-skipped).
- `src/config/schema.help.ts` — FIELD_HELP entries for both `agents.defaults.sandbox.docker.capAdd` and `agents.list[].sandbox.docker.capAdd`.
- `src/config/schema.labels.ts` — FIELD_LABELS entries for both scopes.
- `docs/gateway/sandboxing.md` — paragraph documenting `capAdd` immediately after the `gpus` paragraph.
- `CHANGELOG.md` — top entry in `## 2026.6.2 → ### Changes`.
- `src/agents/sandbox-create-args.test.ts` — new `it("emits Docker --cap-add entries as separate arguments")`.
- `src/agents/sandbox-merge.test.ts` — new `it("resolves sandbox docker capAdd with agent precedence")`.
- `src/config/config.sandbox-docker.test.ts` — two new validation tests (accept array, reject empty-string entry).

11 files changed, +92 insertions.
