### PR TITLE
fix(plugins): guard startup manifest channels

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -1996,6 +1996,57 @@ describe("resolveGatewayStartupPluginIds", () => {
     expect(plan.configuredDeferredChannelPluginIds).toStrictEqual([]);
   });
 
+  it("skips unreadable manifest channel lists while preserving healthy channel plugins", () => {
+    const healthyChannel = withManifestLoadPaths({
+      id: "healthy-channel",
+      channels: ["healthy-channel"],
+      origin: "bundled" as const,
+      enabledByDefault: undefined,
+      providers: [],
+      cliBackends: [],
+    });
+    const brokenChannel = {
+      id: "broken-channel",
+      rootDir: "/tmp/plugins/broken-channel",
+      source: "/tmp/plugins/broken-channel/index.ts",
+      manifestPath: "/tmp/plugins/broken-channel/openclaw.plugin.json",
+      origin: "bundled" as const,
+      enabledByDefault: undefined,
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      get channels() {
+        throw new Error("fuzzplugin channels exploded");
+      },
+    } as unknown as PluginManifestRecord;
+    const registry = {
+      plugins: [healthyChannel, brokenChannel],
+      diagnostics: [],
+    } satisfies PluginManifestRegistry;
+    const index = createInstalledPluginIndexFixture({
+      plugins: [healthyChannel],
+      diagnostics: [],
+    });
+
+    const plan = resolveGatewayStartupPluginPlanFromRegistry({
+      config: {
+        channels: {
+          "healthy-channel": {
+            token: "configured",
+          },
+        },
+      } as OpenClawConfig,
+      env: createPluginPlanningTestEnv(),
+      index,
+      manifestRegistry: registry,
+    });
+
+    expect(plan.channelPluginIds).toStrictEqual(["healthy-channel"]);
+    expect(plan.pluginIds).toStrictEqual(["healthy-channel"]);
+    expect(plan.configuredDeferredChannelPluginIds).toStrictEqual([]);
+  });
+
   it("carries deferred configured channel ids through the startup plan", () => {
     const registry = createManifestRegistryFixtureWithWorkspaceDemoChannel();
     const index = createInstalledPluginIndexFixture(registry);

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -206,14 +206,41 @@ type ManifestRegistryLookup = ReadonlyMap<string, PluginManifestRecord>;
 function createManifestRegistryLookup(
   manifestRegistry: PluginManifestRegistry,
 ): ManifestRegistryLookup {
-  return new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
+  const lookup = new Map<string, PluginManifestRecord>();
+  for (const plugin of manifestRegistry.plugins) {
+    const pluginId = readManifestPluginId(plugin);
+    if (pluginId) {
+      lookup.set(pluginId, plugin);
+    }
+  }
+  return lookup;
+}
+
+function readManifestPluginId(plugin: PluginManifestRecord): string | undefined {
+  try {
+    return typeof plugin.id === "string" && plugin.id.trim() ? plugin.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readManifestChannelIds(manifest: PluginManifestRecord | undefined): readonly string[] {
+  try {
+    const channels = manifest?.channels;
+    if (!Array.isArray(channels)) {
+      return [];
+    }
+    return channels.filter((channelId): channelId is string => typeof channelId === "string");
+  } catch {
+    return [];
+  }
 }
 
 function listManifestChannelIds(
   manifestLookup: ManifestRegistryLookup,
   pluginId: string,
 ): readonly string[] {
-  return manifestLookup.get(pluginId)?.channels ?? [];
+  return readManifestChannelIds(manifestLookup.get(pluginId));
 }
 
 function findManifestPlugin(
@@ -1475,9 +1502,10 @@ export function resolveChannelPluginIdsFromRegistry(params: {
   manifestRegistry: PluginManifestRegistry;
 }): string[] {
   const { manifestRegistry } = params;
-  return manifestRegistry.plugins
-    .filter((plugin) => plugin.channels.length > 0)
-    .map((plugin) => plugin.id);
+  return manifestRegistry.plugins.flatMap((plugin) => {
+    const pluginId = readManifestPluginId(plugin);
+    return pluginId && readManifestChannelIds(plugin).length > 0 ? [pluginId] : [];
+  });
 }
 
 export function resolveConfiguredDeferredChannelPluginIdsFromRegistry(params: {

--- a/src/plugins/plugin-registry-id-normalizer.ts
+++ b/src/plugins/plugin-registry-id-normalizer.ts
@@ -15,22 +15,76 @@ function normalizePluginRegistryAliasKey(value: string): string {
   return normalizePluginRegistryAlias(value).toLowerCase();
 }
 
-function collectObjectKeys(value: Record<string, unknown> | undefined): readonly string[] {
-  return value ? Object.keys(value) : [];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPluginManifestString(read: () => unknown): string | undefined {
+  try {
+    const value = read();
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginManifestStringArray(read: () => unknown): readonly string[] {
+  try {
+    const value = read();
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    return [];
+  }
+}
+
+function readPluginManifestArray(read: () => unknown): readonly unknown[] {
+  try {
+    const value = read();
+    return Array.isArray(value) ? value : [];
+  } catch {
+    return [];
+  }
+}
+
+function collectObjectKeys(read: () => unknown): readonly string[] {
+  try {
+    const value = read();
+    return isRecord(value) ? Object.keys(value) : [];
+  } catch {
+    return [];
+  }
+}
+
+function readSetupProviderIds(plugin: PluginManifestRecord): readonly string[] {
+  return readPluginManifestArray(() => plugin.setup?.providers).flatMap((provider) => {
+    if (!isRecord(provider)) {
+      return [];
+    }
+    const providerId = readPluginManifestString(() => provider.id);
+    return providerId ? [providerId] : [];
+  });
+}
+
+function readPluginId(plugin: PluginManifestRecord): string | undefined {
+  return readPluginManifestString(() => plugin.id);
 }
 
 function listPluginRegistryNormalizerAliases(plugin: PluginManifestRecord): readonly string[] {
+  const pluginId = readPluginId(plugin);
   return [
-    plugin.id,
-    ...(plugin.providers ?? []),
-    ...(plugin.channels ?? []),
-    ...(plugin.setup?.providers?.map((provider) => provider.id) ?? []),
-    ...(plugin.cliBackends ?? []),
-    ...(plugin.setup?.cliBackends ?? []),
-    ...collectObjectKeys(plugin.modelCatalog?.providers),
-    ...collectObjectKeys(plugin.modelCatalog?.aliases),
-    ...collectObjectKeys(plugin.providerAuthAliases),
-    ...(plugin.legacyPluginIds ?? []),
+    ...(pluginId ? [pluginId] : []),
+    ...readPluginManifestStringArray(() => plugin.providers),
+    ...readPluginManifestStringArray(() => plugin.channels),
+    ...readSetupProviderIds(plugin),
+    ...readPluginManifestStringArray(() => plugin.cliBackends),
+    ...readPluginManifestStringArray(() => plugin.setup?.cliBackends),
+    ...collectObjectKeys(() => plugin.modelCatalog?.providers),
+    ...collectObjectKeys(() => plugin.modelCatalog?.aliases),
+    ...collectObjectKeys(() => plugin.providerAuthAliases),
+    ...readPluginManifestStringArray(() => plugin.legacyPluginIds),
   ];
 }
 
@@ -56,13 +110,17 @@ export function createPluginRegistryIdNormalizer(
       includeDisabled: true,
     });
   for (const plugin of [...registry.plugins].toSorted((left, right) =>
-    left.id.localeCompare(right.id),
+    (readPluginId(left) ?? "").localeCompare(readPluginId(right) ?? ""),
   )) {
-    const pluginId = normalizePluginRegistryAlias(plugin.id);
+    const rawPluginId = readPluginId(plugin);
+    if (!rawPluginId) {
+      continue;
+    }
+    const pluginId = normalizePluginRegistryAlias(rawPluginId);
     if (!pluginId) {
       continue;
     }
-    aliases.set(normalizePluginRegistryAliasKey(pluginId), plugin.id);
+    aliases.set(normalizePluginRegistryAliasKey(pluginId), rawPluginId);
     for (const alias of listPluginRegistryNormalizerAliases(plugin)) {
       const normalizedAlias = normalizePluginRegistryAlias(alias);
       const normalizedAliasKey = normalizePluginRegistryAliasKey(alias);


### PR DESCRIPTION
## Summary
- Guard startup manifest channel/id reads so an unreadable plugin manifest channel list does not abort gateway startup planning.
- Guard plugin registry alias collection across manifest ids, providers, channels, setup provider rows, CLI backends, model catalog keys, auth aliases, and legacy ids.
- Add a startup-planning regression that preserves a healthy configured channel plugin when a sibling manifest throws from `channels`.

## Verification
- Direct pre-patch repro: `resolveGatewayStartupPluginPlanFromRegistry()` threw `fuzzplugin channels exploded` before returning healthy startup plugin ids.
- Direct post-patch repro: returned `{ "channelPluginIds": ["healthy-channel"], "configuredDeferredChannelPluginIds": [], "pluginIds": ["healthy-channel"] }`.
- `CI=1 node scripts/run-vitest.mjs run src/plugins/channel-plugin-ids.test.ts --reporter=verbose` passed, 1 file / 125 tests.
- `./node_modules/.bin/oxfmt --write src/plugins/gateway-startup-plugin-ids.ts src/plugins/plugin-registry-id-normalizer.ts src/plugins/channel-plugin-ids.test.ts` passed.
- `./node_modules/.bin/oxlint src/plugins/gateway-startup-plugin-ids.ts src/plugins/plugin-registry-id-normalizer.ts src/plugins/channel-plugin-ids.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings; first run `overall: patch is correct (0.82)`, post-type-fixture rerun `overall: patch is correct (0.93)`.
- AWS Crabbox changed gate passed: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`; provider `aws`; run `run_2014f81203d9`; lease `cbx_88cdb76bf7d6`; type `c7a.8xlarge`; exit 0; lanes `core`, `coreTests`; command 3m20.180s; total 5m38.923s; lease stopped.
- Earlier AWS Crabbox run `run_8fcf908d817d` failed on a test fixture type assertion in `coreTests`; fixed before the passing rerun above.

Behavior addressed: a plugin manifest with an unreadable `channels` field could crash startup plugin planning and plugin config id normalization before healthy channel plugins were selected.
Real environment tested: local Codex worktree with linked repo dependencies plus AWS Crabbox Linux changed-gate proof.
Exact steps or command run after this patch: direct `node --import tsx` repro, focused Vitest, oxfmt, oxlint, diff-check, autoreview, and AWS Crabbox `pnpm check:changed` commands listed above.
Evidence after fix: startup planning skips the unreadable channel manifest and returns the healthy configured channel plugin ids; remote `check:changed` passed the `core` and `coreTests` lanes.
Observed result after fix: assistant startup planning no longer throws for the fuzzed bad manifest channel field, and plugin registry id normalization no longer aborts on the same manifest metadata.
What was not tested: full assistant turn or live Telegram/UI.
