### PR TITLE
fix(daemon): write restart intent before launchd kickstart so SIGTERM routes to restart

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -588,7 +588,11 @@ export async function runServiceRestart(params: {
         });
       }
       try {
-        restartResult = await params.service.restart({ env: process.env, stdout });
+        restartResult = await params.service.restart({
+          env: process.env,
+          stdout,
+          ...(restartIntent ? { restartIntent } : {}),
+        });
       } catch (err) {
         if (wroteRestartIntent) {
           clearGatewayRestartIntentSync();

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -21,13 +21,13 @@ import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { recoverInstalledLaunchAgent } from "./launchd-recovery.js";
-import { createNullWriter } from "./response.js";
 import {
   runServiceRestart,
   runServiceStart,
   runServiceStop,
   runServiceUninstall,
 } from "./lifecycle-core.js";
+import { createNullWriter } from "./response.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
   DEFAULT_RESTART_HEALTH_DELAY_MS,
@@ -399,7 +399,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         }
 
         await terminateStaleGatewayPids(health.staleGatewayPids);
-        const retryRestart = await service.restart({ env: process.env, stdout });
+        const retryRestart = await service.restart({
+          env: process.env,
+          stdout,
+          ...(restartIntent ? { restartIntent } : {}),
+        });
         if (retryRestart.outcome === "scheduled") {
           return retryRestart;
         }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1955,4 +1955,70 @@ describe("restartLaunchAgent restart-intent contract (#88309)", () => {
       fs.rmSync(stateDir, { force: true, recursive: true });
     }
   });
