### PR TITLE
fix(policy): recognize declared tool allowlists

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -1187,6 +1187,7 @@ export function createOpenClawCodingTools(options?: {
     declaredToolAllowlist: buildDeclaredToolAllowlistContext({
       config: options?.config,
       workspaceDir: workspaceRoot,
+      toolDenylist: pluginToolDenylist,
     }),
   });
   if (shouldInheritEffectiveToolAllowlist) {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -92,6 +92,7 @@ import {
 } from "./tool-description-presets.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
+import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -1183,6 +1184,10 @@ export function createOpenClawCodingTools(options?: {
       { policy: inheritedToolPolicy, label: "inherited tools", unavailableCoreToolReason },
     ],
     auditLogLevel: options?.toolPolicyAuditLogLevel,
+    declaredToolAllowlist: buildDeclaredToolAllowlistContext({
+      config: options?.config,
+      workspaceDir: workspaceRoot,
+    }),
   });
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -21,7 +21,11 @@ import {
   buildDefaultToolPolicyPipelineSteps,
   type ToolPolicyPipelineStep,
 } from "../tool-policy-pipeline.js";
-import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../tool-policy.js";
+import {
+  collectExplicitDenylist,
+  mergeAlsoAllowPolicy,
+  resolveToolProfilePolicy,
+} from "../tool-policy.js";
 import type { AnyAgentTool } from "../tools/common.js";
 
 /**
@@ -179,6 +183,9 @@ export function applyFinalEffectiveToolPolicy(
     warn: params.warn,
     steps: pipelineSteps,
     auditLogLevel: params.toolPolicyAuditLogLevel,
-    declaredToolAllowlist: buildDeclaredToolAllowlistContext({ config: params.config }),
+    declaredToolAllowlist: buildDeclaredToolAllowlistContext({
+      config: params.config,
+      toolDenylist: collectExplicitDenylist(pipelineSteps.map((step) => step.policy)),
+    }),
   });
 }

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -15,6 +15,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../subagent-capabilities.js";
+import { buildDeclaredToolAllowlistContext } from "../tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -178,5 +179,6 @@ export function applyFinalEffectiveToolPolicy(
     warn: params.warn,
     steps: pipelineSteps,
     auditLogLevel: params.toolPolicyAuditLogLevel,
+    declaredToolAllowlist: buildDeclaredToolAllowlistContext({ config: params.config }),
   });
 }

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -1,44 +1,126 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizePluginId } from "../plugins/config-state.js";
-import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
+} from "../plugins/manifest-contract-eligibility.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { hasManifestToolAvailability } from "../plugins/manifest-tool-availability.js";
+import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import type { DeclaredToolAllowlistContext } from "./tool-policy.js";
 import { normalizeToolName } from "./tool-policy.js";
 
+type ToolDenylist = ReturnType<typeof compileGlobPatterns>;
+
+function normalizeToolDenylist(list?: string[]): ToolDenylist {
+  return compileGlobPatterns({ raw: list, normalize: normalizeToolName });
+}
+
+function denylistBlocksName(name: string, denylist: ToolDenylist): boolean {
+  const normalized = normalizeToolName(name);
+  return normalized ? matchesAnyGlobPattern(normalized, denylist) : false;
+}
+
+function denylistBlocksPlugin(params: { pluginId: string; denylist: ToolDenylist }): boolean {
+  return (
+    denylistBlocksName(params.pluginId, params.denylist) ||
+    matchesAnyGlobPattern("group:plugins", params.denylist)
+  );
+}
+
+function denylistBlocksPluginTool(params: {
+  pluginId: string;
+  toolName: string;
+  denylist: ToolDenylist;
+}): boolean {
+  return (
+    denylistBlocksPlugin({ pluginId: params.pluginId, denylist: params.denylist }) ||
+    denylistBlocksName(params.toolName, params.denylist)
+  );
+}
+
 function collectConfiguredMcpServerNames(config?: OpenClawConfig): string[] {
-  const servers = config?.mcp?.servers;
-  if (!isRecord(servers)) {
-    return [];
-  }
+  const servers = normalizeConfiguredMcpServers(config?.mcp?.servers);
   return Object.entries(servers)
-    .filter(([, value]) => isRecord(value))
+    .filter(([, value]) => isRecord(value) && value.enabled !== false)
     .map(([name]) => name.trim())
+    .filter(Boolean);
+}
+
+function collectAvailableManifestToolNames(params: {
+  plugin: PluginManifestRecord;
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  denylist: ToolDenylist;
+}): string[] {
+  return (params.plugin.contracts?.tools ?? [])
+    .filter(
+      (toolName) =>
+        !denylistBlocksPluginTool({
+          pluginId: params.plugin.id,
+          toolName,
+          denylist: params.denylist,
+        }),
+    )
+    .filter((toolName) =>
+      hasManifestToolAvailability({
+        plugin: params.plugin,
+        toolNames: [toolName],
+        config: params.config,
+        env: params.env,
+      }),
+    )
+    .map(normalizeToolName)
     .filter(Boolean);
 }
 
 function collectDeclaredPluginContext(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
+  toolDenylist?: string[];
+  env?: NodeJS.ProcessEnv;
 }): Pick<DeclaredToolAllowlistContext, "pluginIds" | "pluginToolNames"> {
   if (params.config?.plugins?.enabled === false) {
     return {};
   }
+  const env = params.env ?? process.env;
   const snapshot = loadManifestMetadataSnapshot({
     config: params.config,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    env,
   });
+  const normalizedPlugins = normalizePluginsConfig(params.config?.plugins);
+  const denylist = normalizeToolDenylist(params.toolDenylist);
   const pluginIds = new Set<string>();
   const pluginToolNames = new Set<string>();
   for (const plugin of snapshot.manifestRegistry.plugins) {
-    const pluginId = normalizePluginId(plugin.id);
-    if (pluginId) {
-      pluginIds.add(pluginId);
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: params.config,
+      }) ||
+      normalizedPlugins.entries[plugin.id]?.enabled === false ||
+      normalizedPlugins.deny.includes(plugin.id) ||
+      denylistBlocksPlugin({ pluginId: plugin.id, denylist })
+    ) {
+      continue;
     }
-    for (const toolName of plugin.contracts?.tools ?? []) {
-      const normalizedToolName = normalizeToolName(toolName);
-      if (normalizedToolName) {
-        pluginToolNames.add(normalizedToolName);
-      }
+    const availableToolNames = collectAvailableManifestToolNames({
+      plugin,
+      config: params.config,
+      env,
+      denylist,
+    });
+    if (availableToolNames.length === 0) {
+      continue;
+    }
+    pluginIds.add(plugin.id);
+    for (const toolName of availableToolNames) {
+      pluginToolNames.add(toolName);
     }
   }
   return { pluginIds, pluginToolNames };
@@ -47,17 +129,19 @@ function collectDeclaredPluginContext(params: {
 export function buildDeclaredToolAllowlistContext(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
+  toolDenylist?: string[];
+  env?: NodeJS.ProcessEnv;
 }): DeclaredToolAllowlistContext | undefined {
-  const mcpServerNames = collectConfiguredMcpServerNames(params.config);
+  const mcpServerNames = uniqueStrings(collectConfiguredMcpServerNames(params.config));
   const pluginContext = collectDeclaredPluginContext(params);
-  const hasDeclaredPlugins =
-    Array.from(pluginContext.pluginIds ?? []).length > 0 ||
-    Array.from(pluginContext.pluginToolNames ?? []).length > 0;
-  if (mcpServerNames.length === 0 && !hasDeclaredPlugins) {
+  const pluginIds = uniqueStrings(pluginContext.pluginIds ?? []);
+  const pluginToolNames = uniqueStrings(pluginContext.pluginToolNames ?? []);
+  if (mcpServerNames.length === 0 && pluginIds.length === 0 && pluginToolNames.length === 0) {
     return undefined;
   }
   return {
-    ...pluginContext,
+    ...(pluginIds.length > 0 ? { pluginIds } : {}),
+    ...(pluginToolNames.length > 0 ? { pluginToolNames } : {}),
     ...(mcpServerNames.length > 0 ? { mcpServerNames } : {}),
   };
 }

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -26,12 +26,10 @@ function denylistBlocksName(name: string, denylist: ToolDenylist): boolean {
 }
 
 function denylistContainsMcpServerEntry(params: {
-  serverName: string;
+  safeServerName: string;
   rawDenylist?: string[];
 }): boolean {
-  const serverPrefix = normalizeToolName(
-    sanitizeServerName(params.serverName, new Set<string>()) + TOOL_NAME_SEPARATOR,
-  );
+  const serverPrefix = normalizeToolName(params.safeServerName + TOOL_NAME_SEPARATOR);
   if (!serverPrefix) {
     return false;
   }
@@ -42,14 +40,14 @@ function denylistContainsMcpServerEntry(params: {
 }
 
 function denylistBlocksMcpServer(params: {
-  serverName: string;
+  safeServerName: string;
   rawDenylist?: string[];
   denylist: ToolDenylist;
 }): boolean {
   return (
     denylistBlocksName("bundle-mcp", params.denylist) ||
     denylistContainsMcpServerEntry({
-      serverName: params.serverName,
+      safeServerName: params.safeServerName,
       rawDenylist: params.rawDenylist,
     })
   );
@@ -79,18 +77,25 @@ function collectConfiguredMcpServerNames(params: {
 }): string[] {
   const servers = normalizeConfiguredMcpServers(params.config?.mcp?.servers);
   const denylist = normalizeToolDenylist(params.toolDenylist);
-  return Object.entries(servers)
-    .filter(([, value]) => isRecord(value) && value.enabled !== false)
-    .filter(
-      ([name]) =>
-        !denylistBlocksMcpServer({
-          serverName: name,
-          rawDenylist: params.toolDenylist,
-          denylist,
-        }),
-    )
-    .map(([name]) => name.trim())
-    .filter(Boolean);
+  const usedServerNames = new Set<string>();
+  const names: string[] = [];
+  for (const [name, value] of Object.entries(servers)) {
+    if (!isRecord(value) || value.enabled === false || !name.trim()) {
+      continue;
+    }
+    const safeServerName = sanitizeServerName(name, usedServerNames);
+    if (
+      denylistBlocksMcpServer({
+        safeServerName,
+        rawDenylist: params.toolDenylist,
+        denylist,
+      })
+    ) {
+      continue;
+    }
+    names.push(safeServerName);
+  }
+  return names;
 }
 
 function collectAvailableManifestToolNames(params: {

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -1,0 +1,63 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginId } from "../plugins/config-state.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import type { DeclaredToolAllowlistContext } from "./tool-policy.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+function collectConfiguredMcpServerNames(config?: OpenClawConfig): string[] {
+  const servers = config?.mcp?.servers;
+  if (!isRecord(servers)) {
+    return [];
+  }
+  return Object.entries(servers)
+    .filter(([, value]) => isRecord(value))
+    .map(([name]) => name.trim())
+    .filter(Boolean);
+}
+
+function collectDeclaredPluginContext(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): Pick<DeclaredToolAllowlistContext, "pluginIds" | "pluginToolNames"> {
+  if (params.config?.plugins?.enabled === false) {
+    return {};
+  }
+  const snapshot = loadManifestMetadataSnapshot({
+    config: params.config,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  });
+  const pluginIds = new Set<string>();
+  const pluginToolNames = new Set<string>();
+  for (const plugin of snapshot.manifestRegistry.plugins) {
+    const pluginId = normalizePluginId(plugin.id);
+    if (pluginId) {
+      pluginIds.add(pluginId);
+    }
+    for (const toolName of plugin.contracts?.tools ?? []) {
+      const normalizedToolName = normalizeToolName(toolName);
+      if (normalizedToolName) {
+        pluginToolNames.add(normalizedToolName);
+      }
+    }
+  }
+  return { pluginIds, pluginToolNames };
+}
+
+export function buildDeclaredToolAllowlistContext(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): DeclaredToolAllowlistContext | undefined {
+  const mcpServerNames = collectConfiguredMcpServerNames(params.config);
+  const pluginContext = collectDeclaredPluginContext(params);
+  const hasDeclaredPlugins =
+    Array.from(pluginContext.pluginIds ?? []).length > 0 ||
+    Array.from(pluginContext.pluginToolNames ?? []).length > 0;
+  if (mcpServerNames.length === 0 && !hasDeclaredPlugins) {
+    return undefined;
+  }
+  return {
+    ...pluginContext,
+    ...(mcpServerNames.length > 0 ? { mcpServerNames } : {}),
+  };
+}

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -46,6 +46,7 @@ function denylistBlocksMcpServer(params: {
 }): boolean {
   return (
     denylistBlocksName("bundle-mcp", params.denylist) ||
+    matchesAnyGlobPattern("group:plugins", params.denylist) ||
     denylistContainsMcpServerEntry({
       safeServerName: params.safeServerName,
       rawDenylist: params.rawDenylist,

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -33,9 +33,10 @@ function denylistContainsMcpServerEntry(params: {
   if (!serverPrefix) {
     return false;
   }
+  const serverWideEntry = serverPrefix + "*";
   return (params.rawDenylist ?? []).some((entry) => {
     const normalized = normalizeToolName(entry);
-    return normalized === "bundle-mcp" || normalized.startsWith(serverPrefix);
+    return normalized === serverWideEntry;
   });
 }
 

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -9,6 +9,7 @@ import {
 } from "../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { hasManifestToolAvailability } from "../plugins/manifest-tool-availability.js";
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "./agent-bundle-mcp-names.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import type { DeclaredToolAllowlistContext } from "./tool-policy.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -22,6 +23,36 @@ function normalizeToolDenylist(list?: string[]): ToolDenylist {
 function denylistBlocksName(name: string, denylist: ToolDenylist): boolean {
   const normalized = normalizeToolName(name);
   return normalized ? matchesAnyGlobPattern(normalized, denylist) : false;
+}
+
+function denylistContainsMcpServerEntry(params: {
+  serverName: string;
+  rawDenylist?: string[];
+}): boolean {
+  const serverPrefix = normalizeToolName(
+    sanitizeServerName(params.serverName, new Set<string>()) + TOOL_NAME_SEPARATOR,
+  );
+  if (!serverPrefix) {
+    return false;
+  }
+  return (params.rawDenylist ?? []).some((entry) => {
+    const normalized = normalizeToolName(entry);
+    return normalized === "bundle-mcp" || normalized.startsWith(serverPrefix);
+  });
+}
+
+function denylistBlocksMcpServer(params: {
+  serverName: string;
+  rawDenylist?: string[];
+  denylist: ToolDenylist;
+}): boolean {
+  return (
+    denylistBlocksName("bundle-mcp", params.denylist) ||
+    denylistContainsMcpServerEntry({
+      serverName: params.serverName,
+      rawDenylist: params.rawDenylist,
+    })
+  );
 }
 
 function denylistBlocksPlugin(params: { pluginId: string; denylist: ToolDenylist }): boolean {
@@ -42,10 +73,22 @@ function denylistBlocksPluginTool(params: {
   );
 }
 
-function collectConfiguredMcpServerNames(config?: OpenClawConfig): string[] {
-  const servers = normalizeConfiguredMcpServers(config?.mcp?.servers);
+function collectConfiguredMcpServerNames(params: {
+  config?: OpenClawConfig;
+  toolDenylist?: string[];
+}): string[] {
+  const servers = normalizeConfiguredMcpServers(params.config?.mcp?.servers);
+  const denylist = normalizeToolDenylist(params.toolDenylist);
   return Object.entries(servers)
     .filter(([, value]) => isRecord(value) && value.enabled !== false)
+    .filter(
+      ([name]) =>
+        !denylistBlocksMcpServer({
+          serverName: name,
+          rawDenylist: params.toolDenylist,
+          denylist,
+        }),
+    )
     .map(([name]) => name.trim())
     .filter(Boolean);
 }
@@ -132,7 +175,12 @@ export function buildDeclaredToolAllowlistContext(params: {
   toolDenylist?: string[];
   env?: NodeJS.ProcessEnv;
 }): DeclaredToolAllowlistContext | undefined {
-  const mcpServerNames = uniqueStrings(collectConfiguredMcpServerNames(params.config));
+  const mcpServerNames = uniqueStrings(
+    collectConfiguredMcpServerNames({
+      config: params.config,
+      toolDenylist: params.toolDenylist,
+    }),
+  );
   const pluginContext = collectDeclaredPluginContext(params);
   const pluginIds = uniqueStrings(pluginContext.pluginIds ?? []);
   const pluginToolNames = uniqueStrings(pluginContext.pluginToolNames ?? []);

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -25,32 +25,27 @@ function denylistBlocksName(name: string, denylist: ToolDenylist): boolean {
   return normalized ? matchesAnyGlobPattern(normalized, denylist) : false;
 }
 
-function denylistContainsMcpServerEntry(params: {
+function denylistBlocksMcpServerNamespace(params: {
   safeServerName: string;
-  rawDenylist?: string[];
+  denylist: ToolDenylist;
 }): boolean {
   const serverPrefix = normalizeToolName(params.safeServerName + TOOL_NAME_SEPARATOR);
   if (!serverPrefix) {
     return false;
   }
-  const serverWideEntry = serverPrefix + "*";
-  return (params.rawDenylist ?? []).some((entry) => {
-    const normalized = normalizeToolName(entry);
-    return normalized === serverWideEntry;
-  });
+  return matchesAnyGlobPattern(serverPrefix, params.denylist);
 }
 
 function denylistBlocksMcpServer(params: {
   safeServerName: string;
-  rawDenylist?: string[];
   denylist: ToolDenylist;
 }): boolean {
   return (
     denylistBlocksName("bundle-mcp", params.denylist) ||
     matchesAnyGlobPattern("group:plugins", params.denylist) ||
-    denylistContainsMcpServerEntry({
+    denylistBlocksMcpServerNamespace({
       safeServerName: params.safeServerName,
-      rawDenylist: params.rawDenylist,
+      denylist: params.denylist,
     })
   );
 }
@@ -89,7 +84,6 @@ function collectConfiguredMcpServerNames(params: {
     if (
       denylistBlocksMcpServer({
         safeServerName,
-        rawDenylist: params.toolDenylist,
         denylist,
       })
     ) {

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -336,6 +336,33 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("does not warn for MCP server namespace allowlist when one exact server tool is denied", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["paperless__delete"],
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["paperless__*"], deny: ["paperless__delete"] },
+          label: "tools",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
   test("warns when plugin group is denied and MCP server namespace is allowlisted", () => {
     const warnings: string[] = [];
     const declared = buildDeclaredToolAllowlistContext({

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -278,6 +278,64 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("warns when bundle MCP is denied and allowlisted", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["bundle-mcp"],
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["bundle-mcp"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (bundle-mcp). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
+  test("warns when denied MCP server namespace is allowlisted", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["paperless__*"],
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["paperless__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
   test("dedupes identical unknown-allowlist warnings across repeated runs", () => {
     const warnings: string[] = [];
     const tools = [{ name: "exec" }] as unknown as DummyTool[];

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -336,6 +336,35 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("warns when broad MCP server wildcard deny covers an allowlisted namespace", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["paperless*"],
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["paperless__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
   test("does not warn for MCP server namespace allowlist when one exact server tool is denied", () => {
     const warnings: string[] = [];
     const declared = buildDeclaredToolAllowlistContext({

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -1,6 +1,7 @@
 // Tool policy pipeline tests cover profile/allowlist filtering, diagnostics,
 // warning dedupe, and plugin-aware policy application.
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -210,6 +211,70 @@ describe("tool-policy-pipeline", () => {
 
     expect(warnings).toEqual([
       "tools: tools.allow allowlist contains unknown entries (papreless__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
+  test("declared context excludes disabled plugin tools", () => {
+    const declared = buildDeclaredToolAllowlistContext({
+      config: { plugins: { entries: { browser: { enabled: false } } } },
+      workspaceDir: process.cwd(),
+    });
+
+    expect(Array.from(declared?.pluginToolNames ?? [])).not.toContain("browser");
+  });
+
+  test("declared context excludes denied plugin tools", () => {
+    const declared = buildDeclaredToolAllowlistContext({
+      config: { plugins: { entries: { browser: { enabled: true } } } },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["browser"],
+    });
+
+    expect(Array.from(declared?.pluginToolNames ?? [])).not.toContain("browser");
+  });
+
+  test("declared context excludes disabled MCP servers", () => {
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: {
+          servers: {
+            paperless: { command: "paperless-mcp" },
+            disabled: { command: "disabled-mcp", enabled: false },
+          },
+        },
+      },
+      workspaceDir: process.cwd(),
+    });
+
+    expect(Array.from(declared?.mcpServerNames ?? [])).toContain("paperless");
+    expect(Array.from(declared?.mcpServerNames ?? [])).not.toContain("disabled");
+  });
+
+  test("warns when disabled MCP server namespace is allowlisted", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { disabled: { command: "disabled-mcp", enabled: false } } },
+      },
+      workspaceDir: process.cwd(),
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["disabled__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (disabled__*). These entries won't match any tool unless the plugin is enabled.",
     ]);
   });
 

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -336,6 +336,35 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("warns when plugin group is denied and MCP server namespace is allowlisted", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: { servers: { paperless: { command: "paperless-mcp" } } },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["group:plugins"],
+    });
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["paperless__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (paperless__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
   test("warns when denied duplicate-safe MCP server namespace is allowlisted", () => {
     const warnings: string[] = [];
     const declared = buildDeclaredToolAllowlistContext({

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -154,6 +154,65 @@ describe("tool-policy-pipeline", () => {
     expect(warnings).toStrictEqual([]);
   });
 
+  test("does not warn for declared plugin tools that are not materialized yet", () => {
+    const warnings: string[] = [];
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: { pluginToolNames: ["llm-task"] },
+      steps: [
+        {
+          policy: { allow: ["llm-task"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  test("does not warn for declared MCP server namespace globs", () => {
+    const warnings: string[] = [];
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: { mcpServerNames: ["paperless", "Home Assistant"] },
+      steps: [
+        {
+          policy: { allow: ["paperless__*", "home-assistant__search"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  test("still warns for undeclared MCP namespace globs", () => {
+    const warnings: string[] = [];
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: { mcpServerNames: ["paperless"] },
+      steps: [
+        {
+          policy: { allow: ["papreless__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (papreless__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
   test("dedupes identical unknown-allowlist warnings across repeated runs", () => {
     const warnings: string[] = [];
     const tools = [{ name: "exec" }] as unknown as DummyTool[];

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -336,6 +336,42 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("warns when denied duplicate-safe MCP server namespace is allowlisted", () => {
+    const warnings: string[] = [];
+    const declared = buildDeclaredToolAllowlistContext({
+      config: {
+        mcp: {
+          servers: {
+            "vigil harbor": { command: "vigil-mcp" },
+            "vigil:harbor": { command: "vigil-alt-mcp" },
+          },
+        },
+      },
+      workspaceDir: process.cwd(),
+      toolDenylist: ["vigil-harbor-2__*"],
+    });
+
+    expect(Array.from(declared?.mcpServerNames ?? [])).toEqual(["vigil-harbor"]);
+
+    applyToolPolicyPipeline({
+      tools: [{ name: "exec" }] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      declaredToolAllowlist: declared,
+      steps: [
+        {
+          policy: { allow: ["vigil-harbor__*", "vigil-harbor-2__*"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(warnings).toEqual([
+      "tools: tools.allow allowlist contains unknown entries (vigil-harbor-2__*). These entries won't match any tool unless the plugin is enabled.",
+    ]);
+  });
+
   test("dedupes identical unknown-allowlist warnings across repeated runs", () => {
     const warnings: string[] = [];
     const tools = [{ name: "exec" }] as unknown as DummyTool[];

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -12,6 +12,7 @@ import {
   buildPluginToolGroups,
   expandPolicyWithPluginGroups,
   normalizeToolName,
+  type DeclaredToolAllowlistContext,
   type ToolPolicyLike,
 } from "./tool-policy.js";
 
@@ -129,6 +130,7 @@ export function applyToolPolicyPipeline(params: {
   warn: (message: string) => void;
   steps: ToolPolicyPipelineStep[];
   auditLogLevel?: ToolPolicyAuditLogLevel;
+  declaredToolAllowlist?: DeclaredToolAllowlistContext;
 }): AnyAgentTool[] {
   const coreToolNames = new Set(
     params.tools
@@ -151,7 +153,12 @@ export function applyToolPolicyPipeline(params: {
     let policy: ToolPolicyLike | undefined = step.policy;
     if (step.stripPluginOnlyAllowlist) {
       // Plugin-only allowlists are valid for deferred tools; warn only for entries that cannot match.
-      const resolved = analyzeAllowlistByToolType(policy, pluginGroups, coreToolNames);
+      const resolved = analyzeAllowlistByToolType(
+        policy,
+        pluginGroups,
+        coreToolNames,
+        params.declaredToolAllowlist,
+      );
       if (resolved.unknownAllowlist.length > 0) {
         const unavailableCoreWarningAllowlist = new Set(
           (step.suppressUnavailableCoreToolWarningAllowlist ?? []).map((entry) =>

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -75,6 +75,40 @@ describe("analyzeAllowlistByToolType", () => {
     expect(policy.unknownAllowlist).toEqual(["apply_patch"]);
   });
 
+  it("recognizes declared plugin tools before they are materialized", () => {
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = analyzeAllowlistByToolType({ allow: ["llm-task"] }, emptyPlugins, coreTools, {
+      pluginToolNames: ["llm-task"],
+    });
+    expect(policy.policy?.allow).toEqual(["llm-task"]);
+    expect(policy.pluginOnlyAllowlist).toBe(true);
+    expect(policy.unknownAllowlist).toStrictEqual([]);
+  });
+
+  it("recognizes declared MCP server namespace allowlists before tools are materialized", () => {
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = analyzeAllowlistByToolType(
+      { allow: ["paperless__*", "home-assistant__search"] },
+      emptyPlugins,
+      coreTools,
+      { mcpServerNames: ["paperless", "Home Assistant"] },
+    );
+    expect(policy.pluginOnlyAllowlist).toBe(true);
+    expect(policy.unknownAllowlist).toStrictEqual([]);
+  });
+
+  it("still reports undeclared MCP namespace allowlist typos", () => {
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = analyzeAllowlistByToolType(
+      { allow: ["papreless__*"] },
+      emptyPlugins,
+      coreTools,
+      { mcpServerNames: ["paperless"] },
+    );
+    expect(policy.pluginOnlyAllowlist).toBe(false);
+    expect(policy.unknownAllowlist).toStrictEqual(["papreless__*"]);
+  });
+
   it("ignores empty plugin ids when building groups", () => {
     const groups = buildPluginToolGroups({
       tools: [{ name: "lobster" }],

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -5,6 +5,7 @@
  */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "./agent-bundle-mcp-names.js";
 import { IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW } from "./sandbox-tool-policy.js";
 import { expandToolGroups, normalizeToolList, normalizeToolName } from "./tool-policy-shared.js";
 export {
@@ -35,6 +36,12 @@ type AllowlistResolution = {
   policy: ToolPolicyLike | undefined;
   unknownAllowlist: string[];
   pluginOnlyAllowlist: boolean;
+};
+
+export type DeclaredToolAllowlistContext = {
+  pluginToolNames?: Iterable<string>;
+  pluginIds?: Iterable<string>;
+  mcpServerNames?: Iterable<string>;
 };
 
 /** Synthetic allowlist entry that means "use default plugin tools". */
@@ -188,11 +195,56 @@ export function expandPolicyWithPluginGroups(
   };
 }
 
