### PR TITLE
feat(memory-core): optional cross-encoder rerank stage for memory search

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1118,5 +1118,13 @@
   {
     "source": "Z.AI (GLM)",
     "target": "Z.AI (GLM)"
+  },
+  {
+    "source": "Memory reranker",
+    "target": "Memory reranker"
+  },
+  {
+    "source": "Plugin SDK runtime helpers",
+    "target": "Plugin SDK runtime helpers"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1256,7 +1256,8 @@
                   "plugins/cli-backend-plugins",
                   "plugins/hooks",
                   "plugins/plugin-permission-requests",
-                  "plugins/adding-capabilities"
+                  "plugins/adding-capabilities",
+                  "plugins/memory-reranker"
                 ]
               },
               {

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -637,6 +637,7 @@ read without importing the plugin runtime.
     "realtimeTranscriptionProviders": ["openai"],
     "realtimeVoiceProviders": ["openai"],
     "memoryEmbeddingProviders": ["local"],
+    "memoryRerankProviders": ["my-reranker"],
     "mediaUnderstandingProviders": ["openai"],
     "imageGenerationProviders": ["openai"],
     "videoGenerationProviders": ["qwen"],
@@ -651,25 +652,26 @@ read without importing the plugin runtime.
 
 Each list is optional:
 
-| Field                            | Type       | What it means                                                                                        |
-| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
-| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                |
-| `agentToolResultMiddleware`      | `string[]` | Runtime ids a bundled plugin may register tool-result middleware for.                                |
-| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                      |
-| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory. |
-| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                |
-| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                |
-| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                        |
-| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                  |
-| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                   |
-| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                     |
-| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                      |
-| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                      |
-| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                             |
-| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                            |
-| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                         |
-| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.  |
-| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                   |
+| Field                            | Type       | What it means                                                                                                                                                           |
+| -------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                                                                                   |
+| `agentToolResultMiddleware`      | `string[]` | Runtime ids a bundled plugin may register tool-result middleware for.                                                                                                   |
+| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                                                                                         |
+| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory.                                                                    |
+| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                                                                                   |
+| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                                                                                   |
+| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                                                                                           |
+| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                                                                                     |
+| `memoryRerankProviders`          | `string[]` | Memory rerank provider ids this plugin owns. Gates `api.registerMemoryRerankProvider`; only one provider may be registered at a time — a second registrant is rejected. |
+| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                                                                                      |
+| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                                                                                        |
+| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                                                                                         |
+| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                                                                                         |
+| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                                                                                                |
+| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                                                                                               |
+| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                                                                                            |
+| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.                                                                     |
+| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                                                                                      |
 
 `contracts.embeddedExtensionFactories` is retained for bundled Codex
 app-server-only extension factories. Bundled tool-result transforms should

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -128,15 +128,32 @@ seam is active when a plugin has registered a provider and inactive otherwise.
 To disable the reranker at the operator level, disable or uninstall the plugin
 that registered it, or add a kill-switch inside the plugin's own config.
 
+## Result ordering
+
+The reranker scores the full pre-MMR candidate pool. After scores are applied,
+core runs MMR diversification using those scores, then applies `minScore`
+filtering and result trimming. The final output order is **rerank then MMR
+composed**: the highest-relevance candidate leads, but MMR may reorder
+near-tied tail entries to promote diversity. The output is therefore **not** a
+pure `rerankScore`-descending list — tail reordering is intentional.
+
 ## Observing rerank state
 
 The rerank state is visible in two places:
 
-**`status().custom.rerank`** — check the plugin's own status output for
-`disabled`, `active`, or `degraded`.
+**`status().custom.rerank`** — the plugin's own status output exposes the
+current rerank state as one of three values:
+
+- `"disabled"` — no reranker is registered.
+- `"active"` — a reranker is registered and applied scores during this search.
+  This value reliably means reranking actually happened.
+- `"degraded"` — a reranker is registered but returned no scores (the provider
+  timed out, returned an error, or was disabled via its own kill-switch). A
+  registered-but-not-working reranker shows `"degraded"`, not a false
+  `"active"`.
 
 **Memory-search debug block** — when memory-search debug output is enabled, the
-debug block includes a `rerank` field with the current state and timing.
+`debug.rerank` field carries the same state and timing information.
 
 ## Related
 

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -1,0 +1,146 @@
+---
+summary: "Plugin-author guide for implementing and registering a memory rerank provider on the builtin sqlite-vec backend"
+read_when:
+  - You are building a cross-encoder or reranker plugin for OpenClaw memory search
+  - You want to reorder memory candidates by relevance before MMR diversification
+  - You need to understand the MemoryRerankProvider contract
+title: "Memory reranker"
+sidebarTitle: "Memory reranker"
+---
+
+A memory rerank provider lets a plugin reorder the wide pre-MMR candidate pool
+produced by the builtin sqlite-vec hybrid backend by cross-encoder relevance,
+before the core applies MMR diversification, score filtering, and result trimming.
+
+This seam is opt-in: no config is needed. Registration alone activates it.
+
+<Note>
+The rerank seam applies **only** to the builtin sqlite-vec backend. The QMD
+backend has its own server-side reranking and does not call this hook.
+</Note>
+
+## The `MemoryRerankProvider` contract
+
+Import the types from `openclaw/plugin-sdk/memory-core-host-runtime-core`:
+
+```typescript
+import type {
+  MemoryRerankProvider,
+  MemoryRerankCandidate,
+  MemoryRerankScore,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+```
+
+```typescript
+interface MemoryRerankCandidate {
+  ref: number; // core-assigned index; stable within a single search call
+  snippet: string; // text excerpt for the cross-encoder
+  source: string; // source tag (e.g. "sqlite-vec")
+}
+
+interface MemoryRerankScore {
+  ref: number; // matches a candidate ref
+  score: number; // normalized relevance in [0, 1]; higher = more relevant
+}
+
+interface MemoryRerankProvider {
+  rerank(params: {
+    query: string;
+    candidates: MemoryRerankCandidate[];
+    signal: AbortSignal;
+  }): Promise<MemoryRerankScore[]>;
+}
+```
+
+**Key constraints:**
+
+- Return one `MemoryRerankScore` per input `ref`. Core rejects responses that
+  drop, duplicate, or add refs.
+- Scores must be in `[0, 1]`. Higher values are more relevant.
+- The provider must return scored refs, not full result objects. It cannot modify
+  candidate content or inject new results.
+- Core owns the deadline and passes an `AbortSignal`. Honor it.
+
+## Registering a provider
+
+Call `api.registerMemoryRerankProvider(provider)` inside your plugin's
+`register(api)` function:
+
+```typescript
+import type { MemoryRerankProvider } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+
+const myReranker: MemoryRerankProvider = {
+  async rerank({ query, candidates, signal }) {
+    // Call your cross-encoder here.
+    // Return scores in [0, 1] for every candidate ref.
+    return candidates.map((c) => ({ ref: c.ref, score: 0.5 }));
+  },
+};
+
+export default definePluginEntry({
+  // ...
+  plugin: {
+    register(api) {
+      api.registerMemoryRerankProvider(myReranker);
+    },
+  },
+});
+```
+
+## Manifest contract
+
+A plugin that registers a memory rerank provider **must** declare
+`memoryRerankProviders` in its `openclaw.plugin.json`. This follows the same
+pattern as other provider contracts:
+
+```json
+{
+  "id": "my-reranker",
+  "contracts": {
+    "memoryRerankProviders": ["my-reranker"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}
+```
+
+See [Plugin manifest](/plugins/manifest) for the full `contracts` reference.
+
+## Behavior and semantics
+
+**Exclusive slot.** Only one plugin may register a memory rerank provider at a
+time. If a second plugin attempts to register, the registration is rejected with
+an error and the first provider remains active.
+
+**Before MMR.** The reranker runs on the full pre-MMR candidate pool, not the
+final result set. After reranking, core applies MMR diversification using the
+reranked scores, then applies `minScore` filtering and result trimming.
+
+**Fail-open.** If the provider returns an error or the core-owned deadline
+expires, the search continues with the original pre-rerank candidate order.
+No search results are lost due to reranker failure.
+
+**No core config.** There is no `openclaw.json` toggle for the reranker. The
+seam is active when a plugin has registered a provider and inactive otherwise.
+To disable the reranker at the operator level, disable or uninstall the plugin
+that registered it, or add a kill-switch inside the plugin's own config.
+
+## Observing rerank state
+
+The rerank state is visible in two places:
+
+**`status().custom.rerank`** — check the plugin's own status output for
+`disabled`, `active`, or `degraded`.
+
+**Memory-search debug block** — when memory-search debug output is enabled, the
+debug block includes a `rerank` field with the current state and timing.
+
+## Related
+
+- [Plugin SDK subpaths](/plugins/sdk-subpaths) — subpath catalog including `memory-core-host-runtime-core`
+- [Plugin SDK runtime helpers](/plugins/sdk-runtime) — `api.runtime` reference
+- [Plugin manifest](/plugins/manifest) — `contracts` field reference
+- [Memory LanceDB](/plugins/memory-lancedb) — example memory plugin

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -146,12 +146,12 @@ pure `rerankScore`-descending list — tail reordering is intentional.
 
 The rerank state is visible in two places:
 
-**`status().custom.rerank`** — the plugin's own status output exposes the
-current rerank state as one of three values:
+**`status().custom.rerank`** — the plugin's own status output exposes an object
+`{ state, failureCount, lastError }`, where `.state` is one of three values:
 
 - `"disabled"` — no reranker is registered.
-- `"active"` — a reranker is registered and applied scores during this search.
-  This value reliably means reranking actually happened.
+- `"active"` — a reranker is registered and applied scores during the most recent
+  search that had candidates. (For strict per-search state, read `debug.rerank`.)
 - `"degraded"` — a reranker is registered but its response was unusable. This
   covers: provider timeout, thrown error, empty score list, incomplete coverage
   (fewer scores than candidates), duplicate refs, out-of-range refs, and
@@ -160,7 +160,16 @@ current rerank state as one of three values:
   shows `"degraded"`, not a false `"active"`.
 
 **Memory-search debug block** — when memory-search debug output is enabled, the
-`debug.rerank` field carries the same state and timing information.
+`debug.rerank` field carries the rerank state for that search (`"active"`,
+`"degraded"`, or `"disabled"`), and is absent when the search had no candidates to
+rerank. It carries state only — no timing information.
+
+When a reranker is active, the cross-encoder ordering is preserved through to the
+`memory_search` tool output: memory results are ordered by `rerankScore`. For
+`corpus=all`, the memory and supplement corpora are balanced by per-corpus
+selection first, then interleaved best-effort (memory by `rerankScore`, supplements
+by their own `score`) — the two scales are not directly comparable, so cross-corpus
+order is approximate while each corpus stays correctly ordered internally.
 
 ## Related
 

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -54,9 +54,14 @@ interface MemoryRerankProvider {
 
 **Key constraints:**
 
-- Return one `MemoryRerankScore` per input `ref`. Core rejects responses that
-  drop, duplicate, or add refs.
-- Scores must be in `[0, 1]`. Higher values are more relevant.
+- Return **exactly one** `MemoryRerankScore` per input `ref` — complete coverage
+  is required. Core rejects responses that drop, duplicate, or add refs.
+- Every score must be a finite number in `[0, 1]`. `NaN`, `Infinity`, values
+  below `0`, and values above `1` are all rejected. Higher values are more
+  relevant.
+- Partial responses (fewer scores than candidates) are treated as invalid and
+  cause core to fall back to the pre-rerank order with `debug.rerank: "degraded"`.
+  Core does not append omitted refs after a partial result.
 - The provider must return scored refs, not full result objects. It cannot modify
   candidate content or inject new results.
 - Core owns the deadline and passes an `AbortSignal`. Honor it.
@@ -147,10 +152,12 @@ current rerank state as one of three values:
 - `"disabled"` — no reranker is registered.
 - `"active"` — a reranker is registered and applied scores during this search.
   This value reliably means reranking actually happened.
-- `"degraded"` — a reranker is registered but returned no scores (the provider
-  timed out, returned an error, or was disabled via its own kill-switch). A
-  registered-but-not-working reranker shows `"degraded"`, not a false
-  `"active"`.
+- `"degraded"` — a reranker is registered but its response was unusable. This
+  covers: provider timeout, thrown error, empty score list, incomplete coverage
+  (fewer scores than candidates), duplicate refs, out-of-range refs, and
+  non-finite or out-of-`[0,1]` scores. Core falls back to the pre-rerank order
+  and no `rerankScore` fields are set. A registered-but-not-working reranker
+  shows `"degraded"`, not a false `"active"`.
 
 **Memory-search debug block** — when memory-search debug output is enabled, the
 `debug.rerank` field carries the same state and timing information.

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -164,12 +164,15 @@ The rerank state is visible in two places:
 `"degraded"`, or `"disabled"`), and is absent when the search had no candidates to
 rerank. It carries state only — no timing information.
 
-When a reranker is active, the cross-encoder ordering is preserved through to the
-`memory_search` tool output: memory results are ordered by `rerankScore`. For
-`corpus=all`, the memory and supplement corpora are balanced by per-corpus
-selection first, then interleaved best-effort (memory by `rerankScore`, supplements
-by their own `score`) — the two scales are not directly comparable, so cross-corpus
-order is approximate while each corpus stays correctly ordered internally.
+The `memory_search` tool preserves the manager's final result order; it does not
+re-rank at the tool boundary. That final order is the manager's composed
+rerank-then-MMR output: the highest-relevance candidate leads, but MMR may reorder
+near-tied tail entries for diversity, so the output is not a pure
+`rerankScore`-descending list (and with no reranker it stays fusion-`score`
+descending). For `corpus=all`, the memory and supplement corpora are balanced by
+per-corpus selection first, then backfilled in corpus order — each corpus keeps its
+internal order, and the two scales (memory rerank/fusion vs supplement raw `score`)
+are never compared across corpora.
 
 ## Related
 

--- a/docs/plugins/memory-reranker.md
+++ b/docs/plugins/memory-reranker.md
@@ -35,7 +35,7 @@ import type {
 interface MemoryRerankCandidate {
   ref: number; // core-assigned index; stable within a single search call
   snippet: string; // text excerpt for the cross-encoder
-  source: string; // source tag (e.g. "sqlite-vec")
+  source: "memory" | "sessions"; // the candidate's memory source (a MemorySource)
 }
 
 interface MemoryRerankScore {

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -367,7 +367,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/memory-core-host-events` | Deprecated compatibility alias; use `plugin-sdk/memory-host-events` |
     | `plugin-sdk/memory-core-host-status` | Memory host status helpers |
     | `plugin-sdk/memory-core-host-runtime-cli` | Memory host CLI runtime helpers |
-    | `plugin-sdk/memory-core-host-runtime-core` | Memory host core runtime helpers |
+    | `plugin-sdk/memory-core-host-runtime-core` | Memory host core runtime helpers. Exports the memory rerank seam: `MemoryRerankProvider`, `MemoryRerankCandidate`, `MemoryRerankScore`, `registerMemoryRerankProvider`, `listMemoryRerankProviders` |
     | `plugin-sdk/memory-core-host-runtime-files` | Memory host file/runtime helpers |
     | `plugin-sdk/memory-host-core` | Vendor-neutral alias for memory host core runtime helpers |
     | `plugin-sdk/memory-host-events` | Vendor-neutral alias for memory host event journal helpers |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -367,7 +367,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/memory-core-host-events` | Deprecated compatibility alias; use `plugin-sdk/memory-host-events` |
     | `plugin-sdk/memory-core-host-status` | Memory host status helpers |
     | `plugin-sdk/memory-core-host-runtime-cli` | Memory host CLI runtime helpers |
-    | `plugin-sdk/memory-core-host-runtime-core` | Memory host core runtime helpers. Exports the memory rerank seam: `MemoryRerankProvider`, `MemoryRerankCandidate`, `MemoryRerankScore`, `registerMemoryRerankProvider`, `listMemoryRerankProviders` |
+    | `plugin-sdk/memory-core-host-runtime-core` | Memory host core runtime helpers. Exports the memory rerank seam types `MemoryRerankProvider`, `MemoryRerankCandidate`, `MemoryRerankScore` plus the `listMemoryRerankProviders` read accessor; reranker registration is via the gated `api.registerMemoryRerankProvider` (manifest contract `memoryRerankProviders`) |
     | `plugin-sdk/memory-core-host-runtime-files` | Memory host file/runtime helpers |
     | `plugin-sdk/memory-host-core` | Vendor-neutral alias for memory host core runtime helpers |
     | `plugin-sdk/memory-host-events` | Vendor-neutral alias for memory host event journal helpers |

--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -67,6 +67,40 @@ describe("memory hybrid helpers", () => {
     expect(b?.textScore).toBeCloseTo(1);
   });
 
+  it("returns score-sorted order without applying MMR (MMR moved to manager)", async () => {
+    const vector = [
+      {
+        id: "1",
+        path: "a.md",
+        startLine: 1,
+        endLine: 2,
+        source: "memory",
+        snippet: "dup one",
+        vectorScore: 0.9,
+      },
+      {
+        id: "2",
+        path: "b.md",
+        startLine: 1,
+        endLine: 2,
+        source: "memory",
+        snippet: "dup one too",
+        vectorScore: 0.85,
+      },
+      {
+        id: "3",
+        path: "c.md",
+        startLine: 1,
+        endLine: 2,
+        source: "memory",
+        snippet: "different",
+        vectorScore: 0.4,
+      },
+    ];
+    const out = await mergeHybridResults({ vector, keyword: [], vectorWeight: 1, textWeight: 0 });
+    expect(out.map((r) => r.path)).toEqual(["a.md", "b.md", "c.md"]);
+  });
+
   it("mergeHybridResults prefers keyword snippet when ids overlap", async () => {
     const merged = await mergeHybridResults({
       vectorWeight: 0.5,

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -1,5 +1,4 @@
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { applyMMRToHybridResults, type MMRConfig, DEFAULT_MMR_CONFIG } from "./mmr.js";
 import {
   applyTemporalDecayToHybridResults,
   type TemporalDecayConfig,
@@ -54,8 +53,6 @@ export async function mergeHybridResults(params: {
   vectorWeight: number;
   textWeight: number;
   workspaceDir?: string;
-  /** MMR configuration for diversity-aware re-ranking */
-  mmr?: Partial<MMRConfig>;
   /** Temporal decay configuration for recency-aware scoring */
   temporalDecay?: Partial<TemporalDecayConfig>;
   /** Test hook for deterministic time-dependent behavior */
@@ -134,8 +131,8 @@ export async function mergeHybridResults(params: {
     };
   });
 
-  // Keep component scores as raw retrieval diagnostics; temporal decay and MMR
-  // only adjust or reorder the combined ranking score.
+  // Keep component scores as raw retrieval diagnostics; temporal decay adjusts
+  // the combined score before sorting. MMR is applied by the manager call site.
   const temporalDecayConfig = { ...DEFAULT_TEMPORAL_DECAY_CONFIG, ...params.temporalDecay };
   const decayed = await applyTemporalDecayToHybridResults({
     results: merged,
@@ -143,13 +140,5 @@ export async function mergeHybridResults(params: {
     workspaceDir: params.workspaceDir,
     nowMs: params.nowMs,
   });
-  const sorted = decayed.toSorted((a, b) => b.score - a.score);
-
-  // Apply MMR re-ranking if enabled
-  const mmrConfig = { ...DEFAULT_MMR_CONFIG, ...params.mmr };
-  if (mmrConfig.enabled) {
-    return applyMMRToHybridResults(sorted, mmrConfig);
-  }
-
-  return sorted;
+  return decayed.toSorted((a, b) => b.score - a.score);
 }

--- a/extensions/memory-core/src/memory/manager-vector-warning.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.ts
@@ -25,3 +25,20 @@ export function logMemoryVectorDegradedWrite(params: {
   );
   return true;
 }
+
+// Latched warn for the cross-encoder rerank stage: emit once on the transition
+// into "degraded" so a failing reranker does not log per query. Returns the next
+// latched state; callers pass `alreadyDegraded` and store the result.
+export function logMemoryRerankDegraded(params: {
+  alreadyDegraded: boolean;
+  reason: string;
+  warn: (message: string) => void;
+}): boolean {
+  if (params.alreadyDegraded) {
+    return true;
+  }
+  params.warn(
+    `memory rerank degraded — ${params.reason}. Falling back to pre-rerank order. Further duplicate warnings suppressed.`,
+  );
+  return true;
+}

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -235,4 +235,30 @@ describe("memory rerank stage", () => {
     const custom = baseline.status().custom as ManagerStatusCustom;
     expect(custom.rerank?.state).toBe("degraded");
   });
+
+  it("(f) reranker returns [] with non-empty candidates: pre-rerank order, degraded state, failureCount 1", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+    expect(preOrder.length).toBeGreaterThan(0);
+
+    // Kill-switched or fail-open plugin returns [] without throwing.
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async (): Promise<MemoryRerankScore[]> => [],
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    // Pre-rerank order preserved (fail-open).
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    // No rerankScore applied since the provider returned no scores.
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    // A registered-but-not-reranking provider must report "degraded", not "active".
+    expect(custom.rerank?.state).toBe("degraded");
+    expect(custom.rerank?.failureCount).toBe(1);
+    expect(custom.rerank?.lastError).toBeTruthy();
+  });
 });

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -30,6 +30,7 @@ function embedText(text: string): number[] {
 // Mock the embedding provider so search() reaches the hybrid merge path without
 // real embeddings; sqlite-vec stays mocked off via test-runtime-mocks.
 vi.mock("./embeddings.js", () => ({
+  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   createEmbeddingProvider: async () => ({
     requestedProvider: "openai",
     provider: {

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -236,6 +236,141 @@ describe("memory rerank stage", () => {
     expect(custom.rerank?.state).toBe("degraded");
   });
 
+  it("(g) score out of range (>1): pre-rerank order, degraded state, no rerankScore applied", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+    expect(preOrder.length).toBeGreaterThan(0);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        // score of 2 is outside [0,1] — must be rejected
+        candidates.map((c) => ({ ref: c.ref, score: 2 })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+    expect(custom.rerank?.failureCount).toBe(1);
+    expect(custom.rerank?.lastError).toBeTruthy();
+  });
+
+  it("(h) score out of range (<0): pre-rerank order, degraded state", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        // score of -1 is outside [0,1] — must be rejected
+        candidates.map((c) => ({ ref: c.ref, score: -1 })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+  });
+
+  it("(i) NaN score: pre-rerank order, degraded state", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        // NaN score must be rejected as non-finite
+        candidates.map((c) => ({ ref: c.ref, score: NaN })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+  });
+
+  it("(j) Infinity score: pre-rerank order, degraded state", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        // Infinity is non-finite — must be rejected
+        candidates.map((c) => ({ ref: c.ref, score: Infinity })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+  });
+
+  it("(k) incomplete scores (provider omits one ref): degraded state, pre-rerank order", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+    expect(preOrder.length).toBeGreaterThan(1);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        // Return all but the last candidate — partial list must be rejected
+        candidates.slice(0, -1).map((c, i) => ({
+          ref: c.ref,
+          score: i / Math.max(1, candidates.length - 1),
+        })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    // Pre-rerank order must be preserved (not a partial reorder).
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    // No rerankScore applied since the response was rejected.
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+    expect(custom.rerank?.failureCount).toBe(1);
+  });
+
   it("(f) reranker returns [] with non-empty candidates: pre-rerank order, degraded state, failureCount 1", async () => {
     const baseline = await getManager();
     if (!ftsAvailable(baseline)) {

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -8,10 +8,14 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   clearMemoryPluginState,
-  registerMemoryRerankProvider,
   type MemoryRerankCandidate,
+  type MemoryRerankProvider,
   type MemoryRerankScore,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-runtime-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
@@ -44,6 +48,24 @@ vi.mock("./embeddings.js", () => ({
 }));
 
 const RERANK_PLUGIN_ID = "test-reranker";
+
+// Seed the exclusive rerank slot through the GATED registration path (the same
+// harness the contract test uses): declare contracts.memoryRerankProviders and
+// register via api.registerMemoryRerankProvider. Keeps this unit test honest —
+// it cannot seed the slot in a way a real third-party plugin couldn't.
+function seedReranker(provider: MemoryRerankProvider, pluginId = RERANK_PLUGIN_ID): void {
+  const { config, registry } = createPluginRegistryFixture();
+  registerVirtualTestPlugin({
+    registry,
+    config,
+    id: pluginId,
+    name: pluginId,
+    contracts: { memoryRerankProviders: [pluginId] },
+    register(api) {
+      api.registerMemoryRerankProvider(provider);
+    },
+  });
+}
 
 type ManagerStatusCustom = {
   rerank?: { state: string; failureCount: number; lastError?: string };
@@ -140,7 +162,7 @@ describe("memory rerank stage", () => {
 
     // Assign ascending scores in candidate (pre-rerank pool) order so descending
     // rerankScore reverses the merge order.
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -165,7 +187,7 @@ describe("memory rerank stage", () => {
     await baseline.sync({ reason: "test" });
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async (): Promise<MemoryRerankScore[]> => {
         throw new Error("reranker boom");
       },
@@ -188,7 +210,7 @@ describe("memory rerank stage", () => {
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
     let abortedFromSignal = false;
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({ signal }: { signal: AbortSignal }): Promise<MemoryRerankScore[]> =>
         await new Promise<MemoryRerankScore[]>((_resolve, reject) => {
           // Never resolve on its own; only the core deadline can abort it.
@@ -218,7 +240,7 @@ describe("memory rerank stage", () => {
     await baseline.sync({ reason: "test" });
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -245,7 +267,7 @@ describe("memory rerank stage", () => {
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
     expect(preOrder.length).toBeGreaterThan(0);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -272,7 +294,7 @@ describe("memory rerank stage", () => {
     await baseline.sync({ reason: "test" });
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -297,7 +319,7 @@ describe("memory rerank stage", () => {
     await baseline.sync({ reason: "test" });
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -322,7 +344,7 @@ describe("memory rerank stage", () => {
     await baseline.sync({ reason: "test" });
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -348,7 +370,7 @@ describe("memory rerank stage", () => {
     const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
     expect(preOrder.length).toBeGreaterThan(1);
 
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async ({
         candidates,
       }: {
@@ -381,7 +403,7 @@ describe("memory rerank stage", () => {
     expect(preOrder.length).toBeGreaterThan(0);
 
     // Kill-switched or fail-open plugin returns [] without throwing.
-    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+    seedReranker({
       rerank: async (): Promise<MemoryRerankScore[]> => [],
     });
 

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -1,0 +1,237 @@
+import { mkdirSync, rmSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  clearMemoryEmbeddingProviders as clearRegistry,
+  registerMemoryEmbeddingProvider as registerAdapter,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import {
+  clearMemoryPluginState,
+  registerMemoryRerankProvider,
+  type MemoryRerankCandidate,
+  type MemoryRerankScore,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./test-runtime-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+import { closeAllMemorySearchManagers } from "./index.js";
+import { registerBuiltInMemoryEmbeddingProviders } from "./provider-adapters.js";
+
+// Term-counting embedding so each fixture chunk gets a distinct vector; vector
+// search is disabled in tests (sqlite-vec mocked off) so ranking comes from FTS,
+// but the mock keeps the provider present so search() reaches the hybrid path.
+const TERMS = ["alpha", "beta", "gamma", "delta"];
+function embedText(text: string): number[] {
+  const lower = text.toLowerCase();
+  return TERMS.map((term) => lower.split(term).length - 1);
+}
+
+// Mock the embedding provider so search() reaches the hybrid merge path without
+// real embeddings; sqlite-vec stays mocked off via test-runtime-mocks.
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "mock",
+      model: "mock-embed",
+      embedQuery: async (text: string) => embedText(text),
+      embedBatch: async (texts: string[]) => texts.map(embedText),
+      close: async () => {},
+    },
+  }),
+}));
+
+const RERANK_PLUGIN_ID = "test-reranker";
+
+type ManagerStatusCustom = {
+  rerank?: { state: string; failureCount: number; lastError?: string };
+};
+
+describe("memory rerank stage", () => {
+  let fixtureRoot = "";
+  let workspaceDir = "";
+  let memoryDir = "";
+  let storePath = "";
+  const managers = new Set<MemoryIndexManager>();
+
+  async function getManager(): Promise<MemoryIndexManager> {
+    const { MemoryIndexManager: ManagerCtor } = await import("./index.js");
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: storePath, vector: { enabled: false } },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: {
+              minScore: 0,
+              // MMR disabled: keep the post-rerank order observable end-to-end.
+              hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+            },
+            sources: ["memory"],
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as unknown as Parameters<typeof ManagerCtor.get>[0]["cfg"];
+    const manager = await ManagerCtor.get({ cfg, agentId: "main" });
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+    managers.add(manager);
+    return manager;
+  }
+
+  beforeEach(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-rerank-"));
+    workspaceDir = path.join(fixtureRoot, "workspace");
+    memoryDir = path.join(workspaceDir, "memory");
+    storePath = path.join(workspaceDir, "index.sqlite");
+    rmSync(workspaceDir, { recursive: true, force: true });
+    mkdirSync(memoryDir, { recursive: true });
+    // Three single-chunk files, each matching the query term so all survive FTS.
+    await fs.writeFile(path.join(memoryDir, "a.md"), "alpha topic one alpha.");
+    await fs.writeFile(path.join(memoryDir, "b.md"), "alpha topic two beta.");
+    await fs.writeFile(path.join(memoryDir, "c.md"), "alpha topic three gamma.");
+    clearRegistry();
+    clearMemoryPluginState();
+    registerBuiltInMemoryEmbeddingProviders({ registerMemoryEmbeddingProvider: registerAdapter });
+  });
+
+  afterEach(async () => {
+    await Promise.all(Array.from(managers).map((m) => m.close()));
+    await closeAllMemorySearchManagers();
+    managers.clear();
+    clearRegistry();
+    clearMemoryPluginState();
+  });
+
+  function ftsAvailable(manager: MemoryIndexManager): boolean {
+    return Boolean(manager.status().fts?.available);
+  }
+
+  it("(a) no reranker: results keep pre-rerank order and state is disabled", async () => {
+    const manager = await getManager();
+    if (!ftsAvailable(manager)) {
+      return;
+    }
+    await manager.sync({ reason: "test" });
+    const results = await manager.search("alpha", { maxResults: 10 });
+    expect(results.length).toBeGreaterThan(1);
+    // No reranker registered: rerankScore must stay unset.
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = manager.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("disabled");
+  });
+
+  it("(b) reranker reorders by descending rerankScore and sets active state", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preRerank = await baseline.search("alpha", { maxResults: 10 });
+    const preOrder = preRerank.map((r) => r.path);
+
+    // Assign ascending scores in candidate (pre-rerank pool) order so descending
+    // rerankScore reverses the merge order.
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> =>
+        candidates.map((c, i) => ({ ref: c.ref, score: i / Math.max(1, candidates.length) })),
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    const postOrder = results.map((r) => r.path);
+    expect(postOrder).toStrictEqual(preOrder.toReversed());
+    expect(results.every((r) => typeof r.rerankScore === "number")).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("active");
+  });
+
+  it("(c) reranker throws: pre-rerank order, degraded state, failureCount 1", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async (): Promise<MemoryRerankScore[]> => {
+        throw new Error("reranker boom");
+      },
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+    expect(custom.rerank?.failureCount).toBe(1);
+    expect(custom.rerank?.lastError).toContain("reranker boom");
+  });
+
+  it("(d) reranker exceeds deadline: pre-rerank order and the signal aborts", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    let abortedFromSignal = false;
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({ signal }: { signal: AbortSignal }): Promise<MemoryRerankScore[]> =>
+        await new Promise<MemoryRerankScore[]>((_resolve, reject) => {
+          // Never resolve on its own; only the core deadline can abort it.
+          signal.addEventListener("abort", () => {
+            abortedFromSignal = true;
+            reject(new Error("aborted"));
+          });
+        }),
+    });
+
+    // Shrink the core deadline so the test does not wait the full 5s.
+    (baseline as unknown as { rerankDeadlineMs: number }).rerankDeadlineMs = 25;
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(abortedFromSignal).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+    expect(custom.rerank?.lastError).toContain("deadline");
+  });
+
+  it("(e) invalid ref: rejected, pre-rerank order, degraded state", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+    const preOrder = (await baseline.search("alpha", { maxResults: 10 })).map((r) => r.path);
+
+    registerMemoryRerankProvider(RERANK_PLUGIN_ID, {
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> => [
+        // Out-of-range ref must be rejected as a failure.
+        { ref: candidates.length + 5, score: 0.9 },
+      ],
+    });
+
+    const results = await baseline.search("alpha", { maxResults: 10 });
+    expect(results.map((r) => r.path)).toStrictEqual(preOrder);
+    expect(results.every((r) => r.rerankScore === undefined)).toBe(true);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("degraded");
+  });
+});

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -418,4 +418,39 @@ describe("memory rerank stage", () => {
     expect(custom.rerank?.failureCount).toBe(1);
     expect(custom.rerank?.lastError).toBeTruthy();
   });
+
+  it("(g) empty candidate pool: reranker is not invoked and rerank state is left untouched", async () => {
+    const baseline = await getManager();
+    if (!ftsAvailable(baseline)) {
+      return;
+    }
+    await baseline.sync({ reason: "test" });
+
+    let invocations = 0;
+    seedReranker({
+      rerank: async ({
+        candidates,
+      }: {
+        candidates: ReadonlyArray<MemoryRerankCandidate>;
+      }): Promise<MemoryRerankScore[]> => {
+        invocations += 1;
+        return candidates.map((c) => ({ ref: c.ref, score: 0.5 }));
+      },
+    });
+
+    // Matching query: the reranker runs and state becomes "active".
+    const hits = await baseline.search("alpha", { maxResults: 10 });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(invocations).toBe(1);
+    expect((baseline.status().custom as ManagerStatusCustom).rerank?.state).toBe("active");
+
+    // No-match query -> empty candidate pool: the reranker must NOT be invoked, and
+    // the prior state must be left untouched (no stale flip, no false "degraded").
+    const empty = await baseline.search("zzzznomatchqyx", { maxResults: 10 });
+    expect(empty.length).toBe(0);
+    expect(invocations).toBe(1);
+    const custom = baseline.status().custom as ManagerStatusCustom;
+    expect(custom.rerank?.state).toBe("active");
+    expect(custom.rerank?.failureCount).toBe(0);
+  });
 });

--- a/extensions/memory-core/src/memory/manager.rerank.test.ts
+++ b/extensions/memory-core/src/memory/manager.rerank.test.ts
@@ -326,7 +326,7 @@ describe("memory rerank stage", () => {
         candidates: ReadonlyArray<MemoryRerankCandidate>;
       }): Promise<MemoryRerankScore[]> =>
         // NaN score must be rejected as non-finite
-        candidates.map((c) => ({ ref: c.ref, score: NaN })),
+        candidates.map((c) => ({ ref: c.ref, score: Number.NaN })),
     });
 
     const results = await baseline.search("alpha", { maxResults: 10 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -717,7 +717,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return merged;
     }
     if (merged.length === 0) {
-      this.rerankState = "active";
+      // Empty candidate pool: nothing to rerank — do not assert "active" since
+      // no scores could be applied. Leave the existing state untouched.
       onDebug?.({ backend: "builtin", rerank: this.rerankState });
       return merged;
     }
@@ -747,8 +748,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (!this.isValidRerankScores(scores, merged.length)) {
         throw new Error("reranker returned invalid or duplicate refs");
       }
+      // An empty scores array means the provider chose not to rank (e.g.
+      // kill-switch on, endpoint down). Treat this as degraded so a
+      // registered-but-not-reranking plugin is visible in observability.
+      // This is intentional: kill-switched = "registered but not reranking" = degraded.
+      if (scores.length === 0) {
+        throw new Error("reranker returned no scores");
+      }
       const reranked = this.reorderByRerankScores(merged, scores);
-      // Re-arm the latch: a recovered provider returns to "active".
+      // Re-arm the latch: a recovered provider returns to "active" only when
+      // scores were actually applied.
       this.rerankState = "active";
       onDebug?.({ backend: "builtin", rerank: this.rerankState });
       return reranked;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -60,6 +60,7 @@ import {
   runMemorySyncWithReadonlyRecovery,
   type MemoryReadonlyRecoveryState,
 } from "./manager-sync-control.js";
+import { applyMMRToHybridResults } from "./mmr.js";
 import { applyTemporalDecayToHybridResults } from "./temporal-decay.js";
 const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = "chunks_vec";
@@ -655,10 +656,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       keyword: keywordResults,
       vectorWeight: hybrid.vectorWeight,
       textWeight: hybrid.textWeight,
-      mmr: hybrid.mmr,
       temporalDecay: hybrid.temporalDecay,
     });
-    const strict = merged.filter((entry) => entry.score >= minScore);
+    const ranked = applyMMRToHybridResults(merged, hybrid.mmr);
+    const strict = ranked.filter((entry) => entry.score >= minScore);
     if (strict.length > 0 || keywordResults.length === 0) {
       return strict.slice(0, maxResults);
     }
@@ -673,7 +674,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       ),
     );
     return this.selectScoredResults(
-      merged.filter((entry) =>
+      ranked.filter((entry) =>
         keywordKeys.has(`${entry.source}:${entry.path}:${entry.startLine}:${entry.endLine}`),
       ),
       maxResults,
@@ -775,7 +776,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     keyword: Array<MemorySearchResult & { id: string; textScore: number }>;
     vectorWeight: number;
     textWeight: number;
-    mmr?: { enabled: boolean; lambda: number };
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
   }): Promise<MemorySearchResult[]> {
     return mergeHybridResults({
@@ -799,7 +799,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       })),
       vectorWeight: params.vectorWeight,
       textWeight: params.textWeight,
-      mmr: params.mmr,
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -717,9 +717,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return merged;
     }
     if (merged.length === 0) {
-      // Empty candidate pool: nothing to rerank — do not assert "active" since
-      // no scores could be applied. Leave the existing state untouched.
-      onDebug?.({ backend: "builtin", rerank: this.rerankState });
+      // Empty candidate pool: the reranker did not run, so don't emit a rerank
+      // state — emitting this.rerankState would report a stale "active" from a
+      // prior search. The earlier onDebug({backend}) stands (debug.rerank absent =
+      // accurate for this query); rerankState is left untouched for status().
       return merged;
     }
     const candidates: MemoryRerankCandidate[] = merged.map((r, i) => ({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -787,10 +787,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  // Enforces the bijection contract: exactly one finite score in [0,1] per
+  // candidate ref. length+unique+range together guarantee full coverage; the
+  // score checks reject NaN, Infinity, and values outside [0,1]. Any violation
+  // routes to the degraded failure path so partial/garbage scores never reach
+  // reorderByRerankScores.
   private isValidRerankScores(
     scores: ReadonlyArray<{ ref: number; score: number }>,
     poolSize: number,
   ): boolean {
+    if (scores.length !== poolSize) {
+      return false;
+    }
     const seen = new Set<number>();
     for (const entry of scores) {
       const ref = entry.ref;
@@ -798,30 +806,27 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         return false;
       }
       seen.add(ref);
+      if (!Number.isFinite(entry.score) || entry.score < 0 || entry.score > 1) {
+        return false;
+      }
     }
     return true;
   }
 
+  // Scores are guaranteed complete (one per candidate) by isValidRerankScores,
+  // so a simple sort-by-rerankScore is sufficient; no "omitted refs appended"
+  // path is needed.
   private reorderByRerankScores(
     merged: MemorySearchResult[],
     scores: ReadonlyArray<{ ref: number; score: number }>,
   ): MemorySearchResult[] {
     const scored: Array<{ item: MemorySearchResult; score: number }> = [];
-    const seen = new Set<number>();
     for (const entry of scores) {
       merged[entry.ref].rerankScore = entry.score;
       scored.push({ item: merged[entry.ref], score: entry.score });
-      seen.add(entry.ref);
     }
     scored.sort((a, b) => b.score - a.score);
-    const ordered = scored.map((s) => s.item);
-    // Append any candidate the provider omitted, preserving original pool order.
-    for (let i = 0; i < merged.length; i += 1) {
-      if (!seen.has(i)) {
-        ordered.push(merged[i]);
-      }
-    }
-    return ordered;
+    return scored.map((s) => s.item);
   }
 
   private selectScoredResults<T extends MemorySearchResult & { score: number }>(

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -745,15 +745,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       });
       rerankPromise.catch(() => {});
       const scores = await Promise.race([rerankPromise, deadline]);
-      if (!this.isValidRerankScores(scores, merged.length)) {
-        throw new Error("reranker returned invalid or duplicate refs");
-      }
-      // An empty scores array means the provider chose not to rank (e.g.
-      // kill-switch on, endpoint down). Treat this as degraded so a
-      // registered-but-not-reranking plugin is visible in observability.
-      // This is intentional: kill-switched = "registered but not reranking" = degraded.
+      // Empty [] (kill-switch / endpoint down) is a degraded failure, not a no-op.
+      // Check it BEFORE the validator: isValidRerankScores requires length === poolSize,
+      // so [] would otherwise read as "invalid refs" instead of the no-scores reason.
       if (scores.length === 0) {
         throw new Error("reranker returned no scores");
+      }
+      if (!this.isValidRerankScores(scores, merged.length)) {
+        throw new Error("reranker returned invalid or duplicate refs");
       }
       const reranked = this.reorderByRerankScores(merged, scores);
       // Re-arm the latch: a recovered provider returns to "active" only when

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -20,6 +20,10 @@ import {
   type MemorySource,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  listMemoryRerankProviders,
+  type MemoryRerankCandidate,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
@@ -60,6 +64,7 @@ import {
   runMemorySyncWithReadonlyRecovery,
   type MemoryReadonlyRecoveryState,
 } from "./manager-sync-control.js";
+import { logMemoryRerankDegraded } from "./manager-vector-warning.js";
 import { applyMMRToHybridResults } from "./mmr.js";
 import { applyTemporalDecayToHybridResults } from "./temporal-decay.js";
 const SNIPPET_MAX_CHARS = 700;
@@ -68,6 +73,8 @@ const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
+// Core-owned outer deadline; the provider also owns its own internal/HTTP timeout.
+const RERANK_DEADLINE_MS = 5000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
 
@@ -163,6 +170,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected batchFailureLastError?: string;
   protected batchFailureLastProvider?: string;
   protected batchFailureLock: Promise<void> = Promise.resolve();
+  // Optional cross-encoder rerank stage (builtin hybrid path). "disabled" = no
+  // provider registered; "degraded" = a registered provider is failing fail-open.
+  protected rerankState: "disabled" | "active" | "degraded" = "disabled";
+  protected rerankFailureCount = 0;
+  protected rerankLastError?: string;
+  protected rerankDeadlineMs = RERANK_DEADLINE_MS;
   protected db: DatabaseSync;
   protected override readonly sources: Set<MemorySource>;
   protected override providerKey: string;
@@ -658,7 +671,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       textWeight: hybrid.textWeight,
       temporalDecay: hybrid.temporalDecay,
     });
-    const ranked = applyMMRToHybridResults(merged, hybrid.mmr);
+    // Optional cross-encoder rerank between merge and MMR (builtin path only).
+    // The qmd backend delegates ranking to its own server-side reranker
+    // (see qmd-manager.ts buildV2Searches ~:2164), so it is not reranked here.
+    const reranked = await this.applyRerankStage(cleaned, merged, opts?.onDebug);
+    const ranked = applyMMRToHybridResults(reranked, hybrid.mmr);
     const strict = ranked.filter((entry) => entry.score >= minScore);
     if (strict.length > 0 || keywordResults.length === 0) {
       return strict.slice(0, maxResults);
@@ -681,6 +698,121 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       minScore,
       relaxedMinScore,
     );
+  }
+
+  // Cross-encoder rerank stage: runs the registered provider under a core-owned
+  // aborting deadline, reorders `merged` by descending rerankScore, and fails
+  // open to pre-rerank order on any timeout/throw/invalid response. Never throws.
+  private async applyRerankStage(
+    query: string,
+    merged: MemorySearchResult[],
+    onDebug?: (debug: MemorySearchRuntimeDebug) => void,
+  ): Promise<MemorySearchResult[]> {
+    const reranker = listMemoryRerankProviders()[0];
+    if (!reranker) {
+      // No provider registered: leave order untouched. "disabled" must never be
+      // conflated with "degraded" (a registered-but-failing provider).
+      this.rerankState = "disabled";
+      onDebug?.({ backend: "builtin", rerank: this.rerankState });
+      return merged;
+    }
+    if (merged.length === 0) {
+      this.rerankState = "active";
+      onDebug?.({ backend: "builtin", rerank: this.rerankState });
+      return merged;
+    }
+    const candidates: MemoryRerankCandidate[] = merged.map((r, i) => ({
+      ref: i,
+      snippet: r.snippet,
+      source: r.source,
+    }));
+    const ac = new AbortController();
+    let timer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        ac.abort();
+        reject(new Error(`deadline exceeded (${this.rerankDeadlineMs}ms)`));
+      }, this.rerankDeadlineMs);
+    });
+    try {
+      // Keep a stable reference so a post-deadline rejection cannot escape as an
+      // unhandledRejection once the deadline has already won the race.
+      const rerankPromise = reranker.provider.rerank({
+        query,
+        candidates,
+        signal: ac.signal,
+      });
+      rerankPromise.catch(() => {});
+      const scores = await Promise.race([rerankPromise, deadline]);
+      if (!this.isValidRerankScores(scores, merged.length)) {
+        throw new Error("reranker returned invalid or duplicate refs");
+      }
+      const reranked = this.reorderByRerankScores(merged, scores);
+      // Re-arm the latch: a recovered provider returns to "active".
+      this.rerankState = "active";
+      onDebug?.({ backend: "builtin", rerank: this.rerankState });
+      return reranked;
+    } catch (err) {
+      // Read the abort flag before our own abort() so timeout stays
+      // distinguishable from a provider error in rerankLastError.
+      const abortedByDeadline = ac.signal.aborted;
+      ac.abort();
+      this.rerankFailureCount += 1;
+      this.rerankLastError = abortedByDeadline
+        ? `deadline exceeded (${this.rerankDeadlineMs}ms)`
+        : formatErrorMessage(err);
+      // Latched: warn only on the transition into "degraded", not per query.
+      logMemoryRerankDegraded({
+        alreadyDegraded: this.rerankState === "degraded",
+        reason: this.rerankLastError,
+        warn: (message) => log.warn(message),
+      });
+      this.rerankState = "degraded";
+      onDebug?.({ backend: "builtin", rerank: this.rerankState });
+      // Fail-open: pre-rerank order. Search must never throw because of rerank.
+      return merged;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  private isValidRerankScores(
+    scores: ReadonlyArray<{ ref: number; score: number }>,
+    poolSize: number,
+  ): boolean {
+    const seen = new Set<number>();
+    for (const entry of scores) {
+      const ref = entry.ref;
+      if (!Number.isInteger(ref) || ref < 0 || ref >= poolSize || seen.has(ref)) {
+        return false;
+      }
+      seen.add(ref);
+    }
+    return true;
+  }
+
+  private reorderByRerankScores(
+    merged: MemorySearchResult[],
+    scores: ReadonlyArray<{ ref: number; score: number }>,
+  ): MemorySearchResult[] {
+    const scored: Array<{ item: MemorySearchResult; score: number }> = [];
+    const seen = new Set<number>();
+    for (const entry of scores) {
+      merged[entry.ref].rerankScore = entry.score;
+      scored.push({ item: merged[entry.ref], score: entry.score });
+      seen.add(entry.ref);
+    }
+    scored.sort((a, b) => b.score - a.score);
+    const ordered = scored.map((s) => s.item);
+    // Append any candidate the provider omitted, preserving original pool order.
+    for (let i = 0; i < merged.length; i += 1) {
+      if (!seen.has(i)) {
+        ordered.push(merged[i]);
+      }
+    }
+    return ordered;
   }
 
   private selectScoredResults<T extends MemorySearchResult & { score: number }>(
@@ -1021,6 +1153,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           successes: this.readonlyRecoverySuccesses,
           failures: this.readonlyRecoveryFailures,
           lastError: this.readonlyRecoveryLastError,
+        },
+        rerank: {
+          state: this.rerankState,
+          failureCount: this.rerankFailureCount,
+          lastError: this.rerankLastError,
         },
       },
     };

--- a/extensions/memory-core/src/memory/mmr.test.ts
+++ b/extensions/memory-core/src/memory/mmr.test.ts
@@ -467,3 +467,14 @@ describe("DEFAULT_MMR_CONFIG", () => {
     expect(DEFAULT_MMR_CONFIG.lambda).toBe(0.7);
   });
 });
+
+describe("mmrRerank relevanceScore", () => {
+  it("ranks by relevanceScore when present, not raw score", () => {
+    const items = [
+      { id: "a", score: 0.9, content: "alpha", relevanceScore: 0.1 },
+      { id: "b", score: 0.1, content: "bravo", relevanceScore: 0.9 },
+    ];
+    const out = mmrRerank(items, { enabled: true, lambda: 1 }); // lambda=1 → pure relevance
+    expect(out.map((i) => i.id)).toEqual(["b", "a"]); // b wins on relevanceScore despite lower score
+  });
+});

--- a/extensions/memory-core/src/memory/mmr.ts
+++ b/extensions/memory-core/src/memory/mmr.ts
@@ -13,6 +13,9 @@ export type MMRItem = {
   id: string;
   score: number;
   content: string;
+  // Optional reranked relevance; when present, drives MMR instead of score so
+  // callers can pass a cross-encoder signal without overloading the raw score.
+  relevanceScore?: number;
 };
 
 export type MMRConfig = {
@@ -66,6 +69,10 @@ export function computeMMRScore(relevance: number, maxSimilarity: number, lambda
   return lambda * relevance - (1 - lambda) * maxSimilarity;
 }
 
+// Relevance signal: prefer relevanceScore when a cross-encoder has set it;
+// fall back to raw score so callers without a reranker are unaffected.
+const rel = (i: MMRItem): number => i.relevanceScore ?? i.score;
+
 /**
  * Re-rank items using Maximal Marginal Relevance (MMR).
  *
@@ -78,6 +85,7 @@ export function computeMMRScore(relevance: number, maxSimilarity: number, lambda
  * @param config - MMR configuration (lambda, enabled)
  * @returns Re-ranked items in MMR order
  */
+
 export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConfig> = {}): T[] {
   const { enabled = DEFAULT_MMR_CONFIG.enabled, lambda = DEFAULT_MMR_CONFIG.lambda } = config;
 
@@ -91,7 +99,7 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
 
   // If lambda is 1, just return sorted by relevance (no diversity penalty)
   if (clampedLambda === 1) {
-    return [...items].toSorted((a, b) => b.score - a.score);
+    return [...items].toSorted((a, b) => rel(b) - rel(a));
   }
 
   // Pre-tokenize all items for efficiency
@@ -100,9 +108,9 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
     tokenCache.set(item.id, tokenize(item.content));
   }
 
-  // Normalize scores to [0, 1] for fair comparison with similarity
-  const maxScore = Math.max(...items.map((i) => i.score));
-  const minScore = Math.min(...items.map((i) => i.score));
+  // Normalize relevance to [0, 1] for fair comparison with similarity
+  const maxScore = Math.max(...items.map(rel));
+  const minScore = Math.min(...items.map(rel));
   const scoreRange = maxScore - minScore;
 
   const normalizeScore = (score: number): number => {
@@ -121,7 +129,7 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
     let bestMMRScore = -Infinity;
 
     for (const candidate of remaining) {
-      const normalizedRelevance = normalizeScore(candidate.score);
+      const normalizedRelevance = normalizeScore(rel(candidate));
       const maxSim = maxSimilarityToSelected(candidate, selected, tokenCache);
       const mmrScore = computeMMRScore(normalizedRelevance, maxSim, clampedLambda);
 
@@ -152,7 +160,13 @@ export function mmrRerank<T extends MMRItem>(items: T[], config: Partial<MMRConf
  * Adapts the generic MMR function to work with the hybrid search result format.
  */
 export function applyMMRToHybridResults<
-  T extends { score: number; snippet: string; path: string; startLine: number },
+  T extends {
+    score: number;
+    snippet: string;
+    path: string;
+    startLine: number;
+    rerankScore?: number;
+  },
 >(results: T[], config: Partial<MMRConfig> = {}): T[] {
   if (results.length === 0) {
     return results;
@@ -169,6 +183,7 @@ export function applyMMRToHybridResults<
       id,
       score: r.score,
       content: r.snippet,
+      relevanceScore: r.rerankScore,
     };
   });
 

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -37,7 +37,6 @@ async function mergeVectorResultsWithTemporalDecay(
     vectorWeight: 1,
     textWeight: 0,
     temporalDecay: { enabled: true, halfLifeDays: 30 },
-    mmr: { enabled: false },
     nowMs: NOW_MS,
     vector,
     keyword: [],

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -442,9 +442,12 @@ describe("memory tools", () => {
     const result = await tool.execute("call_all_corpus", { query: "alpha", corpus: "all" });
     const details = result.details as { results: Array<{ corpus: string; path: string }> };
 
+    // corpus=all block-interleaves the two pre-ordered corpora (memory block, then
+    // supplement block) without a cross-scale re-sort, so memory leads even though
+    // the wiki supplement has a numerically higher but incomparable score.
     expect(details.results.map((entry) => [entry.corpus, entry.path])).toEqual([
-      ["wiki", "entities/alpha.md"],
       ["memory", "MEMORY.md"],
+      ["wiki", "entities/alpha.md"],
     ]);
     expect(getMemorySearchManagerMockCalls()).toBe(1);
   });

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -385,6 +385,73 @@ describe("memory_search unavailable payloads", () => {
     };
     expect(details.debug?.rerank).toBe("active");
   });
+
+  it("preserves rerank ordering in tool output (promoted low-fusion-score doc stays first)", async () => {
+    setMemoryBackend("builtin");
+    // manager.search returns reranked order: a promoted doc with LOW fusion score
+    // but HIGH rerankScore ahead of a demoted doc with high fusion score.
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/promoted.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.3,
+        rerankScore: 0.95,
+        snippet: "cross-encoder promoted this",
+        source: "memory" as const,
+      },
+      {
+        path: "memory/demoted.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.9,
+        rerankScore: 0.1,
+        snippet: "high fusion score, demoted by reranker",
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({ config: { memory: { backend: "builtin" } } });
+    const result = await tool.execute("rerank-order", { query: "anything" });
+    const results = (result.details as { results: Array<{ path: string; rerankScore?: number }> })
+      .results;
+
+    // Before the fix the tool re-sorted by raw score, sinking the promoted doc;
+    // the rerankScore ordering must survive to the tool output.
+    expect(results[0]?.path).toBe("memory/promoted.md");
+    expect(results[0]?.rerankScore).toBe(0.95);
+    expect(results[1]?.path).toBe("memory/demoted.md");
+  });
+
+  it("orders tool output by raw score when no reranker ran (rerankScore absent)", async () => {
+    setMemoryBackend("builtin");
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/low.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.4,
+        snippet: "lower fusion score",
+        source: "memory" as const,
+      },
+      {
+        path: "memory/high.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.8,
+        snippet: "higher fusion score",
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({ config: { memory: { backend: "builtin" } } });
+    const result = await tool.execute("no-rerank", { query: "anything" });
+    const results = (result.details as { results: Array<{ path: string }> }).results;
+
+    // No rerankScore present -> sort falls back to raw score, unchanged behavior.
+    expect(results[0]?.path).toBe("memory/high.md");
+    expect(results[1]?.path).toBe("memory/low.md");
+  });
 });
 
 describe("memory_search corpus labels", () => {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -345,6 +345,7 @@ describe("memory_search unavailable payloads", () => {
         configuredMode?: unknown;
         effectiveMode?: unknown;
         fallback?: unknown;
+        rerank?: unknown;
         hits?: unknown;
         searchMs?: number;
       };
@@ -354,8 +355,35 @@ describe("memory_search unavailable payloads", () => {
     expect(details.debug?.configuredMode).toBe("search");
     expect(details.debug?.effectiveMode).toBe("query");
     expect(details.debug?.fallback).toBe("unsupported-search-flags");
+    expect(details.debug?.rerank).toBeUndefined();
     expect(details.debug?.hits).toBe(1);
     expect(details.debug?.searchMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("surfaces rerank state in search debug when emitted by the backend", async () => {
+    setMemoryBackend("builtin");
+    setMemorySearchImpl(async (opts) => {
+      opts?.onDebug?.({ backend: "builtin", rerank: "active" });
+      return [
+        {
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.9,
+          snippet: "reranked result",
+          source: "memory",
+        },
+      ];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: { memory: { backend: "builtin" } },
+    });
+    const result = await tool.execute("debug", { query: "rerank test" });
+    const details = result.details as {
+      debug?: { rerank?: unknown };
+    };
+    expect(details.debug?.rerank).toBe("active");
   });
 });
 

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -386,54 +386,47 @@ describe("memory_search unavailable payloads", () => {
     expect(details.debug?.rerank).toBe("active");
   });
 
-  it("preserves rerank ordering in tool output (promoted low-fusion-score doc stays first)", async () => {
+  it("preserves the manager's rerank+MMR order (no re-sort by rerankScore or raw score)", async () => {
     setMemoryBackend("builtin");
-    // manager.search returns reranked order: a promoted doc with LOW fusion score
-    // but HIGH rerankScore ahead of a demoted doc with high fusion score.
+    // manager.search returns the rerank-then-MMR composed order. Here MMR kept a
+    // diverse hit ahead of a near-duplicate that has BOTH a higher rerankScore
+    // and a higher fusion score. The tool must preserve the manager's order:
+    // re-sorting by rerankScore (0.85 > 0.6) or by raw score (0.8 > 0.5) would
+    // each wrongly promote the near-duplicate and undo MMR's diversity reorder.
     setMemorySearchImpl(async () => [
       {
-        path: "memory/promoted.md",
+        path: "memory/diverse.md",
         startLine: 1,
         endLine: 2,
-        score: 0.3,
-        rerankScore: 0.95,
-        snippet: "cross-encoder promoted this",
+        score: 0.5,
+        rerankScore: 0.6,
+        snippet: "diverse hit kept ahead by MMR",
         source: "memory" as const,
       },
       {
-        path: "memory/demoted.md",
+        path: "memory/near-duplicate.md",
         startLine: 1,
         endLine: 2,
-        score: 0.9,
-        rerankScore: 0.1,
-        snippet: "high fusion score, demoted by reranker",
+        score: 0.8,
+        rerankScore: 0.85,
+        snippet: "near-duplicate demoted by MMR for diversity",
         source: "memory" as const,
       },
     ]);
 
     const tool = createMemorySearchToolOrThrow({ config: { memory: { backend: "builtin" } } });
-    const result = await tool.execute("rerank-order", { query: "anything" });
-    const results = (result.details as { results: Array<{ path: string; rerankScore?: number }> })
-      .results;
+    const result = await tool.execute("mmr-order", { query: "anything" });
+    const results = (result.details as { results: Array<{ path: string }> }).results;
 
-    // Before the fix the tool re-sorted by raw score, sinking the promoted doc;
-    // the rerankScore ordering must survive to the tool output.
-    expect(results[0]?.path).toBe("memory/promoted.md");
-    expect(results[0]?.rerankScore).toBe(0.95);
-    expect(results[1]?.path).toBe("memory/demoted.md");
+    expect(results[0]?.path).toBe("memory/diverse.md");
+    expect(results[1]?.path).toBe("memory/near-duplicate.md");
   });
 
-  it("orders tool output by raw score when no reranker ran (rerankScore absent)", async () => {
+  it("preserves the manager's order when no reranker ran (rerankScore absent)", async () => {
     setMemoryBackend("builtin");
+    // No reranker: manager.search returns fusion-score-descending order; the tool
+    // preserves it verbatim rather than re-deriving any ranking.
     setMemorySearchImpl(async () => [
-      {
-        path: "memory/low.md",
-        startLine: 1,
-        endLine: 2,
-        score: 0.4,
-        snippet: "lower fusion score",
-        source: "memory" as const,
-      },
       {
         path: "memory/high.md",
         startLine: 1,
@@ -442,13 +435,20 @@ describe("memory_search unavailable payloads", () => {
         snippet: "higher fusion score",
         source: "memory" as const,
       },
+      {
+        path: "memory/low.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.4,
+        snippet: "lower fusion score",
+        source: "memory" as const,
+      },
     ]);
 
     const tool = createMemorySearchToolOrThrow({ config: { memory: { backend: "builtin" } } });
     const result = await tool.execute("no-rerank", { query: "anything" });
     const results = (result.details as { results: Array<{ path: string }> }).results;
 
-    // No rerankScore present -> sort falls back to raw score, unchanged behavior.
     expect(results[0]?.path).toBe("memory/high.md");
     expect(results[1]?.path).toBe("memory/low.md");
   });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -132,56 +132,39 @@ function buildPausedMemoryIndexUnavailableResult(reason: string) {
   });
 }
 
-// Order by the reranker's signal when present (rerankScore, cross-encoder [0,1]),
-// otherwise by raw fusion score. This keeps a promoted low-fusion-score passage
-// in its reranked position in the tool output, while leaving the no-reranker path
-// byte-for-byte unchanged (rerankScore is undefined -> falls back to score). The
-// score tiebreaker preserves fusion ordering when rerankScores are equal.
-function sortMemorySearchToolResults<
-  T extends { score: number; path: string; rerankScore?: number },
->(results: T[]): T[] {
-  return results.toSorted((left, right) => {
-    const leftKey = left.rerankScore ?? left.score;
-    const rightKey = right.rerankScore ?? right.score;
-    if (leftKey !== rightKey) {
-      return rightKey - leftKey;
-    }
-    if (left.score !== right.score) {
-      return right.score - left.score;
-    }
-    return left.path.localeCompare(right.path);
-  });
-}
-
+// The manager returns results already in final composed order (rerank then MMR,
+// or score-descending when no reranker is active). Re-sorting here would undo
+// MMR's diversity reordering, so the tool preserves the manager's order and only
+// trims and balances corpora; corpus=all block-interleaves the two corpora
+// because their score scales (memory rerank/fusion vs supplement raw) are not
+// comparable.
 function mergeMemorySearchCorpusResults(params: {
   memoryResults: MemorySearchToolResult[];
   supplementResults: MemorySearchToolResult[];
   maxResults: number;
   balanceCorpora: boolean;
 }): MemorySearchToolResult[] {
-  const memoryResults = sortMemorySearchToolResults(params.memoryResults);
-  const supplementResults = sortMemorySearchToolResults(params.supplementResults);
-  if (!params.balanceCorpora || memoryResults.length === 0 || supplementResults.length === 0) {
-    return sortMemorySearchToolResults([...memoryResults, ...supplementResults]).slice(
-      0,
-      params.maxResults,
-    );
+  if (
+    !params.balanceCorpora ||
+    params.memoryResults.length === 0 ||
+    params.supplementResults.length === 0
+  ) {
+    return [...params.memoryResults, ...params.supplementResults].slice(0, params.maxResults);
   }
 
   const perCorpusCap = Math.ceil(params.maxResults / 2);
-  const selectedMemory = memoryResults.slice(0, perCorpusCap);
-  const selectedSupplements = supplementResults.slice(0, perCorpusCap);
+  const selectedMemory = params.memoryResults.slice(0, perCorpusCap);
+  const selectedSupplements = params.supplementResults.slice(0, perCorpusCap);
   const selected = [...selectedMemory, ...selectedSupplements];
   if (selected.length < params.maxResults) {
-    selected.push(
-      ...sortMemorySearchToolResults([
-        ...memoryResults.slice(selectedMemory.length),
-        ...supplementResults.slice(selectedSupplements.length),
-      ]).slice(0, params.maxResults - selected.length),
-    );
+    const remaining = [
+      ...params.memoryResults.slice(selectedMemory.length),
+      ...params.supplementResults.slice(selectedSupplements.length),
+    ];
+    selected.push(...remaining.slice(0, params.maxResults - selected.length));
   }
 
-  return sortMemorySearchToolResults(selected).slice(0, params.maxResults);
+  return selected.slice(0, params.maxResults);
 }
 
 function isClosedMemoryStoreError(error: unknown): boolean {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -532,6 +532,7 @@ export function createMemorySearchTool(options: {
                       ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
                       : "n/a",
                   fallback: latestDebug?.fallback,
+                  rerank: latestDebug?.rerank,
                   searchMs: Math.max(0, Date.now() - searchStartedAt),
                   hits: rawResults.length,
                 };

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -132,8 +132,20 @@ function buildPausedMemoryIndexUnavailableResult(reason: string) {
   });
 }
 
-function sortMemorySearchToolResults<T extends { score: number; path: string }>(results: T[]): T[] {
+// Order by the reranker's signal when present (rerankScore, cross-encoder [0,1]),
+// otherwise by raw fusion score. This keeps a promoted low-fusion-score passage
+// in its reranked position in the tool output, while leaving the no-reranker path
+// byte-for-byte unchanged (rerankScore is undefined -> falls back to score). The
+// score tiebreaker preserves fusion ordering when rerankScores are equal.
+function sortMemorySearchToolResults<
+  T extends { score: number; path: string; rerankScore?: number },
+>(results: T[]): T[] {
   return results.toSorted((left, right) => {
+    const leftKey = left.rerankScore ?? left.score;
+    const rightKey = right.rerankScore ?? right.score;
+    if (leftKey !== rightKey) {
+      return rightKey - leftKey;
+    }
     if (left.score !== right.score) {
       return right.score - left.score;
     }

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -430,6 +430,7 @@ export function createMemorySearchTool(options: {
                   configuredMode?: string;
                   effectiveMode?: string;
                   fallback?: string;
+                  rerank?: "active" | "degraded" | "disabled";
                   searchMs: number;
                   hits: number;
                 }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -10,6 +10,33 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  /** Cross-encoder relevance in [0,1]; kept separate from fusion `score` so minScore/telemetry stay on the fusion scale. */
+  rerankScore?: number;
+};
+
+export type MemoryRerankCandidate = {
+  /** Core-assigned dense index into the candidate pool; opaque, stable for the call. */
+  ref: number;
+  /** The passage text a cross-encoder scores. */
+  snippet: string;
+  /** Provided for rerankers that documentably special-case source; otherwise ignored. */
+  source: MemorySource;
+};
+
+export type MemoryRerankScore = {
+  /** MUST be one of the supplied candidate refs; unknown/duplicate refs are rejected by core. */
+  ref: number;
+  /** Normalized relevance in [0,1]; higher = more relevant. */
+  score: number;
+};
+
+export type MemoryRerankProvider = {
+  rerank(params: {
+    query: string;
+    candidates: ReadonlyArray<MemoryRerankCandidate>;
+    /** Core-owned deadline. Provider MUST forward it to its transport and reject promptly on abort. */
+    signal: AbortSignal;
+  }): Promise<ReadonlyArray<MemoryRerankScore>>;
 };
 
 export type MemoryEmbeddingProbeResult = {
@@ -32,6 +59,7 @@ export type MemorySearchRuntimeDebug = {
   configuredMode?: string;
   effectiveMode?: string;
   fallback?: string;
+  rerank?: "active" | "degraded" | "disabled";
 };
 
 export type MemoryReadResult = {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -39,12 +39,12 @@ function readBudgetEnv(name, fallback) {
 let budgets;
 try {
   budgets = {
-    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 316),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10150),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5109),
+    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 308),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 9920),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5031),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3204,
+      3143,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -39,12 +39,12 @@ function readBudgetEnv(name, fallback) {
 let budgets;
 try {
   budgets = {
-    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 308),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 9920),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5031),
+    publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 316),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10150),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5109),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3143,
+      3204,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -39,6 +39,8 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  /** Cross-encoder relevance in [0,1]; kept separate from fusion `score` so minScore/telemetry stay on the fusion scale. */
+  rerankScore?: number;
 };
 
 export type MemoryEmbeddingProbeResult = {

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -39,15 +39,23 @@ export type {
   MemoryPluginPublicArtifactsProvider,
   MemoryPluginRuntime,
   MemoryPromptSectionBuilder,
+  MemoryRerankProviderRegistration,
 } from "../plugins/memory-state.js";
+export type {
+  MemoryRerankCandidate,
+  MemoryRerankProvider,
+  MemoryRerankScore,
+} from "../../packages/memory-host-sdk/src/host/types.js";
 export {
   buildMemoryPromptSection as buildActiveMemoryPromptSection,
   clearMemoryPluginState,
   getMemoryCapabilityRegistration,
   listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
+  listMemoryRerankProviders,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
+  registerMemoryRerankProvider,
 } from "../plugins/memory-state.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";
 export { parseAgentSessionKey } from "../routing/session-key.js";

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -55,7 +55,6 @@ export {
   listMemoryRerankProviders,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
-  registerMemoryRerankProvider,
 } from "../plugins/memory-state.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";
 export { parseAgentSessionKey } from "../routing/session-key.js";

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -81,6 +81,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerMemoryPromptSection() {},
     registerMemoryPromptSupplement() {},
     registerMemoryCorpusSupplement() {},
+    registerMemoryRerankProvider() {},
     registerMemoryFlushPlan() {},
     registerMemoryRuntime() {},
     registerMemoryEmbeddingProvider() {},

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -79,6 +79,7 @@ export type BuildPluginApiParams = {
       | "registerMemoryPromptSection"
       | "registerMemoryPromptSupplement"
       | "registerMemoryCorpusSupplement"
+      | "registerMemoryRerankProvider"
       | "registerMemoryFlushPlan"
       | "registerMemoryRuntime"
       | "registerMemoryEmbeddingProvider"
@@ -172,6 +173,8 @@ const noopRegisterMemoryPromptSection: OpenClawPluginApi["registerMemoryPromptSe
 const noopRegisterMemoryPromptSupplement: OpenClawPluginApi["registerMemoryPromptSupplement"] =
   () => {};
 const noopRegisterMemoryCorpusSupplement: OpenClawPluginApi["registerMemoryCorpusSupplement"] =
+  () => {};
+const noopRegisterMemoryRerankProvider: OpenClawPluginApi["registerMemoryRerankProvider"] =
   () => {};
 const noopRegisterMemoryFlushPlan: OpenClawPluginApi["registerMemoryFlushPlan"] = () => {};
 const noopRegisterMemoryRuntime: OpenClawPluginApi["registerMemoryRuntime"] = () => {};
@@ -283,6 +286,8 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
       handlers.registerMemoryPromptSupplement ?? noopRegisterMemoryPromptSupplement,
     registerMemoryCorpusSupplement:
       handlers.registerMemoryCorpusSupplement ?? noopRegisterMemoryCorpusSupplement,
+    registerMemoryRerankProvider:
+      handlers.registerMemoryRerankProvider ?? noopRegisterMemoryRerankProvider,
     registerMemoryFlushPlan: handlers.registerMemoryFlushPlan ?? noopRegisterMemoryFlushPlan,
     registerMemoryRuntime: handlers.registerMemoryRuntime ?? noopRegisterMemoryRuntime,
     registerMemoryEmbeddingProvider:

--- a/src/plugins/contracts/memory-rerank-provider.contract.test.ts
+++ b/src/plugins/contracts/memory-rerank-provider.contract.test.ts
@@ -1,0 +1,86 @@
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { listMemoryRerankProviders, resetMemoryPluginState } from "../memory-state.js";
+
+afterEach(() => {
+  resetMemoryPluginState();
+});
+
+describe("memory rerank provider registration", () => {
+  it("rejects plugins that did not declare the capability contract", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "not-rerank",
+      name: "Not Rerank",
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+
+    expect(listMemoryRerankProviders()).toHaveLength(0);
+    const diagnostic = registry.registry.diagnostics.find(
+      (entry) => entry.pluginId === "not-rerank",
+    );
+    expect(diagnostic?.message).toBe(
+      "plugin must declare contracts.memoryRerankProviders to register a memory rerank provider",
+    );
+  });
+
+  it("allows plugins that declare the capability contract", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "cross-encoder",
+      name: "Cross Encoder",
+      contracts: {
+        memoryRerankProviders: ["cross-encoder"],
+      },
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+
+    expect(listMemoryRerankProviders().map((entry) => entry.pluginId)).toEqual(["cross-encoder"]);
+  });
+
+  it("warns and keeps the existing owner when a second declaring plugin claims the exclusive slot", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "first-reranker",
+      name: "First Reranker",
+      contracts: { memoryRerankProviders: ["first-reranker"] },
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "second-reranker",
+      name: "Second Reranker",
+      contracts: { memoryRerankProviders: ["second-reranker"] },
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+
+    expect(listMemoryRerankProviders().map((entry) => entry.pluginId)).toEqual(["first-reranker"]);
+    const diagnostic = registry.registry.diagnostics.find(
+      (entry) => entry.pluginId === "second-reranker",
+    );
+    expect(diagnostic?.message).toBe(
+      "memory rerank provider already registered (owner: first-reranker)",
+    );
+  });
+});

--- a/src/plugins/installed-plugin-index-scope-lookup.ts
+++ b/src/plugins/installed-plugin-index-scope-lookup.ts
@@ -8,6 +8,7 @@ const PROVIDER_CONTRIBUTION_CONTRACTS = [
   "externalAuthProviders",
   "embeddingProviders",
   "memoryEmbeddingProviders",
+  "memoryRerankProviders",
   "speechProviders",
   "realtimeTranscriptionProviders",
   "realtimeVoiceProviders",

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import { getCompactionProvider, registerCompactionProvider } from "./compaction-provider.js";
 import { getEmbeddingProvider, registerEmbeddingProvider } from "./embedding-providers.js";
@@ -20,6 +24,7 @@ import {
   buildMemoryPromptSection,
   getMemoryRuntime,
   listMemoryCorpusSupplements,
+  listMemoryRerankProviders,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryPromptSupplement,
@@ -810,6 +815,47 @@ describe("loadOpenClawPlugins active runtime clearing", () => {
     expect(getEmbeddingProvider("stale-embedding")).toBeUndefined();
     expect(getCompactionProvider("stale-compaction")).toBeUndefined();
     expect(getMemoryEmbeddingProvider("stale-memory")).toBeUndefined();
+  });
+});
+
+describe("memory rerank provider contract gate", () => {
+  it("rejects an undeclared plugin and keeps the exclusive slot empty", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "undeclared-rerank",
+      name: "Undeclared Rerank",
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+
+    expect(listMemoryRerankProviders()).toHaveLength(0);
+    const diagnostic = registry.registry.diagnostics.find(
+      (entry) => entry.pluginId === "undeclared-rerank",
+    );
+    expect(diagnostic?.message).toBe(
+      "plugin must declare contracts.memoryRerankProviders to register a memory rerank provider",
+    );
+  });
+
+  it("registers a declaring plugin into the exclusive slot", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "declared-rerank",
+      name: "Declared Rerank",
+      contracts: { memoryRerankProviders: ["declared-rerank"] },
+      register(api) {
+        api.registerMemoryRerankProvider({ rerank: async () => [] });
+      },
+    });
+
+    expect(listMemoryRerankProviders().map((entry) => entry.pluginId)).toEqual(["declared-rerank"]);
   });
 });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -113,6 +113,7 @@ import {
   getMemoryCapabilityRegistration,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  listMemoryRerankProviders,
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -286,6 +287,9 @@ type CachedPluginState = {
   interactiveHandlers?: ReturnType<typeof listPluginInteractiveHandlers>;
   memoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
   memoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements>;
+  // Exclusive single-slot reranker; restored alongside the other memory-state fields so a
+  // warm cache-restore on gateway restart does not silently drop a registered reranker.
+  memoryRerankProvider: ReturnType<typeof listMemoryRerankProviders>[number] | undefined;
   agentHarnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
   embeddingProviders: ReturnType<typeof listRegisteredEmbeddingProviders>;
@@ -1775,6 +1779,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           capability: cached.state.memoryCapability,
           corpusSupplements: cached.state.memoryCorpusSupplements,
           promptSupplements: cached.state.memoryPromptSupplements,
+          rerankProvider: cached.state.memoryRerankProvider,
         });
         activatePluginRegistry(
           cached.state.registry,
@@ -2688,6 +2693,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
+      const previousMemoryRerankProvider = listMemoryRerankProviders()[0];
 
       const beforeRegister = performance.now();
       let registerFailed = false;
@@ -2708,6 +2714,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptSupplements: previousMemoryPromptSupplements,
+            rerankProvider: previousMemoryRerankProvider,
           });
         }
         registry.plugins.push(record);
@@ -2724,6 +2731,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptSupplements: previousMemoryPromptSupplements,
+          rerankProvider: previousMemoryRerankProvider,
         });
         recordPluginError({
           logger,
@@ -2795,6 +2803,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           interactiveHandlers: listPluginInteractiveHandlers(),
           memoryCapability: getMemoryCapabilityRegistration(),
           memoryCorpusSupplements: listMemoryCorpusSupplements(),
+          memoryRerankProvider: listMemoryRerankProviders()[0],
           registry,
           agentHarnesses: listRegisteredAgentHarnesses(),
           compactionProviders: listRegisteredCompactionProviders(),

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -175,6 +175,7 @@ export type PluginManifestContractListKey =
   | "videoGenerationProviders"
   | "musicGenerationProviders"
   | "memoryEmbeddingProviders"
+  | "memoryRerankProviders"
   | "webContentExtractors"
   | "webFetchProviders"
   | "webSearchProviders"
@@ -385,6 +386,7 @@ function mergeManifestContracts(
     "externalAuthProviders",
     "embeddingProviders",
     "memoryEmbeddingProviders",
+    "memoryRerankProviders",
     "speechProviders",
     "realtimeTranscriptionProviders",
     "realtimeVoiceProviders",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -429,6 +429,7 @@ export type PluginManifestContracts = {
   externalAuthProviders?: string[];
   embeddingProviders?: string[];
   memoryEmbeddingProviders?: string[];
+  memoryRerankProviders?: string[];
   speechProviders?: string[];
   realtimeTranscriptionProviders?: string[];
   realtimeVoiceProviders?: string[];
@@ -862,6 +863,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const externalAuthProviders = normalizeTrimmedStringList(value.externalAuthProviders);
   const embeddingProviders = normalizeTrimmedStringList(value.embeddingProviders);
   const memoryEmbeddingProviders = normalizeTrimmedStringList(value.memoryEmbeddingProviders);
+  const memoryRerankProviders = normalizeTrimmedStringList(value.memoryRerankProviders);
   const speechProviders = normalizeTrimmedStringList(value.speechProviders);
   const realtimeTranscriptionProviders = normalizeTrimmedStringList(
     value.realtimeTranscriptionProviders,
@@ -885,6 +887,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
     ...(externalAuthProviders.length > 0 ? { externalAuthProviders } : {}),
     ...(embeddingProviders.length > 0 ? { embeddingProviders } : {}),
     ...(memoryEmbeddingProviders.length > 0 ? { memoryEmbeddingProviders } : {}),
+    ...(memoryRerankProviders.length > 0 ? { memoryRerankProviders } : {}),
     ...(speechProviders.length > 0 ? { speechProviders } : {}),
     ...(realtimeTranscriptionProviders.length > 0 ? { realtimeTranscriptionProviders } : {}),
     ...(realtimeVoiceProviders.length > 0 ? { realtimeVoiceProviders } : {}),

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -9,11 +9,13 @@ import {
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
   listActiveMemoryPublicArtifacts,
+  listMemoryRerankProviders,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
   registerMemoryPromptSupplement,
   registerMemoryPromptSection,
+  registerMemoryRerankProvider,
   registerMemoryRuntime,
   resolveMemoryFlushPlan,
   restoreMemoryPluginState,
@@ -355,5 +357,20 @@ describe("memory plugin state", () => {
     clearMemoryPluginState();
 
     expectClearedMemoryState();
+  });
+
+  it("registerMemoryRerankProvider is an exclusive slot (rejects a second owner)", () => {
+    const p = { rerank: async () => [] };
+    expect(registerMemoryRerankProvider("plugin-a", p)).toEqual({ ok: true });
+    expect(listMemoryRerankProviders().map((r) => r.pluginId)).toEqual(["plugin-a"]);
+    const second = registerMemoryRerankProvider("plugin-b", p);
+    expect(second).toEqual({ ok: false, existingOwner: "plugin-a" });
+    expect(listMemoryRerankProviders()).toHaveLength(1);
+  });
+
+  it("clearMemoryPluginState resets the rerank slot", () => {
+    registerMemoryRerankProvider("plugin-a", { rerank: async () => [] });
+    clearMemoryPluginState();
+    expect(listMemoryRerankProviders()).toHaveLength(0);
   });
 });

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -53,10 +53,12 @@ function expectClearedMemoryState() {
 }
 
 function createMemoryStateSnapshot() {
+  // Mirror exactly what the plugin loader captures/restores for a warm cache hit.
   return {
     capability: getMemoryCapabilityRegistration(),
     corpusSupplements: listMemoryCorpusSupplements(),
     promptSupplements: listMemoryPromptSupplements(),
+    rerankProvider: listMemoryRerankProviders()[0],
   };
 }
 
@@ -372,5 +374,18 @@ describe("memory plugin state", () => {
     registerMemoryRerankProvider("plugin-a", { rerank: async () => [] });
     clearMemoryPluginState();
     expect(listMemoryRerankProviders()).toHaveLength(0);
+  });
+
+  it("restoreMemoryPluginState carries the rerank slot through a snapshot round-trip", () => {
+    // Regression guard: the loader cache snapshot/restore must not drop a registered
+    // reranker on a warm gateway restart.
+    registerMemoryRerankProvider("plugin-a", { rerank: async () => [] });
+    const snapshot = createMemoryStateSnapshot();
+
+    resetMemoryPluginState();
+    expect(listMemoryRerankProviders()).toHaveLength(0);
+
+    restoreMemoryPluginState(snapshot);
+    expect(listMemoryRerankProviders().map((r) => r.pluginId)).toEqual(["plugin-a"]);
   });
 });

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -1,6 +1,6 @@
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { MemorySearchManager } from "../memory-host-sdk/host/types.js";
+import type { MemoryRerankProvider, MemorySearchManager } from "../memory-host-sdk/host/types.js";
 
 export type MemoryPromptSectionBuilder = (params: {
   availableTools: Set<string>;
@@ -57,6 +57,11 @@ export type MemoryCorpusSupplement = {
 export type MemoryCorpusSupplementRegistration = {
   pluginId: string;
   supplement: MemoryCorpusSupplement;
+};
+
+export type MemoryRerankProviderRegistration = {
+  pluginId: string;
+  provider: MemoryRerankProvider;
 };
 
 export type MemoryPromptSupplementRegistration = {
@@ -144,6 +149,7 @@ type MemoryPluginState = {
   capability?: MemoryPluginCapabilityRegistration;
   corpusSupplements: MemoryCorpusSupplementRegistration[];
   promptSupplements: MemoryPromptSupplementRegistration[];
+  rerankProvider?: MemoryRerankProviderRegistration;
 };
 
 const memoryPluginState: MemoryPluginState = {
@@ -202,6 +208,23 @@ export function getMemoryCapabilityRegistration(): MemoryPluginCapabilityRegistr
 
 export function listMemoryCorpusSupplements(): MemoryCorpusSupplementRegistration[] {
   return [...memoryPluginState.corpusSupplements];
+}
+
+// Only one reranker may be active at a time; a second distinct owner is an error not silent last-wins.
+export function registerMemoryRerankProvider(
+  pluginId: string,
+  provider: MemoryRerankProvider,
+): { ok: true } | { ok: false; existingOwner: string } {
+  const existing = memoryPluginState.rerankProvider;
+  if (existing !== undefined && existing.pluginId !== pluginId) {
+    return { ok: false, existingOwner: existing.pluginId };
+  }
+  memoryPluginState.rerankProvider = { pluginId, provider };
+  return { ok: true };
+}
+
+export function listMemoryRerankProviders(): ReadonlyArray<MemoryRerankProviderRegistration> {
+  return memoryPluginState.rerankProvider ? [memoryPluginState.rerankProvider] : [];
 }
 
 /** @deprecated Use registerMemoryCapability(pluginId, { promptBuilder }) instead. */
@@ -347,12 +370,14 @@ export function restoreMemoryPluginState(state: MemoryPluginState): void {
     : undefined;
   memoryPluginState.corpusSupplements = [...state.corpusSupplements];
   memoryPluginState.promptSupplements = [...state.promptSupplements];
+  memoryPluginState.rerankProvider = state.rerankProvider;
 }
 
 export function clearMemoryPluginState(): void {
   memoryPluginState.capability = undefined;
   memoryPluginState.corpusSupplements = [];
   memoryPluginState.promptSupplements = [];
+  memoryPluginState.rerankProvider = undefined;
 }
 
 export const resetMemoryPluginState = clearMemoryPluginState;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -119,6 +119,7 @@ import {
   registerMemoryFlushPlanResolverForPlugin,
   registerMemoryPromptSupplement,
   registerMemoryPromptSectionForPlugin,
+  registerMemoryRerankProvider,
   registerMemoryRuntimeForPlugin,
 } from "./memory-state.js";
 import { createModelCatalogRegistrationHandlers } from "./model-catalog-registration.js";
@@ -3078,6 +3079,29 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               },
               registerMemoryCorpusSupplement: (supplement) => {
                 registerMemoryCorpusSupplement(record.id, supplement);
+              },
+              registerMemoryRerankProvider: (provider) => {
+                // Vendor-neutral seam: the provider carries no id, so declaring the
+                // contract (non-empty list) is the gate, mirroring memoryEmbeddingProviders.
+                if ((record.contracts?.memoryRerankProviders ?? []).length === 0) {
+                  pushDiagnostic({
+                    level: "error",
+                    pluginId: record.id,
+                    source: record.source,
+                    message:
+                      "plugin must declare contracts.memoryRerankProviders to register a memory rerank provider",
+                  });
+                  return;
+                }
+                const result = registerMemoryRerankProvider(record.id, provider);
+                if (!result.ok) {
+                  pushDiagnostic({
+                    level: "error",
+                    pluginId: record.id,
+                    source: record.source,
+                    message: `memory rerank provider already registered (owner: ${result.existingOwner})`,
+                  });
+                }
               },
               registerMemoryFlushPlan: (resolver) => {
                 if (!hasKind(record.kind, "memory")) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2883,6 +2883,10 @@ export type OpenClawPluginApi = {
   registerMemoryCorpusSupplement: (
     supplement: import("./memory-state.js").MemoryCorpusSupplement,
   ) => void;
+  /** Register a cross-encoder rerank provider for memory search results (exclusive slot). */
+  registerMemoryRerankProvider: (
+    provider: import("../memory-host-sdk/host/types.js").MemoryRerankProvider,
+  ) => void;
   /**
    * Register the pre-compaction flush plan resolver for this memory plugin (exclusive slot).
    * @deprecated Use registerMemoryCapability({ flushPlanResolver }) instead.

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -687,6 +687,7 @@ describe("test-projects args", () => {
         includePatterns: [
           "extensions/memory-core/src/memory/index.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
+          "extensions/memory-core/src/memory/manager.rerank.test.ts",
         ],
         watchMode: false,
       },


### PR DESCRIPTION
## Summary

OpenClaw's builtin (sqlite-vec) memory search does first-stage hybrid retrieval (dense `vec0` ∥ FTS5 BM25, fused) → temporal decay → MMR diversity, but has **no second-stage relevance reranker**. MMR reuses the frozen first-stage score and measures only lexical (Jaccard) redundancy — it cannot re-judge query↔document relevance, so a genuinely-best passage that first-stage scoring underranks is dropped before the model sees it.

This adds an **optional, vendor-neutral cross-encoder rerank stage** to the builtin backend, as a plugin-SDK capability:

- New `MemoryRerankProvider` seam: `rerank({ query, candidates, signal }) → { ref, score }[]`. Candidates are passed by **core-assigned `ref`** and the provider returns scored refs (not full results), so it cannot drop/duplicate/fabricate rows; scores are normalized `[0,1]` written to a separate `rerankScore` field (the fusion `score` stays intact for `minScore`/telemetry).
- Registered via `api.registerMemoryRerankProvider`, gated by a `memoryRerankProviders` manifest contract (mirrors the embedding-provider contract). **Single exclusive slot** — a second registering plugin is rejected.
- `MemoryManager.search` runs the reranker on the **wide pre-MMR pool**, then MMR diversifies, then `minScore`/trim. **Fail-open**: an aborting deadline wraps the call; on timeout/error it returns the pre-rerank order.
- **Observable, not fail-silent:** `status().custom.rerank` / the search `debug.rerank` field reports `disabled` (no reranker) / `active` (scores applied) / `degraded` (registered but returned no scores — failing, timed-out, or plugin-disabled), with a latched warn on the active→degraded transition.

**No new core config** — opt-in is registration-based. Core ships **no concrete reranker**; a TEI/`bge-reranker` implementation is a separate plugin.

Intentionally out of scope: the concrete reranker plugin; the **qmd** backend (it delegates ranking to its own server-side reranker — noted inline at the insertion point and in docs).

Reviewers should focus on: the fail-open path in `MemoryManager.search` (must never throw), the `MemoryRerankProvider` refs→scores contract, the `memoryRerankProviders` gate, and the `disabled/active/degraded` observability.

## Linked context

Related #89477 (the RFC; the seam-surface decision lives there — a maintainer closes it on decision).
Related #82985 (a complementary, independent optimization — keep open; see below).

**Relationship to #82985 (`engineCandidates` passthrough) — complementary, not superseded.** The two are easily conflated as competing rerankers, but they solve different problems and can land independently:
- **This PR** adds a *reranking stage* on the **wide pre-MMR pool** (`candidateMultiplier`-expanded, up to ~4× `maxResults`) — so it can promote a passage that first-stage scoring underranked *before* the trim, and MMR then diversifies on the cross-encoder's relevance.
- **#82985** forwards `manager.search()`'s **already-trimmed** output to the existing `MemoryCorpusSupplement.search` so a supplement skips a redundant `manager.search()` roundtrip (#82984). Running *after* the pipeline, it can reorder the surviving top-N but cannot rescue a dropped passage.

So the supplement contract is the wrong *stage* for true reranking, but a fine fit for #82985's roundtrip goal. This seam gives reranking a first-class home (a plugin no longer *needs* the supplement-reranker pattern), yet it does **not** deliver #82985's roundtrip-efficiency benefit for other supplement types — so **#82985 stays open on its own merits**. The two currently overlap textually on `src/plugin-sdk/memory-core-host-runtime-core.ts` and `src/plugins/memory-state.ts`; a rebase resolves that.

Was this requested by a maintainer or owner? — Proposed RFC-first via #89477. Implementation is complete, expert-reviewed, rebased on latest `main`, and fully green, so this is marked **ready for review**; the one open item is the maintainer surface decision in #89477 (the new public SDK API + `memoryRerankProviders` contract).

## Real behavior proof (required for external PRs)

- **Behavior addressed:** the `memory_search` tool now **preserves the manager's composed rerank→MMR order**. The prior tool-boundary code re-sorted results by `rerankScore`, which could **undo MMR's diversity reordering** (ClawSweeper [P1]). The fix removes the tool-boundary re-sort entirely — ordering ownership stays in `MemoryManager.search`; `corpus=all` block-interleaves the two corpora (their score scales are incomparable). With no reranker registered, order is unchanged (fusion-`score` descending). Active/degraded/disabled observability is unchanged.
- **Real environment tested:** OpenClaw built from this branch (the `mergeMemorySearchCorpusResults` change), run in an **isolated** home (`OPENCLAW_HOME=/tmp` throwaway; production `~/.openclaw/openclaw.json` mtime unchanged before/after). A companion plugin implementing `MemoryRerankProvider` registered against a live TEI **bge-reranker-v2-m3** cross-encoder; **bge-m3** base embeddings; a local OpenAI-compatible **Qwen3.6-27B** drove the `openclaw agent --local` turn. Self-hosted tailnet endpoints; no cloud. (A dense-weighted hybrid first stage — `query.hybrid.vectorWeight:1` — was used only to stage a first-stage order that diverges from the cross-encoder; the fix itself is a config-independent ordering *preservation*.)
- **Exact steps or command run after this patch:** indexed a 5-doc corpus, then `openclaw agent --local --json` invoking `memory_search` for *"rotate the signing key in the vault"* **with MMR enabled**, then again with the plugin's kill-switch on.
- **Evidence after fix:** MMR ordering preserved at the tool boundary (terminal capture):
  ```
  debug: {"backend":"builtin","rerank":"active","hits":5}
  #0 near-dup.md   score 0.687  rerankScore 0.977
  #1 decoy.md      score 0.706  rerankScore 0.823
  #2 answer.md     score 0.682  rerankScore 0.967
  #3 access.md     score 0.426  rerankScore 0.000
  #4 runners.md    score 0.453  rerankScore 0.000
  (rerankScore-descending order would be: near-dup, answer, decoy, runners, access)
  ```
  MMR demoted `answer.md` (a near-duplicate of `near-dup.md`, `rerankScore` 0.967) **below** the diverse `decoy.md` (`rerankScore` 0.823) for diversity. The tool output **preserved** that order: it is **neither `rerankScore`-sorted** (which would put `answer` at #1) **nor raw-`score`-sorted** (which would put `decoy` at #0) — it is the manager's composed order. The prior re-sort-by-`rerankScore` would have re-promoted `answer` to #1, undoing MMR.
- **Evidence — degraded (kill-switch on):** same query → `debug.rerank:"degraded"`, no `rerankScore` on any result, fail-open to the base order (observable, not a false `"active"`).
- **Regression test:** `tools.test.ts` *"preserves the manager's rerank+MMR order (no re-sort by rerankScore or raw score)"* — verified to **FAIL** on the prior re-sort and **PASS** after the fix (the manager order disagrees with both a `rerankScore` sort and a raw-`score` sort).
- **Observed result after fix:** MMR demoted the near-duplicate `answer.md` (`rerankScore` 0.967) below the diverse `decoy.md` (`rerankScore` 0.823), and `memory_search` **preserved** that composed order — neither `rerankScore`- nor raw-`score`-sorted — so MMR's diversity reorder reaches the tool output; the prior re-sort would have re-promoted `answer`. Kill-switched, the search fails open to the base order (`degraded`).
- **What was not tested:** the qmd backend (out of scope — its own server-side reranker).
- **Limitations:** isolated dev home + local tailnet model, not the production gateway.

## Tests and validation

Which commands did you run?
- `pnpm tsgo:all` → exit 0 (whole monorepo; note `tsgo:core` excludes `extensions/`)
- `node scripts/run-vitest.mjs extensions/memory-core` → 852 passed
- **Linux Node 24 re-verification** (CI runtime) — committed tree piped via `git archive` into an isolated `node:24` container (no host mount): `pnpm install --frozen-lockfile` + `extensions/memory-core` **852 passed** + `tsgo:extensions` prod & test, all green.
- `pnpm test:contracts:plugins` → 935 passed
- `pnpm check:docs` → clean

What regression coverage was added or updated?
- `manager.rerank.test.ts`: rerank reorder, fail-open-on-throw, deadline→abort, invalid-ref reject, empty-return→degraded, no-reranker→disabled.
- `memory-rerank-provider.contract.test.ts` + `loader.runtime-registry.test.ts`: contract reject (undeclared) / allow (declared) / exclusive-slot conflict.
- `memory-state.test.ts`: exclusive-slot register/clear + snapshot round-trip (warm-restart guard).
- `mmr.test.ts` (relevanceScore drives ranking), `hybrid.test.ts` (merge no longer applies MMR), `tools.test.ts` (**rerank+MMR order preserved at the tool boundary** + `debug.rerank` passthrough), `tools.citations.test.ts` (`corpus=all` block-interleave order).

What failed before this fix, if known? N/A (new capability). Unit/contract tests are supplemental to the live proof above.

## Risk checklist

Did user-visible behavior change? **Yes** — a new opt-in stage; no change when no reranker is registered.
Did config, environment, or migration behavior change? **No** — opt-in is registration-based; no new core config; no migration.
Did security, auth, secrets, network, or tool execution behavior change? **No in core** — core makes no network calls; the (separate) reranker plugin owns its endpoint/auth.
What is the highest-risk area? The fail-open path in `MemoryManager.search` and the new public SDK surface (`MemoryRerankProvider` on `memory-core-host-runtime-core` + the `memoryRerankProviders` manifest contract).
How is that risk mitigated? Aborting deadline + total catch → pre-rerank order on any failure; honest `disabled/active/degraded` state on `status().custom.rerank` + latched warn so a failing reranker is observable, not silent; the ref-based contract makes dropped/duplicated/fabricated results unrepresentable. Branch rebased on latest `main`; `tsgo:all` + memory-core + plugin-contract lanes + `check:docs` all green.

## Current review state

What is the next action? Maintainer review — the implementation is complete, reviewed, rebased on latest `main`, and CI-ready. The remaining open item is the product decision on the new public SDK surface (tracked in #89477).
What is still waiting? Maintainer buy-in on the new public plugin-SDK surface + manifest contract (the direction decision tracked in #89477); the concrete reranker plugin remains a separate deliverable. (#82985 is a complementary, independent optimization — not a competing reranker.)
Which bot or reviewer comments were addressed? ClawSweeper findings addressed across rounds — most recently the **[P1] tool-boundary ordering**: `memory_search` now preserves the manager's composed rerank→MMR order instead of re-sorting by `rerankScore` (which could undo MMR diversity), via a `corpus=all` block-interleave, an MMR-inversion regression test, and the refreshed live proof above ([P2] docs aligned). Earlier rounds: the gate-bypass via the public barrel export (removed), the degraded-reason ordering, the test-API noop, the score-contract completeness, and the `memoryRerankProviders` manifest-gate docs.



