### PR TITLE
fix(config): allow requiresReasoningContentOnAssistantMessages in ModelCompatSchema [AI-assisted]

### DIFF
--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -34,6 +34,7 @@ type SupportedOpenAICompatFields = Pick<
   | "requiresToolResultName"
   | "requiresAssistantAfterToolResult"
   | "requiresThinkingAsText"
+  | "requiresReasoningContentOnAssistantMessages"
   | "openRouterRouting"
   | "vercelGatewayRouting"
   | "zaiToolStream"

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -223,6 +223,7 @@ const ModelCompatSchema = z
     requiresToolResultName: z.boolean().optional(),
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),
+    requiresReasoningContentOnAssistantMessages: z.boolean().optional(),
     toolSchemaProfile: z.string().optional(),
     unsupportedToolSchemaKeywords: z.array(z.string().min(1)).optional(),
     nativeWebSearchTool: z.boolean().optional(),

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -22,4 +22,70 @@ describe("ModelsConfigSchema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  // Regression: https://github.com/openclaw/openclaw/issues/89660
+  // ModelCompatSchema is .strict(); user-facing compat flags consumed at
+  // runtime by detectCompat()/getCompat() must be present in the schema or
+  // gateway startup rejects the config with "Unrecognized key(s) in object".
+  it.each([
+    [
+      "requiresReasoningContentOnAssistantMessages",
+      { requiresReasoningContentOnAssistantMessages: true },
+    ],
+    [
+      "requiresReasoningContentOnAssistantMessages set to false",
+      { requiresReasoningContentOnAssistantMessages: false },
+    ],
+    [
+      "thinkingFormat=deepseek + requiresReasoningContentOnAssistantMessages",
+      {
+        thinkingFormat: "deepseek" as const,
+        requiresReasoningContentOnAssistantMessages: true,
+      },
+    ],
+  ])("accepts custom provider compat with %s", (_label, compat) => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "deepseek-v4-pro",
+              name: "DeepSeek V4 Pro",
+              reasoning: true,
+              compat,
+            },
+          ],
+        },
+      },
+    });
+
+    if (!result.success) {
+      throw new Error(
+        `Schema rejected compat ${JSON.stringify(compat)}: ${JSON.stringify(result.error.issues)}`,
+      );
+    }
+    const provider = result.data?.providers?.["my-proxy"];
+    const model = provider?.models?.[0];
+    if (!model) throw new Error("model missing from parsed config");
+    expect(model.compat).toMatchObject(compat);
+  });
+
+  it("rejects truly unrecognized compat keys (sanity check that .strict() still holds)", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [
+            {
+              id: "x",
+              name: "X",
+              compat: { totallyMadeUpCompatKey: true } as unknown as Record<string, unknown>,
+            },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration; reviewer = 麻酱, code review = Codex CLI). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `ModelCompatSchema` is `.strict()` and was missing `requiresReasoningContentOnAssistantMessages`, so users could not enable the runtime behavior on custom OpenAI-compatible providers — gateway startup rejected the config with `Unrecognized key(s) in object`.
- Solution: Add the optional boolean to `ModelCompatSchema` and to `SupportedOpenAICompatFields` so the schema/type surface matches the runtime consumer in `detectCompat()` / `getCompat()`.
- What changed: `src/config/zod-schema.core.ts` (+1 line in `ModelCompatSchema`), `src/config/types.models.ts` (+1 `Pick` member), `src/config/zod-schema.models.test.ts` (regression coverage, parameterized).
- What did NOT change (scope boundary): No runtime defaults change. `detectOpenAICompletionsCompat()` still derives the flag from provider/baseUrl detection; the flag stays user opt-in. `requiresNonEmptyUserOrAssistantMessage` (also runtime-only, separate issue surface) is not touched.

## Motivation
Custom providers pointing at DeepSeek-compatible proxies cannot currently replicate native DeepSeek provider behavior. `detectCompat` only sets `requiresReasoningContentOnAssistantMessages: true` when `provider === "deepseek"` or `baseUrl.includes("deepseek.com")` (`src/llm/providers/openai-completions.ts:1289`), and `getCompat` already reads `model.compat.requiresReasoningContentOnAssistantMessages` as the user-controlled override (`src/llm/providers/openai-completions.ts:1332-1334`) — but the strict Zod schema blocks users from ever setting it. `thinkingFormat: "deepseek"` is accepted (it IS in the schema), so the asymmetry is purely a missing schema entry.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #89660
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: `ModelsConfigSchema` rejected a custom provider model whose `compat.requiresReasoningContentOnAssistantMessages` was set.
- Real environment tested: local OpenClaw checkout @ upstream/main `f2a46b0661206a0b7264ad05749e2304fbfe6a61`, macOS, Node v22.15.0. Repro drives the real `ModelsConfigSchema` from `src/config/zod-schema.core.ts` via `tsx`, no mocks.
- Exact steps or command run after this patch:
  1. Build a minimal models config with a custom provider whose model sets `compat: { thinkingFormat: "deepseek", requiresReasoningContentOnAssistantMessages: true }`.
  2. `node_modules/.bin/tsx repro-89660.mjs` — runs `ModelsConfigSchema.safeParse(cfg)`.
- Evidence after fix (redacted terminal capture):
  ```text
  === BEFORE the fix (current main) ===
  Parse failed:
    - unrecognized_keys providers.my-proxy.models.0.compat Unrecognized key: "requiresReasoningContentOnAssistantMessages" keys= [ 'requiresReasoningContentOnAssistantMessages' ]
  ❌ Bug #89660 reproduced: schema rejects requiresReasoningContentOnAssistantMessages

  === AFTER the fix (this branch) ===
  ✅ Config accepted; compat= {"thinkingFormat":"deepseek","requiresReasoningContentOnAssistantMessages":true}
  ```
- Observed result after fix: `safeParse` succeeds and preserves the user-supplied flag through to `result.data.providers["my-proxy"].models[0].compat`, ready for `getCompat()` to apply at request time.
- What was not tested: no end-to-end run against a live DeepSeek-compatible proxy (issue is config-validation scoped). Runtime application of the flag is already covered by existing `openai-completions.ts` paths.
- Before evidence: same BEFORE block above (reproduced from local repro driver against upstream/main pre-patch).

## Root Cause (if applicable)
- Root cause: `ModelCompatSchema` (`src/config/zod-schema.core.ts:205`) is declared `.strict()` and enumerated every recognized compat key explicitly, but `requiresReasoningContentOnAssistantMessages` was never added when the runtime flag was introduced. `SupportedOpenAICompatFields` in `src/config/types.models.ts` had the same omission, so even though `OpenAICompletionsCompat` defines the field in `packages/llm-core/src/types.ts:383`, it was filtered out of the user-facing `ModelCompatConfig` shape.
- Missing detection / guardrail: a schema-level positive test that exercises every public flag from `OpenAICompletionsCompat` against `ModelCompatSchema`. (Added a focused regression here; a broader cross-check would be useful follow-up.)
- Contributing context: the flag is currently auto-set only via baseUrl/provider name sniffing in `detectOpenAICompletionsCompat` (`src/agents/openai-completions-compat.ts:119`), so custom proxies that don't include `deepseek.com` in the URL had no other way to opt in.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/zod-schema.models.test.ts`
- Scenario the test should lock in: `ModelsConfigSchema` accepts `compat.requiresReasoningContentOnAssistantMessages` (true/false, with and without `thinkingFormat: "deepseek"`), and still rejects genuinely unknown compat keys so `.strict()` semantics are preserved.
- Why this is the smallest reliable guardrail: the bug is purely about the static schema's key set; a parametrized `safeParse` test catches both the regression and any future drift between the schema and `OpenAICompletionsCompat`.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Users can now set `models.providers.<id>.models[].compat.requiresReasoningContentOnAssistantMessages: boolean` in config. When set, the existing runtime path in `openai-completions.ts` honors it as a user override of the URL-based auto-detection.

## Diagram (if applicable)
```text
Before: user config -> ModelsConfigSchema (strict) -> ❌ unrecognized key -> gateway startup fails
After:  user config -> ModelsConfigSchema (strict) -> ✅ parsed -> getCompat() applies user flag
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node v22.15.0, pnpm (workspace)
- Model/provider: custom OpenAI-compatible (DeepSeek-style proxy)
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.my-proxy.models[0].compat = { thinkingFormat: "deepseek", requiresReasoningContentOnAssistantMessages: true }`

### Steps
1. `git fetch upstream && git checkout fix/model-compat-schema-reasoning-content-flag`
2. `node_modules/.bin/vitest run src/config/zod-schema.models.test.ts` → 5/5 pass
3. `pnpm exec oxfmt --check src/config/zod-schema.core.ts src/config/types.models.ts src/config/zod-schema.models.test.ts` → clean
4. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false --incremental` → no errors
5. Repro driver (`tsx` against the real schema source): BEFORE → ❌ unrecognized key; AFTER → ✅ parsed.
