### PR TITLE
fix(agents): snapshot client tool descriptors

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -6,7 +6,9 @@ import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,
   isClientToolNameConflictError,
+  snapshotClientToolDefinitions,
   toClientToolDefinitions,
+  toClientToolDefinitionsFromSnapshots,
   toToolDefinitions,
 } from "./agent-tool-definition-adapter.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
@@ -212,6 +214,43 @@ describe("toClientToolDefinitions – param coercion", () => {
     );
     expect(calledWith).toEqual({ action: "search", params: { q: "test", page: 1 } });
   });
+
+  it("skips unreadable client tool descriptors while keeping healthy siblings", () => {
+    const hostileTool = {
+      type: "function",
+      get function(): ClientToolDefinition["function"] {
+        throw new Error("client tool function getter exploded");
+      },
+    } as unknown as ClientToolDefinition;
+
+    const defs = toClientToolDefinitions([hostileTool, makeClientTool("lookup")]);
+
+    expect(defs.map((def) => def.name)).toEqual(["lookup"]);
+  });
+
+  it("does not reread skipped client tool descriptors during registration", () => {
+    let reads = 0;
+    const hostileTool = {
+      type: "function",
+      get function(): ClientToolDefinition["function"] {
+        reads += 1;
+        if (reads === 1) {
+          throw new Error("client tool first read exploded");
+        }
+        return {
+          name: "exec",
+          parameters: { type: "object", properties: {} },
+        };
+      },
+    } as unknown as ClientToolDefinition;
+
+    const snapshots = snapshotClientToolDefinitions([hostileTool]);
+    const defs = toClientToolDefinitionsFromSnapshots(snapshots);
+
+    expect(snapshots).toEqual([]);
+    expect(defs).toEqual([]);
+    expect(reads).toBe(1);
+  });
 });
 
 describe("client tool name conflict checks", () => {
@@ -230,6 +269,22 @@ describe("client tool name conflict checks", () => {
         tools: [makeClientTool("Weather"), makeClientTool("weather")],
       }),
     ).toEqual(["Weather", "weather"]);
+  });
+
+  it("skips unreadable client tools while checking name conflicts", () => {
+    const hostileTool = {
+      type: "function",
+      get function(): ClientToolDefinition["function"] {
+        throw new Error("client conflict function getter exploded");
+      },
+    } as unknown as ClientToolDefinition;
+
+    expect(
+      findClientToolNameConflicts({
+        tools: [hostileTool, makeClientTool("exec")],
+        existingToolNames: ["exec"],
+      }),
+    ).toEqual(["exec"]);
   });
 
   it("detects collisions with reserved OpenClaw built-in tool names", () => {

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -23,6 +23,11 @@ import { normalizeToolName } from "./tool-policy.js";
 import { jsonResult, payloadTextResult } from "./tools/common.js";
 
 type AnyAgentTool = AgentTool;
+export type ClientToolFunctionSnapshot = {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+};
 type BeforeToolCallPreparingTool = AnyAgentTool & {
   prepareBeforeToolCallParams?: (
     params: unknown,
@@ -305,7 +310,8 @@ function finalizeToolParamsBeforeExecute(params: {
 export const CLIENT_TOOL_NAME_CONFLICT_PREFIX = "client tool name conflict:";
 
 export function findClientToolNameConflicts(params: {
-  tools: ClientToolDefinition[];
+  tools?: readonly ClientToolDefinition[];
+  toolSnapshots?: readonly ClientToolFunctionSnapshot[];
   existingToolNames?: Iterable<string>;
 }): string[] {
   const existingNormalized = new Set<string>();
@@ -318,11 +324,9 @@ export function findClientToolNameConflicts(params: {
 
   const conflicts = new Set<string>();
   const seenClientNames = new Map<string, string>();
-  for (const tool of params.tools) {
-    const rawName = (tool.function?.name ?? "").trim();
-    if (!rawName) {
-      continue;
-    }
+  const snapshots = params.toolSnapshots ?? snapshotClientToolDefinitions(params.tools ?? []);
+  for (const snapshot of snapshots) {
+    const rawName = snapshot.name.trim();
     const normalizedName = normalizeToolName(rawName);
     if (existingNormalized.has(normalizedName)) {
       conflicts.add(rawName);
@@ -477,15 +481,60 @@ function coerceParamsRecord(value: unknown): Record<string, unknown> {
   return {};
 }
 
+function readClientToolField<T>(read: () => T): { ok: true; value: T } | { ok: false } {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function readClientToolFunctionSnapshot(
+  tool: ClientToolDefinition,
+): ClientToolFunctionSnapshot | null {
+  const functionRead = readClientToolField(() => tool.function);
+  if (!functionRead.ok || !functionRead.value || typeof functionRead.value !== "object") {
+    return null;
+  }
+  const func = functionRead.value;
+  const nameRead = readClientToolField(() => func.name);
+  if (!nameRead.ok || typeof nameRead.value !== "string") {
+    return null;
+  }
+  if (!nameRead.value.trim()) {
+    return null;
+  }
+  const descriptionRead = readClientToolField(() => func.description);
+  const parametersRead = readClientToolField(() => func.parameters);
+  if (!parametersRead.ok) {
+    return null;
+  }
+  return {
+    name: nameRead.value,
+    ...(descriptionRead.ok && typeof descriptionRead.value === "string"
+      ? { description: descriptionRead.value }
+      : {}),
+    parameters: parametersRead.value,
+  };
+}
+
+export function snapshotClientToolDefinitions(
+  tools: readonly ClientToolDefinition[],
+): ClientToolFunctionSnapshot[] {
+  return tools.flatMap((tool) => {
+    const snapshot = readClientToolFunctionSnapshot(tool);
+    return snapshot ? [snapshot] : [];
+  });
+}
+
 // Convert client tools (OpenResponses hosted tools) to ToolDefinition format
 // These tools are intercepted to return a "pending" result instead of executing
-export function toClientToolDefinitions(
-  tools: ClientToolDefinition[],
+export function toClientToolDefinitionsFromSnapshots(
+  tools: readonly ClientToolFunctionSnapshot[],
   onClientToolCall?: ClientToolCallRecorder,
   hookContext?: HookContext,
 ): ToolDefinition[] {
-  return tools.map((tool) => {
-    const func = tool.function;
+  return tools.map((func) => {
     return {
       name: func.name,
       label: func.name,
@@ -544,4 +593,16 @@ export function toClientToolDefinitions(
       },
     } satisfies ToolDefinition;
   });
+}
+
+export function toClientToolDefinitions(
+  tools: readonly ClientToolDefinition[],
+  onClientToolCall?: ClientToolCallRecorder,
+  hookContext?: HookContext,
+): ToolDefinition[] {
+  return toClientToolDefinitionsFromSnapshots(
+    snapshotClientToolDefinitions(tools),
+    onClientToolCall,
+    hookContext,
+  );
 }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
@@ -92,10 +92,17 @@ describe("buildToolSearchRunPlan", () => {
   });
 
   it("counts explicitly allowlisted client tools before they are cataloged later", () => {
+    const hostileTool = {
+      type: "function",
+      get function(): { name: string; parameters: unknown } {
+        throw new Error("client Tool Search function getter exploded");
+      },
+    };
     const plan = buildToolSearchRunPlan({
       visibleTools: [{ name: "tool_search_code" }] as never,
       uncompactedTools: [{ name: "tool_search_code" }] as never,
       clientTools: [
+        hostileTool as never,
         {
           type: "function",
           function: {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
@@ -1,3 +1,7 @@
+import {
+  readClientToolFunctionSnapshot,
+  type ClientToolFunctionSnapshot,
+} from "../../agent-tool-definition-adapter.js";
 import { normalizeToolName } from "../../tool-policy.js";
 import {
   TOOL_CALL_RAW_TOOL_NAME,
@@ -61,6 +65,7 @@ export function buildAutoAddedToolSearchControlNamesForAllowlistCheck(params: {
 
 function collectExplicitlyAllowedClientToolNames(params: {
   clientTools?: CollectAllowedToolNamesParams["clientTools"];
+  clientToolSnapshots?: readonly ClientToolFunctionSnapshot[];
   explicitAllowlistSources: Array<{ entries: string[] }>;
 }): string[] {
   const explicitNames = new Set(
@@ -68,8 +73,14 @@ function collectExplicitlyAllowedClientToolNames(params: {
       source.entries.map((entry) => normalizeToolName(entry)),
     ),
   );
-  return (params.clientTools ?? [])
-    .map((tool) => tool.function?.name)
+  const clientSnapshots =
+    params.clientToolSnapshots ??
+    (params.clientTools ?? []).flatMap((tool) => {
+      const snapshot = readClientToolFunctionSnapshot(tool);
+      return snapshot ? [snapshot] : [];
+    });
+  return clientSnapshots
+    .map((tool) => tool.name)
     .filter((name): name is string => Boolean(name?.trim()))
     .filter((name) => explicitNames.has(normalizeToolName(name)));
 }
@@ -78,6 +89,7 @@ export function buildToolSearchRunPlan(params: {
   visibleTools: CollectAllowedToolNamesParams["tools"];
   uncompactedTools: CollectAllowedToolNamesParams["tools"];
   clientTools?: CollectAllowedToolNamesParams["clientTools"];
+  clientToolSnapshots?: readonly ClientToolFunctionSnapshot[];
   catalogRegistered: boolean;
   catalogToolCount: number;
   controlsEnabled: boolean;
@@ -87,10 +99,12 @@ export function buildToolSearchRunPlan(params: {
   const visibleAllowedToolNames = collectAllowedToolNames({
     tools: params.visibleTools,
     clientTools: params.catalogRegistered ? undefined : params.clientTools,
+    clientToolSnapshots: params.catalogRegistered ? undefined : params.clientToolSnapshots,
   });
   const replayAllowedToolNames = collectAllowedToolNames({
     tools: params.uncompactedTools,
     clientTools: params.clientTools,
+    clientToolSnapshots: params.clientToolSnapshots,
   });
   if (params.controlsEnabled) {
     for (const controlName of params.controlNames ?? TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES) {
@@ -107,6 +121,7 @@ export function buildToolSearchRunPlan(params: {
   const clientCatalogCallableNames = params.catalogRegistered
     ? collectExplicitlyAllowedClientToolNames({
         clientTools: params.clientTools,
+        clientToolSnapshots: params.clientToolSnapshots,
         explicitAllowlistSources: params.explicitAllowlistSources,
       }).map((name) => `tool-search-client:${name}`)
     : [];

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -93,7 +93,8 @@ import {
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,
-  toClientToolDefinitions,
+  snapshotClientToolDefinitions,
+  toClientToolDefinitionsFromSnapshots,
 } from "../../agent-tool-definition-adapter.js";
 import {
   createOpenClawCodingTools,
@@ -1431,6 +1432,7 @@ export async function runEmbeddedAttempt(
         }),
     });
     const clientTools = toolsEnabled && !isRawModelRun ? params.clientTools : undefined;
+    const clientToolSnapshots = clientTools ? snapshotClientToolDefinitions(clientTools) : [];
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.disableTools || isRawModelRun,
@@ -1449,7 +1451,7 @@ export async function runEmbeddedAttempt(
           runtime: bundleMcpSessionRuntime,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+            ...clientToolSnapshots.map((tool) => tool.name),
           ],
         })
       : undefined;
@@ -1464,7 +1466,7 @@ export async function runEmbeddedAttempt(
           cfg: params.config,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
-            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+            ...clientToolSnapshots.map((tool) => tool.name),
             ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
           ],
         })
@@ -1647,6 +1649,7 @@ export async function runEmbeddedAttempt(
       visibleTools: effectiveTools,
       uncompactedTools: uncompactedEffectiveTools,
       clientTools,
+      clientToolSnapshots,
       catalogRegistered: toolSearch.catalogRegistered,
       catalogToolCount: toolSearch.catalogToolCount,
       controlsEnabled: toolSearchControlsEnabledForRun || codeModeControlsEnabledForRun,
@@ -2138,15 +2141,15 @@ export async function runEmbeddedAttempt(
           Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
       });
       const clientToolNameConflicts = findClientToolNameConflicts({
-        tools: clientTools ?? [],
+        toolSnapshots: clientToolSnapshots,
         existingToolNames: [...coreBuiltinToolNames, ...AGENT_RESERVED_TOOL_NAMES],
       });
       if (clientToolNameConflicts.length > 0) {
         throw createClientToolNameConflictError(clientToolNameConflicts);
       }
       let clientToolDefs = clientTools
-        ? toClientToolDefinitions(
-            clientTools,
+        ? toClientToolDefinitionsFromSnapshots(
+            clientToolSnapshots,
             {
               reserve: reserveClientToolCallSlot,
               complete: (toolCallId, toolName, toolParams) => {

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -34,6 +34,31 @@ describe("tool name allowlists", () => {
     expect([...names]).toEqual(["read", "memory_search", "image_generate"]);
   });
 
+  it("skips unreadable client tool descriptors while collecting allowlists", () => {
+    const hostileTool = {
+      type: "function",
+      get function(): ClientToolDefinition["function"] {
+        throw new Error("client allowlist function getter exploded");
+      },
+    } as unknown as ClientToolDefinition;
+
+    const names = collectAllowedToolNames({
+      tools: [createStubTool("read")],
+      clientTools: [
+        hostileTool,
+        {
+          type: "function",
+          function: {
+            name: "client_pick_file",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+
+    expect([...names]).toEqual(["read", "client_pick_file"]);
+  });
+
   it("builds a stable agent session allowlist from custom tool names", () => {
     const allowlist = toSessionToolAllowlist(new Set(["write", "read", "read", "edit"]));
 

--- a/src/agents/embedded-agent-runner/tool-name-allowlist.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.ts
@@ -1,3 +1,7 @@
+import {
+  readClientToolFunctionSnapshot,
+  type ClientToolFunctionSnapshot,
+} from "../agent-tool-definition-adapter.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { ClientToolDefinition } from "./run/params.js";
 
@@ -20,13 +24,20 @@ function addName(names: Set<string>, value: unknown): void {
 export function collectAllowedToolNames(params: {
   tools: AgentTool[];
   clientTools?: ClientToolDefinition[];
+  clientToolSnapshots?: readonly ClientToolFunctionSnapshot[];
 }): Set<string> {
   const names = new Set<string>();
   for (const tool of params.tools) {
     addName(names, tool.name);
   }
-  for (const tool of params.clientTools ?? []) {
-    addName(names, tool.function?.name);
+  const clientSnapshots =
+    params.clientToolSnapshots ??
+    (params.clientTools ?? []).flatMap((tool) => {
+      const snapshot = readClientToolFunctionSnapshot(tool);
+      return snapshot ? [snapshot] : [];
+    });
+  for (const tool of clientSnapshots) {
+    addName(names, tool.name);
   }
   return names;
 }


### PR DESCRIPTION
## Summary

- Snapshot hosted/client tool descriptors once per attempt before reserved-name checks, Tool Search planning, allowlist collection, and registration.
- Skip unreadable or malformed client tool descriptors while keeping healthy sibling client tools available.
- Add regressions for unreadable client descriptor getters, stateful reread bypass, allowlist collection, and Tool Search catalog planning.

## Verification

- Red repro before fix: `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts -t "skips unreadable client tool descriptors" --reporter=verbose` failed with `client tool function getter exploded`.
- `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts --reporter=verbose` passed, 3 files / 38 tests.
- `./node_modules/.bin/oxfmt --write src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts` passed.
- `./node_modules/.bin/oxlint src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after fixing its stateful-reread finding.
- AWS Crabbox changed gate passed: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`; provider `aws`, run `run_14e13fb924a5`, lease `cbx_946f714d0ccf`, type `c7a.8xlarge`, exit 0, lanes `core`, `coreTests`.

## Real behavior proof

Behavior addressed: A malformed hosted/client tool descriptor can no longer crash or bypass admission by throwing on one descriptor read and returning a different tool name on a later read.

Real environment tested: Local focused unit tests plus AWS Crabbox Linux changed gate for the touched core/coreTests lanes.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts src/agents/embedded-agent-runner/tool-name-allowlist.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts --reporter=verbose`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: Local tests passed 38/38; autoreview was clean; AWS Crabbox run `run_14e13fb924a5` completed `pnpm check:changed` with exit 0 for `core` and `coreTests`.

Observed result after fix: Unreadable client descriptors are omitted once, healthy siblings stay registered, reserved-name conflicts are checked against the same descriptor snapshots that registration consumes, and skipped descriptors are not reread later.

What was not tested: Full repo test suite and live provider hosted-tool execution were not run; the remote changed gate covered the affected core lanes.
