### PR TITLE
fix(status): show effective channel model override

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -824,6 +824,37 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("channel override");
   });
 
+  it("shows the effective channel override model when it differs from the default", () => {
+    const text = buildStatusMessage({
+      config: {
+        channels: {
+          modelByChannel: {
+            telegram: {
+              "group-123": "xai/grok-4.3",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "openai/gpt-5.5",
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        channel: "telegram",
+        groupId: "group-123",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Model: xai/grok-4.3");
+    expect(normalized).toContain("channel override");
+    expect(normalized).toContain("Session/default model: openai/gpt-5.5");
+  });
+
   it("uses the channel override model context window instead of stale persisted context", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -481,13 +481,11 @@ const formatVoiceModeLine = (
   return parts.join(" · ");
 };
 
-function resolveChannelModelNote(params: {
+function resolveChannelModelRef(params: {
   config?: OpenClawConfig;
   entry?: SessionEntry;
-  selectedProvider: string;
-  selectedModel: string;
   parentSessionKey?: string;
-}): string | undefined {
+}): { provider: string; model: string; label: string } | undefined {
   if (!params.config || !params.entry) {
     return undefined;
   }
@@ -523,13 +521,13 @@ function resolveChannelModelNote(params: {
   if (!resolvedOverride) {
     return undefined;
   }
-  if (
-    resolvedOverride.ref.provider !== params.selectedProvider ||
-    resolvedOverride.ref.model !== params.selectedModel
-  ) {
-    return undefined;
-  }
-  return "channel override";
+  return {
+    provider: resolvedOverride.ref.provider,
+    model: resolvedOverride.ref.model,
+    label:
+      formatProviderModelRef(resolvedOverride.ref.provider, resolvedOverride.ref.model) ||
+      channelOverride.model,
+  };
 }
 
 function hasUserPinnedModelSelection(entry: SessionEntry | undefined): boolean {
@@ -582,14 +580,20 @@ export function buildStatusMessage(args: StatusArgs): string {
     selectedModel,
     sessionEntry: entry,
   });
+  const channelModelRef = resolveChannelModelRef({
+    config: args.config,
+    entry,
+    parentSessionKey: args.parentSessionKey,
+  });
+  const initialActiveModelLabel = channelModelRef?.label ?? modelRefs.active.label ?? "unknown";
   const initialFallbackState = resolveActiveFallbackState({
     selectedModelRef: modelRefs.selected.label || "unknown",
-    activeModelRef: modelRefs.active.label || "unknown",
+    activeModelRef: initialActiveModelLabel,
     config: args.config,
     state: entry,
   });
-  let activeProvider = modelRefs.active.provider;
-  let activeModel = modelRefs.active.model;
+  let activeProvider = channelModelRef?.provider ?? modelRefs.active.provider;
+  let activeModel = channelModelRef?.model ?? modelRefs.active.model;
   let contextLookupProvider: string | undefined = activeProvider;
   let contextLookupModel = activeModel;
   const runtimeModelRaw = normalizeOptionalString(entry?.model) ?? "";
@@ -716,13 +720,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     typeof resolvedActiveContextTokens === "number"
       ? Math.min(explicitRuntimeContextTokens, resolvedActiveContextTokens)
       : (explicitRuntimeContextTokens ?? resolvedActiveContextTokens);
-  const channelModelNote = resolveChannelModelNote({
-    config: args.config,
-    entry,
-    selectedProvider,
-    selectedModel,
-    parentSessionKey: args.parentSessionKey,
-  });
+  const channelModelNote = channelModelRef ? "channel override" : undefined;
   const persistedContextTokens =
     typeof entry?.contextTokens === "number" && entry.contextTokens > 0
       ? entry.contextTokens
@@ -972,9 +970,16 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
+  const activeAuthLabel = activeAuthLabelValue ? ` · 🔑 ${activeAuthLabelValue}` : "";
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const configuredDefaultModelLabel = normalizeOptionalString(args.configuredDefaultModelLabel);
   const sessionHasPersistedModelSelection = hasUserPinnedModelSelection(entry);
+  const channelOverrideDiffersFromSelected =
+    channelModelRef !== undefined &&
+    channelModelRef.label !== selectedModelLabel &&
+    !areRuntimeModelRefsEquivalent(channelModelRef.label, selectedModelLabel, {
+      config: args.config,
+    });
   const configDefaultDiffersFromSession =
     sessionHasPersistedModelSelection &&
     configuredDefaultModelLabel &&
@@ -991,7 +996,12 @@ export function buildStatusMessage(args: StatusArgs): string {
         `↩️ Clear with: /model ${configuredDefaultModelLabel} or /reset`,
         "📖 Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
       ]
-    : [`🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`];
+    : channelOverrideDiffersFromSelected && channelModelRef
+      ? [
+          `🧠 Model: ${channelModelRef.label}${activeAuthLabel}${modelNote}`,
+          `📌 Session/default model: ${selectedModelLabel}${selectedAuthLabel}`,
+        ]
+      : [`🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`];
 
   // Show configured fallback models (from agent model config)
   const configuredFallbacks = (() => {


### PR DESCRIPTION
## Summary
- resolve channel-level `channels.modelByChannel` overrides in `/status` even when they differ from the session/default model
- show the effective channel override model as the primary model and include the session/default model separately
- add regression coverage for a Telegram channel override differing from the default model

Fixes #89532

## Tests
- `node scripts/run-vitest.mjs src/auto-reply/status.test.ts src/auto-reply/reply/commands-status.test.ts src/channels/model-overrides.test.ts`