### PR TITLE
fix(plugins): wrap unreadable config schemas

### DIFF
--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -240,6 +240,34 @@ describe("schema validator", () => {
     ).toThrow("invalid schema");
   });
 
+  it("rejects unreadable JSON Schema objects with a schema error", () => {
+    const createSchema = () =>
+      new Proxy<Record<string, unknown>>(
+        {
+          type: "object",
+          properties: {
+            url: { type: "string" },
+          },
+        },
+        {
+          ownKeys() {
+            throw new Error("schema keys exploded");
+          },
+        },
+      );
+
+    for (const cache of [true, false]) {
+      expect(() =>
+        validateJsonSchemaValue({
+          cacheKey: `schema-validator.test.unreadable-schema.${cache}`,
+          schema: createSchema() as never,
+          value: { url: "https://example.test" },
+          cache,
+        }),
+      ).toThrow("invalid schema");
+    }
+  });
+
   it("rejects invalid JSON Schema constraint keyword values", () => {
     for (const [cacheKey, schema] of [
       [

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -51,22 +51,43 @@ const annotationOnlyFormats = [
   "uuid",
 ] as const;
 
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function invalidSchemaError(message: string): Error {
+  return new Error(sanitizeTerminalText(`invalid schema: ${message}`));
+}
+
+function runSchemaOperation<T>(operation: () => T): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("invalid schema:")) {
+      throw error;
+    }
+    throw invalidSchemaError(`schema is unreadable (${formatUnknownError(error)})`);
+  }
+}
+
 function fingerprintSchema(schema: JsonSchemaValue): string {
-  return JSON.stringify(schema);
+  return runSchemaOperation(() => JSON.stringify(schema));
 }
 
 function schemaHasDefaults(schema: unknown): boolean {
-  if (!schema || typeof schema !== "object") {
-    return false;
-  }
-  if (Array.isArray(schema)) {
-    return schema.some((item) => schemaHasDefaults(item));
-  }
-  const record = schema as Record<string, unknown>;
-  if (Object.hasOwn(record, "default")) {
-    return true;
-  }
-  return Object.values(record).some((value) => schemaHasDefaults(value));
+  return runSchemaOperation(() => {
+    if (!schema || typeof schema !== "object") {
+      return false;
+    }
+    if (Array.isArray(schema)) {
+      return schema.some((item) => schemaHasDefaults(item));
+    }
+    const record = schema as Record<string, unknown>;
+    if (Object.hasOwn(record, "default")) {
+      return true;
+    }
+    return Object.values(record).some((value) => schemaHasDefaults(value));
+  });
 }
 
 function cloneValidationValue<T>(value: T): T {
@@ -324,30 +345,42 @@ export function validateJsonSchemaValue(params: {
   applyDefaults?: boolean;
   cache?: boolean;
 }): { ok: true; value: unknown } | { ok: false; errors: JsonSchemaValidationError[] } {
-  const schemaError = findJsonSchemaShapeError(params.schema);
+  let schemaError: string | undefined;
+  try {
+    schemaError = findJsonSchemaShapeError(params.schema);
+  } catch (error) {
+    schemaError = `schema is unreadable (${formatUnknownError(error)})`;
+  }
   if (schemaError) {
-    throw new Error(sanitizeTerminalText(`invalid schema: ${schemaError}`));
+    throw invalidSchemaError(schemaError);
   }
 
   const useCache = params.cache !== false;
   if (!useCache) {
-    const validate = compileSchema(params.schema);
+    const validate = runSchemaOperation(() => compileSchema(params.schema));
     const value =
       params.applyDefaults && schemaHasDefaults(params.schema)
-        ? applyDefaultsWithPluginFormatSemantics(params.schema, cloneValidationValue(params.value))
+        ? runSchemaOperation(() =>
+            applyDefaultsWithPluginFormatSemantics(
+              params.schema,
+              cloneValidationValue(params.value),
+            ),
+          )
         : params.value;
-    const errors = checkSchema(validate, value);
+    const errors = runSchemaOperation(() => checkSchema(validate, value));
     if (!errors) {
       return { ok: true, value };
     }
     if (
       params.applyDefaults &&
       value !== params.value &&
-      isDefaultActivatedConditionalFailure({
-        schema: params.schema,
-        originalValue: params.value,
-        defaultedValue: value,
-      })
+      runSchemaOperation(() =>
+        isDefaultActivatedConditionalFailure({
+          schema: params.schema,
+          originalValue: params.value,
+          defaultedValue: value,
+        }),
+      )
     ) {
       return { ok: true, value };
     }
@@ -362,7 +395,7 @@ export function validateJsonSchemaValue(params: {
     !cached ||
     (cached.schema !== params.schema && cached.schemaFingerprint !== schemaFingerprint)
   ) {
-    const validate = compileSchema(params.schema);
+    const validate = runSchemaOperation(() => compileSchema(params.schema));
     cached = {
       hasDefaults: params.applyDefaults ? schemaHasDefaults(params.schema) : false,
       validate,
@@ -376,20 +409,24 @@ export function validateJsonSchemaValue(params: {
 
   const value =
     params.applyDefaults && cached.hasDefaults
-      ? applyDefaultsWithPluginFormatSemantics(params.schema, cloneValidationValue(params.value))
+      ? runSchemaOperation(() =>
+          applyDefaultsWithPluginFormatSemantics(params.schema, cloneValidationValue(params.value)),
+        )
       : params.value;
-  const errors = checkSchema(cached.validate, value);
+  const errors = runSchemaOperation(() => checkSchema(cached.validate, value));
   if (!errors) {
     return { ok: true, value };
   }
   if (
     params.applyDefaults &&
     value !== params.value &&
-    isDefaultActivatedConditionalFailure({
-      schema: params.schema,
-      originalValue: params.value,
-      defaultedValue: value,
-    })
+    runSchemaOperation(() =>
+      isDefaultActivatedConditionalFailure({
+        schema: params.schema,
+        originalValue: params.value,
+        defaultedValue: value,
+      }),
+    )
   ) {
     return { ok: true, value };
   }


### PR DESCRIPTION
## Summary
- wrap plugin JSON-schema validation internals so unreadable schema objects report `invalid schema` instead of raw proxy errors
- cover both cached and uncached validation paths for schema readability failures
- keep the existing validation-result contract unchanged for normal config value failures

## Verification
- `node scripts/run-vitest.mjs src/plugins/schema-validator.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --write src/plugins/schema-validator.ts src/plugins/schema-validator.test.ts`
- `./node_modules/.bin/oxlint src/plugins/schema-validator.ts src/plugins/schema-validator.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fresh-PR `pnpm check:changed`: provider `aws`, run `run_a0ba6b56dddf`, lease `cbx_99b9924884e1`, slug `coral-prawn`, lanes `core`, `coreTests`, exit 0, command 3m48.287s, total 4m6.046s, lease stopped

## Real behavior proof
Behavior addressed: plugin JSON-schema validation no longer leaks raw proxy/schema-read errors when a plugin-owned schema object is unreadable.
Real environment tested: Local focused Vitest lane plus AWS Crabbox fresh-PR changed gate on Linux Node 24.15.0.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/schema-validator.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89587 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`
Evidence after fix: focused test passed 33 tests; remote changed gate passed lanes `core` and `coreTests` in run `run_a0ba6b56dddf`.
Observed result after fix: unreadable schema objects throw the existing sanitized `invalid schema` error shape instead of `schema keys exploded`.
What was not tested: full repository suite.
