### PR TITLE
Return Google Chat thread metadata from message sends

### DIFF
--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -135,6 +135,7 @@ describe("googlechat message actions", () => {
     });
     sendGoogleChatMessage.mockResolvedValue({
       messageName: "spaces/AAA/messages/msg-1",
+      threadName: "spaces/AAA/threads/thread-1",
     });
 
     if (!googlechatMessageActions.handleAction) {
@@ -174,7 +175,12 @@ describe("googlechat message actions", () => {
       thread: "thread-1",
       attachments: [{ attachmentUploadToken: "token-1", contentName: "remote.png" }],
     });
-    expectJsonResult(result, { ok: true, to: "spaces/AAA" });
+    expectJsonResult(result, {
+      ok: true,
+      to: "spaces/AAA",
+      messageName: "spaces/AAA/messages/msg-1",
+      threadName: "spaces/AAA/threads/thread-1",
+    });
   });
 
   it("routes upload-file through the same attachment upload path with filename override", async () => {
@@ -198,6 +204,7 @@ describe("googlechat message actions", () => {
     });
     sendGoogleChatMessage.mockResolvedValue({
       messageName: "spaces/BBB/messages/msg-2",
+      threadName: "spaces/BBB/threads/thread-2",
     });
 
     if (!googlechatMessageActions.handleAction) {
@@ -232,7 +239,12 @@ describe("googlechat message actions", () => {
       thread: undefined,
       attachments: [{ attachmentUploadToken: "token-2", contentName: "renamed.txt" }],
     });
-    expectJsonResult(result, { ok: true, to: "spaces/BBB" });
+    expectJsonResult(result, {
+      ok: true,
+      to: "spaces/BBB",
+      messageName: "spaces/BBB/messages/msg-2",
+      threadName: "spaces/BBB/threads/thread-2",
+    });
   });
 
   it("removes only matching app reactions on react remove", async () => {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -162,7 +162,7 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
               ]
             : undefined,
         });
-        return jsonResult({ ok: true, to: space, ...(sent ?? {}) });
+        return jsonResult({ ok: true, to: space, ...sent });
       }
 
       if (action === "upload-file") {
@@ -175,7 +175,7 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         text: content,
         thread: threadId ?? undefined,
       });
-      return jsonResult({ ok: true, to: space, ...(sent ?? {}) });
+      return jsonResult({ ok: true, to: space, ...sent });
     }
 
     if (action === "react") {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -148,7 +148,7 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           buffer: loaded.buffer,
           contentType: loaded.contentType,
         });
-        await sendGoogleChatMessage({
+        const sent = await sendGoogleChatMessage({
           account,
           space,
           text: content,
@@ -162,20 +162,20 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
               ]
             : undefined,
         });
-        return jsonResult({ ok: true, to: space });
+        return jsonResult({ ok: true, to: space, ...(sent ?? {}) });
       }
 
       if (action === "upload-file") {
         throw new Error("upload-file requires media, filePath, or path");
       }
 
