### PR TITLE
feat(ui): hide empty workboard columns

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:11.780Z",
+  "generatedAt": "2026-06-13T03:39:02.012Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:10.484Z",
+  "generatedAt": "2026-06-13T03:38:59.718Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:10.741Z",
+  "generatedAt": "2026-06-13T03:39:00.183Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:14.091Z",
+  "generatedAt": "2026-06-13T03:39:07.282Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:11.517Z",
+  "generatedAt": "2026-06-13T03:39:01.551Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:12.811Z",
+  "generatedAt": "2026-06-13T03:39:04.043Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:12.038Z",
+  "generatedAt": "2026-06-13T03:39:02.458Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:10.997Z",
+  "generatedAt": "2026-06-13T03:39:00.639Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:11.259Z",
+  "generatedAt": "2026-06-13T03:39:01.114Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:13.835Z",
+  "generatedAt": "2026-06-13T03:39:06.373Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:13.065Z",
+  "generatedAt": "2026-06-13T03:39:04.514Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:10.230Z",
+  "generatedAt": "2026-06-13T03:38:59.154Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:13.322Z",
+  "generatedAt": "2026-06-13T03:39:05.135Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:12.297Z",
+  "generatedAt": "2026-06-13T03:39:02.997Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:12.554Z",
+  "generatedAt": "2026-06-13T03:39:03.555Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:13.580Z",
+  "generatedAt": "2026-06-13T03:39:05.578Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:09.713Z",
+  "generatedAt": "2026-06-13T03:38:56.901Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -34,12 +34,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-10T18:02:09.977Z",
+  "generatedAt": "2026-06-13T03:38:58.644Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "d31dac3a16f784afca7d2c01a614ceeb2d90bb455a67114a0830a3c045210715",
-  "totalKeys": 1335,
-  "translatedKeys": 1302,
+  "sourceHash": "644e37fe678b6c9f31954656d675e2bd8a6f133171ef56c55aabc321ccde5b04",
+  "totalKeys": 1336,
+  "translatedKeys": 1303,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -611,6 +611,7 @@ export const ar: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "البحث في البطاقات",
     allPriorities: "كل الأولويات",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "أفلِت العمل هنا",
     lifecycleUnlinked: "لا توجد جلسة",
     lifecycleUnlinkedDetail: "ابدأ جلسة أو اربطها",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -616,6 +616,7 @@ export const de: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Karten suchen",
     allPriorities: "Alle Prioritäten",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Arbeit hier ablegen",
     lifecycleUnlinked: "Keine Sitzung",
     lifecycleUnlinkedDetail: "Sitzung starten oder verknüpfen",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -610,6 +610,7 @@ export const en: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Search cards",
     allPriorities: "All priorities",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Drop work here",
     lifecycleUnlinked: "No session",
     lifecycleUnlinkedDetail: "Start or link a session",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -613,6 +613,7 @@ export const es: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Buscar tarjetas",
     allPriorities: "Todas las prioridades",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Suelta el trabajo aquí",
     lifecycleUnlinked: "Sin sesión",
     lifecycleUnlinkedDetail: "Inicia o vincula una sesión",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -613,6 +613,7 @@ export const fa: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "جستجوی کارت‌ها",
     allPriorities: "همه اولویت‌ها",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "کار را اینجا رها کنید",
     lifecycleUnlinked: "بدون جلسه",
     lifecycleUnlinkedDetail: "یک جلسه را شروع یا پیوند کنید",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -615,6 +615,7 @@ export const fr: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Rechercher des cartes",
     allPriorities: "Toutes les priorités",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Déposez le travail ici",
     lifecycleUnlinked: "Aucune session",
     lifecycleUnlinkedDetail: "Démarrer ou lier une session",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -612,6 +612,7 @@ export const id: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Cari kartu",
     allPriorities: "Semua prioritas",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Letakkan pekerjaan di sini",
     lifecycleUnlinked: "Tidak ada sesi",
     lifecycleUnlinkedDetail: "Mulai atau tautkan sesi",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -614,6 +614,7 @@ export const it: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Cerca schede",
     allPriorities: "Tutte le priorità",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Rilascia qui il lavoro",
     lifecycleUnlinked: "Nessuna sessione",
     lifecycleUnlinkedDetail: "Avvia o collega una sessione",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -615,6 +615,7 @@ export const ja_JP: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "カードを検索",
     allPriorities: "すべての優先度",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "ここに作業をドロップ",
     lifecycleUnlinked: "セッションなし",
     lifecycleUnlinkedDetail: "セッションを開始またはリンク",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -611,6 +611,7 @@ export const ko: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "카드 검색",
     allPriorities: "모든 우선순위",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "여기에 작업을 놓으세요",
     lifecycleUnlinked: "세션 없음",
     lifecycleUnlinkedDetail: "세션을 시작하거나 연결하세요",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -614,6 +614,7 @@ export const nl: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Kaarten zoeken",
     allPriorities: "Alle prioriteiten",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Sleep werk hierheen",
     lifecycleUnlinked: "Geen sessie",
     lifecycleUnlinkedDetail: "Start of koppel een sessie",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -613,6 +613,7 @@ export const pl: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Szukaj kart",
     allPriorities: "Wszystkie priorytety",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Upuść pracę tutaj",
     lifecycleUnlinked: "Brak sesji",
     lifecycleUnlinkedDetail: "Rozpocznij lub połącz sesję",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -612,6 +612,7 @@ export const pt_BR: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Pesquisar cartões",
     allPriorities: "Todas as prioridades",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Solte o trabalho aqui",
     lifecycleUnlinked: "Nenhuma sessão",
     lifecycleUnlinkedDetail: "Inicie ou vincule uma sessão",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -610,6 +610,7 @@ export const th: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "ค้นหาการ์ด",
     allPriorities: "ทุกลำดับความสำคัญ",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "วางงานที่นี่",
     lifecycleUnlinked: "ไม่มีเซสชัน",
     lifecycleUnlinkedDetail: "เริ่มหรือเชื่อมโยงเซสชัน",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -615,6 +615,7 @@ export const tr: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Kartlarda ara",
     allPriorities: "Tüm öncelikler",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "İşi buraya bırakın",
     lifecycleUnlinked: "Oturum yok",
     lifecycleUnlinkedDetail: "Bir oturum başlatın veya bağlayın",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -614,6 +614,7 @@ export const uk: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Шукати картки",
     allPriorities: "Усі пріоритети",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Перетягніть роботу сюди",
     lifecycleUnlinked: "Немає сесії",
     lifecycleUnlinkedDetail: "Запустіть або пов’яжіть сесію",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -613,6 +613,7 @@ export const vi: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "Tìm kiếm thẻ",
     allPriorities: "Tất cả mức ưu tiên",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "Thả công việc vào đây",
     lifecycleUnlinked: "Không có phiên",
     lifecycleUnlinkedDetail: "Bắt đầu hoặc liên kết một phiên",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -609,6 +609,7 @@ export const zh_CN: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "搜索卡片",
     allPriorities: "所有优先级",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "将工作拖放到此处",
     lifecycleUnlinked: "无会话",
     lifecycleUnlinkedDetail: "启动或关联会话",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -609,6 +609,7 @@ export const zh_TW: TranslationMap = {
     labelsPlaceholder: "ui, docs",
     searchPlaceholder: "搜尋卡片",
     allPriorities: "所有優先順序",
+    hideEmptyColumns: "Hide empty columns",
     emptyColumn: "將工作拖放到這裡",
     lifecycleUnlinked: "沒有工作階段",
     lifecycleUnlinkedDetail: "開始或連結工作階段",

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -137,6 +137,25 @@
   min-width: min(280px, 100%);
 }
 
