### PR TITLE
fix(model-catalog): skip unreadable catalog records

### DIFF
--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ModelCatalogProvider } from "./index.js";
 import { normalizeModelCatalog, normalizeModelCatalogRows } from "./index.js";
 import { buildModelCatalogMergeKey, buildModelCatalogRef } from "./model-catalog-refs.js";
 
@@ -234,5 +235,92 @@ describe("model catalog normalization", () => {
     ]);
     expect(buildModelCatalogRef("OpenAI", "GPT-5.4")).toBe("openai/GPT-5.4");
     expect(buildModelCatalogMergeKey("OpenAI", "GPT-5.4")).toBe("openai::gpt-5.4");
+  });
+
+  it("omits unreadable provider catalog maps while preserving sibling metadata", () => {
+    const unreadableProviders = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("fuzzplugin model catalog providers exploded");
+        },
+      },
+    );
+
+    const catalog = normalizeModelCatalog(
+      {
+        providers: unreadableProviders,
+        aliases: {
+          "OpenAI Alias": {
+            provider: "openai",
+          },
+        },
+        discovery: {
+          openai: "runtime",
+        },
+      },
+      { ownedProviders: new Set(["openai"]) },
+    );
+
+    expect(catalog).toEqual({
+      aliases: {
+        "openai alias": {
+          provider: "openai",
+        },
+      },
+      discovery: {
+        openai: "runtime",
+      },
+    });
+  });
+
+  it("skips unreadable provider catalog rows without dropping healthy siblings", () => {
+    const providers: Record<string, ModelCatalogProvider> = {
+      openai: {
+        models: [{ id: "gpt-5.5" }],
+      },
+    };
+    Object.defineProperty(providers, "fuzzplugin", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin model catalog provider getter exploded");
+      },
+    });
+
+    const catalog = normalizeModelCatalog({ providers }, { ownedProviders: new Set(["openai"]) });
+
+    expect(catalog?.providers).toEqual({
+      openai: {
+        models: [{ id: "gpt-5.5" }],
+      },
+    });
+  });
+
+  it("skips unreadable provider rows while projecting model catalog rows", () => {
+    const providers: Record<string, ModelCatalogProvider> = {
+      openai: {
+        models: [{ id: "gpt-5.5" }],
+      },
+    };
+    Object.defineProperty(providers, "fuzzplugin", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin row provider getter exploded");
+      },
+    });
+
+    expect(normalizeModelCatalogRows({ providers, source: "manifest" })).toEqual([
+      {
+        provider: "openai",
+        id: "gpt-5.5",
+        ref: "openai/gpt-5.5",
+        mergeKey: "openai::gpt-5.5",
+        name: "gpt-5.5",
+        source: "manifest",
+        input: ["text"],
+        reasoning: false,
+        status: "available",
+      },
+    ]);
   });
 });

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -41,6 +41,27 @@ function isBlockedObjectKey(key: string): boolean {
   return key === "__proto__" || key === "prototype" || key === "constructor";
 }
 
