### PR TITLE
fix(provider): harden provider tool schema hooks

### DIFF
--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -431,6 +431,130 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("does not let unreadable provider tool parameters abort sibling normalization", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const unreadable = {
+      name: "fuzzplugin_unreadable",
+      description: "",
+    };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const healthy = {
+      name: "healthy_union",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          mode: {
+            anyOf: [
+              { const: "append", type: "string" },
+              { const: "replace", type: "string" },
+            ],
+          },
+        },
+      },
+    };
+    const tools = [unreadable, healthy] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]).toBe(unreadable);
+    expect(normalized[1]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["append", "replace"],
+        },
+      },
+    });
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: {
+          provider: "deepseek",
+          api: "openai-completions",
+          id: "deepseek-v4-pro",
+        } as never,
+        tools,
+      }),
+    ).toEqual([
+      {
+        toolName: "fuzzplugin_unreadable",
+        toolIndex: 0,
+        violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+      },
+      {
+        toolName: "healthy_union",
+        toolIndex: 1,
+        violations: ["healthy_union.parameters.properties.mode.anyOf"],
+      },
+    ]);
+  });
+
+  it("normalizes non-configurable provider tool parameters on cloned tools", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const immutableTool = {
+      name: "fuzzplugin_immutable",
+      description: "",
+    };
+    Object.defineProperty(immutableTool, "parameters", {
+      enumerable: true,
+      configurable: false,
+      writable: false,
+      value: {
+        type: "object",
+        properties: {
+          mode: {
+            anyOf: [
+              { const: "append", type: "string" },
+              { const: "replace", type: "string" },
+            ],
+          },
+        },
+      },
+    });
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [immutableTool] as never,
+    });
+
+    expect(normalized[0]).not.toBe(immutableTool);
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["append", "replace"],
+        },
+      },
+    });
+  });
+
   it("suppresses openai strict-schema diagnostics because transport falls back to strict false", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
 

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -58,30 +58,177 @@ export function findUnsupportedSchemaKeywords(
 export function normalizeGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
-    }
-    return {
-      ...tool,
-      parameters: cleanSchemaForGemini(tool.parameters),
-    };
+  return normalizeProviderToolParameters(ctx, {
+    normalize: cleanSchemaForGemini,
   });
 }
 
 export function inspectGeminiToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
