### PR TITLE
fix(agents): harden code mode MCP schema docs

### DIFF
--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -356,21 +356,45 @@ function readSchemaRecord(schema: unknown): Record<string, unknown> | undefined 
   return isRecord(schema) ? schema : undefined;
 }
 
+function readRecordField(record: Record<string, unknown>, key: string): unknown {
+  try {
+    return record[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readRecordEntries(record: Record<string, unknown>): Array<[string, unknown]> {
+  let keys: string[];
+  try {
+    keys = Object.keys(record);
+  } catch {
+    return [];
+  }
+  const entries: Array<[string, unknown]> = [];
+  for (const key of keys) {
+    entries.push([key, readRecordField(record, key)]);
+  }
+  return entries;
+}
+
 function readSchemaProperties(schema: unknown): Record<string, unknown> {
   const record = readSchemaRecord(schema);
-  return isRecord(record?.properties) ? record.properties : {};
+  const properties = record ? readRecordField(record, "properties") : undefined;
+  return isRecord(properties) ? Object.fromEntries(readRecordEntries(properties)) : {};
 }
 
 function readSchemaString(schema: unknown, key: string): string | undefined {
   const record = readSchemaRecord(schema);
-  const value = record?.[key];
+  const value = record ? readRecordField(record, key) : undefined;
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function readRequiredKeys(schema: unknown): string[] {
   const record = readSchemaRecord(schema);
-  return Array.isArray(record?.required)
-    ? record.required.filter((entry): entry is string => typeof entry === "string")
+  const required = record ? readRecordField(record, "required") : undefined;
+  return Array.isArray(required)
+    ? required.filter((entry): entry is string => typeof entry === "string")
     : [];
 }
 

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -5,6 +5,7 @@ import {
   clearCodeModeNamespacesForPlugin,
   clearCodeModeNamespacesForTest,
   createCodeModeNamespaceTool,
+  createCodeModeApiVirtualFiles,
   type CodeModeNamespaceRegistration,
   listCodeModeNamespaces,
   registerCodeModeNamespaceForPlugin,
@@ -956,6 +957,53 @@ describe("Code Mode", () => {
       },
     });
     expect(githubCreate.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let hostile MCP schema properties abort namespace API docs", () => {
+    const hostileProperties = new Proxy<Record<string, unknown>>(
+      {
+        value: { type: "string" },
+      },
+      {
+        ownKeys() {
+          throw new Error("fuzzplugin schema properties exploded");
+        },
+        getOwnPropertyDescriptor(target, property) {
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      },
+    );
+    const broken = mcpTool({
+      name: "dofbot__move_angles",
+      serverName: "dofbot",
+      toolName: "move_angles",
+      parameters: {
+        type: "object",
+        properties: hostileProperties,
+        required: ["value"],
+      } as never,
+    });
+
+    const files = createCodeModeApiVirtualFiles([
+      {
+        id: "mcp:dofbot:move_angles",
+        source: "mcp",
+        sourceName: "dofbot",
+        name: broken.name,
+        description: broken.description,
+        parameters: broken.parameters,
+        mcp: {
+          serverName: "dofbot",
+          safeServerName: "dofbot",
+          toolName: "move_angles",
+          operation: "tool",
+        },
+      },
+    ]);
+
+    const serverFile = files.find((file) => file.path === "mcp/dofbot.d.ts");
+    expect(serverFile?.content).toContain("function moveAngles(");
+    expect(serverFile?.content).toContain("value: unknown;");
   });
 
   it("groups MCP resources and prompts under server namespaces", async () => {


### PR DESCRIPTION
## Summary
- Harden code-mode MCP API doc generation against hostile tool schema `properties` maps.
- Snapshot schema properties with guarded key/value reads before rendering MCP TypeScript-style headers.
- Keep generated docs usable by falling back to required-only `unknown` fields when schema details are unreadable.

## Verification
- `node scripts/run-vitest.mjs src/agents/code-mode.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/code-mode-namespaces.ts src/agents/code-mode.test.ts`
- `./node_modules/.bin/oxlint src/agents/code-mode-namespaces.ts src/agents/code-mode.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_fb110c059321`, slug `tidal-krill`, run `run_5f22ef8885e8`, total `4m1.691s`, exit `0`

## Real behavior proof
Behavior addressed: A plugin/MCP tool schema with a hostile `properties` object no longer aborts code-mode MCP API doc generation before code mode can expose useful tool docs.
Real environment tested: Local sparse Codex worktree for focused Vitest/format/lint/autoreview, plus direct AWS Crabbox Linux validation for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/code-mode.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89579 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
Evidence after fix: `src/agents/code-mode.test.ts` passes 54 tests, including a regression for `dofbot__move_angles` with a proxy-backed schema properties map whose key enumeration throws; AWS Crabbox run `run_5f22ef8885e8` passed `pnpm check:changed` with lanes `core`, `coreTests`.
Observed result after fix: `createCodeModeApiVirtualFiles()` still renders `mcp/dofbot.d.ts`; the hostile property falls back to a required `value: unknown` field instead of throwing; remote changed-gate typecheck, lint, and guards pass.
What was not tested: Full repo test suite, live provider calls, and Docker/E2E lanes.
