### PR TITLE
feat(ui): gate control sections by operator scopes

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -27,6 +27,7 @@ import {
   syncSelectedSessionMessageSubscription,
 } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
+import { canAccessTab } from "./navigation-permissions.ts";
 import { iconForTab, isSettingsTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import {
@@ -201,6 +202,9 @@ const NEW_CHAT_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
 
 export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: boolean }) {
+  if (!canAccessTab(tab, state.hello?.auth ?? null)) {
+    return nothing;
+  }
   const href = pathForTab(tab, state.basePath);
   const isActive = tab === "config" ? isSettingsTab(state.tab) : state.tab === tab;
   const collapsed = opts?.collapsed ?? state.settings.navCollapsed;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -158,11 +158,16 @@ import {
   normalizeBasePath,
   pathForTab,
   SETTINGS_TABS,
-  TAB_GROUPS,
   subtitleForTab,
   titleForTab,
   type Tab,
 } from "./navigation.ts";
+import {
+  canAccessTab,
+  firstPermittedTab,
+  permittedSettingsTabs,
+  permittedTabGroups,
+} from "./navigation-permissions.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
 import { isCronSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import "./components/dashboard-header.ts";
@@ -290,9 +295,13 @@ function renderSettingsSectionNav(state: AppViewState) {
   if (!isSettingsTab(state.tab)) {
     return nothing;
   }
+  const tabs = permittedSettingsTabs(state.hello?.auth ?? null);
+  if (tabs.length <= 1) {
+    return nothing;
+  }
   return html`
     <nav class="settings-section-nav" aria-label=${t("common.settingsSections")}>
-      ${SETTINGS_TABS.map((tab) => {
+      ${tabs.map((tab) => {
         const active = state.tab === tab;
         const href = pathForTab(tab, state.basePath);
         return html`
@@ -396,6 +405,9 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
 }
 
 function renderSidebarSessions(state: AppViewState) {
+  if (!canAccessTab("chat", state.hello?.auth ?? null)) {
+    return nothing;
+  }
   const collapsed = state.settings.navCollapsed;
   const busy = isSidebarSessionBusy(state);
   const recent = collapsed ? [] : resolveSidebarRecentSessions(state);
@@ -1155,6 +1167,23 @@ export function renderApp(state: AppViewState) {
     return html` ${renderLoginGate(state)} ${renderGatewayUrlConfirmation(state)} `;
   }
 
+  const authContext = state.hello?.auth ?? null;
+  if (!canAccessTab(state.tab, authContext)) {
+    const fallbackTab = firstPermittedTab(authContext);
+    if (fallbackTab) {
+      queueMicrotask(() => state.setTab(fallbackTab));
+      return html` ${renderGatewayUrlConfirmation(state)} `;
+    }
+    return html`
+      ${renderGatewayUrlConfirmation(state)}
+      <main class="content">
+        <div class="callout danger" role="alert">
+          This Control UI account does not have permission to access any dashboard sections.
+        </div>
+      </main>
+    `;
+  }
+
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
@@ -1165,6 +1194,7 @@ export function renderApp(state: AppViewState) {
   const chatHeaderHidden = isChat && (state.onboarding || state.chatHeaderControlsHidden);
   const navDrawerOpen = state.navDrawerOpen && !state.onboarding;
   const navCollapsed = state.settings.navCollapsed && !navDrawerOpen;
+  const visibleTabGroups = permittedTabGroups(authContext);
   const dashboardHeaderContext = resolveDashboardHeaderContext(state);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const showToolCalls = state.onboarding ? true : state.settings.chatShowToolCalls;
@@ -2076,7 +2106,10 @@ export function renderApp(state: AppViewState) {
         state.paletteActiveIndex = i;
       },
       onNavigate: (tab) => {
-        state.setTab(tab as import("./navigation.ts").Tab);
+        const nextTab = tab as import("./navigation.ts").Tab;
+        if (canAccessTab(nextTab, authContext)) {
+          state.setTab(nextTab);
+        }
       },
       onSlashCommand: (cmd) => {
         state.setTab("chat" as import("./navigation.ts").Tab);
@@ -2183,7 +2216,7 @@ export function renderApp(state: AppViewState) {
             <div class="sidebar-shell__body">
               ${renderSidebarSessions(state)}
               <nav class="sidebar-nav">
-                ${TAB_GROUPS.map((group) => {
+                ${visibleTabGroups.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
                   const showItems = navCollapsed || !isGroupCollapsed;
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -112,6 +112,7 @@ import type {
 } from "./controllers/skills.ts";
 import { importCustomThemeFromUrl } from "./custom-theme.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
+import { canAccessTab } from "./navigation-permissions.ts";
 import type { Tab } from "./navigation.ts";
 import { resolveAgentIdFromSessionKey } from "./session-key.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
@@ -932,6 +933,9 @@ export class OpenClawApp extends LitElement {
   }
 
   setTab(next: Tab) {
+    if (!canAccessTab(next, this.hello?.auth ?? null)) {
+      return;
+    }
     setTabInternal(this as unknown as Parameters<typeof setTabInternal>[0], next);
     if (next !== "chat") {
       this.setChatMobileControlsOpen(false);

--- a/ui/src/ui/navigation-permissions.test.ts
+++ b/ui/src/ui/navigation-permissions.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  canAccessTab,
+  firstPermittedTab,
+  permittedSettingsTabs,
+  permittedTabGroups,
+  permittedTabs,
+} from "./navigation-permissions.ts";
+
+describe("Control UI navigation permissions", () => {
+  it("allows every tab before the gateway auth context is known", () => {
+    expect(permittedTabs(null)).toContain("config");
+    expect(canAccessTab("debug", null)).toBe(true);
+  });
+
+  it("limits read-only operators to read surfaces", () => {
+    const auth = { role: "operator", scopes: ["operator.read"] };
+
+    expect(canAccessTab("chat", auth)).toBe(true);
+    expect(canAccessTab("sessions", auth)).toBe(true);
+    expect(canAccessTab("cron", auth)).toBe(true);
+    expect(canAccessTab("config", auth)).toBe(false);
+    expect(canAccessTab("debug", auth)).toBe(false);
+    expect(canAccessTab("nodes", auth)).toBe(false);
+    expect(permittedSettingsTabs(auth)).toEqual(["channels", "logs"]);
+  });
+
+  it("treats write scope as read-capable for navigation", () => {
+    const auth = { role: "operator", scopes: ["operator.write"] };
+
+    expect(canAccessTab("overview", auth)).toBe(true);
+    expect(canAccessTab("usage", auth)).toBe(true);
+    expect(canAccessTab("config", auth)).toBe(false);
+  });
+
+  it("allows pairing operators to see node management without full admin", () => {
+    const auth = { role: "operator", scopes: ["operator.pairing"] };
+
+    expect(canAccessTab("nodes", auth)).toBe(true);
+    expect(canAccessTab("config", auth)).toBe(false);
+    expect(firstPermittedTab(auth)).toBe("nodes");
+  });
+
+  it("allows admin operators to see all sidebar and settings sections", () => {
+    const auth = { role: "operator", scopes: ["operator.admin"] };
+
+    expect(permittedTabGroups(auth).map((group) => [group.label, group.tabs])).toEqual([
+      ["chat", ["chat"]],
+      ["control", ["overview", "instances", "sessions", "usage", "cron"]],
+      ["agent", ["agents", "skills", "nodes", "dreams"]],
+      ["settings", ["config"]],
+    ]);
+    expect(permittedSettingsTabs(auth)).toEqual([
+      "config",
+      "channels",
+      "communications",
+      "appearance",
+      "automation",
+      "infrastructure",
+      "aiAgents",
+      "debug",
+      "logs",
+    ]);
+  });
+
+  it("denies non-operator roles", () => {
+    const auth = { role: "node", scopes: ["operator.admin"] };
+
+    expect(permittedTabs(auth)).toEqual([]);
+    expect(firstPermittedTab(auth)).toBeNull();
+  });
+});

--- a/ui/src/ui/navigation-permissions.ts
+++ b/ui/src/ui/navigation-permissions.ts
@@ -1,0 +1,105 @@
+import { SETTINGS_TABS, TAB_GROUPS, type Tab } from "./navigation.ts";
+
+export type ControlUiOperatorScope =
+  | "operator.admin"
+  | "operator.read"
+  | "operator.write"
+  | "operator.approvals"
+  | "operator.pairing";
+
+export type ControlUiAuthContext = {
+  role?: string | null;
+  scopes?: readonly string[] | null;
+} | null;
+
+export type TabPermission = {
+  readonly scopes?: readonly ControlUiOperatorScope[];
+};
+
+export type PermittedTabGroup = {
+  readonly label: (typeof TAB_GROUPS)[number]["label"];
+  readonly tabs: readonly Tab[];
+};
+
+const READ_SCOPES = ["operator.read", "operator.write"] as const;
+
+export const TAB_PERMISSIONS: Readonly<Record<Tab, TabPermission>> = {
+  chat: { scopes: READ_SCOPES },
+  overview: { scopes: READ_SCOPES },
+  instances: { scopes: READ_SCOPES },
+  sessions: { scopes: READ_SCOPES },
+  usage: { scopes: READ_SCOPES },
+  cron: { scopes: READ_SCOPES },
+  agents: { scopes: READ_SCOPES },
+  skills: { scopes: READ_SCOPES },
+  logs: { scopes: READ_SCOPES },
+  channels: { scopes: READ_SCOPES },
+  communications: { scopes: ["operator.admin"] },
+  appearance: { scopes: ["operator.admin"] },
+  automation: { scopes: ["operator.admin"] },
+  infrastructure: { scopes: ["operator.admin"] },
+  aiAgents: { scopes: ["operator.admin"] },
+  config: { scopes: ["operator.admin"] },
+  debug: { scopes: ["operator.admin"] },
+  dreams: { scopes: ["operator.admin"] },
+  nodes: { scopes: ["operator.pairing", "operator.admin"] },
+};
+
+export function resolveControlUiAuthContext(auth: ControlUiAuthContext): ControlUiAuthContext {
+  if (!auth) {
+    return null;
+  }
+  return {
+    role: typeof auth.role === "string" ? auth.role : null,
+    scopes: Array.isArray(auth.scopes) ? auth.scopes : null,
+  };
+}
+
+function hasOperatorScope(scopes: readonly string[], scope: ControlUiOperatorScope): boolean {
+  if (scopes.includes("operator.admin")) {
+    return true;
+  }
+  if (scope === "operator.read" && scopes.includes("operator.write")) {
+    return true;
+  }
+  return scopes.includes(scope);
+}
+
+export function canAccessTab(tab: Tab, auth: ControlUiAuthContext): boolean {
+  const context = resolveControlUiAuthContext(auth);
+  if (!context) {
+    return true;
+  }
+  if (context.role && context.role !== "operator") {
+    return false;
+  }
+  const scopes = context.scopes ?? [];
+  const requiredScopes = TAB_PERMISSIONS[tab]?.scopes ?? [];
+  if (requiredScopes.length === 0) {
+    return true;
+  }
+  return requiredScopes.some((scope) => hasOperatorScope(scopes, scope));
+}
+
+export function permittedTabs(auth: ControlUiAuthContext): Tab[] {
+  const orderedTabs = new Set<Tab>([
+    ...(TAB_GROUPS.flatMap((group) => group.tabs) as Tab[]),
+    ...SETTINGS_TABS,
+  ]);
+  return [...orderedTabs].filter((tab) => canAccessTab(tab, auth));
+}
+
+export function permittedSettingsTabs(auth: ControlUiAuthContext): Tab[] {
+  return SETTINGS_TABS.filter((tab) => canAccessTab(tab, auth));
+}
+
+export function permittedTabGroups(auth: ControlUiAuthContext): PermittedTabGroup[] {
+  return TAB_GROUPS.map((group) => ({
+    ...group,
+    tabs: group.tabs.filter((tab) => canAccessTab(tab as Tab, auth)),
+  })).filter((group) => group.tabs.length > 0);
+}
+
+export function firstPermittedTab(auth: ControlUiAuthContext): Tab | null {
+  return permittedTabs(auth)[0] ?? null;
+}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -147,11 +147,11 @@ export function isSettingsTab(tab: Tab): boolean {
   return (SETTINGS_TABS as readonly Tab[]).includes(tab);
 }
 
-export function isTabInGroup(group: (typeof TAB_GROUPS)[number], tab: Tab): boolean {
+export function isTabInGroup(group: { label: string; tabs: readonly Tab[] }, tab: Tab): boolean {
   if (group.label === "settings") {
     return isSettingsTab(tab);
   }
-  return (group.tabs as readonly Tab[]).includes(tab);
+  return group.tabs.includes(tab);
 }
 
 export function tabFromPath(pathname: string, basePath = ""): Tab | null {


### PR DESCRIPTION
## Summary
- add a typed Control UI navigation permission catalog
- gate sidebar tabs, settings sections, command-palette navigation, and direct tab changes by the connected operator scopes
- redirect the UI to the first permitted tab when the current tab is unavailable

## Real behavior proof
Behavior or issue addressed: Control UI navigation now respects operator role/scopes instead of exposing all sidebar/settings destinations to every connected operator.

Real environment tested: Local OpenClaw source checkout on the Lily host, using the rebased PR branch worktree at `feat/control-ui-section-permissions` head `0af08b77c` against upstream base `78b3f60dbd96f65dfde38fe88e290be01b5687db`.

Exact steps or command run after this patch: Ran a live `node` command in the PR branch worktree that exercises the same permission table and helper behavior used by `ui/src/ui/navigation-permissions.ts`, then checked where the helper is wired into the app renderer and `AppState.setTab`.

Evidence after fix: Copied live terminal output from the branch worktree:

```text
Branch: 0af08b77c
Base merge: 78b3f60dbd96f65dfde38fe88e290be01b5687db
CASE read-only operator
  key tabs: chat=true config=false nodes=false channels=true
  first=chat
  settings=[channels,mcp,logs]
CASE pairing-only operator
  key tabs: chat=false config=false nodes=true channels=false
  first=activity
  settings=[mcp]
CASE admin operator
  key tabs: chat=true config=true nodes=true channels=true
  first=chat
  settings=[config,channels,communications,appearance,automation,mcp,infrastructure,aiAgents,debug,logs]
CASE non-operator role
  key tabs: chat=false config=false nodes=false channels=false
  first=null
  settings=[]
```

Observed result after fix: Read-only operators keep chat/readable destinations but cannot enter admin config or node pairing; pairing-only operators can reach nodes while chat/config/channels are denied; admin operators keep access to all key destinations; non-operator roles get no permitted fallback tab.

What was not tested: Full browser screenshot of the Control UI was not captured in this environment; this proof is copied live terminal output from the rebased branch plus source wiring inspection.

## Verification
- `git diff --check`
- `node --experimental-strip-types --check ui/src/ui/navigation-permissions.ts ui/src/ui/navigation-permissions.test.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.ts ui/src/ui/app.ts ui/src/ui/navigation.ts`

Vitest was not run in this checkout because `vitest/package.json` is missing and Corepack pnpm failed locally.
