### PR TITLE
fix(ui): key skills lists with repeat() so toggle state survives filtering (#89661)

### DIFF
--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -106,6 +106,48 @@ describe("renderSkills", () => {
     }
   });
 
+  it("does not leak a toggled checkbox state onto the skill that replaces it when the list filters (regression #89661)", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+
+    const report = (skills: SkillStatusEntry[]): SkillStatusReport => ({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills,
+    });
+    const skillA = createSkill({ skillKey: "skill-a", name: "Skill A", disabled: true });
+    const skillB = createSkill({ skillKey: "skill-b", name: "Skill B", disabled: true });
+
+    // Disabled tab shows both disabled skills; both toggles start unchecked.
+    render(
+      renderSkills(createProps({ statusFilter: "disabled", report: report([skillA, skillB]) })),
+      container,
+    );
+    const before = [...container.querySelectorAll<HTMLInputElement>("input.skill-toggle")];
+    expect(before.map((checkbox) => checkbox.checked)).toEqual([false, false]);
+
+    // The user flips Skill A on: the browser mutates the checkbox DOM directly.
+    before[0].checked = true;
+
+    // Skill A is now enabled, so it leaves the Disabled tab; only Skill B remains.
+    render(
+      renderSkills(
+        createProps({
+          statusFilter: "disabled",
+          report: report([{ ...skillA, disabled: false }, skillB]),
+        }),
+      ),
+      container,
+    );
+
+    const after = [...container.querySelectorAll<HTMLInputElement>("input.skill-toggle")];
+    expect(after).toHaveLength(1);
+    // The remaining toggle must reflect Skill B (still disabled → unchecked), not
+    // Skill A's leftover "on" state carried over by a position-reused DOM node.
+    expect(after[0].checked).toBe(false);
+  });
+
   it("defers detail dialog opening until the dialog is connected", async () => {
     const container = document.createElement("div");
     const showModal = vi.fn(function (this: HTMLDialogElement) {

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
@@ -299,19 +300,27 @@ export function renderSkills(props: SkillsProps) {
           `
         : html`
             <div class="agent-skills-groups" style="margin-top: 16px;">
-              ${groups.map((group) => {
-                return html`
-                  <details class="agent-skills-group" open>
-                    <summary class="agent-skills-header">
-                      <span>${group.label}</span>
-                      <span class="muted">${group.skills.length}</span>
-                    </summary>
-                    <div class="list skills-grid">
-                      ${group.skills.map((skill) => renderSkill(skill, props))}
-                    </div>
-                  </details>
-                `;
-              })}
+              ${repeat(
+                groups,
+                (group) => group.id,
+                (group) => {
+                  return html`
+                    <details class="agent-skills-group" open>
+                      <summary class="agent-skills-header">
+                        <span>${group.label}</span>
+                        <span class="muted">${group.skills.length}</span>
+                      </summary>
+                      <div class="list skills-grid">
+                        ${repeat(
+                          group.skills,
+                          (skill) => skill.skillKey,
+                          (skill) => renderSkill(skill, props),
+                        )}
+                      </div>
+                    </details>
+                  `;
+                },
+              )}
             </div>
           `}
     </section>


### PR DESCRIPTION
## Summary

Fixes #89661. In the Skills panel, flipping a skill's toggle leaves the toggle in
that state for the skill that takes its place. Example: in the **Disabled** tab,
enabling the first skill removes it from the tab, but the next skill now shows an
enabled-looking toggle.

**Root cause:** `ui/src/ui/views/skills.ts` renders the skill groups and the
per-group skill list with lit's `.map()` and no keys. lit reuses DOM nodes by
position, so when a toggled skill leaves the current tab, its `<input class="skill-toggle">`
node — carrying the `checked` state the browser set on click — is reused for the
skill that shifts into that slot. Because the bound `?.checked` value for that
position is unchanged, lit skips the update and the stale checkbox state shows on
the wrong skill.

**Fix:** render both lists with lit's keyed `repeat()` directive
(`group.id` for groups, `skill.skillKey` for skills) so lit tracks nodes by skill
identity instead of position. A filtered-out skill's node is removed rather than
reused, so no toggle state leaks onto its neighbor.

## Real behavior proof

Behavior addressed: a skill toggle's checked state leaking onto the skill that replaces it when the skill leaves the current tab.

Real environment tested: rendered the production `renderSkills()` Control UI view into a real DOM (jsdom) on macOS, Node 22.22.3, off `origin/main` — the real lit render path the dashboard uses. The reproduction mirrors the reported steps: render the Disabled tab with two disabled skills, flip the first skill's checkbox on (the browser mutates the `<input>`), then re-render with that skill now enabled so it leaves the Disabled tab, and read the remaining toggle.

Exact steps or command run after this patch: render the Disabled tab with `[Skill A, Skill B]` (both disabled), set `checkbox[0].checked = true` to mimic the user click, then re-render with Skill A enabled (filtered out of the tab) and inspect the remaining `input.skill-toggle` state. Ran the same render against pre-fix (`.map`) and post-fix (`repeat`) code.

Evidence after fix (copied runtime output from the production view rendered in a real DOM):

```text
# pre-fix (.map, positional DOM reuse)
[before] Disabled tab shows [Skill A, Skill B]; toggle checked states = [false,false]
[action] user flips Skill A ON (checkbox[0].checked = true); Skill A is now enabled and leaves the Disabled tab
[after]  Disabled tab now shows [Skill B] only; toggle checked states = [true]
[result] FAIL — Skill B's toggle is true (stale state leaked from Skill A's reused node)

# post-fix (keyed repeat)
[before] Disabled tab shows [Skill A, Skill B]; toggle checked states = [false,false]
[action] user flips Skill A ON (checkbox[0].checked = true); Skill A is now enabled and leaves the Disabled tab
[after]  Disabled tab now shows [Skill B] only; toggle checked states = [false]
[result] PASS — Skill B's toggle is OFF (correct); no leaked state from Skill A
```

Observed result after fix: the skill that shifts into the vacated slot keeps its own toggle state. Pre-fix, the reused `<input>` node carried Skill A's "on" state onto Skill B; post-fix, Skill B's toggle stays off.

What was not tested: a live Control UI browser screenshot (no running gateway/dashboard session on this host). Reproduced via the production `renderSkills` view rendered in a real DOM instead.

## Supplemental checks (not a substitute for the proof above)

- `pnpm test ui/src/ui/views/skills.test.ts` — 5/5 pass, including a new regression test that renders the real view and fails without this patch (`expected true to be false`).
- Sibling suites (`ui/src/ui/controllers/skills.test.ts`, `agents-panels-tools-skills.browser.test.ts`) — 27/27 pass.
- `pnpm tsgo:test:ui` exit 0; `oxfmt --check` + oxlint clean.

## Files
- `ui/src/ui/views/skills.ts` — key the groups + skills lists with `repeat()`
- `ui/src/ui/views/skills.test.ts` — regression test for the toggle-state leak
