### PR TITLE
fix(update): respect explicit beta channel without fallback to latest

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3858,7 +3858,6 @@ async function updateCommandInternal(
   let currentVersion: string | null = null;
   let targetVersion: string | null = null;
   let downgradeRisk = false;
-  let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
   let packageInstallEnv: NodeJS.ProcessEnv | undefined;
   let packageInstallCwd: string | undefined;
@@ -3980,7 +3979,6 @@ async function updateCommandInternal(
         env: packageInstallEnv,
       }).then((resolved) => {
         tag = resolved.tag;
-        fallbackToLatest = channel === "beta" && resolved.tag === "latest";
         return resolved.version;
       });
     }
@@ -3995,7 +3993,6 @@ async function updateCommandInternal(
       (requestedChannel === null || requestedChannel === storedChannel);
     downgradeRisk =
       canResolveRegistryVersionForPackageTarget(tag) &&
-      !fallbackToLatest &&
       currentVersion != null &&
       (targetVersion == null ? tag !== "latest" : cmp != null && cmp > 0);
     packageInstallSpec ??= resolveGlobalInstallSpec({
@@ -4045,9 +4042,6 @@ async function updateCommandInternal(
     const notes: string[] = [];
     if (opts.tag && updateInstallKind === "git") {
       notes.push("--tag applies to npm installs only; git updates ignore it.");
-    }
-    if (fallbackToLatest) {
-      notes.push("Beta channel resolves to latest for this run (fallback).");
     }
     if (managedServiceRootRedirect) {
       notes.push(

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -312,16 +312,16 @@ describe("resolveNpmChannelTag", () => {
     expect(result.error).toBe("HTTP 404");
   });
 
-  it("falls back to latest when beta is older", async () => {
+  it("returns beta tag version without comparing to latest", async () => {
     versionByTag.beta = "1.0.0-beta.1";
     versionByTag.latest = "1.0.1-1";
 
     const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
-    expect(resolved).toEqual({ tag: "latest", version: "1.0.1-1" });
+    expect(resolved).toEqual({ tag: "beta", version: "1.0.0-beta.1" });
   });
 
-  it("keeps beta when beta is not older", async () => {
+  it("returns beta tag even when latest is older", async () => {
     versionByTag.beta = "1.0.2-beta.1";
     versionByTag.latest = "1.0.1-1";
 
@@ -330,13 +330,13 @@ describe("resolveNpmChannelTag", () => {
     expect(resolved).toEqual({ tag: "beta", version: "1.0.2-beta.1" });
   });
 
-  it("falls back to latest when beta has same base as stable", async () => {
+  it("returns beta tag even when stable has same base version", async () => {
     versionByTag.beta = "1.0.1-beta.2";
     versionByTag.latest = "1.0.1";
 
     const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
-    expect(resolved).toEqual({ tag: "latest", version: "1.0.1" });
+    expect(resolved).toEqual({ tag: "beta", version: "1.0.1-beta.2" });
   });
 
   it("keeps non-beta channels unchanged", async () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -645,28 +645,6 @@ export async function resolveNpmChannelTag(params: {
     env: params.env,
     runCommand: params.runCommand,
   });
-  if (params.channel !== "beta") {
-    return { tag: channelTag, version: channelStatus.version };
-  }
-
-  const latestStatus = await fetchNpmTagVersion({
-    tag: "latest",
-    timeoutMs: params.timeoutMs,
-    command: params.command,
-    cwd: params.cwd,
-    env: params.env,
-    runCommand: params.runCommand,
-  });
-  if (!latestStatus.version) {
-    return { tag: channelTag, version: channelStatus.version };
-  }
-  if (!channelStatus.version) {
-    return { tag: "latest", version: latestStatus.version };
-  }
-  const cmp = compareSemverStrings(channelStatus.version, latestStatus.version);
-  if (cmp != null && cmp < 0) {
-    return { tag: "latest", version: latestStatus.version };
-  }
   return { tag: channelTag, version: channelStatus.version };
 }
 


### PR DESCRIPTION
## What Problem This Solves

When a user runs `openclaw update --channel beta`, the resolver compared the beta tag version against the latest (stable) tag and silently fell back to stable when stable was semantically newer. This violated the user's explicit intent: requesting the beta channel should always resolve the beta tag, not silently redirect to stable.

## Why This Change Was Made

The `resolveNpmChannelTag` function had beta-specific fallback logic that compared beta vs latest and returned `latest` when beta was semantically older. The `update-command.ts` caller also tracked a `fallbackToLatest` flag to suppress downgrade warnings and add a misleading "fallback" note in dry-run output. Both are removed so the explicit channel selection is honored directly.

## User Impact

- Users specifying `--channel beta` now always get the beta version, matching their intent
- No silent fallback to stable on `--channel beta` dry-run or update
- The downgrade warning now correctly surfaces when beta is older than the installed version (previously suppressed by the fallback flag)

## Evidence

- Updated 3 test assertions in `resolveNpmChannelTag` tests: beta channel returns `{ tag: "beta" }` regardless of latest version ordering
- Removed `fallbackToLatest` variable and 3 usage sites in `update-command.ts` (6 lines deleted)
- Removed 16 lines of beta-to-latest comparison logic in `resolveNpmChannelTag` (`update-check.ts`)
- Diff: 3 files, 5 insertions, 33 deletions — all removals, no new runtime paths

Fixes: #88954
