### PR TITLE
fix(agents): skip unreadable tool-search schemas

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -329,6 +329,75 @@ describe("Tool Search", () => {
     expect(clientEntry?.source).toBe("client");
   });
 
+  it("skips unreadable tool schemas when compacting the search catalog", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const readable = pluginTool("fake_readable_schema", "Readable tool");
+    const throwingGetter = pluginTool("fake_schema_getter", "Throws while reading parameters");
+    Object.defineProperty(throwingGetter, "parameters", {
+      configurable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const nestedGetter = pluginTool("fake_nested_schema_getter", "Throws while walking schema");
+    Object.defineProperty(
+      (nestedGetter.parameters as { properties: Record<string, unknown> }).properties,
+      "boom",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("fuzzplugin nested schema getter exploded");
+        },
+      },
+    );
+
+    const compacted = applyToolSearchCatalog({
+      tools: [codeTool, readable, throwingGetter, nestedGetter],
+      config: { tools: { toolSearch: true } } as never,
+      sessionId: "session-unreadable-catalog-schema",
+    });
+
+    expect(compacted.catalogRegistered).toBe(true);
+    expect(compacted.catalogToolCount).toBe(1);
+    expect(
+      testing.sessionCatalogs
+        .get("session:session-unreadable-catalog-schema")
+        ?.entries.map((entry) => entry.name),
+    ).toEqual(["fake_readable_schema"]);
+  });
+
+  it("skips unreadable client tool schemas when appending to the search catalog", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    applyToolSearchCatalog({
+      tools: [codeTool],
+      config,
+      sessionId: "session-client-unreadable-schema",
+    });
+
+    const readable = fakeTool("client_readable_schema", "Readable client tool");
+    const unreadable = fakeTool("client_unreadable_schema", "Unreadable client tool");
+    Object.defineProperty(unreadable, "parameters", {
+      configurable: true,
+      get() {
+        throw new Error("client parameters getter exploded");
+      },
+    });
+    const compacted = addClientToolsToToolSearchCatalog({
+      tools: [readable, unreadable],
+      config,
+      sessionId: "session-client-unreadable-schema",
+    });
+
+    expect(compacted.tools).toEqual([]);
+    expect(compacted.catalogToolCount).toBe(1);
+    expect(
+      testing.sessionCatalogs
+        .get("session:session-client-unreadable-schema")
+        ?.entries.map((entry) => entry.name),
+    ).toEqual(["client_readable_schema"]);
+  });
+
   it("wraps cataloged OpenClaw tools with before_tool_call hooks", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const target = pluginTool("fake_hooked", "Run a hook-aware fake tool");

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -509,6 +509,32 @@ function stableJsonFingerprint(value: unknown, seen = new WeakSet<object>()): st
   return `{${entries.join(",")}}`;
 }
 
