### PR TITLE
fix(gateway): accept --port on gateway health and probe (#79100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway CLI: accept the existing `--port` flag on `gateway health` and `gateway probe` (e.g. `openclaw gateway --port 18789 health`) so local scripts can target a non-default port with the same flag shape as `gateway run --port`; the port routes through `config.gateway.port`, preserving configured local auth/TLS without requiring explicit `--token`/`--password`. (#79100)
 - Release/CI/E2E: fail early when Crabbox sparse-sync full checkouts do not have enough local disk, with guidance for moving the sync root.
 - Build: render independent CLI startup metadata help snapshots concurrently to cut cold build-all metadata time.
 - Plugins: stop timed-out package-boundary prep steps by process group so descendant TypeScript/helper processes do not survive local check cleanup.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -148,7 +148,8 @@ All query commands use WebSocket RPC.
 
   </Tab>
   <Tab title="Shared options">
-    - `--url <url>`: Gateway WebSocket URL.
+    - `--port <port>`: Gateway port on localhost. Pass before the subcommand (e.g. `openclaw gateway --port 18789 health`). Patches the config port; preserves configured auth/TLS and does not override URL semantics.
+    - `--url <url>`: Gateway WebSocket URL (explicit; overrides config and port).
     - `--token <token>`: Gateway token.
     - `--password <password>`: Gateway password.
     - `--timeout <ms>`: timeout/budget (varies per command).
@@ -158,12 +159,14 @@ All query commands use WebSocket RPC.
 </Tabs>
 
 <Note>
-When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
+When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error. Using `--port` instead of `--url` preserves configured credentials and does not require explicit auth.
 </Note>
 
 ### `gateway health`
 
 ```bash
+openclaw gateway health
+openclaw gateway --port 18789 health
 openclaw gateway health --url ws://127.0.0.1:18789
 ```
 

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -166,6 +166,35 @@ describe("gateway-cli coverage", () => {
     expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("gateway --port <N> health routes through config.gateway.port, not a url override (#79100)", async () => {
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "--port", "18799", "health", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const callArgs = firstMockArg(callGateway) as {
+      config?: { gateway?: { port?: number } };
+      url?: unknown;
+    };
+    // The port is patched onto config.gateway.port (so configured local auth/TLS is
+    // preserved), not turned into a synthetic ws:// url that would demand explicit creds.
+    expect(callArgs.config?.gateway?.port).toBe(18799);
+    expect(callArgs.url).toBeUndefined();
+  });
+
+  it("gateway --port <N> probe passes port as a number, not a ws:// url (#79100)", async () => {
+    gatewayStatusCommand.mockClear();
+
+    await runGatewayCommand(["gateway", "--port", "18799", "probe", "--json"]);
+
+    expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+    const probeArgs = firstMockArg(gatewayStatusCommand) as { port?: unknown; url?: unknown };
+    // A numeric port lets gatewayStatusCommand route through resolveTargets, which derives
+    // wss:// vs ws:// from the loaded config's TLS settings instead of hard-coding plaintext.
+    expect(probeArgs.port).toBe(18799);
+    expect(typeof probeArgs.url).not.toBe("string");
+  });
+
   it("registers gateway stability and routes to diagnostics RPC", async () => {
     callGateway.mockClear();
 

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -3,14 +3,18 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
+import { readSourceConfigBestEffort } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
+import { defaultRuntime } from "../../runtime.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { withProgress } from "../progress.js";
+import { parsePort } from "../shared/parse-port.js";
 
 export type GatewayRpcOpts = {
   config?: OpenClawConfig;
   url?: string;
+  port?: string;
   token?: string;
   password?: string;
   timeout?: string;
@@ -29,6 +33,25 @@ export const gatewayCallOpts = (cmd: Command) =>
     .option("--expect-final", "Wait for final response (agent)", false)
     .option("--json", "Output JSON", false);
 
+async function resolveConfigWithPort(
+  base: OpenClawConfig | undefined,
+  port: string | undefined,
+): Promise<OpenClawConfig | undefined> {
+  if (!port) {
+    return base;
+  }
+  const parsed = parsePort(port);
+  if (parsed === null) {
+    defaultRuntime.error("Invalid port");
+    defaultRuntime.exit(1);
+    return base;
+  }
+  // Load the real config so auth, TLS, and mode settings are preserved; only the
+  // gateway port is overridden, so configured local credentials still apply.
+  const real = base ?? (await readSourceConfigBestEffort());
+  return { ...real, gateway: { ...real.gateway, port: parsed } };
+}
+
 export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, params?: unknown) =>
   withProgress(
     {
@@ -38,7 +61,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
     },
     async () =>
       await callGateway({
-        config: opts.config,
+        config: await resolveConfigWithPort(opts.config, opts.port),
         url: opts.url,
         token: opts.token,
         password: opts.password,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -18,6 +18,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatHelpExamples } from "../help-format.js";
+import { parsePort } from "../shared/parse-port.js";
 import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { addGatewayRunCommand } from "./run-command.js";
@@ -138,16 +139,18 @@ function parseDaysOption(raw: unknown, fallback = 30): number {
   return fallback;
 }
 
-function resolveGatewayRpcOptions<T extends { token?: string; password?: string }>(
+function resolveGatewayRpcOptions<T extends { token?: string; password?: string; port?: string }>(
   opts: T,
   command?: Command,
 ): T {
   const parentToken = inheritOptionFromParent<string>(command, "token");
   const parentPassword = inheritOptionFromParent<string>(command, "password");
+  const parentPort = inheritOptionFromParent<string>(command, "port");
   return {
     ...opts,
     token: opts.token ?? parentToken,
     password: opts.password ?? parentPassword,
+    port: opts.port ?? parentPort,
   };
 }
 
@@ -677,6 +680,10 @@ export function registerGatewayCli(program: Command) {
       "Show gateway reachability, auth capability, and read-probe summary (local + remote)",
     )
     .option("--url <url>", "Explicit Gateway WebSocket URL (still probes localhost)")
+    .option(
+      "--port <port>",
+      "Local port override for the gateway probe (preserves TLS/auth from loaded config)",
+    )
     .option("--ssh <target>", "SSH target for remote gateway tunnel (user@host or user@host:port)")
     .option("--ssh-identity <path>", "SSH identity file path")
     .option("--ssh-auto", "Try to derive an SSH target from Bonjour discovery", false)
@@ -687,8 +694,15 @@ export function registerGatewayCli(program: Command) {
     .action(async (opts, command) => {
       await runGatewayCommand(async () => {
         const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        const rawPort = rpcOpts.port;
+        const portNum = rawPort !== undefined ? parsePort(rawPort) : null;
+        if (rawPort !== undefined && portNum === null) {
+          defaultRuntime.error("Invalid port");
+          defaultRuntime.exit(1);
+          return;
+        }
         const { gatewayStatusCommand } = await loadGatewayStatusModule();
-        await gatewayStatusCommand(rpcOpts, defaultRuntime);
+        await gatewayStatusCommand({ ...rpcOpts, port: portNum ?? undefined }, defaultRuntime);
       });
     });
 

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -38,6 +38,7 @@ function loadGatewayTlsModule() {
 export async function gatewayStatusCommand(
   opts: {
     url?: string;
+    port?: number;
     token?: string;
     password?: string;
     timeout?: unknown;
@@ -49,7 +50,13 @@ export async function gatewayStatusCommand(
   runtime: RuntimeEnv,
 ) {
   const startedAt = Date.now();
-  const cfg = await readBestEffortConfig();
+  const rawCfg = await readBestEffortConfig();
+  // Apply the port override onto the loaded config so resolveTargets derives the right
+  // scheme (wss:// vs ws://) from gateway.tls settings rather than hard-coding ws://.
+  const cfg =
+    opts.port != null && opts.port > 0
+      ? { ...rawCfg, gateway: { ...rawCfg.gateway, port: opts.port } }
+      : rawCfg;
   const rich = isRich() && opts.json !== true;
   const defaultTimeoutMs = Math.max(3000, cfg.gateway?.handshakeTimeoutMs ?? 0);
   const overallTimeoutMs = parseTimeoutMs(opts.timeout, defaultTimeoutMs);


### PR DESCRIPTION
## Summary

`gateway run --port 18789` accepts `--port`, but the adjacent query subcommands rejected the same flag:

- `openclaw gateway health --port 18789` → `error: unknown option '--port'`
- `openclaw gateway probe --port 18789` → `error: unknown option '--port'`

So scripts that start a gateway on a controlled local port could not target it through `health`/`probe` with the same visible flag shape as `run`, and the `--url` workaround disables config credential fallback (forcing explicit `--token`/`--password`).

### Fix

Route the existing parent `gateway --port` flag through to the query commands by patching `config.gateway.port` — not by synthesizing a `ws://` URL — so configured local auth and the TLS scheme (`ws://` vs `wss://`) are preserved:

- `resolveGatewayRpcOptions` now inherits the parent `--port` (covers `health`, `call`, `usage-cost`, `stability` via `callGatewayCli`).
- `callGatewayCli` loads the real config and overrides only `gateway.port`, so configured credentials still apply (no forced `--token`/`--password`).
- `gateway probe` gains its own `--port` and passes a **numeric** port to `gatewayStatusCommand`, which patches `config.gateway.port` before `resolveTargets` derives the scheme.
- Invalid ports are rejected via the shared strict `parsePort`.

Usage: `openclaw gateway --port 18789 health` (port before the subcommand, the same place the parent `--port` already lives for `gateway run`).

Fixes #79100

## Real behavior proof

**Behavior addressed**: `gateway health` and `gateway probe` rejected the `--port` that `gateway run` accepts; they now honor the parent `gateway --port <N>` flag by patching `config.gateway.port` (preserving local auth/TLS) instead of erroring or ignoring it.

**Real environment tested**: vitest (`src/cli/gateway-cli.coverage.test.ts`) driving the real `registerGatewayCli` Commander program through `runGatewayCommand([...])` argv parsing, with `callGateway` and `gatewayStatusCommand` mocked at the RPC boundary to capture the resolved options.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cli/gateway-cli.coverage.test.ts`

**Evidence after fix**: `Test Files  1 passed (1)` / `Tests  21 passed (21)`, including the two new #79100 cases. Reverting only the three source edits (keeping the tests) flips exactly those two cases to failing (`Tests  2 failed | 19 passed`), proving the tests bind the fix.

**Observed result after fix**: `gateway --port 18799 health` calls `callGateway` once with `config.gateway.port === 18799` and `url === undefined` (the port is patched onto config, not turned into a url override). `gateway --port 18799 probe` calls `gatewayStatusCommand` once with a numeric `port === 18799` and no string `url`, so `resolveTargets` derives `ws://` vs `wss://` from the loaded config's TLS settings rather than a hard-coded plaintext URL.

**What was not tested**: A live gateway socket round-trip on a real non-default port — the change is in CLI option resolution and config patching, verified by driving the real Commander program and asserting the resolved RPC/probe options; the downstream connect path is unchanged and already covered elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
