### PR TITLE
fix(agents): guard tool definition schema reads

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -10,6 +10,7 @@ import {
   toToolDefinitions,
 } from "./agent-tool-definition-adapter.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
+import { inspectRuntimeToolInputSchemas } from "./tool-schema-projection.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -43,6 +44,28 @@ async function executeTool(tool: AgentTool, callId: string) {
 }
 
 describe("agent tool definition adapter", () => {
+  it("keeps unreadable tool parameter schemas quarantinable", () => {
+    const tool = {
+      name: "fuzzplugin_move_angles",
+      label: "Fuzz Tool",
+      description: "bad schema",
+      get parameters() {
+        throw new Error("schema getter exploded");
+      },
+      execute: async () => ({ content: [] }),
+    } as unknown as AgentTool;
+
+    const defs = toToolDefinitions([tool]);
+    expect(defs[0]?.name).toBe("fuzzplugin_move_angles");
+    expect(inspectRuntimeToolInputSchemas(defs)).toEqual([
+      {
+        toolName: "fuzzplugin_move_angles",
+        toolIndex: 0,
+        violations: ['fuzzplugin_move_angles.parameters.type must be "object"'],
+      },
+    ]);
+  });
+
   it("wraps tool errors into a tool result", async () => {
     const result = await executeThrowingTool("boom", "call1");
 

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -53,6 +53,10 @@ const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
 const EXEC_COMMAND_PARAM_KEYS = new Set(["command", "cmd"]);
+const UNREADABLE_TOOL_PARAMETERS_SCHEMA = Object.freeze({
+  type: "array",
+  description: "Unreadable source tool parameter schema",
+}) as unknown as ToolDefinition["parameters"];
 
 export type ClientToolCallRecorder =
   | ((toolName: string, params: Record<string, unknown>) => void)
@@ -64,6 +68,39 @@ export type ClientToolCallRecorder =
 
 function isAbortSignal(value: unknown): value is AbortSignal {
   return typeof value === "object" && value !== null && "aborted" in value;
+}
+
+function readAgentToolField<TField extends keyof AnyAgentTool>(
+  tool: AnyAgentTool,
+  field: TField,
+): { ok: true; value: AnyAgentTool[TField] } | { ok: false } {
+  try {
+    return { ok: true, value: tool[field] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readAgentToolName(tool: AnyAgentTool): string {
+  const field = readAgentToolField(tool, "name");
+  if (!field.ok || typeof field.value !== "string" || !field.value) {
+    return "tool";
+  }
+  return field.value;
+}
+
+function readAgentToolStringField(
+  tool: AnyAgentTool,
+  field: "label" | "description",
+  fallback: string,
+): string {
+  const value = readAgentToolField(tool, field);
+  return value.ok && typeof value.value === "string" ? value.value : fallback;
+}
+
+function readAgentToolParameters(tool: AnyAgentTool): ToolDefinition["parameters"] {
+  const value = readAgentToolField(tool, "parameters");
+  return value.ok ? value.value : UNREADABLE_TOOL_PARAMETERS_SCHEMA;
 }
 
 function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteArgsLegacy {
@@ -351,14 +388,15 @@ export function toToolDefinitions(
   hookContext?: HookContext,
 ): ToolDefinition[] {
   return tools.map((tool) => {
-    const name = tool.name || "tool";
+    const name = readAgentToolName(tool);
     const normalizedName = normalizeToolName(name);
     const beforeHookWrapped = isToolWrappedWithBeforeToolCallHook(tool);
+    const parameters = readAgentToolParameters(tool);
     return {
       name,
-      label: tool.label ?? name,
-      description: tool.description ?? "",
-      parameters: tool.parameters,
+      label: readAgentToolStringField(tool, "label", name),
+      description: readAgentToolStringField(tool, "description", ""),
+      parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;


### PR DESCRIPTION
## Summary
- guard agent tool definition metadata reads so a hostile or broken tool schema getter cannot crash definition adaptation
- represent unreadable parameter schemas as an invalid schema sentinel, letting runtime schema inspection quarantine the tool instead of silently making it callable
- add a regression covering an unreadable `parameters` getter through `toToolDefinitions`

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --write src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- AWS Crabbox fresh-PR changed gate: `run_7b14851d2861`, provider `aws`, lease `cbx_0edba2027ad0`, slug `golden-prawn`, lanes `core`, `coreTests`, exit 0, command 4m3.778s, total 4m20.268s, lease stopped

## Real behavior proof
Behavior addressed: agent tool definition adaptation no longer throws when a plugin/tool exposes an unreadable `parameters` schema getter.
Real environment tested: local OpenClaw source worktree on Node 24.15.0 for focused regression proof; AWS Crabbox Linux fresh-PR checkout for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-tool-definition-adapter.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89592 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.
Evidence after fix: the regression test builds a tool with `parameters` throwing `schema getter exploded`; `toToolDefinitions` returns a definition and `inspectRuntimeToolInputSchemas` reports `fuzzplugin_move_angles.parameters.type must be "object"`. Remote changed gate `run_7b14851d2861` passed with lanes `core`, `coreTests`.
Observed result after fix: adapter conversion completed, the focused test file passed with 19 tests, and remote `pnpm check:changed` exited 0.
What was not tested: full repository suite beyond changed-gate scope.
