### PR TITLE
fix(channels): guard message action schema discovery

### DIFF
--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -115,6 +115,25 @@ function normalizeToolSchemaContributions(
   return Array.isArray(value) ? value : [value];
 }
 
+function readMessageToolDiscoveryField<K extends keyof ChannelMessageToolDiscovery>(params: {
+  pluginId: string;
+  described: ChannelMessageToolDiscovery | null;
+  field: K;
+}): ChannelMessageToolDiscovery[K] | undefined {
+  // Plugin discovery can return getter/proxy-backed objects; one bad field
+  // must not poison the shared message tool schema for healthy plugins.
+  try {
+    return params.described?.[params.field];
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "describeMessageTool",
+      error,
+    });
+    return undefined;
+  }
+}
+
 type ResolvedChannelMessageActionDiscovery = {
   actions: ChannelMessageActionName[];
   capabilities: readonly ChannelMessageCapability[];
@@ -124,10 +143,29 @@ type ResolvedChannelMessageActionDiscovery = {
 
 type MessageToolMediaSourceParamMap = Partial<Record<ChannelMessageActionName, readonly string[]>>;
 
-function normalizeMessageToolMediaSourceParams(
-  mediaSourceParams: ChannelMessageToolDiscovery["mediaSourceParams"],
-  action?: ChannelMessageActionName,
-): readonly string[] {
+function readSchemaContributionField<K extends keyof ChannelMessageToolSchemaContribution>(params: {
+  pluginId: string;
+  contribution: ChannelMessageToolSchemaContribution;
+  field: K;
+}): ChannelMessageToolSchemaContribution[K] | undefined {
+  try {
+    return params.contribution[params.field];
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "describeMessageTool",
+      error,
+    });
+    return undefined;
+  }
+}
+
+function normalizeMessageToolMediaSourceParams(params: {
+  pluginId: string;
+  mediaSourceParams: ChannelMessageToolDiscovery["mediaSourceParams"];
+  action?: ChannelMessageActionName;
+}): readonly string[] {
+  const { mediaSourceParams } = params;
   if (Array.isArray(mediaSourceParams)) {
     return mediaSourceParams;
   }
@@ -135,13 +173,22 @@ function normalizeMessageToolMediaSourceParams(
     return [];
   }
   const scopedMediaSourceParams = mediaSourceParams as MessageToolMediaSourceParamMap;
-  if (action) {
-    const scoped = scopedMediaSourceParams[action];
-    return Array.isArray(scoped) ? scoped : [];
+  try {
+    if (params.action) {
+      const scoped = scopedMediaSourceParams[params.action];
+      return Array.isArray(scoped) ? scoped : [];
+    }
+    return Object.values(scopedMediaSourceParams).flatMap((scoped) =>
+      Array.isArray(scoped) ? scoped : [],
+    );
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "describeMessageTool",
+      error,
+    });
+    return [];
   }
-  return Object.values(scopedMediaSourceParams).flatMap((scoped) =>
-    Array.isArray(scoped) ? scoped : [],
-  );
 }
 
 export function resolveCurrentChannelMessageToolDiscoveryAdapter(channel?: string | null): {
@@ -200,20 +247,33 @@ export function resolveMessageActionDiscoveryForPlugin(params: {
     context: params.context,
     describeMessageTool: adapter.describeMessageTool,
   });
+  const actions = params.includeActions
+    ? readMessageToolDiscoveryField({ pluginId: params.pluginId, described, field: "actions" })
+    : undefined;
+  const capabilities = params.includeCapabilities
+    ? readMessageToolDiscoveryField({
+        pluginId: params.pluginId,
+        described,
+        field: "capabilities",
+      })
+    : undefined;
+  const schema = params.includeSchema
+    ? readMessageToolDiscoveryField({ pluginId: params.pluginId, described, field: "schema" })
+    : undefined;
+  const mediaSourceParams = readMessageToolDiscoveryField({
+    pluginId: params.pluginId,
+    described,
+    field: "mediaSourceParams",
+  });
   return {
-    actions:
-      params.includeActions && Array.isArray(described?.actions) ? [...described.actions] : [],
-    capabilities:
-      params.includeCapabilities && Array.isArray(described?.capabilities)
-        ? described.capabilities
-        : [],
-    schemaContributions: params.includeSchema
-      ? normalizeToolSchemaContributions(described?.schema)
-      : [],
-    mediaSourceParams: normalizeMessageToolMediaSourceParams(
-      described?.mediaSourceParams,
-      params.action,
-    ),
+    actions: Array.isArray(actions) ? [...actions] : [],
+    capabilities: Array.isArray(capabilities) ? capabilities : [],
+    schemaContributions: normalizeToolSchemaContributions(schema),
+    mediaSourceParams: normalizeMessageToolMediaSourceParams({
+      pluginId: params.pluginId,
+      mediaSourceParams,
+      action: params.action,
+    }),
   };
 }
 
