### PR TITLE
fix(agents): guard tool policy name reads

### DIFF
--- a/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
@@ -239,4 +239,31 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
     expect(filtered).toStrictEqual([]);
   });
+
+  it("does not let an unreadable bundled tool crash policy filtering", () => {
+    const warnings: string[] = [];
+    const unreadable = makeTool("bundleProbe__broken");
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("bundled tool name getter exploded");
+      },
+    });
+    const healthy = makeTool("bundleProbe__bundle_probe");
+    setPluginToolMeta(healthy, { pluginId: "bundle-mcp", optional: false });
+
+    let filtered: AnyAgentTool[] = [];
+    expect(() => {
+      filtered = applyFinalEffectiveToolPolicy({
+        bundledTools: [unreadable, healthy],
+        config: { tools: { allow: ["bundle-mcp"] } },
+        warn: (message) => warnings.push(message),
+      });
+    }).not.toThrow();
+
+    expect(filtered.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
+    expect(warnings).toContain(
+      "tools: policy filtering skipped tool with unreadable name at index 0.",
+    );
+  });
 });

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -93,6 +93,54 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("drops unreadable tools before policy matching", () => {
+    const warnings: string[] = [];
+    const unreadable = {};
+    Object.defineProperty(unreadable, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("tool name getter exploded");
+      },
+    });
+    const tools = [unreadable, { name: "exec" }] as unknown as DummyTool[];
+
+    const filtered = applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      steps: [{ policy: { allow: ["exec"] }, label: "tools.allow" }],
+    });
+
+    expect(filtered).toEqual([{ name: "exec" }]);
+    expect(warnings).toEqual([
+      "tools: policy filtering skipped tool with unreadable name at index 0.",
+    ]);
+  });
+
+  test("keeps readable tool name accessors while policy matching", () => {
+    const warnings: string[] = [];
+
+    class AccessorTool {
+      get name() {
+        return "exec";
+      }
+    }
+
+    const tool = new AccessorTool();
+
+    const filtered = applyToolPolicyPipeline({
+      tools: [tool] as any,
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      steps: [{ policy: { allow: ["exec"] }, label: "tools.allow" }],
+      auditLogLevel: "debug",
+    });
+
+    expect(filtered).toEqual([tool]);
+    expect(Object.getPrototypeOf(filtered[0])).toBe(AccessorTool.prototype);
+    expect(warnings).toEqual([]);
+  });
+
   test("suppresses built-in profile warnings for unavailable gated core tools", () => {
     const warnings = runAllowlistWarningStep({
       allow: ["apply_patch"],

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -1,12 +1,13 @@
-import { filterToolsByPolicy } from "./agent-tools.policy.js";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isKnownCoreToolId } from "./tool-catalog.js";
 import { auditToolPolicyFilter, type ToolPolicyAuditLogLevel } from "./tool-policy-audit.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import {
   analyzeAllowlistByToolType,
-  buildPluginToolGroups,
   expandPolicyWithPluginGroups,
   normalizeToolName,
+  type PluginToolGroups,
   type ToolPolicyLike,
 } from "./tool-policy.js";
 
@@ -37,6 +38,87 @@ export type ToolPolicyPipelineStep = {
   suppressUnavailableCoreToolWarningAllowlist?: string[];
   unavailableCoreToolReason?: string;
 };
+
+type PolicyToolEntry = {
+  tool: AnyAgentTool;
+  name: string;
+};
+
+function readPolicyToolName(tool: AnyAgentTool): { ok: true; name: string } | { ok: false } {
+  try {
+    const name = normalizeToolName(tool.name);
+    return name ? { ok: true, name } : { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readPolicyToolEntries(params: {
+  tools: readonly AnyAgentTool[];
+  warn: (message: string) => void;
+}): PolicyToolEntry[] {
+  let length: number;
+  try {
+    length = params.tools.length;
+  } catch {
+    params.warn("tools: policy filtering skipped unreadable tool list.");
+    return [];
+  }
+  const entries: PolicyToolEntry[] = [];
+  for (let index = 0; index < length; index += 1) {
+    let tool: AnyAgentTool;
+    try {
+      tool = params.tools[index];
+    } catch {
+      params.warn(`tools: policy filtering skipped unreadable tool at index ${index}.`);
+      continue;
+    }
+    const nameRead = readPolicyToolName(tool);
+    if (!nameRead.ok) {
+      params.warn(`tools: policy filtering skipped tool with unreadable name at index ${index}.`);
+      continue;
+    }
+    entries.push({ tool, name: nameRead.name });
+  }
+  return entries;
+}
+
+function buildPluginToolGroupsForPolicyEntries(params: {
+  entries: readonly PolicyToolEntry[];
+  toolMeta: (tool: AnyAgentTool) => { pluginId: string } | undefined;
+}): PluginToolGroups {
+  const all: string[] = [];
+  const byPlugin = new Map<string, string[]>();
+  for (const entry of params.entries) {
+    const meta = params.toolMeta(entry.tool);
+    if (!meta) {
+      continue;
+    }
+    all.push(entry.name);
+    const pluginId = normalizeOptionalLowercaseString(meta.pluginId);
+    if (!pluginId) {
+      continue;
+    }
+    const list = byPlugin.get(pluginId) ?? [];
+    list.push(entry.name);
+    byPlugin.set(pluginId, list);
+  }
+  return { all, byPlugin };
+}
+
+function filterPolicyEntriesByPolicy(
+  entries: readonly PolicyToolEntry[],
+  policy?: ToolPolicyLike,
+): PolicyToolEntry[] {
+  if (!policy) {
+    return [...entries];
+  }
+  return entries.filter((entry) => isToolAllowedByPolicyName(entry.name, policy));
+}
+
+function policyAuditTools(entries: readonly PolicyToolEntry[]): Array<{ name: string }> {
+  return entries.map((entry) => ({ name: entry.name }));
+}
 
 export function buildDefaultToolPolicyPipelineSteps(params: {
   profilePolicy?: ToolPolicyLike;
@@ -122,19 +204,17 @@ export function applyToolPolicyPipeline(params: {
   steps: ToolPolicyPipelineStep[];
   auditLogLevel?: ToolPolicyAuditLogLevel;
 }): AnyAgentTool[] {
+  const entries = readPolicyToolEntries({ tools: params.tools, warn: params.warn });
   const coreToolNames = new Set(
-    params.tools
-      .filter((tool) => !params.toolMeta(tool))
-      .map((tool) => normalizeToolName(tool.name))
-      .filter(Boolean),
+    entries.filter((entry) => !params.toolMeta(entry.tool)).map((entry) => entry.name),
   );
 
-  const pluginGroups = buildPluginToolGroups({
-    tools: params.tools,
+  const pluginGroups = buildPluginToolGroupsForPolicyEntries({
+    entries,
     toolMeta: params.toolMeta,
   });
 
-  let filtered = params.tools;
+  let filtered = entries;
   for (const step of params.steps) {
     if (!step.policy) {
       continue;
@@ -165,14 +245,14 @@ export function applyToolPolicyPipeline(params: {
             hasOtherEntries: otherEntries.length > 0,
           })
         ) {
-          const entries = warningEntries.join(", ");
+          const warningEntryText = warningEntries.join(", ");
           const suffix = describeUnknownAllowlistSuffix({
             pluginOnlyAllowlist: resolved.pluginOnlyAllowlist,
             hasGatedCoreEntries: warnableGatedCoreEntries.length > 0,
             hasOtherEntries: otherEntries.length > 0,
             unavailableCoreToolReason: step.unavailableCoreToolReason,
           });
-          const warning = `tools: ${step.label} allowlist contains unknown entries (${entries}). ${suffix}`;
+          const warning = `tools: ${step.label} allowlist contains unknown entries (${warningEntryText}). ${suffix}`;
           if (rememberToolPolicyWarning(warning)) {
             params.warn(warning);
           }
@@ -186,16 +266,16 @@ export function applyToolPolicyPipeline(params: {
       continue;
     }
     const before = filtered;
-    filtered = filterToolsByPolicy(before, expanded);
+    filtered = filterPolicyEntriesByPolicy(before, expanded);
     auditToolPolicyFilter({
       stepLabel: step.label,
       policy: expanded,
-      before,
-      after: filtered,
+      before: policyAuditTools(before),
+      after: policyAuditTools(filtered),
       logLevel: params.auditLogLevel,
     });
   }
-  return filtered;
+  return filtered.map((entry) => entry.tool);
 }
 
 function shouldWarnAboutUnknownAllowlist(params: {


### PR DESCRIPTION
## Summary
- Snapshot normalized tool names under a guarded read before policy allow/deny matching and audit logging.
- Skip unreadable tool entries with a warning instead of letting a bad `name` getter crash final effective tool policy filtering.
- Add regressions for the policy pipeline, bundled effective tool filtering, and readable accessor-backed plugin tools.

## Verification
- `./node_modules/.bin/oxfmt --write src/agents/tool-policy-pipeline.ts src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts`
- `./node_modules/.bin/oxlint src/agents/tool-policy-pipeline.ts src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts`
- `CI=1 node scripts/run-vitest.mjs run src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts --reporter=verbose`
- `CI=1 node scripts/run-vitest.mjs run src/plugins/tools.optional.test.ts -t "preserves class-backed plugin tool shape while scoping callbacks" --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_8248a4fb30c6`, lease `cbx_1dbc7bc0ade6`, type `c7a.8xlarge`: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

## Real behavior proof
Behavior addressed: A malformed bundled/plugin tool with an unreadable `name` accessor could crash tool policy filtering before later schema validation/quarantine could handle the tool surface.

Real environment tested: Local Codex worktree on branch `fuzz-tool-schema-next65-20260603`, Node/Vitest through `scripts/run-vitest.mjs`; AWS Crabbox `run_8248a4fb30c6` / `cbx_1dbc7bc0ade6`, Linux `c7a.8xlarge`.

Exact steps or command run after this patch: See Verification above.

Evidence after fix: Focused agent tests passed: 2 files, 33 tests. Focused plugin accessor contract test passed: 1 test, 66 skipped. Autoreview reported no accepted/actionable findings. Remote `pnpm check:changed` selected lanes `core, coreTests` and exited 0.

Observed result after fix: Policy matching and audit logging use normalized snapshot names; tools with unreadable names are skipped with a warning, while readable accessor-backed plugin tool instances keep their original prototype.

What was not tested: Full repo suite was not run; `pnpm check:changed` passed remotely for the touched lanes.
