### PR TITLE
fix(llm-core): wrap unreadable tool schemas

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -38,4 +38,34 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  it("reports unreadable plain JSON schema fields as schema errors", () => {
+    const unreadableProperties = new Proxy<Record<string, unknown>>(
+      {
+        amount: { type: "number" },
+      },
+      {
+        ownKeys() {
+          throw new Error("schema properties exploded");
+        },
+      },
+    );
+    const tool = {
+      name: "unreadable-schema-tool",
+      description: "test tool",
+      parameters: {
+        type: "object",
+        properties: unreadableProperties,
+      },
+    } as unknown as Tool;
+
+    expect(() =>
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "unreadable-schema-tool",
+        arguments: { amount: "1" },
+      }),
+    ).toThrow(/Invalid parameter schema for tool "unreadable-schema-tool"/);
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -268,6 +268,14 @@ function getValidator(schema: Tool["parameters"]): ReturnType<typeof Compile> {
   return validator;
 }
 
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function invalidParameterSchemaError(toolName: string, error: unknown): Error {
+  return new Error(`Invalid parameter schema for tool "${toolName}": ${formatUnknownError(error)}`);
+}
+
 function formatValidationPath(error: TLocalizedValidationError): string {
   if (error.keyword === "required") {
     const requiredProperty = (error.params as { requiredProperties?: string[] })
@@ -293,13 +301,36 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
 /** Validates tool arguments against TypeBox or plain JSON-schema parameters. */
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
   const args = structuredClone(toolCall.arguments);
-  Value.Convert(tool.parameters, args);
+  try {
+    Value.Convert(tool.parameters, args);
+  } catch (error) {
+    throw invalidParameterSchemaError(tool.name, error);
+  }
 
-  const validator = getValidator(tool.parameters);
-  if (!hasTypeBoxMetadata(tool.parameters) && isJsonSchemaObject(tool.parameters)) {
+  let validator: ReturnType<typeof Compile>;
+  try {
+    validator = getValidator(tool.parameters);
+  } catch (error) {
+    throw invalidParameterSchemaError(tool.name, error);
+  }
+
+  let shouldCoercePlainJsonSchema: boolean;
+  try {
+    shouldCoercePlainJsonSchema =
+      !hasTypeBoxMetadata(tool.parameters) && isJsonSchemaObject(tool.parameters);
+  } catch (error) {
+    throw invalidParameterSchemaError(tool.name, error);
+  }
+
+  if (shouldCoercePlainJsonSchema) {
     // TypeBox Value.Convert is intentionally conservative for plain JSON schemas;
     // mirror the provider-facing coercions so model-emitted string numbers validate.
-    const coerced = coerceWithJsonSchema(args, tool.parameters);
+    let coerced: unknown;
+    try {
+      coerced = coerceWithJsonSchema(args, tool.parameters);
+    } catch (error) {
+      throw invalidParameterSchemaError(tool.name, error);
+    }
     if (coerced !== args) {
       if (isRecord(args) && isRecord(coerced)) {
         for (const key of Object.keys(args)) {
@@ -307,20 +338,33 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
         }
         Object.assign(args, coerced);
       } else {
-        return validator.Check(coerced) ? coerced : args;
+        try {
+          return validator.Check(coerced) ? coerced : args;
+        } catch (error) {
+          throw invalidParameterSchemaError(tool.name, error);
+        }
       }
     }
   }
 
-  if (validator.Check(args)) {
-    return args;
+  try {
+    if (validator.Check(args)) {
+      return args;
+    }
+  } catch (error) {
+    throw invalidParameterSchemaError(tool.name, error);
   }
 
-  const errors =
-    validator
-      .Errors(args)
-      .map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)
-      .join("\n") || "Unknown validation error";
+  let errors: string;
+  try {
+    errors =
+      validator
+        .Errors(args)
+        .map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)
+        .join("\n") || "Unknown validation error";
+  } catch (error) {
+    throw invalidParameterSchemaError(tool.name, error);
+  }
 
   throw new Error(
     `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`,


### PR DESCRIPTION
## Summary
- wrap unreadable tool parameter schemas in controlled validation errors
- keep ordinary argument validation failures on the existing `Validation failed` path
- add regression coverage for a plain JSON-schema `properties` proxy that throws during validation

## Verification
- `node scripts/run-vitest.mjs packages/llm-core/src/validation.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --write packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts`
- `./node_modules/.bin/oxlint packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh-PR `pnpm check:changed`: provider `aws`, run `run_b84d41ee016a`, lease `cbx_9d0926c6b8aa`, slug `amber-hermit`, lanes `core`, `coreTests`, exit 0, command 4m42.667s, total 5m2.802s, lease stopped

## Real behavior proof
Behavior addressed: tool argument validation no longer leaks raw schema proxy failures when the selected tool has unreadable parameter metadata.
Real environment tested: Local focused Vitest lane plus AWS Crabbox fresh-PR changed gate on Linux Node 24.15.0.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/llm-core/src/validation.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89583 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
Evidence after fix: focused test passed 3 tests; remote changed gate passed lanes `core` and `coreTests` in run `run_b84d41ee016a`.
Observed result after fix: unreadable schema fields are reported as `Invalid parameter schema for tool "unreadable-schema-tool"` instead of the raw proxy trap.
What was not tested: full repository suite.
