### PR TITLE
fix(gateway): promote hot-mode reload-drop to error with remediation

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1104,6 +1104,50 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("logs an error with remediation when hot mode drops a restart-required reload", async () => {
+    // Regression: when the gateway runs in hot reload mode and a config write
+    // touches any restart-required path, the reload plan was dropped behind a
+    // single log.warn that operators routinely missed in aggregator UIs. The
+    // failure mode is silent staleness: the disk config is correct but every
+    // in-process consumer keeps using the old snapshot until the gateway is
+    // restarted by hand. Promote to log.error and include the remediation
+    // command verbatim so log aggregators with level=ERROR alerts catch it.
+    const hotModeRestartRequiredSnapshot = makeSnapshot({
+      sourceConfig: {
+        gateway: { port: 99999, reload: { mode: "hot", debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      runtimeConfig: {
+        gateway: { port: 99999, reload: { mode: "hot", debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      config: {
+        gateway: { port: 99999, reload: { mode: "hot", debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      hash: "hot-mode-restart-required",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(hotModeRestartRequiredSnapshot);
+    const harness = createReloaderHarness(readSnapshot);
+
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    expect(harness.log.warn).not.toHaveBeenCalled();
+    expect(harness.log.error).toHaveBeenCalledTimes(1);
+    const errorMessage = harness.log.error.mock.calls[0]?.[0] as string;
+    expect(errorMessage).toContain("config reload requires gateway restart");
+    expect(errorMessage).toContain("hot mode ignoring");
+    expect(errorMessage).toContain("gateway.port");
+    expect(errorMessage).toContain("openclaw gateway restart");
+
+    await harness.reloader.stop();
+  });
+
   it("plans in-process reloads from source config and ignores runtime materialized paths", async () => {
     const baseInstall = {
       source: "npm" as const,

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -274,10 +274,15 @@ export function startGatewayConfigReloader(opts: {
     }
     if (plan.restartGateway) {
       if (settings.mode === "hot") {
-        opts.log.warn(
+        // Promoted to error so log aggregators / level=ERROR alert rules catch
+        // it. In hot mode the entire reload plan is dropped when any path is
+        // restart-required, so a missed warn here can leave the runtime
+        // serving from a stale config indefinitely. Include the remediation
+        // verbatim so the operator does not have to look it up.
+        opts.log.error(
           `config reload requires gateway restart; hot mode ignoring (${plan.restartReasons.join(
             ", ",
-          )})`,
+          )}). Run \`openclaw gateway restart\` to apply these changes.`,
         );
         return;
       }


### PR DESCRIPTION
## Summary

In hot reload mode, when a config write touches any restart-required path, the runtime drops the whole reload plan behind a single `log.warn`. Operators routinely miss this in log aggregator UIs and the runtime quietly serves a stale snapshot until a manual restart.

Promote the log line to `error`, include the remediation command verbatim, and add a focused regression test.

## Real environment tested

This was the production failure mode that motivated the PR. On a deployed gateway, `openclaw doctor --fix` migrated `agents.defaults.models` keys from legacy ids to canonical ids (a hot-reloadable change on its own) at the same time as renaming `auth.profiles.*` keys (restart-required). The auth-profile rename forced the whole plan to be classified as restart-required; in hot mode the whole plan was dropped with a single `log.warn`. The in-process agent kept resolving the legacy model id for ~4 hours, every Telegram turn aborted with `FailoverError: Unknown model: ...`, and the only operator-visible signal was admin DMs getting a canned `agent failed` reply while group messages silently dropped. `launchctl kickstart -k` of the gateway recovered immediately because the disk config was already correct.

`Behavior addressed`: hot mode silent config staleness when a restart-required key is in the same write as hot-reloadable keys.

`Real environment tested`: deployed gateway (macOS, supervised via launchd, hot reload mode), Codex plugin externalized in `v2026.6.2`, `agents.defaults.models` and `auth.profiles.*` renamed in the same `doctor --fix` change.

`Exact steps or command run after this patch`:

```
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts -t "logs an error with remediation"
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
```

`Evidence after fix`:

```
RUN  v4.1.7 /private/tmp/hot-reload-pr
Test Files  1 passed (1)
Tests  79 passed (79)
Duration  931ms
```

Mutation-verified: reverting the `log.warn` -> `log.error` promotion fails the new test on `harness.log.warn was not called`.

`Observed result after fix`: the existing log line is now `error` level and reads:

```
[error] config reload requires gateway restart; hot mode ignoring (gateway.port). Run `openclaw gateway restart` to apply these changes.
```

A level=ERROR alert rule on the gateway log stream will fire on this immediately, giving the operator a real signal instead of a buried `warn` line. The remediation command is inlined so the operator does not have to look it up.

`What was not tested`: this PR does not change the policy of dropping the whole plan when restart-required keys are present. Partitioning the plan and applying only hot-reloadable subsets would require key-dependency analysis and is intentionally out of scope.

## Verification

- `pnpm test src/gateway/config-reload.test.ts` (79 passed locally)
- `oxfmt --check` clean on both modified files
- `oxlint` clean on both modified files
- Mutation test: reverting the change makes the new test fail