@@ -254,13 +314,34 @@ export function listCrossChannelSchemaSupportedMessageActions(
   });
   const schemaBlockedActions = new Set<ChannelMessageActionName>();
   for (const contribution of resolved.schemaContributions) {
-    if ((contribution.visibility ?? "current-channel") !== "current-channel") {
+    const visibility =
+      readSchemaContributionField({
+        pluginId: pluginActions.pluginId,
+        contribution,
+        field: "visibility",
+      }) ?? "current-channel";
+    if (visibility !== "current-channel") {
       continue;
     }
-    if (!Object.hasOwn(contribution, "actions")) {
+    let hasActions: boolean;
+    try {
+      hasActions = Object.hasOwn(contribution, "actions");
+    } catch (error) {
+      logMessageActionError({
+        pluginId: pluginActions.pluginId,
+        operation: "describeMessageTool",
+        error,
+      });
       return [];
     }
-    const actions = contribution.actions;
+    if (!hasActions) {
+      return [];
+    }
+    const actions = readSchemaContributionField({
+      pluginId: pluginActions.pluginId,
+      contribution,
+      field: "actions",
+    });
     if (!Array.isArray(actions)) {
       return [];
     }
@@ -306,17 +387,31 @@ export function listChannelMessageCapabilitiesForChannel(
   );
 }
 
-function mergeToolSchemaProperties(
-  target: Record<string, TSchema>,
-  source: Record<string, TSchema> | undefined,
-) {
+function mergeToolSchemaProperties(params: {
+  pluginId: string;
+  target: Record<string, TSchema>;
+  contribution: ChannelMessageToolSchemaContribution;
+}) {
+  const source = readSchemaContributionField({
+    pluginId: params.pluginId,
+    contribution: params.contribution,
+    field: "properties",
+  });
   if (!source) {
     return;
   }
-  for (const [name, schema] of Object.entries(source)) {
-    if (!(name in target)) {
-      target[name] = schema;
+  try {
+    for (const [name, schema] of Object.entries(source)) {
+      if (!(name in params.target)) {
+        params.target[name] = schema;
+      }
     }
+  } catch (error) {
+    logMessageActionError({
+      pluginId: params.pluginId,
+      operation: "describeMessageTool",
+      error,
+    });
   }
 }
 
@@ -339,14 +434,27 @@ export function resolveChannelMessageToolSchemaProperties(
       context: discoveryBase,
       includeSchema: true,
     }).schemaContributions) {
-      const visibility = contribution.visibility ?? "current-channel";
+      const visibility =
+        readSchemaContributionField({
+          pluginId: plugin.id,
+          contribution,
+          field: "visibility",
+        }) ?? "current-channel";
       if (currentChannel) {
         if (visibility === "all-configured" || plugin.id === currentChannel) {
-          mergeToolSchemaProperties(properties, contribution.properties);
+          mergeToolSchemaProperties({
+            pluginId: plugin.id,
+            target: properties,
+            contribution,
+          });
         }
         continue;
       }
-      mergeToolSchemaProperties(properties, contribution.properties);
+      mergeToolSchemaProperties({
+        pluginId: plugin.id,
+        target: properties,
+        contribution,
+      });
     }
   }
   if (currentChannel && !seenPluginIds.has(currentChannel)) {
@@ -358,9 +466,18 @@ export function resolveChannelMessageToolSchemaProperties(
         context: discoveryBase,
         includeSchema: true,
       }).schemaContributions) {
-        const visibility = contribution.visibility ?? "current-channel";
+        const visibility =
+          readSchemaContributionField({
+            pluginId: currentActions.pluginId,
+            contribution,
+            field: "visibility",
+          }) ?? "current-channel";
         if (visibility === "all-configured" || currentActions.pluginId === currentChannel) {
-          mergeToolSchemaProperties(properties, contribution.properties);
+          mergeToolSchemaProperties({
+            pluginId: currentActions.pluginId,
+            target: properties,
+            contribution,
+          });
         }
       }
     }

