### PR TITLE
Fix stale exemptions for ClawSweeper actionable labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -68,7 +68,7 @@ jobs:
           days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
@@ -100,7 +100,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           operations-per-run: 2000
           ascending: true
           include-only-assigned: true
@@ -172,7 +172,7 @@ jobs:
           days-before-pr-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
@@ -203,7 +203,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: stale
-          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle
+          exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale,bad-barnacle,clawsweeper:queueable-fix,clawsweeper:source-repro,clawsweeper:fix-shape-clear
           operations-per-run: 2000
           ascending: true
           include-only-assigned: true
@@ -277,6 +277,9 @@ jobs:
               "security",
               "no-stale",
               "bad-barnacle",
+              "clawsweeper:queueable-fix",
+              "clawsweeper:source-repro",
+              "clawsweeper:fix-shape-clear",
             ]);
             const prExemptLabels = new Set(["maintainer", "no-stale", "bad-barnacle"]);
             const maintainerAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);


### PR DESCRIPTION
## Summary

- Update `.github/workflows/stale.yml` so all issue stale lanes exempt durable actionable ClawSweeper labels.
- Add the same durable ClawSweeper labels to the manual `backfill-stale-closures` `issueExemptLabels` set.
- Keep PR stale exemptions unchanged and leave ClawSweeper-side label/removal behavior to openclaw/clawsweeper#247.

Fixes openclaw/openclaw#89564.

## Source Proof

ClawSweeper's latest review on #89564 says the best OpenClaw-side fix is to update every issue stale lane and the manual backfill closure path to exempt durable actionable ClawSweeper issue labels, while keeping the label set limited and leaving ClawSweeper-side behavior to the companion repo issue.

Live issue reads on June 2, 2026 still showed current examples with both `stale` and durable ClawSweeper actionable labels:

- #78640: open, labels include `stale`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`
- #81078: open, labels include `stale`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`
- #81122: open, labels include `stale`, `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`

The durable labels added here are intentionally limited to:

- `clawsweeper:queueable-fix`
- `clawsweeper:source-repro`
- `clawsweeper:fix-shape-clear`

## Real behavior proof

- Behavior or issue addressed: The stale workflow should no longer treat issues carrying durable actionable ClawSweeper labels as stale-eligible, while PR stale exemptions remain unchanged.
- Real environment tested: Local OpenClaw source checkout of PR #89572 at head `f7962de2328758da2acfbe1fce0c1ebd15f75861`, compared against `origin/main` at `1d3cfc4b016898fb6266a48daccee19b52432e0f`. This is real source/workflow-config proof; the scheduled stale workflow was not executed against live issues.
- Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; a Node source assertion over `.github/workflows/stale.yml` checking every issue-capable `actions/stale` lane, the manual `issueExemptLabels` Set, and unchanged PR exemption sets against `origin/main`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output from the local source assertion:

  ```json
  {
    "issueStaleLaneEntries": 4,
    "issueManualSetEntries": 1,
    "requiredClawsweeperLabels": [
      "clawsweeper:queueable-fix",
      "clawsweeper:source-repro",
      "clawsweeper:fix-shape-clear"
    ],
    "issueLaneMissingRequired": [[], [], [], []],
    "issueLaneUnexpectedClawsweeperLabels": [[], [], [], []],
    "manualIssueMissingRequired": [],
    "manualIssueUnexpectedClawsweeperLabels": [],
    "prStaleLaneEntries": 4,
    "prExemptLabelsUnchangedFromOriginMain": true,
    "manualPrExemptLabelsUnchangedFromOriginMain": true,
    "failures": []
  }
  ```

  Additional non-destructive harness output using live sample issue labels:

  ```json
  {
    "workflowHead": "f7962de2328758da2acfbe1fce0c1ebd15f75861",
    "issueStaleLaneEntries": 4,
    "manualIssueBackfillExemptLabelsIncludeRequired": true,
    "prActionsStaleExemptionsUnchangedFromOriginMain": true,
    "manualPrBackfillExemptionsUnchangedFromOriginMain": true,
    "liveIssueSamples": [
      {
        "number": 78640,
        "state": "OPEN",
        "hasStaleLabel": true,
        "durableClawsweeperLabelsPresent": [
          "clawsweeper:queueable-fix",
          "clawsweeper:source-repro",
          "clawsweeper:fix-shape-clear"
        ],
        "scheduledIssueLaneSkips": [true, true, true, true],
        "manualBackfillSkip": true,
        "url": "https://github.com/openclaw/openclaw/issues/78640"
      },
      {
        "number": 81078,
        "state": "OPEN",
        "hasStaleLabel": true,
        "durableClawsweeperLabelsPresent": [
          "clawsweeper:queueable-fix",
          "clawsweeper:source-repro",
          "clawsweeper:fix-shape-clear"
        ],
        "scheduledIssueLaneSkips": [true, true, true, true],
        "manualBackfillSkip": true,
        "url": "https://github.com/openclaw/openclaw/issues/81078"
      },
      {
        "number": 81122,
        "state": "OPEN",
        "hasStaleLabel": true,
        "durableClawsweeperLabelsPresent": [
          "clawsweeper:queueable-fix",
          "clawsweeper:source-repro",
          "clawsweeper:fix-shape-clear"
        ],
        "scheduledIssueLaneSkips": [true, true, true, true],
        "manualBackfillSkip": true,
        "url": "https://github.com/openclaw/openclaw/issues/81122"
      }
    ],
    "liveMutationsPerformed": false,
    "failures": []
  }
  ```

- Observed result after fix: All four issue stale lanes and the manual issue closure backfill set include `clawsweeper:queueable-fix`, `clawsweeper:source-repro`, and `clawsweeper:fix-shape-clear` with no other ClawSweeper labels. PR stale exemptions and manual PR backfill exemptions are unchanged from `origin/main`.
- What was not tested: The scheduled GitHub Actions stale workflow was not run against live stale candidates, and no live issues or pull requests were closed or modified.
- Proof limitations or environment constraints: This workflow change is source-verifiable without safely exercising destructive stale closure behavior. Maintainer override may still be appropriate if the proof gate requires live workflow execution instead of source-only workflow proof.

## Verification

- `git diff --check HEAD~1..HEAD`
- Node source assertion over `.github/workflows/stale.yml` confirming:
  - `exemptIssueLabelEntries: 4`
  - `missingLines: []`
  - `missingSet: []`
- Non-destructive Node harness over live issue labels for #78640, #81078, and #81122 confirming all four issue stale lanes and manual backfill skip them, with `liveMutationsPerformed: false` and `failures: []`.
- `gh search prs --repo openclaw/openclaw --state open --json number,title,url,author,updatedAt,isDraft --limit 30 --match title,body -- "89564 stale workflow ClawSweeper queueable"` returned `[]`

A static YAML parse was attempted with local tools, but `node_modules/yaml`, `yq`, PowerShell `ConvertFrom-Yaml`, and Ruby were unavailable in this worktree environment. This PR only extends existing scalar label lists and a JavaScript string set in a workflow that already parses on `origin/main`.
