### PR TITLE
feat(channels): add Zalo ClawBot external channel entry and documenta…

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -171,6 +171,10 @@
       - any-glob-to-any-file:
           - "extensions/zalo/**"
           - "docs/channels/zalo.md"
+"channel: zaloclawbot":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/channels/zaloclawbot.md"
 "channel: zalouser":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1194,5 +1194,9 @@
   {
     "source": "cohere",
     "target": "cohere"
+  },
+  {
+    "source": "Zalo ClawBot",
+    "target": "Zalo ClawBot"
   }
 ]

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -52,6 +52,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [WhatsApp](/channels/whatsapp) - Most popular; uses Baileys and requires QR pairing.
 - [Yuanbao](/channels/yuanbao) - Tencent Yuanbao bot (external plugin).
 - [Zalo](/channels/zalo) - Zalo Bot API; Vietnam's popular messenger (bundled plugin).
+- [Zalo ClawBot](/channels/zaloclawbot) - Personal Zalo assistant via QR login; owner-bound (external plugin).
 - [Zalo Personal](/channels/zalouser) - Zalo personal account via QR login (bundled plugin).
 
 ## Notes

--- a/docs/channels/zaloclawbot.md
+++ b/docs/channels/zaloclawbot.md
@@ -6,7 +6,9 @@ read_when:
 title: "Zalo ClawBot"
 ---
 
-OpenClaw's official Zalo personal channel plugin, supporting zero-config login authorization via Zalo Mini App QR code scanning.
+OpenClaw connects to Zalo ClawBot through the catalog-listed external
+`@zalo-platforms/openclaw-zaloclawbot` plugin. Login uses a Zalo Mini App QR
+code.
 
 ## Compatibility
 
@@ -30,17 +32,9 @@ openclaw onboard
 
 The wizard installs the plugin from the official catalog (integrity-verified), renders the login QR right in the terminal, and finishes the channel once you scan it with the Zalo app. No extra commands are needed.
 
-## Quick Install
-
-To add the channel to an already-onboarded gateway, run the one-shot installer (installs, enables, restarts, and launches the QR login):
-
-```bash
-npx -y @zalo-platforms/openclaw-zaloclawbot-cli install
-```
-
 ## Manual Installation
 
-If the quick installer script does not fit your environment, follow these steps manually:
+To add the channel to an already-onboarded gateway, follow these steps:
 
 ### 1. Install the plugin
 
@@ -78,7 +72,8 @@ Unlike the standard developer Zalo channel which requires you to register your o
 
 1. **Secure Onboarding:** The QR code resolves to a secure Zalo Mini App that binds a newly-provisioned, private bot under a shared official OA directly to your Zalo User ID.
 2. **Owner-Bound Privacy:** By design, the bot is restricted to communicating _only_ with its owner. Messages from other users are dropped at the platform level, making the connection private and secure.
-3. **Ban-Safe:** Because the connection utilizes the official Zalo Bot Platform APIs, it is officially sanctioned and does not carry the account suspension risks associated with unofficial browser/web-spoof libraries.
+3. **Official API path:** The plugin uses Zalo Bot Platform APIs instead of
+   browser or web-session automation.
 
 ## Under the Hood
 
@@ -87,6 +82,10 @@ The Zalo ClawBot plugin communicates with Zalo APIs via a persistent long-pollin
 - Long-poll connections utilize the `getUpdates` endpoint.
 - Webhooks are disabled by default for local desktop/terminal gateway runs.
 - Messages are processed client-side and mapped directly to your local agent runtime.
+
+The external plugin manages bot credentials under the OpenClaw state directory.
+Treat that directory as sensitive and include it in the same access-control and
+backup policy as the rest of your OpenClaw state.
 
 ---
 

