### PR TITLE
fix(outbound): keep channel send durable when transcript mirror fails (#89626)

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4,6 +4,7 @@ import { chunkText } from "../../auto-reply/chunk.js";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
 import * as mediaCapabilityModule from "../../media/read-capability.js";
 import { createHookRunner } from "../../plugins/hooks.js";
 import { addTestHook } from "../../plugins/hooks.test-helpers.js";
@@ -28,7 +29,9 @@ import {
 import { resolvePreferredOpenClawTmpDir } from "../tmp-openclaw-dir.js";
 
 const mocks = vi.hoisted(() => ({
-  appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
+  appendAssistantMessageToSessionTranscript: vi.fn<() => Promise<SessionTranscriptAppendResult>>(
+    async () => ({ ok: true, sessionFile: "x", messageId: "m" }),
+  ),
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
@@ -3068,6 +3071,68 @@ describe("deliverOutboundPayloads", () => {
     expect(appendOptions?.text).toBe("report.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
+  });
+
+  it("does not fail the channel send when the post-delivery transcript mirror throws", async () => {
+    // Regression for #89626: a transient session-lock failure on the
+    // best-effort transcript mirror must not invalidate an already-delivered
+    // channel message, otherwise the caller retries and re-sends duplicates.
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+    mocks.appendAssistantMessageToSessionTranscript.mockRejectedValueOnce(
+      new Error("session file changed while embedded prompt lock was released"),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "done" }],
+      deps: { matrix: sendMatrix },
+      mirror: {
+        sessionKey: "agent:main:main",
+        text: "done",
+        idempotencyKey: "idem-89626",
+      },
+    });
+
+    // Channel delivered exactly once; the mirror failure was swallowed.
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    const warnCall = requireMockCall(logMocks.warn, "warn");
+    expect(warnCall[0]).toContain(
+      "failed to mirror outbound delivery into session transcript; channel send already succeeded",
+    );
+    expect(warnCall[1]).toMatchObject({ channel: "matrix", sessionKey: "agent:main:main" });
+  });
+
+  it("does not fail the channel send when the transcript mirror reports not-ok", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+    mocks.appendAssistantMessageToSessionTranscript.mockResolvedValueOnce({
+      ok: false,
+      reason: "session locked",
+    });
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "done" }],
+      deps: { matrix: sendMatrix },
+      mirror: {
+        sessionKey: "agent:main:main",
+        text: "done",
+        idempotencyKey: "idem-89626-b",
+      },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    const warnCall = requireMockCall(logMocks.warn, "warn");
+    expect(warnCall[0]).toContain(
+      "failed to mirror outbound delivery into session transcript; channel send already succeeded",
+    );
   });
 
   it("emits message_sent success for text-only deliveries", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1967,14 +1967,36 @@ async function deliverOutboundPayloadsCore(
       mediaUrls: deliveredMirror.mediaUrls,
     });
     if (mirrorText) {
-      const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
-      await appendAssistantMessageToSessionTranscript({
-        agentId: params.mirror.agentId,
-        sessionKey: params.mirror.sessionKey,
-        text: mirrorText,
-        idempotencyKey: params.mirror.idempotencyKey,
-        config: params.cfg,
-      });
+      // The transcript mirror is best-effort bookkeeping that runs *after* the
+      // channel payloads were already delivered (guarded by results.length > 0
+      // above). A failure here — e.g. transient session-lock contention
+      // ("session file changed while embedded prompt lock was released") — must
+      // not propagate, or the caller would treat the whole send as failed and
+      // re-deliver the already-sent message (duplicate announcements). Match the
+      // cron delivery path (mirrorDirectDeliveryIntoTranscript) and downgrade
+      // mirror failures to a warning. The append carries an idempotency key, so
+      // any later reconciliation stays deduplicated.
+      try {
+        const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
+        const mirrorResult = await appendAssistantMessageToSessionTranscript({
+          agentId: params.mirror.agentId,
+          sessionKey: params.mirror.sessionKey,
+          text: mirrorText,
+          idempotencyKey: params.mirror.idempotencyKey,
+          config: params.cfg,
+        });
+        if (!mirrorResult.ok) {
+          log.warn(
+            `failed to mirror outbound delivery into session transcript; channel send already succeeded: ${mirrorResult.reason}`,
+            { channel, to, sessionKey: params.mirror.sessionKey },
+          );
+        }
+      } catch (err) {
+        log.warn(
+          `failed to mirror outbound delivery into session transcript; channel send already succeeded: ${formatErrorMessage(err)}`,
+          { channel, to, sessionKey: params.mirror.sessionKey },
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #89626. The post-delivery transcript **mirror** in `deliverOutboundPayloads`
runs *after* the channel payloads are already sent. Its append was unguarded, so a
transient session-lock failure (`session file changed while embedded prompt lock was
released`) propagated out of the send. The whole send was then reported as `failed`
— discarding the fact that the channel message had already been delivered — and the
sub-agent announce layer retried, re-delivering the message up to **3 times** before
giving up.

The mirror is best-effort local bookkeeping. This change catches both thrown errors
and `{ ok: false }` results, logs a warning, and lets the already-successful channel
delivery stand. This matches the existing cron delivery path
(`mirrorDirectDeliveryIntoTranscript` in `src/cron/isolated-agent/delivery-dispatch.ts`),
so it is consistent with the sibling surface rather than a one-sided patch. The append
still carries its idempotency key, so any later reconciliation stays deduplicated.

## Real behavior proof

Behavior addressed: duplicate sub-agent completion announcement (delivered up to 3x) when the post-send transcript mirror fails on the session lock.

Real environment tested: built OpenClaw source on macOS (Node 22.22.3), exercising the real `deliverOutboundPayloads` runtime path with a real channel outbound adapter and the real subsystem logger. The documented `session file changed while embedded prompt lock was released` lock contention was injected at the transcript-mirror append (env `OPENCLAW_FAULT_MIRROR_THROW=1`) so the race reproduces deterministically; everything downstream is the unmodified production delivery pipeline.

Exact steps or command run after this patch: drove the production `deliverOutboundPayloads({ channel, payloads, mirror })` once with the mirror append forced to fail, observing the channel adapter call count and the runtime log. Ran the same path against the pre-fix (unguarded) and post-fix code.

Evidence after fix (copied runtime/terminal output):

```text
# pre-fix (unguarded mirror append) + injected lock failure
[channel] matrix delivered to !session:main: "Sub-agent run b8efbcc9 complete: task finished."
[repro] deliverOutboundPayloads THREW: session file changed while embedded prompt lock was released
[repro] channel send count = 1 (message already on the wire)

# post-fix (this patch) + injected lock failure
[channel] matrix delivered to !session:main: "Sub-agent run b8efbcc9 complete: task finished."
[outbound/deliver] failed to mirror outbound delivery into session transcript; channel send already succeeded: session file changed while embedded prompt lock was released
[repro] deliverOutboundPayloads returned 1 result(s); did NOT throw.
[repro] channel send count = 1
```

Observed result after fix: with the lock failure injected, the channel adapter is invoked exactly once and `deliverOutboundPayloads` returns the delivered result instead of throwing; the mirror failure is downgraded to a single `[outbound/deliver]` warning. Pre-fix, the same condition throws after the message is already on the wire, which is what drives the sub-agent announce retry to re-deliver duplicates.

What was not tested: an end-to-end live Telegram + Raspberry Pi sub-agent run (no such hardware/model here). The session-lock race was injected deterministically at the mirror-append boundary rather than reproduced via natural timing.

## Supplemental checks (not a substitute for the proof above)

- `pnpm test src/infra/outbound/deliver.test.ts` — 95/95 pass, including 2 new regression tests that fail without this patch.
- `pnpm test` on siblings (`message`, `outbound-send-service`, `subagent-announce-delivery`) — 126/126 pass.
- `pnpm tsgo:core` + `pnpm tsgo:test:src` — exit 0; `oxfmt --check` + oxlint clean.

## Files
- `src/infra/outbound/deliver.ts` — guard the post-delivery transcript mirror append
- `src/infra/outbound/deliver.test.ts` — 2 regression tests + tighten the transcript mock type
