### PR TITLE
fix(acpx): handle Claude ACP model startup options

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -252,6 +252,40 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(ensureInput).not.toHaveProperty("thinking");
   });
 
+  it("normalizes OpenClaw Claude model ids for ACP startup", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "claude" ? "npx @agentclientprotocol/claude-agent-acp" : agentName,
+        list: () => ["claude", "openclaw"],
+      },
+    });
+    const ensure = vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude",
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "persistent",
+      model: "anthropic/claude-sonnet-4-6",
+    });
+
+    expect(readFirstEnsureSessionInput(ensure)).toEqual({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "persistent",
+      model: "claude-sonnet-4-6",
+      sessionOptions: { model: "claude-sonnet-4-6" },
+    });
+  });
+
   it("adds Codex wrapper stderr tail to generic session initialization failures", async () => {
     const wrapperRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-runtime-"));
     const leaseStore = makeLeaseStore();
@@ -893,7 +927,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(setConfigOption).not.toHaveBeenCalled();
   });
 
-  it("still forwards non-timeout config controls for claude-agent-acp", async () => {
+  it("ignores unsupported claude-agent-acp model config controls after startup", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:claude:acp:test",
@@ -913,15 +947,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     await runtime.setConfigOption({
       handle,
       key: "model",
-      value: "claude-sonnet-4.6",
+      value: "anthropic/claude-sonnet-4-6",
     });
 
-    expect(setConfigOption).toHaveBeenCalledOnce();
-    expect(setConfigOption).toHaveBeenCalledWith({
-      handle,
-      key: "model",
-      value: "claude-sonnet-4.6",
-    });
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it("recognizes claude-agent-acp commands", () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -315,6 +315,8 @@ const OPENCLAW_BRIDGE_EXECUTABLE = "openclaw";
 const OPENCLAW_BRIDGE_SUBCOMMAND = "acp";
 const CODEX_ACP_AGENT_ID = "codex";
 const CODEX_ACP_OPENCLAW_PREFIX = "openai/";
+const CLAUDE_ACP_AGENT_ID = "claude";
+const CLAUDE_ACP_OPENCLAW_PREFIX = "anthropic/";
 const CODEX_ACP_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
 const CODEX_ACP_THINKING_ALIASES = new Map<string, string | undefined>([
   ["off", undefined],
@@ -539,6 +541,16 @@ function normalizeCodexAcpModelOverride(
     model,
     ...(reasoningEffort ? { reasoningEffort } : {}),
   };
+}
+
+function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string | undefined {
+  const raw = rawModel?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  return raw.toLowerCase().startsWith(CLAUDE_ACP_OPENCLAW_PREFIX)
+    ? raw.slice(CLAUDE_ACP_OPENCLAW_PREFIX.length).trim() || raw
+    : raw;
 }
 
 function codexAcpSessionModelId(override: CodexAcpModelOverride): string {
@@ -934,6 +946,10 @@ export class AcpxRuntime implements AcpRuntime {
       normalizeAgentName(input.agent) === CODEX_ACP_AGENT_ID && isCodexAcpCommand(command)
         ? normalizeCodexAcpModelOverride(input.model, input.thinking)
         : undefined;
+    const claudeModelOverride =
+      normalizeAgentName(input.agent) === CLAUDE_ACP_AGENT_ID && isClaudeAcpCommand(command)
+        ? normalizeClaudeAcpModelOverride(input.model)
+        : undefined;
     const stableLaunchCommand =
       codexModelOverride && command
         ? appendCodexAcpConfigOverrides(command, codexModelOverride)
@@ -947,6 +963,9 @@ export class AcpxRuntime implements AcpRuntime {
     }));
 
     if (!codexModelOverride) {
+      const normalizedInput = claudeModelOverride
+        ? { ...input, model: claudeModelOverride }
+        : input;
       return await this.runWithLaunchLease({
         sessionKey: input.sessionKey,
         command: stableLaunchCommand,
@@ -955,7 +974,7 @@ export class AcpxRuntime implements AcpRuntime {
           this.withCodexWrapperDiagnostics({
             command: stableLaunchCommand,
             fallbackCode: "ACP_SESSION_INIT_FAILED",
-            run: () => delegate.ensureSession(withAcpxSessionOptions(input)),
+            run: () => delegate.ensureSession(withAcpxSessionOptions(normalizedInput)),
           }),
       });
     }
@@ -1154,7 +1173,11 @@ export class AcpxRuntime implements AcpRuntime {
     const command = await this.resolveCommandForHandle(input.handle);
     const key = input.key.trim().toLowerCase();
     const isCodexAcp = isCodexAcpCommand(command);
-    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcpCommand(command))) {
+    const isClaudeAcp = isClaudeAcpCommand(command);
+    if (WIRE_TIMEOUT_CONFIG_KEYS.has(key) && (isCodexAcp || isClaudeAcp)) {
+      return;
+    }
+    if (isClaudeAcp && key === "model") {
       return;
     }
     if (isCodexAcp) {


### PR DESCRIPTION
## Summary

Fix Claude ACP model selection for managed OpenClaw sessions by handling Claude's startup-only model behaviour explicitly.

This patch:
- normalizes OpenClaw provider-prefixed Claude model ids such as `anthropic/claude-sonnet-4-6` to the bare Claude CLI id `claude-sonnet-4-6` before ACP startup
- suppresses post-startup `session/set_config_option` replay for `model` on `claude-agent-acp`, because Claude ACP rejects that control path after initialization
- keeps the existing timeout suppression behaviour for Claude ACP
- adds targeted runtime tests for the startup normalization and unsupported post-startup model control path

## Why

Direct `acpx --model claude-sonnet-4-6 ... claude exec` works, but managed OpenClaw ACP sessions can carry provider-prefixed model ids from central config and later replay `model` through an adapter path that Claude rejects. That makes exact Claude Sonnet/Opus selection unreliable through managed ACP even though direct Claude/acpx model selection works.

## Verification

Ran locally:

```bash
pnpm exec vitest run --config test/vitest/vitest.extension-acpx.config.ts extensions/acpx/src/runtime.test.ts
pnpm tsgo:test:extensions
pnpm exec oxlint extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts
pnpm exec oxfmt --check --threads=1 extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts
git diff --check
```


## Real behavior proof

Behavior or issue addressed: Claude ACP model selection. The PR handles OpenClaw provider-prefixed Claude model ids by normalizing them to the bare Claude CLI/acpx id at startup and avoids replaying `model` through Claude ACP's unsupported post-startup config-option path.

Real environment tested: Mac Mini local OpenClaw development checkout with Claude Code/acpx installed and authenticated through the Claude subscription route.

Exact steps or command run after this patch:

```bash
/opt/homebrew/bin/acpx --model claude-sonnet-4-6 --timeout 90 --format text --suppress-reads claude exec 'Print exactly LIVE_ACPX_SONNET_OK and nothing else.'
```

Evidence after fix: Terminal output from the real local acpx/Claude setup:

```text
[client] initialize (running)
[client] session/new (running)
[client] session/set_model (running)
[thinking] The user wants me to print exactly "LIVE_ACPX_SONNET_OK" and nothing else.
LIVE_ACPX_SONNET_OK
[done] end_turn
```

Observed result after fix: Direct acpx accepted the bare Claude Sonnet model id that this patch now derives from provider-prefixed OpenClaw model ids before Claude ACP startup. The patched runtime tests also verify that managed OpenClaw passes `claude-sonnet-4-6` into Claude ACP startup and suppresses the unsupported post-startup `model` config replay.

What was not tested: I did not install this source patch into the live production OpenClaw gateway for a managed `sessions_spawn(runtime="acp", agentId="claude", model="anthropic/claude-sonnet-4-6")` smoke; live gateway remains on the released runtime until this patch lands or is deliberately hotfixed.
