### PR TITLE
fix(hooks): honor session-memory hook model override for LLM slug generation [AI-assisted]

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -233,7 +233,8 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
       if (sessionContent && cfg && allowLlmSlug) {
         log.debug("Calling generateSlugViaLLM...");
         // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        const modelOverride = typeof hookConfig?.model === "string" ? hookConfig.model : undefined;
+        slug = await generateSlugViaLLM({ sessionContent, cfg, modelOverride });
         log.debug("Generated slug", { slug });
       }
     }

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -20,7 +20,7 @@ vi.mock("../agents/embedded-agent.js", () => ({
   runEmbeddedAgent: (...args: unknown[]) => runEmbeddedAgentMock(...args),
 }));
 
-import { generateSlugViaLLM } from "./llm-slug-generator.js";
+import { generateSlugViaLLM, resolveSlugGeneratorModelRef } from "./llm-slug-generator.js";
 
 function requireFirstRunOptions(): Record<string, unknown> {
   const [call] = runEmbeddedAgentMock.mock.calls;
@@ -114,5 +114,85 @@ describe("generateSlugViaLLM", () => {
     const options = requireFirstRunOptions();
     expect(options.provider).toBe("openai");
     expect(options.model).toBe("gpt-5.5");
+  });
+  it.each([
+    {
+      name: "uses hook-level provider/model override when given",
+      override: "anthropic/claude-3-5-haiku",
+      expectedProvider: "anthropic",
+      expectedModel: "claude-3-5-haiku",
+    },
+    {
+      name: "uses hook-level bare model with agent default provider",
+      override: "claude-3-5-haiku",
+      expectedProvider: "openai",
+      expectedModel: "claude-3-5-haiku",
+    },
+  ])("session-memory hook model override: $name (#89551)", async (params) => {
+    await generateSlugViaLLM({
+      sessionContent: "hello",
+      cfg: {
+        agents: {
+          defaults: { model: { primary: "gpt-5.5" } },
+        },
+      } as OpenClawConfig,
+      modelOverride: params.override,
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    const options = requireFirstRunOptions();
+    expect(options.provider).toBe(params.expectedProvider);
+    expect(options.model).toBe(params.expectedModel);
+  });
+
+  it.each([
+    { name: "undefined", value: undefined },
+    { name: "empty string", value: "" },
+    { name: "whitespace only", value: "   " },
+  ])("falls back to agent default when modelOverride is $name (#89551)", async (params) => {
+    await generateSlugViaLLM({
+      sessionContent: "hello",
+      cfg: {
+        agents: {
+          defaults: { model: { primary: "gpt-5.5" } },
+        },
+      } as OpenClawConfig,
+      modelOverride: params.value,
+    });
+
+    const options = requireFirstRunOptions();
+    expect(options.provider).toBe("openai");
+    expect(options.model).toBe("gpt-5.5");
+  });
+});
+
+describe("resolveSlugGeneratorModelRef", () => {
+  it("returns the agent default when no override is provided", () => {
+    const ref = resolveSlugGeneratorModelRef({
+      cfg: {
+        agents: { defaults: { model: { primary: "gpt-5.5" } } },
+      } as OpenClawConfig,
+    });
+    expect(ref).toEqual({ provider: "openai", model: "gpt-5.5" });
+  });
+
+  it("honors a hook-level provider/model override", () => {
+    const ref = resolveSlugGeneratorModelRef({
+      cfg: {
+        agents: { defaults: { model: { primary: "gpt-5.5" } } },
+      } as OpenClawConfig,
+      hookModelOverride: "anthropic/claude-3-5-haiku",
+    });
+    expect(ref).toEqual({ provider: "anthropic", model: "claude-3-5-haiku" });
+  });
+
+  it("falls back to the agent default for unparseable overrides", () => {
+    const ref = resolveSlugGeneratorModelRef({
+      cfg: {
+        agents: { defaults: { model: { primary: "gpt-5.5" } } },
+      } as OpenClawConfig,
+      hookModelOverride: "anthropic/",
+    });
+    expect(ref).toEqual({ provider: "openai", model: "gpt-5.5" });
   });
 });

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,12 +12,48 @@ import {
   resolveAgentDir,
 } from "../agents/agent-scope.js";
 import { runEmbeddedAgent } from "../agents/embedded-agent.js";
+import { parseModelRef } from "../agents/model-selection-normalize.js";
+import type { ModelRef } from "../agents/model-selection-normalize.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("llm-slug-generator");
+
+/**
+ * Resolve which model to use for slug generation.
+ *
+ * When the hook config (e.g. `hooks.internal.entries["session-memory"].model`)
+ * provides a `provider/model` (or bare `model`) string, prefer it so the
+ * caller can route slug generation to a cheaper / faster model than the
+ * agent's primary model. Falls back to the agent's default model when the
+ * override is missing, empty, or unparseable.
+ */
+export function resolveSlugGeneratorModelRef(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  hookModelOverride?: unknown;
+}): ModelRef {
+  const fallback = () => resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
+  const raw = params.hookModelOverride;
+  if (typeof raw !== "string") {
+    return fallback();
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return fallback();
+  }
+  const fallbackRef = fallback();
+  const parsed = parseModelRef(trimmed, fallbackRef.provider);
+  if (!parsed) {
+    log.warn(
+      `Ignoring unparseable session-memory hook model override; falling back to agent default`,
+    );
+    return fallbackRef;
+  }
+  return parsed;
+}
 const DEFAULT_SLUG_GENERATOR_TIMEOUT_MS = 15_000;
 
 function resolveSlugGeneratorTimeoutMs(cfg: OpenClawConfig): number {
@@ -34,6 +70,12 @@ function resolveSlugGeneratorTimeoutMs(cfg: OpenClawConfig): number {
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
+  /**
+   * Optional `provider/model` (or bare `model`) override from the hook's
+   * config entry. When present and parseable it takes precedence over the
+   * agent's default model for this slug-generation run.
+   */
+  modelOverride?: string;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
@@ -53,9 +95,10 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    const { provider, model } = resolveDefaultModelForAgent({
+    const { provider, model } = resolveSlugGeneratorModelRef({
       cfg: params.cfg,
       agentId,
+      hookModelOverride: params.modelOverride,
     });
     const timeoutMs = resolveSlugGeneratorTimeoutMs(params.cfg);
 


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration; reviewer = 麻酱, code review = Codex CLI). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `hooks.internal.entries["session-memory"].model` was silently ignored; slug generation always used the agent's default model.
- Solution: introduce a small pure helper that prefers a parseable hook-level model override and falls back to the agent default; thread it through `generateSlugViaLLM`.
- What changed: `src/hooks/llm-slug-generator.ts` (+ helper + new optional `modelOverride` param), `src/hooks/bundled/session-memory/handler.ts` (forwards `hookConfig.model`), `src/hooks/llm-slug-generator.test.ts` (regression tests).
- What did NOT change (scope boundary): no schema change (`HookConfigSchema` already `.passthrough()`), no other hooks touched, no behavior change when the override is absent or unparseable, no agent-level model resolution paths modified.

## Motivation
Users who set a cheaper / faster model on the session-memory hook (e.g. to keep `/reset` slug generation off their primary coding model) expect that override to be used. Today the hook config is read but the `model` field is silently dropped, so the slug call still spends primary-model tokens. This is a behavior bug filed in #89551 and is trivially reproducible with a hook config.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #89551
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: slug-generation model selection now honors `hooks.internal.entries["session-memory"].model`.
- Real environment tested: local OpenClaw checkout @ `upstream/main` `f789081bae123099e5a057ca43d8be35e35c6c48`, macOS, Node `v22.15.0`. Repro drives the real `resolveDefaultModelForAgent` and `resolveSlugGeneratorModelRef` source modules via `tsx` — no mocks, no stubbed providers.
- Exact steps or command run after this patch:
  1. Constructed a config with `agents.defaults.model.primary = "openai/gpt-5.5"` and `hooks.internal.entries["session-memory"].model = "anthropic/claude-3-5-haiku"`.
  2. `node_modules/.bin/tsx repro-89551.mjs` (driver imports source `.ts` by absolute path).
- Evidence after fix (redacted terminal capture):
  ```text
  === BEFORE the fix (current main) ===
  agent default ref: { provider: 'openai', model: 'gpt-5.5' }
  slug-gen ref (BEFORE: simulated current main behavior): { provider: 'openai', model: 'gpt-5.5' }
  hook override requested: anthropic/claude-3-5-haiku
  ❌ Bug #89551 reproduced: slug generator picked openai/gpt-5.5 instead of the hook-level model anthropic/claude-3-5-haiku.

  === AFTER the fix (this branch) ===
  agent default ref: { provider: 'openai', model: 'gpt-5.5' }
  slug-gen ref (AFTER fix): { provider: 'anthropic', model: 'claude-3-5-haiku' }
  ✅ Bug #89551 fixed: hook-level model is honored, fallbacks preserved.
  ```
- Observed result after fix: the slug generator now resolves to the hook-level provider/model when one is configured, and continues to fall back to the agent default for undefined / empty / whitespace / unparseable overrides.
- What was not tested: did not exercise a live `/reset` end-to-end against a real model provider; mocked plugin load warnings (`pi-ai/oauth`) in the repro environment are unrelated to the change.
- Before evidence: same BEFORE block above (captured by stashing the fix and rerunning the same driver).

## Root Cause (if applicable)
- Root cause: `generateSlugViaLLM` in `src/hooks/llm-slug-generator.ts` unconditionally called `resolveDefaultModelForAgent({ cfg, agentId })`, and the session-memory handler read `resolveHookConfig(cfg, "session-memory")` but never extracted or forwarded `hookConfig.model` to the slug generator.
- Missing detection / guardrail: no unit test asserted what `provider`/`model` is sent to `runEmbeddedAgent` when a hook-level model override is present.
- Contributing context: `HookConfigSchema` is `.passthrough()`, so the override silently parsed and survived as `unknown` without ever being consumed.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/hooks/llm-slug-generator.test.ts`.
- Scenario the test should lock in: a hook-level `model` override is honored end-to-end into `runEmbeddedAgent`'s `provider`/`model`; absent / empty / whitespace / unparseable overrides fall back to the agent default.
- Why this is the smallest reliable guardrail: the new helper is the single decision point; `it.each` over the override values exhaustively pins behavior without needing a real provider.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes
- When `hooks.internal.entries["session-memory"].model` is set (and parseable), session-memory slug generation now uses that model. When unset, empty, or unparseable, behavior is unchanged (agent default).

## Diagram (if applicable)
```text
Before: hookConfig.model ──(ignored)── generateSlugViaLLM ── resolveDefaultModelForAgent ── agent default
After:  hookConfig.model ──► generateSlugViaLLM(modelOverride) ──► resolveSlugGeneratorModelRef
                                                                       │
                                                          parseable ──►├──► hook override ref
                                                          else        ─┴──► resolveDefaultModelForAgent
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (the routing target may change to a different already-configured provider; no new outbound surface)
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node `v22.15.0`, pnpm (repo-pinned)
- Model/provider: N/A (driver does not hit a real provider)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model.primary`, `hooks.internal.entries["session-memory"].{enabled,llmSlug,model}`

### Steps
1. `git fetch upstream && git checkout fix/session-memory-hook-model-override`
2. `node_modules/.bin/vitest run src/hooks/llm-slug-generator.test.ts src/hooks/bundled/session-memory/handler.test.ts` → 35 passed
3. `pnpm exec oxfmt --check src/hooks/llm-slug-generator.ts src/hooks/llm-slug-generator.test.ts src/hooks/bundled/session-memory/handler.ts` → clean
4. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false --incremental` → 0 errors
5. Repro driver: BEFORE → ❌ (slug-gen picks `openai/gpt-5.5`), AFTER → ✅ (slug-gen picks `anthropic/claude-3-5-haiku`).
