### PR TITLE
fix(config): guard schema lookup traversal

### DIFF
--- a/src/config/schema.shared.ts
+++ b/src/config/schema.shared.ts
@@ -19,22 +19,59 @@ export function asSchemaObject(value: unknown): object | null {
   return value;
 }
 
+function readSchemaField<K extends keyof JsonSchemaObject>(
+  schema: JsonSchemaObject,
+  key: K,
+): JsonSchemaObject[K] | undefined {
+  try {
+    return schema[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectKeys(value: Record<string, unknown>): string[] | undefined {
+  try {
+    return Object.keys(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectEntries<T>(value: Record<string, T>): Array<[string, T]> | undefined {
+  try {
+    return Object.entries(value);
+  } catch {
+    return undefined;
+  }
+}
+
 export function schemaHasChildren(schema: JsonSchemaObject): boolean {
-  if (schema.properties && Object.keys(schema.properties).length > 0) {
+  const properties = readSchemaField(schema, "properties");
+  if (properties) {
+    const keys = readObjectKeys(properties);
+    if (!keys || keys.length > 0) {
+      return true;
+    }
+  }
+  const additionalProperties = readSchemaField(schema, "additionalProperties");
+  if (additionalProperties && typeof additionalProperties === "object") {
     return true;
   }
-  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
-    return true;
+  const items = readSchemaField(schema, "items");
+  if (Array.isArray(items)) {
+    return items.some((entry) => typeof entry === "object" && entry !== null);
   }
-  if (Array.isArray(schema.items)) {
-    return schema.items.some((entry) => typeof entry === "object" && entry !== null);
-  }
-  for (const branch of [schema.oneOf, schema.anyOf, schema.allOf]) {
+  for (const branch of [
+    readSchemaField(schema, "oneOf"),
+    readSchemaField(schema, "anyOf"),
+    readSchemaField(schema, "allOf"),
+  ]) {
     if (branch?.some((entry) => entry && typeof entry === "object" && schemaHasChildren(entry))) {
       return true;
     }
   }
-  return Boolean(schema.items && typeof schema.items === "object");
+  return Boolean(items && typeof items === "object");
 }
 
 export function findWildcardHintMatch<T>(params: {
@@ -51,7 +88,7 @@ export function findWildcardHintMatch<T>(params: {
       }
     | undefined;
 
-  for (const [hintPath, hint] of Object.entries(params.uiHints)) {
+  for (const [hintPath, hint] of readObjectEntries(params.uiHints) ?? []) {
     const hintParts = params.splitPath(hintPath);
     if (hintParts.length !== targetParts.length) {
       continue;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1015,4 +1015,114 @@ describe("config schema", () => {
   it("returns null for missing config schema paths", () => {
     expect(lookupConfigSchema(baseSchema, "gateway.notReal.path")).toBeNull();
   });
+
+  it("omits unreadable lookup schema maps without throwing", () => {
+    const unreadableProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("lookup properties ownKeys exploded");
+        },
+      },
+    );
+    const response = {
+      schema: {
+        type: "object",
+        properties: {
+          plugin: {
+            type: "object",
+            properties: {
+              config: {
+                type: "object",
+                properties: unreadableProperties,
+              },
+            },
+          },
+        },
+      },
+      uiHints: {},
+      version: "test",
+      generatedAt: "test",
+    } as unknown as Parameters<typeof lookupConfigSchema>[0];
+
+    const lookup = lookupConfigSchema(response, "plugin.config");
+
+    expect(lookup?.schema).toEqual({ type: "object" });
+    expect(lookup?.children).toEqual([]);
+  });
+
+  it("returns null when lookup path traversal reaches an unreadable schema map", () => {
+    const unreadableProperties = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("lookup descriptor exploded");
+        },
+      },
+    );
+    const response = {
+      schema: {
+        type: "object",
+        properties: unreadableProperties,
+      },
+      uiHints: {},
+      version: "test",
+      generatedAt: "test",
+    } as unknown as Parameters<typeof lookupConfigSchema>[0];
+
+    expect(lookupConfigSchema(response, "plugin")).toBeNull();
+  });
+
+  it("does not fall through to wildcard schemas for false property schemas", () => {
+    const response = {
+      schema: {
+        type: "object",
+        properties: {
+          blocked: false,
+        },
+        additionalProperties: {
+          type: "string",
+        },
+      },
+      uiHints: {},
+      version: "test",
+      generatedAt: "test",
+    } as unknown as Parameters<typeof lookupConfigSchema>[0];
+
+    expect(lookupConfigSchema(response, "blocked")).toBeNull();
+  });
+
+  it("keeps child summaries stable when a child schema has unreadable children", () => {
+    const unreadableProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("child properties ownKeys exploded");
+        },
+      },
+    );
+    const response = {
+      schema: {
+        type: "object",
+        properties: {
+          plugin: {
+            type: "object",
+            properties: unreadableProperties,
+          },
+        },
+      },
+      uiHints: {},
+      version: "test",
+      generatedAt: "test",
+    } as unknown as Parameters<typeof lookupConfigSchema>[0];
+
+    const lookup = lookupConfigSchema(response, ".");
+
+    expect(lookup?.children).toContainEqual(
+      expect.objectContaining({
+        key: "plugin",
+        hasChildren: true,
+      }),
+    );
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,6 +34,41 @@ type JsonSchemaObject = JsonSchemaNode & {
 const asJsonSchemaObject = (value: unknown): JsonSchemaObject | null =>
   asSchemaObject(value) as JsonSchemaObject | null;
 
+function readSchemaField<K extends keyof JsonSchemaObject>(
+  schema: JsonSchemaObject,
+  key: K,
+): JsonSchemaObject[K] | undefined {
+  try {
+    return schema[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectEntries<T>(value: Record<string, T>): Array<[string, T]> | undefined {
+  try {
+    return Object.entries(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectValue<T>(value: Record<string, T>, key: string): T | undefined {
+  try {
+    return Object.hasOwn(value, key) ? value[key] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectHasOwn(value: Record<string, unknown>, key: string): boolean | undefined {
+  try {
+    return Object.hasOwn(value, key);
+  } catch {
+    return undefined;
+  }
+}
+
 const FORBIDDEN_LOOKUP_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
 const LOOKUP_SCHEMA_STRING_KEYS = new Set([
   "$id",
@@ -637,14 +672,15 @@ function resolveUiHintMatch(
 }
 
 function resolveItemsSchema(schema: JsonSchemaObject, index?: number): JsonSchemaObject | null {
-  if (Array.isArray(schema.items)) {
+  const items = readSchemaField(schema, "items");
+  if (Array.isArray(items)) {
     const entry =
       index === undefined
-        ? schema.items.find((candidate) => typeof candidate === "object" && candidate !== null)
-        : schema.items[index];
+        ? items.find((candidate) => typeof candidate === "object" && candidate !== null)
+        : items[index];
     return entry && typeof entry === "object" ? entry : null;
   }
-  return schema.items && typeof schema.items === "object" ? schema.items : null;
+  return items && typeof items === "object" ? items : null;
 }
 
 function resolveLookupChildSchema(
@@ -655,9 +691,16 @@ function resolveLookupChildSchema(
     return null;
   }
 
-  const properties = schema.properties;
-  if (properties && Object.hasOwn(properties, segment)) {
-    return asJsonSchemaObject(properties[segment]);
+  const properties = readSchemaField(schema, "properties");
+  if (properties) {
+    const hasProperty = readObjectHasOwn(properties, segment);
+    if (hasProperty === undefined) {
+      return null;
+    }
+    if (hasProperty) {
+      const propertySchema = readObjectValue(properties, segment);
+      return asJsonSchemaObject(propertySchema);
+    }
   }
 
   const itemIndex = parseConfigPathArrayIndex(segment);
@@ -666,8 +709,9 @@ function resolveLookupChildSchema(
     return items;
   }
 
-  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
-    return schema.additionalProperties;
+  const additionalProperties = readSchemaField(schema, "additionalProperties");
+  if (additionalProperties && typeof additionalProperties === "object") {
+    return additionalProperties;
   }
 
   return null;
@@ -676,7 +720,7 @@ function resolveLookupChildSchema(
 function stripSchemaForLookup(schema: JsonSchemaObject, nestedFormDepth = 0): JsonSchemaNode {
   const next: JsonSchemaNode = {};
 
-  for (const [key, value] of Object.entries(schema)) {
+  for (const [key, value] of readObjectEntries(schema) ?? []) {
     if (LOOKUP_SCHEMA_STRING_KEYS.has(key) && typeof value === "string") {
       next[key] = value;
       continue;
@@ -722,31 +766,37 @@ function stripSchemaForLookup(schema: JsonSchemaObject, nestedFormDepth = 0): Js
   }
 
   if (
-    schema.properties &&
+    readSchemaField(schema, "properties") &&
     ((nestedFormDepth > 0 && nestedFormDepth <= LOOKUP_SCHEMA_NESTED_FORM_DEPTH) ||
-      (schema.additionalProperties && typeof schema.additionalProperties === "object"))
+      (() => {
+        const additionalProperties = readSchemaField(schema, "additionalProperties");
+        return additionalProperties && typeof additionalProperties === "object";
+      })())
   ) {
-    next.properties = Object.fromEntries(
-      Object.entries(schema.properties).map(([key, child]) => [
-        key,
-        stripSchemaForLookup(child, nestedFormDepth + 1),
-      ]),
-    );
+    const properties = readSchemaField(schema, "properties");
+    const propertyEntries = properties ? readObjectEntries(properties) : undefined;
+    if (propertyEntries) {
+      next.properties = Object.fromEntries(
+        propertyEntries.map(([key, child]) => [
+          key,
+          stripSchemaForLookup(child, nestedFormDepth + 1),
+        ]),
+      );
+    }
   }
-  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
-    next.additionalProperties = stripSchemaForLookup(
-      schema.additionalProperties,
-      nestedFormDepth + 1,
-    );
+  const additionalProperties = readSchemaField(schema, "additionalProperties");
+  if (additionalProperties && typeof additionalProperties === "object") {
+    next.additionalProperties = stripSchemaForLookup(additionalProperties, nestedFormDepth + 1);
   }
-  if (Array.isArray(schema.items)) {
-    next.items = schema.items.map((item) => stripSchemaForLookup(item, nestedFormDepth + 1));
-  } else if (schema.items && typeof schema.items === "object") {
-    next.items = stripSchemaForLookup(schema.items, nestedFormDepth + 1);
+  const items = readSchemaField(schema, "items");
+  if (Array.isArray(items)) {
+    next.items = items.map((item) => stripSchemaForLookup(item, nestedFormDepth + 1));
+  } else if (items && typeof items === "object") {
+    next.items = stripSchemaForLookup(items, nestedFormDepth + 1);
   }
   if (nestedFormDepth <= LOOKUP_SCHEMA_NESTED_FORM_DEPTH) {
     for (const key of LOOKUP_SCHEMA_COMPOSITION_KEYS) {
-      const variants = schema[key];
+      const variants = readSchemaField(schema, key);
       if (!Array.isArray(variants)) {
         continue;
       }
@@ -766,7 +816,8 @@ function buildLookupChildren(
   resolveReloadMetadata?: ConfigSchemaReloadMetadataResolver,
 ): ConfigSchemaLookupChild[] {
   const children: ConfigSchemaLookupChild[] = [];
-  const required = new Set(schema.required ?? []);
+  const requiredValues = readSchemaField(schema, "required");
+  const required = new Set(Array.isArray(requiredValues) ? requiredValues : []);
 
   const pushChild = (key: string, childSchema: JsonSchemaObject, isRequired: boolean) => {
     const childPath = path ? `${path}.${key}` : key;
@@ -784,15 +835,17 @@ function buildLookupChildren(
     });
   };
 
-  for (const [key, childSchema] of Object.entries(schema.properties ?? {})) {
+  const properties = readSchemaField(schema, "properties");
+  for (const [key, childSchema] of properties ? (readObjectEntries(properties) ?? []) : []) {
     pushChild(key, childSchema, required.has(key));
   }
 
+  const additionalProperties = readSchemaField(schema, "additionalProperties");
   const wildcardSchema =
-    (schema.additionalProperties &&
-    typeof schema.additionalProperties === "object" &&
-    !Array.isArray(schema.additionalProperties)
-      ? schema.additionalProperties
+    (additionalProperties &&
+    typeof additionalProperties === "object" &&
+    !Array.isArray(additionalProperties)
+      ? additionalProperties
       : null) ?? resolveItemsSchema(schema);
   if (wildcardSchema) {
     pushChild("*", wildcardSchema, false);


### PR DESCRIPTION
## Summary
- Guard config schema lookup traversal when schema maps or fields throw during property access/enumeration.
- Omit unreadable lookup child maps instead of crashing, while preserving explicit `false` property schema handling.
- Cover unreadable lookup maps, unreadable traversal, child summary stability, and `properties: { key: false }` fallback behavior.

## Verification
- `node scripts/run-vitest.mjs src/config/schema.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/config/schema.ts src/config/schema.shared.ts src/config/schema.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/schema.ts src/config/schema.shared.ts src/config/schema.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (`run_8ea1d5e09ca6`, lease `cbx_b3bda2bc1b9e`, provider `aws`, exit 0)

## Real behavior proof
Behavior addressed: `lookupConfigSchema` could throw when lookup traversal or child listing reached a schema map whose `properties` enumeration/descriptor access throws.
Real environment tested: local focused config schema test lane in a Codex worktree with symlinked dependencies; remote AWS Crabbox changed gate (`run_8ea1d5e09ca6`, lease `cbx_b3bda2bc1b9e`, provider `aws`).
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/schema.test.ts -- --reporter=dot` plus formatting, oxlint, diff-check, autoreview, and remote `pnpm check:changed` commands listed above.
Evidence after fix: focused config schema suite passed with 53 tests; autoreview reported no accepted/actionable findings; remote `pnpm check:changed` passed lanes `core` and `coreTests` on AWS Crabbox.
Observed result after fix: unreadable schema maps return null or sanitized lookup schema/children instead of throwing; explicit `false` property schemas do not fall through to wildcard schemas.
What was not tested: no live app UI session; this change is covered at config schema unit level plus changed-gate type/lint/guard proof.
