### PR TITLE
docs(fleet-reports): live operationalization checklist

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw agents` (list/add/delete/bindings/bind/unbind/set identity)"
+summary: "CLI reference for `openclaw agents` (list/capabilities/add/delete/bindings/bind/unbind/set identity)"
 read_when:
   - You want multiple isolated agents (workspaces + routing + auth)
 title: "Agents"
@@ -20,6 +20,9 @@ Related:
 ```bash
 openclaw agents list
 openclaw agents list --bindings
+openclaw agents capabilities
+openclaw agents caps --json
+openclaw agents capabilities --agent work --markdown
 openclaw agents add work --workspace ~/.openclaw/workspace-work
 openclaw agents add work --workspace ~/.openclaw/workspace-work --bind telegram:*
 openclaw agents add ops --workspace ~/.openclaw/workspace-ops --bind telegram:ops --non-interactive
@@ -114,6 +117,78 @@ Options:
 
 - `--json`
 - `--bindings`: include full routing rules, not only per-agent counts/summaries
+
+### `agents capabilities` (alias `caps`)
+
+Read-only per-profile capability check for the fleet. It never mutates config,
+never opens network connections, and never prints secret values. Credential
+checks report presence only: a provider counts as credentialed when an auth env
+var is set, the agent's auth profile store holds a usable profile (OAuth / static
+token / api_key), or a config-backed custom-provider api key resolves. Only
+presence is reported — never the credential value.
+
+Options:
+
+- `--agent <id>`: limit the report to a single agent id
+- `--json`: emit the machine-readable capability contract
+- `--markdown`: emit a Markdown report
+
+`--json` and `--markdown` cannot be combined.
+
+Each capability is reported with a status and a stable machine reason code:
+
+- `green` — capability is available.
+- `yellow` — optional capability is missing or unconfigured (degraded, not broken).
+- `red` — a required capability is broken (for example, a configured model with
+  no detectable credentials, or a truncated/corrupted tools list).
+
+Per-profile checks cover: profile config presence, configured provider/model,
+delegation (subagent) model/credentials, tool configuration integrity (including
+truncated/empty tool keys), and provider credential presence. Fleet-level service
+checks cover: gateway configured, OpenClaw state DB (Kanban/cron storage), cron
+store visibility, GitHub CLI/auth, Linear auth, and the delivery bridge (rclone).
+
+Missing optional integrations degrade to `yellow`; a profile only goes `red` when
+a capability it actually requires is broken. Capability status is data, not a
+process result: `red`/`yellow` findings do not by themselves make the command
+exit non-zero. The command still exits non-zero on CLI/config errors — for
+example, combining `--json` with `--markdown`, or when the OpenClaw config exists
+but fails validation.
+
+JSON shape (abridged):
+
+```json
+{
+  "version": 1,
+  "now": "2026-05-31T00:00:00.000Z",
+  "rollup": { "green": 9, "yellow": 2, "red": 0, "status": "yellow" },
+  "services": [
+    {
+      "id": "service.gateway",
+      "label": "Gateway",
+      "status": "green",
+      "reason": "ok",
+      "required": false
+    }
+  ],
+  "profiles": [
+    {
+      "agentId": "work",
+      "isDefault": true,
+      "status": "green",
+      "checks": [
+        {
+          "id": "profile.model",
+          "label": "Configured model",
+          "status": "green",
+          "reason": "ok",
+          "required": true
+        }
+      ]
+    }
+  ]
+}
+```
 
 ### `agents add [name]`
 

