### PR TITLE
fix(agents): quarantine invalid bundle MCP tools

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -37,7 +37,20 @@ async function writeListToolsMcpServer(params: {
   delayMs?: number;
   hang?: boolean;
   inputSchema?: unknown;
-  tools?: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+  tools?: Array<{
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+  }>;
+  toolPages?: Array<
+    Array<{
+      name: string;
+      description?: string;
+      inputSchema?: unknown;
+      outputSchema?: unknown;
+    }>
+  >;
   capabilities?: Record<string, unknown>;
   listToolsMethodNotFound?: boolean;
   callToolIsError?: boolean;
@@ -63,6 +76,7 @@ const tools = ${JSON.stringify(
         },
       ],
     )};
+const toolPages = ${JSON.stringify(params.toolPages ?? null)};
 const callToolIsError = ${params.callToolIsError === true};
 const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
@@ -111,13 +125,17 @@ function handle(message) {
       keepAlive = setInterval(() => {}, 1000);
       return;
     }
-    log("delay tools/list " + delayMs);
+    const pageIndex = toolPages ? Number(message.params?.cursor ?? 0) : 0;
+    const pageTools = toolPages ? (toolPages[pageIndex] ?? []) : tools;
+    const nextCursor = toolPages && pageIndex + 1 < toolPages.length ? String(pageIndex + 1) : undefined;
+    log("delay tools/list " + delayMs + " page " + pageIndex);
     pendingTimer = setTimeout(() => {
       send({
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          tools,
+          tools: pageTools,
+          ...(nextCursor ? { nextCursor } : {}),
         },
       });
     }, delayMs);
