### PR TITLE
fix: keep skill toggles keyed by skill identity

### DIFF
--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -106,6 +106,53 @@ describe("renderSkills", () => {
     }
   });
 
+  it("does not transfer toggle state when a skill leaves the disabled tab", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+
+    const passwordSkill = createSkill({ skillKey: "1password", name: "1Password", disabled: true });
+    const appleNotesSkill = createSkill({
+      skillKey: "apple-notes",
+      name: "Apple Notes",
+      disabled: true,
+    });
+    const report: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [passwordSkill, appleNotesSkill],
+    };
+
+    render(renderSkills(createProps({ report, statusFilter: "disabled" })), container);
+    await Promise.resolve();
+
+    const toggles = container.querySelectorAll<HTMLInputElement>(".skill-toggle");
+    expect(toggles).toHaveLength(2);
+    expect(toggles[0].checked).toBe(false);
+    expect(toggles[1].checked).toBe(false);
+
+    // Simulate the user clicking the 1password toggle before the re-render propagates.
+    // Without repeat(), Lit's dirty-check skips re-setting `.checked = false` on the reused
+    // DOM node, so apple-notes inherits this stale user-driven state.
+    toggles[0].checked = true;
+
+    const updatedReport: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [{ ...passwordSkill, disabled: false }, appleNotesSkill],
+    };
+
+    render(
+      renderSkills(createProps({ report: updatedReport, statusFilter: "disabled" })),
+      container,
+    );
+    await Promise.resolve();
+
+    const updatedToggles = container.querySelectorAll<HTMLInputElement>(".skill-toggle");
+    expect(updatedToggles).toHaveLength(1);
+    expect(updatedToggles[0].checked).toBe(false);
+  });
+
   it("defers detail dialog opening until the dialog is connected", async () => {
     const container = document.createElement("div");
     const showModal = vi.fn(function (this: HTMLDialogElement) {

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -1,6 +1,7 @@
 // Control UI view renders skills screen content.
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
@@ -308,7 +309,11 @@ export function renderSkills(props: SkillsProps) {
                       <span class="muted">${group.skills.length}</span>
                     </summary>
                     <div class="list skills-grid">
-                      ${group.skills.map((skill) => renderSkill(skill, props))}
+                      ${repeat(
+                        group.skills,
+                        (skill) => skill.skillKey,
+                        (skill) => renderSkill(skill, props),
+                      )}
                     </div>
                   </details>
                 `;


### PR DESCRIPTION
## Summary

What problem does this PR solve?
Closes issue #89661. Fixes skill toggle UI behavior by keying the UI component to the skill key.
AI-assisted.

Why does this matter now?
Current behavior is annoying and difficult to use.

What is the intended outcome?
Fix the UI bug.

What is intentionally out of scope?
Everything outside of the UI behavior.

What does success look like?
This is merged and the user experience is improved.

What should reviewers focus on?
Avoiding regression :shrug:  

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #89661 

Which issues, PRs, or discussions are related?

None

Was this requested by a maintainer or owner?

No

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: #89661 
- Real environment tested: Chrome and Firefox on Ubuntu 24.04
- Exact steps or command run after this patch: rebuilt UI with `pnpm ui:build` and tested Control dashboard
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): 
[Screencast from 2026-06-02 20-48-34.webm](https://github.com/user-attachments/assets/05112451-e446-4125-9153-946ee577d23f)

- Observed result after fix: the next skill is not affected
- What was not tested: if the skills are actually enabled/disabled
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged): 
[Screencast from 2026-06-02 20-40-59.webm](https://github.com/user-attachments/assets/300d3e29-e20a-404b-8762-859e651d2766)

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?
`pnpm test ui/src/ui/views/skills.test.ts`

What regression coverage was added or updated?
None

What failed before this fix, if known?
None

If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes

Did config, environment, or migration behavior change? (`Yes/No`)
No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No

What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
