### PR TITLE
fix(channels): guard message action schema discovery

### DIFF
--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -70,7 +70,7 @@ export function createMessageActionDiscoveryContext(
 
 function logMessageActionError(params: {
   pluginId: string;
-  operation: "describeMessageTool";
+  operation: "describeMessageTool" | "schema";
   error: unknown;
 }) {
   const message = formatErrorMessage(params.error);
@@ -113,6 +113,42 @@ function normalizeToolSchemaContributions(
     return [];
   }
   return Array.isArray(value) ? value : [value];
+}
+
+function readSchemaContributionActions(params: {
+  pluginId: string;
+  contribution: ChannelMessageToolSchemaContribution;
+}): ChannelMessageActionName[] | null {
+  try {
+    if (!Object.hasOwn(params.contribution, "actions")) {
+      return null;
+    }
+    const actions = params.contribution.actions;
+    return Array.isArray(actions) ? actions : null;
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "schema",
+      error,
+    });
+    return null;
+  }
+}
+
+function readSchemaContributionProperties(params: {
+  pluginId: string;
+  contribution: ChannelMessageToolSchemaContribution;
+}): Record<string, TSchema> | undefined {
+  try {
+    return params.contribution.properties;
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "schema",
+      error,
+    });
+    return undefined;
+  }
 }
 
 type ResolvedChannelMessageActionDiscovery = {
@@ -257,11 +293,11 @@ export function listCrossChannelSchemaSupportedMessageActions(
     if ((contribution.visibility ?? "current-channel") !== "current-channel") {
       continue;
     }
-    if (!Object.hasOwn(contribution, "actions")) {
-      return [];
-    }
-    const actions = contribution.actions;
-    if (!Array.isArray(actions)) {
+    const actions = readSchemaContributionActions({
+      pluginId: pluginActions.pluginId,
+      contribution,
+    });
+    if (!actions) {
       return [];
     }
     if (actions.length === 0) {
@@ -309,14 +345,23 @@ export function listChannelMessageCapabilitiesForChannel(
 function mergeToolSchemaProperties(
   target: Record<string, TSchema>,
   source: Record<string, TSchema> | undefined,
+  pluginId: string,
 ) {
   if (!source) {
     return;
   }
-  for (const [name, schema] of Object.entries(source)) {
-    if (!(name in target)) {
-      target[name] = schema;
+  try {
+    for (const [name, schema] of Object.entries(source)) {
+      if (!(name in target)) {
+        target[name] = schema;
+      }
     }
+  } catch (error) {
+    logMessageActionError({
+      pluginId,
+      operation: "schema",
+      error,
+    });
   }
 }
 
@@ -342,11 +387,19 @@ export function resolveChannelMessageToolSchemaProperties(
       const visibility = contribution.visibility ?? "current-channel";
       if (currentChannel) {
         if (visibility === "all-configured" || plugin.id === currentChannel) {
-          mergeToolSchemaProperties(properties, contribution.properties);
+          mergeToolSchemaProperties(
+            properties,
+            readSchemaContributionProperties({ pluginId: plugin.id, contribution }),
+            plugin.id,
+          );
         }
         continue;
       }
-      mergeToolSchemaProperties(properties, contribution.properties);
+      mergeToolSchemaProperties(
+        properties,
+        readSchemaContributionProperties({ pluginId: plugin.id, contribution }),
+        plugin.id,
+      );
     }
   }
   if (currentChannel && !seenPluginIds.has(currentChannel)) {
@@ -360,7 +413,11 @@ export function resolveChannelMessageToolSchemaProperties(
       }).schemaContributions) {
         const visibility = contribution.visibility ?? "current-channel";
         if (visibility === "all-configured" || currentActions.pluginId === currentChannel) {
-          mergeToolSchemaProperties(properties, contribution.properties);
+          mergeToolSchemaProperties(
+            properties,
+            readSchemaContributionProperties({ pluginId: currentActions.pluginId, contribution }),
+            currentActions.pluginId,
+          );
         }
       }
     }

--- a/src/channels/plugins/message-actions.test.ts
+++ b/src/channels/plugins/message-actions.test.ts
@@ -193,6 +193,90 @@ describe("message action capability checks", () => {
     ).toHaveProperty("components");
   });
 
+  it("skips unreadable message tool schema properties without dropping healthy siblings", () => {
+    const unreadableProperties = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("message action properties ownKeys exploded");
+        },
+      },
+    );
+    const schemaPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-schema",
+        label: "Demo Schema",
+        capabilities: { chatTypes: ["direct", "group"] },
+        config: {
+          listAccountIds: () => ["default"],
+        },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          schema: [
+            {
+              properties: unreadableProperties,
+            },
+            {
+              properties: {
+                safeText: Type.Optional(Type.String()),
+              },
+            },
+          ],
+        }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "demo-schema", source: "test", plugin: schemaPlugin }]),
+    );
+
+    expect(
+      resolveChannelMessageToolSchemaProperties({
+        cfg: {} as OpenClawConfig,
+        channel: "demo-schema",
+      }),
+    ).toHaveProperty("safeText");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats unreadable current-channel schema action lists as cross-channel blockers", () => {
+    const schemaPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-action-list",
+        label: "Demo Action List",
+        capabilities: { chatTypes: ["direct", "group"] },
+        config: {
+          listAccountIds: () => ["default"],
+        },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["read", "unpin"],
+          schema: {
+            get actions(): never {
+              throw new Error("message action actions getter exploded");
+            },
+            properties: {
+              pinnedMessageId: Type.Optional(Type.String()),
+            },
+          },
+        }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "demo-action-list", source: "test", plugin: schemaPlugin }]),
+    );
+
+    expect(
+      listCrossChannelSchemaSupportedMessageActions({
+        cfg: {} as OpenClawConfig,
+        channel: "demo-action-list",
+      }),
+    ).toStrictEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("filters only actions that depend on current-channel-only schema", () => {
     const scopedSchemaPlugin: ChannelPlugin = {
       ...createChannelTestPluginBase({


### PR DESCRIPTION
## Summary
- Guard channel message-action schema contribution reads so malformed plugin schema fragments do not abort tool schema discovery.
- Skip unreadable schema properties while preserving healthy sibling schema contributions from the same plugin.
- Keep cross-channel action discovery conservative when current-channel schema action metadata is unreadable.

## Verification
- `node scripts/run-vitest.mjs src/channels/plugins/message-actions.test.ts -- --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/channels/plugins/message-action-discovery.ts src/channels/plugins/message-actions.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/channels/plugins/message-action-discovery.ts src/channels/plugins/message-actions.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (`run_b483dce6ac0d`, lease `cbx_aa26a90f1b50`, provider `aws`, exit 0)

## Real behavior proof
Behavior addressed: channel plugin `describeMessageTool()` could return a schema contribution whose `properties` map or current-channel `actions` metadata throws during discovery, aborting message tool schema/action discovery instead of isolating the bad contribution.
Real environment tested: local focused channel message-actions test lane in a Codex worktree with symlinked dependencies; remote AWS Crabbox changed gate (`run_b483dce6ac0d`, lease `cbx_aa26a90f1b50`, provider `aws`).
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/channels/plugins/message-actions.test.ts -- --reporter=dot` plus formatting, oxlint, diff-check, autoreview, and remote `pnpm check:changed` commands listed above.
Evidence after fix: focused channel message-actions suite passed with 12 tests; direct repro returns the healthy sibling schema and logs the bad plugin schema contribution; autoreview reported no accepted/actionable findings; remote `pnpm check:changed` passed lanes `core`, `coreTests`, `extensions`, and `extensionTests` on AWS Crabbox.
Observed result after fix: unreadable schema properties no longer throw and do not drop healthy sibling schema contributions; unreadable current-channel action scoping returns no cross-channel actions instead of throwing.
What was not tested: no live channel plugin runtime session; this change is covered at channel discovery unit level plus changed-gate type/lint/guard proof.