+.workboard-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: var(--workboard-control-height);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.workboard-toggle input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
 .workboard-modal {
   position: fixed;
   inset: 0;

--- a/ui/src/ui/controllers/workboard.ts
+++ b/ui/src/ui/controllers/workboard.ts
@@ -355,6 +355,7 @@ export type WorkboardUiState = {
   agentFilter: string;
   showArchived: boolean;
   layout: "comfortable" | "compact";
+  hideEmptyColumns: boolean;
   draftOpen: boolean;
   editingCardId: string | null;
   draftTitle: string;
@@ -402,6 +403,7 @@ function createDefaultState(): WorkboardUiState {
     agentFilter: "all",
     showArchived: false,
     layout: "compact",
+    hideEmptyColumns: false,
     draftOpen: false,
     editingCardId: null,
     draftTitle: "",

--- a/ui/src/ui/views/workboard.test.ts
+++ b/ui/src/ui/views/workboard.test.ts
@@ -81,6 +81,55 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-card__priority")?.textContent).toContain("high");
   });
 
+  it("can hide empty columns while keeping populated columns visible", () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Keep visible",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const container = document.createElement("div");
+    const props = {
+      host,
+      client: null,
+      connected: true,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      onOpenSession: () => undefined,
+      onRequestUpdate: () => undefined,
+    } satisfies WorkboardRenderProps;
+
+    render(renderWorkboard(props), container);
+    expect(container.querySelectorAll(".workboard-column")).toHaveLength(9);
+
+    const toggle = container.querySelector<HTMLInputElement>(
+      'input[name="workboard-hide-empty-columns"]',
+    );
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    toggle!.checked = true;
+    toggle!.dispatchEvent(new Event("change", { bubbles: true }));
+    render(renderWorkboard(props), container);
+
+    const columnHeadings = Array.from(
+      container.querySelectorAll<HTMLElement>(".workboard-column__header h2"),
+    ).map((heading) => heading.textContent?.trim());
+    expect(state.hideEmptyColumns).toBe(true);
+    expect(container.querySelectorAll(".workboard-column")).toHaveLength(1);
+    expect(columnHeadings).toEqual(["Todo"]);
+    expect(container.textContent).toContain("Todo");
+    expect(container.textContent).toContain("Keep visible");
+  });
+
   it("does not render Invalid Date for Date-invalid card timestamps", () => {
     const host = {};
     const state = getWorkboardState(host);

--- a/ui/src/ui/views/workboard.ts
+++ b/ui/src/ui/views/workboard.ts
@@ -1884,6 +1884,9 @@ export function renderWorkboard(props: WorkboardProps) {
   for (const card of filtered) {
     byStatus.get(card.status)?.push(card);
   }
+  const visibleStatuses = state.hideEmptyColumns
+    ? state.statuses.filter((status) => (byStatus.get(status)?.length ?? 0) > 0)
+    : state.statuses;
   const dialogOpen = state.draftOpen || Boolean(getVisibleDetailCard(state));
 
   return html`
@@ -1975,6 +1978,18 @@ export function renderWorkboard(props: WorkboardProps) {
                 ${icons.layoutComfortable}
               </button>
             </div>
+            <label class="workboard-toggle">
+              <input
+                type="checkbox"
+                name="workboard-hide-empty-columns"
+                .checked=${state.hideEmptyColumns}
+                @change=${(event: Event) => {
+                  state.hideEmptyColumns = (event.currentTarget as HTMLInputElement).checked;
+                  props.onRequestUpdate?.();
+                }}
+              />
+              <span>${t("workboard.hideEmptyColumns")}</span>
+            </label>
           </div>
           <div class="workboard-toolbar__actions">
             <button
@@ -2034,7 +2049,7 @@ export function renderWorkboard(props: WorkboardProps) {
         ${state.error ? html`<div class="callout danger">${state.error}</div>` : nothing}
         ${renderDispatchSummary(state)}
         <div class="workboard-board workboard-board--${state.layout}">
-          ${state.statuses.map((status) => renderColumn(props, status, byStatus.get(status) ?? []))}
+          ${visibleStatuses.map((status) => renderColumn(props, status, byStatus.get(status) ?? []))}
         </div>
       </div>
       ${renderCardModal(props)} ${renderCardDetailsPanel(props)}


### PR DESCRIPTION
## Summary
- Add a Workboard toolbar checkbox to hide status columns that have no currently visible cards.
- Keep the toggle in the existing Workboard UI state and hide columns after search/priority filtering.
- Sync Control UI i18n generated locale fallback metadata for the new label.

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/views/workboard.test.ts`
- `pnpm ui:i18n:check`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/controllers/workboard.ts ui/src/ui/views/workboard.ts ui/src/ui/views/workboard.test.ts ui/src/i18n/locales/en.ts ui/src/styles/workboard.css`
- `git diff --check HEAD~1..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings

## Real behavior proof
Behavior addressed: Workboard operators can hide empty status columns while keeping populated columns visible.
Real environment tested: Local Vite Control UI fixture in the in-app Browser on `http://127.0.0.1:5174/`, importing the real Workboard modules from `http://127.0.0.1:5173/`.
Exact steps or command run after this patch: Opened the fixture, confirmed 9 Workboard columns, clicked the `Hide empty columns` checkbox via the Browser DOM interaction API, then read a fresh DOM snapshot.
Evidence after fix: Browser DOM snapshot showed `checkbox "Hide empty columns" [checked]`, one `.workboard-column`, heading `Todo`, and card title `Keep visible`.
Observed result after fix: Empty status columns disappeared; the populated `Todo` column remained visible.
What was not tested: Screenshot capture in the in-app Browser timed out twice, so visual image proof is not attached; full Control UI gateway-backed navigation was not exercised because the local page was auth-gated without a token.
