### PR TITLE
fix(feishu): wire setup runtime setter

### DIFF
--- a/extensions/feishu/runtime-setter-api.ts
+++ b/extensions/feishu/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Narrow entry point for setFeishuRuntime. Keep setup/runtime registration
+// from pulling in the broader Feishu runtime-api barrel.
+export { setFeishuRuntime } from "./src/runtime.js";

--- a/extensions/feishu/setup-entry.test.ts
+++ b/extensions/feishu/setup-entry.test.ts
@@ -17,5 +17,16 @@ describe("feishu setup entry", () => {
     expect(setupEntry.features).toEqual({ legacyStateMigrations: true });
     expect(typeof setupEntry.loadSetupPlugin).toBe("function");
     expect(setupEntry.loadLegacyStateMigrationDetector?.()).toBeTypeOf("function");
+    expect(typeof setupEntry.setChannelRuntime).toBe("function");
+  });
+
+  it("wires the Feishu runtime from setup-only registration", async () => {
+    const { default: setupEntry } = await import("./setup-entry.js");
+    const runtime = { channel: { inbound: { run: vi.fn() } } };
+
+    setupEntry.setChannelRuntime?.(runtime as never);
+
+    const { getFeishuRuntime } = await import("./src/runtime.js");
+    expect(getFeishuRuntime()).toBe(runtime);
   });
 });

--- a/extensions/feishu/setup-entry.ts
+++ b/extensions/feishu/setup-entry.ts
@@ -17,4 +17,8 @@ export default defineBundledChannelSetupEntry({
     specifier: "./secret-contract-api.js",
     exportName: "channelSecrets",
   },
+  runtime: {
+    specifier: "./runtime-setter-api.js",
+    exportName: "setFeishuRuntime",
+  },
 });


### PR DESCRIPTION
## Summary

- expose `setFeishuRuntime` from the Feishu setup-only entry
- add a narrow runtime setter barrel so setup/runtime registration does not need the broader runtime API
- cover setup-only runtime wiring in the Feishu setup-entry test

## Real behavior proof

Behavior or issue addressed: Feishu setup-only / setup-runtime registration did not initialize the Feishu runtime store. The monitor path can then reach `getFeishuRuntime().channel` without an initialized runtime, causing inbound dispatch for Feishu messages to fail before `channel.inbound.run(...)` can run.

Real environment tested: User-designated remote test machine, fresh shallow `openclaw/openclaw` checkout at `origin/main` plus this patch, Node v22.22.2, pnpm v11.2.2 via corepack.

Exact steps or command run after this patch:

1. `corepack pnpm install --frozen-lockfile --ignore-scripts`
2. `node --import tsx .tmp-check-feishu-runtime.mjs`
3. `corepack pnpm exec vitest run extensions/feishu/setup-entry.test.ts --reporter=dot`

The smoke script imported the patched Feishu setup entry, called `setupEntry.setChannelRuntime(runtime)`, then imported `getFeishuRuntime()` and verified that the stored runtime is the same object and that `channel.inbound.run()` is reachable.

Evidence after fix: Terminal output from the user-designated remote test machine:

```
kind=bundled-channel-setup-entry
setter=function
sameRuntime=true
inboundRun=ok
```

Targeted regression test output from the same remote machine:

```
Test Files  1 passed (1)
Tests       2 passed (2)
```

Observed result after fix: The Feishu setup-only entry now exposes and applies the runtime setter. After setup-only registration calls the setter, `getFeishuRuntime()` returns the active runtime and `getFeishuRuntime().channel.inbound.run` is available instead of undefined.

What was not tested: A live Feishu/Lark tenant message was not sent; the remote verification exercised the runtime-registration path that caused the reported dispatch crash, plus the targeted regression test.

## Supplemental verification

- Local preflight: `git diff --check`
- Local preflight: `git verify-commit HEAD`

Closes #88024
