### PR TITLE
fix(agents): guard system prompt schema stats

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -216,4 +216,39 @@ describe("buildSystemPromptReport", () => {
     });
     expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
   });
+
+  it("keeps reporting when tool schema properties cannot be read", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const unreadableSchema: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(unreadableSchema, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("system prompt schema properties exploded");
+      },
+    });
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        {
+          name: "broken",
+          description: "Broken schema",
+          parameters: unreadableSchema,
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "broken",
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -17,6 +17,18 @@ function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }
 
+function countSchemaProperties(parameters: object): number | null {
+  try {
+    const props = (parameters as Record<string, unknown>).properties;
+    if (!props || typeof props !== "object") {
+      return null;
+    }
+    return Object.keys(props as Record<string, unknown>).length;
+  } catch {
+    return null;
+  }
+}
+
 function extractBetween(input: string, startMarker: string, endMarker: string): string {
   const start = input.indexOf(startMarker);
   if (start === -1) {
@@ -61,14 +73,7 @@ function buildToolSchemaStats(
   const stats = {
     schemaChars: schemaJson.length,
     schemaHash: sha256(schemaJson),
-    propertiesCount: (() => {
-      const schema = parameters as Record<string, unknown>;
-      const props = typeof schema.properties === "object" ? schema.properties : null;
-      if (!props || typeof props !== "object") {
-        return null;
-      }
-      return Object.keys(props as Record<string, unknown>).length;
-    })(),
+    propertiesCount: countSchemaProperties(parameters),
   };
   toolSchemaStatsCache.set(parameters, stats);
   return stats;


### PR DESCRIPTION
## Summary
- Guard system-prompt tool schema property counting against hostile schema accessors.
- Preserve the existing schema JSON size/hash fallback when a schema cannot be stringified.
- Add a regression for an unreadable `properties` getter in tool schema report stats.

## Verification
- `node scripts/run-vitest.mjs src/agents/system-prompt-report.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Blacksmith Testbox-through-Crabbox not retried because the immediately previous gate was blocked by missing local auth (`not authenticated — run 'blacksmith auth login' first`).
- AWS Crabbox fallback: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (run `run_d84d2f12a513`, lease `cbx_ea44ff91f0be`, slug `tidal-crab`, type `c7a.8xlarge`, exit 0, command 3m20.585s, total 5m37.784s; lease cleanup stopped=true).

## Real behavior proof
Behavior addressed: a hostile tool schema can no longer crash system-prompt report generation while computing stats-only `propertiesCount`.
Real environment tested: local Codex GWT on macOS using the repo Vitest wrapper and source lint/format wrappers; remote AWS Crabbox Linux changed gate for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/system-prompt-report.test.ts -- --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.
Evidence after fix: the regression with an unreadable `properties` getter now completes report generation with `schemaChars: 0` and `propertiesCount: null`; remote changed gate selected `core, coreTests` and completed with exit 0.
Observed result after fix: focused Vitest passed 1 file / 11 tests; format, oxlint, diff check, local + branch autoreview, and AWS Crabbox `pnpm check:changed` passed.
What was not tested: Blacksmith Testbox proof was not run because local Blacksmith auth is missing; AWS Crabbox supplied the remote changed-gate proof instead.
