### PR TITLE
fix(slack): drop per-message username/icon override in chat.postMessage path

### DIFF
--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -15,7 +15,6 @@ import {
   sendPayloadMediaSequenceAndFinalize,
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
@@ -52,18 +51,14 @@ function resolveRenderedInteractiveBlocks(
   return blocks.length > 0 ? blocks : undefined;
 }
 
-function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentity | undefined {
-  if (!identity) {
-    return undefined;
-  }
-  const username = normalizeOptionalString(identity.name);
-  const iconUrl = normalizeOptionalString(identity.avatarUrl);
-  const rawEmoji = normalizeOptionalString(identity.emoji);
-  const iconEmoji = !iconUrl && rawEmoji && /^:[^:\s]+:$/.test(rawEmoji) ? rawEmoji : undefined;
-  if (!username && !iconUrl && !iconEmoji) {
-    return undefined;
-  }
-  return { username, iconUrl, iconEmoji };
+function resolveSlackSendIdentity(_identity?: OutboundIdentity): SlackSendIdentity | undefined {
+  // In multi-bot Slack workspaces each agent has its own bot user with a real_name
+  // and avatar. The OutboundIdentity arriving here is the *originating agent's*
+  // identity, not the bot's — forwarding it as username/icon_url makes sub-agent
+  // posts render under the parent agent's name, breaking attribution in shared
+  // channels. Returning undefined lets Slack fall back to each bot's own profile.
+  // Per-message identity override should be opt-in via cfg, not the default.
+  return undefined;
 }
 
 async function sendSlackOutboundMessage(params: {


### PR DESCRIPTION
# fix(slack): stop forwarding parent agent identity to `chat.postMessage`

## Summary

`resolveSlackSendIdentity` in `extensions/slack/src/outbound-adapter.ts` forwards every `OutboundIdentity` it receives to Slack's `chat.postMessage` as `username` / `icon_url` / `icon_emoji`.

In multi-bot Slack workspaces — one Slack bot user per agent, each with its own `real_name` and avatar uploaded — the `OutboundIdentity` arriving here is the **originating agent's** identity (e.g. a coordinator agent's name/avatar), **not the bot user's**. Forwarding it overrides the actual bot user's profile on the message, so sub-agent posts render under the parent agent's name and avatar. Attribution in shared channels breaks: every agent looks like the same agent.

This PR makes `resolveSlackSendIdentity` return `undefined` unconditionally. Slack then falls back to each bot user's configured profile, which is the correct multi-bot behavior.

## Why default-off (not gated)

The existing default ("forward whatever identity the upstream caller hands us") is only correct in single-bot deployments where the bot has no real profile and relies on per-message overlay. That's the historical "Slack app sending as `username=Bot`" pattern.

For any deployment that runs more than one Slack bot user (i.e. anyone using the multi-agent runtime against more than one Slack app), the current default is silently wrong: the bot has a profile, but the per-message override hides it.

Per-message identity overlay still has uses (persona switching inside a single bot, etc.) but it should be **opt-in via cfg**, not the default applied to every send. Callers that need overlay still pass `identity` explicitly into `sendMessageSlack` — that path is unchanged and tested by `send.identity-fallback.test.ts`.

## What changes

- `resolveSlackSendIdentity` body replaced with `return undefined` + rationale comment.
- Unused `normalizeOptionalString` import removed.
- No public API change. `OutboundIdentity` still accepted at the adapter boundary; it's just no longer plumbed through to Slack.

## What does not change

- `sendMessageSlack`'s `identity` parameter still works — callers that pass it directly still get the customize-scope behavior + fallback.
- `chat:write.customize` is no longer required for default sends from the adapter (a small ops win for new installs).
- `outbound-adapter` payload tests, identity-fallback tests, and the 1239-test `extensions/slack` suite all pass unchanged.

## Verification

Local (this PR):

- `pnpm vitest run extensions/slack` → 99 files / 1239 tests green.
- `pnpm tsc -p tsconfig.extensions.json` → clean.
- `pnpm lint:extensions` → clean.

Production (downstream hot-patch with identical body, ~6 hours in flight at filing time):

- Sub-agent posts in shared channels now render under each bot user's own `real_name` and avatar instead of the coordinator's.
- DMs from each bot consistent with bot profile.
- No regressions on `customize-scope` fallback (covered by existing tests anyway).

## Background

Filed by Ki Marketing's multi-bot Slack deployment, where five distinct Slack bot users (one per agent) were all rendering as the coordinator agent because of this identity passthrough. We've been running this exact patch as a `dist/`-level hot-patch since the issue surfaced; landing it upstream lets us retire the hot-patch and matching post-update guard.

## Backwards compat note

Existing single-bot deployments that intentionally relied on the parent-agent overlay will lose it. Migration path: pass `identity` explicitly via `sendMessageSlack` (the path that's already there and tested), or configure each Slack bot user's profile in Slack and let it surface naturally. We do not believe the implicit overlay is load-bearing for any deployment that has uploaded bot profiles.

## Checklist

- [x] tests green locally
- [x] typecheck clean
- [x] lint clean
- [x] no public-API break
- [x] commit message describes the "why"
