### PR TITLE
fix(agents): release session write lock if fence read throws on prompt release

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -136,6 +136,31 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["held"]);
   });
 
+  it("releases the eagerly-held lock even when the fence read throws during prompt release (FAD-845)", async () => {
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocalFad845 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocalFad845,
+      lockOptions,
+    });
+
+    // Simulate a transient, non-ENOENT filesystem error (e.g. EIO/EMFILE) while the
+    // prompt-release path reads the session-file fence. This fires AFTER the controller
+    // has cleared its in-memory `heldLock` reference but BEFORE the underlying file lock
+    // is released, which is the window that orphans the lock.
+    const statError = Object.assign(new Error("simulated I/O failure"), { code: "EIO" });
+    const statSpy = vi.spyOn(fs, "stat").mockRejectedValueOnce(statError);
+
+    await expect(controller.releaseForPrompt()).rejects.toThrow();
+
+    // The underlying file lock MUST still be released; otherwise it is orphaned on the
+    // live gateway process for the full maxHoldMs lease (~17 min), wedging every
+    // subsequent interactive turn with SessionWriteLockTimeoutError. See FAD-845.
+    expect(release).toHaveBeenCalledTimes(1);
+
+    statSpy.mockRestore();
+  });
+
   it("releaseHeldLockForAbort and dispose are idempotent in succession (#86816)", async () => {
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal26 = vi.fn(async () => ({ release }));

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -801,17 +801,27 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
       const lock = heldLock;
       heldLock = undefined;
-      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-      const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
-      const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
-      fenceFingerprint = fingerprint;
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceGeneration =
-        ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
-          ? ownedWrite.generation
-          : (trustedGeneration ?? fenceGeneration);
-      fenceActive = true;
-      await lock.release();
+      // Once `heldLock` is cleared the controller no longer tracks this lock, so the
+      // underlying file lock MUST be released even if the fence bookkeeping below
+      // throws. The fence reads perform filesystem I/O that can fail with a transient
+      // non-ENOENT error (e.g. EIO/EMFILE under load); without this guard such a throw
+      // would orphan the lock on the live gateway process for the full maxHoldMs lease
+      // (~17 min), wedging every subsequent interactive turn with
+      // SessionWriteLockTimeoutError until the watchdog reclaims it. See FAD-845.
+      try {
+        const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+        const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+        const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
+        fenceFingerprint = fingerprint;
+        fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+        fenceGeneration =
+          ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+            ? ownedWrite.generation
+            : (trustedGeneration ?? fenceGeneration);
+        fenceActive = true;
+      } finally {
+        await lock.release();
+      }
     } finally {
       finishHeldLockDrain(drainOwner);
     }


### PR DESCRIPTION
## Problem

On a long-running gateway, a single agent attempt can orphan the per-session write lock on the **live** process, wedging a channel for the full `maxHoldMs` lease (~17 min). Every interactive turn during that window fails with `SessionWriteLockTimeoutError`.

Observed in production: a Discord channel produced no replies from 00:08 until ~00:27, when the lock's lease expired and the watchdog reclaimed it. The lock payload's `pid`/`starttime` matched the live gateway process, so the stale-lock breaker correctly refused to reclaim it (it's a live holder, not a crash orphan) — only the lease TTL freed it.

## Root cause

`releaseHeldLockWithFence` (the embedded-attempt session-lock controller's release-for-prompt path, `src/agents/embedded-agent-runner/run/attempt.session-lock.ts`) does:

```ts
const lock = heldLock;
heldLock = undefined;                                       // controller forgets it holds the lock
const fingerprint = await readSessionFileFingerprint(...);  // fs I/O — can throw
...
fenceSnapshot = await readSessionFileFenceSnapshot(...);    // fs I/O — can throw
fenceActive = true;
await lock.release();                                       // only reached if no throw above
```

`release()` is **not** in a `finally`. If either fence read rejects with a transient non-ENOENT error (e.g. `EIO`/`EMFILE` under load) after `heldLock` is cleared but before `lock.release()`, the function exits with the in-memory reference nulled and the underlying file lock never released.

`releaseForPrompt()` runs on every prompt submission (to free the lock for model I/O), so this is on a hot path. Because the controller thinks it no longer holds the lock, `dispose()` at attempt teardown sees `heldLock === undefined` and does nothing — yet the teardown still releases the in-process session-file **owner mutex**. The next attempt sails past the mutex and blocks on the orphaned **file lock**, failing every turn until the watchdog reclaims it at `maxHoldMs`.

## Fix

Wrap the fence bookkeeping in `try/finally` so the file lock is always released once `heldLock` is cleared, even if the fence reads throw. The original error still propagates — only the lock-release invariant is made exception-safe.

## Testing

- New regression test: a fence-read failure (`fs.stat` rejecting with `EIO`) during `releaseForPrompt` must still release the underlying lock. Fails before the fix (release called 0 times), passes after.
- `attempt.session-lock.test.ts`: 43 pass.
- `session-write-lock.test.ts`: 53 pass.
- Full `agents-embedded-agent` suite: 1301 pass (79 files), no regressions.
- `oxlint` + `oxfmt` clean on changed files.


## Real behavior proof

Beyond the unit test, I exercised the **real lock stack end-to-end** — the real `acquireSessionWriteLock`, the real `@openclaw/fs-safe` file-lock manager, and a real on-disk `.jsonl.lock` — with an end-to-end harness that:

1. starts an attempt (controller eagerly acquires the real session write lock),
2. injects a single transient non-ENOENT `fs.stat` failure (`EIO`) into the fence read during `releaseForPrompt` — the production failure mode under fd/I/O pressure,
3. then has the **next interactive turn** attempt to acquire the same session lock.

Lock options mirror production (`maxHoldMs: 1_020_000` — the ~17 min lease derived from the agent timeout; `timeoutMs: 2_000` for the acquire).

**Before the fix** (current `main`) — the lock is orphaned on the live process and the next turn wedges:
```
[proof] after acquire: lock file on disk = true
[proof] releaseForPrompt threw (expected): EIO
[proof] after release: lock file on disk = true          ← lock leaked
[proof] next interactive acquire: FAILED after 2002ms: SessionWriteLockTimeoutError
```

**After the fix** — the lock is released even though the fence read threw, and the next turn proceeds immediately:
```
[proof] after acquire: lock file on disk = true
[proof] releaseForPrompt threw (expected): EIO
[proof] after release: lock file on disk = false         ← lock released
[proof] next interactive acquire: SUCCEEDED in 1ms
```

This reproduces the exact `SessionWriteLockTimeoutError` wedge on `main` and demonstrates the fix eliminates it — the same symptom seen in production (a Discord channel dead until the `maxHoldMs` lease expired). The harness was throwaway scaffolding (kept out of the diff to preserve its narrowness); the committed regression test covers the same release-invariant at unit scope.

> Note: the `fs.stat` EIO is deliberate fault injection — the bug is a transient-error race that doesn't reproduce on demand in a healthy environment, so the proof induces the documented failure condition against the real lock stack rather than waiting for organic I/O pressure.