-  return ctx.tools.flatMap((tool, toolIndex) => {
-    const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
-      GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
-    );
-    if (violations.length === 0) {
+  return inspectProviderToolSchemasForUnsupportedKeywords(ctx, GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS);
+}
+
+type ProviderToolEntry =
+  | {
+      readonly ok: true;
+      readonly tool: AnyAgentTool;
+      readonly toolIndex: number;
+    }
+  | {
+      readonly ok: false;
+      readonly diagnostic: ProviderToolSchemaDiagnostic;
+    };
+
+function readProviderToolEntries(tools: readonly AnyAgentTool[]): ProviderToolEntry[] {
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [
+      {
+        ok: false,
+        diagnostic: {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["tool[0] is unreadable"],
+        },
+      },
+    ];
+  }
+
+  const entries: ProviderToolEntry[] = [];
+  for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
+    try {
+      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+    } catch {
+      entries.push({
+        ok: false,
+        diagnostic: {
+          toolName: `tool[${toolIndex}]`,
+          toolIndex,
+          violations: [`tool[${toolIndex}] is unreadable`],
+        },
+      });
+    }
+  }
+  return entries;
+}
+
+function readProviderToolField<TField extends "name" | "parameters">(
+  tool: AnyAgentTool,
+  field: TField,
+): { readonly ok: true; readonly value: AnyAgentTool[TField] } | { readonly ok: false } {
+  try {
+    return { ok: true, value: tool[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readProviderToolName(
+  tool: AnyAgentTool,
+  toolIndex: number,
+): { readonly toolName: string; readonly violations: string[] } {
+  const nameRead = readProviderToolField(tool, "name");
+  const toolName =
+    nameRead.ok && typeof nameRead.value === "string" && nameRead.value
+      ? nameRead.value
+      : `tool[${toolIndex}]`;
+  return {
+    toolName,
+    violations: nameRead.ok ? [] : [`${toolName}.name is unreadable`],
+  };
+}
+
+function replaceProviderToolParameters(
+  tool: AnyAgentTool,
+  parameters: AnyAgentTool["parameters"],
+): AnyAgentTool {
+  const next = Object.create(Object.getPrototypeOf(tool)) as AnyAgentTool;
+  const descriptors = Object.getOwnPropertyDescriptors(tool);
+  descriptors.parameters = {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: parameters,
+  };
+  Object.defineProperties(next, descriptors);
+  return next;
+}
+
+function normalizeProviderToolParameters(
+  ctx: ProviderNormalizeToolSchemasContext,
+  options: {
+    readonly normalize: (parameters: unknown) => unknown;
+    readonly normalizeMissing?: () => unknown;
+  },
+): AnyAgentTool[] {
+  return readProviderToolEntries(ctx.tools).flatMap((entry) => {
+    if (!entry.ok) {
       return [];
     }
-    return [{ toolName: tool.name, toolIndex, violations }];
+    const { tool } = entry;
+    const parametersRead = readProviderToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      return [tool];
+    }
+    if (parametersRead.value == null && options.normalizeMissing) {
+      return replaceProviderToolParameters(
+        tool,
+        options.normalizeMissing() as AnyAgentTool["parameters"],
+      );
+    }
+    if (!parametersRead.value || typeof parametersRead.value !== "object") {
+      return tool;
+    }
+    try {
+      const parameters = options.normalize(parametersRead.value);
+      return parameters === parametersRead.value
+        ? tool
+        : replaceProviderToolParameters(tool, parameters as AnyAgentTool["parameters"]);
+    } catch {
+      return [tool];
+    }
+  });
+}
+
+function inspectProviderToolSchemasForUnsupportedKeywords(
+  ctx: ProviderNormalizeToolSchemasContext,
+  unsupportedKeywords: ReadonlySet<string>,
+): ProviderToolSchemaDiagnostic[] {
+  return readProviderToolEntries(ctx.tools).flatMap((entry) => {
+    if (!entry.ok) {
+      return [entry.diagnostic];
+    }
+    const { tool, toolIndex } = entry;
+    const { toolName, violations: descriptorViolations } = readProviderToolName(tool, toolIndex);
+    const parametersRead = readProviderToolField(tool, "parameters");
+    if (!parametersRead.ok) {
+      return [
+        {
+          toolName,
+          toolIndex,
+          violations: [...descriptorViolations, `${toolName}.parameters is unreadable`],
+        },
+      ];
+    }
+    const schemaPath = `${toolName}.parameters`;
+    let violations: string[];
+    try {
+      violations = findUnsupportedSchemaKeywords(
+        parametersRead.value,
+        schemaPath,
+        unsupportedKeywords,
+      );
+    } catch {
+      violations = [`${schemaPath} is unreadable`];
+    }
+    const allViolations = [...descriptorViolations, ...violations];
+    if (allViolations.length === 0) {
+      return [];
+    }
+    return [{ toolName, toolIndex, violations: allViolations }];
   });
 }
 
@@ -91,20 +238,9 @@ export function normalizeOpenAIToolSchemas(
   if (!shouldApplyOpenAIToolCompat(ctx)) {
     return ctx.tools;
   }
-  return ctx.tools.map((tool) => {
-    if (tool.parameters == null) {
-      return {
-        ...tool,
-        parameters: normalizeOpenAIStrictCompatSchema({}),
-      };
-    }
-    if (typeof tool.parameters !== "object") {
-      return tool;
-    }
-    return {
-      ...tool,
-      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
-    };
+  return normalizeProviderToolParameters(ctx, {
+    normalize: normalizeOpenAIStrictCompatSchema,
+    normalizeMissing: () => normalizeOpenAIStrictCompatSchema({}),
   });
 }
 
@@ -465,34 +601,18 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
 export function normalizeDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): AnyAgentTool[] {
-  return ctx.tools.map((tool) => {
-    if (!tool.parameters || typeof tool.parameters !== "object") {
-      return tool;
-    }
-    const parameters = normalizeDeepSeekSchema(tool.parameters);
-    return parameters === tool.parameters
-      ? tool
-      : {
-          ...tool,
-          parameters: parameters as TSchema,
-        };
+  return normalizeProviderToolParameters(ctx, {
+    normalize: normalizeDeepSeekSchema,
   });
 }
 
 export function inspectDeepSeekToolSchemas(
   ctx: ProviderNormalizeToolSchemasContext,
 ): ProviderToolSchemaDiagnostic[] {
-  return ctx.tools.flatMap((tool, toolIndex) => {
-    const violations = findUnsupportedSchemaKeywords(
-      tool.parameters,
-      `${tool.name}.parameters`,
-      DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
-    );
-    if (violations.length === 0) {
-      return [];
-    }
-    return [{ toolName: tool.name, toolIndex, violations }];
-  });
+  return inspectProviderToolSchemasForUnsupportedKeywords(
+    ctx,
+    DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
+  );
 }
 
 export type ProviderToolCompatFamily = "deepseek" | "gemini" | "openai";


### PR DESCRIPTION
## Summary
- Harden provider tool schema normalization against plugin-supplied tools with unreadable `parameters` fields.
- Share guarded tool-field reads across Gemini, DeepSeek, and native OpenAI schema hooks so one poisoned tool does not stop sibling normalization or diagnostics.
- Preserve immutable/non-configurable tool descriptors when cloning with normalized parameters.

## Verification
- `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `./node_modules/.bin/oxlint src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_8278ba4e3a36`, slug `coral-krill`, run `run_a1d9dfbad8d5`, total `6m46.442s`, exit `0`

## Real behavior proof
Behavior addressed: Provider-owned tool schema hooks no longer throw when a plugin tool exposes a throwing `parameters` getter; healthy sibling tools still normalize.
Real environment tested: Local sparse Codex worktree for focused Vitest/format/lint/autoreview, plus direct AWS Crabbox Linux validation for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89571 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
Evidence after fix: `src/plugin-sdk/provider-tools.test.ts` passes 12 tests, including unreadable getter and non-configurable descriptor regressions; AWS Crabbox run `run_a1d9dfbad8d5` passed `pnpm check:changed` with lanes `core`, `coreTests`, `extensions`, `extensionTests`.
Observed result after fix: DeepSeek normalization keeps the unreadable tool untouched, normalizes the healthy sibling, and reports an unreadable-parameters diagnostic instead of throwing; remote changed-gate typecheck, lint, and guards pass.
What was not tested: Full repo test suite, live provider calls, and Docker/E2E lanes.
