### PR TITLE
fix(gateway): ignore unreadable MCP union schema variants

### DIFF
--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -50,6 +50,27 @@ function readLoopbackToolParameters(tool: McpLoopbackTool): Record<string, unkno
   }
 }
 
+function readSchemaField(
+  schema: Record<string, unknown>,
+  key: string,
+): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: schema[key] };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readSchemaEntries(
+  schema: Record<string, unknown>,
+): { ok: true; entries: [string, unknown][] } | { ok: false } {
+  try {
+    return { ok: true, entries: Object.entries(schema) };
+  } catch {
+    return { ok: false };
+  }
+}
+
 function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknown> {
   const variants = (raw.anyOf ?? raw.oneOf) as unknown[] | undefined;
   if (!Array.isArray(variants) || variants.length === 0) {
@@ -65,9 +86,19 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
     if (!isRecord(variant)) {
       continue;
     }
-    const props = isRecord(variant.properties) ? variant.properties : undefined;
+    const propsRead = readSchemaField(variant, "properties");
+    if (!propsRead.ok) {
+      logWarn("mcp loopback: unreadable schema variant properties, ignoring that variant");
+      continue;
+    }
+    const props = isRecord(propsRead.value) ? propsRead.value : undefined;
     if (props) {
-      for (const [key, schema] of Object.entries(props)) {
+      const propsEntries = readSchemaEntries(props);
+      if (!propsEntries.ok) {
+        logWarn("mcp loopback: unreadable schema variant properties, ignoring that variant");
+        continue;
+      }
+      for (const [key, schema] of propsEntries.entries) {
         if (!isPropertySchema(schema)) {
           logWarn(`mcp loopback: malformed schema definition for "${key}", ignoring that variant`);
           continue;
@@ -118,9 +149,9 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
         );
       }
     }
-    requiredSets.push(
-      new Set(Array.isArray(variant.required) ? (variant.required as string[]) : []),
-    );
+    const requiredRead = readSchemaField(variant, "required");
+    const requiredValue = requiredRead.ok ? requiredRead.value : undefined;
+    requiredSets.push(new Set(Array.isArray(requiredValue) ? requiredValue : []));
   }
   const required =
     requiredSets.length > 0

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -493,6 +493,27 @@ describe("buildMcpToolSchema", () => {
       ).toEqual(testCase.expected);
     }
   });
+
+  it("ignores unreadable union schema variants while preserving usable siblings", () => {
+    const unreadableVariant = {};
+    Object.defineProperty(unreadableVariant, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin loopback variant properties exploded");
+      },
+    });
+
+    expect(
+      buildMockMcpToolSchema([
+        makeMockTool({
+          name: "fuzzplugin_move_angles",
+          parameters: {
+            anyOf: [unreadableVariant, angleSchema(ANGLE_NUMBER_PROPERTY, ["angle"])],
+          },
+        }),
+      ])[0]?.inputSchema,
+    ).toEqual(angleSchema(ANGLE_NUMBER_PROPERTY, ["angle"]));
+  });
 });
 
 describe("mcp loopback server", () => {


### PR DESCRIPTION
## Summary
- guard MCP loopback union schema flattening against unreadable nested variant fields
- ignore unreadable union variants while preserving usable sibling schema variants for `tools/list`
- add a regression for a throwing `properties` getter under an `anyOf` tool schema

## Verification
- `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --write src/gateway/mcp-http.schema.ts src/gateway/mcp-http.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/mcp-http.schema.ts src/gateway/mcp-http.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- AWS Crabbox fresh-PR changed gate: `run_99c052e897f3`, provider `aws`, lease `cbx_4dee1dcfcf42`, slug `brisk-shrimp`, lanes `core`, `coreTests`, exit 0, command 4m16.495s, total 4m34.395s, lease stopped

## Real behavior proof
Behavior addressed: MCP loopback `tools/list` schema construction no longer crashes when one union schema variant exposes an unreadable nested `properties` field.
Real environment tested: local OpenClaw source worktree on Node 24.15.0 for focused regression proof; AWS Crabbox Linux fresh-PR checkout for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts -- --reporter=dot`; `crabbox run --provider aws --fresh-pr openclaw/openclaw#89598 --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -e; if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -; sudo apt-get install -y nodejs; fi; node -v; npm -v; sudo corepack enable; env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`.
Evidence after fix: the regression builds a tool with `anyOf: [unreadableVariant, usableVariant]`; `buildMcpToolSchema` ignores the unreadable variant and returns the usable `angle` object schema. Remote changed gate `run_99c052e897f3` passed with lanes `core`, `coreTests`.
Observed result after fix: MCP HTTP gateway test file passed with 27 tests, and remote `pnpm check:changed` exited 0.
What was not tested: full repository suite beyond changed-gate scope.
