### PR TITLE
fix(cron): ignore optional scanner search misses

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -1,6 +1,10 @@
 // Isolated agent helper tests cover low-level cron agent utilities.
 import { describe, expect, it } from "vitest";
-import { isHeartbeatOnlyResponse, pickLastNonEmptyTextFromPayloads } from "./helpers.js";
+import {
+  isHeartbeatOnlyResponse,
+  pickLastNonEmptyTextFromPayloads,
+  resolveCronPayloadOutcome,
+} from "./helpers.js";
 
 type TextPayload = { text?: string | undefined; isError?: boolean | undefined };
 
@@ -42,6 +46,59 @@ const textPayloadPickerCases: Array<{
 describe("text payload pickers", () => {
   it.each(textPayloadPickerCases)("$name", ({ pick, payloads, expected }) => {
     expect(pick(payloads)).toBe(expected);
+  });
+});
+
+describe("resolveCronPayloadOutcome", () => {
+  it("treats a trailing optional search miss as nonfatal after scanner output", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Seattle United uniforms are due today." },
+        {
+          text: '⚠️ 🛠️ search "uniform ordering|FIRST Robotics Competition survey" (agent) failed',
+          isError: true,
+        },
+      ],
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(outcome.embeddedRunError).toBeUndefined();
+    expect(outcome.outputText).toBe("Seattle United uniforms are due today.");
+    expect(outcome.deliveryPayloads).toEqual([{ text: "Seattle United uniforms are due today." }]);
+  });
+
+  it("keeps a trailing optional search miss fatal when no scanner output exists", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: 'search "FIRST Research and Evaluation" in ] → run then echo → run then exit (agent) failed',
+          isError: true,
+        },
+      ],
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe(
+      'search "FIRST Research and Evaluation" in ] → run then echo → run then exit (agent) failed',
+    );
+    expect(outcome.deliveryPayloads).toEqual([
+      {
+        text: 'search "FIRST Research and Evaluation" in ] → run then echo → run then exit (agent) failed',
+        isError: true,
+      },
+    ]);
+  });
+
+  it("keeps non-search tool errors fatal after scanner output", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Seattle United uniforms are due today." },
+        { text: "Write failed: permission denied", isError: true },
+      ],
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe("Write failed: permission denied");
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -199,6 +199,17 @@ export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars
   return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars);
 }
 
+function isOptionalSearchMissPayload(payload: DeliveryPayload | undefined): boolean {
+  if (payload?.isError !== true) {
+    return false;
+  }
+  const text = payload.text?.trim();
+  return (
+    text !== undefined &&
+    /(?:^|\s)search\s+"[^"]+"(?:\s+in\s+.*)?(?:\s+\([^)]*\))?\s+failed$/i.test(text)
+  );
+}
+
 /** Resolves the non-negative heartbeat ack length used for heartbeat-only filtering. */
 export function resolveHeartbeatAckMaxChars(_agentCfg?: { heartbeat?: object }) {
   return DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
@@ -263,6 +274,12 @@ export function resolveCronPayloadOutcome(params: {
     !params.runLevelError &&
     lastErrorPayloadIndex > 0 &&
     params.payloads.slice(0, lastErrorPayloadIndex).some(isSuccessfulCronPayload);
+  const hasOnlyTrailingOptionalSearchMisses =
+    !params.runLevelError &&
+    params.failureSignal?.fatalForCron !== true &&
+    hasSuccessfulPayloadBeforeLastError &&
+    errorPayloads.length > 0 &&
+    errorPayloads.every(isOptionalSearchMissPayload);
   const lastErrorPayload =
     lastErrorPayloadIndex >= 0 ? params.payloads[lastErrorPayloadIndex] : undefined;
   const hasRecoveringTerminalOutput =
@@ -299,7 +316,8 @@ export function resolveCronPayloadOutcome(params: {
     !hasSuccessfulPayloadAfterLastError &&
     !hasPendingPresentationWarning &&
     !hasNonTerminalToolErrorWarning &&
-    !hasRecoveredToolWarning;
+    !hasRecoveredToolWarning &&
+    !hasOnlyTrailingOptionalSearchMisses;
   // Fatal structured errors own the final delivery payload unless later output
   // proves recovery; otherwise cron would announce stale partial success text.
   // Keep structured/media announce payloads intact. Only collapse purely textual


### PR DESCRIPTION
## What Problem This Solves
Koro/Owen scanner crons can produce valid scanner output and complete state updates, then still be marked failed when a trailing optional search/tool lookup misses. That makes a successful scan look like a cron failure and can confuse alert handling. This keeps those trailing optional search misses nonfatal only when prior scanner output is deliverable, while preserving fatal behavior for search-only failures and non-search tool errors.

## Summary
- Treat trailing optional scanner search-miss payloads as nonfatal when prior scanner output is deliverable.
- Keep search misses fatal when there is no successful scanner output.
- Preserve fatal classification for non-search tool errors.

## Evidence
- `/home/henry/projects/openclaw-koro-search-miss-repair/node_modules/.bin/vitest run src/cron/isolated-agent/helpers.test.ts` - 15/15 passed.
- `/home/henry/projects/openclaw-koro-search-miss-repair/node_modules/.bin/oxlint src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/helpers.test.ts` - passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` - passed.
- `git diff --check HEAD~1..HEAD` - passed.

## Notes
- Repaired the conflicted PR branch on current upstream `origin/main` after Mike reported the source-publish blocker.
- Current repaired commit: `ad19ddcbc3700ab00d742771eda666b46d982a40`.
- Original Mike local commit reference: `61017e26fef06f45d33baefbd25bce51fca56af9`; prior rebased PR commits: `e27f0ac840384ad92ad1e49da07e8657026b5a19`, `27ee30c00981b0378e3f68f935edc49f58cd9e1b`.