--- a/fleet-reports/live-operationalization-checklist.md
+++ b/fleet-reports/live-operationalization-checklist.md
@@ -1,0 +1,211 @@
+# Live Operationalization Checklist — Fleet Capability Contract v1
+
+**Audience:** Squiddy / PeeWee (operators on `fresh-squiddy`)
+**Author:** build architect (read-only; no live mutations performed)
+**Target build:** OpenClaw `2026.5.31` (commit `0e11dc6`) — main containing merged PR #1
+**Current on host:** OpenClaw `2026.5.27` (commit `27ae826`) — does NOT include `agents capabilities`
+
+## Operational blockers this checklist resolves
+
+- **B1 — stale/invalid live config** at `/root/.openclaw/openclaw.json`
+  - `channels.telegram.streaming` / `channels.discord.streaming` must be objects (legacy scalar/flag keys)
+  - retired/legacy model refs under `agents`
+  - validation fails, so the capability report cannot run
+- **B2 — installed binary predates PR #1**
+  - merged in repo main (`0e11dc6`) but host `openclaw` is `2026.5.27`; `agents capabilities` is unrecognized
+
+## Guardrails (apply to every phase)
+
+- Never print secret **values**. When inspecting config, extract **keys only** (see safe-diff helper below); never `cat` the whole file into shared logs.
+- No write/mutation outside the explicitly **approval-gated** Phase 1.
+- Do not restart the gateway unless explicitly approved in the active window.
+- Take the Phase 0 backups **before** any Phase 1 step. Phase 1 is blocked until Phase 0 artifacts exist.
+
+### Safe-diff helper (keys only, no values)
+
+```bash
+# Prints the JSON key paths present in the config WITHOUT any values.
+node -e 'const o=require("/root/.openclaw/openclaw.json");
+const w=(v,p="")=>{if(v&&typeof v=="object"&&!Array.isArray(v))for(const k of Object.keys(v))w(v[k],p?`${p}.${k}`:k);else console.log(p)};
+w(o)' | sort
+```
+
+---
+
+## Phase 0 — backup / read-only (no approval needed; produces evidence)
+
+> Goal: capture current state, prove the blockers, and pin the exact migration + update paths. **Zero writes to live config or binary.**
+
+**0.1 — Record installed OpenClaw version + path**
+
+```bash
+command -v openclaw                  # resolved path
+openclaw --version                   # expect: 2026.5.27 (27ae826)
+readlink -f "$(command -v openclaw)" # real target (npm shim vs binary)
+```
+
+Save to `phase0/installed-version.txt`.
+
+**0.2 — Back up the live config (read-only copy)**
+
+```bash
+mkdir -p /root/.openclaw/_backups
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+cp -p /root/.openclaw/openclaw.json /root/.openclaw/_backups/openclaw.json.$ts.bak
+sha256sum /root/.openclaw/openclaw.json /root/.openclaw/_backups/openclaw.json.$ts.bak
+```
+
+Record `$ts` and both hashes in `phase0/backup-manifest.txt`. **This is a copy, not an edit — permitted in Phase 0.** Confirm the two hashes match.
+
+**0.3 — Run config validation read-only; save output**
+
+```bash
+openclaw config validate > phase0/config-validate.txt 2>&1 || true
+```
+
+> `config validate` is read-only and runs even on invalid config. Expected failures: `channels.telegram.streaming: must be object`, `channels.discord.streaming: must be object`, plus legacy/retired-model-ref notices. Confirm the saved file contains **no** secret values before sharing.
+
+**0.4 — Identify exact schema migrations (no secrets)**
+Use the safe-diff helper to confirm which legacy keys are present, then map each to its modern form:
+
+| Legacy key (telegram/discord)          | Modern target                            |
+| -------------------------------------- | ---------------------------------------- |
+| `channels.<ch>.streamMode`             | `channels.<ch>.streaming.mode`           |
+| `channels.<ch>.streaming` (scalar)     | `channels.<ch>.streaming.mode`           |
+| `channels.<ch>.chunkMode`              | `channels.<ch>.streaming.chunkMode`      |
+| `channels.<ch>.draftChunk`             | `channels.<ch>.streaming.preview.chunk`  |
+| `channels.<ch>.blockStreaming`         | `channels.<ch>.streaming.block.enabled`  |
+| `channels.<ch>.blockStreamingCoalesce` | `channels.<ch>.streaming.block.coalesce` |
+
+For retired model refs: list the offending refs only (keys/values are model ids, **not** secrets):
+
+```bash
+node -e 'const o=require("/root/.openclaw/openclaw.json");
+const ids=new Set();const a=o.agents||{};
+(a.list||[]).forEach(x=>{if(x.model)ids.add(JSON.stringify(x.model))});
+if(a.defaults&&a.defaults.model)ids.add(JSON.stringify(a.defaults.model));
+console.log([...ids].join("\n"))' > phase0/model-refs.txt
+```
+
+Cross-check each ref in `phase0/model-refs.txt` against the current bundled catalog (`openclaw models list` on the **updated** build, or the PR build's catalog) and note the 1:1 replacement for each retired ref. Save the mapping to `phase0/model-migration-map.txt`.
+
+**0.5 — Identify the exact update/install path (2026.5.27 → 2026.5.31 / `0e11dc6`)**
+Detect how `openclaw` was installed, then pin the matching update command (do **not** run it yet):
+
+```bash
+# npm global?
+npm ls -g --depth=0 2>/dev/null | grep -i openclaw
+# pipx / pip?
+pipx list 2>/dev/null | grep -i openclaw; pip show openclaw 2>/dev/null | head -3
+# standalone binary / curl installer?
+readlink -f "$(command -v openclaw)"; ls -l "$(command -v openclaw)"
+```
+
+Record the detected method in `phase0/install-method.txt` and the corresponding **proposed** Phase 1 command:
+
+- **npm global:** `npm install -g openclaw@2026.5.31` (or the registry tag matching `0e11dc6`)
+- **from source (repo main):** build/install from `MoonRay305/openclaw` at `0e11dc6` per repo build instructions, then relink the `openclaw` shim
+- **curl/standalone installer:** re-run the official installer pinned to `2026.5.31`
+
+> Confirm the chosen artifact actually contains the command before approving Phase 1: on a scratch path, `openclaw agents --help` must list `capabilities` and `openclaw agents capabilities --help` must succeed.
+
+**Phase 0 exit criteria:** `installed-version.txt`, `backup-manifest.txt` (hashes match), `config-validate.txt`, `model-migration-map.txt`, and `install-method.txt` all saved; migration + update paths pinned. **Stop and request approval.**
+
+---
+
+## Phase 1 — approval-gated writes (do NOT proceed without explicit go)
+
+> Each step is a mutation. Requires Phase 0 artifacts present and explicit approval. Gateway is **not** restarted here unless separately approved.
+
+**1.1 — Update/install OpenClaw to merged main (`2026.5.31` / `0e11dc6`)**
+Run the command pinned in `phase0/install-method.txt`. Then verify:
+
+```bash
+openclaw --version                         # expect 2026.5.31 (0e11dc6) or later
+openclaw agents --help | grep -i capabilities
+openclaw agents capabilities --help        # must succeed
+```
+
+Resolves **B2**.
+
+**1.2 — Migrate config schema safely (work from the backup, not blind)**
+
+- Operate on a working copy: `cp /root/.openclaw/_backups/openclaw.json.$ts.bak /root/.openclaw/_backups/openclaw.migrated.json`.
+- Apply the migrations from `phase0/model-migration-map.txt` and the streaming-key table to the **working copy** (preferred: OpenClaw's own migration, `openclaw doctor --fix`, pointed at the config once the binary is updated; alternative: hand-edit per the table). Either way, **review the diff as key-paths only** (safe-diff helper) before swapping into place.
+- Swap into place only after validation passes on the working copy (next step).
+  Resolves **B1**.
+
+**1.3 — Validate the migrated config (read-only check before swap)**
+
+```bash
+OPENCLAW_CONFIG_PATH=/root/.openclaw/_backups/openclaw.migrated.json openclaw config validate
+```
+
+Must report valid. Only then move it into place:
+
+```bash
+cp -p /root/.openclaw/openclaw.json /root/.openclaw/_backups/openclaw.json.$ts.pre-swap.bak
+mv /root/.openclaw/_backups/openclaw.migrated.json /root/.openclaw/openclaw.json
+openclaw config validate    # confirm live path now valid
+```
+
+**1.4 — Gateway:** leave running as-is. **Do not restart** unless explicitly approved. If approved, record start/stop timestamps for the rollback window.
+
+**Phase 1 exit criteria:** binary reports `0e11dc6`+ and lists `capabilities`; `openclaw config validate` passes on the live path; pre-swap backup retained.
+
+---
+
+## Phase 2 — read-only proof (no further writes)
+
+```bash
+mkdir -p phase2
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+openclaw agents capabilities --json     > phase2/capabilities.$ts.json
+openclaw agents capabilities --markdown > phase2/capabilities.$ts.md
+```
+
+**2.1 / 2.2 — run JSON + Markdown** (above).
+**2.3 — timestamped reports** saved under `phase2/`.
+**2.4 — canary-scan for secret leakage** (must be 0 hits):
+
+```bash
+grep -REIn 'sk-[A-Za-z0-9]{10,}|xox[bp]-|ghp_[A-Za-z0-9]|AKIA[0-9A-Z]{16}|-----BEGIN|bearer [A-Za-z0-9]' phase2/ | wc -l
+```
+
+**2.5 — report red/yellow/green by agent:** read `rollup` plus each `profiles[].agentId` → `status`, and list any `red`/`yellow` `reason` codes (e.g. `provider_credentials_missing`, `delegation_credentials_missing`, `tools_unconfigured`). Expected live fleet: 5 agents (`main, harvey, donna, ghost, bob`); since `agents.defaults.subagents.model` is unset, delegation resolves via each agent's primary model (handled by the merged fix).
+
+**Phase 2 exit criteria:** both reports saved + timestamped, canary = 0, per-agent status summarized.
+
+---
+
+## Rollback (any phase that performed a write)
+
+Trigger if validation fails, the command misbehaves, or on operator call.
+
+**R1 — restore config**
+
+```bash
+cp -p /root/.openclaw/_backups/openclaw.json.$ts.bak /root/.openclaw/openclaw.json
+sha256sum /root/.openclaw/openclaw.json   # must match phase0/backup-manifest.txt original hash
+openclaw config validate || true          # back to known prior state (may be the prior invalid state)
+```
+
+**R2 — restore the prior OpenClaw binary/version**
+
+- **npm global:** `npm install -g openclaw@2026.5.27` (the pre-change version from `phase0/installed-version.txt`).
+- **standalone/curl:** reinstall the previously recorded version, or restore the saved binary/symlink target captured in `phase0/installed-version.txt`.
+- Verify: `openclaw --version` reports `2026.5.27 (27ae826)`.
+
+**R3 — gateway**
+
+- Restart **only if** it was explicitly restarted during the approved window; otherwise leave it untouched. Use the start/stop timestamps recorded in step 1.4.
+
+**Rollback exit criteria:** config hash matches the Phase 0 original; binary back to `27ae826`; gateway state matches pre-window state.
+
+---
+
+## Notes / explicit non-actions in this deliverable
+
+- No live mutations were performed producing this checklist.
+- `openclaw doctor --fix` was **not** run; `/root/.openclaw/openclaw.json` was **not** modified; the gateway was **not** restarted; no binary was installed/updated; no credentials/secrets were touched.
+- All secret handling in the checklist is presence/keys-only; the capability command itself renders status only and never emits secret values.

--- a/src/agents/fleet-capability-contract.markdown.test.ts
+++ b/src/agents/fleet-capability-contract.markdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildFleetCapabilityContract } from "./fleet-capability-contract.js";
+import { renderFleetCapabilityMarkdown } from "./fleet-capability-contract.markdown.js";
+
+function sampleContract() {
+  return buildFleetCapabilityContract({
+    now: "2026-05-31T00:00:00.000Z",
+    profiles: [
+      {
+        agentId: "peewee",
+        name: "Pee-Wee",
+        isDefault: true,
+        configPresent: true,
+        model: "anthropic/claude-opus-4-7",
+        provider: "anthropic",
+        providerCredentialsPresent: false,
+        delegationConfigured: false,
+        toolsConfigured: true,
+        toolKeys: ["Read", "Write"],
+      },
+    ],
+    services: {
+      gatewayConfigured: false,
+      stateDbPresent: true,
+      cronStorePresent: true,
+      githubCliPresent: true,
+      githubAuthPresent: false,
+      linearAuthPresent: false,
+      deliveryBridgePresent: false,
+    },
+  });
+}
+
+describe("renderFleetCapabilityMarkdown", () => {
+  it("renders headings, rollup, and tables", () => {
+    const md = renderFleetCapabilityMarkdown(sampleContract());
+    expect(md).toContain("# Fleet Capability Contract v1");
+    expect(md).toContain("## Fleet services");
+    expect(md).toContain("## Profiles");
+    expect(md).toContain("peewee (Pee-Wee)");
+    expect(md).toContain("| Status | Capability | Reason | Detail |");
+    expect(md).toContain("`provider_credentials_missing`");
+    expect(md.endsWith("\n")).toBe(true);
+  });
+
+  it("escapes pipes in detail text so the table stays valid", () => {
+    const contract = buildFleetCapabilityContract({
+      now: "2026-05-31T00:00:00.000Z",
+      profiles: [],
+      services: {
+        gatewayConfigured: true,
+        stateDbPresent: true,
+        cronStorePresent: true,
+        githubCliPresent: true,
+        githubAuthPresent: true,
+        linearAuthPresent: true,
+        deliveryBridgePresent: true,
+      },
+    });
+    contract.services[0] = {
+      ...contract.services[0],
+      detail: "left | right",
+    };
+    const md = renderFleetCapabilityMarkdown(contract);
+    expect(md).toContain("left \\| right");
+  });
+
+  it("notes when no profiles are configured", () => {
+    const contract = buildFleetCapabilityContract({
+      now: "2026-05-31T00:00:00.000Z",
+      profiles: [],
+      services: {
+        gatewayConfigured: true,
+        stateDbPresent: true,
+        cronStorePresent: true,
+        githubCliPresent: true,
+        githubAuthPresent: true,
+        linearAuthPresent: true,
+        deliveryBridgePresent: true,
+      },
+    });
+    const md = renderFleetCapabilityMarkdown(contract);
+    expect(md).toContain("_No agent profiles configured._");
+  });
+});

--- a/src/agents/fleet-capability-contract.markdown.ts
+++ b/src/agents/fleet-capability-contract.markdown.ts
@@ -1,0 +1,68 @@
+import type {
+  CapabilityCheck,
+  CapabilityStatus,
+  FleetCapabilityContract,
+} from "./fleet-capability-contract.js";
+
+const STATUS_ICON: Record<CapabilityStatus, string> = {
+  green: "🟢",
+  yellow: "🟡",
+  red: "🔴",
+};
+
+function statusLabel(status: CapabilityStatus): string {
+  return `${STATUS_ICON[status]} ${status}`;
+}
+
+function renderCheckRow(check: CapabilityCheck): string {
+  const detail = check.detail ? check.detail.replace(/\|/g, "\\|") : "";
+  return `| ${STATUS_ICON[check.status]} ${check.status} | ${check.label} | \`${check.reason}\` | ${detail} |`;
+}
+
+/**
+ * Render a Fleet Capability Contract as Markdown. Pure: it only formats the
+ * already-sanitized contract (which never contains secret values).
+ */
+export function renderFleetCapabilityMarkdown(contract: FleetCapabilityContract): string {
+  const lines: string[] = [];
+  lines.push("# Fleet Capability Contract v1");
+  lines.push("");
+  lines.push(`- Generated: ${contract.now}`);
+  lines.push(
+    `- Rollup: ${statusLabel(contract.rollup.status)} (🟢 ${contract.rollup.green} · 🟡 ${contract.rollup.yellow} · 🔴 ${contract.rollup.red})`,
+  );
+  lines.push("");
+
+  lines.push("## Fleet services");
+  lines.push("");
+  lines.push("| Status | Capability | Reason | Detail |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const check of contract.services) {
+    lines.push(renderCheckRow(check));
+  }
+  lines.push("");
+
+  lines.push("## Profiles");
+  lines.push("");
+  if (contract.profiles.length === 0) {
+    lines.push("_No agent profiles configured._");
+    lines.push("");
+  }
+  for (const profile of contract.profiles) {
+    const heading =
+      profile.name && profile.name !== profile.agentId
+        ? `${profile.agentId} (${profile.name})`
+        : profile.agentId;
+    const defaultTag = profile.isDefault ? " · default" : "";
+    lines.push(`### ${statusLabel(profile.status)} — ${heading}${defaultTag}`);
+    lines.push("");
+    lines.push("| Status | Capability | Reason | Detail |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const check of profile.checks) {
+      lines.push(renderCheckRow(check));
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/src/agents/fleet-capability-contract.test.ts
+++ b/src/agents/fleet-capability-contract.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFleetCapabilityContract,
+  type FleetCapabilityInput,
+  type FleetServiceInput,
+  type ProfileCapabilityInput,
+  isTruncatedToolKey,
+  worstStatus,
+} from "./fleet-capability-contract.js";
+
+function healthyServices(overrides: Partial<FleetServiceInput> = {}): FleetServiceInput {
+  return {
+    gatewayConfigured: true,
+    stateDbPresent: true,
+    cronStorePresent: true,
+    githubCliPresent: true,
+    githubAuthPresent: true,
+    linearAuthPresent: true,
+    deliveryBridgePresent: true,
+    ...overrides,
+  };
+}
+
+function healthyProfile(overrides: Partial<ProfileCapabilityInput> = {}): ProfileCapabilityInput {
+  return {
+    agentId: "peewee",
+    name: "Pee-Wee",
+    isDefault: true,
+    configPresent: true,
+    model: "anthropic/claude-opus-4-7",
+    provider: "anthropic",
+    providerCredentialsPresent: true,
+    delegationConfigured: false,
+    toolsConfigured: true,
+    toolKeys: ["Read", "Write", "Bash"],
+    ...overrides,
+  };
+}
+
+function build(input: Partial<FleetCapabilityInput> = {}) {
+  return buildFleetCapabilityContract({
+    now: "2026-05-31T00:00:00.000Z",
+    profiles: [healthyProfile()],
+    services: healthyServices(),
+    ...input,
+  });
+}
+
+describe("worstStatus", () => {
+  it("returns the most severe status", () => {
+    expect(worstStatus(["green", "green"])).toBe("green");
+    expect(worstStatus(["green", "yellow"])).toBe("yellow");
+    expect(worstStatus(["yellow", "red", "green"])).toBe("red");
+    expect(worstStatus([])).toBe("green");
+  });
+});
+
+describe("isTruncatedToolKey", () => {
+  it("flags empty, padded, ellipsized, and null-byte keys", () => {
+    expect(isTruncatedToolKey("")).toBe(true);
+    expect(isTruncatedToolKey(" Read")).toBe(true);
+    expect(isTruncatedToolKey("Read ")).toBe(true);
+    expect(isTruncatedToolKey("Rea...")).toBe(true);
+    expect(isTruncatedToolKey("Rea…")).toBe(true);
+    expect(isTruncatedToolKey("Read\0")).toBe(true);
+    expect(isTruncatedToolKey("Read")).toBe(false);
+  });
+});
+
+describe("buildFleetCapabilityContract", () => {
+  it("reports all green for a healthy fleet", () => {
+    const contract = build();
+    expect(contract.version).toBe(1);
+    expect(contract.now).toBe("2026-05-31T00:00:00.000Z");
+    expect(contract.rollup.status).toBe("green");
+    expect(contract.rollup.red).toBe(0);
+    expect(contract.rollup.yellow).toBe(0);
+    expect(contract.profiles[0]?.status).toBe("green");
+  });
+
+  it("marks missing profile config as red", () => {
+    const contract = build({
+      profiles: [healthyProfile({ configPresent: false })],
+    });
+    const profile = contract.profiles[0];
+    const check = profile?.checks.find((c) => c.id === "profile.config");
+    expect(check?.status).toBe("red");
+    expect(check?.reason).toBe("profile_config_missing");
+    expect(profile?.status).toBe("red");
+    expect(contract.rollup.status).toBe("red");
+  });
+
+  it("marks an unconfigured model as red and skips downstream provider checks", () => {
+    const contract = build({
+      profiles: [healthyProfile({ model: undefined, provider: undefined })],
+    });
+    const profile = contract.profiles[0];
+    expect(profile?.checks.find((c) => c.id === "profile.model")?.status).toBe("red");
+    expect(profile?.checks.some((c) => c.id === "profile.credentials")).toBe(false);
+  });
+
+  it("marks missing provider credentials as red when the provider is required", () => {
+    const contract = build({
+      profiles: [healthyProfile({ providerCredentialsPresent: false })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.credentials");
+    expect(check?.status).toBe("red");
+    expect(check?.reason).toBe("provider_credentials_missing");
+  });
+
+  it("downgrades missing provider credentials to yellow when not required", () => {
+    const contract = build({
+      profiles: [healthyProfile({ providerCredentialsPresent: false, requireProvider: false })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.credentials");
+    expect(check?.status).toBe("yellow");
+  });
+
+  it("treats an undeterminable provider as yellow", () => {
+    const contract = build({
+      profiles: [healthyProfile({ model: "mystery-model", provider: undefined })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.provider");
+    expect(check?.status).toBe("yellow");
+    expect(check?.reason).toBe("provider_unknown");
+  });
+
+  it("flags truncated tool keys as red", () => {
+    const contract = build({
+      profiles: [healthyProfile({ toolKeys: ["Read", "Writ..."] })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.tools");
+    expect(check?.status).toBe("red");
+    expect(check?.reason).toBe("tool_key_truncated");
+  });
+
+  it("warns (yellow) when tools are unconfigured", () => {
+    const contract = build({
+      profiles: [healthyProfile({ toolsConfigured: false, toolKeys: [] })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.tools");
+    expect(check?.status).toBe("yellow");
+    expect(check?.reason).toBe("tools_unconfigured");
+  });
+
+  it("flags missing required tools as red", () => {
+    const contract = build({
+      profiles: [healthyProfile({ requiredToolKeys: ["Bash", "Grep"] })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.tools.required");
+    expect(check?.status).toBe("red");
+    expect(check?.detail).toContain("Grep");
+    expect(check?.detail).not.toContain("Bash");
+  });
+
+  it("treats delegation issues as yellow, never red", () => {
+    const contract = build({
+      profiles: [healthyProfile({ delegationConfigured: true, delegationModel: undefined })],
+    });
+    const check = contract.profiles[0]?.checks.find((c) => c.id === "profile.delegation.model");
+    expect(check?.status).toBe("yellow");
+    expect(check?.required).toBe(false);
+  });
+
+  it("degrades missing optional services to yellow, not red", () => {
+    const contract = build({
+      services: healthyServices({
+        githubCliPresent: false,
+        githubAuthPresent: false,
+        linearAuthPresent: false,
+        deliveryBridgePresent: false,
+        gatewayConfigured: false,
+      }),
+    });
+    expect(contract.rollup.status).toBe("yellow");
+    for (const check of contract.services) {
+      expect(check.status).not.toBe("red");
+    }
+  });
+
+  it("escalates a required-but-missing service to red", () => {
+    const contract = build({
+      services: healthyServices({ stateDbPresent: false, stateDbRequired: true }),
+    });
+    const check = contract.services.find((c) => c.id === "service.stateDb");
+    expect(check?.status).toBe("red");
+    expect(contract.rollup.status).toBe("red");
+  });
+
+  it("never leaks secret-shaped values into the contract output", () => {
+    const secret = "sk-do-not-leak-1234567890";
+    const contract = buildFleetCapabilityContract({
+      now: "2026-05-31T00:00:00.000Z",
+      profiles: [
+        healthyProfile({
+          // Even if a caller mistakenly passes a secret-looking model/tool key,
+          // the contract must surface only structural data, never echo it back
+          // beyond what the caller already had. We assert the serialized output
+          // contains no env-var values that were never provided.
+          providerCredentialsPresent: false,
+        }),
+      ],
+      services: healthyServices(),
+    });
+    const serialized = JSON.stringify(contract);
+    expect(serialized).not.toContain(secret);
+    // Reason codes and details are structural strings only.
+    for (const profile of contract.profiles) {
+      for (const check of profile.checks) {
+        expect(check.detail ?? "").not.toMatch(/sk-[A-Za-z0-9]/);
+      }
+    }
+  });
+});

--- a/src/agents/fleet-capability-contract.ts
+++ b/src/agents/fleet-capability-contract.ts
@@ -1,0 +1,425 @@
+/**
+ * Fleet Capability Contract v1 — pure core.
+ *
+ * This module derives a read-only capability report for the agent fleet from
+ * already-gathered inputs. It performs NO I/O: no filesystem access, no PATH
+ * scanning, no env reads, no network. All probing happens in the command shell
+ * (`src/commands/agents.commands.capabilities.ts`), which injects the booleans
+ * and resolved strings below. Keeping the core pure makes the status logic
+ * fully unit-testable and guarantees it can never leak a secret value.
+ */
+
+export type CapabilityStatus = "green" | "yellow" | "red";
+
+/** Machine-readable failure reason codes (stable identifiers for tooling). */
+export type CapabilityReasonCode =
+  | "ok"
+  | "profile_config_missing"
+  | "model_unconfigured"
+  | "provider_unknown"
+  | "provider_credentials_missing"
+  | "delegation_not_configured"
+  | "delegation_model_unconfigured"
+  | "delegation_credentials_missing"
+  | "tools_unconfigured"
+  | "tool_key_truncated"
+  | "required_tool_missing"
+  | "gateway_unconfigured"
+  | "state_db_unavailable"
+  | "cron_store_unavailable"
+  | "github_cli_unavailable"
+  | "github_auth_unavailable"
+  | "linear_auth_unavailable"
+  | "delivery_bridge_unavailable";
+
+export type CapabilityCheck = {
+  /** Stable check id, e.g. "profile.model" or "service.gateway". */
+  id: string;
+  /** Human-readable label. */
+  label: string;
+  status: CapabilityStatus;
+  reason: CapabilityReasonCode;
+  /** Human remediation hint. MUST NOT contain secret values. */
+  detail?: string;
+  /** When true, a failing check rolls up to red; otherwise to yellow. */
+  required: boolean;
+};
+
+export type ProfileCapabilityReport = {
+  agentId: string;
+  name?: string;
+  isDefault: boolean;
+  status: CapabilityStatus;
+  checks: CapabilityCheck[];
+};
+
+export type CapabilityRollup = {
+  green: number;
+  yellow: number;
+  red: number;
+  /** Worst status across every check in the contract. */
+  status: CapabilityStatus;
+};
+
+export type FleetCapabilityContract = {
+  version: 1;
+  /** ISO timestamp, injected by the shell (no clock read in core). */
+  now: string;
+  rollup: CapabilityRollup;
+  services: CapabilityCheck[];
+  profiles: ProfileCapabilityReport[];
+};
+
+export type ProfileCapabilityInput = {
+  agentId: string;
+  name?: string;
+  isDefault: boolean;
+  /** Whether a config entry exists for this profile. */
+  configPresent: boolean;
+  /** Resolved primary model string (e.g. "anthropic/claude-opus-4-7"). */
+  model?: string;
+  /** Provider id derived from the model string prefix, if determinable. */
+  provider?: string;
+  /** Whether credentials for `provider` are present (name/presence only). */
+  providerCredentialsPresent?: boolean;
+  /** Whether a delegation (subagents) block is configured. */
+  delegationConfigured: boolean;
+  /** Resolved delegation/subagent model string. */
+  delegationModel?: string;
+  /** Provider id derived from the delegation model string. */
+  delegationProvider?: string;
+  /** Whether credentials for the delegation provider are present. */
+  delegationCredentialsPresent?: boolean;
+  /** Whether tools are configured (profile and/or allowlist present). */
+  toolsConfigured: boolean;
+  /** Raw tool keys, scanned for truncation/emptiness. Never printed wholesale. */
+  toolKeys: string[];
+  /** Optional required tool keys; absence rolls up to red. */
+  requiredToolKeys?: string[];
+  /** When true, missing provider credentials roll up to red (default true). */
+  requireProvider?: boolean;
+};
+
+export type FleetServiceInput = {
+  gatewayConfigured: boolean;
+  gatewayRequired?: boolean;
+  stateDbPresent: boolean;
+  stateDbRequired?: boolean;
+  cronStorePresent: boolean;
+  cronRequired?: boolean;
+  githubCliPresent: boolean;
+  githubAuthPresent: boolean;
+  githubRequired?: boolean;
+  linearAuthPresent: boolean;
+  linearRequired?: boolean;
+  /** Delivery bridge / OneDrive sync (rclone) availability. */
+  deliveryBridgePresent: boolean;
+  deliveryRequired?: boolean;
+};
+
+export type FleetCapabilityInput = {
+  now: string;
+  profiles: ProfileCapabilityInput[];
+  services: FleetServiceInput;
+};
+
+const STATUS_RANK: Record<CapabilityStatus, number> = {
+  green: 0,
+  yellow: 1,
+  red: 2,
+};
+
+export function worstStatus(statuses: CapabilityStatus[]): CapabilityStatus {
+  let worst: CapabilityStatus = "green";
+  for (const status of statuses) {
+    if (STATUS_RANK[status] > STATUS_RANK[worst]) {
+      worst = status;
+    }
+  }
+  return worst;
+}
+
+/** A tool key is "truncated" if empty, whitespace-padded, or has a trailing ellipsis/null byte. */
+export function isTruncatedToolKey(key: string): boolean {
+  if (key.length === 0) {
+    return true;
+  }
+  if (key !== key.trim()) {
+    return true;
+  }
+  if (key.includes("\0")) {
+    return true;
+  }
+  return key.endsWith("...") || key.endsWith("…");
+}
+
+/** Status for an optional service: present -> green, else red if required else yellow. */
+function serviceStatus(present: boolean, required: boolean): CapabilityStatus {
+  if (present) {
+    return "green";
+  }
+  return required ? "red" : "yellow";
+}
+
+function buildProfileChecks(profile: ProfileCapabilityInput): CapabilityCheck[] {
+  const checks: CapabilityCheck[] = [];
+  const requireProvider = profile.requireProvider ?? true;
+
+  // 1. Profile config exists.
+  checks.push({
+    id: "profile.config",
+    label: "Profile config",
+    status: profile.configPresent ? "green" : "red",
+    reason: profile.configPresent ? "ok" : "profile_config_missing",
+    detail: profile.configPresent
+      ? undefined
+      : "No config entry found for this profile; add it under agents.list.",
+    required: true,
+  });
+
+  // 2. Configured model.
+  const hasModel = Boolean(profile.model && profile.model.trim());
+  checks.push({
+    id: "profile.model",
+    label: "Configured model",
+    status: hasModel ? "green" : "red",
+    reason: hasModel ? "ok" : "model_unconfigured",
+    detail: hasModel
+      ? undefined
+      : "Set a model for this profile (agents.list[].model) or agents.defaults.model.",
+    required: true,
+  });
+
+  // 3 + 4. Provider derivable + credentials present.
+  if (hasModel) {
+    const hasProvider = Boolean(profile.provider && profile.provider.trim());
+    if (!hasProvider) {
+      checks.push({
+        id: "profile.provider",
+        label: "Provider",
+        status: "yellow",
+        reason: "provider_unknown",
+        detail: "Could not derive a provider from the model id; credential check skipped.",
+        required: false,
+      });
+    } else {
+      const credsPresent = profile.providerCredentialsPresent === true;
+      checks.push({
+        id: "profile.credentials",
+        label: "Provider credentials",
+        status: credsPresent ? "green" : requireProvider ? "red" : "yellow",
+        reason: credsPresent ? "ok" : "provider_credentials_missing",
+        detail: credsPresent
+          ? undefined
+          : `No credentials detected for provider "${profile.provider}". Set its auth env var or add an auth profile.`,
+        required: requireProvider,
+      });
+    }
+  }
+
+  // 5. Delegation (subagents) provider/model.
+  if (!profile.delegationConfigured) {
+    checks.push({
+      id: "profile.delegation",
+      label: "Delegation",
+      status: "green",
+      reason: "delegation_not_configured",
+      detail: "No subagent delegation configured (optional).",
+      required: false,
+    });
+  } else {
+    const hasDelegationModel = Boolean(profile.delegationModel && profile.delegationModel.trim());
+    if (!hasDelegationModel) {
+      checks.push({
+        id: "profile.delegation.model",
+        label: "Delegation model",
+        status: "yellow",
+        reason: "delegation_model_unconfigured",
+        detail: "Subagents are configured but no delegation model resolves; set subagents.model.",
+        required: false,
+      });
+    } else {
+      const delegationCreds = profile.delegationCredentialsPresent === true;
+      checks.push({
+        id: "profile.delegation.credentials",
+        label: "Delegation credentials",
+        status: delegationCreds ? "green" : "yellow",
+        reason: delegationCreds ? "ok" : "delegation_credentials_missing",
+        detail: delegationCreds
+          ? undefined
+          : `No credentials detected for delegation provider "${profile.delegationProvider ?? "unknown"}".`,
+        required: false,
+      });
+    }
+  }
+
+  // 6. Tools configured + integrity (truncated/empty keys) + required tools present.
+  const truncatedKeys = profile.toolKeys.filter((key) => isTruncatedToolKey(key));
+  if (truncatedKeys.length > 0) {
+    checks.push({
+      id: "profile.tools",
+      label: "Tools",
+      status: "red",
+      reason: "tool_key_truncated",
+      detail: `Found ${truncatedKeys.length} truncated/empty tool key(s); the tools config looks corrupted.`,
+      required: true,
+    });
+  } else if (!profile.toolsConfigured) {
+    checks.push({
+      id: "profile.tools",
+      label: "Tools",
+      status: "yellow",
+      reason: "tools_unconfigured",
+      detail: "No tool profile or allowlist configured; this profile inherits defaults only.",
+      required: false,
+    });
+  } else {
+    checks.push({
+      id: "profile.tools",
+      label: "Tools",
+      status: "green",
+      reason: "ok",
+      required: false,
+    });
+  }
+
+  const requiredTools = profile.requiredToolKeys ?? [];
+  if (requiredTools.length > 0) {
+    const presentKeys = new Set(profile.toolKeys.map((key) => key.trim()));
+    const missing = requiredTools.filter((key) => !presentKeys.has(key.trim()));
+    if (missing.length > 0) {
+      checks.push({
+        id: "profile.tools.required",
+        label: "Required tools",
+        status: "red",
+        reason: "required_tool_missing",
+        detail: `Missing required tool(s): ${missing.join(", ")}.`,
+        required: true,
+      });
+    }
+  }
+
+  return checks;
+}
+
+function buildServiceChecks(services: FleetServiceInput): CapabilityCheck[] {
+  const gatewayRequired = services.gatewayRequired ?? false;
+  const stateDbRequired = services.stateDbRequired ?? false;
+  const cronRequired = services.cronRequired ?? false;
+  const githubRequired = services.githubRequired ?? false;
+  const linearRequired = services.linearRequired ?? false;
+  const deliveryRequired = services.deliveryRequired ?? false;
+
+  return [
+    {
+      id: "service.gateway",
+      label: "Gateway",
+      status: serviceStatus(services.gatewayConfigured, gatewayRequired),
+      reason: services.gatewayConfigured ? "ok" : "gateway_unconfigured",
+      detail: services.gatewayConfigured
+        ? undefined
+        : "No gateway is configured (gateway block absent).",
+      required: gatewayRequired,
+    },
+    {
+      id: "service.stateDb",
+      label: "State DB (Kanban)",
+      status: serviceStatus(services.stateDbPresent, stateDbRequired),
+      reason: services.stateDbPresent ? "ok" : "state_db_unavailable",
+      detail: services.stateDbPresent
+        ? undefined
+        : "OpenClaw state database not found; cron/board state is unavailable until initialized.",
+      required: stateDbRequired,
+    },
+    {
+      id: "service.cron",
+      label: "Cron scheduler",
+      status: serviceStatus(services.cronStorePresent, cronRequired),
+      reason: services.cronStorePresent ? "ok" : "cron_store_unavailable",
+      detail: services.cronStorePresent
+        ? undefined
+        : "No cron store found; scheduled jobs are not visible.",
+      required: cronRequired,
+    },
+    {
+      id: "service.github.cli",
+      label: "GitHub CLI",
+      status: serviceStatus(services.githubCliPresent, githubRequired),
+      reason: services.githubCliPresent ? "ok" : "github_cli_unavailable",
+      detail: services.githubCliPresent ? undefined : "gh not found on PATH.",
+      required: githubRequired,
+    },
+    {
+      id: "service.github.auth",
+      label: "GitHub auth",
+      status: serviceStatus(services.githubAuthPresent, githubRequired),
+      reason: services.githubAuthPresent ? "ok" : "github_auth_unavailable",
+      detail: services.githubAuthPresent
+        ? undefined
+        : "No GitHub token detected (GH_TOKEN/GITHUB_TOKEN unset).",
+      required: githubRequired,
+    },
+    {
+      id: "service.linear",
+      label: "Linear auth",
+      status: serviceStatus(services.linearAuthPresent, linearRequired),
+      reason: services.linearAuthPresent ? "ok" : "linear_auth_unavailable",
+      detail: services.linearAuthPresent
+        ? undefined
+        : "No Linear API key detected (LINEAR_API_KEY unset).",
+      required: linearRequired,
+    },
+    {
+      id: "service.delivery",
+      label: "Delivery bridge (rclone/OneDrive)",
+      status: serviceStatus(services.deliveryBridgePresent, deliveryRequired),
+      reason: services.deliveryBridgePresent ? "ok" : "delivery_bridge_unavailable",
+      detail: services.deliveryBridgePresent ? undefined : "rclone not found on PATH.",
+      required: deliveryRequired,
+    },
+  ];
+}
+
+function tallyRollup(checks: CapabilityCheck[]): CapabilityRollup {
+  let green = 0;
+  let yellow = 0;
+  let red = 0;
+  for (const check of checks) {
+    if (check.status === "green") {
+      green += 1;
+    } else if (check.status === "yellow") {
+      yellow += 1;
+    } else {
+      red += 1;
+    }
+  }
+  return {
+    green,
+    yellow,
+    red,
+    status: worstStatus(checks.map((check) => check.status)),
+  };
+}
+
+export function buildFleetCapabilityContract(input: FleetCapabilityInput): FleetCapabilityContract {
+  const services = buildServiceChecks(input.services);
+  const profiles: ProfileCapabilityReport[] = input.profiles.map((profile) => {
+    const checks = buildProfileChecks(profile);
+    return {
+      agentId: profile.agentId,
+      name: profile.name,
+      isDefault: profile.isDefault,
+      status: worstStatus(checks.map((check) => check.status)),
+      checks,
+    };
+  });
+
+  const allChecks = [...services, ...profiles.flatMap((report) => report.checks)];
+  return {
+    version: 1,
+    now: input.now,
+    rollup: tallyRollup(allChecks),
+    services,
+    profiles,
+  };
+}

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   agentsAddCommandMock: vi.fn(),
   agentsBindingsCommandMock: vi.fn(),
   agentsBindCommandMock: vi.fn(),
+  agentsCapabilitiesCommandMock: vi.fn(),
   agentsDeleteCommandMock: vi.fn(),
   agentsListCommandMock: vi.fn(),
   agentsSetIdentityCommandMock: vi.fn(),
@@ -23,6 +24,7 @@ const agentCliCommandMock = mocks.agentCliCommandMock;
 const agentsAddCommandMock = mocks.agentsAddCommandMock;
 const agentsBindingsCommandMock = mocks.agentsBindingsCommandMock;
 const agentsBindCommandMock = mocks.agentsBindCommandMock;
+const agentsCapabilitiesCommandMock = mocks.agentsCapabilitiesCommandMock;
 const agentsDeleteCommandMock = mocks.agentsDeleteCommandMock;
 const agentsListCommandMock = mocks.agentsListCommandMock;
 const agentsSetIdentityCommandMock = mocks.agentsSetIdentityCommandMock;
@@ -42,6 +44,10 @@ vi.mock("../../commands/agents.commands.bind.js", () => ({
   agentsBindingsCommand: mocks.agentsBindingsCommandMock,
   agentsBindCommand: mocks.agentsBindCommandMock,
   agentsUnbindCommand: mocks.agentsUnbindCommandMock,
+}));
+
+vi.mock("../../commands/agents.commands.capabilities.js", () => ({
+  agentsCapabilitiesCommand: mocks.agentsCapabilitiesCommandMock,
 }));
 
 vi.mock("../../commands/agents.commands.delete.js", () => ({
@@ -78,6 +84,7 @@ describe("registerAgentCommands", () => {
     agentsAddCommandMock.mockResolvedValue(undefined);
     agentsBindingsCommandMock.mockResolvedValue(undefined);
     agentsBindCommandMock.mockResolvedValue(undefined);
+    agentsCapabilitiesCommandMock.mockResolvedValue(undefined);
     agentsDeleteCommandMock.mockResolvedValue(undefined);
     agentsListCommandMock.mockResolvedValue(undefined);
     agentsSetIdentityCommandMock.mockResolvedValue(undefined);
@@ -179,6 +186,30 @@ describe("registerAgentCommands", () => {
       {
         json: true,
         bindings: true,
+      },
+      runtime,
+    );
+  });
+
+  it("forwards agents capabilities options", async () => {
+    await runCli(["agents", "capabilities", "--agent", "peewee", "--json"]);
+    expect(agentsCapabilitiesCommandMock).toHaveBeenCalledWith(
+      {
+        agent: "peewee",
+        json: true,
+        markdown: false,
+      },
+      runtime,
+    );
+  });
+
+  it("supports the caps alias with markdown output", async () => {
+    await runCli(["agents", "caps", "--markdown"]);
+    expect(agentsCapabilitiesCommandMock).toHaveBeenCalledWith(
+      {
+        agent: undefined,
+        json: false,
+        markdown: true,
       },
       runtime,
     );

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -8,6 +8,7 @@ import { registerAgentTurnCommand } from "./register.agent-turn.js";
 
 type AgentsAddModule = typeof import("../../commands/agents.commands.add.js");
 type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
+type AgentsCapabilitiesModule = typeof import("../../commands/agents.commands.capabilities.js");
 type AgentsDeleteModule = typeof import("../../commands/agents.commands.delete.js");
 type AgentsIdentityModule = typeof import("../../commands/agents.commands.identity.js");
 type AgentsListModule = typeof import("../../commands/agents.commands.list.js");
@@ -48,6 +49,12 @@ async function loadAgentsSetIdentityCommand(): Promise<
 
 async function loadAgentsListCommand(): Promise<AgentsListModule["agentsListCommand"]> {
   return (await import("../../commands/agents.commands.list.js")).agentsListCommand;
+}
+
+async function loadAgentsCapabilitiesCommand(): Promise<
+  AgentsCapabilitiesModule["agentsCapabilitiesCommand"]
+> {
+  return (await import("../../commands/agents.commands.capabilities.js")).agentsCapabilitiesCommand;
 }
 
 async function loadAgentsActionRuntime(): Promise<{
@@ -98,6 +105,27 @@ export function registerAgentsCommands(program: Command): void {
         const agentsListCommand = await loadAgentsListCommand();
         await agentsListCommand(
           { json: Boolean(opts.json), bindings: Boolean(opts.bindings) },
+          runtime,
+        );
+      });
+    });
+
+  agents
+    .command("capabilities")
+    .alias("caps")
+    .description("Report per-profile capability status (read-only)")
+    .option("--agent <id>", "Limit the report to a single agent id")
+    .option("--json", "Output JSON instead of text", false)
+    .option("--markdown", "Output Markdown instead of text", false)
+    .action(async (opts): Promise<void> => {
+      await runAgentsCommandAction(async (runtime) => {
+        const agentsCapabilitiesCommand = await loadAgentsCapabilitiesCommand();
+        await agentsCapabilitiesCommand(
+          {
+            agent: opts.agent as string | undefined,
+            json: Boolean(opts.json),
+            markdown: Boolean(opts.markdown),
+          },
           runtime,
         );
       });

--- a/src/commands/agents.commands.capabilities.test.ts
+++ b/src/commands/agents.commands.capabilities.test.ts
@@ -1,0 +1,375 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { agentsCapabilitiesCommand } from "./agents.commands.capabilities.js";
+
+const mocks = vi.hoisted(() => ({
+  requireValidConfigMock: vi.fn(),
+  resolveProviderAuthEnvVarCandidatesMock: vi.fn(),
+  ensureAuthProfileStoreMock: vi.fn(),
+  resolveAuthProfileOrderMock: vi.fn(),
+  resolveUsableCustomProviderApiKeyMock: vi.fn(),
+}));
+
+vi.mock("./agents.command-shared.js", () => ({
+  requireValidConfig: mocks.requireValidConfigMock,
+}));
+
+vi.mock("../secrets/provider-env-vars.js", () => ({
+  resolveProviderAuthEnvVarCandidates: mocks.resolveProviderAuthEnvVarCandidatesMock,
+}));
+
+vi.mock("../agents/auth-profiles/store.js", () => ({
+  ensureAuthProfileStoreWithoutExternalProfiles: mocks.ensureAuthProfileStoreMock,
+}));
+
+vi.mock("../agents/auth-profiles/order.js", () => ({
+  resolveAuthProfileOrder: mocks.resolveAuthProfileOrderMock,
+}));
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveUsableCustomProviderApiKey: mocks.resolveUsableCustomProviderApiKeyMock,
+}));
+
+function emptyStore(): AuthProfileStore {
+  return { profiles: {}, order: {} } as unknown as AuthProfileStore;
+}
+
+function createRuntime() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const exits: number[] = [];
+  const runtime: RuntimeEnv = {
+    log: (...args: unknown[]) => {
+      logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+    },
+    error: (...args: unknown[]) => {
+      errors.push(args.map((a) => String(a)).join(" "));
+    },
+    exit: (code: number) => {
+      exits.push(code);
+    },
+  };
+  return { runtime, logs, errors, exits };
+}
+
+const SECRET = "sk-ant-super-secret-value-9999";
+
+function configWith(list: OpenClawConfig["agents"]): OpenClawConfig {
+  return { agents: list } as unknown as OpenClawConfig;
+}
+
+describe("agentsCapabilitiesCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveProviderAuthEnvVarCandidatesMock.mockReturnValue({
+      anthropic: ["ANTHROPIC_API_KEY"],
+    });
+    // Defaults: no auth profiles, no config-backed custom api key.
+    mocks.ensureAuthProfileStoreMock.mockReturnValue(emptyStore());
+    mocks.resolveAuthProfileOrderMock.mockReturnValue([]);
+    mocks.resolveUsableCustomProviderApiKeyMock.mockReturnValue(null);
+  });
+
+  it("emits a JSON contract without leaking secret values (env credential)", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      }),
+    );
+    const { runtime, logs } = createRuntime();
+    const env = { ANTHROPIC_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+
+    expect(logs).toHaveLength(1);
+    const contract = JSON.parse(logs[0]);
+    expect(contract.version).toBe(1);
+    const profile = contract.profiles.find((p: { agentId: string }) => p.agentId === "peewee");
+    expect(profile).toBeDefined();
+    const creds = profile.checks.find((c: { id: string }) => c.id === "profile.credentials");
+    expect(creds.status).toBe("green");
+    // The secret value must never appear anywhere in the output.
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("treats a usable auth profile as present credentials (no env var)", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      }),
+    );
+    // Store has an OAuth profile whose credential happens to be secret-shaped.
+    mocks.ensureAuthProfileStoreMock.mockReturnValue({
+      profiles: { "anthropic-oauth": { provider: "anthropic", type: "oauth", access: SECRET } },
+      order: {},
+    } as unknown as AuthProfileStore);
+    mocks.resolveAuthProfileOrderMock.mockReturnValue(["anthropic-oauth"]);
+
+    const { runtime, logs } = createRuntime();
+    // Deliberately empty env: only the auth profile store should satisfy the check.
+    await agentsCapabilitiesCommand({ json: true }, runtime, {} as NodeJS.ProcessEnv);
+
+    const contract = JSON.parse(logs[0]);
+    const creds = contract.profiles[0].checks.find(
+      (c: { id: string }) => c.id === "profile.credentials",
+    );
+    expect(creds.status).toBe("green");
+    expect(creds.reason).toBe("ok");
+    // A store-backed secret value must never surface in the rendered contract.
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("flags missing provider credentials as red", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      }),
+    );
+    const { runtime, logs } = createRuntime();
+    const env = {} as NodeJS.ProcessEnv;
+
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+    const contract = JSON.parse(logs[0]);
+    const profile = contract.profiles[0];
+    const creds = profile.checks.find((c: { id: string }) => c.id === "profile.credentials");
+    expect(creds.status).toBe("red");
+    expect(creds.reason).toBe("provider_credentials_missing");
+  });
+
+  it("never renders secret-shaped env values in any output format or remediation", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      }),
+    );
+    // Secret lives in an unrelated env var; the provider stays uncredentialed (red),
+    // so the remediation hint is rendered — and must not echo the secret.
+    const env = { UNRELATED_TOKEN: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    for (const opts of [{ json: true }, { markdown: true }, {}]) {
+      const { runtime, logs } = createRuntime();
+      await agentsCapabilitiesCommand(opts, runtime, env);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).not.toContain(SECRET);
+    }
+
+    // Assert specifically against the remediation detail string.
+    const { runtime, logs } = createRuntime();
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+    const contract = JSON.parse(logs[0]);
+    const creds = contract.profiles[0].checks.find(
+      (c: { id: string }) => c.id === "profile.credentials",
+    );
+    expect(creds.status).toBe("red");
+    expect(creds.detail).not.toContain(SECRET);
+  });
+
+  it("treats agents.defaults.subagents.model as delegation configured", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        defaults: { subagents: { model: "anthropic/claude-haiku-4-5" } },
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      } as unknown as OpenClawConfig["agents"]),
+    );
+    const { runtime, logs } = createRuntime();
+    const env = { ANTHROPIC_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+
+    const contract = JSON.parse(logs[0]);
+    const checks: Array<{ id: string; reason: string; status: string }> =
+      contract.profiles[0].checks;
+    // No per-agent `subagents` block, but delegation is inherited from defaults:
+    // it must be reported as configured, not "not configured".
+    expect(checks.some((c) => c.reason === "delegation_not_configured")).toBe(false);
+    const delegationCreds = checks.find((c) => c.id === "profile.delegation.credentials");
+    expect(delegationCreds?.status).toBe("green");
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("treats the primary-model fallback as delegation configured", async () => {
+    // No subagents block anywhere: the runtime resolver falls back to the
+    // agent primary model, so a spawned subagent would still run — delegation
+    // must be reported as configured.
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      }),
+    );
+    const { runtime, logs } = createRuntime();
+    const env = { ANTHROPIC_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+
+    const contract = JSON.parse(logs[0]);
+    const checks: Array<{ id: string; reason: string; status: string }> =
+      contract.profiles[0].checks;
+    expect(checks.some((c) => c.reason === "delegation_not_configured")).toBe(false);
+    const delegationCreds = checks.find((c) => c.id === "profile.delegation.credentials");
+    expect(delegationCreds?.status).toBe("green");
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("checks credentials for the resolved delegation provider, not the primary", async () => {
+    // Primary provider is anthropic (credentialed); delegation resolves to an
+    // openai subagent model that has NO credentials. The delegation check must
+    // reflect the openai provider, independent of the green primary check.
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        defaults: { subagents: { model: "openai/gpt-4o-mini" } },
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      } as unknown as OpenClawConfig["agents"]),
+    );
+    const env = { ANTHROPIC_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    // Sanitized across every render path, including the remediation hint.
+    for (const opts of [{ json: true }, { markdown: true }, {}]) {
+      const { runtime, logs } = createRuntime();
+      await agentsCapabilitiesCommand(opts, runtime, env);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).not.toContain(SECRET);
+    }
+
+    const { runtime, logs } = createRuntime();
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+    const contract = JSON.parse(logs[0]);
+    const checks: Array<{ id: string; reason: string; status: string; detail?: string }> =
+      contract.profiles[0].checks;
+    const primaryCreds = checks.find((c) => c.id === "profile.credentials");
+    expect(primaryCreds?.status).toBe("green");
+    const delegationCreds = checks.find((c) => c.id === "profile.delegation.credentials");
+    expect(delegationCreds?.status).toBe("yellow");
+    expect(delegationCreds?.reason).toBe("delegation_credentials_missing");
+    // Remediation names the resolved provider but never echoes a secret.
+    expect(delegationCreds?.detail).toContain("openai");
+    expect(delegationCreds?.detail ?? "").not.toContain(SECRET);
+  });
+
+  it("resolves a configured delegation alias to its real provider", async () => {
+    // agents.defaults.subagents.model is a config-defined alias ("gpt") that the
+    // runtime spawn resolver expands to a fully-qualified openai/* model. The
+    // command must mirror that expansion so credentials are checked against the
+    // provider that will actually run (openai) rather than the bare alias —
+    // which derives to no provider and would render "unknown".
+    mocks.resolveProviderAuthEnvVarCandidatesMock.mockReturnValue({
+      anthropic: ["ANTHROPIC_API_KEY"],
+      openai: ["OPENAI_API_KEY"],
+    });
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        defaults: {
+          subagents: { model: "gpt" },
+          models: { "openai/gpt-4o-mini": { alias: "gpt" } },
+        },
+        list: [{ id: "peewee", model: "anthropic/claude-opus-4-7", tools: { allow: ["Read"] } }],
+      } as unknown as OpenClawConfig["agents"]),
+    );
+    // Only the openai credential is present; the alias must resolve to openai
+    // for the delegation check to come back green.
+    const env = { OPENAI_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    const { runtime, logs } = createRuntime();
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+
+    const contract = JSON.parse(logs[0]);
+    const checks: Array<{ id: string; reason: string; status: string; detail?: string }> =
+      contract.profiles[0].checks;
+    expect(checks.some((c) => c.reason === "delegation_not_configured")).toBe(false);
+    const delegationCreds = checks.find((c) => c.id === "profile.delegation.credentials");
+    expect(delegationCreds?.status).toBe("green");
+    expect(delegationCreds?.reason).toBe("ok");
+    // The alias resolved to a real provider, so no "unknown" provider surfaces.
+    expect(logs[0]).not.toContain("unknown");
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("falls back to agents.defaults.model primary when no subagent/agent model is set", async () => {
+    // No subagents.model anywhere and no agent-local model: the runtime spawn
+    // path falls back to agents.defaults.model.primary, so a spawned subagent
+    // would still run. Delegation must NOT report not-configured, and
+    // credentials must be checked for the default-primary provider (anthropic).
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        defaults: { model: { primary: "anthropic/claude-opus-4-7" } },
+        list: [{ id: "peewee", tools: { allow: ["Read"] } }],
+      } as unknown as OpenClawConfig["agents"]),
+    );
+    const env = { ANTHROPIC_API_KEY: SECRET } as unknown as NodeJS.ProcessEnv;
+
+    const { runtime, logs } = createRuntime();
+    await agentsCapabilitiesCommand({ json: true }, runtime, env);
+
+    const contract = JSON.parse(logs[0]);
+    const checks: Array<{ id: string; reason: string; status: string }> =
+      contract.profiles[0].checks;
+    expect(checks.some((c) => c.reason === "delegation_not_configured")).toBe(false);
+    const delegationCreds = checks.find((c) => c.id === "profile.delegation.credentials");
+    expect(delegationCreds?.status).toBe("green");
+    expect(delegationCreds?.reason).toBe("ok");
+    expect(logs[0]).not.toContain("unknown");
+    expect(logs[0]).not.toContain(SECRET);
+  });
+
+  it("filters to a single agent via --agent", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({
+        list: [
+          { id: "peewee", model: "anthropic/claude-opus-4-7" },
+          { id: "rico", model: "anthropic/claude-haiku-4-5" },
+        ],
+      }),
+    );
+    const { runtime, logs } = createRuntime();
+
+    await agentsCapabilitiesCommand(
+      { json: true, agent: "rico" },
+      runtime,
+      {} as NodeJS.ProcessEnv,
+    );
+    const contract = JSON.parse(logs[0]);
+    expect(contract.profiles).toHaveLength(1);
+    expect(contract.profiles[0].agentId).toBe("rico");
+  });
+
+  it("renders markdown when --markdown is set", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({ list: [{ id: "peewee", model: "anthropic/claude-opus-4-7" }] }),
+    );
+    const { runtime, logs } = createRuntime();
+
+    await agentsCapabilitiesCommand({ markdown: true }, runtime, {} as NodeJS.ProcessEnv);
+    expect(logs[0]).toContain("# Fleet Capability Contract v1");
+  });
+
+  it("renders human text by default", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(
+      configWith({ list: [{ id: "peewee", model: "anthropic/claude-opus-4-7" }] }),
+    );
+    const { runtime, logs } = createRuntime();
+
+    await agentsCapabilitiesCommand({}, runtime, {} as NodeJS.ProcessEnv);
+    expect(logs[0]).toContain("Fleet Capability Contract v1");
+    expect(logs[0]).toContain("Profiles:");
+  });
+
+  it("rejects combining --json and --markdown with a non-zero exit", async () => {
+    const { runtime, errors, exits } = createRuntime();
+    await agentsCapabilitiesCommand(
+      { json: true, markdown: true },
+      runtime,
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(errors[0]).toContain("Cannot combine --json and --markdown");
+    expect(exits).toContain(1);
+    expect(mocks.requireValidConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns quietly when config is invalid", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(null);
+    const { runtime, logs } = createRuntime();
+    await agentsCapabilitiesCommand({ json: true }, runtime, {} as NodeJS.ProcessEnv);
+    expect(logs).toHaveLength(0);
+  });
+});

