### PR TITLE
fix(canvas): use crypto randomness for A2UI action IDs

### DIFF
--- a/extensions/canvas/src/host/a2ui-app/bootstrap.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap.js
@@ -104,6 +104,22 @@ const statusShadow = isAndroid
   : "0 10px 24px rgba(0, 0, 0, 0.25)";
 const statusBlur = isAndroid ? "10px" : "14px";
 
+const bytesToHex = (bytes) =>
+  Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+
+const createA2UIActionId = () => {
+  const crypto = globalThis.crypto;
+  if (crypto?.randomUUID) {
+    return crypto.randomUUID();
+  }
+  if (!crypto?.getRandomValues) {
+    throw new Error("A2UI action IDs require Web Crypto random values.");
+  }
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return `a2ui_${Date.now()}_${bytesToHex(bytes)}`;
+};
+
 const postNativeMessage = (handler, payload) => {
   Reflect.apply(handler.postMessage, handler, [payload]);
 };
@@ -378,10 +394,7 @@ class OpenClawA2UIHost extends LitElement {
   }
 
   #makeActionId() {
-    return (
-      globalThis.crypto?.randomUUID?.() ??
-      `a2ui_${Date.now()}_${Math.random().toString(16).slice(2)}`
-    );
+    return createA2UIActionId();
   }
 
   #setToast(text, kind = "ok", timeoutMs = 1400) {


### PR DESCRIPTION
## Summary

- Replaces the Canvas A2UI action id `Math.random()` fallback with Web Crypto randomness.
- Keeps `crypto.randomUUID()` as the preferred path when available.
- Falls back to a 16-byte `crypto.getRandomValues()` hex suffix when `randomUUID()` is unavailable.
- Fails closed if Web Crypto random values are not available instead of producing predictable action ids.

## Linked context

Which issue does this close?

Closes: none

Which issues, PRs, or discussions are related?

Related: suggested issue for `extensions/canvas/src/host/a2ui-app/bootstrap.js` weak fallback action id generation.

Was this requested by a maintainer or owner?

No direct maintainer request; this is a narrow contributor security hardening fix from the suggested issue list.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Canvas A2UI action ids no longer use `Math.random()` when `crypto.randomUUID()` is unavailable.
- Real environment tested: generated Canvas A2UI asset served from `extensions/canvas/src/host/a2ui/index.html`, exercised in system Google Chrome 148 via Playwright.
- Exact steps or command run after this patch: ran a Node/Playwright probe that served `extensions/canvas/src/host/a2ui`, injected a browser `crypto` object with `randomUUID` removed and `getRandomValues` wrapped, dispatched an `a2uiaction` event on `openclaw-a2ui-host`, and asserted the generated action id shape plus the `getRandomValues(16)` call.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "randomUUIDType": "undefined",
  "getRandomValuesCalls": [
    16
  ],
  "action": {
    "id": "a2ui_1780423681323_878a2436e2e8c51d62a957f671bda453",
    "name": "proof-action",
    "surfaceId": "main",
    "sourceComponentId": "proof-button",
    "timestamp": "2026-06-02T18:08:01.323Z"
  },
  "pendingAction": {
    "id": "a2ui_1780423681323_878a2436e2e8c51d62a957f671bda453",
    "name": "proof-action",
    "phase": "error",
    "startedAt": 1780423681326,
    "error": "missing native bridge"
  },
  "secureFallbackUsed": true,
  "getRandomValuesUsed": true
}
```

- Observed result after fix: with `crypto.randomUUID` unavailable, the A2UI action id used the `a2ui_<timestamp>_<32 hex chars>` fallback and `crypto.getRandomValues` was called with 16 bytes. The missing native bridge error is expected in the standalone browser probe after the id is generated.
- What was not tested: native iOS/Android WebView bridge delivery, full `pnpm check`, and the full Canvas plugin suite.
- Proof limitations or environment constraints: the real browser proof dispatches a synthetic A2UI action event against the generated host asset, because the native Canvas bridge is not available in this local browser environment.
- Before evidence (optional but encouraged): source before this patch used `Math.random().toString(16).slice(2)` in the fallback path.

## Tests and validation

Which commands did you run?

```bash
pnpm canvas:a2ui:bundle
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/canvas/scripts/bundle-a2ui.test.ts -- --reporter=verbose
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/canvas/src/host/server.test.ts -- --reporter=verbose
git diff --check -- extensions/canvas/src/host/a2ui-app/bootstrap.js
pnpm changed:lanes --json --base upstream/main
```

What regression coverage was added or updated?

No source test file was added; the changed action id helper is private browser runtime code inside the A2UI asset. The runtime path was covered with the browser proof above, and the existing Canvas bundle and host tests remained green.

What failed before this fix, if known?

The fallback action id path used predictable `Math.random()` output when `crypto.randomUUID()` was unavailable.

If no test was added, why not?

There is no existing narrow unit seam for the private browser action id method. Adding a broader test harness just for this helper would be larger than the fix; the browser proof exercises the actual generated asset path.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No for supported Web Crypto environments; unsupported environments without `getRandomValues` now fail closed instead of generating predictable ids.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, action id generation no longer uses insecure randomness in the fallback path.

What is the highest-risk area?

Very old browser/WebView environments that lack both `crypto.randomUUID()` and `crypto.getRandomValues()`.

How is that risk mitigated?

Modern Canvas browser targets provide Web Crypto random values; failing closed is safer than sending predictable action ids.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer review and CI. Local focused proof is complete.

Which bot or reviewer comments were addressed?

None yet.
