### PR TITLE
Add Velanir runtime delta

### DIFF
--- a/.github/workflows/velanir-openclaw-release.yml
+++ b/.github/workflows/velanir-openclaw-release.yml
@@ -1,0 +1,216 @@
+name: Velanir OpenClaw Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish to the Velanir S3 lane, for example v2026.5.4
+        required: true
+        type: string
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: velanir-openclaw-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.33.2"
+  AWS_REGION: "us-east-1"
+  S3_BUCKET: "oct8-packages"
+  RELEASE_PREFIX: "releases/velanir-openclaw"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+
+      - name: Verify version matches tag
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid release tag: ${RELEASE_TAG}"
+            exit 1
+          fi
+          TAG_VERSION="${RELEASE_TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "Tag ${RELEASE_TAG} does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Releasing Velanir OpenClaw $PKG_VERSION"
+
+      - name: Test Velanir bootstrap seam
+        run: |
+          set -euo pipefail
+          pnpm test src/agents/workspace.load-extra-bootstrap-files.test.ts src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Pack Velanir OpenClaw artifact
+        id: pack
+        env:
+          OPENCLAW_PREPACK_PREPARED: "1"
+        run: |
+          set -euo pipefail
+          PACK_OUTPUT="$RUNNER_TEMP/npm-pack-output.txt"
+          npm pack --json 2>&1 | tee "$PACK_OUTPUT"
+          RAW_TARBALL=$(node - "$PACK_OUTPUT" <<'NODE'
+          const fs = require("node:fs");
+          const input = fs.readFileSync(process.argv[2], "utf8");
+
+          function arrayEndFrom(start) {
+            let depth = 0;
+            let inString = false;
+            let escape = false;
+            for (let i = start; i < input.length; i += 1) {
+              const char = input[i];
+              if (inString) {
+                if (escape) {
+                  escape = false;
+                } else if (char === "\\") {
+                  escape = true;
+                } else if (char === "\"") {
+                  inString = false;
+                }
+                continue;
+              }
+              if (char === "\"") {
+                inString = true;
+              } else if (char === "[") {
+                depth += 1;
+              } else if (char === "]") {
+                depth -= 1;
+                if (depth === 0) {
+                  return i + 1;
+                }
+              }
+            }
+            return -1;
+          }
+
+          for (let start = input.indexOf("["); start !== -1; start = input.indexOf("[", start + 1)) {
+            const end = arrayEndFrom(start);
+            if (end === -1) {
+              continue;
+            }
+            try {
+              const parsed = JSON.parse(input.slice(start, end));
+              const first = Array.isArray(parsed) ? parsed[0] : null;
+              if (first && typeof first.filename === "string" && first.filename) {
+                process.stdout.write(first.filename);
+                process.exit(0);
+              }
+            } catch {
+              // Keep scanning; npm lifecycle output can legally precede the JSON.
+            }
+          }
+
+          console.error("Could not find npm pack --json output with a filename.");
+          process.exit(1);
+          NODE
+          )
+          if [[ -z "$RAW_TARBALL" || ! -f "$RAW_TARBALL" ]]; then
+            echo "npm pack did not produce a tarball file." >&2
+            exit 1
+          fi
+          VERSION=$(node -p "require('./package.json').version")
+          TARBALL="velanir-openclaw-${VERSION}.tgz"
+          cp "$RAW_TARBALL" "$TARBALL"
+          shasum -a 256 "$TARBALL" | awk '{print $1}' > "${TARBALL}.sha256"
+          node - "$TARBALL" "$VERSION" <<'NODE'
+          const { execFileSync } = require("node:child_process");
+          const tarball = process.argv[2];
+          const expectedVersion = process.argv[3];
+          const meta = JSON.parse(execFileSync("tar", ["-xOf", tarball, "package/package.json"], { encoding: "utf8" }));
+          if (meta.name !== "openclaw" || meta.version !== expectedVersion || !meta.bin?.openclaw) {
+            throw new Error(`unexpected package metadata: ${meta.name ?? "<missing>"}@${meta.version ?? "<missing>"}`);
+          }
+          NODE
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+          echo "checksum=${TARBALL}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Write release manifest
+        id: manifest
+        env:
+          VERSION: ${{ steps.pack.outputs.version }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+          CHECKSUM_FILE: ${{ steps.pack.outputs.checksum }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git remote add upstream https://github.com/openclaw/openclaw.git || true
+          git fetch --depth=200 --no-tags upstream main
+          export UPSTREAM_BASE_SHA=$(git merge-base HEAD upstream/main || git rev-parse HEAD)
+          export FORK_SHA=$(git rev-parse HEAD)
+          export CHECKSUM=$(cat "$CHECKSUM_FILE")
+          export MANIFEST="velanir-openclaw-${VERSION}.manifest.json"
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const manifest = {
+            artifactName: process.env.TARBALL,
+            artifactSha256: process.env.CHECKSUM,
+            packageName: "openclaw",
+            packageVersion: process.env.VERSION,
+            forkRepository: process.env.REPOSITORY,
+            forkSha: process.env.FORK_SHA,
+            upstreamRepository: "openclaw/openclaw",
+            upstreamBaseSha: process.env.UPSTREAM_BASE_SHA,
+            builtAt: new Date().toISOString(),
+            patches: [
+              "bootstrap-extra-files.allowedBasenames",
+              "extensions.velanir-participation-gate"
+            ]
+          };
+          fs.writeFileSync(process.env.MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
+          echo "manifest=${MANIFEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: velanir-openclaw-${{ steps.pack.outputs.version }}
+          path: |
+            ${{ steps.pack.outputs.tarball }}
+            ${{ steps.pack.outputs.checksum }}
+            ${{ steps.manifest.outputs.manifest }}
+          if-no-files-found: error
+
+      - name: Configure AWS credentials
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch' }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: github-actions-velanir-openclaw-release
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload release bundle to S3
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.pack.outputs.version }}"
+          aws s3 cp "${{ steps.pack.outputs.tarball }}" "s3://${S3_BUCKET}/${RELEASE_PREFIX}/velanir-openclaw-${VERSION}.tgz"
+          aws s3 cp "${{ steps.pack.outputs.checksum }}" "s3://${S3_BUCKET}/${RELEASE_PREFIX}/velanir-openclaw-${VERSION}.tgz.sha256"
+          aws s3 cp "${{ steps.manifest.outputs.manifest }}" "s3://${S3_BUCKET}/${RELEASE_PREFIX}/velanir-openclaw-${VERSION}.manifest.json"
+          printf '%s' "$VERSION" | aws s3 cp - "s3://${S3_BUCKET}/${RELEASE_PREFIX}/latest-version.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Skills own workflows; root owns hard policy and routing.
 ## Start
 
 - Repo: `https://github.com/openclaw/openclaw`
+- Velanir fork: read `VELANIR_OPENCLAW.md` before changing bootstrap files, release packaging, runtime install behavior, or upstream merge-conflict resolution.
 - Replies: repo-root refs only: `extensions/telegram/src/index.ts:80`. No absolute paths, no `~/`.
 - Docs/user-visible work: `pnpm docs:list`, then read relevant docs only.
 - Fix/triage answers need source, tests, current/shipped behavior, and dependency contract proof.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Skill Workshop: add the Control UI navigation, styled dashboard, proposal today view, revision dialog, file preview modal, searchable preview files, reusable session handoff, and localized strings.
 - Plugins: externalize Tokenjuice as the official `@openclaw/tokenjuice` plugin with npm and ClawHub publish metadata.
 - Plugins: externalize the GitHub Copilot agent runtime as the official `@openclaw/copilot` plugin with npm and ClawHub publish metadata.
+- Plugins: add the Velanir participation gate plugin, configurable bootstrap extra-file basenames, and the Velanir S3 release workflow.
 - iOS: add hosted push relay defaults, realtime Talk playback, and a guarded WebSocket ping path for more reliable mobile sessions. (#88096, #88105, #88231)
 - iOS: support native iPad display layouts.
 - Workboard: add orchestration primitives and agent coordination tools for multi-agent planning and run tracking. (#87469)

--- a/VELANIR_OPENCLAW.md
+++ b/VELANIR_OPENCLAW.md
@@ -1,0 +1,77 @@
+# Velanir OpenClaw Fork Notes
+
+This fork exists to keep Velanir's machine-install runtime close to upstream
+OpenClaw while supporting Velanir workspace bootstrap files and the Velanir
+participation gate extension needed by customer digital coworkers.
+
+Companion platform decision record:
+`docs/plans/velanir-openclaw-runtime-plan.md` in the Velanir platform repo.
+
+Companion platform maintenance runbook:
+`docs/runbooks/openclaw-fork-maintenance.md` in the Velanir platform repo.
+
+On Dan's development machine, this checkout
+(`/Users/danbotero/Developer/forked-openclaw`) is the retained Velanir fork
+checkout. `/Users/danbotero/Developer/openclaw` is an upstream study clone only.
+Do not recreate long-lived local worktrees for this patch unless there is a
+clear temporary reason.
+
+## Current fork-owned behavior
+
+- Keep the npm package metadata as `openclaw`.
+- Publish machine-install artifacts to S3 as `velanir-openclaw-<version>.tgz`.
+- Preserve the generic `bootstrap-extra-files.allowedBasenames` config seam.
+- Keep the fork branch focused on the small Velanir runtime delta:
+  `bootstrap-extra-files.allowedBasenames` plus the bundled
+  `velanir-participation-gate` extension.
+- Bundle `extensions/velanir-participation-gate` into the normal OpenClaw
+  runtime artifact instead of installing it ad hoc from the platform monorepo.
+  This keeps customer machines on one versioned S3 artifact and avoids hidden
+  private workspace package dependencies.
+
+## Release workflow notes
+
+The Velanir S3 release workflow intentionally keeps package metadata as
+`openclaw` and renames only the uploaded S3 artifact. Its `npm pack --json`
+step must tolerate lifecycle output around the JSON payload; keep that parser
+aligned with OpenClaw's normal npm release workflow if upstream changes it.
+
+The workflow has a manual `workflow_dispatch` tag input so a fixed workflow can
+publish an existing tag after a failed tag-triggered run without deleting or
+recreating the tag.
+
+## Merge guidance
+
+When updating from upstream OpenClaw, preserve an equivalent opt-in mechanism
+for custom bootstrap basenames. Do not hardcode Velanir filenames into
+`VALID_BOOTSTRAP_NAMES` unless there is no other viable short-term option.
+
+The platform config uses this seam so files such as `COMPANY.md`,
+`ROLE_PROFILE.md`, `MANAGER.md`, `TEAM.md`, and `CONTACTS.md` can be included
+in normal agent Project Context without rewriting the OpenClaw package identity.
+
+If upstream accepts a generic replacement, prefer the upstream version and
+remove this fork patch.
+
+The participation gate is Velanir-specific product behavior. It uses
+`before_dispatch` to decide whether a digital coworker should participate in
+group/channel conversations, reads platform participation context with scoped
+runtime DPoP auth, and fails open when context or classification is unavailable.
+The extension is bundled but disabled by default; platform-rendered
+`openclaw.json` must explicitly enable `plugins.entries.velanir-participation-gate`
+for coworkers participating in the Phase 8 rollout.
+Keep it bundled with the forked runtime artifact until there is a public
+OpenClaw-native equivalent or a documented plugin distribution lane that can
+preserve the same runtime identity guarantees.
+
+## Verification
+
+After changing this fork-owned seam, run:
+
+```bash
+pnpm test src/agents/workspace.load-extra-bootstrap-files.test.ts src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+pnpm tsgo:core
+pnpm tsgo:extensions
+node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/velanir-participation-gate/index.test.ts
+node scripts/tsdown-build.mjs && node scripts/runtime-postbuild.mjs && node scripts/test-built-plugin-singleton.mjs
+```

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -74,6 +74,13 @@ const rootBundledPluginRuntimeDependencies = [
   "tokenjuice",
 ] as const;
 
+const rootPackagedInstallStabilityDependencies = [
+  // @mariozechner/pi-ai declares @mistralai/mistralai as ^2.2.0. Keep this
+  // direct root dependency so npm tarball installs do not float to a broken
+  // newly published Mistral client before our packaged release can be rebuilt.
+  "@mistralai/mistralai",
+] as const;
+
 const config = {
   ignoreFiles: [
     "scripts/**",
@@ -149,6 +156,7 @@ const config = {
         "sqlite-vec",
         "tree-sitter-bash",
         ...rootBundledPluginRuntimeDependencies,
+        ...rootPackagedInstallStabilityDependencies,
       ],
       project: [
         "src/**/*.ts!",

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -235,7 +235,8 @@ Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YY
       "entries": {
         "bootstrap-extra-files": {
           "enabled": true,
-          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md"]
+          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md", "PROJECT.md"],
+          "allowedBasenames": ["PROJECT.md"]
         }
       }
     }
@@ -243,7 +244,7 @@ Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YY
 }
 ```
 
-Paths resolve relative to workspace. Only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+Paths resolve relative to workspace. By default, only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`). Use `allowedBasenames` to opt in to additional exact filenames.
 
 <a id="command-logger"></a>
 

--- a/extensions/velanir-participation-gate/index.test.ts
+++ b/extensions/velanir-participation-gate/index.test.ts
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { importJWK, jwtVerify } from "jose";
+import { describe, expect, it } from "vitest";
+import participationGatePlugin, {
+  messageClearlyAddressesIdentity,
+  normalizeConfig,
+  parseClassifierShouldRespond,
+  parseParticipationContext,
+  PLUGIN_ID,
+  PARTICIPATION_CONTEXT_SCOPE,
+  runEmbeddedClassifierModel,
+  RuntimeParticipationContextAuthClient,
+} from "./index.js";
+
+function decodeJwtSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8")) as Record<string, unknown>;
+}
+
+function decodeJwt(token: string): {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+} {
+  const [header, payload] = token.split(".");
+  if (!header || !payload) {
+    throw new Error("invalid test jwt");
+  }
+  return {
+    header: decodeJwtSegment(header),
+    payload: decodeJwtSegment(payload),
+  };
+}
+
+function requestInputUrl(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+describe("velanir participation gate", () => {
+  it("defaults to runtime platform auth and shadow mode", () => {
+    const config = normalizeConfig(
+      {},
+      {
+        OCT8_API_URL: "https://api.oct8.io",
+        OCT8_COWORKER_ID: "coworker-1",
+      },
+    );
+
+    expect(config.mode).toBe("shadow");
+    expect(config.platform.authMode).toBe("runtime");
+    expect(config.platform.token).toBeUndefined();
+    expect(config.platform.baseUrl).toBe("https://api.oct8.io");
+    expect(config.platform.coworkerId).toBe("coworker-1");
+  });
+
+  it("uses static token only when explicitly configured", () => {
+    const config = normalizeConfig(
+      { platform: { authMode: "static-token" } },
+      {
+        OCT8_API_URL: "https://api.oct8.io",
+        OCT8_COWORKER_ID: "coworker-1",
+        OCT8_PARTICIPATION_CONTEXT_TOKEN: "local-token",
+      },
+    );
+
+    expect(config.platform.authMode).toBe("static-token");
+    expect(config.platform.token).toBe("local-token");
+  });
+
+  it("parses platform participation context without keeping self in coworkers", () => {
+    expect(
+      parseParticipationContext({
+        data: {
+          self: { id: "self", names: ["Tanya"] },
+          coworkers: [
+            { id: "self", names: ["Tanya"] },
+            { id: "other", names: ["Cedric"], roleSummary: "Operations" },
+          ],
+        },
+      }),
+    ).toEqual({
+      self: { id: "self", names: ["Tanya"] },
+      coworkers: [{ id: "other", names: ["Cedric"], roleSummary: "Operations" }],
+    });
+  });
+
+  it("recognizes direct address patterns", () => {
+    expect(
+      messageClearlyAddressesIdentity("Cedric, can you check this?", {
+        id: "cedric",
+        names: ["Cedric Alvarez", "Cedric"],
+      }),
+    ).toBe(true);
+    expect(
+      messageClearlyAddressesIdentity("This is general project chatter.", {
+        id: "cedric",
+        names: ["Cedric Alvarez"],
+      }),
+    ).toBe(false);
+  });
+
+  it("fails open when classifier output is malformed", () => {
+    expect(parseClassifierShouldRespond('{ "shouldRespond": false }')).toBe(false);
+    expect(parseClassifierShouldRespond("not json")).toBe(true);
+  });
+
+  it("registers before_dispatch", () => {
+    const hooks: Array<{ name: string; timeoutMs?: number }> = [];
+    participationGatePlugin.register({
+      id: PLUGIN_ID,
+      name: "Velanir Participation Gate",
+      source: "test",
+      registrationMode: "runtime",
+      config: {},
+      pluginConfig: {
+        context: { source: "static" },
+        staticContext: { self: { id: "self", names: ["Riley"] }, coworkers: [] },
+      },
+      runtime: {},
+      logger: {},
+      on(name: string, _handler: unknown, opts?: { timeoutMs?: number }) {
+        hooks.push({ name, timeoutMs: opts?.timeoutMs });
+      },
+    } as never);
+
+    expect(hooks).toEqual([{ name: "before_dispatch", timeoutMs: 7_000 }]);
+  });
+
+  it("runs the embedded classifier without model-incompatible temperature params", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const config = normalizeConfig({
+      classifier: {
+        provider: "openai",
+        model: "gpt-5.4-nano",
+        timeoutMs: 1234,
+        maxOutputTokens: 12,
+      },
+    });
+
+    await expect(
+      runEmbeddedClassifierModel({
+        api: {
+          config: { agents: {} },
+          runtime: {
+            agent: {
+              runEmbeddedAgent: async (params: Record<string, unknown>) => {
+                calls.push(params);
+                return { payloads: [{ text: '{ "shouldRespond": false }' }] };
+              },
+              resolveAgentWorkspaceDir: () => "/tmp/openclaw-workspace",
+            },
+          },
+        } as never,
+        config,
+        prompt: "Decide.",
+      }),
+    ).resolves.toBe('{ "shouldRespond": false }');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      prompt: "Decide.",
+      workspaceDir: "/tmp/openclaw-workspace",
+      provider: "openai",
+      model: "gpt-5.4-nano",
+      timeoutMs: 1234,
+      modelRun: true,
+      disableTools: true,
+      disableMessageTool: true,
+      streamParams: {
+        maxTokens: 12,
+      },
+    });
+    expect(calls[0]?.streamParams).not.toHaveProperty("temperature");
+  });
+
+  it("requests a DPoP token and signs the participation context GET", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "participation-gate-auth-"));
+    const runtimeIdentityId = "11111111-1111-4111-8111-111111111111";
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const client = new RuntimeParticipationContextAuthClient({
+      env: {
+        OCT8_SECRETS_MODE: "runtime",
+        OCT8_API_URL: "https://api.oct8.io",
+        OCT8_RUNTIME_TOKEN_ISSUER: "https://api.oct8.io",
+        OCT8_RUNTIME_IDENTITY_ID: runtimeIdentityId,
+        OCT8_RUNTIME_STATE_DIR: stateDir,
+      },
+      fetchImpl: async (url, init = {}) => {
+        requests.push({ url: requestInputUrl(url), init });
+        return new Response(
+          JSON.stringify({
+            access_token: "issued-access-token",
+            token_type: "DPoP",
+            expires_in: 900,
+            scope: PARTICIPATION_CONTEXT_SCOPE,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+      now: () => 1_700_000_000_000,
+    });
+
+    try {
+      const headers = await client.authorizationHeaders(
+        "https://api.oct8.io/v1/runtime/coworkers/22222222-2222-4222-8222-222222222222/participation-context?ignored=true",
+      );
+
+      expect(headers.Authorization).toBe("DPoP issued-access-token");
+      expect(requests).toHaveLength(1);
+      const tokenRequest = requests[0];
+      expect(tokenRequest).toBeDefined();
+      if (!tokenRequest) {
+        throw new Error("missing token request");
+      }
+      expect(tokenRequest.url).toBe("https://api.oct8.io/v1/runtime/token");
+      expect(typeof tokenRequest.init.body).toBe("string");
+
+      const body = new URLSearchParams(tokenRequest.init.body as string);
+      expect(body.get("grant_type")).toBe("client_credentials");
+      expect(body.get("client_id")).toBe(runtimeIdentityId);
+      expect(body.get("scope")).toBe(PARTICIPATION_CONTEXT_SCOPE);
+
+      const assertion = decodeJwt(body.get("client_assertion") ?? "");
+      expect(assertion.header).toMatchObject({ alg: "ES256" });
+      expect(assertion.payload).toMatchObject({
+        iss: runtimeIdentityId,
+        sub: runtimeIdentityId,
+        aud: "https://api.oct8.io/v1/runtime/token",
+      });
+
+      const tokenRequestHeaders = tokenRequest.init.headers as Record<string, string>;
+      const tokenProof = decodeJwt(tokenRequestHeaders.DPoP ?? "");
+      expect(tokenProof.header).toMatchObject({ typ: "dpop+jwt", alg: "ES256" });
+      expect(tokenProof.header.jwk).toMatchObject({
+        kty: "EC",
+        crv: "P-256",
+        alg: "ES256",
+        use: "sig",
+      });
+      expect(tokenProof.header.jwk).not.toHaveProperty("d");
+      const publicKey = await importJWK(tokenProof.header.jwk as JsonWebKey, "ES256");
+      await expect(
+        jwtVerify(body.get("client_assertion") ?? "", publicKey, {
+          algorithms: ["ES256"],
+          issuer: runtimeIdentityId,
+          subject: runtimeIdentityId,
+          audience: "https://api.oct8.io/v1/runtime/token",
+        }),
+      ).resolves.toBeDefined();
+      expect(tokenProof.payload).toMatchObject({
+        htm: "POST",
+        htu: "https://api.oct8.io/v1/runtime/token",
+      });
+
+      const getProof = decodeJwt(headers.DPoP);
+      expect(getProof.header).toMatchObject({ typ: "dpop+jwt", alg: "ES256" });
+      expect(getProof.payload).toMatchObject({
+        htm: "GET",
+        htu: "https://api.oct8.io/v1/runtime/coworkers/22222222-2222-4222-8222-222222222222/participation-context",
+      });
+      expect(getProof.payload.ath).toBe(
+        createHash("sha256").update("issued-access-token", "ascii").digest("base64url"),
+      );
+      await expect(
+        jwtVerify(headers.DPoP, publicKey, { algorithms: ["ES256"] }),
+      ).resolves.toBeDefined();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/velanir-participation-gate/index.ts
+++ b/extensions/velanir-participation-gate/index.ts
@@ -1,0 +1,1323 @@
+import {
+  createHash,
+  createPrivateKey,
+  generateKeyPairSync,
+  randomUUID,
+  sign as cryptoSign,
+  type KeyObject,
+} from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+
+export const PLUGIN_ID = "velanir-participation-gate";
+export const PARTICIPATION_CONTEXT_SCOPE = "participation-context:read";
+export const CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 20;
+const DEFAULT_MAX_MESSAGES = 5;
+const DEFAULT_REFRESH_MS = 5 * 60 * 1_000;
+const DEFAULT_PLATFORM_ENDPOINT_PATH = "/v1/runtime/coworkers/{coworkerId}/participation-context";
+const TOKEN_REFRESH_SKEW_MS = 30_000;
+const RUNTIME_TOKEN_REQUEST_TIMEOUT_MS = 10_000;
+const CONTEXT_FETCH_TIMEOUT_MS = 5_000;
+const ASSERTION_TTL_SECONDS = 60;
+const PRIVATE_KEY_FILE = "private-key.jwk";
+
+type ParticipationMode = "shadow" | "enforce";
+type ParticipationContextSource = "platform" | "static";
+type PlatformContextAuthMode = "runtime" | "static-token";
+
+type PluginLogger = {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+type CoworkerParticipationIdentity = {
+  id: string;
+  names: string[];
+  roleSummary?: string;
+};
+
+type ParticipationContext = {
+  self: CoworkerParticipationIdentity;
+  coworkers: CoworkerParticipationIdentity[];
+};
+
+type ClassifierConfig = {
+  provider?: string;
+  model?: string;
+  authProfileId?: string;
+  timeoutMs: number;
+  maxOutputTokens: number;
+};
+
+type PlatformContextConfig = {
+  authMode: PlatformContextAuthMode;
+  baseUrl?: string;
+  coworkerId?: string;
+  token?: string;
+  endpointPath: string;
+};
+
+type ParticipationGateConfig = {
+  mode: ParticipationMode;
+  classifier: ClassifierConfig;
+  context: {
+    source: ParticipationContextSource;
+    maxMessages: number;
+    refreshMs: number;
+  };
+  platform: PlatformContextConfig;
+  staticContext?: ParticipationContext;
+  logging: {
+    decisions: boolean;
+    includeContent: boolean;
+  };
+};
+
+type BeforeDispatchEvent = {
+  content?: string;
+  body?: string;
+  channel?: string;
+  sessionKey?: string;
+  senderId?: string;
+  isGroup?: boolean;
+  timestamp?: number;
+};
+
+type BeforeDispatchContext = {
+  channelId?: string;
+  accountId?: string;
+  conversationId?: string;
+  sessionKey?: string;
+  senderId?: string;
+};
+
+type ParticipationDecisionReason =
+  | "dm"
+  | "out_of_scope"
+  | "empty_message"
+  | "context_unavailable"
+  | "direct_address_self"
+  | "direct_address_other_coworker"
+  | "classifier_true"
+  | "classifier_false"
+  | "classifier_error";
+
+type ParticipationDecision = {
+  shouldRespond: boolean;
+  reason: ParticipationDecisionReason;
+  source: "rule" | "classifier" | "fallback";
+  latencyMs?: number;
+  error?: string;
+};
+
+type HistoryMessage = {
+  senderId?: string;
+  content: string;
+};
+
+type RuntimeApi = OpenClawPluginApi & {
+  pluginConfig?: unknown;
+  logger?: PluginLogger;
+  runtime?: {
+    agent?: {
+      runEmbeddedAgent?: (params: Record<string, unknown>) => Promise<unknown>;
+      runEmbeddedPiAgent?: (params: Record<string, unknown>) => Promise<unknown>;
+      resolveAgentWorkspaceDir?: (config: unknown) => string;
+    };
+  };
+};
+
+type RuntimeSecretsEnv = {
+  apiUrl: string;
+  tokenIssuer: string;
+  runtimeIdentityId: string;
+  stateDir: string;
+  keyId?: string;
+};
+
+type PrivateRuntimeJwk = JsonWebKey & {
+  kty: "EC";
+  crv: "P-256";
+  d: string;
+  x: string;
+  y: string;
+  kid: string;
+  alg: "ES256";
+  use: "sig";
+};
+
+type PublicRuntimeJwk = JsonWebKey & {
+  kty: "EC";
+  crv: "P-256";
+  x: string;
+  y: string;
+  kid: string;
+  alg: "ES256";
+  use: "sig";
+};
+
+type RuntimeKeyState = {
+  keyId: string;
+  privateKey: KeyObject;
+  publicKeyJwk: PublicRuntimeJwk;
+};
+
+type ParticipationContextProvider = {
+  load: () => Promise<ParticipationContext>;
+};
+
+type ParticipationContextAuthClient = {
+  authorizationHeaders: (requestUrl: string) => Promise<Record<string, string>>;
+};
+
+type RuntimeTokenCache = {
+  accessToken: string;
+  expiresAtMs: number;
+};
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | {
+      [key: string]: JsonValue;
+    };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const KEY_ID_RE = /^[A-Za-z0-9._:-]{8,160}$/;
+const PRIVATE_JWK_FIELDS = new Set(["d", "p", "q", "dp", "dq", "qi", "oth", "k"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readPositiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined;
+}
+
+function normalizeMode(value: unknown): ParticipationMode {
+  return value === "enforce" ? "enforce" : "shadow";
+}
+
+function normalizeContextSource(value: unknown): ParticipationContextSource {
+  return value === "static" ? "static" : "platform";
+}
+
+function normalizePlatformAuthMode(value: unknown): PlatformContextAuthMode {
+  return value === "static-token" ? "static-token" : "runtime";
+}
+
+function normalizeClassifier(value: unknown): ClassifierConfig {
+  const record = isRecord(value) ? value : {};
+  return {
+    provider: readString(record.provider),
+    model: readString(record.model),
+    authProfileId: readString(record.authProfileId),
+    timeoutMs: readPositiveInteger(record.timeoutMs, DEFAULT_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS,
+    maxOutputTokens:
+      readPositiveInteger(record.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS) ||
+      DEFAULT_MAX_OUTPUT_TOKENS,
+  };
+}
+
+function normalizePlatform(value: unknown, env: NodeJS.ProcessEnv): PlatformContextConfig {
+  const record = isRecord(value) ? value : {};
+  const authMode = normalizePlatformAuthMode(record.authMode);
+  return {
+    authMode,
+    baseUrl: readString(record.baseUrl) ?? readString(env.OCT8_API_URL),
+    coworkerId: readString(record.coworkerId) ?? readString(env.OCT8_COWORKER_ID),
+    token:
+      authMode === "static-token"
+        ? (readString(record.token) ?? readString(env.OCT8_PARTICIPATION_CONTEXT_TOKEN))
+        : undefined,
+    endpointPath: readString(record.endpointPath) ?? DEFAULT_PLATFORM_ENDPOINT_PATH,
+  };
+}
+
+function normalizeNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const names = value.map(readString).filter((entry): entry is string => Boolean(entry));
+  return [...new Set(names)];
+}
+
+function normalizeIdentity(value: unknown): CoworkerParticipationIdentity | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const id = readString(value.id);
+  const names = normalizeNames(value.names);
+  if (!id || names.length === 0) {
+    return undefined;
+  }
+  const roleSummary = readString(value.roleSummary);
+  return {
+    id,
+    names,
+    ...(roleSummary ? { roleSummary } : {}),
+  };
+}
+
+function normalizeStaticContext(value: unknown): ParticipationContext | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const self = normalizeIdentity(value.self);
+  if (!self) {
+    return undefined;
+  }
+  const coworkers = Array.isArray(value.coworkers)
+    ? value.coworkers
+        .map(normalizeIdentity)
+        .filter((entry): entry is CoworkerParticipationIdentity => Boolean(entry))
+        .filter((entry) => entry.id !== self.id)
+    : [];
+  return { self, coworkers };
+}
+
+export function normalizeConfig(
+  pluginConfig: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): ParticipationGateConfig {
+  const record = isRecord(pluginConfig) ? pluginConfig : {};
+  const contextRecord = isRecord(record.context) ? record.context : {};
+  const loggingRecord = isRecord(record.logging) ? record.logging : {};
+
+  return {
+    mode: normalizeMode(record.mode),
+    classifier: normalizeClassifier(record.classifier),
+    context: {
+      source: normalizeContextSource(contextRecord.source),
+      maxMessages: readPositiveInteger(contextRecord.maxMessages, DEFAULT_MAX_MESSAGES),
+      refreshMs:
+        readPositiveInteger(contextRecord.refreshMs, DEFAULT_REFRESH_MS) || DEFAULT_REFRESH_MS,
+    },
+    platform: normalizePlatform(record.platform, env),
+    staticContext: normalizeStaticContext(record.staticContext),
+    logging: {
+      decisions: loggingRecord.decisions !== false,
+      includeContent: loggingRecord.includeContent === true,
+    },
+  };
+}
+
+function normalizeBaseUrl(value: string, key: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${key} must be a valid absolute URL.`);
+  }
+  if (url.protocol !== "https:" && url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+    throw new Error(`${key} must use https outside local development.`);
+  }
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/+$/, "");
+}
+
+function requiredEnvString(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) {
+    throw new Error(`${key} is required.`);
+  }
+  return value;
+}
+
+function readRuntimeSecretsEnv(env: NodeJS.ProcessEnv = process.env): RuntimeSecretsEnv {
+  const mode = env.OCT8_SECRETS_MODE?.trim();
+  if (mode && mode !== "runtime") {
+    throw new Error("Runtime participation auth only supports OCT8_SECRETS_MODE=runtime.");
+  }
+
+  const apiUrl = normalizeBaseUrl(requiredEnvString(env, "OCT8_API_URL"), "OCT8_API_URL");
+  const tokenIssuer = normalizeBaseUrl(
+    env.OCT8_RUNTIME_TOKEN_ISSUER?.trim() || apiUrl,
+    "OCT8_RUNTIME_TOKEN_ISSUER",
+  );
+  const runtimeIdentityId = requiredEnvString(env, "OCT8_RUNTIME_IDENTITY_ID");
+  if (!UUID_RE.test(runtimeIdentityId)) {
+    throw new Error("OCT8_RUNTIME_IDENTITY_ID must be a runtime identity UUID.");
+  }
+
+  const keyId = env.OCT8_RUNTIME_KEY_ID?.trim();
+  if (keyId && !KEY_ID_RE.test(keyId)) {
+    throw new Error(
+      "OCT8_RUNTIME_KEY_ID must be 8-160 characters using letters, numbers, dots, underscores, colons, or hyphens.",
+    );
+  }
+
+  return {
+    apiUrl,
+    tokenIssuer,
+    runtimeIdentityId,
+    stateDir: requiredEnvString(env, "OCT8_RUNTIME_STATE_DIR"),
+    ...(keyId ? { keyId } : {}),
+  };
+}
+
+function runtimeUrl(baseUrl: string, pathname: string): string {
+  const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return `${baseUrl.replace(/\/+$/, "")}${normalizedPath}`;
+}
+
+function runtimeStatePaths(stateDir: string) {
+  const root = path.join(stateDir, "oct8-secrets");
+  return {
+    root,
+    privateKeyPath: path.join(root, PRIVATE_KEY_FILE),
+  };
+}
+
+async function ensureStateRoot(root: string): Promise<void> {
+  await fs.mkdir(root, { recursive: true, mode: 0o700 });
+  await fs.chmod(root, 0o700).catch(() => undefined);
+}
+
+async function readJsonFile(pathname: string): Promise<JsonValue | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(pathname, "utf8")) as JsonValue;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return undefined;
+    }
+    throw new Error(`Failed to read runtime state file ${path.basename(pathname)}.`, {
+      cause: error,
+    });
+  }
+}
+
+async function createJsonFileExclusive(
+  pathname: string,
+  value: unknown,
+): Promise<"created" | "exists"> {
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(pathname, "wx", 0o600);
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") {
+      return "exists";
+    }
+    throw new Error(`Failed to create runtime state file ${path.basename(pathname)}.`, {
+      cause: error,
+    });
+  }
+
+  try {
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+  } finally {
+    await handle.close();
+  }
+  await fs.chmod(pathname, 0o600).catch(() => undefined);
+  return "created";
+}
+
+function publicJwkFromPrivate(privateJwk: PrivateRuntimeJwk): PublicRuntimeJwk {
+  const publicJwk = Object.fromEntries(
+    Object.entries(privateJwk).filter(([key]) => !PRIVATE_JWK_FIELDS.has(key)),
+  ) as PublicRuntimeJwk;
+
+  return {
+    ...publicJwk,
+    kty: "EC",
+    crv: "P-256",
+    kid: privateJwk.kid,
+    alg: "ES256",
+    use: "sig",
+  };
+}
+
+function assertPrivateRuntimeJwk(value: unknown): PrivateRuntimeJwk {
+  if (!isRecord(value)) {
+    throw new Error("Runtime private key state must be a JSON object.");
+  }
+  if (
+    value.kty !== "EC" ||
+    value.crv !== "P-256" ||
+    value.alg !== "ES256" ||
+    value.use !== "sig" ||
+    typeof value.kid !== "string" ||
+    typeof value.d !== "string" ||
+    typeof value.x !== "string" ||
+    typeof value.y !== "string"
+  ) {
+    throw new Error("Runtime private key state is not an ES256 private JWK.");
+  }
+  return value as unknown as PrivateRuntimeJwk;
+}
+
+function generatePrivateRuntimeJwk(keyId: string): PrivateRuntimeJwk {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const exported = privateKey.export({ format: "jwk" });
+  return {
+    ...exported,
+    kty: "EC",
+    crv: "P-256",
+    kid: keyId,
+    alg: "ES256",
+    use: "sig",
+  } as PrivateRuntimeJwk;
+}
+
+async function loadRuntimeKey(env: RuntimeSecretsEnv): Promise<RuntimeKeyState> {
+  const paths = runtimeStatePaths(env.stateDir);
+  await ensureStateRoot(paths.root);
+
+  const stored = await readJsonFile(paths.privateKeyPath);
+  let privateJwk: PrivateRuntimeJwk;
+  if (stored === undefined) {
+    privateJwk = generatePrivateRuntimeJwk(env.keyId ?? `oct8-runtime-${randomUUID()}`);
+    const result = await createJsonFileExclusive(paths.privateKeyPath, privateJwk);
+    if (result === "exists") {
+      privateJwk = assertPrivateRuntimeJwk(await readJsonFile(paths.privateKeyPath));
+    }
+  } else {
+    privateJwk = assertPrivateRuntimeJwk(stored);
+  }
+
+  if (env.keyId && privateJwk.kid !== env.keyId) {
+    throw new Error("OCT8_RUNTIME_KEY_ID does not match the stored runtime key.");
+  }
+
+  return {
+    keyId: privateJwk.kid,
+    privateKey: createPrivateKey({ key: privateJwk, format: "jwk" }),
+    publicKeyJwk: publicJwkFromPrivate(privateJwk),
+  };
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function toBase64UrlJson(value: object): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function signJwtPayload(params: {
+  key: RuntimeKeyState;
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+}): string {
+  const header = toBase64UrlJson(params.header);
+  const payload = toBase64UrlJson(params.payload);
+  const signingInput = `${header}.${payload}`;
+  const signature = cryptoSign("sha256", Buffer.from(signingInput, "utf8"), {
+    key: params.key.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function signRuntimeAssertion(params: {
+  key: RuntimeKeyState;
+  runtimeIdentityId: string;
+  audience: string;
+}): string {
+  const now = nowSeconds();
+  return signJwtPayload({
+    key: params.key,
+    header: { alg: "ES256", kid: params.key.keyId },
+    payload: {
+      jti: randomUUID(),
+      iss: params.runtimeIdentityId,
+      sub: params.runtimeIdentityId,
+      aud: params.audience,
+      iat: now,
+      exp: now + ASSERTION_TTL_SECONDS,
+    },
+  });
+}
+
+function accessTokenHash(accessToken: string): string {
+  return createHash("sha256").update(accessToken, "ascii").digest("base64url");
+}
+
+function signDpopProof(params: {
+  key: RuntimeKeyState;
+  method: "GET" | "POST";
+  htu: string;
+  accessToken?: string;
+}): string {
+  const payload: Record<string, unknown> = {
+    htm: params.method,
+    htu: params.htu,
+    jti: randomUUID(),
+    iat: nowSeconds(),
+  };
+  if (params.accessToken) {
+    payload.ath = accessTokenHash(params.accessToken);
+  }
+  return signJwtPayload({
+    key: params.key,
+    header: {
+      typ: "dpop+jwt",
+      alg: "ES256",
+      jwk: params.key.publicKeyJwk,
+    },
+    payload,
+  });
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchWithTimeout(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function participationContextHtu(tokenIssuer: string, requestUrl: string): string {
+  const parsed = new URL(requestUrl);
+  return runtimeUrl(tokenIssuer, parsed.pathname);
+}
+
+export class RuntimeParticipationContextAuthClient implements ParticipationContextAuthClient {
+  private runtimeEnv: RuntimeSecretsEnv | undefined;
+  private keyPromise: Promise<RuntimeKeyState> | undefined;
+  private token: RuntimeTokenCache | undefined;
+
+  constructor(
+    private readonly options: {
+      env?: NodeJS.ProcessEnv;
+      fetchImpl?: typeof fetch;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  async authorizationHeaders(requestUrl: string): Promise<Record<string, string>> {
+    const accessToken = await this.accessToken();
+    const env = this.env();
+    const key = await this.key();
+    const dpopProof = signDpopProof({
+      key,
+      method: "GET",
+      htu: participationContextHtu(env.tokenIssuer, requestUrl),
+      accessToken,
+    });
+
+    return {
+      Authorization: `DPoP ${accessToken}`,
+      DPoP: dpopProof,
+    };
+  }
+
+  private env(): RuntimeSecretsEnv {
+    this.runtimeEnv ??= readRuntimeSecretsEnv(this.options.env);
+    return this.runtimeEnv;
+  }
+
+  private key(): Promise<RuntimeKeyState> {
+    this.keyPromise ??= loadRuntimeKey(this.env());
+    return this.keyPromise;
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  private async accessToken(): Promise<string> {
+    const now = this.now();
+    if (this.token && this.token.expiresAtMs - TOKEN_REFRESH_SKEW_MS > now) {
+      return this.token.accessToken;
+    }
+
+    const env = this.env();
+    const key = await this.key();
+    const endpoint = runtimeUrl(env.apiUrl, "/v1/runtime/token");
+    const audience = runtimeUrl(env.tokenIssuer, "/v1/runtime/token");
+    const form = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: env.runtimeIdentityId,
+      client_assertion_type: CLIENT_ASSERTION_TYPE,
+      client_assertion: signRuntimeAssertion({
+        key,
+        runtimeIdentityId: env.runtimeIdentityId,
+        audience,
+      }),
+      scope: PARTICIPATION_CONTEXT_SCOPE,
+    });
+
+    const response = await fetchWithTimeout(
+      this.options.fetchImpl ?? fetch,
+      endpoint,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+          DPoP: signDpopProof({ key, method: "POST", htu: audience }),
+        },
+        body: form.toString(),
+      },
+      RUNTIME_TOKEN_REQUEST_TIMEOUT_MS,
+    );
+    const payload = await parseJson(response);
+    if (!response.ok) {
+      const statusText = response.statusText ? ` ${response.statusText}` : "";
+      throw new Error(`Runtime token request failed with ${response.status}${statusText}.`);
+    }
+    if (
+      !isRecord(payload) ||
+      typeof payload.access_token !== "string" ||
+      payload.token_type !== "DPoP" ||
+      payload.scope !== PARTICIPATION_CONTEXT_SCOPE ||
+      typeof payload.expires_in !== "number" ||
+      !Number.isFinite(payload.expires_in) ||
+      payload.expires_in <= 0
+    ) {
+      throw new Error("Runtime token response was invalid.");
+    }
+
+    this.token = {
+      accessToken: payload.access_token,
+      expiresAtMs: now + payload.expires_in * 1_000,
+    };
+    return payload.access_token;
+  }
+}
+
+function createRuntimeParticipationContextAuthClient(): RuntimeParticipationContextAuthClient {
+  return new RuntimeParticipationContextAuthClient();
+}
+
+function parseIdentity(value: unknown): CoworkerParticipationIdentity | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const id = readString(value.id);
+  const names = normalizeNames(value.names);
+  if (!id || names.length === 0) {
+    return undefined;
+  }
+  const roleSummary = readString(value.roleSummary);
+  return {
+    id,
+    names,
+    ...(roleSummary ? { roleSummary } : {}),
+  };
+}
+
+export function parseParticipationContext(payload: unknown): ParticipationContext {
+  const candidate = isRecord(payload) && isRecord(payload.data) ? payload.data : payload;
+  if (!isRecord(candidate)) {
+    throw new Error("participation context response must be an object");
+  }
+
+  const self = parseIdentity(candidate.self);
+  if (!self) {
+    throw new Error("participation context response is missing self identity");
+  }
+
+  const coworkers = Array.isArray(candidate.coworkers)
+    ? candidate.coworkers
+        .map(parseIdentity)
+        .filter((entry): entry is CoworkerParticipationIdentity => Boolean(entry))
+        .filter((entry) => entry.id !== self.id)
+    : [];
+
+  return { self, coworkers };
+}
+
+function buildParticipationContextUrl(config: PlatformContextConfig): string {
+  if (!config.baseUrl) {
+    throw new Error("platform context baseUrl is not configured");
+  }
+  if (!config.coworkerId) {
+    throw new Error("platform context coworkerId is not configured");
+  }
+
+  const endpointPath = config.endpointPath.replace(
+    "{coworkerId}",
+    encodeURIComponent(config.coworkerId),
+  );
+  return new URL(endpointPath, config.baseUrl.endsWith("/") ? config.baseUrl : `${config.baseUrl}/`)
+    .href;
+}
+
+function createStaticParticipationContextProvider(
+  context: ParticipationContext | undefined,
+): ParticipationContextProvider {
+  return {
+    async load() {
+      if (!context) {
+        throw new Error("static participation context is not configured");
+      }
+      return context;
+    },
+  };
+}
+
+function createPlatformParticipationContextProvider(
+  config: ParticipationGateConfig,
+  options: {
+    fetchImpl?: typeof fetch;
+    runtimeAuthClient?: ParticipationContextAuthClient;
+  } = {},
+): ParticipationContextProvider {
+  let cached: { expiresAt: number; context: ParticipationContext } | undefined;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const runtimeAuthClient =
+    options.runtimeAuthClient ?? createRuntimeParticipationContextAuthClient();
+
+  return {
+    async load() {
+      const now = Date.now();
+      if (cached && cached.expiresAt > now) {
+        return cached.context;
+      }
+
+      const url = buildParticipationContextUrl(config.platform);
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (config.platform.authMode === "static-token") {
+        if (!config.platform.token) {
+          throw new Error("static platform context token is not configured");
+        }
+        headers.Authorization = `Bearer ${config.platform.token}`;
+        if (config.platform.coworkerId) {
+          headers["X-Velanir-Coworker-Id"] = config.platform.coworkerId;
+        }
+      } else {
+        Object.assign(headers, await runtimeAuthClient.authorizationHeaders(url));
+      }
+
+      const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        { method: "GET", headers },
+        CONTEXT_FETCH_TIMEOUT_MS,
+      );
+      if (!response.ok) {
+        throw new Error(`platform context request failed with ${response.status}`);
+      }
+      const context = parseParticipationContext(await response.json());
+      cached = {
+        context,
+        expiresAt: now + config.context.refreshMs,
+      };
+      return context;
+    },
+  };
+}
+
+function createParticipationContextProvider(
+  config: ParticipationGateConfig,
+): ParticipationContextProvider {
+  if (config.context.source === "static") {
+    return createStaticParticipationContextProvider(config.staticContext);
+  }
+  return createPlatformParticipationContextProvider(config);
+}
+
+function messageText(event: BeforeDispatchEvent): string {
+  return (event.body ?? event.content ?? "").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function namePattern(name: string): string | undefined {
+  const trimmed = name.trim();
+  if (trimmed.length < 2) {
+    return undefined;
+  }
+  return escapeRegExp(trimmed).replace(/\s+/g, "\\s+");
+}
+
+function matchesAnyPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function buildDirectAddressPatterns(name: string): RegExp[] {
+  const pattern = namePattern(name);
+  if (!pattern) {
+    return [];
+  }
+  const left = "(^|[^A-Za-z0-9_])";
+  const right = "(?=$|[^A-Za-z0-9_])";
+  return [
+    new RegExp(`${left}@${pattern}${right}`, "i"),
+    new RegExp(`(^|[\\s\\n])${pattern}\\s*[:,]`, "i"),
+    new RegExp(`${left}(hey|hi|hello|yo)\\s+${pattern}${right}`, "i"),
+    new RegExp(
+      `${left}${pattern}\\s+(can|could|would|will|please|do|take|help|look|check|own|handle|review|summarize|find|send|create|update)${right}`,
+      "i",
+    ),
+    new RegExp(`${left}(can|could|would|will)\\s+${pattern}\\s+`, "i"),
+  ];
+}
+
+export function messageClearlyAddressesIdentity(
+  content: string,
+  identity: CoworkerParticipationIdentity,
+): boolean {
+  if (!content.trim()) {
+    return false;
+  }
+  return identity.names.some((name) =>
+    matchesAnyPattern(content, buildDirectAddressPatterns(name)),
+  );
+}
+
+function messageClearlyAddressesAnotherCoworker(
+  content: string,
+  context: ParticipationContext,
+): boolean {
+  return context.coworkers.some((coworker) => messageClearlyAddressesIdentity(content, coworker));
+}
+
+function conversationKey(event: BeforeDispatchEvent, ctx: BeforeDispatchContext): string {
+  return (
+    ctx.conversationId ??
+    ctx.sessionKey ??
+    event.sessionKey ??
+    event.channel ??
+    ctx.channelId ??
+    "unknown"
+  );
+}
+
+function createParticipationHistoryStore() {
+  const messagesByConversation = new Map<string, HistoryMessage[]>();
+
+  return {
+    recent(event: BeforeDispatchEvent, ctx: BeforeDispatchContext, maxMessages: number) {
+      if (maxMessages <= 0) {
+        return [];
+      }
+      const messages = messagesByConversation.get(conversationKey(event, ctx)) ?? [];
+      return messages.slice(-maxMessages);
+    },
+
+    record(event: BeforeDispatchEvent, ctx: BeforeDispatchContext, maxMessages: number) {
+      if (maxMessages <= 0) {
+        return;
+      }
+      const content = messageText(event);
+      if (!content) {
+        return;
+      }
+      const key = conversationKey(event, ctx);
+      const current = messagesByConversation.get(key) ?? [];
+      current.push({
+        senderId: event.senderId ?? ctx.senderId,
+        content,
+      });
+      if (current.length > maxMessages) {
+        current.splice(0, current.length - maxMessages);
+      }
+      messagesByConversation.set(key, current);
+    },
+  };
+}
+
+function stripCodeFences(value: string): string {
+  const trimmed = value.trim();
+  const match = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(trimmed);
+  return (match?.[1] ?? trimmed).trim();
+}
+
+function formatIdentity(identity: CoworkerParticipationIdentity): string {
+  const role = identity.roleSummary ? ` Role: ${identity.roleSummary}` : "";
+  return `- ${identity.names.join(", ")}.${role}`;
+}
+
+function buildClassifierPrompt(input: {
+  context: ParticipationContext;
+  recentMessages: HistoryMessage[];
+  currentMessage: HistoryMessage;
+}): string {
+  const coworkers = input.context.coworkers.length
+    ? input.context.coworkers.map(formatIdentity).join("\n")
+    : "- None known.";
+  const recentMessages =
+    input.recentMessages.length > 0
+      ? input.recentMessages
+          .map((message) => {
+            const sender = message.senderId ? `${message.senderId}: ` : "";
+            return `- ${sender}${message.content}`;
+          })
+          .join("\n")
+      : "- No recent messages available.";
+  const currentSender = input.currentMessage.senderId ? `${input.currentMessage.senderId}: ` : "";
+
+  return [
+    "You decide whether a digital coworker should respond in a group or channel conversation.",
+    "Answer only whether it is this coworker's turn to respond.",
+    "",
+    "This coworker:",
+    formatIdentity(input.context.self),
+    "",
+    "Other digital coworkers in this organization:",
+    coworkers,
+    "",
+    "Recent conversation:",
+    recentMessages,
+    "",
+    "Current message:",
+    `${currentSender}${input.currentMessage.content}`,
+    "",
+    "Return only valid JSON with this exact shape:",
+    '{ "shouldRespond": true }',
+    "or",
+    '{ "shouldRespond": false }',
+    "",
+    "Return true when:",
+    "- the message directly addresses this coworker",
+    "- the message asks this coworker to do something",
+    "- the message is a follow-up to this coworker",
+    "- this coworker is clearly the responsible person for the request",
+    "",
+    "Return false when:",
+    "- the message is ambient team conversation",
+    "- the message is clearly for another person or coworker",
+    "- the coworker would be interrupting",
+    "- no response is expected from this coworker",
+    "",
+    "Do not include confidence scores, prose, markdown, or explanations.",
+  ].join("\n");
+}
+
+export function parseClassifierShouldRespond(output: string): boolean {
+  try {
+    const parsed = JSON.parse(stripCodeFences(output));
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as { shouldRespond?: unknown }).shouldRespond === "boolean"
+    ) {
+      return (parsed as { shouldRespond: boolean }).shouldRespond;
+    }
+  } catch {
+    return true;
+  }
+  return true;
+}
+
+function collectAssistantText(result: unknown): string {
+  if (typeof result === "string") {
+    return result.trim();
+  }
+  if (!isRecord(result) || !Array.isArray(result.payloads)) {
+    return "";
+  }
+  return result.payloads
+    .map((payload) => {
+      if (!isRecord(payload)) {
+        return "";
+      }
+      return payload.isError === true || typeof payload.text !== "string" ? "" : payload.text;
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export async function runEmbeddedClassifierModel(params: {
+  api: RuntimeApi;
+  config: ParticipationGateConfig;
+  prompt: string;
+}): Promise<string> {
+  const agentRuntime = params.api.runtime?.agent;
+  const runEmbeddedAgent = agentRuntime?.runEmbeddedAgent ?? agentRuntime?.runEmbeddedPiAgent;
+  if (typeof runEmbeddedAgent !== "function") {
+    throw new Error("OpenClaw embedded agent runtime is unavailable");
+  }
+
+  const provider = params.config.classifier.provider;
+  const model = params.config.classifier.model;
+  if (!provider || !model) {
+    throw new Error("classifier provider/model is not configured");
+  }
+
+  let tmpDir: string | undefined;
+  try {
+    tmpDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "velanir-participation-gate-"),
+    );
+    const runId = `participation-gate-${randomUUID()}`;
+    const result = await runEmbeddedAgent({
+      sessionId: runId,
+      sessionFile: path.join(tmpDir, "session.json"),
+      workspaceDir: agentRuntime?.resolveAgentWorkspaceDir?.(params.api.config) ?? process.cwd(),
+      config: params.api.config,
+      prompt: params.prompt,
+      timeoutMs: params.config.classifier.timeoutMs,
+      runId,
+      modelRun: true,
+      provider,
+      model,
+      authProfileId: params.config.classifier.authProfileId,
+      authProfileIdSource: params.config.classifier.authProfileId ? "user" : "auto",
+      streamParams: {
+        maxTokens: params.config.classifier.maxOutputTokens,
+      },
+      disableTools: true,
+      disableMessageTool: true,
+    });
+    const text = collectAssistantText(result);
+    if (!text) {
+      throw new Error("classifier returned empty output");
+    }
+    return text;
+  } finally {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+}
+
+async function classifyShouldRespond(params: {
+  api: RuntimeApi;
+  config: ParticipationGateConfig;
+  input: {
+    context: ParticipationContext;
+    recentMessages: HistoryMessage[];
+    currentMessage: HistoryMessage;
+  };
+}): Promise<boolean> {
+  const output = await runEmbeddedClassifierModel({
+    api: params.api,
+    config: params.config,
+    prompt: buildClassifierPrompt(params.input),
+  });
+  return parseClassifierShouldRespond(output);
+}
+
+function decision(
+  shouldRespond: boolean,
+  reason: ParticipationDecision["reason"],
+  source: ParticipationDecision["source"],
+  startedAt: number,
+  error?: unknown,
+): ParticipationDecision {
+  const message = errorMessage(error);
+  return {
+    shouldRespond,
+    reason,
+    source,
+    latencyMs: Date.now() - startedAt,
+    ...(message ? { error: message } : {}),
+  };
+}
+
+async function decideParticipation(params: {
+  api: RuntimeApi;
+  config: ParticipationGateConfig;
+  event: BeforeDispatchEvent;
+  ctx: BeforeDispatchContext;
+  contextProvider: ParticipationContextProvider;
+  history: ReturnType<typeof createParticipationHistoryStore>;
+}): Promise<ParticipationDecision> {
+  const startedAt = Date.now();
+
+  if (params.event.isGroup !== true) {
+    return decision(true, "dm", "rule", startedAt);
+  }
+
+  const content = messageText(params.event);
+  if (!content) {
+    return decision(true, "empty_message", "rule", startedAt);
+  }
+
+  const recentMessages = params.history.recent(
+    params.event,
+    params.ctx,
+    params.config.context.maxMessages,
+  );
+
+  let context: ParticipationContext;
+  try {
+    context = await params.contextProvider.load();
+  } catch (error) {
+    params.history.record(params.event, params.ctx, params.config.context.maxMessages);
+    return decision(true, "context_unavailable", "fallback", startedAt, error);
+  }
+
+  try {
+    if (messageClearlyAddressesIdentity(content, context.self)) {
+      return decision(true, "direct_address_self", "rule", startedAt);
+    }
+
+    if (messageClearlyAddressesAnotherCoworker(content, context)) {
+      return decision(false, "direct_address_other_coworker", "rule", startedAt);
+    }
+
+    const shouldRespond = await classifyShouldRespond({
+      api: params.api,
+      config: params.config,
+      input: {
+        context,
+        recentMessages,
+        currentMessage: {
+          senderId: params.event.senderId ?? params.ctx.senderId,
+          content,
+        },
+      },
+    });
+
+    return decision(
+      shouldRespond,
+      shouldRespond ? "classifier_true" : "classifier_false",
+      "classifier",
+      startedAt,
+    );
+  } catch (error) {
+    return decision(true, "classifier_error", "fallback", startedAt, error);
+  } finally {
+    params.history.record(params.event, params.ctx, params.config.context.maxMessages);
+  }
+}
+
+function errorMessage(error: unknown): string | undefined {
+  if (error === undefined || error === null) {
+    return undefined;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return error.toString();
+  }
+  return "unknown error";
+}
+
+function eventContent(event: BeforeDispatchEvent): string {
+  return (event.body ?? event.content ?? "").trim();
+}
+
+function field(name: string, value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return `${name}=${value}`;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return `${name}=${value.toString()}`;
+  }
+  return `${name}=${JSON.stringify(value) ?? "unknown"}`;
+}
+
+function logParticipationDecision(params: {
+  logger?: PluginLogger;
+  config: ParticipationGateConfig;
+  decision: ParticipationDecision;
+  event: BeforeDispatchEvent;
+  ctx: BeforeDispatchContext;
+}): void {
+  if (!params.config.logging.decisions) {
+    return;
+  }
+  const outcome = params.decision.shouldRespond
+    ? "respond"
+    : params.config.mode === "enforce"
+      ? "skip"
+      : "would_skip";
+  const parts = [
+    "velanir-participation-gate:",
+    field("mode", params.config.mode),
+    field("outcome", outcome),
+    field("reason", params.decision.reason),
+    field("source", params.decision.source),
+    field("channel", params.ctx.channelId ?? params.event.channel),
+    field("conversation", params.ctx.conversationId),
+    field("session", params.ctx.sessionKey ?? params.event.sessionKey),
+    field("sender", params.event.senderId ?? params.ctx.senderId),
+    field("latencyMs", params.decision.latencyMs),
+    field("model", params.config.classifier.model),
+    field("error", params.decision.error),
+    params.config.logging.includeContent
+      ? field("content", JSON.stringify(eventContent(params.event)))
+      : undefined,
+  ].filter((entry): entry is string => Boolean(entry));
+
+  params.logger?.info?.(parts.join(" "));
+}
+
+export default definePluginEntry({
+  id: PLUGIN_ID,
+  name: "Velanir Participation Gate",
+  description:
+    "Decides whether a digital coworker should respond in group and channel conversations before the main agent runs.",
+  register(api: OpenClawPluginApi) {
+    const runtimeApi = api as RuntimeApi;
+    const config = normalizeConfig(runtimeApi.pluginConfig);
+    const contextProvider = createParticipationContextProvider(config);
+    const history = createParticipationHistoryStore();
+
+    api.on(
+      "before_dispatch",
+      async (event, ctx) => {
+        const decisionResult = await decideParticipation({
+          api: runtimeApi,
+          config,
+          event,
+          ctx,
+          contextProvider,
+          history,
+        });
+
+        logParticipationDecision({
+          logger: runtimeApi.logger,
+          config,
+          decision: decisionResult,
+          event,
+          ctx,
+        });
+
+        if (!decisionResult.shouldRespond && config.mode === "enforce") {
+          return { handled: true };
+        }
+        return undefined;
+      },
+      { timeoutMs: config.classifier.timeoutMs + 2_000 },
+    );
+  },
+});

--- a/extensions/velanir-participation-gate/openclaw.plugin.json
+++ b/extensions/velanir-participation-gate/openclaw.plugin.json
@@ -1,0 +1,115 @@
+{
+  "id": "velanir-participation-gate",
+  "activation": {
+    "onStartup": true
+  },
+  "enabledByDefault": false,
+  "name": "Velanir Participation Gate",
+  "description": "Decides whether a digital coworker should respond in group and channel conversations before the main agent runs.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "mode": {
+        "type": "string",
+        "enum": ["shadow", "enforce"],
+        "default": "shadow"
+      },
+      "classifier": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": { "type": "string", "minLength": 1 },
+          "model": { "type": "string", "minLength": 1 },
+          "authProfileId": { "type": "string", "minLength": 1 },
+          "timeoutMs": { "type": "number", "minimum": 1, "default": 5000 },
+          "maxOutputTokens": { "type": "number", "minimum": 1, "default": 20 }
+        }
+      },
+      "context": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": ["platform", "static"],
+            "default": "platform"
+          },
+          "maxMessages": { "type": "number", "minimum": 0, "default": 5 },
+          "refreshMs": { "type": "number", "minimum": 1, "default": 300000 }
+        }
+      },
+      "platform": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "authMode": {
+            "type": "string",
+            "enum": ["runtime", "static-token"],
+            "default": "runtime"
+          },
+          "baseUrl": { "type": "string", "minLength": 1 },
+          "coworkerId": { "type": "string", "minLength": 1 },
+          "token": { "type": "string", "minLength": 1 },
+          "endpointPath": { "type": "string", "minLength": 1 }
+        }
+      },
+      "staticContext": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "self": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "names"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "names": { "type": "array", "items": { "type": "string" } },
+              "roleSummary": { "type": "string" }
+            }
+          },
+          "coworkers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "names"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "names": { "type": "array", "items": { "type": "string" } },
+                "roleSummary": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "logging": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "decisions": { "type": "boolean", "default": true },
+          "includeContent": { "type": "boolean", "default": false }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "mode": {
+      "label": "Mode",
+      "help": "shadow logs decisions without suppressing replies; enforce suppresses skipped group/channel turns."
+    },
+    "platform.authMode": {
+      "label": "Platform Auth Mode",
+      "help": "runtime uses scoped runtime identity tokens. static-token is local/prototype only."
+    },
+    "platform.token": {
+      "label": "Platform Token",
+      "help": "Prototype-only static bearer token. Used only when platform.authMode is static-token.",
+      "sensitive": true
+    },
+    "logging.includeContent": {
+      "label": "Log Message Content",
+      "help": "Default off. Enable only for controlled debugging."
+    }
+  }
+}

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -79,6 +79,38 @@ describe("loadExtraBootstrapFiles", () => {
     ]);
   });
 
+  it("skips custom bootstrap basenames unless they are explicitly allowed", async () => {
+    const workspaceDir = await createWorkspaceDir("custom-default");
+    await fs.writeFile(path.join(workspaceDir, "COMPANY.md"), "company", "utf-8");
+
+    const { files, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
+      "COMPANY.md",
+    ]);
+
+    expect(files).toHaveLength(0);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: "invalid-bootstrap-filename",
+          detail: "unsupported bootstrap basename: COMPANY.md",
+        }),
+      ]),
+    );
+  });
+
+  it("loads explicitly allowed custom bootstrap basenames", async () => {
+    const workspaceDir = await createWorkspaceDir("custom-allowed");
+    await fs.writeFile(path.join(workspaceDir, "COMPANY.md"), "company", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["COMPANY.md"], {
+      allowedBasenames: ["COMPANY.md"],
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.name).toBe("COMPANY.md");
+    expect(files[0]?.content).toBe("company");
+  });
+
   it("keeps path-traversal attempts outside workspace excluded", async () => {
     const rootDir = await createWorkspaceDir("root");
     const workspaceDir = path.join(rootDir, "workspace");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -157,7 +157,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_USER_FILENAME
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
-  | typeof DEFAULT_MEMORY_FILENAME;
+  | typeof DEFAULT_MEMORY_FILENAME
+  | (string & {});
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -196,6 +197,27 @@ const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_FILENAME,
 ]);
+
+type ExtraBootstrapLoadOptions = {
+  allowedBasenames?: readonly string[];
+};
+
+function isValidCustomBootstrapBasename(name: string): boolean {
+  return (
+    name.length > 0 && name !== "." && name !== ".." && !name.includes("/") && !name.includes("\\")
+  );
+}
+
+function resolveAllowedBootstrapNames(options?: ExtraBootstrapLoadOptions): ReadonlySet<string> {
+  const allowed = new Set(VALID_BOOTSTRAP_NAMES);
+  for (const rawName of options?.allowedBasenames ?? []) {
+    const name = rawName.trim();
+    if (isValidCustomBootstrapBasename(name)) {
+      allowed.add(name);
+    }
+  }
+  return allowed;
+}
 
 const OPTIONAL_BOOTSTRAP_FILENAMES: ReadonlySet<string> = new Set([
   DEFAULT_SOUL_FILENAME,
@@ -1194,14 +1216,16 @@ async function resolveExtraBootstrapPatternPaths(
 export async function loadExtraBootstrapFiles(
   dir: string,
   extraPatterns: string[],
+  options?: ExtraBootstrapLoadOptions,
 ): Promise<WorkspaceBootstrapFile[]> {
-  const loaded = await loadExtraBootstrapFilesWithDiagnostics(dir, extraPatterns);
+  const loaded = await loadExtraBootstrapFilesWithDiagnostics(dir, extraPatterns, options);
   return loaded.files;
 }
 
 export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
+  options?: ExtraBootstrapLoadOptions,
 ): Promise<{
   files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
@@ -1210,6 +1234,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
     return { files: [], diagnostics: [] };
   }
   const resolvedDir = resolveUserPath(dir);
+  const allowedBootstrapNames = resolveAllowedBootstrapNames(options);
 
   // Resolve glob patterns into concrete file paths
   const resolvedPaths = new Set<string>();
@@ -1228,9 +1253,12 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
-    // Only load files whose basename is a recognized bootstrap filename
     const baseName = path.basename(relPath);
-    if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
+    // Velanir fork maintenance: keep custom bootstrap basenames as an opt-in
+    // hook option instead of hardcoding product filenames here. If upstream
+    // changes this loader, preserve an equivalent config seam. See
+    // VELANIR_OPENCLAW.md.
+    if (!allowedBootstrapNames.has(baseName)) {
       diagnostics.push({
         path: filePath,
         reason: "invalid-bootstrap-filename",

--- a/src/hooks/bundled/bootstrap-extra-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-extra-files/HOOK.md
@@ -47,7 +47,10 @@ workspace root.
 - `paths` (string[]): preferred list of glob/path patterns.
 - `patterns` (string[]): alias of `paths`.
 - `files` (string[]): alias of `paths`.
+- `allowedBasenames` (string[]): additional exact basenames to accept beyond
+  the built-in bootstrap filenames.
 
 All paths are resolved from the workspace and must stay inside it (including realpath checks).
-Only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
-`IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+By default, only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`,
+`TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+Use `allowedBasenames` to opt in to additional exact filenames.

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -7,7 +7,7 @@ import type { AgentBootstrapHookContext } from "../../hooks.js";
 import { createHookEvent } from "../../hooks.js";
 import handler from "./handler.js";
 
-function createBootstrapExtraConfig(paths: string[]): OpenClawConfig {
+function createBootstrapExtraConfig(paths: string[], allowedBasenames?: string[]): OpenClawConfig {
   return {
     hooks: {
       internal: {
@@ -15,6 +15,7 @@ function createBootstrapExtraConfig(paths: string[]): OpenClawConfig {
           "bootstrap-extra-files": {
             enabled: true,
             paths,
+            ...(allowedBasenames ? { allowedBasenames } : {}),
           },
         },
       },
@@ -71,6 +72,45 @@ describe("bootstrap-extra-files hook", () => {
     expect(injected.map((f) => path.relative(tempDir, f.path))).toContain(
       path.join("packages", "core", "AGENTS.md"),
     );
+  });
+
+  it("appends custom basename files when explicitly allowed", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-custom-");
+    await fs.writeFile(path.join(tempDir, "COMPANY.md"), "company", "utf-8");
+
+    const cfg = createBootstrapExtraConfig(["COMPANY.md"], ["COMPANY.md"]);
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:main",
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    const injected = context.bootstrapFiles.find((f) => f.name === "COMPANY.md");
+    expect(injected?.content).toBe("company");
+  });
+
+  it("keeps custom basename files out of subagent minimal bootstrap context", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-custom-subagent-");
+    await fs.writeFile(path.join(tempDir, "COMPANY.md"), "company", "utf-8");
+
+    const cfg = createBootstrapExtraConfig(["COMPANY.md"], ["COMPANY.md"]);
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:subagent:abc",
+      rootFiles: [
+        { name: "AGENTS.md", content: "root agents" },
+        { name: "TOOLS.md", content: "root tools" },
+      ],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
+    await handler(event);
+    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
   });
 
   it("re-applies subagent bootstrap allowlist after extras are added", async () => {

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -22,6 +22,10 @@ function resolveExtraBootstrapPatterns(hookConfig: Record<string, unknown>): str
   return normalizeTrimmedStringList(hookConfig.files);
 }
 
+function resolveAllowedBasenames(hookConfig: Record<string, unknown>): string[] {
+  return normalizeTrimmedStringList(hookConfig.allowedBasenames);
+}
+
 const bootstrapExtraFilesHook: HookHandler = async (event) => {
   if (!isAgentBootstrapEvent(event)) {
     return;
@@ -34,6 +38,7 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
   }
 
   const patterns = resolveExtraBootstrapPatterns(hookConfig as Record<string, unknown>);
+  const allowedBasenames = resolveAllowedBasenames(hookConfig as Record<string, unknown>);
   if (patterns.length === 0) {
     return;
   }
@@ -42,6 +47,7 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
     const { files: extras, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(
       context.workspaceDir,
       patterns,
+      { allowedBasenames },
     );
     if (diagnostics.length > 0) {
       log.debug("skipped extra bootstrap candidates", {

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { runMessageAction } from "./message-action-runner.js";
 
@@ -67,8 +67,12 @@ function registerSlackTextPlugin() {
 }
 
 describe("runMessageAction core send routing", () => {
+  beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
   afterEach(() => {
-    setActivePluginRegistry(createTestRegistry([]));
+    resetPluginRuntimeStateForTest();
     ttsMocks.maybeApplyTtsToPayload
       .mockReset()
       .mockImplementation(async (params: { payload: unknown }) => params.payload);
@@ -195,13 +199,22 @@ describe("runMessageAction core send routing", () => {
             id: "telegram",
             outbound: {
               deliveryMode: "direct",
-              sendText: vi.fn(),
+              sendText: vi.fn().mockResolvedValue({
+                channel: "telegram",
+                messageId: "t1",
+                chatId: "-1001234567890",
+              }),
             },
             messaging: {
               normalizeTarget: (raw) =>
-                raw === "-1001234567890:topic:42" ? "telegram:-1001234567890:topic:42" : undefined,
+                raw.trim() === "-1001234567890:topic:42"
+                  ? "telegram:-1001234567890:topic:42"
+                  : raw.trim() || undefined,
+              inferTargetChatType: () => "group",
               targetResolver: {
-                looksLikeId: (raw) => raw === "-1001234567890:topic:42",
+                looksLikeId: (_raw, normalized) =>
+                  normalized === "telegram:-1001234567890:topic:42",
+                hint: "<chatId>",
               },
             },
           }),

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -22,6 +22,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/thread-ownership/index.ts",
+  "extensions/velanir-participation-gate/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
@@ -34,6 +35,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
+  "extensions/velanir-participation-gate/index.ts": ["before_dispatch"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]


### PR DESCRIPTION
## Summary

- Squashes the DanBot Velanir fork delta into one commit on current canonical `openclaw/openclaw:main`.
- Adds the Velanir participation gate plugin, its manifest, contract coverage, and plugin boundary invariant coverage.
- Adds the configurable `bootstrap-extra-files.allowedBasenames` seam with docs/tests, plus the Velanir S3 release workflow and fork notes.

## Base / Tags

- PR base: canonical `openclaw/openclaw:main` at `1d3cfc4b01` (`Policy: add data handling conformance checks (#87056)`).
- Latest canonical tag by version sort: `v2026.6.2-alpha.2` (tag object `54b452b36759ddef8e6b08c43ae800f9280e9f7f`, peeled commit `788dba4009237e6808dfdf4d5f29ca585dd9776e`).
- Latest tag reachable from canonical `main`: `v2026.4.19-beta.2`.
- `v2026.6.2-alpha.2` is not on the current `main` line (`main...v2026.6.2-alpha.2^{}` is `7`/`16` commits apart), so this PR is based on canonical `main` to keep the upstream PR diff clean.

## Verification

- `pnpm docs:list`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs run src/agents/workspace.load-extra-bootstrap-files.test.ts src/hooks/bundled/bootstrap-extra-files/handler.test.ts extensions/velanir-participation-gate/index.test.ts src/infra/outbound/message-action-runner.core-send.test.ts src/plugins/contracts/boundary-invariants.test.ts`
- `pnpm check:no-conflict-markers`
- `git diff --check openclaw-upstream/main...HEAD`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:extensions`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core:test`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:extensions:test`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm lint:core`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm lint:extensions`
- `node scripts/check-docs-i18n-glossary.mjs --base openclaw-upstream/main --head HEAD`
- `pnpm docs:check-links`
- Workflow YAML parse check for `.github/workflows/velanir-openclaw-release.yml`

## Notes

- Broad Testbox `check:changed` could not be dispatched from this machine because local Crabbox/Blacksmith binaries were unavailable.
- Local `check-changed` wrapper was blocked by missing `corepack`; the affected lanes were covered with the targeted commands above.
- `pnpm check:workflows` was blocked by missing local `actionlint`/fallback support; the Velanir workflow YAML parsed cleanly.
