### PR TITLE
fix: include persisted plugin contracts for migrations

### DIFF
--- a/src/plugins/manifest-contract-runtime.test.ts
+++ b/src/plugins/manifest-contract-runtime.test.ts
@@ -62,7 +62,6 @@ describe("resolveManifestContractRuntimePluginResolution", () => {
     expect(loadPluginMetadataSnapshot).toHaveBeenCalledWith({
       config: {},
       env: process.env,
-      preferPersisted: false,
     });
   });
 });

--- a/src/plugins/manifest-contract-runtime.ts
+++ b/src/plugins/manifest-contract-runtime.ts
@@ -12,10 +12,6 @@ export type ManifestContractRuntimePluginResolution = {
   bundledCompatPluginIds: string[];
 };
 
-const DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS = {
-  preferPersisted: false,
-} as const;
-
 export function resolveManifestContractRuntimePluginResolution(params: {
   cfg?: OpenClawConfig;
   contract: PluginManifestContractListKey;
@@ -24,7 +20,6 @@ export function resolveManifestContractRuntimePluginResolution(params: {
   const snapshot = loadPluginMetadataSnapshot({
     config: params.cfg ?? {},
     env: process.env,
-    ...DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS,
   });
   const allContractPlugins = snapshot.plugins.filter((plugin) =>
     hasManifestContractValue({

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -225,7 +225,6 @@ describe("migration provider runtime", () => {
     expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
       config: cfg,
       env: process.env,
-      preferPersisted: false,
     });
     const manifestParams = requireMockCallArg(
       mocks.loadPluginManifestRegistry,
@@ -288,7 +287,6 @@ describe("migration provider runtime", () => {
     expect(mocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
       config: {},
       env: process.env,
-      preferPersisted: false,
       workspaceDir: undefined,
     });
     const manifestParams = requireMockCallArg(


### PR DESCRIPTION
## Summary
- Fixes #89609.
- Let manifest-contract runtime lookup use the normal plugin metadata snapshot instead of forcing `preferPersisted: false`.
- This allows standalone migration-provider discovery to see enabled persisted/global plugin install records while preserving the existing availability filtering and bundled compat handling.

## Verification
- `node scripts/run-vitest.mjs src/plugins/migration-provider-runtime.test.ts src/plugins/manifest-contract-runtime.test.ts src/commands/migrate.test.ts`

## Real behavior proof
Behavior addressed: standalone migration-provider manifest-contract lookup can discover a migration provider declared by an enabled persisted/global plugin install record.

Real environment tested: local OpenClaw source checkout on Linux with a temporary `OPENCLAW_STATE_DIR`, a real persisted installed-plugin index, and a real global plugin fixture declaring `contracts.migrationProviders: ["demo-global"]`.

Exact steps or command run after this patch:

```sh
node --import tsx /tmp/openclaw-real-proof-89609.mjs
```

Evidence after fix:

```text
stateDir=/tmp/openclaw-89609-real-N3TEmT/state
persistedIndexPlugins=global-migrate-demo
persistedInstallRecords=global-migrate-demo
resolvedMigrationContractPlugins=global-migrate-demo
bundledCompatPluginIds=<none>
```

Observed result after fix: the resolver returned `global-migrate-demo` from the persisted/global plugin record; this was the path previously blocked by `preferPersisted: false`.

Supplemental test output:

```text
[test] passed 2 Vitest shards in 13.40s
commands: 40 passed
plugins: 5 passed
```

What was not tested: a live global npm install of the Codex plugin.