-      await sendGoogleChatMessage({
+      const sent = await sendGoogleChatMessage({
         account,
         space,
         text: content,
         thread: threadId ?? undefined,
       });
-      return jsonResult({ ok: true, to: space });
+      return jsonResult({ ok: true, to: space, ...(sent ?? {}) });
     }
 
     if (action === "react") {

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -142,7 +142,7 @@ export async function sendGoogleChatMessage(params: {
   thread?: string;
   cardsV2?: GoogleChatCardV2[];
   attachments?: Array<{ attachmentUploadToken: string; contentName?: string }>;
-}): Promise<{ messageName?: string } | null> {
+}): Promise<{ messageName?: string; threadName?: string } | null> {
   const { account, space, text, thread, cardsV2, attachments } = params;
   if (
     text &&
@@ -175,11 +175,11 @@ export async function sendGoogleChatMessage(params: {
     urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
   }
   const url = urlObj.toString();
-  const result = await fetchJson<{ name?: string }>(account, url, {
+  const result = await fetchJson<{ name?: string; thread?: { name?: string } }>(account, url, {
     method: "POST",
     body: JSON.stringify(body),
   });
-  return result ? { messageName: result.name } : null;
+  return result ? { messageName: result.name, threadName: result.thread?.name } : null;
 }
 
 export async function updateGoogleChatMessage(params: {

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -99,10 +99,15 @@ const account = {
   config: {},
 } as ResolvedGoogleChatAccount;
 
-function stubSuccessfulSend(name: string) {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValue(new Response(JSON.stringify({ name }), { status: 200 }));
+function stubSuccessfulSend(name: string, threadName?: string) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({ name, ...(threadName ? { thread: { name: threadName } } : {}) }),
+      {
+        status: 200,
+      },
+    ),
+  );
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
@@ -239,9 +244,9 @@ describe("sendGoogleChatMessage", () => {
   });
 
   it("adds messageReplyOption when sending to an existing thread", async () => {
-    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/123");
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/123", "spaces/AAA/threads/xyz");
 
-    await sendGoogleChatMessage({
+    const result = await sendGoogleChatMessage({
       account,
       space: "spaces/AAA",
       text: "hello",
@@ -260,6 +265,10 @@ describe("sendGoogleChatMessage", () => {
     };
     expect(body.text).toBe("hello");
     expect(body.thread?.name).toBe("spaces/AAA/threads/xyz");
+    expect(result).toEqual({
+      messageName: "spaces/AAA/messages/123",
+      threadName: "spaces/AAA/threads/xyz",
+    });
   });
 
   it("does not set messageReplyOption for non-thread sends", async () => {


### PR DESCRIPTION
## Summary

- Return `threadName` alongside `messageName` from Google Chat message sends.
- Include the returned message/thread metadata in the Google Chat `message` action result.
- Cover plain sends and attachment sends in action tests, plus API extraction of `thread.name`.

## Why

- Workflows that create a Google Chat thread need the canonical thread identifier to persist it and post later updates into the same thread.
- The API already returned the created message name; this extends the same routing metadata surface to include the created/resolved thread name.

## Real behavior proof

Behavior or issue addressed: Google Chat `message` sends now return the canonical `messageName` and `threadName` from the Chat API response, so a workflow that creates an Operations thread can persist the returned `spaces/.../threads/...` resource and post later updates into that same thread.

Real environment tested: Real OpenClaw gateway on `agente-servicios-1.psi.unc.edu.ar` with Google Chat enabled. The installed `@openclaw/googlechat` plugin was patched with this change before the PR was opened. Mesa de Entrada creates a Google Chat thread in the internal Operations space, stores returned routing metadata in SQLite, then wakes `serviciotina-operaciones` through `sessions_send`. Private Google Chat space IDs, thread IDs, message IDs, user data, and service details are redacted below.

Exact steps or command run after this patch: Applied the patched Google Chat send/action behavior to the installed Google Chat plugin on the real gateway, restarted OpenClaw, submitted a real report through Mesa de Entrada, let Mesa create the initial Operations Google Chat message, sent a later clarification for the same ticket, and verified the durable state with a redacted SSH/Python SQLite read from `/root/.openclaw/serviciotina/state.sqlite`.

Evidence after fix: Redacted copied live output from the real SQLite case store after the Google Chat flow:

```text
case:
  ticket_key: SVC-3151
  status: open
  ops_thread: spaces/REDACTED_SPACE/threads/REDACTED_THREAD
  ops_message: spaces/REDACTED_SPACE/messages/REDACTED_MESSAGE
  ops_session_key: agent:serviciotina-operaciones:svc-3151
  updated_at: 2026-06-02T11:51:29.141292Z
events:
  - upsert_case @ 2026-06-02T11:20:37.128007Z
  - created_and_escalated @ 2026-06-02T11:20:42.330914Z
  - public_clarification @ 2026-06-02T11:22:36.160272Z
  - ops_closed @ 2026-06-02T11:29:33.872723Z
  - ops_update_received @ 2026-06-02T11:30:11.373026Z
  - ops_googlechat_close_resent @ 2026-06-02T11:51:29.141292Z
```

Observed result after fix: The first internal Operations notification created a Google Chat thread and returned routing metadata to the agent. Mesa de Entrada persisted `ops_thread` and `ops_message` for `SVC-3151`. A later public clarification was recorded against the same case and sent to Operations without creating a second Operations session. Operations used the persisted `ops_thread` to publish the case update/close into the same Google Chat thread. The live Google Chat UI showed the initial report and later update in the same Operations thread.

What was not tested: I did not run this exact source checkout as a fresh packaged plugin install; the live proof used the same code shape patched into the installed Google Chat plugin on the real gateway. Google Chat resource IDs are redacted because they identify private spaces and messages.

## Verification

- `pnpm test extensions/googlechat/src/actions.test.ts extensions/googlechat/src/targets.test.ts`
- `pnpm check:changed`
- `pnpm lint --threads=8`
- `git diff --check`

## AI assistance

This PR was prepared with Codex assistance. I understand the code change: Google Chat send calls now return the canonical message and thread resources from the Chat API response, and the Google Chat `message` action includes those fields in its JSON result so workflows can persist the thread and post later updates into the same thread.
