### PR TITLE
fix(memory-wiki): use crypto randomness for import run IDs

### DIFF
--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
@@ -649,7 +649,7 @@ function preserveExistingPageBlocks(rendered: string, existing: string): string 
 }
 
 function buildRunId(exportPath: string, nowIso: string): string {
-  const seed = `${exportPath}:${nowIso}:${Math.random()}`;
+  const seed = `${exportPath}:${nowIso}:${randomBytes(16).toString("hex")}`;
   return `chatgpt-${createHash("sha1").update(seed).digest("hex").slice(0, 12)}`;
 }
 

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -564,12 +564,14 @@ cli note
     expect(dryRun.createdCount).toBe(1);
     await expect(fs.readdir(path.join(rootDir, "sources"))).resolves.toStrictEqual([]);
 
+    const mathRandom = vi.spyOn(Math, "random");
     const applied = await runWikiChatGptImport({
       config,
       exportPath: exportDir,
       json: true,
     });
     expect(applied.runId).toMatch(/^chatgpt-[a-f0-9]{12}$/u);
+    expect(mathRandom).not.toHaveBeenCalled();
     expect(applied.createdCount).toBe(1);
     const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
       (entry) => entry !== "index.md",


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- ChatGPT import run IDs in the memory-wiki plugin included `Math.random()` in their seed.
- This PR switches that seed entropy to Node crypto randomness while preserving the existing `chatgpt-<12 hex>` run ID shape.

Why does this matter now?

- Import run IDs are used to track and roll back ChatGPT import runs. Predictable fallback randomness is avoidable here.

What is the intended outcome?

- Applied ChatGPT imports continue to produce valid run IDs, backed by cryptographic randomness instead of `Math.random()`.

What is intentionally out of scope?

- No change to rollback behavior, page rendering, import semantics, or run ID format.

What does success look like?

- A real ChatGPT import still creates one source page and returns a valid `chatgpt-[a-f0-9]{12}` run ID.

What should reviewers focus on?

- Whether `randomBytes(16)` is the right narrow replacement and whether the regression test is scoped enough.

## Linked context

Which issue does this close?

Closes N/A

Which issues, PRs, or discussions are related?

Related N/A

Was this requested by a maintainer or owner?

No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ChatGPT import run IDs should still be generated successfully after replacing `Math.random()` seed entropy with crypto randomness.
- Real environment tested: Debian Linux x86_64 source checkout on this PR branch, Node v24.15.0, pnpm 11.2.2.
- Exact steps or command run after this patch: Ran a `node --import tsx` script that created a temporary memory-wiki vault, wrote a minimal ChatGPT `conversations.json` export, called `importChatGptConversations`, and printed the import result.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied console output from the real script run:

```json
{
  "runId": "chatgpt-5991ad3c1bdc",
  "createdCount": 1,
  "updatedCount": 0,
  "skippedCount": 0,
  "pageCount": 1,
  "runIdMatchesExpectedShape": true
}
```

- Observed result after fix: The import completed, created one source page, and returned a valid `chatgpt-[a-f0-9]{12}` run ID.
- What was not tested: Full gateway startup, Obsidian rendering, rollback through the end-user CLI, and release/package Docker lanes.
- Proof limitations or environment constraints: This proof intentionally avoids starting or touching any running local OpenClaw gateway/app instance; it exercises the plugin import code directly in a temporary filesystem vault.
- Before evidence (optional but encouraged): The new regression assertion would fail on the previous implementation because `buildRunId()` called `Math.random()`.

## Tests and validation

Which commands did you run?

```bash
pnpm test extensions/memory-wiki/src/cli.test.ts -- --reporter=verbose
git diff --check
pnpm changed:lanes --json
```

What regression coverage was added or updated?

- Updated `extensions/memory-wiki/src/cli.test.ts` to assert ChatGPT import application no longer calls `Math.random()` while still returning a valid run ID.

What failed before this fix, if known?

- The new `Math.random()` spy assertion would fail against the old `buildRunId()` implementation.

If no test was added, why not?

N/A. A focused regression assertion was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No. The run ID format stays the same.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, security hardening only: the local import run ID seed now uses Node crypto randomness. No auth, secrets, network, permissions, or tool execution surface changed.

What is the highest-risk area?

- Low risk: preserving run ID format and import/rollback compatibility.

How is that risk mitigated?

- The existing import/rollback CLI test still exercises dry-run, apply, and rollback.
- The real proof confirms an applied import still returns a valid run ID and creates a page.

## Current review state

What is the next action?

Maintainer review of the narrow memory-wiki hardening change.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review. No known local follow-up is pending.

Which bot or reviewer comments were addressed?

None yet.
