### PR TITLE
fix(agents): contain provider schema hook failures

### DIFF
--- a/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   inspectProviderToolSchemasWithPlugin: vi.fn(),
@@ -22,6 +22,10 @@ const { logProviderToolSchemaDiagnostics, normalizeProviderToolSchemas } =
   await import("./tool-schema-runtime.js");
 
 describe("tool schema runtime diagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("stays quiet when a provider reports no diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([]);
 
@@ -57,6 +61,42 @@ describe("tool schema runtime diagnostics", () => {
     );
   });
 
+  it("keeps original tools when provider schema normalization throws", () => {
+    const tools = [{ name: "alpha" }] as never;
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("normalizer exploded");
+    });
+
+    expect(
+      normalizeProviderToolSchemas({
+        provider: "example",
+        tools,
+      }),
+    ).toBe(tools);
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema normalization failed for example; keeping original tool schemas",
+      { provider: "example", toolCount: 1, error: "normalizer exploded" },
+    );
+  });
+
+  it("rethrows provider schema normalization errors when requested", () => {
+    const tools = [{ name: "alpha" }] as never;
+    mocks.normalizeProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("normalizer exploded");
+    });
+
+    expect(() =>
+      normalizeProviderToolSchemas({
+        provider: "example",
+        tools,
+        throwOnProviderToolSchemaError: true,
+      }),
+    ).toThrow("normalizer exploded");
+
+    expect(mocks.log.warn).not.toHaveBeenCalled();
+  });
+
   it("logs one summarized warning for provider tool schema diagnostics", () => {
     mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce([
       { toolName: "alpha", toolIndex: 0, violations: ["one", "two"] },
@@ -80,6 +120,61 @@ describe("tool schema runtime diagnostics", () => {
         diagnostics: [
           { index: 0, tool: "alpha", violations: ["one", "two"], violationCount: 2 },
           { index: 1, tool: "beta", violations: ["one"], violationCount: 1 },
+        ],
+      },
+    );
+  });
+
+  it("does not throw when provider schema diagnostics throw or are malformed", () => {
+    mocks.inspectProviderToolSchemasWithPlugin.mockImplementationOnce(() => {
+      throw new Error("inspector exploded");
+    });
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [{ name: "alpha" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      "provider tool schema diagnostics failed for example",
+      { provider: "example", toolCount: 1, error: "inspector exploded" },
+    );
+
+    const malformedDiagnostics = [
+      {
+        get toolName() {
+          throw new Error("tool name exploded");
+        },
+        get violations() {
+          throw new Error("violations exploded");
+        },
+      },
+    ];
+    mocks.inspectProviderToolSchemasWithPlugin.mockReturnValueOnce(malformedDiagnostics);
+
+    expect(() =>
+      logProviderToolSchemaDiagnostics({
+        provider: "example",
+        tools: [{ name: "alpha" }] as never,
+      }),
+    ).not.toThrow();
+
+    expect(mocks.log.warn).toHaveBeenLastCalledWith(
+      "provider tool schema diagnostics: 1 tool for example: unknown (1 violation)",
+      {
+        provider: "example",
+        toolCount: 1,
+        diagnosticCount: 1,
+        tools: ["0:alpha"],
+        diagnostics: [
+          {
+            index: undefined,
+            tool: "unknown",
+            violations: ["diagnostic is unreadable"],
+            violationCount: 1,
+          },
         ],
       },
     );

--- a/src/agents/embedded-agent-runner/tool-schema-runtime.ts
+++ b/src/agents/embedded-agent-runner/tool-schema-runtime.ts
@@ -22,6 +22,13 @@ type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = u
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowRuntimePluginLoad?: boolean;
+  throwOnProviderToolSchemaError?: boolean;
+};
+
+type ReadableProviderToolSchemaDiagnostic = {
+  toolName: string;
+  toolIndex?: number;
+  violations: string[];
 };
 
 function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, TResult = unknown>(
@@ -49,15 +56,27 @@ export function normalizeProviderToolSchemas<
   TResult = unknown,
 >(params: ProviderToolSchemaParams<TSchemaType, TResult>): AgentTool<TSchemaType, TResult>[] {
   const provider = params.provider.trim();
-  const pluginNormalized = normalizeProviderToolSchemasWithPlugin({
-    provider,
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    runtimeHandle: params.runtimeHandle,
-    allowRuntimePluginLoad: params.allowRuntimePluginLoad,
-    context: buildProviderToolSchemaContext(params, provider),
-  });
+  let pluginNormalized: unknown;
+  try {
+    pluginNormalized = normalizeProviderToolSchemasWithPlugin({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      runtimeHandle: params.runtimeHandle,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
+      context: buildProviderToolSchemaContext(params, provider),
+    });
+  } catch (error) {
+    if (params.throwOnProviderToolSchemaError) {
+      throw error;
+    }
+    log.warn(
+      `provider tool schema normalization failed for ${provider}; keeping original tool schemas`,
+      { provider, toolCount: readToolCount(params.tools), error: describeProviderHookError(error) },
+    );
+    return params.tools;
+  }
   return Array.isArray(pluginNormalized)
     ? (pluginNormalized as AgentTool<TSchemaType, TResult>[])
     : params.tools;
@@ -68,31 +87,42 @@ export function normalizeProviderToolSchemas<
  */
 export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParams): void {
   const provider = params.provider.trim();
-  const diagnostics = inspectProviderToolSchemasWithPlugin({
-    provider,
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    runtimeHandle: params.runtimeHandle,
-    allowRuntimePluginLoad: params.allowRuntimePluginLoad,
-    context: buildProviderToolSchemaContext(params, provider),
-  });
+  let diagnostics: unknown;
+  try {
+    diagnostics = inspectProviderToolSchemasWithPlugin({
+      provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      runtimeHandle: params.runtimeHandle,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
+      context: buildProviderToolSchemaContext(params, provider),
+    });
+  } catch (error) {
+    log.warn(`provider tool schema diagnostics failed for ${provider}`, {
+      provider,
+      toolCount: readToolCount(params.tools),
+      error: describeProviderHookError(error),
+    });
+    return;
+  }
   if (!Array.isArray(diagnostics)) {
     return;
   }
-  if (diagnostics.length === 0) {
+  const readableDiagnostics = readProviderToolSchemaDiagnostics(diagnostics);
+  if (readableDiagnostics.length === 0) {
     return;
   }
 
-  const summary = summarizeProviderToolSchemaDiagnostics(diagnostics);
+  const summary = summarizeProviderToolSchemaDiagnostics(readableDiagnostics);
   log.warn(
-    `provider tool schema diagnostics: ${diagnostics.length} ${diagnostics.length === 1 ? "tool" : "tools"} for ${params.provider}: ${summary}`,
+    `provider tool schema diagnostics: ${readableDiagnostics.length} ${readableDiagnostics.length === 1 ? "tool" : "tools"} for ${provider}: ${summary}`,
     {
-      provider: params.provider,
-      toolCount: params.tools.length,
-      diagnosticCount: diagnostics.length,
-      tools: params.tools.map((tool, index) => `${index}:${tool.name}`),
-      diagnostics: diagnostics.map((diagnostic) => ({
+      provider,
+      toolCount: readToolCount(params.tools),
+      diagnosticCount: readableDiagnostics.length,
+      tools: summarizeToolNames(params.tools),
+      diagnostics: readableDiagnostics.map((diagnostic) => ({
         index: diagnostic.toolIndex,
         tool: diagnostic.toolName,
         violations: diagnostic.violations.slice(0, 12),
@@ -103,7 +133,7 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
 }
 
 function summarizeProviderToolSchemaDiagnostics(
-  diagnostics: readonly ProviderToolSchemaDiagnostic[],
+  diagnostics: readonly ReadableProviderToolSchemaDiagnostic[],
 ) {
   const visible = diagnostics.slice(0, 6).map((diagnostic) => {
     const violationCount = diagnostic.violations.length;
@@ -111,4 +141,105 @@ function summarizeProviderToolSchemaDiagnostics(
   });
   const remaining = diagnostics.length - visible.length;
   return remaining > 0 ? `${visible.join(", ")}, +${remaining} more` : visible.join(", ");
+}
+
+function describeProviderHookError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function readToolCount(tools: readonly unknown[]): number {
+  try {
+    return tools.length;
+  } catch {
+    return 0;
+  }
+}
+
+function summarizeToolNames(tools: readonly AnyAgentTool[]): string[] {
+  const count = readToolCount(tools);
+  const names: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    try {
+      const name = normalizeDiagnosticText(tools[index]?.name) ?? "unknown";
+      names.push(`${index}:${name}`);
+    } catch {
+      names.push(`${index}:unknown`);
+    }
+  }
+  return names;
+}
+
+function readProviderToolSchemaDiagnostics(
+  diagnostics: readonly ProviderToolSchemaDiagnostic[],
+): ReadableProviderToolSchemaDiagnostic[] {
+  let count: number;
+  try {
+    count = diagnostics.length;
+  } catch {
+    return [{ toolName: "unknown", violations: ["diagnostics are unreadable"] }];
+  }
+  const readableDiagnostics: ReadableProviderToolSchemaDiagnostic[] = [];
+  for (let index = 0; index < count; index += 1) {
+    try {
+      readableDiagnostics.push(readProviderToolSchemaDiagnostic(diagnostics[index]));
+    } catch {
+      readableDiagnostics.push({
+        toolName: "unknown",
+        toolIndex: index,
+        violations: ["diagnostic is unreadable"],
+      });
+    }
+  }
+  return readableDiagnostics;
+}
+
+function readProviderToolSchemaDiagnostic(
+  diagnostic: ProviderToolSchemaDiagnostic,
+): ReadableProviderToolSchemaDiagnostic {
+  const readableDiagnostic: ReadableProviderToolSchemaDiagnostic = {
+    toolName: "unknown",
+    violations: ["diagnostic is unreadable"],
+  };
+  try {
+    readableDiagnostic.toolName = normalizeDiagnosticText(diagnostic.toolName) ?? "unknown";
+  } catch {
+    return readableDiagnostic;
+  }
+  try {
+    if (typeof diagnostic.toolIndex === "number" && Number.isInteger(diagnostic.toolIndex)) {
+      readableDiagnostic.toolIndex = diagnostic.toolIndex;
+    }
+  } catch {
+    // Keep the diagnostic visible even if optional metadata is hostile.
+  }
+  try {
+    if (Array.isArray(diagnostic.violations)) {
+      readableDiagnostic.violations = normalizeViolationTexts(diagnostic.violations);
+    }
+  } catch {
+    readableDiagnostic.violations = ["diagnostic is unreadable"];
+  }
+  return readableDiagnostic;
+}
+
+function normalizeViolationTexts(violations: readonly unknown[]): string[] {
+  const normalized: string[] = [];
+  for (const entry of violations) {
+    const violation = normalizeDiagnosticText(entry);
+    if (violation) {
+      normalized.push(violation);
+    }
+  }
+  return normalized.length > 0 ? normalized : ["diagnostic has no readable violations"];
+}
+
+function normalizeDiagnosticText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
 }

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -27,6 +27,7 @@ type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult
   model?: ProviderRuntimeModel;
   runtimeHandle?: ProviderRuntimePluginHandle;
   allowProviderRuntimePluginLoad?: boolean;
+  throwOnProviderToolSchemaError?: boolean;
   onPreNormalizationSchemaDiagnostics?: (
     diagnostics: readonly RuntimeToolSchemaDiagnostic[],
     tools: readonly AgentTool<TSchemaType, TResult>[],
@@ -110,6 +111,9 @@ export function normalizeAgentRuntimeTools<
       model: params.model,
       runtimeHandle: params.runtimeHandle,
       allowRuntimePluginLoad: params.allowProviderRuntimePluginLoad,
+      ...(params.throwOnProviderToolSchemaError !== undefined
+        ? { throwOnProviderToolSchemaError: params.throwOnProviderToolSchemaError }
+        : {}),
     });
   const normalizedTools = Array.isArray(normalized) ? normalized : normalizableTools;
   return preserveRuntimeToolMetadata(normalizableTools, normalizedTools);

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -182,6 +182,7 @@ export function collectActiveToolSchemaProjectionWarnings(params: {
         modelId: modelRef.model,
         modelApi: runtimeModelContext.modelApi,
         model: runtimeModelContext.model,
+        throwOnProviderToolSchemaError: true,
         onPreNormalizationSchemaDiagnostics: (diagnostics) =>
           preNormalizationDiagnostics.push(...diagnostics),
       });

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -620,6 +620,7 @@ function collectBundleMcpRuntimeToolSchemaFindings(params: {
       modelId: params.modelRef.model,
       modelApi: params.model.api,
       model: params.model,
+      throwOnProviderToolSchemaError: true,
       onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
         preNormalizationFindings.push(
           ...diagnostics.map((diagnostic) =>
@@ -714,6 +715,7 @@ function collectAgentRuntimeToolSchemaFindings(params: {
       modelId: params.modelRef.model,
       modelApi: params.model.api,
       model: params.model,
+      throwOnProviderToolSchemaError: true,
       onPreNormalizationSchemaDiagnostics: (diagnostics, sourceTools) => {
         preNormalizationFindings.push(
           ...diagnostics.map((diagnostic) =>


### PR DESCRIPTION
## Summary
- Contain provider tool-schema normalization hook failures at assistant runtime so one bad provider/plugin hook cannot crash model projection before content.
- Keep doctor/runtime health checks strict by opting them into rethrowing provider schema normalization failures.
- Normalize provider schema diagnostics before logging so malformed diagnostic entries cannot crash the warning path.

## Verification
- `CI=1 node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.test.ts src/flows/doctor-core-checks.runtime-errors.test.ts src/commands/doctor/shared/active-tool-schema-warnings.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --write src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.ts src/flows/doctor-core-checks.runtime.ts src/commands/doctor/shared/active-tool-schema-warnings.ts`
- `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/tool-schema-runtime.ts src/agents/embedded-agent-runner/tool-schema-runtime.test.ts src/agents/runtime-plan/tools.ts src/flows/doctor-core-checks.runtime.ts src/commands/doctor/shared/active-tool-schema-warnings.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_23545b82a3f6`, lease `cbx_29277eee67f0`, type `c7a.8xlarge`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed with exit 0; lanes `core`, `coreTests`; lease stopped.

## Real behavior proof
Behavior addressed: Provider-owned tool-schema normalization/diagnostic hooks can no longer crash assistant runtime projection before content, while doctor still reports normalization failures as health findings.
Real environment tested: Local Codex worktree on branch `fuzz-tool-schema-next64-20260603` at commit `3662c8cea8284ccbe35c05864419a655959a00d6`; remote AWS Crabbox changed gate `run_23545b82a3f6` / `cbx_29277eee67f0`.
Exact steps or command run after this patch: Focused Vitest command above covered runtime hook fallback, runtime-plan flag forwarding, doctor runtime errors, and active doctor warnings; AWS Crabbox ran `pnpm check:changed` remotely.
Evidence after fix: 4 focused test files passed; oxfmt, oxlint, git diff check, autoreview, and AWS Crabbox `check:changed` passed.
Observed result after fix: Runtime normalization falls back to the already-filtered tools and logs a warning; doctor call sites opt into rethrowing and keep surfacing provider/plugin schema normalization failures.
What was not tested: Live provider/tool execution against a real third-party provider plugin was not run; this lane covers the runtime boundary with focused unit tests and remote changed gates.
