### PR TITLE
fix(agents): quarantine unreadable tool schemas before normalization

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -126,6 +126,27 @@ function requireToolExecute(tool: OpenClawCodingTool): NonNullable<OpenClawCodin
   return tool.execute;
 }
 
+function createPluginTool(name: string): OpenClawCodingTool {
+  return {
+    name,
+    label: name,
+    description: `${name} test tool`,
+    parameters: { type: "object", properties: {} },
+    execute: vi.fn(),
+  };
+}
+
+function createUnreadableParametersTool(name: string): OpenClawCodingTool {
+  const tool = createPluginTool(name);
+  Object.defineProperty(tool, "parameters", {
+    enumerable: true,
+    get() {
+      throw new Error(`${name} parameters getter exploded`);
+    },
+  });
+  return tool;
+}
+
 function latestCreateOpenClawToolsOptions(): OpenClawToolsOptions {
   const calls = vi.mocked(createOpenClawTools).mock.calls;
   const lastCall = calls.at(-1);
@@ -621,6 +642,49 @@ describe("createOpenClawCodingTools", () => {
       expect(resolvePluginToolsSpy).toHaveBeenCalledTimes(1);
       const pluginToolOptions = resolvePluginToolsSpy.mock.calls[0]?.[0].options;
       expect(pluginToolOptions?.authProfileStore).toBe(authProfileStore);
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
+  it("quarantines unreadable plugin tool schemas before core schema normalization", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const unreadableTool = createUnreadableParametersTool("fuzzplugin_unreadable");
+    const healthyTool = createPluginTool("fuzzplugin_healthy");
+    const onPreNormalizationSchemaDiagnostics = vi.fn();
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([unreadableTool, healthyTool]);
+
+    try {
+      const tools = createOpenClawCodingTools({
+        config: testConfig,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["fuzzplugin_unreadable", "fuzzplugin_healthy"],
+        onPreNormalizationSchemaDiagnostics,
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+      expect(toolNameList(tools)).toEqual(["fuzzplugin_healthy"]);
+      expect(onPreNormalizationSchemaDiagnostics).toHaveBeenCalledTimes(1);
+      const [diagnostics, sourceTools] = onPreNormalizationSchemaDiagnostics.mock.calls[0] ?? [];
+      expect(diagnostics).toEqual([
+        {
+          toolName: "fuzzplugin_unreadable",
+          toolIndex: 0,
+          violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+        },
+      ]);
+      expect(sourceTools?.[0]).toBe(unreadableTool);
+      expect(sourceTools?.[1]).toBe(healthyTool);
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -99,6 +99,10 @@ import {
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
 import {
+  filterProviderNormalizableTools,
+  type RuntimeToolSchemaDiagnostic,
+} from "./tool-schema-projection.js";
+import {
   createToolSearchTools,
   resolveToolSearchConfig,
   TOOL_CALL_RAW_TOOL_NAME,
@@ -369,6 +373,20 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
   };
 }
 
+function logProviderSchemaProjectionDiagnostics(
+  diagnostics: readonly RuntimeToolSchemaDiagnostic[],
+): void {
+  if (diagnostics.length === 0) {
+    return;
+  }
+  const summary = diagnostics
+    .map((diagnostic) => `${diagnostic.toolName}: ${diagnostic.violations.join(", ")}`)
+    .join("; ");
+  logWarn(
+    `agents/tools: quarantined ${diagnostics.length} unsupported tool schema${diagnostics.length === 1 ? "" : "s"} before provider schema normalization: ${summary}.`,
+  );
+}
+
 export { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 
 export const testing = {
@@ -514,6 +532,11 @@ export function createOpenClawCodingTools(options?: {
   onYield?: (message: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
+  /** Reports schemas quarantined before provider-specific normalization. */
+  onPreNormalizationSchemaDiagnostics?: (
+    diagnostics: readonly RuntimeToolSchemaDiagnostic[],
+    tools: readonly AnyAgentTool[],
+  ) => void;
   /** Lower routine policy-removal audits for diagnostic-only tool probes. */
   toolPolicyAuditLogLevel?: "info" | "debug";
   /** Live observer called after wrapped tool outcomes are recorded. */
@@ -1119,14 +1142,27 @@ export function createOpenClawCodingTools(options?: {
     ],
     auditLogLevel: options?.toolPolicyAuditLogLevel,
   });
-  if (shouldInheritEffectiveToolAllowlist) {
-    replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, subagentFiltered);
-  }
   options?.recordToolPrepStage?.("authorization-policy");
+  const normalizableToolProjection = filterProviderNormalizableTools(subagentFiltered);
+  if (normalizableToolProjection.diagnostics.length > 0) {
+    if (options?.onPreNormalizationSchemaDiagnostics) {
+      options.onPreNormalizationSchemaDiagnostics(
+        normalizableToolProjection.diagnostics,
+        subagentFiltered,
+      );
+    } else {
+      logProviderSchemaProjectionDiagnostics(normalizableToolProjection.diagnostics);
+    }
+  }
+  if (shouldInheritEffectiveToolAllowlist) {
+    replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, [
+      ...normalizableToolProjection.tools,
+    ]);
+  }
   // Always normalize tool JSON Schemas before handing them to OpenClaw model runtime.
   // Without this, some providers (notably OpenAI) will reject root-level union schemas.
   // Provider-specific cleaning: Gemini needs constraint keywords stripped, but Anthropic expects them.
-  const normalized = subagentFiltered.map((tool) =>
+  const normalized = normalizableToolProjection.tools.map((tool) =>
     normalizeToolParameters(tool, {
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -792,6 +792,14 @@ async function compactEmbeddedAgentSessionDirectOnce(
           : undefined,
       sessionId: params.sessionId,
       runId: params.runId,
+      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+        logRuntimeToolSchemaQuarantine({
+          diagnostics,
+          tools: sourceTools,
+          runId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+        }),
       groupId: params.groupId,
       groupChannel: params.groupChannel,
       groupSpace: params.groupSpace,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1242,6 +1242,14 @@ export async function runEmbeddedAttempt(
             runtimeToolAllowlist: effectiveToolsAllow,
             authProfileStore: params.authProfileStore,
             recordToolPrepStage: (name) => corePluginToolStages.mark(name),
+            onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) =>
+              logRuntimeToolSchemaQuarantine({
+                diagnostics,
+                tools: sourceTools,
+                runId: params.runId,
+                sessionKey: params.sessionKey,
+                sessionId: params.sessionId,
+              }),
             onToolOutcome: params.onToolOutcome,
             skillsSnapshot: skillsSnapshotForRun,
             onYield: (message) => {

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -196,6 +196,8 @@ export function buildEffectiveToolInventoryEntries(
 
 export function buildRuntimeCompatibleToolInventory(params: {
   tools: readonly AnyAgentTool[];
+  preNormalizationDiagnostics?: readonly RuntimeToolSchemaDiagnostic[];
+  preNormalizationTools?: readonly AnyAgentTool[];
   cfg: OpenClawConfig;
   workspaceDir?: string;
   modelProvider?: string;
@@ -206,9 +208,10 @@ export function buildRuntimeCompatibleToolInventory(params: {
   entries: EffectiveToolInventoryEntry[];
   notices: EffectiveToolInventoryNotice[];
 } {
-  const rawToolsByName = buildReadableRawToolsByName(params.tools);
+  const rawToolsByName = buildReadableRawToolsByName(params.preNormalizationTools ?? params.tools);
   const preNormalizationProjection = filterProviderNormalizableTools(params.tools);
   const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [
+    ...(params.preNormalizationDiagnostics ?? []),
     ...preNormalizationProjection.diagnostics,
   ];
   const normalizedTools = normalizeAgentRuntimeTools({

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -376,6 +376,45 @@ describe("resolveEffectiveToolInventory", () => {
     ]);
   });
 
+  it("preserves inventory notices for schemas quarantined during tool construction", async () => {
+    const healthy = mockTool({ name: "exec", label: "Exec", description: "Run shell commands" });
+    const rejected = mockTool({
+      name: "fuzzplugin_unreadable",
+      label: "Fuzzplugin Unreadable",
+      description: "Unreadable plugin schema",
+    });
+    const createToolsMock = vi.fn<typeof createOpenClawCodingTools>((options) => {
+      options?.onPreNormalizationSchemaDiagnostics?.(
+        [
+          {
+            toolName: "fuzzplugin_unreadable",
+            toolIndex: 1,
+            violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+          },
+        ],
+        [healthy, rejected],
+      );
+      return [healthy];
+    });
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal16 } =
+      await loadHarness({
+        createToolsMock,
+        pluginMeta: { fuzzplugin_unreadable: { pluginId: "fuzzplugin" } },
+      });
+
+    const result = resolveEffectiveToolInventoryLocal16({ cfg: {} });
+
+    expect(result.groups.flatMap((group) => group.tools.map((tool) => tool.id))).toEqual(["exec"]);
+    expect(result.notices).toEqual([
+      {
+        id: "unsupported-tool-schema:fuzzplugin_unreadable",
+        severity: "warning",
+        message:
+          'Tool "fuzzplugin_unreadable" from plugin "fuzzplugin" has an unsupported runtime input schema (fuzzplugin_unreadable.parameters is unreadable) and was quarantined before model projection. Fix or disable the owner, or remove the tool from active allowlists.',
+      },
+    ]);
+  });
+
   it("reports unreadable inventory tool entries without crashing", async () => {
     const healthy = mockTool({ name: "exec", label: "Exec", description: "Run shell commands" });
     const tools = new Proxy([healthy] as AnyAgentTool[], {

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -17,6 +17,7 @@ import { resolveModel } from "./embedded-agent-runner/model.js";
 import { resolveBundledStaticCatalogModel } from "./embedded-agent-runner/model.static-catalog.js";
 import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
 import { normalizeToolName } from "./tool-policy.js";
+import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
 import {
   buildEffectiveToolInventoryGroups,
   buildRuntimeCompatibleToolInventory,
@@ -27,6 +28,7 @@ import type {
   EffectiveToolInventoryResult,
   ResolveEffectiveToolInventoryParams,
 } from "./tools-effective-inventory.types.js";
+import type { AnyAgentTool } from "./tools/common.js";
 
 export {
   buildEffectiveToolInventoryEntries,
@@ -310,6 +312,8 @@ export function resolveEffectiveToolInventory(
     modelProvider: params.modelProvider,
     modelId: params.modelId,
   });
+  const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];
+  let preNormalizationTools: readonly AnyAgentTool[] | undefined;
 
   const effectiveTools = createOpenClawCodingTools({
     agentId,
@@ -338,9 +342,15 @@ export function resolveEffectiveToolInventory(
     modelHasVision: params.modelHasVision,
     requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     disableMessageTool: params.disableMessageTool,
+    onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
+      preNormalizationDiagnostics.push(...diagnostics);
+      preNormalizationTools = sourceTools;
+    },
   });
   const projectedInventory = buildRuntimeCompatibleToolInventory({
     tools: effectiveTools,
+    preNormalizationDiagnostics,
+    preNormalizationTools,
     cfg: params.cfg,
     workspaceDir,
     modelProvider: params.modelProvider,

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -159,6 +159,19 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelContextWindowTokens: runtimeModelContext.modelContextWindowTokens,
         allowGatewaySubagentBinding: true,
         toolPolicyAuditLogLevel: "debug",
+        onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
+          for (const diagnostic of diagnostics) {
+            const tool = readToolByIndex(sourceTools, diagnostic.toolIndex);
+            const pluginId = readPluginId(tool);
+            warnings.push(
+              formatDiagnostic({
+                agentId,
+                diagnostic,
+                ...(pluginId ? { pluginId } : {}),
+              }),
+            );
+          }
+        },
       });
     } catch (error) {
       warnings.push(

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -682,6 +682,7 @@ function collectAgentRuntimeToolSchemaFindings(params: {
   modelRef: { provider: string; model: string };
   model: ProviderRuntimeModel;
 }): readonly HealthFinding[] {
+  const preNormalizationFindings: HealthFinding[] = [];
   let tools: AnyAgentTool[];
   try {
     tools = createOpenClawCodingTools({
@@ -696,12 +697,24 @@ function collectAgentRuntimeToolSchemaFindings(params: {
       allowGatewaySubagentBinding: true,
       emitBeforeToolCallDiagnostics: false,
       toolPolicyAuditLogLevel: "debug",
+      onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
+        preNormalizationFindings.push(
+          ...diagnostics.map((diagnostic) =>
+            toolSchemaDiagnosticToFinding({
+              agentId: params.agentId,
+              tools: sourceTools,
+              diagnostic,
+            }),
+          ),
+        );
+      },
     });
   } catch (error) {
-    return [agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error })];
+    return [
+      ...preNormalizationFindings,
+      agentRuntimeToolLoadFailureFinding({ agentId: params.agentId, error }),
+    ];
   }
-
-  const preNormalizationFindings: HealthFinding[] = [];
 
   let normalizedTools: AnyAgentTool[];
   try {


### PR DESCRIPTION
## Summary
- Quarantine provider-un-normalizable tool schemas inside `createOpenClawCodingTools` before core/provider normalization can touch hostile descriptors.
- Preserve pre-normalization diagnostics for embedded runs, compaction, doctor checks, and effective tool inventory notices.
- Add regressions for unreadable plugin parameter getters and inventory notices for construction-time quarantines.

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/flows/doctor-core-checks.runtime.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts src/agents/tools-effective-inventory.test.ts -- --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tools.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/compact.ts src/commands/doctor/shared/active-tool-schema-warnings.ts src/flows/doctor-core-checks.runtime.ts src/agents/tools-effective-inventory.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `pnpm check:changed`: provider `aws`, run `run_c8060ac9459a`, lease `cbx_681f56f9d848`, slug `brisk-krill`, type `c7a.8xlarge`, lanes `core, coreTests`, exit 0, command 7m8.12s, total 7m26.855s.

## Real behavior proof
Behavior addressed: malformed plugin/channel tool schemas with unreadable `parameters` descriptors are quarantined before provider schema normalization, while runtime, doctor, and inventory diagnostics still report the rejected tool.

Real environment tested: local OpenClaw source worktree on branch `fuzz-tool-schema-next44-20260602`, head `d00cce3977346ce86e0eb43c2a3995258d1eff78`, plus AWS Crabbox fresh PR checkout for `openclaw/openclaw#89603`.

Exact steps or command run after this patch: ran the Verification commands above after the final rebase and push; Crabbox command used `crabbox run --provider aws --fresh-pr openclaw/openclaw#89603 --idle-timeout 30m --ttl 90m --timing-json --shell -- "... corepack pnpm check:changed"`.

Evidence after fix: focused Vitest shards passed with 29 unit tests, 7 command tests, and 82 agent tests; changed-file oxlint passed; diff check passed; autoreview returned no accepted/actionable findings; Crabbox `pnpm check:changed` passed for `core, coreTests`.

Observed result after fix: unreadable plugin tool schemas are filtered out before normalization, diagnostics are forwarded to runtime/doctor/inventory surfaces, and healthy sibling tools remain available.

What was not tested: full repo `pnpm check` and live provider/tool execution were not run.