+function canReadStableJsonFingerprint(value: unknown): boolean {
+  try {
+    stableJsonFingerprint(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function canCatalogEntryBeProjected(entry: ToolSearchCatalogEntry): boolean {
+  try {
+    void entry.id;
+    void entry.source;
+    void entry.sourceName;
+    void entry.name;
+    void entry.label;
+    void entry.description;
+    void entry.tool;
+    return (
+      canReadStableJsonFingerprint(entry.mcp) && canReadStableJsonFingerprint(entry.parameters)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function catalogToolIdentity(tool: CatalogTool): number {
   const existing = catalogToolIdentities.get(tool);
   if (existing !== undefined) {
@@ -661,6 +687,19 @@ function toCatalogEntry(
     parameters: tool.parameters,
     tool: catalogTool,
   };
+}
+
+function tryToCatalogEntry(
+  tool: CatalogTool,
+  sourceOverride?: CatalogSource,
+  hookContext?: HookContext,
+): ToolSearchCatalogEntry | undefined {
+  try {
+    const entry = toCatalogEntry(tool, sourceOverride, hookContext);
+    return canCatalogEntryBeProjected(entry) ? entry : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function shouldCatalogTool(tool: AnyAgentTool): boolean {
@@ -890,10 +929,10 @@ export function registerToolSearchCatalog(params: {
     ? (params.catalogRef?.current ?? (primaryKey ? sessionCatalogs.get(primaryKey) : undefined))
     : undefined;
   const byId = new Map<string, ToolSearchCatalogEntry>();
-  for (const entry of prior?.entries ?? []) {
+  for (const entry of prior?.entries.filter(canCatalogEntryBeProjected) ?? []) {
     byId.set(entry.id, entry);
   }
-  for (const entry of params.entries) {
+  for (const entry of params.entries.filter(canCatalogEntryBeProjected)) {
     byId.set(entry.id, entry);
     byId.set(entry.name, entry);
   }
@@ -1276,7 +1315,10 @@ export function applyToolCatalogCompaction(params: {
       continue;
     }
     if (shouldCatalog(tool)) {
-      catalog.push(toCatalogEntry(tool, undefined, params.toolHookContext));
+      const entry = tryToCatalogEntry(tool, undefined, params.toolHookContext);
+      if (entry) {
+        catalog.push(entry);
+      }
       continue;
     }
     visible.push(tool);
@@ -1365,16 +1407,19 @@ export function addClientToolsToToolCatalog(params: {
   if (!existing) {
     return { tools: params.tools, compacted: false, catalogToolCount: 0 };
   }
+  const entries = params.tools
+    .map((tool) => tryToCatalogEntry(tool, "client"))
+    .filter((entry): entry is ToolSearchCatalogEntry => entry !== undefined);
   registerToolSearchCatalog({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     runId: params.runId,
     catalogRef: params.catalogRef,
-    entries: params.tools.map((tool) => toCatalogEntry(tool, "client")),
+    entries,
     append: true,
   });
-  return { tools: [], compacted: params.tools.length > 0, catalogToolCount: params.tools.length };
+  return { tools: [], compacted: params.tools.length > 0, catalogToolCount: entries.length };
 }
 
 function toJsonSafe(value: unknown): unknown {


### PR DESCRIPTION
## Summary

- Prevent Tool Search catalog setup from crashing when a tool exposes unreadable schema metadata.
- Skip catalog entries whose `parameters` or MCP metadata cannot be safely read and fingerprinted, while preserving readable tools in the same catalog.
- Apply the same guard to appended client tools so a single malformed client tool does not break the compact prompt surface.
- Out of scope: adding new diagnostics UI for skipped Tool Search entries; this PR keeps the agent session bootable and covered by focused regression tests.

## Linked context

No linked issue.

Related: continuing tool-schema fuzzing hardening across OpenClaw agent/tool surfaces.

Was this requested by a maintainer or owner? Maintainer fuzzing lane.

## Real behavior proof

Behavior addressed: Tool Search compaction could throw while reading or fingerprinting a malformed tool schema, preventing the agent run from starting with Tool Search enabled.

Real environment tested: Local OpenClaw sparse GWT on branch `fuzz-tool-schema-next45-20260602`, Node/Vitest through repo wrappers.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-search.ts src/agents/tool-search.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: Focused Vitest passed 1 file / 27 tests on rebased head `d2f740672a4`; oxlint exited 0 for the touched files; diff check exited 0; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.82)`.

Observed result after fix: Tool Search compaction and client-tool catalog append skip unreadable schema entries and keep readable entries registered instead of throwing.

What was not tested: Full repo test suite and live provider/tool-search runtime sessions were not run locally; broad changed-gate proof is being run separately through Crabbox after PR creation.

Proof limitations or environment constraints: Local checkout is a sparse Codex worktree, so broad `pnpm` gates are routed remote per repo policy.

Before evidence: Regression tests construct tools with throwing `parameters` getters and nested throwing schema getters; without the guard, catalog entry creation/fingerprinting would throw.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts -- --reporter=dot`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-search.ts src/agents/tool-search.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Added Tool Search tests for unreadable plugin tool schemas during catalog compaction.
- Added Tool Search tests for unreadable client tool schemas during catalog append.

What failed before this fix, if known?

- Reading `tool.parameters` or recursively fingerprinting `entry.parameters` could throw before Tool Search had a chance to register the compacted catalog.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed/unreadable tools are skipped from Tool Search instead of crashing catalog setup.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Tool availability: unreadable tools are no longer discoverable through Tool Search.

How is that risk mitigated?

Only entries whose schema metadata cannot be read and fingerprinted are skipped; readable entries in the same catalog remain available, and the behavior is covered for both plugin and client tool paths.

## Current review state

What is the next action?

Await remote changed-gate proof and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Author is running remote `pnpm check:changed` proof after PR creation.

Which bot or reviewer comments were addressed?

None yet. Local and branch autoreview both reported no accepted/actionable findings.

Agent transcript: `.agents/skills/agent-transcript/scripts/agent-transcript find` returned `[]`; no sanitized transcript was available to attach.
