### PR TITLE
fix(ollama): guard tool schema normalization

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -258,6 +258,84 @@ describe("createOllamaStreamFn thinking events", () => {
     });
   });
 
+  it("degrades unreadable tool schemas instead of aborting request construction", async () => {
+    const unreadableRootSchema = new Proxy(
+      { type: "object", properties: {} },
+      {
+        ownKeys() {
+          throw new Error("ollama root schema ownKeys exploded");
+        },
+      },
+    );
+    const unreadableProperties = new Proxy(
+      { query: { type: "string" } },
+      {
+        ownKeys() {
+          throw new Error("ollama properties ownKeys exploded");
+        },
+      },
+    );
+    const unreadableVariants = new Proxy([{ type: "string" }], {
+      get(target, property, receiver) {
+        if (property === Symbol.iterator) {
+          throw new Error("ollama variants iterator exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const events = await streamOllamaEvents([makeOllamaResponse({ content: "ok" })], {}, {
+      messages: [{ role: "user", content: "test" }],
+      tools: [
+        {
+          name: "root_schema_tool",
+          description: "Root schema fallback",
+          parameters: unreadableRootSchema,
+        },
+        {
+          name: "nested_schema_tool",
+          description: "Nested schema fallback",
+          parameters: {
+            type: "object",
+            properties: unreadableProperties,
+            anyOf: unreadableVariants,
+          },
+        },
+      ],
+    } as never);
+
+    expect(events.map((event) => event.type)).not.toContain("error");
+    const request = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0] as {
+      init: { body: string };
+    };
+    const body = JSON.parse(request.init.body) as {
+      tools: Array<{
+        function: {
+          name: string;
+          parameters: Record<string, unknown>;
+        };
+      }>;
+    };
+    expect(body.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "root_schema_tool",
+          description: "Root schema fallback",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "nested_schema_tool",
+          description: "Nested schema fallback",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
+
   it("promotes standalone bracketed local-model tool text to a structured tool call", async () => {
     const rawToolText = [
       "[mempalace_mempalace_search]",

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -815,6 +815,27 @@ function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefi
   return undefined;
 }
 
+function readOllamaSchemaEntries(
+  schema: Record<string, unknown>,
+): Array<[string, unknown]> | undefined {
+  try {
+    return Object.entries(schema);
+  } catch {
+    return undefined;
+  }
+}
+
+function readOllamaSchemaArray(schema: unknown): unknown[] | undefined {
+  if (!Array.isArray(schema)) {
+    return undefined;
+  }
+  try {
+    return Array.from(schema);
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeOllamaToolSchema(schema: unknown, isRoot = false): Record<string, unknown> {
   if (!isRecord(schema)) {
     return {
@@ -823,25 +844,39 @@ function normalizeOllamaToolSchema(schema: unknown, isRoot = false): Record<stri
     };
   }
 
+  const entries = readOllamaSchemaEntries(schema);
+  if (!entries) {
+    return {
+      type: "object",
+      properties: {},
+    };
+  }
+
   const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema)) {
+  for (const [key, value] of entries) {
     if (key === "properties" && isRecord(value)) {
-      normalized.properties = Object.fromEntries(
-        Object.entries(value).map(([propertyName, propertySchema]) => [
-          propertyName,
-          normalizeOllamaToolSchema(propertySchema),
-        ]),
-      );
+      const propertyEntries = readOllamaSchemaEntries(value);
+      normalized.properties = {};
+      if (propertyEntries) {
+        for (const [propertyName, propertySchema] of propertyEntries) {
+          (normalized.properties as Record<string, unknown>)[propertyName] =
+            normalizeOllamaToolSchema(propertySchema);
+        }
+      }
       continue;
     }
     if (key === "items") {
-      normalized.items = Array.isArray(value)
-        ? value.map((entry) => normalizeOllamaToolSchema(entry))
+      const items = readOllamaSchemaArray(value);
+      normalized.items = items
+        ? items.map((entry) => normalizeOllamaToolSchema(entry))
         : normalizeOllamaToolSchema(value);
       continue;
     }
-    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      normalized[key] = value.map((entry) => normalizeOllamaToolSchema(entry));
+    if (key === "anyOf" || key === "oneOf" || key === "allOf") {
+      const variants = readOllamaSchemaArray(value);
+      if (variants) {
+        normalized[key] = variants.map((entry) => normalizeOllamaToolSchema(entry));
+      }
       continue;
     }
     normalized[key] = value;


### PR DESCRIPTION
## Summary
- guard Ollama tool-schema normalization around unreadable schema objects and arrays
- fall back to an empty object schema for unreadable root/properties containers and skip unreadable union arrays
- add a regression that proves request construction continues instead of emitting a schema error event

## Verification
- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts -- --reporter=dot` (13 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts`
- `./node_modules/.bin/oxlint extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (run `run_5c62cd94abad`, lease `cbx_6a7410df957e`, slug `silver-krill`, exit 0, lease stopped)

## Real behavior proof
Behavior addressed: Ollama request construction no longer turns unreadable/proxy-backed tool schemas into a provider error event before the request can be sent.

Real environment tested: Local Codex worktree focused Vitest with mocked Ollama fetch; AWS Crabbox Linux `c7a.8xlarge` changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts`; `./node_modules/.bin/oxlint extensions/ollama/src/stream.ts extensions/ollama/src/stream.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: The regression sends tools through `createOllamaStreamFn` with unreadable root, `properties`, and `anyOf` containers; the stream does not emit an `error` event and the outgoing request body uses fallback object schemas. AWS Crabbox selected `extensions` and `extensionTests`, then passed extension typecheck, extension test typecheck, extension lint, sidecar loader guard, and runtime import-cycle guard.

Observed result after fix: Focused Vitest passed 13 tests, formatting/lint/diff checks passed, autoreview reported no accepted/actionable findings, and AWS Crabbox `pnpm check:changed` completed in 4m16.151s command time / 6m57.997s total with exit 0.

What was not tested: Live Ollama server/tool-call round trip.
