### PR TITLE
fix(subagent): don't propagate inheritedToolAllowlist to child session

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -35,7 +35,6 @@ import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
 import type { BootstrapContextMode } from "./bootstrap-files.js";
 import {
-  inheritedToolAllowPatch,
   inheritedToolDenyPatch,
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
@@ -1303,7 +1302,6 @@ export async function spawnSubagentDirect(
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
-    ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
     ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
     ...plan.initialSessionPatch,
   };


### PR DESCRIPTION
## Problem

When a subagent is configured with MCP tools in `subagentPolicy`, those
tools are silently unavailable at runtime. The root cause is a pipeline
ordering issue: `inheritedToolAllowPatch()` writes the parent's tool
allowlist into the child session *before* MCP tools are materialized,
so the allowlist never contains the MCP tool names and they get filtered
out by the tool policy pipeline.

### Steps to reproduce

1. Configure a subagent with MCP tools in config
2. Spawn the subagent via `sessions_spawn`
3. Observed that the MCP tools are not available to the subagent
   despite being correctly configured

## Fix

Remove `...inheritedToolAllowPatch(ctx.inheritedToolAllowlist)` from
`initialChildSessionPatch`. Subagents should be governed by their own
tool policies, not the parent's inherited allowlist.

### Changes

- `src/agents/subagent-spawn.ts`: delete one line + clean up unused import