### PR TITLE
fix(agents): guard tool parameter schema inlining

### DIFF
--- a/src/agents/agent-tools-parameter-schema.ts
+++ b/src/agents/agent-tools-parameter-schema.ts
@@ -125,6 +125,14 @@ function setOwnSchemaProperty(target: Record<string, unknown>, key: string, valu
   });
 }
 
+function readSchemaEntries(value: Record<string, unknown>): Array<[string, unknown]> | undefined {
+  try {
+    return Object.entries(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function hasTopLevelArrayKeyword(
   schemaRecord: Record<string, unknown>,
   key: TopLevelConditionalKey,
@@ -394,13 +402,19 @@ function extendSchemaDefs(
         definitions: new Map<string, unknown>(),
       };
   if (defsEntry) {
-    for (const [key, value] of Object.entries(defsEntry)) {
-      next.$defs.set(key, value);
+    const entries = readSchemaEntries(defsEntry);
+    if (entries) {
+      for (const [key, value] of entries) {
+        next.$defs.set(key, value);
+      }
     }
   }
   if (legacyDefsEntry) {
-    for (const [key, value] of Object.entries(legacyDefsEntry)) {
-      next.definitions.set(key, value);
+    const entries = readSchemaEntries(legacyDefsEntry);
+    if (entries) {
+      for (const [key, value] of entries) {
+        next.definitions.set(key, value);
+      }
     }
   }
   return next;
@@ -534,7 +548,11 @@ function inlineLocalSchemaRefsWithDefs(
   }
 
   const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
+  const entries = readSchemaEntries(obj);
+  if (!entries) {
+    return {};
+  }
+  for (const [key, value] of entries) {
     if (key === "$defs" || key === "definitions" || key === "components") {
       continue;
     }
@@ -547,7 +565,7 @@ function inlineLocalSchemaRefsWithDefs(
         result,
         key,
         Object.fromEntries(
-          Object.entries(value).map(([entryKey, entryValue]) => [
+          (readSchemaEntries(value) ?? []).map(([entryKey, entryValue]) => [
             entryKey,
             inlineLocalSchemaRefsWithDefs(entryValue, nextDefs, refStack, state, rootDocument),
           ]),

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -44,6 +44,39 @@ describe("normalizeToolParameterSchema", () => {
     });
   });
 
+  it("normalizes unreadable schema containers to empty object schemas", () => {
+    const unreadableRoot = new Proxy(
+      { type: "object", properties: {} },
+      {
+        ownKeys() {
+          throw new Error("root schema ownKeys exploded");
+        },
+      },
+    );
+    const unreadableProperties = new Proxy(
+      { query: { type: "string" } },
+      {
+        ownKeys() {
+          throw new Error("properties ownKeys exploded");
+        },
+      },
+    );
+
+    expect(normalizeToolParameterSchema(unreadableRoot)).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(
+      normalizeToolParameterSchema({
+        type: "object",
+        properties: unreadableProperties,
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
   it("leaves top-level allOf schemas unchanged", () => {
     const schema = {
       allOf: [{ type: "object", properties: { id: { type: "string" } } }],


### PR DESCRIPTION
## Summary
- guard local tool-parameter schema `$ref` inlining against unreadable schema containers
- degrade unreadable root and nested schema maps to the existing empty object schema fallback
- add regression coverage for proxy-backed root schemas and `parameters.properties` maps

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-tools.schema.test.ts -- --reporter=dot` (42 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (run `run_24516f7ab390`, lease `cbx_2d8235283b17`, slug `brisk-prawn`, exit 0, lease stopped)

## Real behavior proof
Behavior addressed: Tool parameter schema normalization no longer crashes while inlining local schema refs when a plugin/tool supplies unreadable schema containers.

Real environment tested: Local Codex worktree focused Vitest; AWS Crabbox Linux `c7a.8xlarge` changed gate.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-tools.schema.test.ts -- --reporter=dot`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts`; `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tools-parameter-schema.ts src/agents/agent-tools.schema.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: The regression calls `normalizeToolParameterSchema` with an unreadable root schema and an unreadable nested `properties` map; both return the existing empty object schema fallback instead of throwing from `Object.entries` during local ref inlining. AWS Crabbox selected `core` and `coreTests`, then passed core typecheck, core test typecheck, changed-file lint, and repo guard checks.

Observed result after fix: Focused Vitest passed 42 tests, formatting/lint/diff checks passed, autoreview reported no accepted/actionable findings, and AWS Crabbox `pnpm check:changed` completed in 3m23.474s command time / 5m50.442s total with exit 0.

What was not tested: Live assistant turn with an installed hostile plugin.
