### PR TITLE
fix(model-catalog): guard model id policies

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   collectManifestModelIdNormalizationPolicies,
+  type ManifestModelIdNormalizationProvider,
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelIdWithPolicies,
   stripSelfProviderModelPrefix,
@@ -24,6 +25,80 @@ describe("provider model id policy normalization", () => {
 
     expect(normalizeStaticProviderModelIdWithPolicies("google-vertex", "pro", policies)).toBe(
       "gemini-3.1-pro-preview",
+    );
+  });
+
+  it("skips unreadable manifest policy maps while preserving healthy plugins", () => {
+    const unreadableProviders = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("fuzzplugin modelIdNormalization providers exploded");
+        },
+      },
+    );
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers: unreadableProviders,
+        },
+      },
+      {
+        modelIdNormalization: {
+          providers: {
+            openai: {
+              aliases: {
+                pro: "gpt-5.5",
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("openai", "pro", policies)).toBe("gpt-5.5");
+  });
+
+  it("skips unreadable manifest policy rows while preserving healthy providers", () => {
+    const providers: Record<string, ManifestModelIdNormalizationProvider> = {
+      openai: {
+        aliases: {
+          pro: "gpt-5.5",
+        },
+      },
+    };
+    Object.defineProperty(providers, "fuzzplugin", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin modelIdNormalization provider getter exploded");
+      },
+    });
+
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers,
+        },
+      },
+    ]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("openai", "pro", policies)).toBe("gpt-5.5");
+  });
+
+  it("ignores unreadable manifest policy fields while applying readable fallbacks", () => {
+    const policy: ManifestModelIdNormalizationProvider = {
+      prefixWhenBare: "openrouter",
+    };
+    Object.defineProperty(policy, "aliases", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin modelIdNormalization aliases exploded");
+      },
+    });
+    const policies = new Map([["openai", policy]]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("openai", "pro", policies)).toBe(
+      "openrouter/pro",
     );
   });
 

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -24,13 +24,107 @@ let currentManifestModelIdNormalizationPolicies:
   | ReadonlyMap<string, ManifestModelIdNormalizationProvider>
   | undefined;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readModelIdNormalizationProviders(plugin: ManifestModelIdNormalizationRecord): unknown {
+  try {
+    return plugin.modelIdNormalization?.providers;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRecordEntries(value: unknown): Array<[string, unknown]> {
+  if (!isRecord(value)) {
+    return [];
+  }
+  let keys: string[];
+  try {
+    keys = Object.keys(value);
+  } catch {
+    return [];
+  }
+  const entries: Array<[string, unknown]> = [];
+  for (const key of keys) {
+    try {
+      entries.push([key, value[key]]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+function readPolicyField<K extends keyof ManifestModelIdNormalizationProvider>(
+  policy: ManifestModelIdNormalizationProvider,
+  field: K,
+): ManifestModelIdNormalizationProvider[K] | undefined {
+  try {
+    return policy[field];
+  } catch {
+    return undefined;
+  }
+}
+
+function readArrayEntries(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  let length: number;
+  try {
+    length = value.length;
+  } catch {
+    return [];
+  }
+  const entries: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      if (!(index in value)) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    try {
+      entries.push(value[index]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
+function readStringMapValue(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  let raw: unknown;
+  try {
+    raw = value[key];
+  } catch {
+    return undefined;
+  }
+  return typeof raw === "string" ? raw : undefined;
+}
+
+function readRecordStringField(value: unknown, field: string): string | undefined {
+  return readStringMapValue(value, field);
+}
+
 export function collectManifestModelIdNormalizationPolicies(
   plugins: readonly ManifestModelIdNormalizationRecord[],
 ): Map<string, ManifestModelIdNormalizationProvider> {
   const policies = new Map<string, ManifestModelIdNormalizationProvider>();
   for (const plugin of plugins) {
-    for (const [provider, policy] of Object.entries(plugin.modelIdNormalization?.providers ?? {})) {
-      policies.set(normalizeLowercaseStringOrEmpty(provider), policy);
+    for (const [provider, policy] of readRecordEntries(readModelIdNormalizationProviders(plugin))) {
+      if (isRecord(policy)) {
+        policies.set(
+          normalizeLowercaseStringOrEmpty(provider),
+          policy as ManifestModelIdNormalizationProvider,
+        );
+      }
     }
   }
   return policies;
@@ -83,24 +177,41 @@ export function normalizeProviderModelIdWithPolicies(params: {
     return modelId;
   }
 
-  for (const prefix of policy.stripPrefixes ?? []) {
+  for (const prefix of readArrayEntries(readPolicyField(policy, "stripPrefixes"))) {
     const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
-    if (normalizedPrefix && normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)) {
+    if (
+      typeof prefix === "string" &&
+      normalizedPrefix &&
+      normalizeLowercaseStringOrEmpty(modelId).startsWith(normalizedPrefix)
+    ) {
       modelId = modelId.slice(prefix.length);
       break;
     }
   }
 
-  modelId = policy.aliases?.[normalizeLowercaseStringOrEmpty(modelId)] ?? modelId;
+  modelId =
+    readStringMapValue(
+      readPolicyField(policy, "aliases"),
+      normalizeLowercaseStringOrEmpty(modelId),
+    ) ?? modelId;
 
   if (!hasProviderPrefix(modelId)) {
-    for (const rule of policy.prefixWhenBareAfterAliasStartsWith ?? []) {
-      if (normalizeLowercaseStringOrEmpty(modelId).startsWith(rule.modelPrefix.toLowerCase())) {
-        return formatPrefixedModelId(rule.prefix, modelId);
+    for (const rule of readArrayEntries(
+      readPolicyField(policy, "prefixWhenBareAfterAliasStartsWith"),
+    )) {
+      const modelPrefix = readRecordStringField(rule, "modelPrefix");
+      const prefix = readRecordStringField(rule, "prefix");
+      if (
+        modelPrefix &&
+        prefix &&
+        normalizeLowercaseStringOrEmpty(modelId).startsWith(modelPrefix.toLowerCase())
+      ) {
+        return formatPrefixedModelId(prefix, modelId);
       }
     }
-    if (policy.prefixWhenBare) {
-      return formatPrefixedModelId(policy.prefixWhenBare, modelId);
+    const prefixWhenBare = readPolicyField(policy, "prefixWhenBare");
+    if (typeof prefixWhenBare === "string" && prefixWhenBare) {
+      return formatPrefixedModelId(prefixWhenBare, modelId);
     }
   }
 


### PR DESCRIPTION
## Summary
- guard plugin-owned model-id normalization provider maps before collecting manifest policies
- skip unreadable policy rows and tolerate unreadable policy fields while preserving healthy model-id normalization behavior
- add regressions for hostile `modelIdNormalization.providers` maps, provider row getters, and unreadable policy alias fields

## Verification
- `node --import tsx/esm -e 'import { collectManifestModelIdNormalizationPolicies, normalizeStaticProviderModelIdWithPolicies } from "./packages/model-catalog-core/src/provider-model-id-normalization.ts"; const providers = new Proxy({ openai: { aliases: { pro: "gpt-5.5" } } }, { ownKeys(){ throw new Error("fuzzplugin modelIdNormalization providers exploded"); } }); const policies = collectManifestModelIdNormalizationPolicies([{ modelIdNormalization: { providers } }, { modelIdNormalization: { providers: { openai: { aliases: { mini: "gpt-5.4" } } } } }]); console.log(normalizeStaticProviderModelIdWithPolicies("openai", "mini", policies));'`
- `CI=1 node scripts/run-vitest.mjs run packages/model-catalog-core/src/provider-model-id-normalization.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --write packages/model-catalog-core/src/provider-model-id-normalization.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts`
- `./node_modules/.bin/oxlint packages/model-catalog-core/src/provider-model-id-normalization.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` (run `run_f558bd0821ff`, lease `cbx_7efdfca7b907`, exit 0)

## Real behavior proof
Behavior addressed: Plugin manifest model-id normalization metadata with unreadable provider maps, provider rows, or policy fields no longer aborts policy collection or model-id normalization.
Real environment tested: Local Codex worktree on Node via the repo Vitest wrapper, plus AWS Crabbox Linux changed-gate proof.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run packages/model-catalog-core/src/provider-model-id-normalization.test.ts --reporter=verbose`, the direct `node --import tsx/esm -e ...collectManifestModelIdNormalizationPolicies...` repro above, and AWS Crabbox `pnpm check:changed` via run `run_f558bd0821ff`.
Evidence after fix: The direct hostile `ownKeys` repro returned `gpt-5.4`; the focused Vitest file passed 8 tests; AWS Crabbox `check:changed` selected `core, coreTests` and exited 0.
Observed result after fix: Unreadable model-id policy metadata is skipped while healthy sibling policies and readable fallback fields still normalize model ids.
What was not tested: No full-suite, Docker, or live-provider proof; this change is limited to model-id policy metadata normalization and focused changed-gate coverage.