+function buildDeclaredMcpToolPrefixes(serverNames?: Iterable<string>): Set<string> {
+  const prefixes = new Set<string>();
+  const usedNames = new Set<string>();
+  for (const serverName of serverNames ?? []) {
+    const safeName = sanitizeServerName(serverName, usedNames);
+    const prefix = normalizeToolName(safeName + TOOL_NAME_SEPARATOR);
+    if (prefix) {
+      prefixes.add(prefix);
+    }
+  }
+  return prefixes;
+}
+
+function normalizeDeclaredPluginIds(values?: Iterable<string>): Set<string> {
+  return new Set(
+    Array.from(values ?? [], (value) => normalizeOptionalLowercaseString(value)).filter(
+      (value): value is string => Boolean(value),
+    ),
+  );
+}
+
+function normalizeDeclaredToolNames(values?: Iterable<string>): Set<string> {
+  return new Set(
+    Array.from(values ?? [], (value) => normalizeToolName(value)).filter((value): value is string =>
+      Boolean(value),
+    ),
+  );
+}
+
+function isDeclaredMcpAllowlistEntry(entry: string, prefixes: Set<string>): boolean {
+  if (prefixes.size === 0) {
+    return false;
+  }
+  if (entry === "bundle-mcp") {
+    return true;
+  }
+  for (const prefix of prefixes) {
+    if (entry.length > prefix.length && entry.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Classifies allowlists as core, plugin-only, or unknown for diagnostics. */
 export function analyzeAllowlistByToolType(
   policy: ToolPolicyLike | undefined,
   groups: PluginToolGroups,
   coreTools: Set<string>,
+  declaredTools?: DeclaredToolAllowlistContext,
 ): AllowlistResolution {
   if (!policy?.allow || policy.allow.length === 0) {
     return { policy, unknownAllowlist: [], pluginOnlyAllowlist: false };
@@ -201,8 +253,15 @@ export function analyzeAllowlistByToolType(
   if (normalized.length === 0) {
     return { policy, unknownAllowlist: [], pluginOnlyAllowlist: false };
   }
-  const pluginIds = new Set(groups.byPlugin.keys());
-  const pluginTools = new Set(groups.all);
+  const pluginIds = new Set([
+    ...groups.byPlugin.keys(),
+    ...normalizeDeclaredPluginIds(declaredTools?.pluginIds),
+  ]);
+  const pluginTools = new Set([
+    ...groups.all,
+    ...normalizeDeclaredToolNames(declaredTools?.pluginToolNames),
+  ]);
+  const mcpToolPrefixes = buildDeclaredMcpToolPrefixes(declaredTools?.mcpServerNames);
   const unknownAllowlist: string[] = [];
   let hasOnlyPluginEntries = true;
   for (const entry of normalized) {
@@ -211,7 +270,10 @@ export function analyzeAllowlistByToolType(
       continue;
     }
     const isPluginEntry =
-      entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
+      entry === "group:plugins" ||
+      pluginIds.has(entry) ||
+      pluginTools.has(entry) ||
+      isDeclaredMcpAllowlistEntry(entry, mcpToolPrefixes);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
     if (!isPluginEntry) {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -11,6 +11,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../agents/subagent-capabilities.js";
+import { buildDeclaredToolAllowlistContext } from "../agents/tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -232,6 +233,10 @@ export function resolveGatewayScopedTools(params: {
       { policy: subagentPolicy, label: "subagent tools.allow" },
       { policy: inheritedToolPolicy, label: "inherited tools" },
     ],
+    declaredToolAllowlist: buildDeclaredToolAllowlistContext({
+      config: params.cfg,
+      workspaceDir,
+    }),
   });
 
   const gatewayDenySet = new Set([

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -236,6 +236,7 @@ export function resolveGatewayScopedTools(params: {
     declaredToolAllowlist: buildDeclaredToolAllowlistContext({
       config: params.cfg,
       workspaceDir,
+      toolDenylist: explicitDenylist,
     }),
   });
 

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -234,6 +234,7 @@ export function resolveSkillDispatchTools(params: {
     declaredToolAllowlist: buildDeclaredToolAllowlistContext({
       config: params.cfg,
       workspaceDir: params.workspaceDir,
+      toolDenylist: explicitDenylist,
     }),
   });
   if (explicitPolicyList.some(hasRestrictiveAllowPolicy)) {

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -13,6 +13,7 @@ import {
   isSubagentEnvelopeSession,
   resolveSubagentCapabilityStore,
 } from "../../agents/subagent-capabilities.js";
+import { buildDeclaredToolAllowlistContext } from "../../agents/tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -230,6 +231,10 @@ export function resolveSkillDispatchTools(params: {
       { policy: subagentPolicy, label: "subagent tools.allow" },
       { policy: inheritedToolPolicy, label: "inherited tools" },
     ],
+    declaredToolAllowlist: buildDeclaredToolAllowlistContext({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+    }),
   });
   if (explicitPolicyList.some(hasRestrictiveAllowPolicy)) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, policyFiltered);


### PR DESCRIPTION
## Summary
- Before this change, valid declared plugin/MCP allowlist entries could be reported as unknown because the analyzer only knew about materialized tools.
- Recognize declared tool allowlists while filtering unavailable tools out of the declared context.
- Filter denied MCP namespaces from declared allowlists, including `bundle-mcp`, sanitized server prefixes such as `paperless__*`, duplicate-safe suffixed prefixes such as `vigil-harbor-2__*`, broader wildcard denies such as `paperless*`, and exact tool denies such as `paperless__delete`.
- Keep this scoped to runtime policy diagnostics only; no config schema/options, CLI flags, plugin API/contract, env vars, migrations, or runtime tool filtering surface changes.

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/tool-policy-pipeline.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts src/plugins/tools.optional.test.ts src/agents/agent-bundle-mcp-tools.request-boundary.test.ts --reporter=dot` (3 shards, 114 tests)
- `node_modules/oxfmt/bin/oxfmt --check --threads=1 src/agents/tool-policy-declared-context.ts src/agents/tool-policy-pipeline.test.ts src/skills/runtime/tool-dispatch.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/effective-tool-policy.ts src/gateway/tool-resolution.ts`
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-policy-declared-context.ts src/agents/tool-policy-pipeline.test.ts`
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/skills/runtime/tool-dispatch.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/effective-tool-policy.ts src/gateway/tool-resolution.ts`
- `git diff --check`

## Real Behavior Proof
- GitHub `Real behavior proof` workflow passed on current head `55d6738b585a036b29a5e864f013f5d6e4de1d93`: https://github.com/openclaw/openclaw/actions/runs/27647305107/job/81762308906
- GitHub checks for current head `55d6738b585a036b29a5e864f013f5d6e4de1d93` are green; merge state is `CLEAN`.

## Current Head
- Rebased on current `main`.
- Signed head: `55d6738b585a036b29a5e864f013f5d6e4de1d93`.
