### PR TITLE
chore(tooling): restore sqlite cache deadcode allowlist

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -2,6 +2,13 @@
 // generated/build inputs, manifest-discovered plugin surfaces, live-test
 // helpers, or package bridge files that static production scanning cannot see.
 export const KNIP_UNUSED_FILE_ALLOWLIST = [
+  // Per-agent SQLite scaffold is intentionally landed before runtime migration
+  // callers so the schema and scoped cache API can be reviewed together.
+  "src/agents/cache/agent-cache-store.sqlite.ts",
+  "src/agents/cache/agent-cache-store.ts",
+  "src/state/openclaw-agent-db.paths.ts",
+  "src/state/openclaw-agent-db.ts",
+  "src/state/openclaw-agent-schema.generated.ts",
 ];
 
 // Knip can disagree across supported local/CI platforms for files that are


### PR DESCRIPTION
Summary:
- Restore the five SQLite cache/state files to `KNIP_UNUSED_FILE_ALLOWLIST`.
- Current `upstream/main` at `3d4d30fd5a` reports those files as unexpected unused files after `85633eb615` removed them.
- This keeps `check-dependencies` aligned with the intentional pre-runtime-migration SQLite scaffold.

Real behavior proof:
Before the patch, on a detached current `upstream/main` worktree at `3d4d30fd5a`, `pnpm deadcode:unused-files` failed with:

```text
Unexpected unused files:
  src/agents/cache/agent-cache-store.sqlite.ts
  src/agents/cache/agent-cache-store.ts
  src/state/openclaw-agent-db.paths.ts
  src/state/openclaw-agent-db.ts
  src/state/openclaw-agent-schema.generated.ts
```

After restoring the allowlist entries on this branch, the same real scanner passes:

```text
$ pnpm deadcode:unused-files
$ node scripts/check-deadcode-unused-files.mjs
[deadcode] Knip unused-file allowlist matched 36 intentional entries.
```

Validation:
- `pnpm deadcode:unused-files`
- `pnpm deadcode:dependencies`
- `git diff --check`
