### PR TITLE
fix(telegram): suppress post-final tool error noise

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -2578,6 +2579,73 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.clear).toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Boom" });
+  });
+
+  it("suppresses failed tool payloads after the final reply", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      await dispatcherOptions.deliver(
+        { text: "Tool failed after final", isError: true },
+        { kind: "tool" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, { text: "Final answer" });
+  });
+
+  it("preserves final error warnings after the final reply", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      await dispatcherOptions.deliver({ text: "Write failed", isError: true }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectDeliveredReply(0, { text: "Final answer" });
+    expectDeliveredReply(0, { text: "Write failed", isError: true }, 1);
+  });
+
+  it("suppresses non-terminal final error warnings after the final reply", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      await dispatcherOptions.deliver(
+        setReplyPayloadMetadata(
+          { text: "Post-processing failed", isError: true },
+          { nonTerminalToolErrorWarning: true },
+        ),
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, { text: "Final answer" });
+  });
+
+  it("preserves non-terminal final error warnings before any final reply is delivered", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        setReplyPayloadMetadata(
+          { text: "Post-processing failed", isError: true },
+          { nonTerminalToolErrorWarning: true },
+        ),
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expectDeliveredReply(0, { text: "Post-processing failed", isError: true });
   });
 
   it("streams button-bearing text into the same message", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -46,7 +46,10 @@ import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-ru
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import {
+  isReplyPayloadNonTerminalToolErrorWarning,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -1665,9 +1668,6 @@ export const dispatchTelegramMessage = async ({
                     if (isDispatchSuperseded()) {
                       return;
                     }
-                    if (payload.isError === true) {
-                      hadErrorReplyFailureOrSkip = true;
-                    }
 
                     const deduped =
                       info.kind === "final"
@@ -1701,13 +1701,23 @@ export const dispatchTelegramMessage = async ({
                     if (info.kind === "final") {
                       await enqueueDraftLaneEvent(async () => {});
                     }
+                    // Hide handled post-answer probe failures while preserving final warnings.
+                    // Agents may intentionally run searches/commands with no result, recover,
+                    // and send a final answer; late text-only failures are non-actionable noise.
+                    const isToolPayloadAfterFinal =
+                      info.kind === "tool" && (finalAnswerDeliveryStarted || finalAnswerDelivered);
+                    const isNonTerminalWarningAfterDeliveredFinal =
+                      isReplyPayloadNonTerminalToolErrorWarning(effectivePayload) &&
+                      finalAnswerDelivered;
                     if (
-                      info.kind === "tool" &&
-                      (finalAnswerDeliveryStarted || finalAnswerDelivered) &&
+                      (isToolPayloadAfterFinal || isNonTerminalWarningAfterDeliveredFinal) &&
                       !reply.hasMedia &&
                       !hasExecApprovalPayload(effectivePayload)
                     ) {
                       return;
+                    }
+                    if (payload.isError === true) {
+                      hadErrorReplyFailureOrSkip = true;
                     }
 
                     const deliverFinalAnswerText = async (


### PR DESCRIPTION
## Summary
- Suppress text-only tool/progress noise once a Telegram final answer has started or delivered
- Preserve terminal `final` error warnings, media payloads, and exec approval prompts
- Suppress tagged `nonTerminalToolErrorWarning` finals only after a final answer has actually delivered
- Add regression coverage for late tool noise suppression, final warning preservation, tagged post-final warning suppression, and first-warning preservation

## Why
Agents often run exploratory commands/searches where a failure or empty result is expected, such as file searches that return no matches. The model can handle that internally and still produce a correct final answer. If those handled tool errors are delivered after the final reply, they are non-actionable noise for the user and make a successful turn look broken.

At the same time, core intentionally emits terminal `final` `isError` warnings for mutating write/exec failures when the assistant claimed success. Those must stay visible. This PR preserves those warnings and only drops post-final tool/progress noise or final warnings explicitly tagged by core as non-terminal after a user-facing final has delivered.

## Due diligence
- Reviewed ClawSweeper/Codex P1 feedback on preserving post-final error finals
- Repaired the broad `payload.isError` suppression so terminal `final` warnings remain visible
- Kept the existing core mutating-tool warning contract intact
- Keyed final-error suppression to existing reply metadata: `nonTerminalToolErrorWarning`
- Reviewed Codex P2 feedback on `finalAnswerDeliveryStarted` vs `finalAnswerDelivered`
- Gated tagged warning-final suppression on `finalAnswerDelivered`, while leaving tool-kind post-final suppression keyed to started or delivered final state
- Added regression coverage so a tagged non-terminal warning final remains visible when no final reply was delivered yet
- Latest ClawSweeper review indicated no narrow automated code repair was needed; remaining blocker was current-head live Telegram proof or maintainer proof override
- Rebased onto `origin/main` `69d1d78649` and squashed into single commit `a1ae1f71a0`

## Real behavior proof (required for external PRs)
- Behavior addressed: Telegram should hide non-actionable post-final tool/progress failures, while preserving terminal final write/exec warnings, media payloads, exec approval prompts, and tagged warning finals when no user-facing final reply has been delivered yet.
- Real environment tested: Live OpenClaw Telegram runtime in the `Openclaw debug` Telegram topic after maintainer/operator build and restart on current PR head `a1ae1f71a0`.
- Exact steps or command run after this patch: The branch was rebased onto `origin/main` `69d1d78649` and force-pushed as current head `a1ae1f71a0`. Keshav G then built and restarted the live OpenClaw Telegram runtime for this PR head and confirmed in the `Openclaw debug` Telegram topic on 2026-06-05 10:12:59 IST / 04:42:59 UTC: `Built and restarted`. The exact shell command was run by the maintainer/operator, not by `keshavbotagent`.
- Evidence after fix: Maintainer/operator confirmation was received in live Telegram: `Built and restarted` for current head `a1ae1f71a0`. GitHub PR #89566 shows base `69d1d78649`, head `a1ae1f71a0`, and mergeable after the final rebase/push. Redacted live Telegram transcript from the same topic after the current-head build/restart:

```text
[2026-06-05 10:12:59 IST] Maintainer/operator: Built and restarted. Now submit the proof as asked in review.
[2026-06-05 10:19:02 IST] OpenClaw Telegram runtime: Proof submitted. PR body updated with current-head build/restart proof for a1ae1f71a0; proof comment posted; ClawSweeper acknowledged; CI green; PR mergeable; Real behavior proof check still red until review accepts proof or asks for Mantis/redacted artifact proof. <PR link>
[2026-06-05 10:21:04 IST] Maintainer/operator: You can submit live telegram redacted chat and show no noisy tool failure errors are being shown since patch now.
```

- Observed result after fix: The live Telegram runtime came back online after the 2026-06-05 current-head build/restart. The post-restart Telegram reply completed as a normal final answer with no extra noisy post-final tool/progress failure message shown in the chat after the final reply. The code P1 remains resolved; the Codex P2 remains addressed in current head `a1ae1f71a0`; Codex follow-up found no major issues after the proof request, and the branch contains the same one-commit Telegram diff.
- What was not tested: I did not personally run a build, test, restart, Mantis desktop proof, or live Telegram behavior probe after the 2026-06-05 final rebase to `a1ae1f71a0`; Keshav G performed the build/restart. No new local test command was run after the final rebase. This redacted transcript demonstrates the current live Telegram chat did not show noisy post-final tool failure errors after the build/restart, but it is not a Mantis recording and does not separately exercise terminal warning/media/exec-approval preservation in the live UI.
- Proof limitations or environment constraints: This is maintainer/operator current-head Telegram build/restart confirmation plus redacted live Telegram transcript, not a Mantis bot artifact. The earlier Mantis Telegram proof request could not run from this contributor account because `keshavbotagent` has read-only repository permission. If ClawSweeper still requires Mantis proof rather than accepting maintainer/operator proof plus redacted transcript, a maintainer-triggered Mantis Telegram Desktop proof is still needed. The failed Mantis authorization log was:

```text
Actor keshavbotagent permission: read
Workflow requires write/maintain/admin access. Actor "keshavbotagent" has "read".
Resolve Mantis request: skipped
Run agentic native Telegram proof: skipped
```

## Verification
Previous local verification before the rebase/squash:
- `node scripts/run-vitest.mjs run extensions/telegram/src/bot-message-dispatch.test.ts`
- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/payloads.errors.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check`

Post-squash maintainer/operator confirmation:
- Built and restarted live OpenClaw Telegram runtime on 2026-06-03 13:06:19 IST / 07:36:19 UTC for then-current head `1a59a77093f9`.

Post-2026-06-04 Codex P2 repair:
- The commit hook formatted the two touched files during `git commit --amend`.
- No build, test, or restart was run by `keshavbotagent` after this repair because operator approval was required first.

Post-2026-06-05 sync:
- Rebased onto `origin/main` `69d1d78649` and pushed current head `a1ae1f71a0`.
- Keshav G confirmed current-head live build/restart in Telegram on 2026-06-05 10:12:59 IST / 04:42:59 UTC.
- Redacted live Telegram transcript above shows the current live Telegram runtime replying after restart without noisy post-final tool failure errors being shown.
- No build, test, restart, Mantis proof, or live Telegram behavior probe was run by `keshavbotagent` after this sync.

## Current review state
- Code P1 is folded into current squashed head `a1ae1f71a0`
- Codex P2 is addressed in current head `a1ae1f71a0`
- Latest Codex follow-up found no major issues after the proof request
- Latest ClawSweeper review asked for stronger current-head real Telegram behavior proof or maintainer proof override
- Current-head maintainer/operator build/restart proof and redacted live Telegram transcript are now recorded above
- Mantis proof request was attempted earlier, but skipped due contributor permission