### PR TITLE
fix(gateway): ignore unreadable tool action schemas

### DIFF
--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -175,6 +175,19 @@ vi.mock("../agents/openclaw-tools.js", () => {
       },
     },
     {
+      name: "unreadable_schema_test",
+      parameters: {
+        type: "object",
+        get properties() {
+          throw new Error("schema properties getter exploded");
+        },
+      },
+      execute: async (_toolCallId: string, args: unknown) => ({
+        ok: true,
+        args,
+      }),
+    },
+    {
       name: "diffs_compat_test",
       parameters: {
         type: "object",
@@ -827,6 +840,21 @@ describe("POST /tools/invoke", () => {
     const body = await expectOkInvokeResponse(res);
     expect(body.result?.observedFormat).toBe("pdf");
     expect(body.result?.observedFileFormat).toBeUndefined();
+  });
+
+  it("does not fail HTTP tool invocation when the schema action probe is unreadable", async () => {
+    setMainAllowedTools({ allow: ["unreadable_schema_test"] });
+
+    const res = await invokeToolAuthed({
+      tool: "unreadable_schema_test",
+      action: "legacy",
+      args: { mode: "ok" },
+      sessionKey: "main",
+    });
+
+    const body = await expectOkInvokeResponse(res);
+    expect(body.result?.args).toEqual({ mode: "ok" });
+    expect(firstHookCallArg().params).toEqual({ mode: "ok" });
   });
 
   it("requires operator.write scope for HTTP tool invocation", async () => {

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -94,14 +94,19 @@ function mergeActionIntoArgsIfSupported(params: {
   if (!action || args.action !== undefined) {
     return args;
   }
-  const schemaObj = toolSchema as { properties?: Record<string, unknown> } | null;
-  const hasAction = Boolean(
-    schemaObj &&
-    typeof schemaObj === "object" &&
-    schemaObj.properties &&
-    "action" in schemaObj.properties,
-  );
-  return hasAction ? { ...args, action } : args;
+  return schemaSupportsAction(toolSchema) ? { ...args, action } : args;
+}
+
+function schemaSupportsAction(toolSchema: unknown): boolean {
+  if (!toolSchema || typeof toolSchema !== "object") {
+    return false;
+  }
+  try {
+    const properties = (toolSchema as { properties?: unknown }).properties;
+    return Boolean(properties && typeof properties === "object" && "action" in properties);
+  } catch {
+    return false;
+  }
 }
 
 function getErrorMessage(err: unknown): string {


### PR DESCRIPTION
## Summary

- Guard the `/tools/invoke` legacy `action` merge probe against unreadable tool schema `properties` access.
- Preserve invocation when the schema cannot be inspected by treating it as not supporting the legacy top-level `action` shortcut.
- Add HTTP gateway regression coverage for an unreadable schema action probe.

## Verification

- `node scripts/run-vitest.mjs src/gateway/tools-invoke-http.test.ts -- --reporter=dot` (31 tests)
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/tools-invoke-shared.ts src/gateway/tools-invoke-http.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/tools-invoke-shared.ts src/gateway/tools-invoke-http.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (provider `aws`, run `run_4c1b33ce7e51`, lease `cbx_a476f6e70927`, slug `swift-lobster`, type `c7a.8xlarge`, lanes `core, coreTests`, exit 0, command 3m17.478s, total 6m03.248s)

## Real behavior proof

Behavior addressed: `/tools/invoke` no longer fails before execution when a plugin/tool schema has an unreadable `properties` accessor during the optional legacy `action` merge probe.

Real environment tested: local Gateway HTTP invoke unit fixture plus AWS Crabbox Linux changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/tools-invoke-http.test.ts -- --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.

Evidence after fix: the new unreadable-schema regression keeps the response successful and confirms both the hook and tool receive unchanged args without an injected `action` field; remote changed gate passed lanes `core, coreTests`.

Observed result after fix: `src/gateway/tools-invoke-http.test.ts` passed 31 tests; Crabbox run `run_4c1b33ce7e51` exited 0.

What was not tested: no live external Gateway instance was exercised; this is covered by the HTTP unit fixture and remote changed gate.