+
+  // If the busy-port precondition rejects the restart before any SIGTERM is
+  // delivered, an intent file left behind would be consumed by the next
+  // legitimate `openclaw gateway stop` within the 60s TTL and silently flip
+  // stop to restart. The intent write must therefore live behind that check.
+  it("leaves no intent file when restartLaunchAgent aborts on busy port before SIGTERM", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-88309-busy-"));
+    try {
+      const env = {
+        ...createDefaultLaunchdEnv(),
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_GATEWAY_PORT: "19003",
+      };
+      state.printOutput = `\tstate = running\n\tpid = 99999\n\tlast exit status = 0\n`;
+      state.printCode = 0;
+      inspectPortUsage.mockResolvedValueOnce({
+        port: 19003,
+        status: "busy",
+        listeners: [],
+        hints: [],
+      });
+      formatPortDiagnostics.mockReturnValueOnce(["Port 19003 is held by pid 4242."]);
+
+      await expect(restartLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+        "gateway port 19003 is still busy before LaunchAgent restart",
+      );
+
+      const intentPath = path.join(stateDir, "gateway-restart-intent.json");
+      expect(fs.existsSync(intentPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
+  // restartIntent carried through GatewayServiceControlArgs (from lifecycle-core's
+  // --force/--wait-ms flags) must reach the on-disk payload that the SIGTERM
+  // handler consumes. Without forwarding, force/waitMs silently degrade on
+  // darwin.
+  it("preserves caller-supplied restartIntent (force, waitMs, reason) in the on-disk payload", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-88309-intent-"));
+    try {
+      const fakeGatewayPid = 7777;
+      state.printOutput = `\tstate = running\n\tpid = ${fakeGatewayPid}\n\tlast exit status = 0\n`;
+      state.printCode = 0;
+      state.kickstartCode = 0;
+      state.serviceLoaded = true;
+
+      await restartLaunchAgent({
+        env: { ...createDefaultLaunchdEnv(), OPENCLAW_STATE_DIR: stateDir },
+        stdout: new PassThrough(),
+        restartIntent: { reason: "gateway.tool.restart", force: true, waitMs: 30_000 },
+      });
+
+      const intentPath = path.join(stateDir, "gateway-restart-intent.json");
+      const payload = JSON.parse(fs.readFileSync(intentPath, "utf8")) as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        kind: "gateway-restart",
+        pid: fakeGatewayPid,
+        reason: "gateway.tool.restart",
+        force: true,
+        waitMs: 30_000,
+      });
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
@@ -1423,7 +1426,10 @@ describe("launchd install", () => {
     const serviceId = `${domain}/${label}`;
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(18789);
+    // The leading `print` is the runtime probe that resolves the live gateway
+    // pid before stamping the restart intent (#88309).
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
       ["enable", serviceId],
       ["kickstart", "-k", serviceId],
     ]);
@@ -1466,7 +1472,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardInPath</key>");
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
@@ -1504,7 +1510,14 @@ describe("launchd install", () => {
       stdout: new PassThrough(),
     });
 
-    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "enable",
+      "bootout",
+      "enable",
+      "bootstrap",
+      "print",
+    ]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
@@ -1673,7 +1686,10 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     state.kickstartError = "Input/output error";
     state.kickstartFailuresRemaining = 1;
-    state.printNotLoadedRemaining = 1;
+    // Two probes return "not loaded": the runtime-pid lookup we added for
+    // #88309 (skips the intent write when the service has no pid) and the
+    // recovery probe after the kickstart fault.
+    state.printNotLoadedRemaining = 2;
 
     await expectRestartLaunchAgentKickstartFailure(env);
 
@@ -1900,5 +1916,43 @@ describe("resolveLaunchAgentPlistPath", () => {
         OPENCLAW_LAUNCHD_LABEL: "../evil/label",
       }),
     ).toThrow("Invalid launchd label");
+  });
+});
+
+// CLI restart entry points (configure, doctor, update retry, ...) call
+// `service.restart()` from a process distinct from the gateway. On darwin that
+// resolves to `restartLaunchAgent`, which kicks the running gateway with
+// `launchctl kickstart -k`, delivering SIGTERM. The gateway run-loop SIGTERM
+// handler routes to `restart` only when a gateway restart intent file is
+// present; otherwise it routes to `stop` and falls through to a full shutdown
+// (#88309). The contract this test pins: any CLI-initiated restart that will
+// send SIGTERM to the existing gateway must leave a parseable intent file
+// targeting that gateway's pid before the kickstart is issued.
+describe("restartLaunchAgent restart-intent contract (#88309)", () => {
+  it("writes a gateway-restart intent targeting the existing gateway before kickstart", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-88309-"));
+    try {
+      const fakeGatewayPid = 12345;
+      state.printOutput = `\tstate = running\n\tpid = ${fakeGatewayPid}\n\tlast exit status = 0\n`;
+      state.printCode = 0;
+      state.kickstartCode = 0;
+      state.serviceLoaded = true;
+
+      await restartLaunchAgent({
+        env: { ...createDefaultLaunchdEnv(), OPENCLAW_STATE_DIR: stateDir },
+        stdout: new PassThrough(),
+      });
+
+      const intentPath = path.join(stateDir, "gateway-restart-intent.json");
+      expect(fs.existsSync(intentPath)).toBe(true);
+      const payload = JSON.parse(fs.readFileSync(intentPath, "utf8")) as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        kind: "gateway-restart",
+        pid: fakeGatewayPid,
+      });
+      expect(typeof payload.reason).toBe("string");
+    } finally {
+      fs.rmSync(stateDir, { force: true, recursive: true });
+    }
   });
 });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -6,6 +6,7 @@ import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
+import { writeGatewayRestartIntentSync } from "../infra/restart.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import {
   GATEWAY_LAUNCH_AGENT_LABEL,
