### PR TITLE
fix(agents): skip unreadable Anthropic tool schemas

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -649,6 +649,16 @@ describe("anthropic transport stream", () => {
         },
       },
     });
+    const unreadableNameTool = {
+      description: "Broken name",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadableNameTool, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("anthropic tool name exploded");
+      },
+    });
     const streamFn = createAnthropicMessagesTransportStreamFn();
     const stream = await Promise.resolve(
       streamFn(
@@ -657,6 +667,7 @@ describe("anthropic transport stream", () => {
           systemPrompt: "Follow policy.",
           messages: [{ role: "user", content: "Read the file" }],
           tools: [
+            unreadableNameTool,
             {
               name: "read",
               description: "Read a file",
@@ -1221,6 +1232,25 @@ describe("anthropic transport stream", () => {
   });
 
   it("skips malformed tools when building Anthropic payloads", async () => {
+    const unreadableParametersTool = {
+      name: "bad_parameters_tool",
+      description: "unreadable schema",
+      execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+    };
+    Object.defineProperty(unreadableParametersTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("anthropic tool parameters exploded");
+      },
+    });
+    const unreadablePropertiesSchema: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(unreadablePropertiesSchema, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("anthropic tool properties exploded");
+      },
+    });
+
     await runTransportStream(
       makeAnthropicTransportModel(),
       {
@@ -1230,6 +1260,21 @@ describe("anthropic transport stream", () => {
             name: "bad_plugin_tool",
             description: "missing schema",
             execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+          },
+          unreadableParametersTool,
+          {
+            name: "bad_properties_tool",
+            description: "unreadable properties",
+            parameters: unreadablePropertiesSchema,
+          },
+          {
+            name: "null_schema_fields_tool",
+            description: "null schema fields",
+            parameters: {
+              type: "object",
+              properties: null,
+              required: null,
+            },
           },
           {
             name: "good_plugin_tool",
@@ -1250,8 +1295,13 @@ describe("anthropic transport stream", () => {
     );
 
     const tools = requireArray(latestAnthropicRequest().payload.tools, "tools");
-    expect(tools).toHaveLength(1);
-    const tool = requireRecord(tools[0], "tool");
+    expect(tools).toHaveLength(2);
+    const nullFieldTool = findRecord(tools, (record) => record.name === "null_schema_fields_tool");
+    expect(requireRecord(nullFieldTool.input_schema, "input schema")).toMatchObject({
+      properties: {},
+      required: [],
+    });
+    const tool = findRecord(tools, (record) => record.name === "good_plugin_tool");
     expect(tool.name).toBe("good_plugin_tool");
     expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -243,11 +243,16 @@ function toClaudeCodeName(name: string): string {
 function fromClaudeCodeName(name: string, tools: Context["tools"] | undefined): string {
   if (tools && tools.length > 0) {
     const lowerName = normalizeLowercaseStringOrEmpty(name);
-    const matchedTool = tools.find(
-      (tool) => normalizeLowercaseStringOrEmpty(tool.name) === lowerName,
-    );
-    if (matchedTool) {
-      return matchedTool.name;
+    for (const tool of tools) {
+      let toolName: unknown;
+      try {
+        toolName = tool.name;
+      } catch {
+        continue;
+      }
+      if (typeof toolName === "string" && normalizeLowercaseStringOrEmpty(toolName) === lowerName) {
+        return toolName;
+      }
     }
   }
   return name;
@@ -474,6 +479,31 @@ function ensureNonEmptyAnthropicMessages(messages: Array<Record<string, unknown>
     : [{ role: "user", content: EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT }];
 }
 
+type AnthropicToolCandidate = NonNullable<Context["tools"]>[number];
+type AnthropicToolFieldRead = { readable: true; value: unknown } | { readable: false };
+
+function readAnthropicToolField(
+  tool: AnthropicToolCandidate,
+  field: "name" | "description" | "parameters",
+): AnthropicToolFieldRead {
+  try {
+    return { readable: true, value: (tool as unknown as Record<string, unknown>)[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function readAnthropicSchemaField(
+  schema: Record<string, unknown>,
+  field: "properties" | "required",
+): AnthropicToolFieldRead {
+  try {
+    return { readable: true, value: schema[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   if (!tools) {
     return [];
@@ -490,20 +520,43 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   for (const tool of tools) {
     // Main quarantine happens when plugin tools materialize; this keeps Anthropic
     // safe for direct/custom tool arrays that bypass the plugin registry.
+    const nameRead = readAnthropicToolField(tool, "name");
+    const parametersRead = readAnthropicToolField(tool, "parameters");
+    if (!nameRead.readable || !parametersRead.readable) {
+      continue;
+    }
+    const rawParameters = parametersRead.value;
     const parameters =
-      tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters)
-        ? (tool.parameters as Record<string, unknown>)
+      rawParameters && typeof rawParameters === "object" && !Array.isArray(rawParameters)
+        ? (rawParameters as Record<string, unknown>)
         : undefined;
-    if (!parameters) {
+    if (typeof nameRead.value !== "string" || !parameters) {
+      continue;
+    }
+    const propertiesRead = readAnthropicSchemaField(parameters, "properties");
+    const requiredRead = readAnthropicSchemaField(parameters, "required");
+    const descriptionRead = readAnthropicToolField(tool, "description");
+    if (!propertiesRead.readable || !requiredRead.readable) {
+      continue;
+    }
+    const properties = propertiesRead.value;
+    const required = requiredRead.value;
+    if (
+      (properties !== undefined && properties !== null && typeof properties !== "object") ||
+      (required !== undefined && required !== null && !Array.isArray(required))
+    ) {
       continue;
     }
     converted.push({
-      name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
-      description: tool.description,
+      name: isOAuthToken ? toClaudeCodeName(nameRead.value) : nameRead.value,
+      description:
+        descriptionRead.readable && typeof descriptionRead.value === "string"
+          ? descriptionRead.value
+          : undefined,
       input_schema: {
         type: "object",
-        properties: parameters.properties || {},
-        required: parameters.required || [],
+        properties: properties ?? {},
+        required: required ?? [],
       },
     });
   }


### PR DESCRIPTION
## Summary
- Skip malformed direct/custom Anthropic tools whose `name`, `parameters`, `properties`, or `required` fields cannot be read.
- Preserve valid sibling tools in the outgoing Anthropic payload and keep `null` schema fields normalized to empty `properties` / `required` defaults.
- Harden OAuth Claude Code tool-name remapping so unreadable skipped tools cannot crash response-side tool-call decoding.

## Verification
- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox attempt before `9a29bd9750e`: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (run `run_8ac95dd9b14e`, lease `cbx_406500c83aae`, slug `coral-crab`, type `c7a.8xlarge`) failed in `typecheck core` with TS2352 on the direct `Tool<TSchema>` to record assertion; fixed by asserting through `unknown` first. Lease cleanup stopped=true.
- AWS Crabbox final: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (run `run_0495005e0bee`, lease `cbx_dfaff3f49231`, slug `amber-crab`, type `c7a.8xlarge`, exit 0, command 3m21.723s, total 5m49.849s; lease cleanup stopped=true).

## Real behavior proof
Behavior addressed: malformed direct/custom Anthropic tool schemas can no longer poison the whole assistant transport request or OAuth tool-call response remapping before valid sibling tools can be used.
Real environment tested: local Codex GWT on macOS using the repo Vitest wrapper and source lint/format wrappers; remote AWS Crabbox Linux changed gate for `pnpm check:changed`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts -- --reporter=dot`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.
Evidence after fix: regressions cover unreadable `parameters`, unreadable nested `properties`, valid `null` schema fields, and unreadable `name` during OAuth remapping while preserving the valid `good_plugin_tool` / `read` tool paths; remote changed gate selected `core, coreTests` and completed with exit 0.
Observed result after fix: focused Vitest passed 1 file / 51 tests; format, oxlint, diff check, local + branch autoreview, and AWS Crabbox `pnpm check:changed` passed.
What was not tested: Blacksmith Testbox proof was not run because local Blacksmith auth is missing; AWS Crabbox supplied the remote changed-gate proof instead.
