### PR TITLE
fix(gateway): accept --port on gateway health and probe (#79100)

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -148,7 +148,8 @@ All query commands use WebSocket RPC.
 
   </Tab>
   <Tab title="Shared options">
-    - `--url <url>`: Gateway WebSocket URL.
+    - `--port <port>`: Gateway port on localhost; accepted before or after the subcommand (e.g. `openclaw gateway --port 18789 health` or `openclaw gateway health --port 18789`). Patches `config.gateway.port`; preserves configured auth/TLS and does not override URL semantics.
+    - `--url <url>`: Gateway WebSocket URL (explicit; overrides config and port).
     - `--token <token>`: Gateway token.
     - `--password <password>`: Gateway password.
     - `--timeout <ms>`: timeout/budget (varies per command).
@@ -158,12 +159,15 @@ All query commands use WebSocket RPC.
 </Tabs>
 
 <Note>
-When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
+When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error. Using `--port` instead of `--url` preserves configured credentials and does not require explicit auth.
 </Note>
 
 ### `gateway health`
 
 ```bash
+openclaw gateway health
+openclaw gateway --port 18789 health
+openclaw gateway health --port 18789
 openclaw gateway health --url ws://127.0.0.1:18789
 ```
 

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -176,6 +176,62 @@ describe("gateway-cli coverage", () => {
     expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("gateway --port <N> health routes through config.gateway.port, not a url override (#79100)", async () => {
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "--port", "18799", "health", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const callArgs = firstMockArg(callGateway) as {
+      config?: { gateway?: { port?: number } };
+      url?: unknown;
+    };
+    // The port is patched onto config.gateway.port (so configured local auth/TLS is
+    // preserved), not turned into a synthetic ws:// url that would demand explicit creds.
+    expect(callArgs.config?.gateway?.port).toBe(18799);
+    expect(callArgs.url).toBeUndefined();
+  });
+
+  it("gateway --port <N> probe passes port as a number, not a ws:// url (#79100)", async () => {
+    gatewayStatusCommand.mockClear();
+
+    await runGatewayCommand(["gateway", "--port", "18799", "probe", "--json"]);
+
+    expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+    const probeArgs = firstMockArg(gatewayStatusCommand) as { port?: unknown; url?: unknown };
+    // A numeric port lets gatewayStatusCommand route through resolveTargets, which derives
+    // wss:// vs ws:// from the loaded config's TLS settings instead of hard-coding plaintext.
+    expect(probeArgs.port).toBe(18799);
+    expect(typeof probeArgs.url).not.toBe("string");
+  });
+
+  it("gateway health --port <N> (flag after the subcommand) also patches config.gateway.port (#79100)", async () => {
+    callGateway.mockClear();
+
+    // The exact spelling the issue reports as rejected; it must work via the --port option now
+    // on the shared gatewayCallOpts, not only the parent-position `gateway --port <N> health`.
+    await runGatewayCommand(["gateway", "health", "--port", "18799", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const callArgs = firstMockArg(callGateway) as {
+      config?: { gateway?: { port?: number } };
+      url?: unknown;
+    };
+    expect(callArgs.config?.gateway?.port).toBe(18799);
+    expect(callArgs.url).toBeUndefined();
+  });
+
+  it("gateway probe --port <N> (flag after the subcommand) also passes a numeric port (#79100)", async () => {
+    gatewayStatusCommand.mockClear();
+
+    await runGatewayCommand(["gateway", "probe", "--port", "18799", "--json"]);
+
+    expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+    const probeArgs = firstMockArg(gatewayStatusCommand) as { port?: unknown; url?: unknown };
+    expect(probeArgs.port).toBe(18799);
+    expect(typeof probeArgs.url).not.toBe("string");
+  });
+
   it("registers gateway stability and routes to diagnostics RPC", async () => {
     callGateway.mockClear();
 

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -221,6 +221,22 @@ describe("gateway-cli coverage", () => {
     expect(callArgs.url).toBeUndefined();
   });
 
+  it("gateway health --port <N> marks the explicit port as config-preferred over env (#79100)", async () => {
+    callGateway.mockClear();
+
+    await withEnvOverride({ OPENCLAW_GATEWAY_PORT: "19001" }, async () => {
+      await runGatewayCommand(["gateway", "health", "--port", "18799", "--json"]);
+    });
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    const callArgs = firstMockArg(callGateway) as {
+      config?: { gateway?: { port?: number } };
+      preferConfigGatewayPort?: boolean;
+    };
+    expect(callArgs.config?.gateway?.port).toBe(18799);
+    expect(callArgs.preferConfigGatewayPort).toBe(true);
+  });
+
   it("gateway probe --port <N> (flag after the subcommand) also passes a numeric port (#79100)", async () => {
     gatewayStatusCommand.mockClear();
 
@@ -230,6 +246,18 @@ describe("gateway-cli coverage", () => {
     const probeArgs = firstMockArg(gatewayStatusCommand) as { port?: unknown; url?: unknown };
     expect(probeArgs.port).toBe(18799);
     expect(typeof probeArgs.url).not.toBe("string");
+  });
+
+  it("gateway probe --port <N> passes the explicit port even when OPENCLAW_GATEWAY_PORT is set (#79100)", async () => {
+    gatewayStatusCommand.mockClear();
+
+    await withEnvOverride({ OPENCLAW_GATEWAY_PORT: "19001" }, async () => {
+      await runGatewayCommand(["gateway", "probe", "--port", "18799", "--json"]);
+    });
+
+    expect(gatewayStatusCommand).toHaveBeenCalledTimes(1);
+    const probeArgs = firstMockArg(gatewayStatusCommand) as { port?: unknown };
+    expect(probeArgs.port).toBe(18799);
   });
 
   it("registers gateway stability and routes to diagnostics RPC", async () => {

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -70,6 +70,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
     async () =>
       await callGateway({
         config: await resolveConfigWithPort(opts.config, opts.port),
+        preferConfigGatewayPort: Boolean(opts.port),
         url: opts.url,
         token: opts.token,
         password: opts.password,

--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -4,14 +4,18 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
+import { readSourceConfigBestEffort } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
+import { defaultRuntime } from "../../runtime.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { withProgress } from "../progress.js";
+import { parsePort } from "../shared/parse-port.js";
 
 export type GatewayRpcOpts = {
   config?: OpenClawConfig;
   url?: string;
+  port?: string;
   token?: string;
   password?: string;
   timeout?: string;
@@ -24,11 +28,34 @@ const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
 export const gatewayCallOpts = (cmd: Command) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option(
+      "--port <port>",
+      "Local gateway port override (patches config.gateway.port; preserves configured auth/TLS, alternative to --url)",
+    )
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--expect-final", "Wait for final response (agent)", false)
     .option("--json", "Output JSON", false);
+
+async function resolveConfigWithPort(
+  base: OpenClawConfig | undefined,
+  port: string | undefined,
+): Promise<OpenClawConfig | undefined> {
+  if (!port) {
+    return base;
+  }
+  const parsed = parsePort(port);
+  if (parsed === null) {
+    defaultRuntime.error("Invalid port");
+    defaultRuntime.exit(1);
+    return base;
+  }
+  // Load the real config so auth, TLS, and mode settings are preserved; only the
+  // gateway port is overridden, so configured local credentials still apply.
+  const real = base ?? (await readSourceConfigBestEffort());
+  return { ...real, gateway: { ...real.gateway, port: parsed } };
+}
 
 export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, params?: unknown) => {
   const timeoutMs = parseTimeoutMsWithFallback(opts.timeout, DEFAULT_GATEWAY_RPC_TIMEOUT_MS, {
@@ -42,7 +69,7 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
     },
     async () =>
       await callGateway({
-        config: opts.config,
+        config: await resolveConfigWithPort(opts.config, opts.port),
         url: opts.url,
         token: opts.token,
         password: opts.password,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -19,6 +19,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatHelpExamples } from "../help-format.js";
+import { parsePort } from "../shared/parse-port.js";
 import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { addGatewayRunCommand } from "./run-command.js";
@@ -140,16 +141,18 @@ function parseDaysOption(raw: unknown, fallback = 30): number {
   return fallback;
 }
 
-function resolveGatewayRpcOptions<T extends { token?: string; password?: string }>(
+function resolveGatewayRpcOptions<T extends { token?: string; password?: string; port?: string }>(
   opts: T,
   command?: Command,
 ): T {
   const parentToken = inheritOptionFromParent<string>(command, "token");
   const parentPassword = inheritOptionFromParent<string>(command, "password");
+  const parentPort = inheritOptionFromParent<string>(command, "port");
   return {
     ...opts,
     token: opts.token ?? parentToken,
     password: opts.password ?? parentPassword,
+    port: opts.port ?? parentPort,
   };
 }
 
@@ -679,6 +682,10 @@ export function registerGatewayCli(program: Command) {
       "Show gateway reachability, auth capability, and read-probe summary (local + remote)",
     )
     .option("--url <url>", "Explicit Gateway WebSocket URL (still probes localhost)")
+    .option(
+      "--port <port>",
+      "Local port override for the gateway probe (preserves TLS/auth from loaded config)",
+    )
     .option("--ssh <target>", "SSH target for remote gateway tunnel (user@host or user@host:port)")
     .option("--ssh-identity <path>", "SSH identity file path")
     .option("--ssh-auto", "Try to derive an SSH target from Bonjour discovery", false)
@@ -689,8 +696,15 @@ export function registerGatewayCli(program: Command) {
     .action(async (opts, command) => {
       await runGatewayCommand(async () => {
         const rpcOpts = resolveGatewayRpcOptions(opts, command);
+        const rawPort = rpcOpts.port;
+        const portNum = rawPort !== undefined ? parsePort(rawPort) : null;
+        if (rawPort !== undefined && portNum === null) {
+          defaultRuntime.error("Invalid port");
+          defaultRuntime.exit(1);
+          return;
+        }
         const { gatewayStatusCommand } = await loadGatewayStatusModule();
-        await gatewayStatusCommand(rpcOpts, defaultRuntime);
+        await gatewayStatusCommand({ ...rpcOpts, port: portNum ?? undefined }, defaultRuntime);
       });
     });
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -92,6 +92,10 @@ function loadDaemonStatusGatherModule() {
 function gatewayCallOpts(cmd: Command): Command {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option(
+      "--port <port>",
+      "Local gateway port override (patches config.gateway.port; preserves configured auth/TLS, alternative to --url)",
+    )
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", "10000")

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -18,7 +18,15 @@ const mocks = vi.hoisted(() => {
         auth: { token: "ltok" },
       },
     })),
-    resolveGatewayPort: vi.fn((_cfg?: unknown) => 18789),
+    resolveGatewayPort: vi.fn((cfg?: unknown, env?: NodeJS.ProcessEnv) => {
+      const envPortRaw = env?.OPENCLAW_GATEWAY_PORT?.trim();
+      const envPort = envPortRaw ? Number(envPortRaw) : NaN;
+      if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65_535) {
+        return envPort;
+      }
+      const configPort = (cfg as { gateway?: { port?: unknown } } | undefined)?.gateway?.port;
+      return typeof configPort === "number" && configPort > 0 ? configPort : 18789;
+    }),
     discoverGatewayBeacons: vi.fn(async (_opts?: unknown): Promise<GatewayBonjourBeacon[]> => []),
     pickPrimaryTailnetIPv4: vi.fn(() => "100.64.0.10"),
     sshStop,
@@ -297,7 +305,14 @@ function mockLocalTokenEnvRefConfig(envTokenId = "MISSING_GATEWAY_TOKEN") {
 
 async function runGatewayStatus(
   runtime: ReturnType<typeof createRuntimeCapture>["runtime"],
-  opts: { timeout: string; json?: boolean; ssh?: string; sshAuto?: boolean; sshIdentity?: string },
+  opts: {
+    timeout: string;
+    json?: boolean;
+    port?: number;
+    ssh?: string;
+    sshAuto?: boolean;
+    sshIdentity?: string;
+  },
 ) {
   await gatewayStatusCommand(opts, asRuntimeEnv(runtime));
 }
@@ -367,6 +382,29 @@ describe("gateway-status command", () => {
     const firstTarget = requireRecord(targets[0], "first gateway target");
     requireRecord(firstTarget.health, "first target health");
     requireRecord(firstTarget.summary, "first target summary");
+  });
+
+  it("lets explicit --port override OPENCLAW_GATEWAY_PORT for probe targets and network hints", async () => {
+    const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
+
+    await withEnvAsync({ OPENCLAW_GATEWAY_PORT: "19001" }, async () => {
+      readBestEffortConfig.mockResolvedValueOnce({
+        gateway: {
+          mode: "local",
+          auth: { mode: "token", token: "ltok" },
+        },
+      } as never);
+
+      await runGatewayStatus(runtime, { timeout: "1000", json: true, port: 18799 });
+    });
+
+    expect(runtimeErrors).toHaveLength(0);
+    expect(requireProbeCall("ws://127.0.0.1:18799").timeoutMs).toBe(1_000);
+    expect(readProbeCalls().some((call) => call.url === "ws://127.0.0.1:19001")).toBe(false);
+    const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+      network?: { localLoopbackUrl?: string };
+    };
+    expect(parsed.network?.localLoopbackUrl).toBe("ws://127.0.0.1:18799");
   });
 
   it("surfaces degraded model-pricing health as a warning", async () => {

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
     })),
     resolveGatewayPort: vi.fn((cfg?: unknown, env?: NodeJS.ProcessEnv) => {
       const envPortRaw = env?.OPENCLAW_GATEWAY_PORT?.trim();
-      const envPort = envPortRaw ? Number(envPortRaw) : NaN;
+      const envPort = envPortRaw ? Number(envPortRaw) : Number.NaN;
       if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65_535) {
         return envPort;
       }

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -36,6 +36,10 @@ function loadGatewayTlsModule() {
   return gatewayTlsModuleLoader.load();
 }
 
+function resolveGatewayPortIgnoringEnv(cfg?: Parameters<typeof resolveGatewayPort>[0]): number {
+  return resolveGatewayPort(cfg, { ...process.env, OPENCLAW_GATEWAY_PORT: undefined });
+}
+
 /** Resolves gateway status inputs, probes targets, then writes JSON or text output. */
 export async function gatewayStatusCommand(
   opts: {
@@ -65,9 +69,11 @@ export async function gatewayStatusCommand(
   const wideAreaDomain = resolveWideAreaDiscoveryDomain({
     configDomain: cfg.discovery?.wideArea?.domain,
   });
-  const baseTargets = resolveTargets(cfg, opts.url);
-  const network = buildNetworkHints(cfg);
-  const remotePort = resolveGatewayPort(cfg);
+  const resolveStatusGatewayPort =
+    opts.port != null && opts.port > 0 ? resolveGatewayPortIgnoringEnv : resolveGatewayPort;
+  const baseTargets = resolveTargets(cfg, opts.url, resolveStatusGatewayPort);
+  const network = buildNetworkHints(cfg, resolveStatusGatewayPort);
+  const remotePort = resolveStatusGatewayPort(cfg);
   const discoveryTimeoutMs = Math.min(1200, overallTimeoutMs);
 
   let sshTarget = sanitizeSshTarget(opts.ssh) ?? sanitizeSshTarget(cfg.gateway?.remote?.sshTarget);

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -40,6 +40,7 @@ function loadGatewayTlsModule() {
 export async function gatewayStatusCommand(
   opts: {
     url?: string;
+    port?: number;
     token?: string;
     password?: string;
     timeout?: unknown;
@@ -51,7 +52,13 @@ export async function gatewayStatusCommand(
   runtime: RuntimeEnv,
 ) {
   const startedAt = Date.now();
-  const cfg = await readBestEffortConfig();
+  const rawCfg = await readBestEffortConfig();
+  // Apply the port override onto the loaded config so resolveTargets derives the right
+  // scheme (wss:// vs ws://) from gateway.tls settings rather than hard-coding ws://.
+  const cfg =
+    opts.port != null && opts.port > 0
+      ? { ...rawCfg, gateway: { ...rawCfg.gateway, port: opts.port } }
+      : rawCfg;
   const rich = isRich() && opts.json !== true;
   const defaultTimeoutMs = Math.max(3000, cfg.gateway?.handshakeTimeoutMs ?? 0);
   const overallTimeoutMs = parseTimeoutMs(opts.timeout, defaultTimeoutMs);

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -86,8 +86,14 @@ function normalizeWsUrl(value: string): string | null {
   return trimmed;
 }
 
+type ResolvePort = (cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => number;
+
 /** Builds the deduplicated ordered gateway probe targets from CLI input and config. */
-export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): GatewayStatusTarget[] {
+export function resolveTargets(
+  cfg: OpenClawConfig,
+  explicitUrl?: string,
+  resolvePort: ResolvePort = resolveGatewayPort,
+): GatewayStatusTarget[] {
   const targets: GatewayStatusTarget[] = [];
   const add = (t: GatewayStatusTarget) => {
     if (!targets.some((x) => x.url === t.url)) {
@@ -111,7 +117,7 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
     });
   }
 
-  const port = resolveGatewayPort(cfg);
+  const port = resolvePort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   add({
     id: "localLoopback",
@@ -253,9 +259,12 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
 }
 
 /** Builds local and tailnet gateway URL hints for the configured gateway port. */
-export function buildNetworkHints(cfg: OpenClawConfig) {
+export function buildNetworkHints(
+  cfg: OpenClawConfig,
+  resolvePort: ResolvePort = resolveGatewayPort,
+) {
   const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
-  const port = resolveGatewayPort(cfg);
+  const port = resolvePort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   return {
     localLoopbackUrl: `${localScheme}://127.0.0.1:${port}`,

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -997,6 +997,38 @@ describe("buildGatewayConnectionDetails", () => {
     }
   });
 
+  it("lets explicit CLI port prefer config.gateway.port over OPENCLAW_GATEWAY_PORT", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", port: 18799 },
+    });
+    resolveGatewayPort.mockImplementation((cfg?: unknown, env?: NodeJS.ProcessEnv) => {
+      const envPortRaw = env?.OPENCLAW_GATEWAY_PORT?.trim();
+      const envPort = envPortRaw ? Number(envPortRaw) : NaN;
+      if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65_535) {
+        return envPort;
+      }
+      const configPort = (cfg as OpenClawConfig | undefined)?.gateway?.port;
+      return typeof configPort === "number" && configPort > 0 ? configPort : 18789;
+    });
+    const previousPort = process.env.OPENCLAW_GATEWAY_PORT;
+    try {
+      process.env.OPENCLAW_GATEWAY_PORT = "19001";
+
+      expect(buildGatewayConnectionDetails().url).toBe("ws://127.0.0.1:19001");
+      expect(
+        buildGatewayConnectionDetails({
+          preferConfigGatewayPort: true,
+        }).url,
+      ).toBe("ws://127.0.0.1:18799");
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PORT;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PORT = previousPort;
+      }
+    }
+  });
+
   it("falls back to the default config loader when test deps drift", () => {
     const tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-call-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1001,13 +1001,13 @@ describe("buildGatewayConnectionDetails", () => {
     getRuntimeConfig.mockReturnValue({
       gateway: { mode: "local", bind: "loopback", port: 18799 },
     });
-    resolveGatewayPort.mockImplementation((cfg?: unknown, env?: NodeJS.ProcessEnv) => {
+    resolveGatewayPort.mockImplementation((cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => {
       const envPortRaw = env?.OPENCLAW_GATEWAY_PORT?.trim();
-      const envPort = envPortRaw ? Number(envPortRaw) : NaN;
+      const envPort = envPortRaw ? Number(envPortRaw) : Number.NaN;
       if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65_535) {
         return envPort;
       }
-      const configPort = (cfg as OpenClawConfig | undefined)?.gateway?.port;
+      const configPort = cfg?.gateway?.port;
       return typeof configPort === "number" && configPort > 0 ? configPort : 18789;
     });
     const previousPort = process.env.OPENCLAW_GATEWAY_PORT;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1001,13 +1001,13 @@ describe("buildGatewayConnectionDetails", () => {
     getRuntimeConfig.mockReturnValue({
       gateway: { mode: "local", bind: "loopback", port: 18799 },
     });
-    resolveGatewayPort.mockImplementation((cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => {
-      const envPortRaw = env?.OPENCLAW_GATEWAY_PORT?.trim();
+    resolveGatewayPort.mockImplementation((cfg, env) => {
+      const envPortRaw = (env as NodeJS.ProcessEnv | undefined)?.OPENCLAW_GATEWAY_PORT?.trim();
       const envPort = envPortRaw ? Number(envPortRaw) : Number.NaN;
       if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65_535) {
         return envPort;
       }
-      const configPort = cfg?.gateway?.port;
+      const configPort = (cfg as OpenClawConfig | undefined)?.gateway?.port;
       return typeof configPort === "number" && configPort > 0 ? configPort : 18789;
     });
     const previousPort = process.env.OPENCLAW_GATEWAY_PORT;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -69,6 +69,11 @@ type CallGatewayBaseOptions = {
   password?: string;
   tlsFingerprint?: string;
   config?: OpenClawConfig;
+  /**
+   * Explicit CLI --port is already patched onto config.gateway.port. When set,
+   * local target resolution ignores OPENCLAW_GATEWAY_PORT so the visible flag wins.
+   */
+  preferConfigGatewayPort?: boolean;
   method: string;
   params?: unknown;
   expectFinal?: boolean;
@@ -348,18 +353,28 @@ function resolveGatewayPortValue(config?: OpenClawConfig, env?: NodeJS.ProcessEn
   return resolveGatewayPortFn(config, env);
 }
 
+function omitGatewayPortEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const { OPENCLAW_GATEWAY_PORT: _openClawGatewayPort, ...rest } = env;
+  return rest;
+}
+
 export function buildGatewayConnectionDetails(
   options: {
     config?: OpenClawConfig;
     url?: string;
     configPath?: string;
     urlSource?: "cli" | "env";
+    preferConfigGatewayPort?: boolean;
   } = {},
 ): GatewayConnectionDetails {
   return buildGatewayConnectionDetailsWithResolvers(options, {
     getRuntimeConfig: () => loadGatewayConfigForConnectionDetails(),
     resolveConfigPath: (env) => resolveGatewayConfigPath(env),
-    resolveGatewayPort: (config, env) => resolveGatewayPortValue(config, env),
+    resolveGatewayPort: (config, env) =>
+      resolveGatewayPortValue(
+        config,
+        options.preferConfigGatewayPort ? omitGatewayPortEnv(env ?? process.env) : env,
+      ),
   });
 }
 
@@ -1022,6 +1037,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     config: context.config,
     url: context.urlOverride,
     urlSource: context.urlOverrideSource,
+    preferConfigGatewayPort: opts.preferConfigGatewayPort,
     ...(opts.configPath ? { configPath: opts.configPath } : {}),
   });
   const url = connectionDetails.url;


### PR DESCRIPTION
## Summary

`gateway run --port 18789` accepts `--port`, but the adjacent query subcommands rejected the same flag:

- `openclaw gateway health --port 18789` -> `error: unknown option '--port'`
- `openclaw gateway probe --port 18789` -> `error: unknown option '--port'`

So scripts that start a gateway on a controlled local port could not target it through `health`/`probe` with the same visible flag shape as `run`, and the `--url` workaround disables config credential fallback (forcing explicit `--token`/`--password`).

### Fix

Accept `--port` on the gateway query commands in both spellings: before the subcommand (`gateway --port 18789 health`, inherited from the parent) and after it (`gateway health --port 18789`, the exact spelling the issue reports).

- `gatewayCallOpts` accepts `--port`, so `health`, `call`, `usage-cost`, and `stability` accept the flag after the subcommand.
- `resolveGatewayRpcOptions` still inherits the parent `--port` for the before-subcommand spelling.
- `callGatewayCli` loads the real config and overrides only `gateway.port`, then marks that explicit CLI port as preferred so `OPENCLAW_GATEWAY_PORT` cannot silently retarget the request.
- `gateway probe` passes a numeric `port` to `gatewayStatusCommand`; target/network-hint resolution ignores `OPENCLAW_GATEWAY_PORT` only for that explicit-port path, while preserving the normal env-over-config behavior when `--port` is omitted.
- Config-based auth and TLS scheme selection are still preserved; the implementation does not turn the port into a synthetic `ws://` URL.

Fixes #79100

## Real behavior proof

**Behavior addressed**: `openclaw gateway health --port <N>` and `openclaw gateway probe --port <N>` should accept the subcommand-position port flag and connect to a real gateway on that non-default local port. When `OPENCLAW_GATEWAY_PORT` is also set to a different port, the explicit CLI `--port` must win.

**Real environment tested**: Local Linux source checkout on commit `09ae914c7c`, using an isolated temporary OpenClaw home/config under `/media/vdc/0668001470/workSpace/claw-campaign/.proof-89623/env-port-precedence-dist-1780485149`, a real `gateway run` process listening on loopback port `19323`, and the built `node dist/entry.js` CLI entry for the client commands. The temporary config was `gateway.mode=local`, `gateway.bind=loopback`, and `gateway.auth.mode=none`; `OPENCLAW_SKIP_CHANNELS=1`/`OPENCLAW_SKIP_PROVIDERS=1` only skipped external channel sidecars.

**Exact steps or command run after this patch**:

```sh
PROOF_ROOT=/media/vdc/0668001470/workSpace/claw-campaign/.proof-89623/env-port-precedence-dist-1780485149
export HOME="$PROOF_ROOT/home"
export OPENCLAW_HOME="$PROOF_ROOT/home"
export OPENCLAW_STATE_DIR="$PROOF_ROOT/home/.openclaw"
export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
export OPENCLAW_SKIP_CHANNELS=1
export OPENCLAW_SKIP_PROVIDERS=1
export OPENCLAW_TEST_FAST=1

node dist/entry.js gateway run --dev --reset --port 19323 --bind loopback --auth none --allow-unconfigured --ws-log compact
# After the gateway logged `ready`, set gateway.auth.mode=none in the isolated config so the CLI preserves matching local auth config.
export OPENCLAW_GATEWAY_PORT=19001
node dist/entry.js gateway health --port 19323 --json --timeout 15000
node dist/entry.js gateway probe --port 19323 --json --timeout 8000

git diff --check
node scripts/run-vitest.mjs src/cli/gateway-cli.coverage.test.ts
node scripts/run-vitest.mjs src/gateway/call.test.ts
node scripts/run-vitest.mjs src/commands/gateway-status.test.ts src/commands/gateway-status/helpers.test.ts
```

**Evidence after fix**:

Gateway startup reached the real listener on port `19323`:

```text
[gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 8.3s)
[gateway] ready
```

With `OPENCLAW_GATEWAY_PORT=19001`, the subcommand-position health command still returned a real gateway health payload for the explicit `--port 19323` target:

```text
$ OPENCLAW_GATEWAY_PORT=19001 node dist/entry.js gateway health --port 19323 --json --timeout 15000
{
  "ok": true,
  "defaultAgentId": "dev",
  "agents": [
    {
      "agentId": "dev",
      "isDefault": true
    }
  ]
}
```

With the same conflicting environment variable, the probe command targeted `19323`, not `19001`:

```text
$ OPENCLAW_GATEWAY_PORT=19001 node dist/entry.js gateway probe --port 19323 --json --timeout 8000
{
  "ok": true,
  "degraded": true,
  "primaryTargetId": "localLoopback",
  "network": {
    "localLoopbackUrl": "ws://127.0.0.1:19323",
    "localTailnetUrl": "ws://100.93.92.6:19323"
  },
  "targets": [
    {
      "id": "localLoopback",
      "url": "ws://127.0.0.1:19323",
      "connect": {
        "ok": true,
        "latencyMs": 89,
        "error": "timeout"
      },
      "auth": {
        "role": "operator",
        "capability": "read_only"
      }
    }
  ]
}
```

The probe was marked degraded because one follow-up read diagnostic timed out under an 8s probe timeout, but the connection and target-selection evidence is the behavior under test: both `network.localLoopbackUrl` and the target URL are `ws://127.0.0.1:19323` while `OPENCLAW_GATEWAY_PORT=19001` was set.

Focused tests also cover the env-precedence regression:

```text
$ git diff --check
# no output

$ node scripts/run-vitest.mjs src/cli/gateway-cli.coverage.test.ts
Test Files  1 passed (1)
Tests  25 passed (25)

$ node scripts/run-vitest.mjs src/gateway/call.test.ts
Test Files  1 passed (1)
Tests  94 passed (94)

$ node scripts/run-vitest.mjs src/commands/gateway-status.test.ts src/commands/gateway-status/helpers.test.ts
Test Files  2 passed (2)
Tests  41 passed (41)
```

**Observed result after fix**: Both `gateway health --port 19323` and `gateway probe --port 19323` accepted the port after the subcommand. In a conflicting environment with `OPENCLAW_GATEWAY_PORT=19001`, `health` returned `ok: true` and `probe` reported `network.localLoopbackUrl` plus the local target URL as `ws://127.0.0.1:19323`, proving the explicit CLI port wins for both RPC calls and probe/status target resolution.

**What was not tested**: TLS (`wss://`) and token/password auth variants were not live-tested in this proof; focused tests cover that the implementation preserves config-based auth/TLS selection by patching `config.gateway.port` instead of forcing a `--url` override. The normal env-over-config behavior when `--port` is omitted remains covered by existing config/daemon tests and the new `buildGatewayConnectionDetails` regression test.
