### PR TITLE
fix(plugins): harden plugin tool shape reads

### DIFF
--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -141,23 +141,45 @@ function asJsonObject(value: unknown): JsonObject {
   return value as JsonObject;
 }
 
+function readToolDescriptorField<T>(read: () => T): T | undefined {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
-}): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
+}): CachedPluginToolDescriptor | null {
+  const name = readToolDescriptorField(() => params.tool.name);
+  const description = readToolDescriptorField(() => params.tool.description);
+  const inputSchema = readToolDescriptorField(() => params.tool.parameters);
+  if (typeof name !== "string" || !name.trim() || typeof description !== "string") {
+    return null;
+  }
+  if (!inputSchema || typeof inputSchema !== "object" || Array.isArray(inputSchema)) {
+    return null;
+  }
+  const label = readToolDescriptorField(() => (params.tool as { label?: unknown }).label);
   const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  const displaySummaryRaw = readToolDescriptorField(() => params.tool.displaySummary);
+  const displaySummary =
+    typeof displaySummaryRaw === "string" && displaySummaryRaw.trim()
+      ? displaySummaryRaw
+      : undefined;
   return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
+    ...(displaySummary ? { displaySummary } : {}),
     optional: params.optional,
     descriptor: {
-      name: params.tool.name,
+      name,
       ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
+      description,
+      inputSchema: asJsonObject(inputSchema),
       owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      executor: { kind: "plugin", pluginId: params.pluginId, toolName: name },
     },
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -163,6 +163,19 @@ function createMalformedTool(name: string) {
   };
 }
 
