### PR TITLE
fix(google-meet): force English Meet UI via hl=en so automation works on any locale

### DIFF
--- a/extensions/google-meet/index.create.test.ts
+++ b/extensions/google-meet/index.create.test.ts
@@ -303,7 +303,7 @@ describe("google-meet create flow", () => {
         return false;
       }
       const body = proxy.body as Record<string, unknown>;
-      return proxy.path === "/tabs/open" && body.url === "https://meet.google.com/new";
+      return proxy.path === "/tabs/open" && body.url === "https://meet.google.com/new?hl=en";
     });
   });
 
@@ -425,7 +425,9 @@ describe("google-meet create flow", () => {
               payload: {
                 result: {
                   targetId:
-                    proxy.body?.url === "https://meet.google.com/new" ? "create-tab" : "join-tab",
+                    proxy.body?.url === "https://meet.google.com/new?hl=en"
+                      ? "create-tab"
+                      : "join-tab",
                   title: "Meet",
                   url: proxy.body?.url,
                 },

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -2284,7 +2284,7 @@ describe("google-meet plugin", () => {
         method: "POST",
         path: "/tabs/open",
         timeoutMs: 30000,
-        body: { url: "https://meet.google.com/abc-defg-hij" },
+        body: { url: "https://meet.google.com/abc-defg-hij?hl=en" },
       });
       expect(openCall[3]).toEqual({ progress: false });
       expect(
@@ -3095,7 +3095,7 @@ describe("google-meet plugin", () => {
       method: "POST",
       path: "/tabs/open",
       timeoutMs: 30000,
-      body: { url: "https://meet.google.com/abc-defg-hij" },
+      body: { url: "https://meet.google.com/abc-defg-hij?hl=en" },
     });
     const startCall = nodesInvoke.mock.calls.find(([rawCall]) => {
       const call = requireRecord(rawCall, "node invoke");
@@ -4089,7 +4089,7 @@ describe("google-meet plugin", () => {
       const request = requireRecord(params, "local browser open request");
       expect(request.method).toBe("POST");
       expect(request.path).toBe("/tabs/open");
-      expect(request.body).toStrictEqual({ url: "https://meet.google.com/abc-defg-hij" });
+      expect(request.body).toStrictEqual({ url: "https://meet.google.com/abc-defg-hij?hl=en" });
       expect(extra).toStrictEqual({ progress: false });
     } finally {
       Object.defineProperty(process, "platform", { value: originalPlatform });

--- a/extensions/google-meet/src/transports/chrome-browser-proxy.test.ts
+++ b/extensions/google-meet/src/transports/chrome-browser-proxy.test.ts
@@ -1,7 +1,24 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { callBrowserProxyOnNode } from "./chrome-browser-proxy.js";
+import { callBrowserProxyOnNode, forceMeetEnglishUi } from "./chrome-browser-proxy.js";
+
+describe("forceMeetEnglishUi", () => {
+  it("pins hl=en on Meet URLs", () => {
+    expect(forceMeetEnglishUi("https://meet.google.com/abc-defg-hij")).toBe(
+      "https://meet.google.com/abc-defg-hij?hl=en",
+    );
+    expect(forceMeetEnglishUi("https://meet.google.com/new")).toBe(
+      "https://meet.google.com/new?hl=en",
+    );
+  });
+
+  it("overrides an existing hl and keeps other params", () => {
+    expect(forceMeetEnglishUi("https://meet.google.com/abc-defg-hij?hl=zh-TW&authuser=1")).toBe(
+      "https://meet.google.com/abc-defg-hij?hl=en&authuser=1",
+    );
+  });
+});
 
 describe("Google Meet Chrome browser proxy", () => {
   it("reports malformed node proxy payloadJSON with an owned error", async () => {

--- a/extensions/google-meet/src/transports/chrome-browser-proxy.ts
+++ b/extensions/google-meet/src/transports/chrome-browser-proxy.ts
@@ -11,6 +11,19 @@ export type BrowserTab = {
   url?: string;
 };
 
+// Meet automation scripts match English UI labels ("Join now", "Turn off microphone").
+// hl=en pins the Meet page language regardless of account/browser locale; without it,
+// non-English profiles render localized labels and every DOM matcher goes blind.
+export function forceMeetEnglishUi(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set("hl", "en");
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 export function normalizeMeetUrlForReuse(url: string | undefined): string | undefined {
   if (!url) {
     return undefined;

--- a/extensions/google-meet/src/transports/chrome-create.ts
+++ b/extensions/google-meet/src/transports/chrome-create.ts
@@ -4,6 +4,7 @@ import type { GoogleMeetConfig } from "../config.js";
 import {
   asBrowserTabs,
   callBrowserProxyOnNode,
+  forceMeetEnglishUi,
   readBrowserTab,
   resolveChromeNode,
   type BrowserTab,
@@ -198,7 +199,9 @@ export const CREATE_MEET_FROM_BROWSER_SCRIPT = `async () => {
   }
   const href = current();
   if (meetUrlPattern.test(href)) {
-    return { meetingUri: href, browserUrl: href, browserTitle: document.title, notes };
+    // The /new redirect keeps the hl=en param we open with; strip query/hash so the
+    // meeting link handed to users stays canonical instead of forcing English on them.
+    return { meetingUri: href.split(/[?#]/)[0], browserUrl: href, browserTitle: document.title, notes };
   }
   const pageText = text(document.body);
   if (clickButton(/\\buse microphone\\b/i, "Accepted Meet microphone prompt with browser automation.")) {
@@ -287,7 +290,7 @@ export async function createMeetWithBrowserProxyOnNode(params: {
         nodeId,
         method: "POST",
         path: "/tabs/open",
-        body: { url: GOOGLE_MEET_NEW_URL },
+        body: { url: forceMeetEnglishUi(GOOGLE_MEET_NEW_URL) },
         timeoutMs: stepTimeoutMs,
       }),
     );

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -416,11 +416,11 @@ function meetStatusScript(params: {
   const host = location.hostname.toLowerCase();
   const pageUrl = location.href;
   const permissionNeeded = /permission needed|microphone problem|speaker problem|allow.*(microphone|camera)|blocked.*(microphone|camera)|permission.*(microphone|camera|speaker)/i.test(permissionText);
-  let mic = findCallControlButton(/^\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i);
+  let mic = findCallControlButton(/^\\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i);
   if (!mic) {
     const callControls = document.querySelector('[role="region"][aria-label="Call controls"]');
     mic = [...(callControls?.querySelectorAll('button') || [])].find((button) =>
-      /^\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i.test(buttonLabel(button))
+      /^\\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i.test(buttonLabel(button))
     );
   }
   if (!readOnly && allowMicrophone && mic && /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic))) {

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -416,11 +416,11 @@ function meetStatusScript(params: {
   const host = location.hostname.toLowerCase();
   const pageUrl = location.href;
   const permissionNeeded = /permission needed|microphone problem|speaker problem|allow.*(microphone|camera)|blocked.*(microphone|camera)|permission.*(microphone|camera|speaker)/i.test(permissionText);
-  let mic = findCallControlButton(/^\\s*(?:turn (?:off|on) microphone|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ)|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b/i);
+  let mic = findCallControlButton(/^\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i);
   if (!mic) {
     const callControls = document.querySelector('[role="region"][aria-label="Call controls"]');
     mic = [...(callControls?.querySelectorAll('button') || [])].find((button) =>
-      /^\\s*(?:turn (?:off|on) microphone|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ)|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b/i.test(buttonLabel(button))
+      /^\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i.test(buttonLabel(button))
     );
   }
   if (!readOnly && allowMicrophone && mic && /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic))) {

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -403,7 +403,7 @@ function meetStatusScript(params: {
       return pattern.test(label) && !/remotely mute|someone else/i.test(label) && !button.disabled;
     });
   const input = [...document.querySelectorAll('input')].find((el) =>
-    /your name/i.test(el.getAttribute('aria-label') || el.placeholder || '')
+    /your name|您的姓名|姓名|nombre|nom|name/i.test(el.getAttribute('aria-label') || el.placeholder || '')
   );
   if (!readOnly && ${JSON.stringify(params.autoJoin)} && input && !input.value) {
     input.focus();
@@ -416,27 +416,27 @@ function meetStatusScript(params: {
   const host = location.hostname.toLowerCase();
   const pageUrl = location.href;
   const permissionNeeded = /permission needed|microphone problem|speaker problem|allow.*(microphone|camera)|blocked.*(microphone|camera)|permission.*(microphone|camera|speaker)/i.test(permissionText);
-  let mic = findCallControlButton(/^\\s*turn (?:off|on) microphone\\b/i);
+  let mic = findCallControlButton(/^\\s*(?:turn (?:off|on) microphone|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ)|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b/i);
   if (!mic) {
     const callControls = document.querySelector('[role="region"][aria-label="Call controls"]');
     mic = [...(callControls?.querySelectorAll('button') || [])].find((button) =>
-      /^\\s*turn (?:off|on) microphone\\b/i.test(buttonLabel(button))
+      /^\\s*(?:turn (?:off|on) microphone|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ)|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b/i.test(buttonLabel(button))
     );
   }
-  if (!readOnly && allowMicrophone && mic && /turn on microphone/i.test(buttonLabel(mic))) {
+  if (!readOnly && allowMicrophone && mic && /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic))) {
     mic.click();
     notes.push("Attempted to turn on the Meet microphone for talk-back mode.");
   }
-  if (!readOnly && !allowMicrophone && mic && /turn off microphone/i.test(mic.getAttribute('aria-label') || text(mic))) {
+  if (!readOnly && !allowMicrophone && mic && /(?:turn off microphone|關閉麥克風|关闭麦克风|マイクをオフ|desactivar micrófono|désactiver le micro|mikrofon ausschalten)/i.test(mic.getAttribute('aria-label') || text(mic))) {
     mic.click();
     notes.push("Muted Meet microphone for observe-only mode.");
   }
   const join = !readOnly && ${JSON.stringify(params.autoJoin)}
-    ? findButton(/join now|ask to join/i)
+    ? findButton(/join now|ask to join|立即加入|要求加入|申請加入|申请加入|同时在?此处加入|同時在?這裡加入|Join here too|今すぐ参加|参加をリクエスト|こちらからも参加|unirse|solicitar unirse|rejoindre|participer|demander à participer|jetzt teilnehmen|teilnahme erbitten/i) || buttons.find(b => b.getAttribute('jsname') === 'Qx7uuf')
     : null;
   if (join) join.click();
-  const microphoneChoice = findButton(/\\buse microphone\\b/i);
-  const noMicrophoneChoice = findButton(/\\b(continue|join|use) without (microphone|mic)\\b|\\bnot now\\b/i);
+  const microphoneChoice = findButton(/\\buse microphone\\b|使用麥克風|使用麦克风|マイクを使用|usar micrófono|utiliser le micro|mikrofon verwenden/i);
+  const noMicrophoneChoice = findButton(/\\b(continue|join|use) without (microphone|mic)\\b|\\bnot now\\b|不使用麥克風直接加入|不開啟麥克風直接加入|不使用麦克风直接加入|不开启麦克风直接加入|マイクなしで参加|unirse sin micrófono|continuer sans micro|ohne mikrofon teilnehmen/i);
   if (!readOnly && allowMicrophone && microphoneChoice) {
     microphoneChoice.click();
     notes.push("Accepted Meet microphone prompt with browser automation.");
@@ -444,7 +444,7 @@ function meetStatusScript(params: {
     noMicrophoneChoice.click();
     notes.push("Skipped Meet microphone prompt for observe-only mode.");
   }
-  const inCall = buttons.some((button) => /leave call/i.test(button.getAttribute('aria-label') || text(button)));
+  const inCall = buttons.some((button) => /(?:leave call|離開|結束|结束|退出|hang up|salir|quitter|verlassen)/i.test(button.getAttribute('aria-label') || text(button)) || button.getAttribute('jsname') === 'HeV7id');
   const routeMeetAudioOutput = async () => {
     if (
       !allowMicrophone ||
@@ -501,7 +501,7 @@ function meetStatusScript(params: {
   let lastCaptionSpeaker;
   let lastCaptionText;
   let recentTranscript = [];
-  const captionSelector = '[role="region"][aria-label*="aption" i], [aria-live="polite"][role="region"], div[aria-live="polite"]';
+  const captionSelector = '[role="region"][aria-label*="aption" i], [role="region"][aria-label*="字幕" i], [role="region"][aria-label*="cc" i], [aria-live="polite"][role="region"], div[aria-live="polite"]';
   const captionState = (() => {
     if (!captureCaptions) return undefined;
     const w = window;
@@ -521,7 +521,7 @@ function meetStatusScript(params: {
     const clean = String(captionText || "").replace(/\\s+/g, " ").trim();
     const cleanSpeaker = String(speaker || "").replace(/\\s+/g, " ").trim();
     if (!clean || clean.length < 2) return;
-    if (/^(turn on captions|turn off captions|captions)$/i.test(clean)) return;
+    if (/^(turn on captions|turn off captions|captions|開啟字幕|开启字幕|字幕をオン|字幕をオフ|關閉字幕|关闭字幕|activar subtítulos|desactivar subtítulos|activer les sous-titres|désactiver les sous-titres|untertitel einschalten|untertitel ausschalten)$/i.test(clean)) return;
     const key = (cleanSpeaker + "\\n" + clean).toLowerCase();
     if (captionState.seen[key]) return;
     captionState.seen[key] = true;
@@ -545,12 +545,12 @@ function meetStatusScript(params: {
   };
   if (captionState) {
     if (!readOnly && inCall && !captionState.enabledAttempted) {
-      const captionButton = findButton(/turn on captions|show captions|captions/i);
+      const captionButton = findButton(/turn on captions|show captions|captions|開啟字幕|开启字幕|字幕をオン|activar subtítulos|activer les sous-titres|untertitel einschalten/i);
       const captionLabel = captionButton ? (captionButton.getAttribute("aria-label") || captionButton.getAttribute("data-tooltip") || text(captionButton)) : "";
       if (captionButton) {
         captionState.enabledAttempted = true;
         captionsEnabledAttempted = true;
-        if (!/turn off captions|hide captions/i.test(captionLabel)) {
+        if (!/turn off captions|hide captions|關閉字幕|关闭字幕|字幕をオフ|desactivar subtítulos|désactiver les sous-titres|untertitel ausschalten/i.test(captionLabel)) {
           captionButton.click();
           notes.push("Attempted to enable Meet captions for observe-only transcript health.");
         }
@@ -579,16 +579,16 @@ function meetStatusScript(params: {
     lastCaptionText = last?.text;
     recentTranscript = lines.slice(-5);
   }
-  const lobbyWaiting = !inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join/i.test(pageText);
-  const leaveReason = /you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended/i.test(pageText)
-    ? pageText.match(/you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended/i)?.[0]
+  const lobbyWaiting = !inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join|等待對方同意|等待主辦人同意|要求加入|等待批准|等待接纳|参加のリクエスト中|esperando|en attente|teilnahme angefragt/i.test(pageText);
+  const leaveReason = /you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended|你已離開這場會議|通話已結束|會議已結束|你已离开这场会议|会議から退出しました|has salido|vous avez quitté|sie haben die besprechung verlassen/i.test(pageText)
+    ? pageText.match(/you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended|你已離開這場會議|通話已結束|會議已結束|你已离开这场会议|会議から退出しました|has salido|vous avez quitté|sie haben die besprechung verlassen/i)?.[0]
     : undefined;
   let manualActionReason;
   let manualActionMessage;
-  if (!inCall && (host === "accounts.google.com" || /use your google account|to continue to google meet|choose an account|sign in to (join|continue)/i.test(pageText))) {
+  if (!inCall && (host === "accounts.google.com" || /use your google account|to continue to google meet|choose an account|sign in to (join|continue)|使用您的 Google 帳戶|選擇帳戶|登入|使用您的 Google 帐户|选择帐户|登录|ログイン|iniciar sesión|se connecter|anmelden/i.test(pageText))) {
     manualActionReason = "google-login-required";
     manualActionMessage = "Sign in to Google in the OpenClaw browser profile, then retry the Meet join.";
-  } else if (!inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join/i.test(pageText)) {
+  } else if (!inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join|等待對方同意|等待主辦人同意|要求加入|等待批准|等待接纳|参加のリクエスト中|esperando|en attente|teilnahme angefragt/i.test(pageText)) {
     manualActionReason = "meet-admission-required";
     manualActionMessage = "Admit the OpenClaw browser participant in Google Meet, then retry speech.";
   } else if (permissionNeeded) {
@@ -596,7 +596,7 @@ function meetStatusScript(params: {
     manualActionMessage = allowMicrophone
       ? "Allow microphone/camera/speaker permissions for Meet in the OpenClaw browser profile, then retry."
       : "Join without microphone/camera permissions in the OpenClaw browser profile, then retry.";
-  } else if (!inCall && (allowMicrophone ? !microphoneChoice : !noMicrophoneChoice) && /do you want people to hear you in the meeting/i.test(pageText)) {
+  } else if (!inCall && (allowMicrophone ? !microphoneChoice : !noMicrophoneChoice) && /do you want people to hear you in the meeting|你希望大家在會議中聽到你的聲音嗎|在会议中听到你的声音吗/i.test(pageText)) {
     manualActionReason = "meet-audio-choice-required";
     manualActionMessage = allowMicrophone
       ? "Meet is showing the microphone choice. Click Use microphone in the OpenClaw browser profile, then retry."
@@ -606,7 +606,7 @@ function meetStatusScript(params: {
     clickedJoin: Boolean(join),
     clickedMicrophoneChoice: Boolean(allowMicrophone && microphoneChoice),
     inCall,
-    micMuted: mic ? /turn on microphone/i.test(buttonLabel(mic)) : undefined,
+    micMuted: mic ? /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic)) : undefined,
     lobbyWaiting,
     leaveReason,
     captioning,

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -1,3 +1,4 @@
+// Google Meet plugin module implements chrome behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
@@ -22,6 +23,7 @@ import {
 import {
   asBrowserTabs,
   callBrowserProxyOnNode,
+  forceMeetEnglishUi,
   isSameMeetUrlForReuse,
   normalizeMeetUrlForReuse,
   readBrowserTab,
@@ -403,7 +405,7 @@ function meetStatusScript(params: {
       return pattern.test(label) && !/remotely mute|someone else/i.test(label) && !button.disabled;
     });
   const input = [...document.querySelectorAll('input')].find((el) =>
-    /your name|您的姓名|姓名|nombre|nom|name/i.test(el.getAttribute('aria-label') || el.placeholder || '')
+    /your name/i.test(el.getAttribute('aria-label') || el.placeholder || '')
   );
   if (!readOnly && ${JSON.stringify(params.autoJoin)} && input && !input.value) {
     input.focus();
@@ -416,27 +418,27 @@ function meetStatusScript(params: {
   const host = location.hostname.toLowerCase();
   const pageUrl = location.href;
   const permissionNeeded = /permission needed|microphone problem|speaker problem|allow.*(microphone|camera)|blocked.*(microphone|camera)|permission.*(microphone|camera|speaker)/i.test(permissionText);
-  let mic = findCallControlButton(/^\\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i);
+  let mic = findCallControlButton(/^\\s*turn (?:off|on) microphone\\b/i);
   if (!mic) {
     const callControls = document.querySelector('[role="region"][aria-label="Call controls"]');
     mic = [...(callControls?.querySelectorAll('button') || [])].find((button) =>
-      /^\\s*(?:(?:turn (?:off|on) microphone|(?:activar|desactivar) micrófono|(?:activer|désactiver) le micro|mikrofon (?:einschalten|ausschalten))\\b|關閉麥克風|開啟麥克風|关闭麦克风|开启麦克风|マイクを(?:オン|オフ))/i.test(buttonLabel(button))
+      /^\\s*turn (?:off|on) microphone\\b/i.test(buttonLabel(button))
     );
   }
-  if (!readOnly && allowMicrophone && mic && /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic))) {
+  if (!readOnly && allowMicrophone && mic && /turn on microphone/i.test(buttonLabel(mic))) {
     mic.click();
     notes.push("Attempted to turn on the Meet microphone for talk-back mode.");
   }
-  if (!readOnly && !allowMicrophone && mic && /(?:turn off microphone|關閉麥克風|关闭麦克风|マイクをオフ|desactivar micrófono|désactiver le micro|mikrofon ausschalten)/i.test(mic.getAttribute('aria-label') || text(mic))) {
+  if (!readOnly && !allowMicrophone && mic && /turn off microphone/i.test(mic.getAttribute('aria-label') || text(mic))) {
     mic.click();
     notes.push("Muted Meet microphone for observe-only mode.");
   }
   const join = !readOnly && ${JSON.stringify(params.autoJoin)}
-    ? findButton(/join now|ask to join|立即加入|要求加入|申請加入|申请加入|同时在?此处加入|同時在?這裡加入|Join here too|今すぐ参加|参加をリクエスト|こちらからも参加|unirse|solicitar unirse|rejoindre|participer|demander à participer|jetzt teilnehmen|teilnahme erbitten/i) || buttons.find(b => b.getAttribute('jsname') === 'Qx7uuf')
+    ? findButton(/join now|ask to join|join here too/i)
     : null;
   if (join) join.click();
-  const microphoneChoice = findButton(/\\buse microphone\\b|使用麥克風|使用麦克风|マイクを使用|usar micrófono|utiliser le micro|mikrofon verwenden/i);
-  const noMicrophoneChoice = findButton(/\\b(continue|join|use) without (microphone|mic)\\b|\\bnot now\\b|不使用麥克風直接加入|不開啟麥克風直接加入|不使用麦克风直接加入|不开启麦克风直接加入|マイクなしで参加|unirse sin micrófono|continuer sans micro|ohne mikrofon teilnehmen/i);
+  const microphoneChoice = findButton(/\\buse microphone\\b/i);
+  const noMicrophoneChoice = findButton(/\\b(continue|join|use) without (microphone|mic)\\b|\\bnot now\\b/i);
   if (!readOnly && allowMicrophone && microphoneChoice) {
     microphoneChoice.click();
     notes.push("Accepted Meet microphone prompt with browser automation.");
@@ -444,7 +446,7 @@ function meetStatusScript(params: {
     noMicrophoneChoice.click();
     notes.push("Skipped Meet microphone prompt for observe-only mode.");
   }
-  const inCall = buttons.some((button) => /(?:leave call|離開|結束|结束|退出|hang up|salir|quitter|verlassen)/i.test(button.getAttribute('aria-label') || text(button)) || button.getAttribute('jsname') === 'HeV7id');
+  const inCall = buttons.some((button) => /leave call/i.test(button.getAttribute('aria-label') || text(button)));
   const routeMeetAudioOutput = async () => {
     if (
       !allowMicrophone ||
@@ -501,7 +503,7 @@ function meetStatusScript(params: {
   let lastCaptionSpeaker;
   let lastCaptionText;
   let recentTranscript = [];
-  const captionSelector = '[role="region"][aria-label*="aption" i], [role="region"][aria-label*="字幕" i], [role="region"][aria-label*="cc" i], [aria-live="polite"][role="region"], div[aria-live="polite"]';
+  const captionSelector = '[role="region"][aria-label*="aption" i], [aria-live="polite"][role="region"], div[aria-live="polite"]';
   const captionState = (() => {
     if (!captureCaptions) return undefined;
     const w = window;
@@ -521,7 +523,7 @@ function meetStatusScript(params: {
     const clean = String(captionText || "").replace(/\\s+/g, " ").trim();
     const cleanSpeaker = String(speaker || "").replace(/\\s+/g, " ").trim();
     if (!clean || clean.length < 2) return;
-    if (/^(turn on captions|turn off captions|captions|開啟字幕|开启字幕|字幕をオン|字幕をオフ|關閉字幕|关闭字幕|activar subtítulos|desactivar subtítulos|activer les sous-titres|désactiver les sous-titres|untertitel einschalten|untertitel ausschalten)$/i.test(clean)) return;
+    if (/^(turn on captions|turn off captions|captions)$/i.test(clean)) return;
     const key = (cleanSpeaker + "\\n" + clean).toLowerCase();
     if (captionState.seen[key]) return;
     captionState.seen[key] = true;
@@ -545,12 +547,12 @@ function meetStatusScript(params: {
   };
   if (captionState) {
     if (!readOnly && inCall && !captionState.enabledAttempted) {
-      const captionButton = findButton(/turn on captions|show captions|captions|開啟字幕|开启字幕|字幕をオン|activar subtítulos|activer les sous-titres|untertitel einschalten/i);
+      const captionButton = findButton(/turn on captions|show captions|captions/i);
       const captionLabel = captionButton ? (captionButton.getAttribute("aria-label") || captionButton.getAttribute("data-tooltip") || text(captionButton)) : "";
       if (captionButton) {
         captionState.enabledAttempted = true;
         captionsEnabledAttempted = true;
-        if (!/turn off captions|hide captions|關閉字幕|关闭字幕|字幕をオフ|desactivar subtítulos|désactiver les sous-titres|untertitel ausschalten/i.test(captionLabel)) {
+        if (!/turn off captions|hide captions/i.test(captionLabel)) {
           captionButton.click();
           notes.push("Attempted to enable Meet captions for observe-only transcript health.");
         }
@@ -579,16 +581,16 @@ function meetStatusScript(params: {
     lastCaptionText = last?.text;
     recentTranscript = lines.slice(-5);
   }
-  const lobbyWaiting = !inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join|等待對方同意|等待主辦人同意|要求加入|等待批准|等待接纳|参加のリクエスト中|esperando|en attente|teilnahme angefragt/i.test(pageText);
-  const leaveReason = /you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended|你已離開這場會議|通話已結束|會議已結束|你已离开这场会议|会議から退出しました|has salido|vous avez quitté|sie haben die besprechung verlassen/i.test(pageText)
-    ? pageText.match(/you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended|你已離開這場會議|通話已結束|會議已結束|你已离开这场会议|会議から退出しました|has salido|vous avez quitté|sie haben die besprechung verlassen/i)?.[0]
+  const lobbyWaiting = !inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join/i.test(pageText);
+  const leaveReason = /you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended/i.test(pageText)
+    ? pageText.match(/you left the meeting|you.?ve left the meeting|removed from the meeting|you were removed|call ended|meeting ended/i)?.[0]
     : undefined;
   let manualActionReason;
   let manualActionMessage;
-  if (!inCall && (host === "accounts.google.com" || /use your google account|to continue to google meet|choose an account|sign in to (join|continue)|使用您的 Google 帳戶|選擇帳戶|登入|使用您的 Google 帐户|选择帐户|登录|ログイン|iniciar sesión|se connecter|anmelden/i.test(pageText))) {
+  if (!inCall && (host === "accounts.google.com" || /use your google account|to continue to google meet|choose an account|sign in to (join|continue)/i.test(pageText))) {
     manualActionReason = "google-login-required";
     manualActionMessage = "Sign in to Google in the OpenClaw browser profile, then retry the Meet join.";
-  } else if (!inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join|等待對方同意|等待主辦人同意|要求加入|等待批准|等待接纳|参加のリクエスト中|esperando|en attente|teilnahme angefragt/i.test(pageText)) {
+  } else if (!inCall && /asking to be let in|you.?ll join when someone lets you in|waiting to be let in|ask to join/i.test(pageText)) {
     manualActionReason = "meet-admission-required";
     manualActionMessage = "Admit the OpenClaw browser participant in Google Meet, then retry speech.";
   } else if (permissionNeeded) {
@@ -596,7 +598,7 @@ function meetStatusScript(params: {
     manualActionMessage = allowMicrophone
       ? "Allow microphone/camera/speaker permissions for Meet in the OpenClaw browser profile, then retry."
       : "Join without microphone/camera permissions in the OpenClaw browser profile, then retry.";
-  } else if (!inCall && (allowMicrophone ? !microphoneChoice : !noMicrophoneChoice) && /do you want people to hear you in the meeting|你希望大家在會議中聽到你的聲音嗎|在会议中听到你的声音吗/i.test(pageText)) {
+  } else if (!inCall && (allowMicrophone ? !microphoneChoice : !noMicrophoneChoice) && /do you want people to hear you in the meeting/i.test(pageText)) {
     manualActionReason = "meet-audio-choice-required";
     manualActionMessage = allowMicrophone
       ? "Meet is showing the microphone choice. Click Use microphone in the OpenClaw browser profile, then retry."
@@ -606,7 +608,7 @@ function meetStatusScript(params: {
     clickedJoin: Boolean(join),
     clickedMicrophoneChoice: Boolean(allowMicrophone && microphoneChoice),
     inCall,
-    micMuted: mic ? /(?:turn on microphone|開啟麥克風|开启麦克风|マイクをオン|activar micrófono|activer le micro|mikrofon einschalten)/i.test(buttonLabel(mic)) : undefined,
+    micMuted: mic ? /turn on microphone/i.test(buttonLabel(mic)) : undefined,
     lobbyWaiting,
     leaveReason,
     captioning,
@@ -689,7 +691,7 @@ async function openMeetWithBrowserRequest(params: {
       await params.callBrowser({
         method: "POST",
         path: "/tabs/open",
-        body: { url: params.url },
+        body: { url: forceMeetEnglishUi(params.url) },
         timeoutMs,
       }),
     );

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -1,8 +1,7 @@
 // Intentional Knip unused-file findings. These are dynamic entrypoints,
 // generated/build inputs, manifest-discovered plugin surfaces, live-test
 // helpers, or package bridge files that static production scanning cannot see.
-export const KNIP_UNUSED_FILE_ALLOWLIST = [
-];
+export const KNIP_UNUSED_FILE_ALLOWLIST = [];
 
 // Knip can disagree across supported local/CI platforms for files that are
 // only reachable through test-only import graphs, sparse-checkout proof
@@ -45,4 +44,9 @@ export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
   "ui/src/ui/browser-redact.ts",
   "extensions/qa-lab/src/auth-profile.fixture.ts",
   "extensions/qa-lab/src/codex-plugin.fixture.ts",
+  "src/agents/cache/agent-cache-store.sqlite.ts",
+  "src/agents/cache/agent-cache-store.ts",
+  "src/state/openclaw-agent-db.paths.ts",
+  "src/state/openclaw-agent-db.ts",
+  "src/state/openclaw-agent-schema.generated.ts",
 ];

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -1,7 +1,8 @@
 // Intentional Knip unused-file findings. These are dynamic entrypoints,
 // generated/build inputs, manifest-discovered plugin surfaces, live-test
 // helpers, or package bridge files that static production scanning cannot see.
-export const KNIP_UNUSED_FILE_ALLOWLIST = [];
+export const KNIP_UNUSED_FILE_ALLOWLIST = [
+];
 
 // Knip can disagree across supported local/CI platforms for files that are
 // only reachable through test-only import graphs, sparse-checkout proof

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -44,9 +44,4 @@ export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
   "ui/src/ui/browser-redact.ts",
   "extensions/qa-lab/src/auth-profile.fixture.ts",
   "extensions/qa-lab/src/codex-plugin.fixture.ts",
-  "src/agents/cache/agent-cache-store.sqlite.ts",
-  "src/agents/cache/agent-cache-store.ts",
-  "src/state/openclaw-agent-db.paths.ts",
-  "src/state/openclaw-agent-db.ts",
-  "src/state/openclaw-agent-schema.generated.ts",
 ];


### PR DESCRIPTION
## What Problem This Solves

The Google Meet browser automation script matches English UI labels (`join now|ask to join`, `leave call`, `turn (off|on) microphone`, `your name`, caption selectors). When the browser profile or Google account uses another language (e.g. Traditional Chinese), every DOM matcher goes blind: the bot cannot click join, detect in-call state, mute/unmute, or enable captions.

## Why This Change Was Made

An earlier revision of this PR translated ~15 regex literals into 6 hand-picked languages. Review showed that approach is fragile (unanchored alternates like `unirse`, `退出`, `登入`, and bare `name` false-positive on unrelated buttons/inputs; `activar micrófono` is a substring of `Desactivar micrófono`, inverting mute detection) and still one-sided (`chrome-create.ts` untouched, all other locales still broken).

This revision fixes it at one seam instead: append `hl=en` (Google's standard UI-language parameter) to every Meet URL the plugin opens, so the Meet page always renders English labels and the existing matchers work for **all** locales — join and create flows both.

- `forceMeetEnglishUi()` in `chrome-browser-proxy.ts`, applied at both `/tabs/open` call sites (`chrome.ts` join flow, `chrome-create.ts` create flow).
- The created meeting link returned to users is stripped of query/hash so nobody is handed a `?hl=en` link.
- The join regex additionally matches the `Join here too` button (the "Switch here?" dialog shown when the same account is already in the meeting on another device — the scenario from the original repro).
- Session/tab-reuse matching is unaffected: `normalizeMeetUrlForReuse` compares by pathname only.

Known limitation: a pre-existing Meet tab the user opened manually in a non-English locale is reused as-is (focus only, no navigation) — same behavior as before this PR; tabs opened by the plugin always carry `hl=en`.

## User Impact

Meet join, talk-back, transcription, and meeting creation work on any account/browser locale. The automated Meet tab renders in English (visible if the browser window is watched); shared meeting links stay canonical.

## Evidence

Live-verified over CDP against a signed-in **zh-TW** Edge profile (Arch Linux, Edg 147):

- `https://meet.google.com/landing` → `lang="zh-TW"`, buttons `發起會議`/`加入`; `https://meet.google.com/landing?hl=en` → `lang="en"`, buttons `New meeting`/`Join`.
- Real meeting pre-join `https://meet.google.com/qeo-ngsk-cqw?hl=en` → `lang="en"`, `Join now`, `Use Companion mode` (without `hl=en`: `立即加入`).
- `https://meet.google.com/new?hl=en` → redirect lands on `https://meet.google.com/yyr-vogp-vft?hl=en` (param preserved), in-call UI English: `Turn off microphone`, `Share screen`.

Second locale, live-verified over CDP against a signed-out **Japanese** Chromium 148 (`--lang=ja --accept-lang=ja-JP,ja`, fresh profile):

- `https://meet.google.com/qeo-ngsk-cqw` → `lang="ja"`, buttons `ホーム画面に戻る`, `マイクとカメラを使用せずに続行`; same URL with `?hl=en` → `lang="en"`, `Return to home screen`, `Continue without microphone and camera` (the exact mic-choice label the automation matches). This also covers the signed-out/guest path, complementing the signed-in zh-TW run.

Local validation: `pnpm test extensions/google-meet` → 10 files, 168 tests passed (includes new `forceMeetEnglishUi` unit tests and updated `/tabs/open` URL assertions); `pnpm tsgo:extensions` and `pnpm tsgo:test:extensions` clean; oxlint/oxfmt clean.

Not tested: other locales beyond zh-TW (signed-in) and ja (guest) — the fix is locale-independent by construction since the page always renders English.

