### PR TITLE
fix(plugins): harden installed index stale metadata

### DIFF
--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
-import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import {
+  normalizeSortedUniqueStringEntries,
+  normalizeSortedUniqueTrimmedStringList,
+} from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.js";
+import { isRecord } from "../utils.js";
 import type { PluginCompatCode } from "./compat/registry.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
@@ -22,45 +26,79 @@ import type { PluginPackageChannel } from "./manifest.js";
 import { isPathInside, safeRealpathSync } from "./path-safety.js";
 import { hasKind } from "./slots.js";
 
+function readArray(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readRecordKeys(value: unknown): string[] {
+  return isRecord(value) ? Object.keys(value) : [];
+}
+
+function normalizeRecordStringList(value: unknown): string[] {
+  return normalizeSortedUniqueTrimmedStringList(value);
+}
+
+function buildContractContributionInfo(value: unknown): Record<string, string[]> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const contracts: Record<string, string[]> = {};
+  for (const [key, entries] of Object.entries(value)) {
+    if (Array.isArray(entries)) {
+      contracts[key] = normalizeRecordStringList(entries);
+    }
+  }
+  return contracts;
+}
+
+function listModelCatalogContributionProviders(value: unknown): string[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+  const suppressions = readArray(value.suppressions).flatMap((entry) =>
+    isRecord(entry) ? normalizeRecordStringList([entry.provider]) : [],
+  );
+  return [...readRecordKeys(value.providers), ...readRecordKeys(value.aliases), ...suppressions];
+}
+
+function listCommandAliases(value: unknown): string[] {
+  return readArray(value).flatMap((alias) =>
+    isRecord(alias) ? normalizeRecordStringList([alias.name]) : [],
+  );
+}
+
 function buildStartupInfo(record: PluginManifestRecord): InstalledPluginStartupInfo {
+  const activation = isRecord(record.activation) ? record.activation : undefined;
   return {
-    sidecar: record.activation?.onStartup === true,
+    sidecar: activation?.onStartup === true,
     memory: hasKind(record.kind, "memory"),
     deferConfiguredChannelFullLoadUntilAfterListen:
       record.startupDeferConfiguredChannelFullLoadUntilAfterListen === true,
-    agentHarnesses: normalizeSortedUniqueStringEntries([
-      ...(record.activation?.onAgentHarnesses ?? []),
-      ...(record.cliBackends ?? []),
+    agentHarnesses: normalizeRecordStringList([
+      ...readArray(activation?.onAgentHarnesses),
+      ...readArray(record.cliBackends),
     ]),
-    configPaths: normalizeSortedUniqueStringEntries(record.activation?.onConfigPaths),
+    configPaths: normalizeRecordStringList(activation?.onConfigPaths),
   };
 }
 
 function buildContributionInfo(record: PluginManifestRecord): InstalledPluginContributionInfo {
-  const contracts = Object.fromEntries(
-    Object.entries(record.contracts ?? {}).map(([key, values]) => [
-      key,
-      normalizeSortedUniqueStringEntries(values),
-    ]),
-  );
   return {
-    channels: normalizeSortedUniqueStringEntries(record.channels),
-    channelConfigs: normalizeSortedUniqueStringEntries(Object.keys(record.channelConfigs ?? {})),
-    providers: normalizeSortedUniqueStringEntries(record.providers),
-    modelCatalogProviders: normalizeSortedUniqueStringEntries([
-      ...Object.keys(record.modelCatalog?.providers ?? {}),
-      ...Object.keys(record.modelCatalog?.aliases ?? {}),
-      ...(record.modelCatalog?.suppressions ?? []).map((entry) => entry.provider),
-    ]),
-    modelSupportPrefixes: normalizeSortedUniqueStringEntries(record.modelSupport?.modelPrefixes),
-    modelSupportPatterns: normalizeSortedUniqueStringEntries(record.modelSupport?.modelPatterns),
-    autoEnableProviderIds: normalizeSortedUniqueStringEntries(
-      record.autoEnableWhenConfiguredProviders,
+    channels: normalizeRecordStringList(record.channels),
+    channelConfigs: normalizeSortedUniqueStringEntries(readRecordKeys(record.channelConfigs)),
+    providers: normalizeRecordStringList(record.providers),
+    modelCatalogProviders: normalizeSortedUniqueStringEntries(
+      listModelCatalogContributionProviders(record.modelCatalog),
     ),
-    commandAliases: normalizeSortedUniqueStringEntries(
-      record.commandAliases?.map((alias) => alias.name),
+    modelSupportPrefixes: normalizeRecordStringList(
+      isRecord(record.modelSupport) ? record.modelSupport.modelPrefixes : undefined,
     ),
-    contracts,
+    modelSupportPatterns: normalizeRecordStringList(
+      isRecord(record.modelSupport) ? record.modelSupport.modelPatterns : undefined,
+    ),
+    autoEnableProviderIds: normalizeRecordStringList(record.autoEnableWhenConfiguredProviders),
+    commandAliases: normalizeSortedUniqueStringEntries(listCommandAliases(record.commandAliases)),
+    contracts: buildContractContributionInfo(record.contracts),
   };
 }
 
@@ -68,31 +106,32 @@ export function collectPluginManifestCompatCodes(
   record: PluginManifestRecord,
 ): readonly PluginCompatCode[] {
   const codes: PluginCompatCode[] = [];
-  if (record.providerAuthEnvVars && Object.keys(record.providerAuthEnvVars).length > 0) {
+  if (readRecordKeys(record.providerAuthEnvVars).length > 0) {
     codes.push("provider-auth-env-vars");
   }
-  if (record.channelEnvVars && Object.keys(record.channelEnvVars).length > 0) {
+  if (readRecordKeys(record.channelEnvVars).length > 0) {
     codes.push("channel-env-vars");
   }
-  if (record.activation?.onProviders?.length) {
+  const activation = isRecord(record.activation) ? record.activation : undefined;
+  if (readArray(activation?.onProviders).length) {
     codes.push("activation-provider-hint");
   }
-  if (record.activation?.onAgentHarnesses?.length) {
+  if (readArray(activation?.onAgentHarnesses).length) {
     codes.push("activation-agent-harness-hint");
   }
-  if (record.activation?.onChannels?.length) {
+  if (readArray(activation?.onChannels).length) {
     codes.push("activation-channel-hint");
   }
-  if (record.activation?.onCommands?.length) {
+  if (readArray(activation?.onCommands).length) {
     codes.push("activation-command-hint");
   }
-  if (record.activation?.onRoutes?.length) {
+  if (readArray(activation?.onRoutes).length) {
     codes.push("activation-route-hint");
   }
-  if (record.activation?.onConfigPaths?.length) {
+  if (readArray(activation?.onConfigPaths).length) {
     codes.push("activation-config-path-hint");
   }
-  if (record.activation?.onCapabilities?.length) {
+  if (readArray(activation?.onCapabilities).length) {
     codes.push("activation-capability-hint");
   }
   return normalizeSortedUniqueStringEntries(codes) as readonly PluginCompatCode[];

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -375,6 +375,76 @@ describe("installed plugin index", () => {
     expect(records[0]?.startup.sidecar).toBe(false);
   });
 
+  it("ignores malformed stale contribution metadata while building index records", () => {
+    const rootDir = makeTempDir();
+    writeRuntimeEntry(rootDir);
+    const manifestPath = path.join(rootDir, "openclaw.plugin.json");
+
+    const records = buildInstalledPluginIndexRecords({
+      candidates: [createPluginCandidate({ rootDir })],
+      registry: {
+        plugins: [
+          {
+            id: "malformed-stale-record",
+            providers: 42,
+            cliBackends: 42,
+            skills: [],
+            hooks: [],
+            contracts: {
+              tools: 42,
+              migrationProviders: ["legacy-import"],
+            },
+            modelCatalog: {
+              providers: 42,
+              aliases: "demo",
+              suppressions: [null, { provider: "suppressed-demo" }],
+            },
+            modelSupport: {
+              modelPrefixes: 42,
+              modelPatterns: ["^demo-"],
+            },
+            commandAliases: [null, { name: "safe-command" }],
+            activation: {
+              onProviders: "demo",
+              onAgentHarnesses: 42,
+              onConfigPaths: 42,
+            },
+            providerAuthEnvVars: "DEMO_API_KEY",
+            channelEnvVars: 42,
+            origin: "global",
+            rootDir,
+            source: path.join(rootDir, "index.ts"),
+            manifestPath,
+          } as unknown as PluginManifestRecord,
+        ],
+        diagnostics: [],
+      },
+      diagnostics: [],
+      installRecords: {},
+    });
+
+    const record = records[0];
+    expectRecordFields(requireRecord(record, "installed plugin record"), {
+      pluginId: "malformed-stale-record",
+      compat: [],
+    });
+    expect(record?.startup.agentHarnesses).toEqual([]);
+    expect(record?.startup.configPaths).toEqual([]);
+    expect(record?.contributions).toEqual({
+      channels: [],
+      channelConfigs: [],
+      providers: [],
+      modelCatalogProviders: ["suppressed-demo"],
+      modelSupportPrefixes: [],
+      modelSupportPatterns: ["^demo-"],
+      autoEnableProviderIds: [],
+      commandAliases: ["safe-command"],
+      contracts: {
+        migrationProviders: ["legacy-import"],
+      },
+    });
+  });
+
   it("indexes manifestless Claude bundles without missing-manifest diagnostics", () => {
     const rootDir = path.join(makeTempDir(), "workspace");
     writeManifestlessClaudeBundle(rootDir);


### PR DESCRIPTION
## Summary
- Harden installed plugin index record building against stale manifest records with malformed contribution/startup metadata.
- Keep valid contribution metadata intact while dropping malformed non-record/non-array fields instead of throwing during cold index refresh.
- Add regression coverage for scalar contract lists, malformed model catalog suppression rows, null command aliases, and scalar activation hints.

## Verification
- `node --import tsx --input-type=module` direct stale-record repro: contracts scalar, modelCatalog null suppression, commandAliases null, startup scalar lists all build records without throwing.
- `CI=1 node scripts/run-vitest.mjs run src/plugins/installed-plugin-index.test.ts --reporter=verbose` (31 passed)
- `./node_modules/.bin/oxfmt --write src/plugins/installed-plugin-index-record-builder.ts src/plugins/installed-plugin-index.test.ts`
- `./node_modules/.bin/oxlint src/plugins/installed-plugin-index-record-builder.ts src/plugins/installed-plugin-index.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no accepted/actionable findings)
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_fc42c242dbca`, run `run_d9422e34104b`, exit 0

## Real behavior proof
Behavior addressed: stale or malformed plugin manifest records can no longer crash installed plugin index record generation through malformed contribution/startup metadata.
Real environment tested: local Codex worktree plus AWS Crabbox Linux remote changed gate.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/plugins/installed-plugin-index.test.ts --reporter=verbose`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
Evidence after fix: the focused installed plugin index suite passed with 31 tests; AWS Crabbox run `run_d9422e34104b` completed `pnpm check:changed` with exit 0.
Observed result after fix: malformed scalar/null metadata is ignored for cold index contribution facts while valid array-backed metadata is preserved.
What was not tested: full repo-wide `pnpm check`/`pnpm test`.
