### PR TITLE
fix(agents): reclaim session write-locks held past the holder's own maxHoldMs

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -98,8 +98,11 @@ Transcript mutations use a session write lock on the transcript file. Lock acqui
 `session.writeLock.acquireTimeoutMs` before surfacing a busy-session error; the default is `60000`
 ms. Raise this only when legitimate prep, cleanup, compaction, or transcript mirror work contends
 longer on slow machines. `session.writeLock.staleMs` controls when an existing lock can be
-reclaimed as stale; the default is `1800000` ms. `session.writeLock.maxHoldMs` controls the
-in-process watchdog release threshold; the default is `300000` ms. Emergency env overrides are
+reclaimed as stale; the default is `1800000` ms. `session.writeLock.maxHoldMs` is the hard hold
+limit: the holder's own in-process watchdog releases the lock at this threshold, and a contending
+writer may also reclaim a lock held past this deadline (when the lock file is unchanged) so a
+wedged holder whose watchdog cannot fire does not pin the session; the default is `300000` ms.
+Emergency env overrides are
 `OPENCLAW_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS`, `OPENCLAW_SESSION_WRITE_LOCK_STALE_MS`, and
 `OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS`.
 

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -467,6 +467,34 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("reclaims a live OpenClaw-owned lock that exceeded its own maxHoldMs", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {
+        stdio: "ignore",
+      });
+      if (!owner.pid) {
+        throw new Error("missing lock owner pid");
+      }
+      // Live OpenClaw owner, within staleMs but past its own recorded maxHoldMs: a stuck
+      // holder whose in-process watchdog can never fire must still be reclaimable. (#87483)
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: owner.pid,
+          createdAt: new Date(Date.now() - 30_000).toISOString(),
+          maxHoldMs: 1_000,
+        }),
+        "utf8",
+      );
+
+      try {
+        await expectCurrentPidOwnsLock({ sessionFile, timeoutMs: 500, staleMs: 600_000 });
+      } finally {
+        owner.kill("SIGTERM");
+      }
+    });
+  });
+
   it("retries when a stale lock report disappears before diagnostics", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       const owner = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "openclaw"], {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -46,7 +46,10 @@ export const DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS = 5 * 60 * 1000;
 export const DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
-const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
+// "too-old" (past global staleMs) stays report-only — a live holder may still be within its own
+// maxHoldMs. "hold-exceeded" (past the holder's OWN recorded maxHoldMs) is overdue by contract and
+// reclaimable; acquire's remove-if-unchanged still skips a lock whose file changed (e.g. a release). (#87483)
+const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old"]);
 
 /**
  * Yield control to the event loop so other sessions can make progress

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1651,7 +1651,7 @@ export const FIELD_HELP: Record<string, string> = {
   "session.writeLock.staleMs":
     "Milliseconds before an existing session transcript lock can be treated as stale and reclaimed. Default: 1800000; env override: OPENCLAW_SESSION_WRITE_LOCK_STALE_MS.",
   "session.writeLock.maxHoldMs":
-    "Milliseconds a held in-process session transcript lock may remain held before the watchdog releases it. Default: 300000; env override: OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS.",
+    "Milliseconds a held session transcript lock may remain held before it is reclaimed: the holder's own in-process watchdog releases it, and a contending writer may also reclaim it once this deadline passes if the lock file is unchanged. Default: 300000; env override: OPENCLAW_SESSION_WRITE_LOCK_MAX_HOLD_MS.",
   "session.agentToAgent":
     "Groups controls for inter-agent session exchanges, including loop prevention limits on reply chaining. Keep defaults unless you run advanced agent-to-agent automation with strict turn caps.",
   "session.agentToAgent.maxPingPongTurns":


### PR DESCRIPTION
### Summary

- **Problem**: Issue #87483 reports that a session write-lock file held by a **live** gateway process persists for hours past `maxHoldMs`/`staleMs`; the watchdog never reclaims it, so later requests fail with `session file locked (timeout 60000ms): pid=…`. The reporter's holder process was alive and busy (83% CPU) while holding the lock for 8+ hours despite the lock recording `maxHoldMs: 1020000` (17 min).
- **Root Cause**: There are two reclaim mechanisms and both fail for a live-but-stuck holder:
  1. The per-process watchdog (`ensureWatchdogStarted`) is a `setInterval` running **inside the holding process**. If that process is stuck in a synchronous CPU-bound loop, its event loop is blocked and the watchdog timer never fires, so the holder never self-releases.
  2. A contending process inspects the lock and, at `acquireSessionWriteLock` time (with `respectMaxHold` on), correctly flags it `hold-exceeded` (age past the holder's own recorded `maxHoldMs`). But `shouldRemoveContendedLockFile` (the `shouldRemoveStaleLock` callback the lock library consults under `staleRecovery: "remove-if-unchanged"`) treats **both** `too-old` and `hold-exceeded` as report-only: `REPORT_ONLY_STALE_LOCK_REASONS = {"too-old", "hold-exceeded"}`. When a live holder's only stale reasons are these, the function returns `false` (don't remove), the library throws `file_lock_stale`, and the acquire eventually fails — the lock is never reclaimed even though it is past the holder's own declared max hold. So a live-but-stuck holder pins the lock forever: it cannot self-release (event loop blocked) and contenders are forbidden from reclaiming it.
- **Fix**: Remove `"hold-exceeded"` from `REPORT_ONLY_STALE_LOCK_REASONS`. A holder past its **own recorded `maxHoldMs`** is overdue by its own contract and is reclaimable by a contender. `"too-old"` (past the global `staleMs` heuristic) stays report-only — a live holder may still be working within its own declared `maxHoldMs`, so we do not steal its lock on the global heuristic alone. The acquire path's `remove-if-unchanged` recovery still skips a lock whose file has changed (e.g. a concurrent release), so only a genuinely stalled holder loses the lock.
- **What changed**:
  - `src/agents/session-write-lock.ts` — drop `"hold-exceeded"` from `REPORT_ONLY_STALE_LOCK_REASONS` (one element + an explanatory comment).
  - `src/agents/session-write-lock.test.ts` — add an integration regression: a live OpenClaw-owned lock past its own `maxHoldMs` (but within `staleMs`) is now reclaimed by `acquireSessionWriteLock`.
  - `src/config/schema.help.ts` and `docs/reference/session-management-compaction.md` — document that `session.writeLock.maxHoldMs` is the hard hold limit enforced both by the holder's watchdog and by a contending reclaim (help string + reference prose only).
- **What did NOT change (scope boundary)**:
  - `"too-old"` stays report-only, so a live holder past the global `staleMs` but within its own `maxHoldMs` is still respected (covered by the existing "reports live OpenClaw-owned stale locks without removing them" test).
  - The `cleanStaleLockFiles` doctor sweep does not pass `respectMaxHold` and therefore never produces `hold-exceeded`; its behavior is unchanged (it still force-removes only dead/recycled/orphan locks, never a live holder's).
  - No new config key, schema field, default, env var, or doctor migration; the only config/docs touch is the existing `session.writeLock.maxHoldMs` help string and its reference doc, updated to match the behavior. No plugin SDK surface, no dependency changes. The watchdog interval, timeout, `staleMs`, and `maxHoldMs` resolution are untouched.

### Reproduction

1. A long-running gateway holds a session write-lock and gets stuck in a synchronous CPU loop (event loop blocked).
2. The holder's in-process watchdog can't fire, so the lock is never self-released past `maxHoldMs`.
3. Another request tries to write the same session; it sees the lock past the holder's `maxHoldMs` but cannot reclaim it.
4. **Before this PR**: the contender fails with a stale/`session file locked` error; the lock persists until the gateway restarts or the file is deleted manually.
5. **After this PR**: the contender reclaims the lock (the stalled holder's overdue lock is removed-if-unchanged) and proceeds.

Deterministic source reproduction (added as a regression test): a live OpenClaw-owned lock file with `maxHoldMs: 1000` and `createdAt` 30s ago, acquired with a large `staleMs`. Before the fix the acquire throws `SessionWriteLockStaleError: session file lock stale (hold-exceeded): … alive=true`; after the fix it reclaims the lock.

### Real behavior proof

**Behavior addressed (#87483 — a stalled live holder's lock is reclaimable)**: a session write-lock held past the holder's own `maxHoldMs` by a live OpenClaw process is reclaimed by a contender instead of pinning the session indefinitely.

**Real environment tested (Linux, Node — Vitest against the production `acquireSessionWriteLock` with a real spawned OpenClaw-recognized owner process; no live gateway)**: verified via `session-write-lock.test.ts`, plus core type-check, lint, and format on the changed files. A live overnight gateway lockup was not reproduced.

**Exact steps or command run after this patch (repo-root)**: `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts`; `node scripts/run-tsgo.mjs -p tsconfig.core.json`; `oxfmt --check` and `oxlint` on the changed files.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 session-write-lock.test.ts   Tests  54 passed (54)
```

The new case fails on current `main` exactly as the issue describes — `SessionWriteLockStaleError: session file lock stale (hold-exceeded): pid=… alive=true ageMs=30005` — and passes after dropping `"hold-exceeded"` from the report-only set, while all 53 existing cases (including the conservative "report live too-old locks without removing them") stay green.

**Observed result after fix (overdue live holder reclaimed; conservative live holder respected)**: a live holder past its own `maxHoldMs` is reclaimed; a live holder merely past the global `staleMs` (within its `maxHoldMs`) is still only reported, not removed.

**What was not tested (live overnight gateway lockup)**: the multi-hour real-gateway lock retention was not reproduced live; the proof is the deterministic module-level reproduction.

### Risk / Mitigation

- **Risk**: reclaiming a live holder's lock could race with a holder still writing the transcript. **Mitigation**: no new race is introduced. The target case is a *wedged* holder whose event loop is blocked — it cannot be writing the transcript (transcript writes are async and need the event loop). A holder that is still making progress is already released at `maxHoldMs` by its **own** in-process watchdog (`runLockWatchdogCheck` force-releases without aborting in-flight work), so `maxHoldMs` was already the hard hold limit before this change; the cross-process reclaim only restores that limit for the wedged case where the watchdog cannot fire. `remove-if-unchanged` additionally skips a lock whose file changed.
- **Risk**: behavior change in session-state concurrency. **Mitigation**: the change narrows report-only to the global `staleMs` heuristic; it does not touch thresholds, the watchdog, or the doctor sweep, and the conservative live-`too-old` behavior is preserved (covered by an existing test).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / session write-lock

### Linked Issue/PR

Fixes #87483