+function createToolWithThrowingGetter(
+  name: string,
+  property: "description" | "name" | "parameters",
+) {
+  const tool = makeTool(name);
+  Object.defineProperty(tool, property, {
+    get() {
+      throw new Error(`${property} exploded`);
+    },
+  });
+  return tool;
+}
+
 function installConsoleMethodSpy(method: "log" | "warn") {
   const spy = vi.fn();
   loggingState.rawConsole = {
@@ -1935,6 +1948,52 @@ describe("resolvePluginTools optional tools", () => {
     expectSingleDiagnosticMessage(
       registry.diagnostics,
       "plugin tool is malformed (schema-bug): broken_tool missing parameters object",
+    );
+  });
+
+  it("skips plugin tools with unreadable schema getters while keeping valid siblings", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "schema-getter-bug",
+        optional: false,
+        source: "/tmp/schema-getter-bug.js",
+        names: ["broken_schema", "valid_tool"],
+        factory: () => [
+          createToolWithThrowingGetter("broken_schema", "parameters"),
+          makeTool("valid_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (schema-getter-bug): broken_schema unreadable parameters object",
+    );
+  });
+
+  it("reports unreadable plugin tool names without poisoning valid siblings", () => {
+    const registry = setRegistry([
+      {
+        pluginId: "name-getter-bug",
+        optional: false,
+        source: "/tmp/name-getter-bug.js",
+        names: ["broken_name", "valid_tool"],
+        factory: () => [
+          createToolWithThrowingGetter("broken_name", "name"),
+          makeTool("valid_tool"),
+        ],
+      },
+    ]);
+
+    const tools = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(tools, ["valid_tool"]);
+    expectSingleDiagnosticMessage(
+      registry.diagnostics,
+      "plugin tool is malformed (name-getter-bug): missing non-empty name",
     );
   });
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -107,12 +107,14 @@ function runWithPluginToolScope<T>(entry: PluginToolRegistration, run: () => T):
 }
 
 function isAgentTool(value: unknown): value is AnyAgentTool {
-  return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof (value as { execute?: unknown }).execute === "function"
-  );
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  try {
+    return typeof (value as { execute?: unknown }).execute === "function";
+  } catch {
+    return false;
+  }
 }
 
 function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTool): AnyAgentTool {
@@ -316,7 +318,11 @@ function readPluginToolName(tool: unknown): string {
     return "";
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
-  return typeof tool.name === "string" ? tool.name.trim() : "";
+  try {
+    return typeof tool.name === "string" ? tool.name.trim() : "";
+  } catch {
+    return "";
+  }
 }
 
 function toElapsedMs(value: number): number {
@@ -452,10 +458,27 @@ function describeMalformedPluginTool(tool: unknown): string | undefined {
   if (!name) {
     return "missing non-empty name";
   }
-  if (typeof tool.execute !== "function") {
+  let execute: unknown;
+  try {
+    execute = tool.execute;
+  } catch {
+    return `${name} unreadable execute function`;
+  }
+  if (typeof execute !== "function") {
     return `${name} missing execute function`;
   }
-  if (!isRecord(tool.parameters)) {
+  try {
+    void tool.description;
+  } catch {
+    return `${name} unreadable description`;
+  }
+  let parameters: unknown;
+  try {
+    parameters = tool.parameters;
+  } catch {
+    return `${name} unreadable parameters object`;
+  }
+  if (!isRecord(parameters)) {
     return `${name} missing parameters object`;
   }
   return undefined;
@@ -1220,6 +1243,9 @@ export function resolvePluginTools(params: {
     const availableList = manifestPlugin
       ? listRaw.filter((tool) => {
           const toolName = readPluginToolName(tool);
+          if (!toolName) {
+            return true;
+          }
           const normalizedToolName = normalizeToolName(toolName);
           if (
             isManifestToolOptional(manifestPlugin, toolName) &&
@@ -1284,10 +1310,11 @@ export function resolvePluginTools(params: {
         continue;
       }
       const tool = toolRaw as AnyAgentTool;
+      const toolName = readPluginToolName(tool);
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,
-            toolNames: [tool.name],
+            toolNames: [toolName],
           })
         : [];
       if (undeclared.length > 0) {
@@ -1301,9 +1328,9 @@ export function resolvePluginTools(params: {
         });
         continue;
       }
-      const normalizedToolName = normalizeToolName(tool.name);
+      const normalizedToolName = normalizeToolName(toolName);
       if (normalizedNameSet.has(normalizedToolName) || existingNormalized.has(normalizedToolName)) {
-        const message = `plugin tool name conflict (${entry.pluginId}): ${tool.name}`;
+        const message = `plugin tool name conflict (${entry.pluginId}): ${toolName}`;
         if (!params.suppressNameConflicts) {
           context.logger.error(message);
           registry.diagnostics.push({
@@ -1316,31 +1343,32 @@ export function resolvePluginTools(params: {
         continue;
       }
       normalizedNameSet.add(normalizedToolName);
-      existing.add(tool.name);
+      existing.add(toolName);
       existingNormalized.add(normalizedToolName);
       const optional = isPluginToolOptional({
         entry,
         manifestPlugin,
-        toolName: tool.name,
+        toolName,
       });
       pluginToolMeta.set(tool, {
         pluginId: entry.pluginId,
         optional,
         trustedLocalMedia: isTrustedManifestLocalMediaTool({
           manifestPlugin,
-          toolName: tool.name,
+          toolName,
         }),
       });
       if (manifestPlugin) {
         const capturedDescriptors = capturedDescriptorsByPluginId.get(entry.pluginId) ?? [];
-        capturedDescriptors.push(
-          capturePluginToolDescriptor({
-            pluginId: entry.pluginId,
-            tool,
-            optional,
-          }),
-        );
-        capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        const capturedDescriptor = capturePluginToolDescriptor({
+          pluginId: entry.pluginId,
+          tool,
+          optional,
+        });
+        if (capturedDescriptor) {
+          capturedDescriptors.push(capturedDescriptor);
+          capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        }
       }
       tools.push(tool);
     }


### PR DESCRIPTION
## Summary
- Harden plugin tool runtime shape checks against hostile getters on tool names, descriptions, execute functions, and parameter schemas.
- Keep malformed plugin tools isolated so a bad tool cannot poison valid sibling tools from the same plugin.
- Make plugin tool descriptor cache capture best-effort, skipping unsafe descriptors instead of crashing tool resolution.

## Verification
- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts`
- `./node_modules/.bin/oxlint src/plugins/tools.ts src/plugins/tool-descriptor-cache.ts src/plugins/tools.optional.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: `run_c9a000f050c7`, lease `cbx_0ed4afbe8e64`, slug `blue-barnacle`, provider `aws`, exit 0; lanes `core`, `coreTests`; command 4m1.980s, total 4m19.807s

## Real behavior proof
Behavior addressed: plugin tools with hostile getters on runtime tool shape fields no longer crash plugin tool resolution before healthy sibling tools can be exposed.
Real environment tested: local sparse OpenClaw worktree on branch `fuzz-tool-schema-next35-20260602`, plus AWS Crabbox PR checkout for `openclaw/openclaw#89559` at head `7da8f82c5f3`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts -- --reporter=dot`; remote `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.
Evidence after fix: focused plugin tools tests passed with 69 tests; AWS Crabbox `run_c9a000f050c7` passed `pnpm check:changed` with `core` and `coreTests` lanes selected.
Observed result after fix: malformed getter-backed plugin tools are skipped with diagnostics while valid sibling tools remain available; descriptor cache capture skips unsafe descriptors rather than failing tool resolution.
What was not tested: no live third-party plugin runtime was exercised beyond mocked plugin registry coverage and the remote changed gate.