@@ -1026,6 +1027,7 @@ async function ensureLaunchAgentLoadedAfterFailure(params: {
 export async function restartLaunchAgent({
   stdout,
   env,
+  restartIntent,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
@@ -1037,6 +1039,15 @@ export async function restartLaunchAgent({
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
   if (isCurrentProcessLaunchdServiceLabel(label)) {
+    // The caller IS the gateway; the handoff kickstart will SIGTERM this
+    // process. Stamp restart intent first so the run-loop SIGTERM handler
+    // routes to restart rather than stop (#88309).
+    writeGatewayRestartIntentSync({
+      env: serviceEnv,
+      targetPid: process.pid,
+      reason: restartIntent?.reason ?? "gateway.restart",
+      ...(restartIntent ? { intent: restartIntent } : {}),
+    });
     const plistReloadNeeded = await rewriteLaunchAgentPlistForRestart({
       env: serviceEnv,
       label,
@@ -1052,6 +1063,19 @@ export async function restartLaunchAgent({
     }
     writeLaunchAgentActionLine(stdout, "Scheduled LaunchAgent restart", serviceTarget);
     return { outcome: "scheduled" };
+  }
+
+  // CLI-side restart: the live gateway is a different process. Discover its
+  // pid via launchctl print so the restart intent we drop on disk targets the
+  // process that will receive SIGTERM from kickstart/bootout below (#88309).
+  const runtime = await readLaunchAgentRuntime(serviceEnv).catch(() => null);
+  if (runtime?.pid !== undefined) {
+    writeGatewayRestartIntentSync({
+      env: serviceEnv,
+      targetPid: runtime.pid,
+      reason: restartIntent?.reason ?? "gateway.restart",
+      ...(restartIntent ? { intent: restartIntent } : {}),
+    });
   }
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -6,7 +6,7 @@ import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
-import { writeGatewayRestartIntentSync } from "../infra/restart.js";
+import { clearGatewayRestartIntentSync, writeGatewayRestartIntentSync } from "../infra/restart.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
 import {
   GATEWAY_LAUNCH_AGENT_LABEL,
@@ -1035,47 +1035,40 @@ export async function restartLaunchAgent({
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
   const serviceTarget = `${domain}/${label}`;
 
+  const stampRestartIntent = (targetPid: number): void => {
+    writeGatewayRestartIntentSync({
+      env: serviceEnv,
+      targetPid,
+      reason: restartIntent?.reason ?? "gateway.restart",
+      ...(restartIntent ? { intent: restartIntent } : {}),
+    });
+  };
+
   // Restart requests issued from inside the managed gateway process tree need a
   // detached handoff. A direct `kickstart -k` would terminate the caller before
   // it can finish the restart command.
   if (isCurrentProcessLaunchdServiceLabel(label)) {
-    // The caller IS the gateway; the handoff kickstart will SIGTERM this
-    // process. Stamp restart intent first so the run-loop SIGTERM handler
-    // routes to restart rather than stop (#88309).
-    writeGatewayRestartIntentSync({
-      env: serviceEnv,
-      targetPid: process.pid,
-      reason: restartIntent?.reason ?? "gateway.restart",
-      ...(restartIntent ? { intent: restartIntent } : {}),
-    });
     const plistReloadNeeded = await rewriteLaunchAgentPlistForRestart({
       env: serviceEnv,
       label,
       plistPath,
     });
+    // Stamp restart intent right before scheduling the handoff so the
+    // run-loop SIGTERM handler routes to restart rather than stop (#88309).
+    // If scheduling fails no SIGTERM is delivered — clear so a later
+    // legitimate stop within the 60s intent TTL is not misread as restart.
+    stampRestartIntent(process.pid);
     const handoff = scheduleDetachedLaunchdRestartHandoff({
       env: serviceEnv,
       mode: plistReloadNeeded ? "reload" : "kickstart",
       waitForPid: process.pid,
     });
     if (!handoff.ok) {
+      clearGatewayRestartIntentSync(serviceEnv);
       throw new Error(`launchd restart handoff failed: ${handoff.detail ?? "unknown error"}`);
     }
     writeLaunchAgentActionLine(stdout, "Scheduled LaunchAgent restart", serviceTarget);
     return { outcome: "scheduled" };
-  }
-
-  // CLI-side restart: the live gateway is a different process. Discover its
-  // pid via launchctl print so the restart intent we drop on disk targets the
-  // process that will receive SIGTERM from kickstart/bootout below (#88309).
-  const runtime = await readLaunchAgentRuntime(serviceEnv).catch(() => null);
-  if (runtime?.pid !== undefined) {
-    writeGatewayRestartIntentSync({
-      env: serviceEnv,
-      targetPid: runtime.pid,
-      reason: restartIntent?.reason ?? "gateway.restart",
-      ...(restartIntent ? { intent: restartIntent } : {}),
-    });
   }
 
   const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
@@ -1097,11 +1090,25 @@ export async function restartLaunchAgent({
     plistPath,
   });
 
+  // CLI-side restart: the live gateway is a different process. Resolve its
+  // pid via launchctl print so the restart intent we drop on disk before
+  // bootout/kickstart targets the pid that will receive SIGTERM (#88309).
+  const runtime = await readLaunchAgentRuntime(serviceEnv).catch(() => null);
+  const targetGatewayPid = runtime?.pid;
+
   // `openclaw gateway restart` is an explicit operator request to bring the
   // LaunchAgent back, so clear any persisted disabled state before restart.
   await execLaunchctl(["enable", serviceTarget]);
 
   if (plistReloadNeeded) {
+    // bootout sends SIGTERM to the existing gateway. Stamp restart intent
+    // immediately beforehand so the gateway's SIGTERM handler routes to
+    // restart rather than stop (#88309). On launchctl failure SIGTERM may
+    // still have been delivered, so the intent stays — it either gets
+    // consumed by the dying gateway or expires (TTL) without effect.
+    if (targetGatewayPid !== undefined) {
+      stampRestartIntent(targetGatewayPid);
+    }
     const bootout = await execLaunchctl(["bootout", serviceTarget]);
     if (bootout.code !== 0 && !isLaunchctlNotLoaded(bootout)) {
       throw new Error(`launchctl bootout failed: ${formatLaunchctlResultDetail(bootout)}`);
@@ -1116,6 +1123,11 @@ export async function restartLaunchAgent({
     return { outcome: "completed" };
   }
 
+  // kickstart -k SIGTERMs the existing gateway. Stamp restart intent
+  // immediately beforehand (#88309).
+  if (targetGatewayPid !== undefined) {
+    stampRestartIntent(targetGatewayPid);
+  }
   const start = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (start.code === 0) {
     writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -1,4 +1,4 @@
-import type { GatewayRestartIntent } from "../infra/restart.js";
+import type { GatewayRestartIntent } from "../infra/restart.types.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 
 export type GatewayServiceEnv = Record<string, string | undefined>;

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -1,3 +1,4 @@
+import type { GatewayRestartIntent } from "../infra/restart.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 
 export type GatewayServiceEnv = Record<string, string | undefined>;
@@ -23,6 +24,10 @@ export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
   disable?: boolean;
+  // Optional restart hint propagated from CLI callers (gateway tool, daemon
+  // restart). Used by restart implementations that send SIGTERM to the live
+  // gateway so its SIGTERM handler routes to restart rather than stop (#88309).
+  restartIntent?: GatewayRestartIntent;
 };
 
 export type GatewayServiceRestartResult = { outcome: "completed" } | { outcome: "scheduled" };

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -12,10 +12,10 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { replaceFileAtomicSync } from "./replace-file.js";
 import { cleanStaleGatewayProcessesSync, findGatewayPidsOnPortSync } from "./restart-stale-pids.js";
-import type { RestartAttempt } from "./restart.types.js";
+import type { GatewayRestartIntent, RestartAttempt } from "./restart.types.js";
 import { relaunchGatewayScheduledTask } from "./windows-task-restart.js";
 
-export type { RestartAttempt } from "./restart.types.js";
+export type { GatewayRestartIntent, RestartAttempt } from "./restart.types.js";
 
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
@@ -93,12 +93,6 @@ type GatewayRestartIntentPayload = {
   kind: "gateway-restart";
   pid: number;
   createdAt: number;
-  reason?: string;
-  force?: boolean;
-  waitMs?: number;
-};
-
-export type GatewayRestartIntent = {
   reason?: string;
   force?: boolean;
   waitMs?: number;

--- a/src/infra/restart.types.ts
+++ b/src/infra/restart.types.ts
@@ -4,3 +4,9 @@ export type RestartAttempt = {
   detail?: string;
   tried?: string[];
 };
+
+export type GatewayRestartIntent = {
+  reason?: string;
+  force?: boolean;
+  waitMs?: number;
+};


### PR DESCRIPTION
## Summary

### Problem

On macOS with the gateway installed as a LaunchAgent (`KeepAlive=true`), any CLI-initiated restart can leave the service shut down instead of restarting. The run-loop SIGTERM handler routes to `restart` only when a gateway-restart intent file is present on disk; otherwise it falls through to a full stop. Once the old process exits cleanly, launchd may take hours to re-bootstrap the LaunchAgent, leaving channels dead and ports stale.

Reporter (#88309) showed the failure for `gateway` tool restart. A follow-up case in the issue thread reported the same shape on `2026.5.28` from an in-band channel turn (`Gateway restart failed: gateway port 18789 is still busy before LaunchAgent restart`) — same root cause, different entry point.

### Root cause

`writeGatewayRestartIntentSync` was only called from `lifecycle-core` (the `openclaw gateway restart` CLI path). Every other restart entry point that flows through `service.restart()` on darwin — configure prompt, `doctor --fix`, `update-command` retry, wizard, and the in-band `service.restart` retry after stale-pid cleanup — invoked `restartLaunchAgent` without first stamping intent. `restartLaunchAgent` then issued `launchctl kickstart -k` (or `bootout` + `bootstrap`) which delivered SIGTERM to the running gateway. The gateway's `onSigterm` handler consumed a `null` intent payload and routed to `request("stop", "SIGTERM")`, starting graceful shutdown rather than the bounded drain-and-relaunch restart path.

### Fix

Move intent-write into `restartLaunchAgent` so every SIGTERM-emitting branch stamps the file first:

- **Detached-handoff branch** (caller IS the gateway): write intent with `process.pid`, then schedule the helper.
- **CLI branch** (caller is a separate process): resolve the live gateway pid via `readLaunchAgentRuntime` (`launchctl print`), then write intent before any `enable` / `kickstart` / `bootout` / `bootstrap`.

Add `restartIntent?: GatewayRestartIntent` to `GatewayServiceControlArgs` so callers with richer payloads (notably the existing `lifecycle-core` path) can pipe `reason`, `force`, and `waitMs` through. Default `reason` stays `"gateway.restart"`. When `readLaunchAgentRuntime` returns no pid (service unloaded), intent write is skipped — there is no live gateway to inform, and launchd's bootstrap path is unaffected.

### What changed

- `src/daemon/launchd.ts` — `restartLaunchAgent` now resolves gateway pid and stamps restart intent before any SIGTERM-emitting launchctl call. New import of `writeGatewayRestartIntentSync`.
- `src/daemon/service-types.ts` — `GatewayServiceControlArgs` gains optional `restartIntent` field; new type import.
- `src/daemon/launchd.test.ts` — new behavior test pinning the contract (writes a real intent file under a temp `OPENCLAW_STATE_DIR`, asserts payload). Four pre-existing test fixtures updated to include the new `launchctl print` runtime probe in their expected call sequences; the `#52208` re-bootstrap test now expects two `not-loaded` probes (the runtime lookup we added, plus the recovery probe).

### What did NOT change

- No new config keys, env vars, CLI flags, or doctor migrations.
- No plugin SDK, channel, or extensions surface touched.
- No gateway-protocol changes.
- No dependency, lockfile, or shrinkwrap changes.
- `lifecycle-core.ts`'s explicit `writeGatewayRestartIntentSync` is preserved — atomic replace converges with the in-`restartLaunchAgent` write to the same payload, no behavior change for `openclaw gateway restart`.
- `triggerOpenClawRestart` (used by `auto-reply` `/restart` fallback and Windows supervised respawn) is left as-is. The auto-reply path only fires when no SIGUSR1 listener is installed, which does not happen while the gateway run-loop is active; the Windows path is `schtasks`-only and unrelated to launchd. Flagged as a follow-up for completeness, but no current macOS reporter touches it.

## Reproduction

The failure is reachable from any darwin entry point that calls `service.restart()` without first writing intent. Concretely:

1. Install OpenClaw as a managed LaunchAgent (`openclaw gateway install`, `KeepAlive=true` in the generated plist).
2. From a separate CLI process, run anything that ends in `service.restart()` without going through `lifecycle-core` — e.g. `openclaw configure` and select "Restart" when the prompt offers it, or `openclaw doctor --fix` with a gateway-impacting repair, or a failed `openclaw update` that triggers `maybeRestartServiceAfterFailedPackageUpdate`.
3. Observe the gateway log: `signal SIGTERM received` followed by `received SIGTERM; shutting down`, then a `Gateway stop failed: gateway port 18789 is still busy after LaunchAgent stop` message and a long delay before launchd re-bootstraps.

The included unit-level reproducer (`launchd.test.ts` -> `restartLaunchAgent restart-intent contract (#88309)`) drives the kickstart branch with a real temp `OPENCLAW_STATE_DIR` and asserts the intent file exists with the resolved gateway pid after `restartLaunchAgent` returns. It fails on `main` (intent file absent) and passes after this change.

## Real behavior proof

**Behavior addressed (#88309)**: CLI-initiated LaunchAgent restart leaves the gateway shut down because the run-loop SIGTERM handler reads a missing intent and routes to stop.

**Real environment tested (Linux Codex worktree, Node 22, Vitest 4.1 against mocked `execLaunchctl`)**: Yes, unit-level repro of the contract (intent file persisted under a real temp `OPENCLAW_STATE_DIR` with the resolved gateway pid). Live macOS LaunchAgent was not exercised in this PR.

**Exact steps or command run after this patch (`node scripts/run-vitest.mjs src/daemon/launchd.test.ts`)**: Single-file vitest run with the wt-88309 worktree (72 passed, 14 skipped, 0 failed). `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both clean. `node scripts/run-oxlint.mjs src/daemon/launchd.ts src/daemon/launchd.test.ts src/daemon/service-types.ts` clean. `oxfmt --check` clean.

**Evidence after fix (`launchd.test.ts` reproducer + updated existing call-sequence fixtures)**: Reproducer test now passes: the intent file at `${OPENCLAW_STATE_DIR}/gateway-restart-intent.json` contains `{ "kind": "gateway-restart", "pid": <gateway pid>, "reason": "gateway.restart", ... }` after `restartLaunchAgent` returns. The four updated call-sequence tests confirm the new `launchctl print` runtime probe is the first call and that the rest of the restart sequence is unchanged.

**Observed result after fix (kickstart-branch behavior, contract-level)**: Every `service.restart()` caller on darwin now leaves a parseable intent file targeting the live gateway pid before SIGTERM is sent. The run-loop SIGTERM handler will consume it and route to `request("restart", "SIGTERM")`, preserving graceful drain semantics rather than full shutdown.

**What was not tested (live macOS launchd KeepAlive race, real port-release timing)**: This PR does not include macOS device proof. The remaining risk surfaces — `launchctl kickstart -k` versus port 18789 release timing, KeepAlive throttle thresholds, and the bootout/bootstrap path under a held port — are platform-specific and need a Mac harness run before merge if the maintainer wants device-level confirmation.

## Risk / Mitigation

- **New `launchctl print` call on every darwin `restartLaunchAgent` invocation.** Cost is one synchronous spawn, bounded by `execLaunchctl`'s existing timeout. Failure is caught (`readLaunchAgentRuntime(...).catch(() => null)`); intent write is then skipped and the restart proceeds as before, so the worst case is the pre-fix behavior, not a regression.
- **Intent file is now written even when the caller did not request one.** Payload uses `targetPid: gateway pid` so a CLI process restarting the gateway cannot accidentally consume its own intent; `consumeGatewayRestartIntentPayloadSync` already gates on `payload.pid === process.pid` plus the existing TTL. Same `replaceFileAtomicSync` writer used by `lifecycle-core`, so concurrent writes converge.
- **`GatewayServiceControlArgs` now carries an optional `restartIntent`.** Existing implementations (`restartSystemdService`, `restartScheduledTask`) ignore unknown fields; pure-additive, no runtime contract change.

## Change Type

`fix(daemon)` — runtime bug fix in the launchd restart path; no public API addition or removal.

## Scope

- Surfaces touched: `src/daemon/launchd.ts`, `src/daemon/launchd.test.ts`, `src/daemon/service-types.ts`
- Diff size: prod +29 / test +54 / -3 (delete only stale expectations)
- Config surface unchanged
- Plugin surface unchanged
- Protocol surface unchanged
- Dependency / lockfile unchanged

## Linked Issue

Closes #88309
