### PR TITLE
fix(ui/skills): prevent skill toggle state transfer on list mutation (#89661)

### DIFF
--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -415,6 +415,60 @@ describe("renderSkills", () => {
     expect(chips.some((chip) => normalizeText(chip) === "Clean")).toBe(false);
     expect(verdictChip?.classList.contains("chip-ok")).toBe(false);
   });
+
+  it("does not transfer toggle UI state when a skill is removed from the list", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+
+    const skillA = createSkill({ skillKey: "skill-a", name: "Skill A", disabled: true });
+    const skillB = createSkill({ skillKey: "skill-b", name: "Skill B", disabled: true });
+
+    const report: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [skillA, skillB],
+    };
+
+    // Render with both skills in the disabled tab
+    render(
+      renderSkills(
+        createProps({
+          report,
+          statusFilter: "disabled",
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    let toggles = container.querySelectorAll<HTMLInputElement>(".skill-toggle");
+    expect(toggles.length).toBe(2);
+    expect(toggles[0]!.checked).toBe(false);
+    expect(toggles[1]!.checked).toBe(false);
+
+    // Simulate skill-a being enabled (removed from disabled tab)
+    const updatedReport: SkillStatusReport = {
+      ...report,
+      skills: [{ ...skillA, disabled: false }, skillB],
+    };
+
+    render(
+      renderSkills(
+        createProps({
+          report: updatedReport,
+          statusFilter: "disabled",
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    toggles = container.querySelectorAll<HTMLInputElement>(".skill-toggle");
+    expect(toggles.length).toBe(1);
+    // The remaining skill-b should still be unchecked (disabled)
+    expect(toggles[0]!.checked).toBe(false);
+  });
 });
 
 function installDialogMethod(

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
@@ -307,7 +308,11 @@ export function renderSkills(props: SkillsProps) {
                       <span class="muted">${group.skills.length}</span>
                     </summary>
                     <div class="list skills-grid">
-                      ${group.skills.map((skill) => renderSkill(skill, props))}
+                      ${repeat(
+                        group.skills,
+                        (skill) => skill.skillKey,
+                        (skill) => renderSkill(skill, props),
+                      )}
                     </div>
                   </details>
                 `;


### PR DESCRIPTION
## Summary

Fixes #89661.

When a skill toggle was flipped and the skill moved to another tab (e.g., from Disabled to Ready), the checkbox UI state was incorrectly transferred to the next skill in the list. This happened because the skill list in `renderSkills` used a plain `.map()` without keys, causing lit-html to reuse DOM nodes by position rather than by identity.

## Changes

- `ui/src/ui/views/skills.ts`: Replaced plain `.map()` with lit's `repeat` directive, using `skill.skillKey` as the unique key. This ensures each skill gets its own stable DOM node, preventing state leakage between list items.
- `ui/src/ui/views/skills.test.ts`: Added a regression test that renders two disabled skills, simulates one being enabled (removed from the disabled tab), and asserts that the remaining skill's toggle stays unchecked.

## Verification

- `pnpm test ui/src/ui/views/skills.test.ts` — all 5 tests pass (including the new regression test).
