### PR TITLE
fix(feishu): scope queues by topic sessions

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -110,7 +110,7 @@ function shouldSendNoVisibleReplyFallback(dispatchResult: {
   );
 }
 
-function resolveConfiguredFeishuGroupSessionScope(params: {
+export function resolveConfiguredFeishuGroupSessionScope(params: {
   groupConfig?: {
     groupSessionScope?: FeishuGroupSessionScope;
     topicSessionMode?: "enabled" | "disabled";
@@ -129,7 +129,7 @@ function resolveConfiguredFeishuGroupSessionScope(params: {
   );
 }
 
-function isFeishuTopicSessionScope(scope: FeishuGroupSessionScope): boolean {
+export function isFeishuTopicSessionScope(scope: FeishuGroupSessionScope): boolean {
   return scope === "group_topic" || scope === "group_topic_sender";
 }
 

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -46,11 +46,13 @@ type FeishuMessageReceiveHandlerContext = {
   getBotOpenId?: (accountId: string) => string | undefined;
   getBotName?: (accountId: string) => string | undefined;
   resolveSequentialKey?: (params: {
+    cfg: ClawdbotConfig;
     accountId: string;
     event: FeishuMessageEvent;
     botOpenId?: string;
     botName?: string;
-  }) => string;
+    runtime?: RuntimeEnv;
+  }) => string | Promise<string>;
 };
 
 function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
@@ -184,11 +186,13 @@ export function createFeishuMessageReceiveHandler({
   });
 
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
-    const sequentialKey = resolveSequentialKey({
+    const sequentialKey = await resolveSequentialKey({
+      cfg,
       accountId,
       event,
       botOpenId: getBotOpenId(accountId),
       botName: getBotName(accountId),
+      runtime,
     });
     const task = () =>
       handleMessage({

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, it } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./bot.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
+
+const cfg = {
+  channels: {
+    feishu: {
+      appId: "cli_test",
+      appSecret: "secret_test",
+      groups: {
+        oc_topic_chat: {
+          groupSessionScope: "group_topic",
+        },
+        oc_topic_sender_chat: {
+          groupSessionScope: "group_topic_sender",
+        },
+      },
+    },
+  },
+} as ClawdbotConfig;
 
 function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  chatType?: FeishuMessageEvent["message"]["chat_type"];
+  rootId?: string;
+  threadId?: string;
 }): FeishuMessageEvent {
   return {
     sender: {
@@ -18,9 +39,11 @@ function createTextEvent(params: {
     message: {
       message_id: params.messageId ?? "om_message_1",
       chat_id: params.chatId ?? "oc_dm_chat",
-      chat_type: "p2p",
+      chat_type: params.chatType ?? "p2p",
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
+      ...(params.rootId ? { root_id: params.rootId } : {}),
+      ...(params.threadId ? { thread_id: params.threadId } : {}),
     },
   } as FeishuMessageEvent;
 }
@@ -31,42 +54,118 @@ describe("getFeishuSequentialKey", () => {
     [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat"],
     [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control"],
     [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw"],
-  ])("resolves sequential key %#", (event, expected) => {
-    expect(
+  ])("resolves sequential key %#", async (event, expected) => {
+    await expect(
       getFeishuSequentialKey({
+        cfg,
         accountId: "default",
         event,
       }),
-    ).toBe(expected);
+    ).resolves.toBe(expected);
   });
 
-  it("keeps /btw on a stable per-chat lane across different message ids", () => {
+  it("keeps /btw on a stable per-chat lane across different message ids", async () => {
     const first = createTextEvent({ text: "/btw one", messageId: "om_message_1" });
     const second = createTextEvent({ text: "/btw two", messageId: "om_message_2" });
 
-    expect(
+    await expect(
       getFeishuSequentialKey({
+        cfg,
         accountId: "default",
         event: first,
       }),
-    ).toBe("feishu:default:oc_dm_chat:btw");
-    expect(
+    ).resolves.toBe("feishu:default:oc_dm_chat:btw");
+    await expect(
       getFeishuSequentialKey({
+        cfg,
         accountId: "default",
         event: second,
       }),
-    ).toBe("feishu:default:oc_dm_chat:btw");
+    ).resolves.toBe("feishu:default:oc_dm_chat:btw");
   });
 
-  it("falls back to a stable btw lane when the message id is unavailable", () => {
+  it("falls back to a stable btw lane when the message id is unavailable", async () => {
     const event = createTextEvent({ text: "/btw what changed?" });
     delete (event.message as { message_id?: string }).message_id;
 
-    expect(
+    await expect(
       getFeishuSequentialKey({
+        cfg,
         accountId: "default",
         event,
       }),
-    ).toBe("feishu:default:oc_dm_chat:btw");
+    ).resolves.toBe("feishu:default:oc_dm_chat:btw");
+  });
+
+  it("uses the configured topic session scope for group queue keys", async () => {
+    const first = createTextEvent({
+      text: "topic one",
+      chatId: "oc_topic_chat",
+      chatType: "topic_group",
+      threadId: "omt_topic_1",
+    });
+    const second = createTextEvent({
+      text: "topic two",
+      chatId: "oc_topic_chat",
+      chatType: "topic_group",
+      threadId: "omt_topic_2",
+    });
+
+    await expect(getFeishuSequentialKey({ cfg, accountId: "default", event: first })).resolves.toBe(
+      "feishu:default:oc_topic_chat:topic:omt_topic_1",
+    );
+    await expect(
+      getFeishuSequentialKey({ cfg, accountId: "default", event: second }),
+    ).resolves.toBe("feishu:default:oc_topic_chat:topic:omt_topic_2");
+  });
+
+  it("keeps control lanes scoped within the topic queue", async () => {
+    const event = createTextEvent({
+      text: "/stop",
+      chatId: "oc_topic_chat",
+      chatType: "topic_group",
+      threadId: "omt_topic_1",
+    });
+
+    await expect(getFeishuSequentialKey({ cfg, accountId: "default", event })).resolves.toBe(
+      "feishu:default:oc_topic_chat:topic:omt_topic_1:control",
+    );
+  });
+
+  it("hydrates a missing topic thread id before resolving the queue key", async () => {
+    const event = createTextEvent({
+      text: "topic",
+      chatId: "oc_topic_chat",
+      chatType: "topic_group",
+      messageId: "om_message_missing_thread",
+    });
+
+    await expect(
+      getFeishuSequentialKey({
+        cfg,
+        accountId: "default",
+        event,
+        fetchMessage: async () => ({
+          messageId: "om_message_missing_thread",
+          chatId: "oc_topic_chat",
+          content: "topic",
+          contentType: "text",
+          threadId: "omt_hydrated",
+        }),
+      }),
+    ).resolves.toBe("feishu:default:oc_topic_chat:topic:omt_hydrated");
+  });
+
+  it("uses topic and sender for group_topic_sender queue keys", async () => {
+    const event = createTextEvent({
+      text: "topic sender",
+      chatId: "oc_topic_sender_chat",
+      chatType: "topic_group",
+      threadId: "omt_topic_1",
+    });
+
+    await expect(getFeishuSequentialKey({ cfg, accountId: "default", event })).resolves.toBe(
+      "feishu:default:oc_topic_sender_chat:topic:omt_topic_1:sender:ou_sender_1",
+    );
   });
 });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -8,7 +8,11 @@ const cfg = {
     feishu: {
       appId: "cli_test",
       appSecret: "secret_test",
+      groupSessionScope: "group_topic",
       groups: {
+        oc_group_chat: {
+          groupSessionScope: "group",
+        },
         oc_topic_chat: {
           groupSessionScope: "group_topic",
         },
@@ -97,7 +101,7 @@ describe("getFeishuSequentialKey", () => {
     ).resolves.toBe("feishu:default:oc_dm_chat:btw");
   });
 
-  it("uses the configured topic session scope for group queue keys", async () => {
+  it("uses configured topic thread_id scope for group queue keys", async () => {
     const first = createTextEvent({
       text: "topic one",
       chatId: "oc_topic_chat",
@@ -117,6 +121,55 @@ describe("getFeishuSequentialKey", () => {
     await expect(
       getFeishuSequentialKey({ cfg, accountId: "default", event: second }),
     ).resolves.toBe("feishu:default:oc_topic_chat:topic:omt_topic_2");
+  });
+
+  it("keeps group queues chat-scoped when groupSessionScope is group", async () => {
+    const event = createTextEvent({
+      text: "plain group",
+      chatId: "oc_group_chat",
+      chatType: "topic_group",
+      threadId: "omt_topic_1",
+    });
+
+    await expect(getFeishuSequentialKey({ cfg, accountId: "default", event })).resolves.toBe(
+      "feishu:default:oc_group_chat",
+    );
+  });
+
+  it("uses the top-level groupSessionScope thread_id when a group has no override", async () => {
+    const event = createTextEvent({
+      text: "global topic scope",
+      chatId: "oc_global_topic_chat",
+      chatType: "topic_group",
+      threadId: "omt_global_topic_1",
+    });
+
+    await expect(getFeishuSequentialKey({ cfg, accountId: "default", event })).resolves.toBe(
+      "feishu:default:oc_global_topic_chat:topic:omt_global_topic_1",
+    );
+  });
+
+  it("does not hydrate thread_id when groupSessionScope keeps the chat queue", async () => {
+    const event = createTextEvent({
+      text: "plain group without thread id",
+      chatId: "oc_group_chat",
+      chatType: "topic_group",
+      messageId: "om_group_scope_message",
+    });
+    let fetched = false;
+
+    await expect(
+      getFeishuSequentialKey({
+        cfg,
+        accountId: "default",
+        event,
+        fetchMessage: async () => {
+          fetched = true;
+          throw new Error("should not fetch for chat-scoped queues");
+        },
+      }),
+    ).resolves.toBe("feishu:default:oc_group_chat");
+    expect(fetched).toBe(false);
   });
 
   it("keeps control lanes scoped within the topic queue", async () => {

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -2,18 +2,45 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
-import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { resolveFeishuGroupSession } from "./bot-content.js";
+import {
+  isFeishuTopicSessionScope,
+  parseFeishuMessageEvent,
+  resolveConfiguredFeishuGroupSessionScope,
+  type FeishuMessageEvent,
+} from "./bot.js";
+import { resolveFeishuGroupConfig } from "./policy.js";
+import { getMessageFeishu } from "./send.js";
+import { isFeishuGroupChatType } from "./types.js";
 
-export function getFeishuSequentialKey(params: {
+export async function getFeishuSequentialKey(params: {
+  cfg: ClawdbotConfig;
   accountId: string;
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
-}): string {
-  const { accountId, event, botOpenId, botName } = params;
-  const chatId = event.message.chat_id?.trim() || "unknown";
-  const baseKey = `feishu:${accountId}:${chatId}`;
+  runtime?: RuntimeEnv;
+  fetchMessage?: typeof getMessageFeishu;
+}): Promise<string> {
+  const {
+    cfg,
+    accountId,
+    event,
+    botOpenId,
+    botName,
+    runtime,
+    fetchMessage = getMessageFeishu,
+  } = params;
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
+  const baseKey = await resolveFeishuSequentialBaseKey({
+    accountId,
+    cfg,
+    fetchMessage,
+    parsed,
+    runtime,
+  });
   const text = parsed.content.trim();
 
   if (isAbortRequestText(text)) {
@@ -25,4 +52,62 @@ export function getFeishuSequentialKey(params: {
   }
 
   return baseKey;
+}
+
+async function resolveFeishuSequentialBaseKey(params: {
+  accountId: string;
+  cfg: ClawdbotConfig;
+  fetchMessage: typeof getMessageFeishu;
+  parsed: ReturnType<typeof parseFeishuMessageEvent>;
+  runtime?: RuntimeEnv;
+}): Promise<string> {
+  const { accountId, cfg, fetchMessage, parsed, runtime } = params;
+  const chatId = parsed.chatId?.trim() || "unknown";
+  if (!isFeishuGroupChatType(parsed.chatType)) {
+    return `feishu:${accountId}:${chatId}`;
+  }
+
+  try {
+    const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+    const feishuCfg = account.config;
+    const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId });
+    const groupSessionScope = resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg });
+    let effectiveThreadId = parsed.threadId;
+    if (
+      parsed.chatType === "topic_group" &&
+      !effectiveThreadId &&
+      isFeishuTopicSessionScope(groupSessionScope)
+    ) {
+      try {
+        effectiveThreadId =
+          (
+            await fetchMessage({
+              cfg,
+              accountId: account.accountId,
+              messageId: parsed.messageId,
+            })
+          )?.threadId?.trim() || undefined;
+      } catch (err) {
+        (runtime?.log ?? console.log)(
+          `feishu[${account.accountId}]: failed to hydrate topic thread_id for sequential key message=${parsed.messageId}: ${String(err)}`,
+        );
+      }
+    }
+    const groupSession = resolveFeishuGroupSession({
+      chatId,
+      senderOpenId: parsed.senderOpenId,
+      messageId: parsed.messageId,
+      rootId: parsed.rootId,
+      threadId: effectiveThreadId,
+      chatType: parsed.chatType,
+      groupConfig,
+      feishuCfg,
+    });
+    return `feishu:${accountId}:${groupSession.peerId || chatId}`;
+  } catch (err) {
+    (runtime?.log ?? console.log)(
+      `feishu[${accountId}]: failed to resolve scoped sequential key for chat=${chatId}: ${String(err)}`,
+    );
+    return `feishu:${accountId}:${chatId}`;
+  }
 }

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -63,8 +63,9 @@ async function resolveFeishuSequentialBaseKey(params: {
 }): Promise<string> {
   const { accountId, cfg, fetchMessage, parsed, runtime } = params;
   const chatId = parsed.chatId?.trim() || "unknown";
+  const chatKey = `feishu:${accountId}:${chatId}`;
   if (!isFeishuGroupChatType(parsed.chatType)) {
-    return `feishu:${accountId}:${chatId}`;
+    return chatKey;
   }
 
   try {
@@ -72,6 +73,10 @@ async function resolveFeishuSequentialBaseKey(params: {
     const feishuCfg = account.config;
     const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId });
     const groupSessionScope = resolveConfiguredFeishuGroupSessionScope({ groupConfig, feishuCfg });
+    if (groupSessionScope === "group") {
+      return chatKey;
+    }
+
     let effectiveThreadId = parsed.threadId;
     if (
       parsed.chatType === "topic_group" &&
@@ -108,6 +113,6 @@ async function resolveFeishuSequentialBaseKey(params: {
     (runtime?.log ?? console.log)(
       `feishu[${accountId}]: failed to resolve scoped sequential key for chat=${chatId}: ${String(err)}`,
     );
-    return `feishu:${accountId}:${chatId}`;
+    return chatKey;
   }
 }


### PR DESCRIPTION
## Summary

What problem does this PR solve?


Why does this matter now?


What is the intended outcome?


What is intentionally out of scope?


What does success look like?


What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?


What regression coverage was added or updated?


What failed before this fix, if known?


If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)


Did config, environment, or migration behavior change? (`Yes/No`)


Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)


What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
