### PR TITLE
fix(agents): restore model-fetch info logs

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -210,6 +210,10 @@ These flags log through normal OpenClaw logging, so `openclaw logs --follow`
 and the Control UI Logs tab show them. Without the flags, the same diagnostics
 remain available at `debug` level.
 
+`[model-fetch]` response metadata (provider, API, model, status, latency) is
+always emitted at `info` level regardless of `OPENCLAW_DEBUG_MODEL_TRANSPORT`,
+so basic model transport hygiene is visible without debug flags.
+
 ### Trace correlation
 
 File logs are JSONL. When a log call carries a valid diagnostic trace context,

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -210,9 +210,11 @@ These flags log through normal OpenClaw logging, so `openclaw logs --follow`
 and the Control UI Logs tab show them. Without the flags, the same diagnostics
 remain available at `debug` level.
 
-`[model-fetch]` response metadata (provider, API, model, status, latency) is
-always emitted at `info` level regardless of `OPENCLAW_DEBUG_MODEL_TRANSPORT`,
-so basic model transport hygiene is visible without debug flags.
+`[model-fetch]` start and response metadata (provider, API, model, status,
+latency, and request fields such as method, URL, timeout, proxy, and policy)
+is always emitted at `info` level regardless of
+`OPENCLAW_DEBUG_MODEL_TRANSPORT`, so basic model transport hygiene is visible
+without debug flags.
 
 ### Trace correlation
 

--- a/src/agents/model-transport-debug.test.ts
+++ b/src/agents/model-transport-debug.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { emitModelTransportDebug } from "./model-transport-debug.js";
+
+describe("emitModelTransportDebug", () => {
+  function createLogger() {
+    return {
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Parameters<typeof emitModelTransportDebug>[0];
+  }
+
+  it("emits model-fetch metadata at info level by default", () => {
+    const log = createLogger();
+
+    emitModelTransportDebug(
+      log,
+      "[model-fetch] response provider=openai api=chat model=gpt status=200 latencyMs=42",
+    );
+
+    expect(log.info).toHaveBeenCalledWith(
+      "[model-fetch] response provider=openai api=chat model=gpt status=200 latencyMs=42",
+    );
+    expect(log.debug).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-model-fetch transport diagnostics at debug level by default", () => {
+    const log = createLogger();
+
+    emitModelTransportDebug(log, "[model-sse] event type=response.output_text.delta");
+
+    expect(log.debug).toHaveBeenCalledWith("[model-sse] event type=response.output_text.delta");
+    expect(log.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/model-transport-debug.ts
+++ b/src/agents/model-transport-debug.ts
@@ -68,9 +68,13 @@ export function isModelTransportDebugEnabled(env: ModelTransportDebugEnv = proce
   );
 }
 
-/** Emits transport diagnostics at info level only when debug env explicitly enables them. */
+function isModelFetchMetadataMessage(message: string): boolean {
+  return message.startsWith("[model-fetch]");
+}
+
+/** Emits model-fetch metadata at info level by default; other diagnostics require debug env. */
 export function emitModelTransportDebug(log: SubsystemLogger, message: string): void {
-  if (isModelTransportDebugEnabled()) {
+  if (isModelFetchMetadataMessage(message) || isModelTransportDebugEnabled()) {
     log.info(message);
     return;
   }


### PR DESCRIPTION
## Summary

Restores default `info` logging for `[model-fetch]` request metadata (`start` / `response` / `error`) so provider/model/API/status/latency diagnostics are visible in normal gateway logs again.

## Changes

- Treat `[model-fetch]` transport metadata messages as default `info` logs.
- Keep non-`[model-fetch]` transport diagnostics, payload debug, and SSE debug behind the existing debug/env-gated path.
- Add regression coverage for both boundaries.

## Real behavior proof

Behavior or issue addressed: After the fix, `[model-fetch]` metadata is emitted through `log.info` by default, while non-fetch transport diagnostics still use `log.debug` unless model transport debug is enabled.

Real environment tested: Repository `openclaw/openclaw`, branch `fix/model-fetch-info-logs`, commit `e01b06db7a fix(agents): restore model-fetch info logs`, using local Node with the repository `tsx` loader from the PR worktree.

Exact steps or command run after this patch:

```shell
node --import tsx --input-type=module - <<'NODE'
import { emitModelTransportDebug } from './src/agents/model-transport-debug.ts';
const calls = { info: [], debug: [] };
const log = { info: (m) => calls.info.push(m), debug: (m) => calls.debug.push(m) };
emitModelTransportDebug(log, '[model-fetch] response provider=openai api=chat model=gpt status=200 latencyMs=42');
emitModelTransportDebug(log, '[model-sse] event type=response.output_text.delta');
console.log(JSON.stringify(calls, null, 2));
if (calls.info.length !== 1 || calls.debug.length !== 1) process.exit(1);
NODE
```

Evidence after fix: Copied terminal output from the branch after the fix:

```json
{
  "info": [
    "[model-fetch] response provider=openai api=chat model=gpt status=200 latencyMs=42"
  ],
  "debug": [
    "[model-sse] event type=response.output_text.delta"
  ]
}
```

Observed result after fix: The `[model-fetch]` metadata message is visible through the `info` path by default. The `[model-sse]` diagnostic remains on the `debug` path, preserving the existing debug gating for non-fetch transport diagnostics.

What was not tested: A full gateway run against a live provider is out of scope for this proof. The proof exercises the shared logging helper used by the `[model-fetch]` start/response/error call sites and avoids sending live model traffic.

## Test Plan

- `node --import tsx --input-type=module - ...` direct behavior check for `[model-fetch]` vs `[model-sse]` logging
- `pnpm exec oxlint src/agents/model-transport-debug.ts src/agents/model-transport-debug.test.ts`
- `node scripts/test-projects.mjs src/agents/model-transport-debug.test.ts`

## Risk

Low. The change only promotes non-payload `[model-fetch]` metadata messages back to `info`; payload/SSE/debug diagnostics remain gated.

Fixes #89300