--- a/docs/channels/zaloclawbot.md
+++ b/docs/channels/zaloclawbot.md
@@ -1,0 +1,84 @@
+---
+summary: "Zalo ClawBot channel setup through the external openclaw-zaloclawbot plugin"
+read_when:
+  - You want a personal Zalo assistant bot with QR-code login
+  - You are installing or troubleshooting the openclaw-zaloclawbot channel plugin
+title: "Zalo ClawBot"
+---
+
+OpenClaw's official Zalo personal channel plugin, supporting zero-config login authorization via Zalo Mini App QR code scanning.
+
+## Compatibility
+
+| Plugin Version | OpenClaw Version | npm dist-tag | Status        |
+| -------------- | ---------------- | ------------ | ------------- |
+| 0.1.x          | >=2026.4.10      | `latest`     | Active / Beta |
+
+## Prerequisites
+
+- Node.js **>= 22**
+- [OpenClaw](https://docs.openclaw.ai/install) must be installed (`openclaw` CLI available).
+- A Zalo account on a mobile device to scan the login QR code.
+
+## Quick Install
+
+Run the following command to install the plugin, enable it, and launch the QR login flow:
+
+```bash
+npx -y @zalo-platforms/openclaw-zaloclawbot-cli install
+```
+
+## Manual Installation
+
+If the quick installer script does not fit your environment, follow these steps manually:
+
+### 1. Install the plugin
+
+```bash
+openclaw plugins install "@zalo-platforms/openclaw-zaloclawbot"
+```
+
+### 2. Enable the plugin in config
+
+```bash
+openclaw config set plugins.entries.openclaw-zaloclawbot.enabled true
+```
+
+### 3. Generate QR code and log in
+
+```bash
+openclaw channels login --channel openclaw-zaloclawbot
+```
+
+Scan the terminal-rendered QR code using the Zalo mobile app, accept the Terms of Use inside the Zalo Mini App, and authorize the session.
+
+### 4. Restart the gateway
+
+```bash
+openclaw gateway restart
+```
+
+---
+
+## How It Works
+
+Unlike the standard developer Zalo channel which requires you to register your own Zalo Official Account (OA) and paste static developer credentials, Zalo ClawBot operates as an **owner-bound personal assistant** using a shared, official infrastructure:
+
+1. **Secure Onboarding:** The QR code resolves to a secure Zalo Mini App that binds a newly-provisioned, private bot under a shared official OA directly to your Zalo User ID.
+2. **Owner-Bound Privacy:** By design, the bot is restricted to communicating _only_ with its owner. Messages from other users are dropped at the platform level, making the connection private and secure.
+3. **Ban-Safe:** Because the connection utilizes the official Zalo Bot Platform APIs, it is officially sanctioned and does not carry the account suspension risks associated with unofficial browser/web-spoof libraries.
+
+## Under the Hood
+
+The Zalo ClawBot plugin communicates with Zalo APIs via a persistent long-polling message loop. To maintain a clean and lightweight runtime:
+
+- Long-poll connections utilize the `getUpdates` endpoint.
+- Webhooks are disabled by default for local desktop/terminal gateway runs.
+- Messages are processed client-side and mapped directly to your local agent runtime.
+
+---
+
+## Troubleshooting
+
+- **QR Login Timeout:** The login token (`zbsk`) expires after 5 minutes for security reasons. If the QR code expires before you scan it, simply rerun the login command to generate a new one.
+- **Gateway Fails to Load:** Ensure your OpenClaw host version is `2026.4.10` or higher. Older versions do not support the external npm-plugin installation ledger.

--- a/docs/channels/zaloclawbot.md
+++ b/docs/channels/zaloclawbot.md
@@ -20,9 +20,19 @@ OpenClaw's official Zalo personal channel plugin, supporting zero-config login a
 - [OpenClaw](https://docs.openclaw.ai/install) must be installed (`openclaw` CLI available).
 - A Zalo account on a mobile device to scan the login QR code.
 
+## Install with onboard (recommended)
+
+Run the OpenClaw onboarding wizard and pick **Zalo ClawBot** from the channel menu:
+
+```bash
+openclaw onboard
+```
+
+The wizard installs the plugin from the official catalog (integrity-verified), renders the login QR right in the terminal, and finishes the channel once you scan it with the Zalo app. No extra commands are needed.
+
 ## Quick Install
 
-Run the following command to install the plugin, enable it, and launch the QR login flow:
+To add the channel to an already-onboarded gateway, run the one-shot installer (installs, enables, restarts, and launches the QR login):
 
 ```bash
 npx -y @zalo-platforms/openclaw-zaloclawbot-cli install
@@ -35,8 +45,10 @@ If the quick installer script does not fit your environment, follow these steps 
 ### 1. Install the plugin
 
 ```bash
-openclaw plugins install "@zalo-platforms/openclaw-zaloclawbot"
+openclaw plugins install "@zalo-platforms/openclaw-zaloclawbot@0.1.4"
 ```
+
+Use the exact pinned version shown above (it matches the official catalog entry), so OpenClaw verifies the package against the catalog integrity hash during install.
 
 ### 2. Enable the plugin in config
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1132,6 +1132,7 @@
                   "channels/feishu",
                   "channels/yuanbao",
                   "channels/zalo",
+                  "channels/zaloclawbot",
                   "channels/zalouser"
                 ]
               },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -317,6 +317,10 @@
       "destination": "/channels/zalo"
     },
     {
+      "source": "/channels/openclaw-zaloclawbot",
+      "destination": "/channels/zaloclawbot"
+    },
+    {
       "source": "/providers/whatsapp",
       "destination": "/channels/whatsapp"
     },

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -134,7 +134,7 @@
         "channel": {
           "id": "openclaw-zaloclawbot",
           "label": "Zalo ClawBot",
-          "selectionLabel": "Zalo ClawBot (personal assistant)",
+          "selectionLabel": "Zalo ClawBot (QR)",
           "detailLabel": "Zalo ClawBot",
           "docsPath": "/channels/zaloclawbot",
           "docsLabel": "zaloclawbot",
@@ -153,9 +153,9 @@
           }
         },
         "install": {
-          "npmSpec": "@zalo-platforms/openclaw-zaloclawbot@0.1.0",
+          "npmSpec": "@zalo-platforms/openclaw-zaloclawbot@0.1.4",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-nXXGdFWUKtyvV8nhKLW6h008sbjBvhViSUJmKcLLlB/+N1VeaWFwHZmVTkTRbYYpjPWPDHjl289+pUncwsYxcQ==",
+          "expectedIntegrity": "sha512-5IxZriHJYACLLGqkCPPsTP9tas62kXEOFqTFAFMdunAM3SPhIJwVFRp0WvoP/m7L2PX85weD0g8LOtxM93VDYg==",
           "minHostVersion": ">=2026.4.10"
         }
       }

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -122,6 +122,45 @@
       }
     },
     {
+      "name": "@zalo-platforms/openclaw-zaloclawbot",
+      "description": "OpenClaw Zalo ClawBot channel plugin by the Zalo Platforms team.",
+      "source": "external",
+      "kind": "channel",
+      "openclaw": {
+        "plugin": {
+          "id": "openclaw-zaloclawbot",
+          "label": "Zalo ClawBot"
+        },
+        "channel": {
+          "id": "openclaw-zaloclawbot",
+          "label": "Zalo ClawBot",
+          "selectionLabel": "Zalo ClawBot (personal assistant)",
+          "detailLabel": "Zalo ClawBot",
+          "docsPath": "/channels/zaloclawbot",
+          "docsLabel": "zaloclawbot",
+          "blurb": "Personal Zalo assistant bot via QR-code login — owner-bound, no setup.",
+          "aliases": ["zaloclawbot", "zalo-clawbot"],
+          "order": 82
+        },
+        "channelConfigs": {
+          "openclaw-zaloclawbot": {
+            "label": "Zalo ClawBot",
+            "description": "Personal Zalo assistant — QR-onboarded, owner-bound.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "install": {
+          "npmSpec": "@zalo-platforms/openclaw-zaloclawbot@0.1.0",
+          "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-nXXGdFWUKtyvV8nhKLW6h008sbjBvhViSUJmKcLLlB/+N1VeaWFwHZmVTkTRbYYpjPWPDHjl289+pUncwsYxcQ==",
+          "minHostVersion": ">=2026.4.10"
+        }
+      }
+    },
+    {
       "name": "@openclaw/discord",
       "description": "OpenClaw Discord channel plugin",
       "source": "official",

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -49,3 +49,9 @@ describeChannelCatalogEntryContract({
   npmSpec: "openclaw-plugin-yuanbao@2.13.1",
   alias: "yb",
 });
+
+describeChannelCatalogEntryContract({
+  channelId: "openclaw-zaloclawbot",
+  npmSpec: "@zalo-platforms/openclaw-zaloclawbot@0.1.4",
+  alias: "zaloclawbot",
+});


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**

Exposes the official Zalo ClawBot external channel (`@zalo-platforms/openclaw-zaloclawbot`) in the OpenClaw onboarding TUI and documentation. This solves the gap for a secure, vendor-backed, zero-configuration personal bot integration.

**Why does this matter now?**

Zalo users are currently using fragmented community channels. This adds the official, vendor-sanctioned personal channel, ensuring it can benefit directly from upcoming platform-side updates.

**What is the intended outcome?**

Users can select and automatically install `Zalo ClawBot` directly from the `openclaw onboard` QuickStart channel menu, and find a dedicated docs page at `/channels/zaloclawbot` (registered in docs nav, channels index, and the zh-CN i18n glossary — the latter because `docs:check-i18n-glossary` hardcodes `glossary.zh-CN.json` and requires an entry for any new doc title/link label).

**What is intentionally out of scope?**

The plugin source code itself (published on npm, to be open-sourced separately on GitHub).

**What does success look like?**

A user selects `Zalo ClawBot` in the `openclaw onboard` TUI; the plugin is fetched from npm (integrity-verified) and registered; the plugin's setup wizard renders the login QR in the TUI; after the user scans it the channel is enabled and the gateway restarts — all in one flow. (Verified end-to-end against `@0.1.4`; see Real behavior proof.)

**What should reviewers focus on?**

Verification of the catalog entry metadata (integrity hash, package name, host version requirement) and the correctness of the documentation page.

---

## Linked context

**Which issue does this close?**

Closes # (none, this is a community addition proposal)

**Which issues, PRs, or discussions are related?**

Related to an ongoing private discussion with Peter Steinberger regarding Zalo channel consolidation and regional maintainership.

**Was this requested by a maintainer or owner?**

Yes. We are aligned with Peter Steinberger on pursuing an official Zalo integration; coordination on next steps is still in progress, and this PR is the concrete artifact for that discussion.

---

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Exposing the official external Zalo ClawBot channel in the QuickStart onboarding menu, with an in-TUI QR login that installs the plugin from the catalog and completes the channel in a single `openclaw onboard` flow.
- Real environment tested: Published npm package `@zalo-platforms/openclaw-zaloclawbot@0.1.4` installed from the public registry by a patched OpenClaw build `2026.6.8` on macOS. The catalog pins `@0.1.4` with the registry `expectedIntegrity` sha512, so install is integrity-verified.
- Exact steps or command run after this patch: `node openclaw.mjs onboard` from a patched build (catalog includes this entry), selected `Zalo ClawBot (QR)` from the QuickStart channel menu, then scanned the terminal-rendered QR with the Zalo mobile app.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Redacted terminal capture of the patched `openclaw onboard` flow (menu → catalog install → in-TUI QR → scan → enable → gateway restart):

```
🦞 OpenClaw 2026.6.8 (f911a93)

QuickStart channel menu:
  ● Zalo ClawBot (QR)  (download from @zalo-platforms/openclaw-zaloclawbot@0.1.4)

◇  Installed Zalo ClawBot plugin
◇  Scan with Zalo (QR expires in 5 min)
   [QR rendered in the onboard TUI — encodes a short-lived (5 min) login token]
   If the QR doesn't render, open this URL in Zalo:
   https://zalo.me/s/[REDACTED]/?zbsk=[REDACTED]
◇  Waiting for Zalo login confirmation…
◇  Connected to Zalo. account clawbot-bot-[REDACTED]
◇  Selected channels
   Zalo ClawBot — Personal Zalo bot — QR-onboarded, owner-bound. Docs: zaloclawbot
◇  Gateway service restarted.
└  Onboarding complete.
```

https://github.com/user-attachments/assets/d4748cad-df35-4211-a8d2-d09562cb1f0c

<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/b89a4d84-96b2-40fc-a9bf-0e0dc0912977" />

- Observed result after fix: The host installed `@0.1.4` from npm (integrity-verified via the catalog), rendered the login QR inside the onboard TUI, accepted the scan (`Connected to Zalo`), enabled the channel, restarted the gateway, and finished onboarding — with no errors.
- What was not tested: Production webhook delivery (out of scope for the initial release's polling mode; the plugin defaults to long-polling for local gateway runs).
- Proof limitations or environment constraints: None affecting the shipped default. The published package defaults to the production endpoints (`bot.zaloplatforms.com` / `bot-api.zaloplatforms.com`); staging is only reachable via explicit `ZALOCLAWBOT_*` env overrides used during plugin development.

---

## Tests and validation

**Which commands did you run?**

`pnpm build && pnpm check && pnpm test:contracts:channels`, plus the targeted gates for the touched surfaces: `test/official-channel-catalog.test.ts` (third-party external entries must be exactly pinned with integrity), `src/plugins/official-external-plugin-catalog.test.ts`, `pnpm format:docs:check`, `pnpm docs:check-mdx`, `pnpm docs:check-i18n-glossary`, and `pnpm docs:check-links`. All gates were re-run after the review-fix commit.

**What regression coverage was added or updated?**

None (external channel metadata and docs only). The existing catalog policy test already enforces the exact-pin-with-integrity invariant over this entry.

**What failed before this fix, if known?**

N/A

**If no test was added, why not?**

This PR only adds external catalog metadata and a documentation page; it does not touch core channel engine code.

---

## Risk checklist

**Did user-visible behavior change?** `Yes`

Zalo ClawBot now appears in the QuickStart channel list and the docs channel nav.

**Did config, environment, or migration behavior change?** `No`

**Did security, auth, secrets, network, or tool execution behavior change?** `Yes` (scoped)

This adds a trusted official-catalog install entry, meaning the host will fetch and run a third-party npm package when the user selects this channel. Mitigated by the exact version pin plus `expectedIntegrity` sha512 hash, per the same policy as the existing third-party external entries (weixin, wecom, yuanbao). Authentication and network calls are delegated entirely to the external plugin, keeping OpenClaw core agnostic.

**What is the highest-risk area?**

Incorrect NPM package integrity hash or version mismatch.

**How is that risk mitigated?**

Verified the hash directly via `npm view @zalo-platforms/openclaw-zaloclawbot@0.1.4 dist.integrity` before updating the catalog, and the catalog policy test (`test/official-channel-catalog.test.ts`) enforces exact pinning with integrity for all third-party external entries. The manual install command in the docs uses the same exact pinned spec, so manual installs also get the catalog integrity check.

---

## Current review state

**What is the next action?**

Maintainer review for the upcoming release (the maintainer confirmed he'll land it for the next release). The only remaining items are a maintainer trust decision and the GitHub label - both maintainer-only.

**What is still waiting on author, maintainer, CI, or external proof?**

- Author: none. The latest ClawSweeper re-review's author-side P1 (the quick-install helper sitting outside the catalog trust boundary) is addressed — the `@zalo-platforms/openclaw-zaloclawbot-cli` installer no longer force-installs the plugin; it goes through the integrity-verified `plugins install <pkg>@<pin>` path, exactly like the manual install (republished as CLI `0.1.4`).
- Maintainer: trust/product approval for the `@zalo-platforms` package as an official catalog entry (ClawSweeper's "accept this package as trusted" option), and creation of the `channel: zaloclawbot` GitHub label referenced by the new labeler rule (labels cannot be created by external contributors).

**Which bot or reviewer comments were addressed?**

ClawSweeper review — all findings addressed in this PR's commits:

- [P1] Proof of the patched onboard flow → captured end-to-end against the published `@0.1.4` on host `2026.6.8` (see Real behavior proof). The plugin now contributes a `configureInteractive` setup wizard, so `openclaw onboard` renders the QR in-TUI and completes the channel in one flow — the proof is the changed onboarding surface, not the standalone login flow the earlier screenshot showed.
- [P2] Manual install bypassing the integrity pin → docs instruct the exact catalog-pinned spec (`@zalo-platforms/openclaw-zaloclawbot@0.1.4`), the only form the install planner attaches `expectedIntegrity` to.
- [P2] Docs route mismatch with published package metadata → the published plugin's `docsPath`/`docsLabel` align to `/channels/zaloclawbot`, the catalog pin + integrity hash track the published version, and a `docs.json` redirect `/channels/openclaw-zaloclawbot` → `/channels/zaloclawbot` resolves older metadata.
- [P3] Missing labeler coverage → added a `channel: zaloclawbot` rule for `docs/channels/zaloclawbot.md`.

ClawSweeper re-review (after the rebase) — proof accepted (`proof: sufficient`, video). Two P1s remained:

- [P1] Quick-install npx helper outside the catalog trust boundary (`docs/channels/zaloclawbot.md`) → the installer CLI (`@zalo-platforms/openclaw-zaloclawbot-cli`) no longer force-installs the plugin. It installs the catalog-pinned version through the integrity-verified `plugins install` path; upgrades uninstall the old version first instead of force-replacing it. Every documented install path is now catalog-backed, mirroring the already-merged `openclaw-weixin` quick-install. Republished as CLI `0.1.4`.
- [P1] Official-trust promotion of the package given plugin-owned JSON token storage under the state dir → this is a maintainer trust decision (ClawSweeper's "accept this package as trusted" option), not an in-repo repair. It is the same token-storage model and catalog-entry shape as the merged `openclaw-weixin` channel (`accounts/<id>.json` under the state dir). Raised with the maintainer (Vincent Koc) for reconfirmation.
