### PR TITLE
fix(plugin-sdk): guard provider tool schema walks

### DIFF
--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -11,6 +11,31 @@ import {
 } from "./provider-tools.js";
 
 describe("buildProviderToolCompatFamilyHooks", () => {
+  function createUnreadableSchemaMap(label: string): Record<string, unknown> {
+    return new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error(`${label} ownKeys exploded`);
+        },
+        getOwnPropertyDescriptor() {
+          return { configurable: true, enumerable: true };
+        },
+      },
+    );
+  }
+
+  function createUnreadableSchemaArray(label: string): unknown[] {
+    return new Proxy([{}], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error(`${label} entry exploded`);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+  }
+
   function normalizeOpenAIParameters(parameters: unknown): unknown {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [{ name: "demo", description: "", parameters }] as never;
@@ -395,6 +420,149 @@ describe("buildProviderToolCompatFamilyHooks", () => {
         tools: [permissiveTool],
       }),
     ).toStrictEqual([]);
+  });
+
+  it("does not throw when provider compatibility normalizers see unreadable schema maps", () => {
+    const openAIHooks = buildProviderToolCompatFamilyHooks("openai");
+    const openAIParameters = createUnreadableSchemaMap("openai parameters");
+    const openAITool = { name: "openai_tool", description: "", parameters: openAIParameters };
+
+    expect(() =>
+      openAIHooks.normalizeToolSchemas({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        modelApi: "openai-responses",
+        model: {
+          provider: "openai",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          id: "gpt-5.4",
+        } as never,
+        tools: [openAITool] as never,
+      }),
+    ).not.toThrow();
+
+    const deepSeekHooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const deepSeekParameters = createUnreadableSchemaMap("deepseek parameters");
+    const deepSeekTool = {
+      name: "deepseek_tool",
+      description: "",
+      parameters: deepSeekParameters,
+    };
+
+    const normalized = deepSeekHooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [deepSeekTool] as never,
+    });
+
+    expect(normalized[0]?.parameters).toBe(deepSeekParameters);
+
+    const unionArray = createUnreadableSchemaArray("deepseek anyOf");
+    const unionParameters = {
+      type: "object",
+      properties: {
+        mode: {
+          anyOf: unionArray,
+        },
+      },
+    };
+
+    const unionNormalized = deepSeekHooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [
+        { name: "deepseek_union_tool", description: "", parameters: unionParameters },
+      ] as never,
+    });
+
+    expect(unionNormalized[0]?.parameters).toBe(unionParameters);
+  });
+
+  it("reports unreadable provider inspection schema maps without throwing", () => {
+    const geminiHooks = buildProviderToolCompatFamilyHooks("gemini");
+    const geminiDiagnostics = geminiHooks.inspectToolSchemas({
+      provider: "gemini",
+      modelId: "gemini-2.5-pro",
+      modelApi: "gemini",
+      model: {
+        provider: "gemini",
+        api: "gemini",
+        id: "gemini-2.5-pro",
+      } as never,
+      tools: [
+        {
+          name: "gemini_tool",
+          description: "",
+          parameters: {
+            type: "object",
+            properties: createUnreadableSchemaMap("gemini properties"),
+          },
+        },
+      ] as never,
+    });
+
+    expect(geminiDiagnostics).toStrictEqual([
+      {
+        toolName: "gemini_tool",
+        toolIndex: 0,
+        violations: ["gemini_tool.parameters.properties is unreadable"],
+      },
+    ]);
+
+    const deepSeekHooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const deepSeekDiagnostics = deepSeekHooks.inspectToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools: [
+        {
+          name: "deepseek_tool",
+          description: "",
+          parameters: {
+            type: "object",
+            properties: createUnreadableSchemaMap("deepseek properties"),
+          },
+        },
+      ] as never,
+    });
+
+    expect(deepSeekDiagnostics).toStrictEqual([
+      {
+        toolName: "deepseek_tool",
+        toolIndex: 0,
+        violations: ["deepseek_tool.parameters.properties is unreadable"],
+      },
+    ]);
+
+    expect(
+      findOpenAIStrictSchemaViolations(
+        {
+          type: "object",
+          required: ["mode"],
+          additionalProperties: false,
+          properties: createUnreadableSchemaMap("openai strict properties"),
+        },
+        "openai_tool.parameters",
+      ),
+    ).toStrictEqual(["openai_tool.parameters.properties is unreadable"]);
   });
 
   it("skips openai strict-tool normalization on non-native routes", () => {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -18,28 +18,35 @@ export function findUnsupportedSchemaKeywords(
   path: string,
   unsupportedKeywords: ReadonlySet<string>,
 ): string[] {
-  if (!schema || typeof schema !== "object") {
-    return [];
+  const arrayEntries = readSchemaArrayEntries(schema);
+  if (arrayEntries === "unreadable") {
+    return [`${path} is unreadable`];
   }
-  if (Array.isArray(schema)) {
-    return schema.flatMap((item, index) =>
+  if (arrayEntries) {
+    return arrayEntries.flatMap(([index, item]) =>
       findUnsupportedSchemaKeywords(item, `${path}[${index}]`, unsupportedKeywords),
     );
   }
-  const record = schema as Record<string, unknown>;
+  const entries = readSchemaObjectEntries(schema);
+  if (entries === "unreadable") {
+    return [`${path} is unreadable`];
+  }
+  if (!entries) {
+    return [];
+  }
   const violations: string[] = [];
-  const properties =
-    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
-      ? (record.properties as Record<string, unknown>)
-      : undefined;
-  if (properties) {
-    for (const [key, value] of Object.entries(properties)) {
+  const properties = readSchemaField(schema, "properties");
+  const propertyEntries = readSchemaObjectEntries(properties);
+  if (propertyEntries === "unreadable") {
+    violations.push(`${path}.properties is unreadable`);
+  } else if (propertyEntries) {
+    for (const [key, value] of propertyEntries) {
       violations.push(
         ...findUnsupportedSchemaKeywords(value, `${path}.properties.${key}`, unsupportedKeywords),
       );
     }
   }
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entries) {
     if (key === "properties") {
       continue;
     }
@@ -174,14 +181,66 @@ const OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS = new Set([
   "unevaluatedProperties",
 ]);
 
+type SchemaArrayEntries = [number, unknown][] | "unreadable" | undefined;
+type SchemaObjectEntries = [string, unknown][] | "unreadable" | undefined;
+type SchemaObjectKeys = string[] | "unreadable" | undefined;
+
+function readSchemaArrayEntries(value: unknown): SchemaArrayEntries {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return Array.from({ length: value.length }, (_, index) => [index, value[index]]);
+  } catch {
+    return "unreadable";
+  }
+}
+
+function readSchemaObjectEntries(value: unknown): SchemaObjectEntries {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return Object.entries(value as Record<string, unknown>);
+  } catch {
+    return "unreadable";
+  }
+}
+
+function readSchemaObjectKeys(value: unknown): SchemaObjectKeys {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return Object.keys(value as Record<string, unknown>);
+  } catch {
+    return "unreadable";
+  }
+}
+
+function readSchemaField(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return (value as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeOpenAIStrictCompatSchemaMap(schema: unknown): unknown {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+  const entries = readSchemaObjectEntries(schema);
+  if (entries === "unreadable") {
+    return schema;
+  }
+  if (!entries) {
     return schema;
   }
 
   let changed = false;
   const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+  for (const [key, value] of entries) {
     const next = normalizeOpenAIStrictCompatSchemaRecursive(value, {
       promoteEmptyObject: false,
     });
@@ -195,9 +254,13 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
   schema: unknown,
   options: NormalizeOpenAIStrictCompatOptions,
 ): unknown {
-  if (Array.isArray(schema)) {
+  const arrayEntries = readSchemaArrayEntries(schema);
+  if (arrayEntries === "unreadable") {
+    return schema;
+  }
+  if (arrayEntries) {
     let changed = false;
-    const normalized = schema.map((entry) => {
+    const normalized = arrayEntries.map(([, entry]) => {
       const next = normalizeOpenAIStrictCompatSchemaRecursive(entry, {
         promoteEmptyObject: false,
       });
@@ -210,10 +273,13 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
     return schema;
   }
 
-  const record = schema as Record<string, unknown>;
+  const entries = readSchemaObjectEntries(schema);
+  if (entries === "unreadable" || !entries) {
+    return schema;
+  }
   let changed = false;
   const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entries) {
     const next = OPENAI_STRICT_COMPAT_SCHEMA_MAP_KEYS.has(key)
       ? normalizeOpenAIStrictCompatSchemaMap(value)
       : OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS.has(key)
@@ -256,7 +322,7 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
     normalized.properties &&
     typeof normalized.properties === "object" &&
     !Array.isArray(normalized.properties) &&
-    Object.keys(normalized.properties as Record<string, unknown>).length === 0;
+    readSchemaObjectKeys(normalized.properties)?.length === 0;
 
   if (normalized.type === "object" && !Array.isArray(normalized.required) && hasEmptyProperties) {
     normalized.required = [];
@@ -280,11 +346,15 @@ export function findOpenAIStrictSchemaViolations(
   path: string,
   options?: { requireObjectRoot?: boolean },
 ): string[] {
-  if (Array.isArray(schema)) {
+  const arrayEntries = readSchemaArrayEntries(schema);
+  if (arrayEntries === "unreadable") {
+    return [`${path} is unreadable`];
+  }
+  if (arrayEntries) {
     if (options?.requireObjectRoot) {
       return [`${path}.type`];
     }
-    return schema.flatMap((item, index) =>
+    return arrayEntries.flatMap(([index, item]) =>
       findOpenAIStrictSchemaViolations(item, `${path}[${index}]`),
     );
   }
@@ -295,34 +365,37 @@ export function findOpenAIStrictSchemaViolations(
     return [];
   }
 
-  const record = schema as Record<string, unknown>;
+  const entries = readSchemaObjectEntries(schema);
+  if (entries === "unreadable" || !entries) {
+    return [`${path} is unreadable`];
+  }
   const violations: string[] = [];
   for (const key of ["anyOf", "oneOf", "allOf"] as const) {
-    if (Array.isArray(record[key])) {
+    if (Array.isArray(readSchemaField(schema, key))) {
       violations.push(`${path}.${key}`);
     }
   }
-  if (Array.isArray(record.type)) {
+  if (Array.isArray(readSchemaField(schema, "type"))) {
     violations.push(`${path}.type`);
   }
 
-  const properties =
-    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
-      ? (record.properties as Record<string, unknown>)
-      : undefined;
+  const type = readSchemaField(schema, "type");
+  const additionalProperties = readSchemaField(schema, "additionalProperties");
+  const requiredValue = readSchemaField(schema, "required");
+  const propertyEntries = readSchemaObjectEntries(readSchemaField(schema, "properties"));
 
-  if (record.type === "object") {
-    if (record.additionalProperties !== false) {
+  if (type === "object") {
+    if (additionalProperties !== false) {
       violations.push(`${path}.additionalProperties`);
     }
-    const required = Array.isArray(record.required)
-      ? record.required.filter((entry): entry is string => typeof entry === "string")
+    const required = Array.isArray(requiredValue)
+      ? requiredValue.filter((entry): entry is string => typeof entry === "string")
       : undefined;
     if (!required) {
       violations.push(`${path}.required`);
-    } else if (properties) {
+    } else if (propertyEntries !== "unreadable" && propertyEntries) {
       const requiredSet = new Set(required);
-      for (const key of Object.keys(properties)) {
+      for (const [key] of propertyEntries) {
         if (!requiredSet.has(key)) {
           violations.push(`${path}.required.${key}`);
         }
@@ -330,13 +403,15 @@ export function findOpenAIStrictSchemaViolations(
     }
   }
 
-  if (properties) {
-    for (const [key, value] of Object.entries(properties)) {
+  if (propertyEntries === "unreadable") {
+    violations.push(`${path}.properties is unreadable`);
+  } else if (propertyEntries) {
+    for (const [key, value] of propertyEntries) {
       violations.push(...findOpenAIStrictSchemaViolations(value, `${path}.properties.${key}`));
     }
   }
 
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entries) {
     if (key === "properties") {
       continue;
     }
@@ -365,23 +440,28 @@ function isNullSchemaVariant(schema: unknown): boolean {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return false;
   }
-  const record = schema as Record<string, unknown>;
-  if (record.type === "null") {
+  const type = readSchemaField(schema, "type");
+  if (type === "null") {
     return true;
   }
-  if (Array.isArray(record.type) && record.type.length === 1 && record.type[0] === "null") {
+  if (Array.isArray(type) && type.length === 1 && type[0] === "null") {
     return true;
   }
-  if ("const" in record && record.const === null) {
+  if (readSchemaField(schema, "const") === null) {
     return true;
   }
-  return Array.isArray(record.enum) && record.enum.length === 1 && record.enum[0] === null;
+  const enumValues = readSchemaField(schema, "enum");
+  return Array.isArray(enumValues) && enumValues.length === 1 && enumValues[0] === null;
 }
 
 function normalizeDeepSeekSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
+  const arrayEntries = readSchemaArrayEntries(schema);
+  if (arrayEntries === "unreadable") {
+    return schema;
+  }
+  if (arrayEntries) {
     let changed = false;
-    const normalized = schema.map((entry) => {
+    const normalized = arrayEntries.map(([, entry]) => {
       const next = normalizeDeepSeekSchema(entry);
       changed ||= next !== entry;
       return next;
@@ -392,16 +472,17 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     return schema;
   }
 
-  const record = schema as Record<string, unknown>;
-  const unionKey = Array.isArray(record.anyOf)
-    ? "anyOf"
-    : Array.isArray(record.oneOf)
-      ? "oneOf"
-      : undefined;
+  const entries = readSchemaObjectEntries(schema);
+  if (entries === "unreadable" || !entries) {
+    return schema;
+  }
+  const anyOf = readSchemaField(schema, "anyOf");
+  const oneOf = readSchemaField(schema, "oneOf");
+  const unionKey = Array.isArray(anyOf) ? "anyOf" : Array.isArray(oneOf) ? "oneOf" : undefined;
 
   let changed = false;
   const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
+  for (const [key, value] of entries) {
     if (key === "anyOf" || key === "oneOf") {
       if (key === unionKey) {
         changed = true;
@@ -417,8 +498,11 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     return changed ? normalized : schema;
   }
 
-  const variants = record[unionKey] as unknown[];
-  const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
+  const variantEntries = readSchemaArrayEntries(readSchemaField(schema, unionKey));
+  if (variantEntries === "unreadable" || !variantEntries) {
+    return schema;
+  }
+  const normalizedVariants = variantEntries.map(([, entry]) => normalizeDeepSeekSchema(entry));
   const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
   const hasNullVariant = nonNullVariants.length < normalizedVariants.length;
 
@@ -458,8 +542,7 @@ function isStringConstVariant(entry: unknown): entry is { const: string } {
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     return false;
   }
-  const record = entry as Record<string, unknown>;
-  return typeof record.const === "string";
+  return typeof readSchemaField(entry, "const") === "string";
 }
 
 export function normalizeDeepSeekToolSchemas(


### PR DESCRIPTION
## Summary
- Guard provider tool-schema compatibility walkers against unreadable plugin-owned schema objects and arrays.
- Preserve schemas during OpenAI/DeepSeek normalization when containers cannot be read instead of throwing or silently widening unions.
- Report unreadable Gemini/DeepSeek inspection maps as provider tool-schema diagnostics.

## Verification
- `node --import tsx --input-type=module` direct provider-hook repro: OpenAI normalize root, Gemini inspect properties, DeepSeek normalize root, and DeepSeek inspect properties no longer throw.
- `CI=1 node scripts/run-vitest.mjs run src/plugin-sdk/provider-tools.test.ts src/plugin-sdk/schema-normalization-runtime-contract.test.ts --reporter=verbose` (16 passed)
- `./node_modules/.bin/oxfmt --write src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `./node_modules/.bin/oxlint src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` found two real issues; both fixed. Final rerun clean, no accepted/actionable findings.
- AWS Crabbox `pnpm check:changed`: provider `aws`, lease `cbx_7a7ad5903ffb`, run `run_87d8e7265bfd`, exit 0

## Real behavior proof
Behavior addressed: provider SDK tool-schema compatibility hooks can no longer crash when plugin-owned schema maps or arrays are unreadable during provider-specific normalization or inspection.
Real environment tested: local Codex worktree plus AWS Crabbox Linux remote changed gate.
Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/plugin-sdk/provider-tools.test.ts src/plugin-sdk/schema-normalization-runtime-contract.test.ts --reporter=verbose`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
Evidence after fix: focused provider SDK schema normalization tests passed with 16 tests; direct repro returned/detected unreadable schemas instead of throwing; AWS Crabbox run `run_87d8e7265bfd` completed `pnpm check:changed` with exit 0.
Observed result after fix: OpenAI/DeepSeek normalizers preserve unreadable schemas, Gemini/DeepSeek inspectors emit explicit unreadable-map diagnostics, and unreadable DeepSeek unions are not silently widened.
What was not tested: full repo-wide `pnpm check`/`pnpm test`.