--- a/src/channels/plugins/message-actions.test.ts
+++ b/src/channels/plugins/message-actions.test.ts
@@ -193,6 +193,114 @@ describe("message action capability checks", () => {
     ).toHaveProperty("components");
   });
 
+  it("skips unreadable message tool discovery schema while preserving healthy schema contributions", () => {
+    const badPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-bad-schema",
+        label: "Demo Bad Schema",
+        capabilities: { chatTypes: ["direct", "group"] },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          get schema(): never {
+            throw new Error("fuzzplugin schema exploded");
+          },
+        }),
+      },
+    };
+    const healthyPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-healthy-schema",
+        label: "Demo Healthy Schema",
+        capabilities: { chatTypes: ["direct", "group"] },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          schema: {
+            visibility: "all-configured",
+            properties: {
+              healthyParam: Type.Optional(Type.String()),
+            },
+          },
+        }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "demo-bad-schema", source: "test", plugin: badPlugin },
+        { pluginId: "demo-healthy-schema", source: "test", plugin: healthyPlugin },
+      ]),
+    );
+
+    expect(
+      resolveChannelMessageToolSchemaProperties({
+        cfg: {} as OpenClawConfig,
+        channel: "demo-healthy-schema",
+      }),
+    ).toHaveProperty("healthyParam");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("fuzzplugin schema exploded"));
+  });
+
+  it("skips unreadable message tool schema properties while preserving healthy schema contributions", () => {
+    const unreadableProperties = new Proxy({} as Record<string, never>, {
+      ownKeys() {
+        throw new Error("fuzzplugin schema properties exploded");
+      },
+    });
+    const badPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-bad-properties",
+        label: "Demo Bad Properties",
+        capabilities: { chatTypes: ["direct", "group"] },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          schema: {
+            visibility: "all-configured",
+            properties: unreadableProperties,
+          },
+        }),
+      },
+    };
+    const healthyPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "demo-healthy-properties",
+        label: "Demo Healthy Properties",
+        capabilities: { chatTypes: ["direct", "group"] },
+      }),
+      actions: {
+        describeMessageTool: () => ({
+          actions: ["send"],
+          schema: {
+            visibility: "all-configured",
+            properties: {
+              fallbackParam: Type.Optional(Type.String()),
+            },
+          },
+        }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "demo-bad-properties", source: "test", plugin: badPlugin },
+        { pluginId: "demo-healthy-properties", source: "test", plugin: healthyPlugin },
+      ]),
+    );
+
+    expect(
+      resolveChannelMessageToolSchemaProperties({
+        cfg: {} as OpenClawConfig,
+        channel: "demo-healthy-properties",
+      }),
+    ).toHaveProperty("fallbackParam");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("fuzzplugin schema properties exploded"),
+    );
+  });
+
   it("filters only actions that depend on current-channel-only schema", () => {
     const scopedSchemaPlugin: ChannelPlugin = {
       ...createChannelTestPluginBase({


### PR DESCRIPTION
## Summary
- guards plugin-owned message-tool discovery field reads so getter/proxy-backed action schema metadata cannot crash channel schema discovery
- skips unreadable schema/property contributions while preserving healthy plugin message-tool schema fields
- adds regressions for an unreadable discovery `schema` getter and unreadable schema `properties` map

## Verification
- `node --import tsx - <<'EOF' ... EOF` bad-discovery repro returns `["healthyParam"]`
- `CI=1 node scripts/run-vitest.mjs run src/channels/plugins/message-actions.test.ts --reporter=verbose`
- `./node_modules/.bin/oxlint src/channels/plugins/message-action-discovery.ts src/channels/plugins/message-actions.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`: run `run_b652ada6cd29`, lease `cbx_c69f1cc8dabd`, provider `aws`, exit 0

Behavior addressed: a malformed channel plugin message-tool discovery result no longer crashes shared message schema discovery before healthy plugin fields can be projected.
Real environment tested: local Codex worktree on macOS with repo symlinked dependencies; AWS Crabbox Linux remote changed gate.
Exact steps or command run after this patch: direct bad-discovery repro; focused channel Vitest file; oxlint on touched files; diff whitespace check; local autoreview; AWS Crabbox `pnpm check:changed`.
Evidence after fix: repro returned `["healthyParam"]`; focused suite passed 12 tests; oxlint and diff check passed; autoreview reported no actionable findings; AWS Crabbox `run_b652ada6cd29` passed with exit 0.
Observed result after fix: unreadable plugin schema metadata is logged and skipped while healthy message-tool schema contributions remain available.
What was not tested: full repo-wide `pnpm check` was not run.
