### PR TITLE
fix(agents): harden system prompt tool reporting

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -216,4 +216,83 @@ describe("buildSystemPromptReport", () => {
     });
     expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
   });
+
+  it("keeps reporting when tool metadata getters throw", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const tool = {
+      get name() {
+        throw new Error("name exploded");
+      },
+      get description() {
+        throw new Error("description exploded");
+      },
+      get label() {
+        throw new Error("label exploded");
+      },
+      get parameters() {
+        throw new Error("parameters exploded");
+      },
+    };
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [tool] as never,
+    });
+
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "(unknown)",
+      summaryChars: 0,
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[0]?.summaryHash).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("keeps reporting when schema properties cannot be inspected", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const hostileProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("properties exploded");
+        },
+      },
+    );
+    const schema = {
+      type: "object",
+      properties: hostileProperties,
+    };
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        {
+          name: "hostile_schema",
+          description: "Hostile schema",
+          parameters: schema,
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "hostile_schema",
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -17,6 +17,14 @@ function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
+function readReportField<T>(read: () => T): T | undefined {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
 function extractBetween(input: string, startMarker: string, endMarker: string): string {
   const start = input.indexOf(startMarker);
   if (start === -1) {
@@ -63,11 +71,13 @@ function buildToolSchemaStats(
     schemaHash: sha256(schemaJson),
     propertiesCount: (() => {
       const schema = parameters as Record<string, unknown>;
-      const props = typeof schema.properties === "object" ? schema.properties : null;
+      const props = readReportField(() =>
+        typeof schema.properties === "object" ? schema.properties : null,
+      );
       if (!props || typeof props !== "object") {
         return null;
       }
-      return Object.keys(props as Record<string, unknown>).length;
+      return readReportField(() => Object.keys(props as Record<string, unknown>).length) ?? null;
     })(),
   };
   toolSchemaStatsCache.set(parameters, stats);
@@ -80,10 +90,17 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
     if (cached) {
       return cached;
     }
-    const name = tool.name;
-    const summary = tool.description?.trim() || tool.label?.trim() || "";
+    const rawName = readReportField(() => tool.name);
+    const name = typeof rawName === "string" && rawName.trim() ? rawName.trim() : "(unknown)";
+    const rawDescription = readReportField(() => tool.description);
+    const rawLabel = readReportField(() => tool.label);
+    const summary =
+      (typeof rawDescription === "string" ? rawDescription.trim() : "") ||
+      (typeof rawLabel === "string" ? rawLabel.trim() : "");
     const summaryChars = summary.length;
-    const schemaStats = buildToolSchemaStats(tool.parameters);
+    const schemaStats = buildToolSchemaStats(
+      readReportField(() => tool.parameters) as AgentTool["parameters"],
+    );
     const entry = { name, summaryChars, summaryHash: sha256(summary), ...schemaStats };
     toolReportEntryCache.set(tool, entry);
     return entry;


### PR DESCRIPTION
## Summary
- Harden system prompt report generation against tool metadata getters that throw while reading name, description, label, or parameters.
- Keep schema size/property telemetry best-effort when schema `properties` cannot be inspected.
- Add regressions for hostile tool metadata and schema property maps.

## Verification
- `node scripts/run-vitest.mjs src/agents/system-prompt-report.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `./node_modules/.bin/oxlint src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: `run_ce70c25396bb`, lease `cbx_4c50955aacf9`, slug `amber-crayfish`, provider `aws`, exit 0; lanes `core`, `coreTests`; command 3m53.894s, total 4m10.601s

## Real behavior proof
Behavior addressed: system prompt report generation no longer aborts when plugin-owned tool metadata or schema fields throw during reporting.
Real environment tested: local sparse OpenClaw worktree on branch `fuzz-tool-schema-next36-20260602`, plus AWS Crabbox PR checkout for `openclaw/openclaw#89565` at head `f0c3c45ed40`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/system-prompt-report.test.ts -- --reporter=dot`; remote `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.
Evidence after fix: focused system prompt report tests passed with 12 tests; AWS Crabbox `run_ce70c25396bb` passed `pnpm check:changed` with `core` and `coreTests` lanes selected.
Observed result after fix: report generation emits conservative fallback entries instead of throwing, preserving prompt/report telemetry for the rest of the turn.
What was not tested: no live third-party plugin runtime was exercised beyond mocked hostile tool/report fixtures and the remote changed gate.
