### PR TITLE
fix(agents): harden tool search schema catalog

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1030,4 +1030,54 @@ describe("Tool Search", () => {
     });
     expect(second.catalogReused).toBe(false);
   });
+
+  it("ignores unreadable catalog parameters without dropping sibling tools", async () => {
+    const config = {
+      tools: {
+        toolSearch: { enabled: true, mode: "tools" },
+      },
+    } as never;
+    const sessionId = "session-unreadable-schema";
+    const controls = createToolSearchTools({ config, sessionId });
+    const searchTool = controls.find((tool) => tool.name === TOOL_SEARCH_RAW_TOOL_NAME);
+    const describeTool = controls.find((tool) => tool.name === TOOL_DESCRIBE_RAW_TOOL_NAME);
+    if (!searchTool || !describeTool) {
+      throw new Error("Expected raw Tool Search controls");
+    }
+    const hostile = pluginTool("fake_unreadable_schema", "Tool with unreadable parameters");
+    hostile.parameters = new Proxy<Record<string, unknown>>(
+      {
+        type: "object",
+        properties: {
+          value: { type: "string" },
+        },
+      },
+      {
+        ownKeys() {
+          throw new Error("schema keys exploded");
+        },
+      },
+    );
+    const healthy = pluginTool("fake_healthy_schema", "Healthy sibling tool");
+
+    const compacted = applyToolSearchCatalog({
+      tools: [...controls, hostile, healthy],
+      config,
+      sessionId,
+    });
+
+    expect(compacted.catalogRegistered).toBe(true);
+    expect(compacted.catalogToolCount).toBe(2);
+
+    const searchResult = await searchTool.execute("search-unreadable-schema", {
+      query: "healthy",
+    });
+    const hits = searchResult.details as Array<{ name?: string }>;
+    expect(hits.map((hit) => hit.name)).toContain("fake_healthy_schema");
+
+    const describeResult = await describeTool.execute("describe-unreadable-schema", {
+      id: "fake_unreadable_schema",
+    });
+    expect(resultDetails(describeResult).parameters).toEqual({});
+  });
 });

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -503,10 +503,42 @@ function stableJsonFingerprint(value: unknown, seen = new WeakSet<object>()): st
     return `[${value.map((item) => stableJsonFingerprint(item, seen)).join(",")}]`;
   }
   const record = value as Record<string, unknown>;
-  const entries = Object.keys(record)
-    .toSorted()
-    .map((key) => `${JSON.stringify(key)}:${stableJsonFingerprint(record[key], seen)}`);
+  let keys: string[];
+  try {
+    keys = Object.keys(record);
+  } catch {
+    return '"[Unreadable]"';
+  }
+  const entries = keys.toSorted().map((key) => {
+    let child: unknown;
+    try {
+      child = record[key];
+    } catch {
+      child = "[Unreadable]";
+    }
+    return `${JSON.stringify(key)}:${stableJsonFingerprint(child, seen)}`;
+  });
   return `{${entries.join(",")}}`;
+}
+
+function readCatalogParameters(tool: CatalogTool): unknown {
+  try {
+    return tool.parameters;
+  } catch {
+    return {};
+  }
+}
+
+function toJsonSafeCatalogParameters(parameters: unknown): unknown {
+  if (parameters === undefined) {
+    return undefined;
+  }
+  try {
+    const text = JSON.stringify(parameters);
+    return text === undefined ? undefined : JSON.parse(text);
+  } catch {
+    return {};
+  }
 }
 
 function catalogToolIdentity(tool: CatalogTool): number {
@@ -658,7 +690,7 @@ function toCatalogEntry(
     name: tool.name,
     label: tool.label,
     description: tool.description ?? "",
-    parameters: tool.parameters,
+    parameters: toJsonSafeCatalogParameters(readCatalogParameters(tool)),
     tool: catalogTool,
   };
 }


### PR DESCRIPTION
## Summary
- make Tool Search catalog fingerprinting tolerate unreadable schema objects
- snapshot catalog parameters into JSON-safe metadata so describe/search cannot be poisoned by hostile schema proxies
- add regression coverage proving a bad tool schema does not drop healthy sibling tools

## Verification
- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --write src/agents/tool-search.ts src/agents/tool-search.test.ts`
- `./node_modules/.bin/oxlint src/agents/tool-search.ts src/agents/tool-search.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh-PR `pnpm check:changed`: provider `aws`, run `run_70d5c1158d4d`, lease `cbx_f3719233771e`, slug `violet-shrimp`, lanes `core`, `coreTests`, exit 0, command 3m57.523s, total 4m15.514s, lease stopped

## Real behavior proof
Behavior addressed: Tool Search catalog ingestion no longer crashes when a plugin/tool provides unreadable `parameters` metadata.
Real environment tested: Local focused Vitest lane plus AWS Crabbox fresh-PR changed gate on Linux Node 24.15.0.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89582 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
Evidence after fix: focused test passed 26 tests; remote changed gate passed lanes `core` and `coreTests` in run `run_70d5c1158d4d`.
Observed result after fix: the healthy sibling tool remains searchable, and describing the hostile tool returns an empty safe `parameters` object.
What was not tested: full repository suite.
