### PR TITLE
fix(googlechat): fall back to text link on media upload 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Google Chat: fall back to sending the media URL as a text link when app-auth attachment upload returns 403. Thanks @SebTardif.
+
 ## 2026.6.2
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 Docs: https://docs.openclaw.ai
 
-## Unreleased
-
-### Fixes
-
-- Google Chat: fall back to sending the media URL as a text link when app-auth attachment upload returns 403. Thanks @SebTardif.
-
 ## 2026.6.2
 
 ### Highlights

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -234,6 +234,134 @@ describe("googlechat message actions", () => {
     expectJsonResult(result, { ok: true, to: "spaces/BBB" });
   });
 
+  it("falls back to sending the media URL as text when upload returns 403", async () => {
+    const account = buildAccount({
+      config: { mediaMaxMb: 5 },
+    });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    const readRemoteMediaBuffer = vi.fn(async () => ({
+      buffer: Buffer.from("remote-bytes"),
+      fileName: "remote.png",
+      contentType: "image/png",
+    }));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: {
+        media: {
+          readRemoteMediaBuffer,
+        },
+      },
+    });
+    uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-fallback",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    const result = await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "caption",
+        media: "https://example.com/file.png",
+      },
+      cfg: {},
+      accountId: "default",
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.com/file.png",
+      thread: undefined,
+    });
+    expectJsonResult(result, { ok: true, to: "spaces/AAA" });
+  });
+
+  it("propagates 403 upload errors for local media paths", async () => {
+    const account = buildAccount({
+      config: { mediaMaxMb: 5 },
+    });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    const readFile = vi.fn(async () => Buffer.from("local-bytes"));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: {
+        media: {
+          readRemoteMediaBuffer: vi.fn(),
+        },
+      },
+    });
+    uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await expect(
+      googlechatMessageActions.handleAction({
+        action: "send",
+        params: {
+          to: "spaces/AAA",
+          message: "caption",
+          media: "/tmp/workspace/notes.md",
+        },
+        cfg: {},
+        accountId: "default",
+        mediaLocalRoots: ["/tmp/workspace"],
+        mediaReadFile: readFile,
+      } as never),
+    ).rejects.toThrow("403");
+
+    expect(sendGoogleChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-403 upload errors", async () => {
+    const account = buildAccount({
+      config: { mediaMaxMb: 5 },
+    });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    const readRemoteMediaBuffer = vi.fn(async () => ({
+      buffer: Buffer.from("remote-bytes"),
+      fileName: "remote.png",
+      contentType: "image/png",
+    }));
+    getGoogleChatRuntime.mockReturnValue({
+      channel: {
+        media: {
+          readRemoteMediaBuffer,
+        },
+      },
+    });
+    uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 500: Internal Server Error"),
+    );
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await expect(
+      googlechatMessageActions.handleAction({
+        action: "send",
+        params: {
+          to: "spaces/AAA",
+          message: "caption",
+          media: "https://example.com/file.png",
+        },
+        cfg: {},
+        accountId: "default",
+      } as never),
+    ).rejects.toThrow("500");
+
+    expect(sendGoogleChatMessage).not.toHaveBeenCalled();
+  });
+
   it("removes only matching app reactions on react remove", async () => {
     const account = buildAccount({
       config: { botUser: "users/app-bot" },

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -140,19 +140,37 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           readStringParam(params, "title") ??
           loaded.fileName ??
           "attachment";
-        const upload = await uploadGoogleChatAttachment({
-          account,
-          space,
-          filename: uploadFileName,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-        });
+        let upload: { attachmentUploadToken?: string } | undefined;
+        try {
+          upload = await uploadGoogleChatAttachment({
+            account,
+            space,
+            filename: uploadFileName,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+          });
+        } catch (uploadErr) {
+          if (/\b403\b/.test(String(uploadErr))) {
+            if (/^https?:\/\//i.test(mediaUrl)) {
+              // App-auth scope insufficient; fall back to URL as text.
+              const fallbackText = content ? `${content}\n${mediaUrl}` : mediaUrl;
+              await sendGoogleChatMessage({
+                account,
+                space,
+                text: fallbackText,
+                thread: threadId ?? undefined,
+              });
+              return jsonResult({ ok: true, to: space });
+            }
+          }
+          throw uploadErr;
+        }
         await sendGoogleChatMessage({
           account,
           space,
           text: content,
           thread: threadId ?? undefined,
-          attachments: upload.attachmentUploadToken
+          attachments: upload?.attachmentUploadToken
             ? [
                 {
                   attachmentUploadToken: upload.attachmentUploadToken,

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -310,19 +310,41 @@ export const googlechatOutboundAdapter = {
           });
       const { sendGoogleChatMessage, uploadGoogleChatAttachment } =
         await loadGoogleChatChannelRuntime();
-      const upload = await uploadGoogleChatAttachment({
-        account,
-        space,
-        filename: loaded.fileName ?? "attachment",
-        buffer: loaded.buffer,
-        contentType: loaded.contentType,
-      });
+      let upload: { attachmentUploadToken?: string } | undefined;
+      try {
+        upload = await uploadGoogleChatAttachment({
+          account,
+          space,
+          filename: loaded.fileName ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+      } catch (uploadErr) {
+        if (/\b403\b/.test(String(uploadErr))) {
+          // App-auth service accounts lack the chat.messages.create scope
+          // required for media uploads. Fall back to sending the URL as text.
+          const fallbackText = text ? `${text}\n${mediaUrl}` : (mediaUrl ?? "");
+          const result = await sendGoogleChatMessage({
+            account,
+            space,
+            text: fallbackText,
+            thread,
+          });
+          const messageId = result?.messageName ?? "";
+          return {
+            messageId,
+            chatId: space,
+            receipt: createGoogleChatSendReceipt({ messageId, chatId: space, kind: "text" }),
+          };
+        }
+        throw uploadErr;
+      }
       const result = await sendGoogleChatMessage({
         account,
         space,
         text,
         thread,
-        attachments: upload.attachmentUploadToken
+        attachments: upload?.attachmentUploadToken
           ? [
               {
                 attachmentUploadToken: upload.attachmentUploadToken,

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -321,6 +321,9 @@ export const googlechatOutboundAdapter = {
         });
       } catch (uploadErr) {
         if (/\b403\b/.test(String(uploadErr))) {
+          if (!/^https?:\/\//i.test(mediaUrl)) {
+            throw uploadErr;
+          }
           // App-auth service accounts lack the chat.messages.create scope
           // required for media uploads. Fall back to sending the URL as text.
           const fallbackText = text ? `${text}\n${mediaUrl}` : (mediaUrl ?? "");

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -406,6 +406,62 @@ describe("googlechatPlugin outbound sendMedia", () => {
     expect(result.chatId).toBe("spaces/AAA");
     expect(result.receipt.primaryPlatformMessageId).toBe("spaces/AAA/messages/msg-2");
   });
+
+  it("falls back to sending the media URL as text when upload returns 403", async () => {
+    readRemoteMediaBufferMock.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+      fileName: "remote.png",
+    });
+    uploadGoogleChatAttachmentMock.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-fallback",
+    });
+
+    const cfg = createGoogleChatCfg();
+
+    const result = await googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      text: "caption",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "caption\nhttps://example.com/image.png",
+      }),
+    );
+    expect(result.messageId).toBe("spaces/AAA/messages/msg-fallback");
+    expect(result.chatId).toBe("spaces/AAA");
+  });
+
+  it("propagates non-403 upload errors", async () => {
+    readRemoteMediaBufferMock.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+      fileName: "remote.png",
+    });
+    uploadGoogleChatAttachmentMock.mockRejectedValueOnce(
+      new Error("Google Chat upload 500: Internal Server Error"),
+    );
+
+    const cfg = createGoogleChatCfg();
+
+    await expect(
+      googlechatOutboundAdapter.attachedResults.sendMedia({
+        cfg,
+        to: "spaces/AAA",
+        text: "caption",
+        mediaUrl: "https://example.com/image.png",
+        accountId: "default",
+      }),
+    ).rejects.toThrow("500");
+  });
 });
 
 describe("googlechatPlugin threading", () => {

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -440,6 +440,32 @@ describe("googlechatPlugin outbound sendMedia", () => {
     expect(result.chatId).toBe("spaces/AAA");
   });
 
+  it("propagates 403 upload errors for local media paths", async () => {
+    loadOutboundMediaFromUrlMock.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+      fileName: "image.png",
+    });
+    uploadGoogleChatAttachmentMock.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+
+    const cfg = createGoogleChatCfg();
+
+    await expect(
+      googlechatOutboundAdapter.attachedResults.sendMedia({
+        cfg,
+        to: "spaces/AAA",
+        text: "caption",
+        mediaUrl: "/tmp/workspace/image.png",
+        mediaLocalRoots: ["/tmp/workspace"],
+        accountId: "default",
+      }),
+    ).rejects.toThrow("403");
+
+    expect(sendGoogleChatMessageMock).not.toHaveBeenCalled();
+  });
+
   it("propagates non-403 upload errors", async () => {
     readRemoteMediaBufferMock.mockResolvedValue({
       buffer: Buffer.from("image"),

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -111,13 +111,30 @@ export async function deliverGoogleChatReply(params: {
           url: mediaUrl,
           maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
         });
-        const upload = await uploadAttachmentForReply({
-          account,
-          spaceId,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-          filename: loaded.fileName ?? "attachment",
-        });
+        let upload: { attachmentUploadToken?: string } | undefined;
+        try {
+          upload = await uploadAttachmentForReply({
+            account,
+            spaceId,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+            filename: loaded.fileName ?? "attachment",
+          });
+        } catch (uploadErr) {
+          if (/\b403\b/.test(String(uploadErr))) {
+            // App-auth scope insufficient for media upload; fall back to URL as text.
+            const fallbackText = caption ? `${caption}\n${mediaUrl}` : mediaUrl;
+            await sendGoogleChatMessage({
+              account,
+              space: spaceId,
+              text: fallbackText,
+              thread: payload.replyToId,
+            });
+            statusSink?.({ lastOutboundAt: Date.now() });
+            return;
+          }
+          throw uploadErr;
+        }
         if (!upload.attachmentUploadToken) {
           throw new Error("missing attachment upload token");
         }

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -122,6 +122,9 @@ export async function deliverGoogleChatReply(params: {
           });
         } catch (uploadErr) {
           if (/\b403\b/.test(String(uploadErr))) {
+            if (!/^https?:\/\//i.test(mediaUrl)) {
+              throw uploadErr;
+            }
             // App-auth scope insufficient for media upload; fall back to URL as text.
             const fallbackText = caption ? `${caption}\n${mediaUrl}` : mediaUrl;
             await sendGoogleChatMessage({

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -141,4 +141,70 @@ describe("Google Chat reply delivery", () => {
       attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
     });
   });
+
+  it("falls back to sending the media URL as text when upload returns 403", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
+    });
+    const runtime = createRuntime();
+    const statusSink = vi.fn();
+    mocks.deleteGoogleChatMessage.mockResolvedValue(undefined);
+    mocks.uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/fallback" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "https://example.invalid/reply.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      statusSink,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.invalid/reply.png",
+      thread: "spaces/AAA/threads/root",
+    });
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-403 upload errors to the error handler", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
+    });
+    const runtime = createRuntime();
+    mocks.deleteGoogleChatMessage.mockResolvedValue(undefined);
+    mocks.uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 500: Internal Server Error"),
+    );
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "https://example.invalid/reply.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
+    );
+  });
 });

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -179,6 +179,36 @@ describe("Google Chat reply delivery", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("propagates 403 upload errors for local media paths", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "image.png" },
+    });
+    const runtime = createRuntime();
+    mocks.deleteGoogleChatMessage.mockResolvedValue(undefined);
+    mocks.uploadGoogleChatAttachment.mockRejectedValueOnce(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "/tmp/workspace/image.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      typingMessageName: "spaces/AAA/messages/typing",
+    });
+
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
+    );
+  });
+
   it("propagates non-403 upload errors to the error handler", async () => {
     const core = createCore({
       media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },


### PR DESCRIPTION
Fixes #89430

## Summary

When Google Chat is configured with app authentication (`chat.bot` scope), any agent reply with media fails because `attachments:upload` returns 403 `PERMISSION_DENIED`. Per Google's docs, media upload requires user auth (`chat.messages.create`), not app auth. The entire message is lost because the upload error propagates uncaught.

This fix catches 403 errors from the upload call in both delivery paths:
- `channel.adapters.ts` (main outbound adapter)
- `monitor-reply-delivery.ts` (sub-agent announce and monitor replies)

On 403, instead of failing the entire message, the code falls back to sending the media URL as a text link so the user still receives the artifact. Non-403 upload errors propagate unchanged.

4 regression tests cover the fallback and error propagation in both paths.

Closes #89430

## Real behavior proof

- **Behavior or issue addressed:** Google Chat agents with app auth cannot deliver images/files; the upload returns 403 and the entire message is lost.
- **Real environment tested:** macOS 15.5, Node v22.19.0, OpenClaw built from patched source at `/tmp/wt-89606`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/wt-89606
  pnpm install --frozen-lockfile
  pnpm build

  # Verify the fallback is in the production bundle
  grep -n '403' dist/googlechat-*.js

  # Run the regression tests
  npx vitest run extensions/googlechat/src/channel.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts --reporter=verbose
  ```

- **Evidence after fix:** terminal output from the patched build:

  Terminal confirms all 4 new tests exercise the 403 fallback and error propagation:

  ```console
  $ npx vitest run extensions/googlechat/src/channel.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts --reporter=verbose
  ✓ googlechatPlugin outbound sendMedia > falls back to sending the media URL as text when upload returns 403
  ✓ googlechatPlugin outbound sendMedia > propagates non-403 upload errors
  ✓ Google Chat reply delivery > falls back to sending the media URL as text when upload returns 403
  ✓ Google Chat reply delivery > propagates non-403 upload errors to the error handler
  Test Files  2 passed (2)
  Tests  24 passed (24)
  ```

- **Observed result after fix:** When the Google Chat attachment upload fails with 403 (app-auth scope insufficient), the adapter sends `caption + URL` as a text message instead of failing silently. The user receives the media artifact as a clickable link. Non-403 errors still propagate to the outer error handler.
- **What was not tested:** Live Google Chat workspace with a service-account-only bot, triggering a media reply to confirm the text-link fallback renders correctly in the Chat client.

