### PR TITLE
fix(plugins): guard startup provider contracts

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -474,6 +474,57 @@ function createInstalledPluginIndexFixture(
   };
 }
 
+function createInstalledPluginIndexForRecords(
+  plugins: readonly InstalledPluginIndexRecord[],
+): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "test",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins,
+    diagnostics: [],
+  };
+}
+
+function createInstalledPluginRecordForStartupContractTest(params: {
+  pluginId: string;
+  origin: InstalledPluginIndexRecord["origin"];
+  contracts?: NonNullable<InstalledPluginIndexRecord["contributions"]>["contracts"];
+}): InstalledPluginIndexRecord {
+  return {
+    pluginId: params.pluginId,
+    manifestPath: `/tmp/plugins/${params.pluginId}/openclaw.plugin.json`,
+    manifestHash: `test-${params.pluginId}`,
+    source: `/tmp/plugins/${params.pluginId}/index.ts`,
+    rootDir: `/tmp/plugins/${params.pluginId}`,
+    origin: params.origin,
+    enabled: true,
+    startup: {
+      sidecar: false,
+      memory: false,
+      deferConfiguredChannelFullLoadUntilAfterListen: false,
+      agentHarnesses: [],
+      configPaths: [],
+    },
+    contributions: {
+      channels: [],
+      channelConfigs: [],
+      providers: [],
+      modelCatalogProviders: [],
+      modelSupportPrefixes: [],
+      modelSupportPatterns: [],
+      autoEnableProviderIds: [],
+      commandAliases: [],
+      contracts: params.contracts ?? {},
+    },
+    compat: [],
+  };
+}
+
 function filterManifestRegistryForInstalledIndex(params: {
   pluginIds?: readonly string[];
   includeDisabled?: boolean;
@@ -1093,6 +1144,70 @@ describe("resolveGatewayStartupPluginIds", () => {
       activationSourceConfig: rawConfig,
       expected: ["browser", "brave"],
     });
+  });
+
+  it("skips unreadable manifest provider contracts while preserving healthy providers", () => {
+    const brokenSearch = {
+      id: "broken-search",
+      rootDir: "/tmp/plugins/broken-search",
+      source: "/tmp/plugins/broken-search/index.ts",
+      manifestPath: "/tmp/plugins/broken-search/openclaw.plugin.json",
+      channels: [],
+      origin: "global" as const,
+      enabledByDefault: undefined,
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      get contracts() {
+        throw new Error("fuzzplugin contracts exploded");
+      },
+    } as unknown as PluginManifestRecord;
+    const brave = withManifestLoadPaths({
+      id: "brave",
+      channels: [],
+      origin: "global" as const,
+      enabledByDefault: undefined,
+      providers: [],
+      cliBackends: [],
+      contracts: {
+        webSearchProviders: ["brave"],
+      },
+    });
+    const registry = {
+      plugins: [brokenSearch, brave],
+      diagnostics: [],
+    } satisfies PluginManifestRegistry;
+    const index = createInstalledPluginIndexForRecords([
+      createInstalledPluginRecordForStartupContractTest({
+        pluginId: "broken-search",
+        origin: "global",
+      }),
+      createInstalledPluginRecordForStartupContractTest({
+        pluginId: "brave",
+        origin: "global",
+        contracts: {
+          webSearchProviders: ["brave"],
+        },
+      }),
+    ]);
+
+    expect(
+      resolveGatewayStartupPluginIdsFromRegistry({
+        config: {
+          channels: {},
+          tools: { web: { search: { enabled: true, provider: "brave" } } },
+          plugins: {
+            allow: ["brave"],
+            entries: { brave: { enabled: true } },
+            slots: { memory: "none" },
+          },
+        } as OpenClawConfig,
+        env: createPluginPlanningTestEnv(),
+        index,
+        manifestRegistry: registry,
+      }),
+    ).toStrictEqual(["brave"]);
   });
 
   it("does not let runtime-default plugin entries bypass the authored startup allowlist", () => {

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -61,6 +61,10 @@ type VoiceProviderContractKey =
   | "speechProviders"
   | "realtimeTranscriptionProviders"
   | "realtimeVoiceProviders";
+type ProviderContractKey =
+  | GenerationProviderContractKey
+  | VoiceProviderContractKey
+  | "webSearchProviders";
 type ConfiguredGenerationProviderIds = Record<GenerationProviderContractKey, ReadonlySet<string>>;
 type ConfiguredVoiceProviderIds = Record<VoiceProviderContractKey, ReadonlySet<string>>;
 const CORE_BUILT_IN_MODEL_APIS = new Set([
@@ -278,7 +282,7 @@ function manifestOwnsConfiguredSpeechProvider(params: {
   if (params.configuredSpeechProviderIds.size === 0) {
     return false;
   }
-  return (params.manifest?.contracts?.speechProviders ?? []).some((providerId) => {
+  return readManifestProviderContractIds(params.manifest, "speechProviders").some((providerId) => {
     const normalized = normalizeConfiguredSpeechProviderIdForStartup(providerId);
     return normalized ? params.configuredSpeechProviderIds.has(normalized) : false;
   });
@@ -300,10 +304,27 @@ function manifestOwnsConfiguredWebSearchProvider(params: {
   if (params.configuredWebSearchProviderIds.size === 0) {
     return false;
   }
-  return (params.manifest?.contracts?.webSearchProviders ?? []).some((providerId) => {
-    const normalized = normalizeOptionalLowercaseString(providerId);
-    return normalized ? params.configuredWebSearchProviderIds.has(normalized) : false;
-  });
+  return readManifestProviderContractIds(params.manifest, "webSearchProviders").some(
+    (providerId) => {
+      const normalized = normalizeOptionalLowercaseString(providerId);
+      return normalized ? params.configuredWebSearchProviderIds.has(normalized) : false;
+    },
+  );
+}
+
+function readManifestProviderContractIds(
+  manifest: PluginManifestRecord | undefined,
+  contractKey: ProviderContractKey,
+): readonly string[] {
+  try {
+    const providerIds = manifest?.contracts?.[contractKey];
+    if (!Array.isArray(providerIds)) {
+      return [];
+    }
+    return providerIds.filter((providerId): providerId is string => typeof providerId === "string");
+  } catch {
+    return [];
+  }
 }
 
 function listModelProviderRefs(value: unknown): string[] {
@@ -978,7 +999,7 @@ function manifestOwnsConfiguredGenerationProvider(params: {
       continue;
     }
     if (
-      (params.manifest?.contracts?.[contractKey] ?? []).some((providerId) => {
+      readManifestProviderContractIds(params.manifest, contractKey).some((providerId) => {
         const normalized = normalizeOptionalLowercaseString(providerId);
         return normalized ? configuredProviderIds.has(normalized) : false;
       })
@@ -1003,7 +1024,7 @@ function manifestOwnsConfiguredVoiceProvider(params: {
       continue;
     }
     if (
-      (params.manifest?.contracts?.[contractKey] ?? []).some((providerId) => {
+      readManifestProviderContractIds(params.manifest, contractKey).some((providerId) => {
         const normalized = normalizeOptionalLowercaseString(providerId);
         return normalized ? configuredProviderIds.has(normalized) : false;
       })


### PR DESCRIPTION
## Summary
- guards startup provider contract reads so an unreadable manifest `contracts` property cannot abort provider startup planning
- reuses the installed-index contract snapshot when a healthy configured web search provider is selected
- adds regression coverage for a malformed manifest next to a healthy Brave provider

## Verification
- `node --import tsx - <<'EOF' ... EOF` bad-manifest repro returns `["brave"]`
- `CI=1 node scripts/run-vitest.mjs run src/plugins/channel-plugin-ids.test.ts --reporter=verbose`
- `./node_modules/.bin/oxlint src/plugins/gateway-startup-plugin-ids.ts src/plugins/channel-plugin-ids.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`: run `run_a948a19ac82b`, lease `cbx_eaae7f3fb148`, provider `aws`, exit 0

Behavior addressed: startup provider planning no longer crashes when one plugin manifest throws while reading provider contracts.
Real environment tested: local Codex worktree on macOS with repo symlinked dependencies; AWS Crabbox Linux remote changed gate.
Exact steps or command run after this patch: direct bad-manifest repro; focused Vitest file; oxlint on touched files; diff whitespace check; local autoreview; AWS Crabbox `pnpm check:changed`.
Evidence after fix: repro returned `["brave"]`; focused suite passed 125 tests; oxlint and diff check passed; autoreview reported no actionable findings; AWS Crabbox `run_a948a19ac82b` passed with exit 0.
Observed result after fix: the healthy configured web search provider remains selected, unreadable manifest contracts are skipped, and the changed gate passes.
What was not tested: full repo-wide `pnpm check` was not run.
