### PR TITLE
fix(process): return timeout code for killed commands

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -471,6 +471,13 @@ two-party event loops that do not go through the shared inbound reply runner.
     const hint = api.runtime.system.formatNativeDependencyHint(pkg);
     ```
 
+    `runCommandWithTimeout(...)` returns captured `stdout` and `stderr`, optional
+    truncation counts, `code`, `signal`, `killed`, `termination`, and
+    `noOutputTimedOut`. Timeout and no-output-timeout results report `code: 124`
+    when the child process does not provide a non-zero exit code. Non-timeout
+    signal exits can still return `code: null`, so use `termination` and
+    `noOutputTimedOut` to distinguish timeout reasons.
+
   </Accordion>
   <Accordion title="api.runtime.events">
     Event subscriptions.

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -234,7 +234,7 @@ describe("runCommandWithTimeout", () => {
       const result = await resultPromise;
       expect(result.termination).toBe("no-output-timeout");
       expect(result.noOutputTimedOut).toBe(true);
-      expect(result.code).not.toBe(0);
+      expect(result.code).toBe(124);
     },
   );
 
@@ -255,7 +255,7 @@ describe("runCommandWithTimeout", () => {
       const result = await resultPromise;
       expect(result.termination).toBe("timeout");
       expect(result.noOutputTimedOut).toBe(false);
-      expect(result.code).not.toBe(0);
+      expect(result.code).toBe(124);
     },
   );
 

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -263,6 +263,7 @@ export type CommandOptions = {
 const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 const WINDOWS_CLOSE_STATE_POLL_MS = 10;
 const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
+const TIMEOUT_EXIT_CODE = 124;
 const DEFAULT_COMMAND_OUTPUT_MAX_BYTES = 16 * 1024 * 1024;
 
 type CapturedOutputBuffers = {
@@ -307,7 +308,6 @@ function appendCapturedOutput(
     }
   }
 }
-
 export function resolveProcessExitCode(params: {
   explicitCode: number | null | undefined;
   childExitCode: number | null | undefined;
@@ -614,8 +614,8 @@ export async function runCommandWithTimeout(
             : "exit";
       const normalizedCode =
         termination === "timeout" || termination === "no-output-timeout"
-          ? resolvedCode === 0
-            ? 124
+          ? resolvedCode == null || resolvedCode === 0
+            ? TIMEOUT_EXIT_CODE
             : resolvedCode
           : resolvedCode;
       resolve({

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -459,7 +459,7 @@ describe("windows command wrapper behavior", () => {
         child.emit("close", null, "SIGKILL");
         const result = await resultPromise;
         expect(result.termination).toBe("timeout");
-        expect(result.code).not.toBe(0);
+        expect(result.code).toBe(124);
       });
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

Fixes a timeout result edge case in `runCommandWithTimeout`.

When a timed-out child process was killed without a numeric exit code, the result could keep `code: null`. Some plugin callers normalize missing status fields to success, which can make partial timeout output look cacheable.

This now reports `code: 124` for timeout and no-output-timeout terminations. Non-timeout signal exits still keep `code: null`.

Related #73743

## Verification

- Docker Node 22: `pnpm test src/process/exec.test.ts src/process/exec.windows.test.ts`
- Result: 2 files passed, 29 tests passed

## Real behavior proof

- Behavior or issue addressed: timed-out `runCommandWithTimeout` result now returns nonzero `code: 124` instead of `null`.
- Real environment tested: Docker `node:22-bookworm`, Node v22.22.3, pnpm 11.2.2.
- Exact steps or command run after this patch: ran a real child process through `runCommandWithTimeout`; child wrote `ready`, then stayed alive until timeout.
- Evidence after fix:

```json
{
  "code": 124,
  "termination": "timeout",
  "noOutputTimedOut": false,
  "killed": true,
  "stdout": "ready",
  "signal": "SIGKILL"
}
```

- Observed result after fix: partial stdout was preserved, but the timeout result is unambiguously nonzero.
- What was not tested: full macOS launchd recipes fan-out and ClawKitchen cache poisoning were not reproduced locally.