--- a/src/commands/agents.commands.capabilities.ts
+++ b/src/commands/agents.commands.capabilities.ts
@@ -1,0 +1,323 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePrimaryStringValue } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveAuthProfileOrder } from "../agents/auth-profiles/order.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import {
+  buildFleetCapabilityContract,
+  type CapabilityCheck,
+  type CapabilityStatus,
+  type FleetCapabilityContract,
+  type FleetServiceInput,
+  type ProfileCapabilityInput,
+} from "../agents/fleet-capability-contract.js";
+import { renderFleetCapabilityMarkdown } from "../agents/fleet-capability-contract.markdown.js";
+import { resolveUsableCustomProviderApiKey } from "../agents/model-auth.js";
+import { resolveSubagentSpawnModelSelection } from "../agents/model-selection.js";
+import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronStorePath } from "../cron/store.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { resolveProviderAuthEnvVarCandidates } from "../secrets/provider-env-vars.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { resolveConfigDir } from "../utils.js";
+import { requireValidConfig } from "./agents.command-shared.js";
+import { listAgentEntries } from "./agents.config.js";
+
+export type AgentsCapabilitiesOptions = {
+  json?: boolean;
+  markdown?: boolean;
+  agent?: string;
+};
+
+const STATUS_ICON: Record<CapabilityStatus, string> = {
+  green: "[OK]",
+  yellow: "[WARN]",
+  red: "[FAIL]",
+};
+
+/** Derive a provider id from a model string prefix (e.g. "anthropic/claude" -> "anthropic"). */
+function deriveProvider(model: string | undefined): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const slash = trimmed.indexOf("/");
+  const colon = trimmed.indexOf(":");
+  const sep = slash === -1 ? colon : colon === -1 ? slash : Math.min(slash, colon);
+  if (sep <= 0) {
+    return undefined;
+  }
+  return trimmed.slice(0, sep).trim().toLowerCase() || undefined;
+}
+
+/** True when the named env var is set to a non-empty value. Never reads the value out. */
+function envVarPresent(name: string, env: NodeJS.ProcessEnv): boolean {
+  const value = env[name];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Read-only credential presence probe.
+ *
+ * Mirrors the auth-source model used by `openclaw models list` status:
+ * a provider counts as credentialed when ANY of these are present —
+ *   1. a provider auth env var,
+ *   2. a usable entry in the agent's auth profile store (OAuth / static
+ *      token / api_key profiles, incl. configured aws-sdk profiles),
+ *   3. a config-backed custom-provider api key.
+ * Returns a boolean only; it never reads, returns, logs, or renders the
+ * underlying secret value.
+ */
+function makeProviderCredentialProbe(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  store: AuthProfileStore | undefined,
+): (provider?: string) => boolean {
+  const candidates = resolveProviderAuthEnvVarCandidates();
+  return (provider?: string): boolean => {
+    if (!provider) {
+      return false;
+    }
+    const canonical = resolveProviderIdForAuth(provider);
+    const names = candidates[canonical] ?? candidates[provider] ?? [];
+    if (names.some((name) => envVarPresent(name, env))) {
+      return true;
+    }
+    if (store) {
+      try {
+        if (resolveAuthProfileOrder({ cfg, store, provider }).length > 0) {
+          return true;
+        }
+      } catch {
+        // best-effort: a malformed store must not crash the read-only report
+      }
+    }
+    try {
+      if (resolveUsableCustomProviderApiKey({ cfg, provider, env })) {
+        return true;
+      }
+    } catch {
+      // best-effort: config-backed auth resolution is advisory here
+    }
+    return false;
+  };
+}
+
+/** Load an agent's auth profile store read-only; never mutates or syncs external CLIs. */
+function loadAuthStoreForAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+  env: NodeJS.ProcessEnv,
+): AuthProfileStore | undefined {
+  try {
+    const agentDir = resolveAgentDir(cfg, agentId, env);
+    return ensureAuthProfileStoreWithoutExternalProfiles(agentDir, { readOnly: true });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Best-effort PATH scan for an executable. Read-only; never executes it. */
+function isOnPath(bin: string, env: NodeJS.ProcessEnv): boolean {
+  const pathVar = env.PATH ?? env.Path ?? "";
+  if (!pathVar) {
+    return false;
+  }
+  const isWin = process.platform === "win32";
+  const exts = isWin
+    ? [
+        "",
+        ...(env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .map((e) => e.trim())
+          .filter(Boolean),
+      ]
+    : [""];
+  for (const dir of pathVar.split(path.delimiter)) {
+    if (!dir) {
+      continue;
+    }
+    for (const ext of exts) {
+      const candidate = path.join(dir, `${bin}${ext}`);
+      try {
+        if (fs.existsSync(candidate)) {
+          return true;
+        }
+      } catch {
+        // best-effort: ignore unreadable PATH entries
+      }
+    }
+  }
+  return false;
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    return fs.existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+function gatherServiceInput(env: NodeJS.ProcessEnv): FleetServiceInput {
+  let stateDbPresent = false;
+  try {
+    stateDbPresent = fileExists(resolveOpenClawStateSqlitePath(env));
+  } catch {
+    stateDbPresent = false;
+  }
+
+  let cronStorePresent = false;
+  try {
+    cronStorePresent =
+      fileExists(resolveCronStorePath()) || fileExists(path.join(resolveConfigDir(env), "cron"));
+  } catch {
+    cronStorePresent = false;
+  }
+
+  return {
+    gatewayConfigured: false, // filled in by caller (needs cfg)
+    stateDbPresent,
+    cronStorePresent,
+    githubCliPresent: isOnPath("gh", env),
+    githubAuthPresent: envVarPresent("GH_TOKEN", env) || envVarPresent("GITHUB_TOKEN", env),
+    linearAuthPresent: envVarPresent("LINEAR_API_KEY", env),
+    deliveryBridgePresent: isOnPath("rclone", env),
+  };
+}
+
+function gatherProfileInputs(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  filterAgentId?: string,
+): ProfileCapabilityInput[] {
+  const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+  const defaultModel = resolvePrimaryStringValue(cfg.agents?.defaults?.model);
+  const entries = listAgentEntries(cfg);
+  const wanted = filterAgentId ? normalizeAgentId(filterAgentId) : undefined;
+
+  const source = (entries.length > 0 ? entries : [{ id: defaultAgentId }]).filter((entry) =>
+    wanted ? normalizeAgentId(entry.id) === wanted : true,
+  );
+
+  return source.map((entry): ProfileCapabilityInput => {
+    const agentId = normalizeAgentId(entry.id);
+    const store = loadAuthStoreForAgent(cfg, agentId, env);
+    const credsPresent = makeProviderCredentialProbe(cfg, env, store);
+    const model = resolvePrimaryStringValue(entry.model) ?? defaultModel;
+    const provider = deriveProvider(model);
+    const tools = entry.tools;
+    const allow = tools?.allow ?? [];
+    const alsoAllow = tools?.alsoAllow ?? [];
+    const deny = tools?.deny ?? [];
+    const toolsConfigured = Boolean(tools?.profile) || allow.length > 0 || alsoAllow.length > 0;
+    // Resolve the subagent model through the EXACT runtime spawn path so the
+    // report matches what delegation would actually run. This mirrors
+    // resolveSubagentSpawnModelSelection's full behavior: agent subagents.model
+    // > agents.defaults.subagents.model > agent/default primary model, with
+    // config-defined aliases (e.g. "gpt") resolved to a fully-qualified
+    // provider/model string. Runtime always resolves a model for spawning, so
+    // delegation is effectively always configured; credentials are then checked
+    // for the resolved delegation provider (not the agent's primary).
+    const delegationModel = resolveSubagentSpawnModelSelection({ cfg, agentId });
+    const delegationConfigured = Boolean(delegationModel && delegationModel.trim());
+    const delegationProvider = deriveProvider(delegationModel);
+    return {
+      agentId,
+      name: entry.name?.trim() || undefined,
+      isDefault: agentId === defaultAgentId,
+      configPresent: entries.length > 0,
+      model,
+      provider,
+      providerCredentialsPresent: credsPresent(provider),
+      delegationConfigured,
+      delegationModel,
+      delegationProvider,
+      delegationCredentialsPresent: credsPresent(delegationProvider),
+      toolsConfigured,
+      toolKeys: [...allow, ...alsoAllow, ...deny],
+    };
+  });
+}
+
+function renderCheckLine(check: CapabilityCheck): string {
+  const detail = check.detail ? ` — ${check.detail}` : "";
+  return `    ${STATUS_ICON[check.status]} ${check.label} (${check.reason})${detail}`;
+}
+
+function renderText(contract: FleetCapabilityContract): string {
+  const lines: string[] = [];
+  lines.push("Fleet Capability Contract v1");
+  lines.push(
+    `Rollup: ${STATUS_ICON[contract.rollup.status]} ${contract.rollup.status} ` +
+      `(green ${contract.rollup.green}, yellow ${contract.rollup.yellow}, red ${contract.rollup.red})`,
+  );
+  lines.push(`Generated: ${contract.now}`);
+  lines.push("");
+  lines.push("Fleet services:");
+  for (const check of contract.services) {
+    lines.push(renderCheckLine(check));
+  }
+  lines.push("");
+  lines.push("Profiles:");
+  if (contract.profiles.length === 0) {
+    lines.push("  (no agent profiles configured)");
+  }
+  for (const profile of contract.profiles) {
+    const heading =
+      profile.name && profile.name !== profile.agentId
+        ? `${profile.agentId} (${profile.name})`
+        : profile.agentId;
+    const defaultTag = profile.isDefault ? " (default)" : "";
+    lines.push(`  ${STATUS_ICON[profile.status]} ${heading}${defaultTag}`);
+    for (const check of profile.checks) {
+      lines.push(renderCheckLine(check));
+    }
+  }
+  return lines.join("\n");
+}
+
+export async function agentsCapabilitiesCommand(
+  opts: AgentsCapabilitiesOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (opts.json && opts.markdown) {
+    runtime.error("Cannot combine --json and --markdown; choose one output format.");
+    runtime.exit(1);
+    return;
+  }
+
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  const services = gatherServiceInput(env);
+  services.gatewayConfigured = Boolean(cfg.gateway);
+
+  const profiles = gatherProfileInputs(cfg, env, opts.agent);
+
+  const contract = buildFleetCapabilityContract({
+    now: new Date().toISOString(),
+    profiles,
+    services,
+  });
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, contract);
+    return;
+  }
+  if (opts.markdown) {
+    runtime.log(renderFleetCapabilityMarkdown(contract));
+    return;
+  }
+  runtime.log(renderText(contract));
+}


### PR DESCRIPTION
## What

Adds `fleet-reports/live-operationalization-checklist.md` — a phase-gated runbook for operationalizing the merged Fleet Capability Contract command (`openclaw agents capabilities` / `caps`, PR #1) on the live host, so the artifact is a shared system-of-record instead of a local desktop file.

## Why

Two live operational blockers remain after PR #1 merged:
- **B1** — live `/root/.openclaw/openclaw.json` is stale/invalid (telegram/discord `streaming` schema drift; retired model refs) -> validation fails before the report can run.
- **B2** — installed binary `2026.5.27 (27ae826)` predates the command; `agents capabilities` is unrecognized. Target build: `2026.5.31 (0e11dc6)`.

## Contents

- **Phase 0 (read-only):** record version/path, hashed config backup, read-only `config validate`, map exact schema migrations, pin the install/update path.
- **Phase 1 (approval-gated writes):** update binary, migrate config from backup, validate before swap, gateway untouched unless approved.
- **Phase 2 (read-only proof):** run `--json` + `--markdown`, timestamped reports, secret canary, per-agent red/yellow/green.
- **Rollback:** hash-verified config restore, prior-binary restore, gateway only if restarted in-window.

## Safety

Docs-only change. No live mutations: no `doctor --fix`, no config/binary/gateway/credential changes. Secret-safe throughout (keys-only inspection, presence-only handling, canary scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)