+function readRecordEntries(value: unknown): Array<[string, unknown]> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  let keys: string[];
+  try {
+    keys = Object.keys(value);
+  } catch {
+    return undefined;
+  }
+  const entries: Array<[string, unknown]> = [];
+  for (const key of keys) {
+    try {
+      entries.push([key, value[key]]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
 function normalizeOptionalString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -81,11 +102,12 @@ function normalizeOwnedProviderSet(providers: ReadonlySet<string>): ReadonlySet<
 }
 
 function normalizeStringMap(value: unknown): Record<string, string> | undefined {
-  if (!isRecord(value)) {
+  const entries = readRecordEntries(value);
+  if (!entries) {
     return undefined;
   }
   const normalized: Record<string, string> = {};
-  for (const [rawKey, rawValue] of Object.entries(value)) {
+  for (const [rawKey, rawValue] of entries) {
     const key = normalizeSafeRecordKey(rawKey);
     const mapValue = normalizeOptionalString(rawValue) ?? "";
     if (key && mapValue) {
@@ -534,11 +556,12 @@ function normalizeModelCatalogProviders(
   value: unknown,
   ownedProviders: ReadonlySet<string>,
 ): Record<string, ModelCatalogProvider> | undefined {
-  if (!isRecord(value)) {
+  const entries = readRecordEntries(value);
+  if (!entries) {
     return undefined;
   }
   const providers: Record<string, ModelCatalogProvider> = {};
-  for (const [rawProviderId, rawProvider] of Object.entries(value)) {
+  for (const [rawProviderId, rawProvider] of entries) {
     const providerId = normalizeModelCatalogProviderId(rawProviderId);
     if (!providerId || !ownedProviders.has(providerId)) {
       continue;
@@ -555,11 +578,12 @@ function normalizeModelCatalogAliases(
   value: unknown,
   ownedProviders: ReadonlySet<string>,
 ): Record<string, ModelCatalogAlias> | undefined {
-  if (!isRecord(value)) {
+  const entries = readRecordEntries(value);
+  if (!entries) {
     return undefined;
   }
   const aliases: Record<string, ModelCatalogAlias> = {};
-  for (const [rawAlias, rawTarget] of Object.entries(value)) {
+  for (const [rawAlias, rawTarget] of entries) {
     const alias = normalizeModelCatalogProviderId(rawAlias);
     if (!alias || !isRecord(rawTarget)) {
       continue;
@@ -624,11 +648,12 @@ function normalizeModelCatalogDiscovery(
   value: unknown,
   ownedProviders: ReadonlySet<string>,
 ): Record<string, ModelCatalogDiscovery> | undefined {
-  if (!isRecord(value)) {
+  const entries = readRecordEntries(value);
+  if (!entries) {
     return undefined;
   }
   const discovery: Record<string, ModelCatalogDiscovery> = {};
-  for (const [rawProviderId, rawMode] of Object.entries(value)) {
+  for (const [rawProviderId, rawMode] of entries) {
     const providerId = normalizeModelCatalogProviderId(rawProviderId);
     const mode = normalizeOptionalString(rawMode) ?? "";
     if (providerId && ownedProviders.has(providerId) && MODEL_CATALOG_DISCOVERY_MODES.has(mode)) {
@@ -726,9 +751,15 @@ export function normalizeModelCatalogRows(params: {
   providers: Record<string, ModelCatalogProvider>;
   source: ModelCatalogSource;
 }): NormalizedModelCatalogRow[] {
-  return Object.entries(params.providers)
+  return (readRecordEntries(params.providers) ?? [])
     .flatMap(([provider, providerCatalog]) =>
-      normalizeModelCatalogProviderRows({ provider, providerCatalog, source: params.source }),
+      isRecord(providerCatalog)
+        ? normalizeModelCatalogProviderRows({
+            provider,
+            providerCatalog: providerCatalog as ModelCatalogProvider,
+            source: params.source,
+          })
+        : [],
     )
     .toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
 }


### PR DESCRIPTION
## Summary
- guard model catalog map enumeration so unreadable plugin-owned provider maps are omitted instead of crashing normalization
- preserve healthy provider catalog rows, aliases, discovery metadata, and row projection when sibling entries are unreadable
- add focused regressions for hostile provider maps and provider row getters

## Verification
- `node --import tsx/esm -e 'import { normalizeModelCatalog } from "./packages/model-catalog-core/src/index.ts"; const hostile = new Proxy({ openai: { models: [{ id: "gpt-5.5" }] } }, { ownKeys(){ throw new Error("fuzzplugin model catalog providers exploded"); } }); console.log(JSON.stringify(normalizeModelCatalog({ providers: hostile, discovery: { openai: "runtime" } }, { ownedProviders: new Set(["openai"]) })));'`
- `CI=1 node scripts/run-vitest.mjs run packages/model-catalog-core/src/model-catalog-normalize.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --write packages/model-catalog-core/src/model-catalog-normalize.ts packages/model-catalog-core/src/model-catalog-normalize.test.ts`
- `./node_modules/.bin/oxlint packages/model-catalog-core/src/model-catalog-normalize.ts packages/model-catalog-core/src/model-catalog-normalize.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (run `run_55d172e82734`, lease `cbx_45974fc9f419`, exit 0)

## Real behavior proof
Behavior addressed: Plugin-provided model catalogs with unreadable provider maps or provider row getters no longer abort catalog normalization.
Real environment tested: Local Codex worktree on Node via the repo Vitest wrapper, plus AWS Crabbox Linux changed-gate proof.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run packages/model-catalog-core/src/model-catalog-normalize.test.ts --reporter=verbose`, the direct `node --import tsx/esm -e ...normalizeModelCatalog...` repro above, and AWS Crabbox `pnpm check:changed` via run `run_55d172e82734`.
Evidence after fix: The direct hostile `ownKeys` repro returned `{"discovery":{"openai":"runtime"}}`; the focused Vitest file passed 5 tests; AWS Crabbox `check:changed` selected `core, coreTests` and exited 0.
Observed result after fix: Unreadable catalog maps/rows are skipped while healthy sibling metadata and provider rows remain available.
What was not tested: No full-suite, Docker, or live-provider proof; this change is limited to model catalog normalization and focused changed-gate coverage.
