### PR TITLE
fix(outbound): stop schema-padded poll modifiers from blocking send

### DIFF
--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -362,6 +362,29 @@ describe("runMessageAction send validation", () => {
       }),
     ).rejects.toThrow(/use action "poll" instead of "send"/i);
   });
+
+  it("allows send when only schema-padded shared poll modifiers are present", async () => {
+    // LLMs routinely echo the shared `message` tool schema's poll modifier
+    // defaults (`pollDurationHours: 1`, `pollMulti: false`) on every plain
+    // `send` call alongside the rest of the schema-padded slots. Without a
+    // pollQuestion or pollOption present, these defaults are noise — not
+    // poll intent — and must not block the send.
+    const result = await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "#C12345678",
+        message: "hello",
+        pollQuestion: "",
+        pollOption: [],
+        pollDurationHours: 1,
+        pollMulti: false,
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+  });
 });
 
 describe("message body alias normalization", () => {

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -12,8 +12,8 @@ describe("poll params", () => {
     ).toBe(false);
   });
 
-  it.each([{ key: "pollMulti" }, { key: "pollAnonymous" }, { key: "pollPublic" }])(
-    "treats $key=true as poll creation intent",
+  it.each([{ key: "pollAnonymous" }, { key: "pollPublic" }])(
+    "treats channel-extra $key=true as poll creation intent",
     ({ key }) => {
       expect(
         hasPollCreationParams({
@@ -23,27 +23,44 @@ describe("poll params", () => {
     },
   );
 
-  it("treats non-zero finite numeric poll params as poll creation intent", () => {
+  it("treats non-zero finite numeric channel-extra poll params as poll creation intent", () => {
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "+60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "-5" })).toBe(true);
-    expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "0x10" })).toBe(false);
   });
 
-  it("does not treat zero-valued numeric poll params as poll creation intent", () => {
+  it("does not treat zero-valued numeric channel-extra poll params as poll creation intent", () => {
     // Zero values are typically defaults/unset values from tool schemas,
     // not intentional poll creation. Fixes #52118.
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: 0 })).toBe(false);
-    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
     expect(hasPollCreationParams({ poll_duration_seconds: 0 })).toBe(false);
+  });
+
+  it("does not treat shared modifier params (pollDurationHours, pollMulti) as poll creation intent without a question or options", () => {
+    // These two are exposed by the shared `message` tool schema for both
+    // `send` and `poll` actions, so LLMs routinely schema-pad them on every
+    // plain `send` call with their schema-implied defaults (1 for an integer
+    // with `minimum: 1`, `false` for a boolean). Treating those defaults as
+    // poll intent blocks routine sends — see the regression that motivated
+    // this carve-out.
+    expect(hasPollCreationParams({ pollDurationHours: 1 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: 1, pollMulti: false })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ poll_duration_hours: "0" })).toBe(false);
+    expect(hasPollCreationParams({ pollMulti: true })).toBe(false);
+  });
+
+  it("still flags shared modifier params when accompanied by a question or options", () => {
+    expect(hasPollCreationParams({ pollQuestion: "Ready?", pollDurationHours: 1 })).toBe(true);
+    expect(hasPollCreationParams({ pollOption: ["Yes", "No"], pollMulti: true })).toBe(true);
   });
 
   it("treats string-encoded boolean poll params as poll creation intent when true", () => {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -74,8 +74,18 @@ function hasExplicitUnknownPollValue(key: string, value: unknown): boolean {
   return false;
 }
 
-export function hasPollCreationParams(params: Record<string, unknown>): boolean {
-  for (const key of SHARED_POLL_CREATION_PARAM_NAMES) {
+// Among the shared poll params, only the content-bearing fields (pollQuestion,
+// pollOption) signal poll intent on their own. The modifier fields
+// (pollDurationHours, pollMulti) are exposed by the shared `message` tool
+// schema for both `send` and `poll` actions, so LLMs routinely echo their
+// schema-implied defaults (`1`, `false`) on plain `send` calls — see issue
+// for context. Treating those modifier defaults as "the agent meant to create
+// a poll" produces false positives and blocks routine sends. The modifiers
+// only count when accompanied by a content-bearing field.
+const CONTENT_BEARING_SHARED_POLL_PARAM_NAMES = ["pollQuestion", "pollOption"] as const;
+
+function hasContentBearingPollCreationParam(params: Record<string, unknown>): boolean {
+  for (const key of CONTENT_BEARING_SHARED_POLL_PARAM_NAMES) {
     const def = POLL_CREATION_PARAM_DEFS[key];
     const value = readPollParamRaw(params, key);
     if (def.kind === "string" && typeof value === "string" && value.trim().length > 0) {
@@ -92,30 +102,18 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
         return true;
       }
     }
-    if (def.kind === "positiveInteger") {
-      // Treat zero-valued numeric defaults as unset, but preserve any non-zero
-      // numeric value as explicit poll intent so invalid durations still hit
-      // the poll-only validation path.
-      if (typeof value === "number" && Number.isFinite(value) && value !== 0) {
-        return true;
-      }
-      if (typeof value === "string") {
-        const trimmed = value.trim();
-        const parsed = parseStrictFiniteNumber(trimmed);
-        if (parsed !== undefined && parsed !== 0) {
-          return true;
-        }
-      }
-    }
-    if (def.kind === "boolean") {
-      if (value === true) {
-        return true;
-      }
-      if (typeof value === "string" && normalizeLowercaseStringOrEmpty(value) === "true") {
-        return true;
-      }
-    }
   }
+  return false;
+}
+
+export function hasPollCreationParams(params: Record<string, unknown>): boolean {
+  if (hasContentBearingPollCreationParam(params)) {
+    return true;
+  }
+  // Channel-specific poll-prefixed params (e.g. pollDurationSeconds,
+  // pollPublic) are not part of the shared schema, so an explicit value still
+  // indicates deliberate poll intent and continues to trigger the validator
+  // even without a pollQuestion/pollOption.
   for (const [key, value] of Object.entries(params)) {
     if (isChannelPollCreationParamName(key) && hasExplicitUnknownPollValue(key, value)) {
       return true;


### PR DESCRIPTION
## Summary

`hasPollCreationParams` previously treated **any** of the shared poll params (`pollQuestion`, `pollOption`, `pollDurationHours`, `pollMulti`) as poll intent if present with a non-zero / non-default value.

The shared `message` tool schema exposes those last two for both `send` and `poll` actions, and agent models routinely echo the schema's implied defaults (`1` for the `minimum: 1` integer, `false` for the boolean) on every plain `send` call alongside the rest of the schema-padded slots. The validator interpreted `pollDurationHours: 1` on its own as "the agent meant to create a poll", so `runMessageAction` threw:

> Poll fields require action "poll"; use action "poll" instead of "send".

…on routine sends, blocking agent replies from any channel whose outbound goes through `runMessageAction` (i.e. all of them). I first observed this on the Slack channel — Slack is where the regression surfaced for our deployment — but the bug is in shared/core code (`src/poll-params.ts`, used by `src/agents/tools/message-tool.ts` and `src/infra/outbound/message-action-runner.ts`), so the same tool-call shape would hit Telegram, Discord, or any other channel a `message`-tool agent talks to.

This PR narrows the shared-param branch to the content-bearing fields (`pollQuestion`, `pollOption`). Channel-extra `poll*` params (`pollDurationSeconds`, `pollPublic`, `pollAnonymous`, …) remain strict because they aren't part of the shared tool-schema surface, so an explicit value still signals deliberate intent.

## What changed

- `src/poll-params.ts` — split shared-param handling: only `pollQuestion` / `pollOption` count as standalone intent. Channel-extra detection is unchanged.
- `src/poll-params.test.ts` — updated two existing assertions and added a new test for the schema-pad shape.
- `src/infra/outbound/message-action-runner.send-validation.test.ts` — added an integration case asserting `runMessageAction` accepts a `send` with schema-padded `pollDurationHours: 1` / `pollMulti: false`.

## Behavior change for existing assertions

Two unit-level assertions changed semantics, both intentionally:

| Input | Old | New | Why |
|---|---|---|---|
| `{ pollMulti: true }` alone | poll intent | not intent | A boolean modifier with no question or options is not a valid poll; in practice this combination only appears from schema-padding. |
| `{ pollDurationHours: -1 }` alone | poll intent | not intent | Same rationale. The shared-schema modifier alone is no longer enough. |

Channel-extra equivalents (`pollAnonymous: true`, `pollPublic: true`, `pollDurationSeconds: -5`) are unchanged and still count as intent, because they are not part of the schema-padded surface that agents echo on every send.

## Alternative considered

A more invasive fix would be to make the shared `message` tool schema action-aware: drop `pollDurationHours` / `pollMulti` from the `send` action's parameter surface entirely so agents never see them when calling `send`. That addresses the root cause ("LLMs echo schema-implied defaults on every call") instead of catching it at the validator. It's a bigger schema-side change touching `buildMessageToolPollProps` and the action-to-schema mapping. Happy to take that direction if maintainers prefer it; this PR is the minimal locality-of-change fix at the validator gate.

## Real behavior proof

**Behavior or issue addressed**: `hasPollCreationParams` returned `true` for `{ pollDurationHours: 1 }` alone — the value LLMs schema-pad onto every `send` tool call (the schema is `Type.Optional(Type.Integer({ minimum: 1 }))`). `runMessageAction` then threw `Poll fields require action "poll"; use action "poll" instead of "send"`, blocking the send. First surfaced as an agent that could no longer reply in any Slack thread it was @mentioned in; the same tool-call shape would affect every channel that routes through `runMessageAction`.

**Real environment tested**: OpenClaw `2026.5.28` (npm `openclaw@2026.5.28`), running in a production container `openclaw-…` on a Coolify host. Agent model `openrouter/openrouter/auto` (thinking=high). Slack channel via socket mode. Same bundled validator code path as upstream `main`: `dist/message-action-runner-*.js` calling `hasPollCreationParams` from the bundled `poll-params` module.

**Exact steps or command run after this patch**: I applied the equivalent semantic narrowing in the running container's bundled `dist/message-action-runner-*.js` via a small `node` patch script (guard the throw on `pollQuestion` non-empty OR `pollOption` non-empty), `docker restart`-ed the container, then @mentioned the agent in a Slack thread to elicit the same tool-call shape that previously failed.

**Evidence after fix**: redacted runtime logs and copied live output from the patched container. Failing tool-call shape captured from the pre-patch agent session transcript (10 occurrences in a single failed session, one shown, sensitive IDs redacted to `…`):

```json
{
  "action": "send",
  "channel": "slack",
  "target": "channel:C…",
  "message": "<@U…> hi",
  "threadId": "…",
  "pollQuestion": "",
  "pollOption": [],
  "pollDurationHours": 1,
  "pollMulti": false
}
```

Before patch: every such call threw `Poll fields require action "poll"…` and no reply was delivered. After patch + `docker restart`, the gateway's runtime log showed clean startup and the message went out without the validator error:

```
[gateway] http server listening (10 plugins: …, slack, …; 3.7s)
[slack] [default] starting provider
[slack] channels resolved: … (+21)
[slack] socket mode connected
[gateway] ready
```

The same tool-call shape (with `pollDurationHours: 1, pollMulti: false`) then went through `runMessageAction` and produced a delivered Slack message — no `Poll fields require action "poll"` thrown, no rejection in the outbound path.

**Observed result after fix**: agent replied in-thread in Slack with the user-facing text. Outbound delivery completed with the workspace plugin returning a Slack message id. The validator no longer blocks schema-padded `send` calls.

**What was not tested**: I did not write a full end-to-end test against a real Slack workspace inside this PR's CI — the regression observed in the live container is the proof. I also did not exercise channels other than Slack (Telegram, Discord, …) for the same shape, though the failing code path is channel-agnostic and the integration test in `message-action-runner.send-validation.test.ts` uses the channel-agnostic `runDrySend` helper.

## Local test results on this PR

Vitest 4.1.7, node 22.18.0, pnpm 11.2.2:

Changed-files lanes (`node scripts/test-projects.mjs --changed origin/main`):
- `vitest.unit-fast.config.ts`: 1/1 file, 11/11 tests pass
- `vitest.infra.config.ts`: 1/1 file, 24/24 tests pass (includes the new integration assertion)

Shared-surface lanes (`pnpm test:contracts`):
- `vitest.contracts-channel-registry.config.ts`: 11/11 files, 29/29 tests pass
- `vitest.contracts-channel-session.config.ts`: 11/11 files, 34/34 tests pass

The plugin-contracts portion of `pnpm test:contracts` (`vitest.contracts-plugin.config.ts`) stalled with no output on my machine and was killed by the runner's watchdog; the touched files are not referenced by that lane, but flagging it for CI to confirm.

## AI assistance disclosure

- [x] AI-assisted (Claude / Claude Code). I read the failing transcript, the validator, the tool-schema callsite, and the existing tests; chose the narrowing scope; wrote the fix and tests; ran the targeted Vitest shards and the channels-contracts lane.
- [x] Real-behavior proof above is from my own OpenClaw deployment, not from AI-generated mocks.
- [x] I understand what the code does — the change is a strict subset of the previous logic for content-bearing inputs: any input that returned `true` before still returns `true`, *except* shared-modifier-only inputs that match the schema-pad shape.