@@ -769,11 +787,178 @@ describe("session MCP runtime", () => {
     try {
       const catalog = await runtime.getCatalog();
 
-      expect(catalog.servers).toEqual({});
+      expect(catalog.servers.fuzzplugin?.toolCount).toBe(0);
       expect(catalog.tools).toEqual([]);
       expect(catalog.diagnostics?.[0]?.serverName).toBe("fuzzplugin");
+      expect(catalog.diagnostics?.[0]?.message).toContain("slow_tool");
       expect(catalog.diagnostics?.[0]?.message).toContain("Invalid input: expected");
       expect(catalog.diagnostics?.[0]?.message).toContain("object");
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips invalid tools/list entries while keeping healthy siblings", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-mixed-schema-"));
+    const serverPath = path.join(tempDir, "mixed-schema.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      tools: [
+        {
+          name: "bad_array_schema",
+          inputSchema: { type: "array", items: { type: "number" } },
+        },
+        {
+          name: "healthy_tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-mixed-schema",
+      sessionKey: "agent:test:session-mixed-schema",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            fuzzplugin: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["healthy_tool"]);
+      expect(catalog.servers.fuzzplugin?.toolCount).toBe(1);
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("fuzzplugin");
+      expect(catalog.diagnostics?.[0]?.message).toContain("bad_array_schema");
+      expect(catalog.diagnostics?.[0]?.message).toContain("Invalid input");
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips tools whose output schema metadata cannot be cached", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-output-schema-"));
+    const serverPath = path.join(tempDir, "output-schema.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      tools: [
+        {
+          name: "bad_output_schema",
+          inputSchema: { type: "object", properties: {} },
+          outputSchema: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            type: "object",
+            dependencies: { mode: 123 },
+          },
+        },
+        {
+          name: "healthy_tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-output-schema",
+      sessionKey: "agent:test:session-output-schema",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            fuzzplugin: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["healthy_tool"]);
+      expect(catalog.servers.fuzzplugin?.toolCount).toBe(1);
+      expect(catalog.diagnostics?.[0]?.serverName).toBe("fuzzplugin");
+      expect(catalog.diagnostics?.[0]?.message).toContain("bad_output_schema");
+      expect(catalog.diagnostics?.[0]?.message).toContain("metadata cache failed");
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rebuilds metadata cache for surviving tools after paginated quarantine", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-paged-schema-"));
+    const serverPath = path.join(tempDir, "paged-schema.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      toolPages: [
+        [
+          {
+            name: "requires_output",
+            inputSchema: { type: "object", properties: {} },
+            outputSchema: {
+              type: "object",
+              properties: { ok: { type: "boolean" } },
+              required: ["ok"],
+            },
+          },
+        ],
+        [
+          {
+            name: "bad_output_schema",
+            inputSchema: { type: "object", properties: {} },
+            outputSchema: {
+              $schema: "https://json-schema.org/draft/2020-12/schema",
+              type: "object",
+              dependencies: { mode: 123 },
+            },
+          },
+        ],
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-paged-schema",
+      sessionKey: "agent:test:session-paged-schema",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            fuzzplugin: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["requires_output"]);
+      expect(catalog.diagnostics?.[0]?.message).toContain("bad_output_schema");
+      await expect(runtime.callTool("fuzzplugin", "requires_output", {})).rejects.toThrow(
+        "has an output schema",
+      );
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });
@@ -914,7 +1099,17 @@ function handle(message) {
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          tools: [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }],
+          tools: [
+            {
+              name: "ok_tool",
+              inputSchema: { type: "object", properties: {} },
+              outputSchema: {
+                type: "object",
+                properties: { ok: { type: "boolean" } },
+                required: ["ok"],
+              },
+            },
+          ],
         },
       });
       setTimeout(() => {

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -2,7 +2,12 @@ import crypto from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { ErrorCode, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ErrorCode,
+  ResultSchema,
+  ToolSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv-provider.js";
 import type {
@@ -13,6 +18,7 @@ import type {
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { Compile } from "typebox/compile";
+import * as z from "zod/v4";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -46,6 +52,11 @@ type BundleMcpSession = {
 
 type LoadedMcpConfig = ReturnType<typeof loadEmbeddedAgentMcpConfig>;
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
+type ListedToolsPage = {
+  tools: ListedTool[];
+  nextCursor?: string;
+  diagnostics: string[];
+};
 type CreateSessionMcpRuntime = (
   params: Parameters<typeof createSessionMcpRuntime>[0] & { configFingerprint?: string },
 ) => SessionMcpRuntime;
@@ -59,6 +70,11 @@ const BUNDLE_MCP_FAILURE_COOLDOWN_MS = 60_000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
 const BUNDLE_MCP_METADATA_TEXT_LIMIT = 1_200;
 let bundleMcpCatalogListTimeoutMs: number | undefined;
+
+const LenientListToolsResultSchema = ResultSchema.extend({
+  nextCursor: z.string().optional(),
+  tools: z.array(z.unknown()),
+});
 
 type McpToolSelection = {
   include?: readonly string[];
@@ -213,16 +229,120 @@ function redactErrorUrls(error: unknown): string {
   return redactSensitiveUrlLikeString(String(error));
 }
 
-async function listAllTools(client: Client, timeoutMs: number) {
+function describeZodIssues(error: { issues?: unknown }): string {
+  if (!Array.isArray(error.issues)) {
+    return "schema validation failed";
+  }
+  const messages = error.issues
+    .map((issue) => {
+      if (!issue || typeof issue !== "object") {
+        return "";
+      }
+      const record = issue as { path?: unknown; message?: unknown };
+      const path =
+        Array.isArray(record.path) && record.path.length > 0 ? record.path.join(".") : "tool";
+      const message = typeof record.message === "string" ? record.message : "invalid value";
+      return `${path}: ${message}`;
+    })
+    .filter(Boolean);
+  return messages.length > 0 ? messages.join(", ") : "schema validation failed";
+}
+
+function describeListedToolName(value: unknown, index: number): string {
+  if (isMcpConfigRecord(value) && typeof value.name === "string") {
+    const name = value.name.trim();
+    if (name) {
+      return `"${name}"`;
+    }
+  }
+  return `at index ${index}`;
+}
+
+function cacheListedToolMetadata(
+  client: Client,
+  tools: ListedTool[],
+): {
+  tools: ListedTool[];
+  diagnostics: string[];
+} {
+  const cacheToolMetadata = (
+    client as unknown as {
+      cacheToolMetadata?: (tools: ListedTool[]) => void;
+    }
+  ).cacheToolMetadata;
+  if (typeof cacheToolMetadata !== "function") {
+    return { tools, diagnostics: [] };
+  }
+  try {
+    cacheToolMetadata.call(client, tools);
+    return { tools, diagnostics: [] };
+  } catch (error) {
+    const cacheableTools: ListedTool[] = [];
+    const diagnostics: string[] = [];
+    for (const [index, tool] of tools.entries()) {
+      try {
+        cacheToolMetadata.call(client, [tool]);
+        cacheableTools.push(tool);
+      } catch (toolError) {
+        diagnostics.push(
+          `tools/list skipped tool ${describeListedToolName(tool, index)} because metadata cache failed: ${redactErrorUrls(toolError)}`,
+        );
+      }
+    }
+    if (cacheableTools.length > 0) {
+      // The SDK cache method clears then rebuilds; call it once with the
+      // surviving tool set so call-time output/task behavior stays intact.
+      cacheToolMetadata.call(client, cacheableTools);
+    }
+    if (diagnostics.length === 0) {
+      diagnostics.push(`tools/list metadata cache failed: ${redactErrorUrls(error)}`);
+    }
+    return { tools: cacheableTools, diagnostics };
+  }
+}
+
+function parseListedToolsPage(page: { tools: unknown[]; nextCursor?: string }): ListedToolsPage {
   const tools: ListedTool[] = [];
+  const diagnostics: string[] = [];
+  for (const [index, value] of page.tools.entries()) {
+    const parsed = ToolSchema.safeParse(value);
+    if (!parsed.success) {
+      diagnostics.push(
+        `tools/list skipped invalid tool ${describeListedToolName(value, index)}: ${describeZodIssues(parsed.error)}`,
+      );
+      continue;
+    }
+    tools.push(parsed.data as ListedTool);
+  }
+  return {
+    tools,
+    diagnostics,
+    ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+  };
+}
+
+async function listToolsPage(client: Client, cursor: string | undefined, timeoutMs: number) {
+  const params = cursor ? { cursor } : undefined;
+  const page = await client.request(
+    { method: "tools/list", ...(params ? { params } : {}) },
+    LenientListToolsResultSchema,
+    { timeout: timeoutMs },
+  );
+  return parseListedToolsPage(page);
+}
+
+async function listAllTools(client: Client, timeoutMs: number): Promise<ListedToolsPage> {
+  const tools: ListedTool[] = [];
+  const diagnostics: string[] = [];
   let cursor: string | undefined;
   do {
-    const params = cursor ? { cursor } : undefined;
-    const page = await client.listTools(params, { timeout: timeoutMs });
+    const page = await listToolsPage(client, cursor, timeoutMs);
     tools.push(...page.tools);
+    diagnostics.push(...page.diagnostics);
     cursor = page.nextCursor;
   } while (cursor);
-  return tools;
+  const cached = cacheListedToolMetadata(client, tools);
+  return { tools: cached.tools, diagnostics: [...diagnostics, ...cached.diagnostics] };
 }
 
 function isMcpMethodNotFoundError(error: unknown): boolean {
@@ -237,12 +357,12 @@ async function listAllToolsBestEffort(params: {
   client: Client;
   timeoutMs: number;
   suppressUnsupported: boolean;
-}): Promise<ListedTool[]> {
+}): Promise<ListedToolsPage> {
   try {
     return await listAllTools(params.client, params.timeoutMs);
   } catch (error) {
     if (params.suppressUnsupported && isMcpMethodNotFoundError(error)) {
-      return [];
+      return { tools: [], diagnostics: [] };
     }
     throw error;
   }
@@ -634,13 +754,22 @@ export function createSessionMcpRuntime(params: {
             const capabilities = summarizeServerCapabilities(
               session.client.getServerCapabilities(),
             );
-            const listedTools = await listAllToolsBestEffort({
+            const listed = await listAllToolsBestEffort({
               client: session.client,
               timeoutMs: getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
               suppressUnsupported: Boolean(
                 !capabilities.tools && (capabilities.resources || capabilities.prompts),
               ),
             });
+            for (const message of listed.diagnostics) {
+              diagnostics.push({
+                serverName,
+                safeServerName,
+                launchSummary: resolved.description,
+                message,
+              });
+            }
+            const listedTools = listed.tools;
             failIfDisposed();
             const selection = getMcpToolSelection(rawServer);
             const exposedTools = listedTools.filter((tool) =>


### PR DESCRIPTION
## Summary
- Request bundled MCP `tools/list` with a permissive outer schema, then validate tools one by one.
- Quarantine invalid MCP tool entries and SDK metadata-cache failures with catalog diagnostics while keeping healthy sibling tools available.
- Preserve SDK metadata caching for surviving tools, including paginated lists and empty/all-invalid refreshes, so output-schema validation and task-support behavior remain intact.

## Verification
- `./node_modules/.bin/oxfmt --write src/agents/agent-bundle-mcp-runtime.ts src/agents/agent-bundle-mcp-runtime.test.ts`
- `./node_modules/.bin/oxlint src/agents/agent-bundle-mcp-runtime.ts src/agents/agent-bundle-mcp-runtime.test.ts`
- `CI=1 node scripts/run-vitest.mjs run src/agents/agent-bundle-mcp-runtime.test.ts -t "keeps active MCP sessions usable when catalog refresh records diagnostics|rebuilds metadata cache for surviving tools after paginated quarantine|skips tools whose output schema metadata cannot be cached" --reporter=verbose`
- `CI=1 node scripts/run-vitest.mjs run src/agents/agent-bundle-mcp-runtime.test.ts --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_1f1dd0c0fc88`, lease `cbx_93cd7d890628`, type `c7a.8xlarge`: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

## Real behavior proof
Behavior addressed: A bundled MCP server could return one invalid `tools/list` entry and cause OpenClaw to reject the whole list, dropping healthy sibling tools and reporting only a server-level startup diagnostic.

Real environment tested: Local Codex worktree on branch `fuzz-tool-schema-next66-20260603`, Node/Vitest through `scripts/run-vitest.mjs`; AWS Crabbox `run_1f1dd0c0fc88` / `cbx_93cd7d890628`, Linux `c7a.8xlarge`.

Exact steps or command run after this patch: See Verification above.

Evidence after fix: The pre-patch regression failed with `catalog.tools` equal to `[]` instead of `healthy_tool`. After the patch, focused MCP tests passed for invalid input-schema quarantine, invalid output-metadata quarantine, paginated metadata-cache preservation, and all-invalid refresh cache clearing. Full `agent-bundle-mcp-runtime.test.ts` passed: 1 file, 33 tests. Autoreview reported no accepted/actionable findings. Remote `pnpm check:changed` selected lanes `core, coreTests` and exited 0.

Observed result after fix: Invalid MCP tools are skipped with diagnostics naming the offending tool; healthy sibling tools remain in the catalog; surviving tools are re-cached through the SDK metadata path; stale metadata is cleared when a refresh leaves no surviving tools.

What was not tested: Full repo suite was not run; `pnpm check:changed` passed remotely for the touched lanes.
