### PR TITLE
fix(shared): harden JSON schema default traversal

### DIFF
--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyJsonSchemaDefaults,
+  findJsonSchemaShapeError,
+  normalizeJsonSchemaForTypeBox,
+} from "./json-schema-defaults.js";
+import type { JsonSchemaObject } from "./json-schema.types.js";
+
+function unreadableSchemaMap(): Record<string, JsonSchemaObject> {
+  return new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error("schema map exploded");
+      },
+    },
+  ) as Record<string, JsonSchemaObject>;
+}
+
+describe("json schema defaults", () => {
+  it("bounds unreadable schema maps during shape checks and default projection", () => {
+    const schema = {
+      type: "object",
+      properties: unreadableSchemaMap(),
+    } as JsonSchemaObject;
+    const value = { existing: true };
+
+    expect(findJsonSchemaShapeError(schema)).toBe("<schema>.properties: unreadable schema map");
+    expect(normalizeJsonSchemaForTypeBox(schema)).toEqual({
+      type: "object",
+      properties: {},
+    });
+    expect(applyJsonSchemaDefaults(schema, value)).toBe(value);
+  });
+
+  it("does not partially apply sibling defaults when a schema map is unreadable", () => {
+    const schema = {
+      type: "object",
+      properties: unreadableSchemaMap(),
+      dependentSchemas: {
+        existing: {
+          properties: {
+            added: { default: true },
+          },
+        },
+      },
+    } as JsonSchemaObject;
+    const value = { existing: true };
+
+    expect(applyJsonSchemaDefaults(schema, value)).toEqual({ existing: true });
+    expect(value).toEqual({ existing: true });
+  });
+
+  it("does not return partially mutated values when a later default cannot be cloned", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        first: { default: "applied before failure" },
+        second: { default: () => "not cloneable" },
+      },
+    } as unknown as JsonSchemaObject;
+    const value = {};
+
+    expect(applyJsonSchemaDefaults(schema, value)).toBe(value);
+    expect(value).toEqual({});
+  });
+});

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -82,6 +82,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function readObjectEntries(value: Record<string, unknown>): Array<[string, unknown]> | undefined {
+  try {
+    return Object.entries(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectValues(value: Record<string, unknown>): unknown[] | undefined {
+  try {
+    return Object.values(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectKeys(value: Record<string, unknown>): string[] | undefined {
+  try {
+    return Object.keys(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function schemaTypeIncludes(schema: Record<string, unknown>, type: string): boolean {
   return schema.type === type || (Array.isArray(schema.type) && schema.type.includes(type));
 }
@@ -106,17 +130,23 @@ function normalizeSchemaMap(value: unknown): unknown {
   if (!isRecord(value)) {
     return value;
   }
-  return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [key, normalizeJsonSchemaNode(entry)]),
-  );
+  const entries = readObjectEntries(value);
+  if (!entries) {
+    return {};
+  }
+  return Object.fromEntries(entries.map(([key, entry]) => [key, normalizeJsonSchemaNode(entry)]));
 }
 
 function normalizeSchemaDependencies(value: unknown): unknown {
   if (!isRecord(value)) {
     return value;
   }
+  const entries = readObjectEntries(value);
+  if (!entries) {
+    return {};
+  }
   return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [
+    entries.map(([key, entry]) => [
       key,
       isStringArray(entry) ? entry : normalizeJsonSchemaNode(entry),
     ]),
@@ -168,8 +198,12 @@ function normalizeJsonSchemaNode(schema: unknown): unknown {
     return schema;
   }
   const normalizedSchema = normalizeAdditionalPropertiesSchema(expandJsonSchemaTypeArray(schema));
+  const entries = readObjectEntries(normalizedSchema);
+  if (!entries) {
+    return false;
+  }
   return Object.fromEntries(
-    Object.entries(normalizedSchema).map(([key, value]) => {
+    entries.map(([key, value]) => {
       if (key === "$dynamicRef" && normalizedSchema.$ref === undefined) {
         return ["$ref", value];
       }
@@ -232,7 +266,7 @@ function resolveLocalAnchor(
     if (!isRecord(value)) {
       continue;
     }
-    for (const entry of Object.values(value)) {
+    for (const entry of readObjectValues(value) ?? []) {
       const resolved = resolveLocalAnchor(entry as JsonSchemaValue, anchor, false);
       if (resolved !== undefined) {
         return resolved;
@@ -240,7 +274,7 @@ function resolveLocalAnchor(
     }
   }
   if (isRecord(schema.dependencies)) {
-    for (const entry of Object.values(schema.dependencies)) {
+    for (const entry of readObjectValues(schema.dependencies) ?? []) {
       if (isStringArray(entry)) {
         continue;
       }
@@ -391,7 +425,7 @@ function resolveSchemaResourceRef(
       if (!isRecord(value)) {
         continue;
       }
-      for (const entry of Object.values(value)) {
+      for (const entry of readObjectValues(value) ?? []) {
         const resolved = visit(entry as JsonSchemaValue, currentBaseId);
         if (resolved.found) {
           return resolved;
@@ -399,7 +433,7 @@ function resolveSchemaResourceRef(
       }
     }
     if (isRecord(current.dependencies)) {
-      for (const entry of Object.values(current.dependencies)) {
+      for (const entry of readObjectValues(current.dependencies) ?? []) {
         if (isStringArray(entry)) {
           continue;
         }
@@ -456,7 +490,11 @@ function resolveSchemaRef(
 }
 
 export function normalizeJsonSchemaForTypeBox(schema: JsonSchemaValue): JsonSchemaValue {
-  return normalizeJsonSchemaNode(schema) as JsonSchemaValue;
+  try {
+    return normalizeJsonSchemaNode(schema) as JsonSchemaValue;
+  } catch {
+    return false;
+  }
 }
 
 function isStringArray(value: unknown): value is string[] {
@@ -539,7 +577,11 @@ function validateSchemaKeywordShapes(
     if (!isRecord(schema.dependentRequired)) {
       return `${path}.dependentRequired: expected string array map`;
     }
-    for (const [key, value] of Object.entries(schema.dependentRequired)) {
+    const entries = readObjectEntries(schema.dependentRequired);
+    if (!entries) {
+      return `${path}.dependentRequired: unreadable string array map`;
+    }
+    for (const [key, value] of entries) {
       if (!isStringArray(value)) {
         return `${path}.dependentRequired.${key}: expected string array`;
       }
@@ -549,7 +591,11 @@ function validateSchemaKeywordShapes(
     if (!isRecord(schema.dependencies)) {
       return `${path}.dependencies: expected schema or string array map`;
     }
-    for (const [key, value] of Object.entries(schema.dependencies)) {
+    const entries = readObjectEntries(schema.dependencies);
+    if (!entries) {
+      return `${path}.dependencies: unreadable schema or string array map`;
+    }
+    for (const [key, value] of entries) {
       if (!isStringArray(value) && typeof value !== "boolean" && !isRecord(value)) {
         return `${path}.dependencies.${key}: expected schema or string array`;
       }
@@ -612,7 +658,11 @@ function findJsonSchemaNodeError(
     if (!isRecord(value)) {
       return `${path}.${key}: expected schema map`;
     }
-    for (const [entryKey, entry] of Object.entries(value)) {
+    const entries = readObjectEntries(value);
+    if (!entries) {
+      return `${path}.${key}: unreadable schema map`;
+    }
+    for (const [entryKey, entry] of entries) {
       const error = findJsonSchemaNodeError(
         entry,
         `${path}.${key}.${entryKey}`,
@@ -626,7 +676,11 @@ function findJsonSchemaNodeError(
     }
   }
   if (isRecord(schema.dependencies)) {
-    for (const [key, value] of Object.entries(schema.dependencies)) {
+    const entries = readObjectEntries(schema.dependencies);
+    if (!entries) {
+      return `${path}.dependencies: unreadable schema or string array map`;
+    }
+    for (const [key, value] of entries) {
       if (isStringArray(value)) {
         continue;
       }
@@ -701,7 +755,11 @@ function findJsonSchemaNodeError(
 }
 
 export function findJsonSchemaShapeError(schema: JsonSchemaValue): string | undefined {
-  return findJsonSchemaNodeError(schema, "<schema>", schema, schema, undefined);
+  try {
+    return findJsonSchemaNodeError(schema, "<schema>", schema, schema, undefined);
+  } catch {
+    return "<schema>: unreadable schema";
+  }
 }
 
 function cloneDefault<T>(value: T): T {
@@ -775,7 +833,7 @@ function inlineLocalRefsForMatch(
         resolvingRefs,
       );
       resolvingRefs.delete(refKey);
-      if (Object.keys(siblingSchema).length === 0) {
+      if ((readObjectKeys(siblingSchema) ?? []).length === 0) {
         return inlinedTarget;
       }
       return {
@@ -792,42 +850,52 @@ function inlineLocalRefsForMatch(
       };
     }
   }
+  const entries = readObjectEntries(schema);
+  if (!entries) {
+    return false;
+  }
   return Object.fromEntries(
-    Object.entries(schema).map(([key, value]) => {
+    entries.map(([key, value]) => {
       if (schemaMapKeywords.has(key) && isRecord(value)) {
+        const mapEntries = readObjectEntries(value);
         return [
           key,
-          Object.fromEntries(
-            Object.entries(value).map(([entryKey, entry]) => [
-              entryKey,
-              inlineLocalRefsForMatch(
-                entry as JsonSchemaValue,
-                root,
-                currentResourceRoot,
-                currentResourceBaseId,
-                resolvingRefs,
-              ),
-            ]),
-          ),
-        ];
-      }
-      if (key === "dependencies" && isRecord(value)) {
-        return [
-          key,
-          Object.fromEntries(
-            Object.entries(value).map(([entryKey, entry]) => [
-              entryKey,
-              isStringArray(entry)
-                ? entry
-                : inlineLocalRefsForMatch(
+          mapEntries
+            ? Object.fromEntries(
+                mapEntries.map(([entryKey, entry]) => [
+                  entryKey,
+                  inlineLocalRefsForMatch(
                     entry as JsonSchemaValue,
                     root,
                     currentResourceRoot,
                     currentResourceBaseId,
                     resolvingRefs,
                   ),
-            ]),
-          ),
+                ]),
+              )
+            : {},
+        ];
+      }
+      if (key === "dependencies" && isRecord(value)) {
+        const dependencyEntries = readObjectEntries(value);
+        return [
+          key,
+          dependencyEntries
+            ? Object.fromEntries(
+                dependencyEntries.map(([entryKey, entry]) => [
+                  entryKey,
+                  isStringArray(entry)
+                    ? entry
+                    : inlineLocalRefsForMatch(
+                        entry as JsonSchemaValue,
+                        root,
+                        currentResourceRoot,
+                        currentResourceBaseId,
+                        resolvingRefs,
+                      ),
+                ]),
+              )
+            : {},
         ];
       }
       if (schemaValueKeywords.has(key) || schemaArrayKeywords.has(key)) {
@@ -873,7 +941,11 @@ function applyObjectPropertyDefaults(
   currentResourceBaseId: string | undefined,
 ): Record<string, unknown> {
   const properties = isRecord(schema.properties) ? schema.properties : {};
-  for (const [key, propertySchema] of Object.entries(properties)) {
+  const propertyEntries = readObjectEntries(properties);
+  if (!propertyEntries) {
+    throw new Error("unreadable schema properties");
+  }
+  for (const [key, propertySchema] of propertyEntries) {
     const currentValue = value[key];
     const defaultedValue = applySchemaDefaults(
       propertySchema as JsonSchemaValue,
@@ -891,14 +963,22 @@ function applyObjectPropertyDefaults(
   }
   const patternMatchedKeys = new Set<string>();
   if (isRecord(schema.patternProperties)) {
-    for (const [pattern, propertySchema] of Object.entries(schema.patternProperties)) {
+    const patternEntries = readObjectEntries(schema.patternProperties);
+    if (!patternEntries) {
+      throw new Error("unreadable schema patternProperties");
+    }
+    for (const [pattern, propertySchema] of patternEntries) {
       let regex: RegExp;
       try {
         regex = new RegExp(pattern);
       } catch {
         continue;
       }
-      for (const key of Object.keys(value)) {
+      const valueKeys = readObjectKeys(value);
+      if (!valueKeys) {
+        throw new Error("unreadable value keys");
+      }
+      for (const key of valueKeys) {
         if (!regex.test(key)) {
           continue;
         }
@@ -916,7 +996,11 @@ function applyObjectPropertyDefaults(
   }
   if (isRecord(schema.additionalProperties)) {
     const additionalSchema = schema.additionalProperties as JsonSchemaValue;
-    for (const key of Object.keys(value)) {
+    const valueKeys = readObjectKeys(value);
+    if (!valueKeys) {
+      throw new Error("unreadable value keys");
+    }
+    for (const key of valueKeys) {
       if (Object.hasOwn(properties, key) || patternMatchedKeys.has(key)) {
         continue;
       }
@@ -943,7 +1027,11 @@ function applyObjectDependencyDefaults(
 ): Record<string, unknown> {
   let nextValue = value;
   if (isRecord(schema.dependencies)) {
-    for (const [key, dependencySchema] of Object.entries(schema.dependencies)) {
+    const dependencyEntries = readObjectEntries(schema.dependencies);
+    if (!dependencyEntries) {
+      throw new Error("unreadable schema dependencies");
+    }
+    for (const [key, dependencySchema] of dependencyEntries) {
       if (!Object.hasOwn(nextValue, key) || isStringArray(dependencySchema)) {
         continue;
       }
@@ -958,7 +1046,11 @@ function applyObjectDependencyDefaults(
     }
   }
   if (isRecord(schema.dependentSchemas)) {
-    for (const [key, dependentSchema] of Object.entries(schema.dependentSchemas)) {
+    const dependentSchemaEntries = readObjectEntries(schema.dependentSchemas);
+    if (!dependentSchemaEntries) {
+      throw new Error("unreadable schema dependentSchemas");
+    }
+    for (const [key, dependentSchema] of dependentSchemaEntries) {
       if (!Object.hasOwn(nextValue, key)) {
         continue;
       }
@@ -1019,12 +1111,12 @@ function countSchemaNodes(schema: JsonSchemaValue, seen = new Set<object>()): nu
     if (!isRecord(value)) {
       continue;
     }
-    for (const entry of Object.values(value)) {
+    for (const entry of readObjectValues(value) ?? []) {
       count += countSchemaNodes(entry as JsonSchemaValue, seen);
     }
   }
   if (isRecord(schema.dependencies)) {
-    for (const entry of Object.values(schema.dependencies)) {
+    for (const entry of readObjectValues(schema.dependencies) ?? []) {
       if (!isStringArray(entry)) {
         count += countSchemaNodes(entry as JsonSchemaValue, seen);
       }
@@ -1262,5 +1354,15 @@ function applySchemaDefaults(
 }
 
 export function applyJsonSchemaDefaults<T>(schema: JsonSchemaValue, value: T): T {
-  return applySchemaDefaults(schema, value) as T;
+  let target: T;
+  try {
+    target = cloneDefault(value);
+  } catch {
+    return value;
+  }
+  try {
+    return applySchemaDefaults(schema, target) as T;
+  } catch {
+    return value;
+  }
 }


### PR DESCRIPTION
## Summary

- Harden shared JSON Schema traversal against unreadable schema maps during shape checks, TypeBox normalization, ref matching, and default projection.
- Keep default application all-or-nothing by applying defaults to a cloned value and returning the original unchanged when schema traversal/default cloning fails.
- Add regressions for unreadable `properties` maps and partial default mutation after a later default fails to clone.

## Verification

- `node scripts/run-vitest.mjs src/shared/json-schema-defaults.test.ts src/plugins/schema-validator.test.ts src/agents/agent-bundle-mcp-runtime.test.ts -- --reporter=dot` passed: 2 shards; 35 unit-fast tests and 30 agent tests.
- `./node_modules/.bin/oxfmt --check src/shared/json-schema-defaults.ts src/shared/json-schema-defaults.test.ts` passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/shared/json-schema-defaults.ts src/shared/json-schema-defaults.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean; no accepted/actionable findings.
- AWS Crabbox `pnpm check:changed` passed. Provider: `aws`; run: `run_f3ea7dd553b0`; lease: `cbx_cd1a62a605a7`; slug: `tidal-barnacle`; exit 0; lanes: `core`, `coreTests`; command 3m22.915s; total 5m42.968s; lease stopped.

## Real behavior proof

Behavior addressed: Shared JSON Schema helpers no longer leak raw errors or partially apply defaults when plugin/MCP-owned schema maps are unreadable.

Real environment tested: Local focused proof in a fresh GWT on current `origin/main`; AWS Crabbox changed gate on provider `aws`.

Exact steps or command run after this patch: Ran the focused Vitest command above plus direct schema probes for unreadable `properties` maps and partial mutation recovery.

Evidence after fix: `findJsonSchemaShapeError()` reports `<schema>.properties: unreadable schema map`; `validateJsonSchemaValue()` reports `invalid schema: <schema>.properties: unreadable schema map`; default projection returns the original value unchanged when traversal fails.

Observed result after fix: Focused tests, formatting, lint, diff check, autoreview, and AWS Crabbox `pnpm check:changed` passed.

What was not tested: Full suite, live providers, and browser/E2E paths.

