### PR TITLE
fix(exec): reject corrupt shell snapshots

### DIFF
--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -412,6 +412,67 @@ describe("exec shell snapshots", () => {
     await expect(runAlias()).resolves.toBe("new");
   });
 
+  it("refreshes fresh cached snapshots that no longer parse", async () => {
+    const bash = resolveBashForTest();
+    if (!bash) {
+      return;
+    }
+
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-corrupt-home-"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-corrupt-state-"));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-snapshot-corrupt-cwd-"));
+    tempDirs.push(home, stateDir, cwd);
+    setSnapshotStateForTest(stateDir, { home });
+    fs.writeFileSync(path.join(home, ".bashrc"), "alias oc_clean_alias='printf ok'\n");
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const shellArgs = getPosixShellArgs(bash);
+    const wrap = async (): Promise<string> =>
+      await maybeWrapCommandWithShellSnapshot({
+        command: "oc_clean_alias",
+        shell: bash,
+        shellArgs,
+        cwd,
+        env,
+      });
+
+    const firstWrapped = await wrap();
+    expect(firstWrapped).not.toBe("oc_clean_alias");
+    const snapshotDir = resolveShellSnapshotDir(env);
+    const snapshotFiles = fs.readdirSync(snapshotDir).filter((entry) => entry.endsWith(".sh"));
+    expect(snapshotFiles).toHaveLength(1);
+    const snapshotPath = path.join(snapshotDir, snapshotFiles[0]);
+    fs.writeFileSync(
+      snapshotPath,
+      [
+        "# OpenClaw exec shell snapshot. Generated; do not edit.",
+        "unalias -a 2>/dev/null || true",
+        "oc_broken_fn() {",
+        "        --!(no-*)dir*",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    resetShellSnapshotCacheForTests();
+
+    const wrapped = await wrap();
+    const result = spawnSync(bash, [...shellArgs, wrapped], {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("ok");
+    expect(result.stderr).toBe("");
+    expect(fs.readFileSync(snapshotPath, "utf8")).not.toContain("--!(no-*)dir*");
+  });
+
   it("refuses to persist aliases or functions with literal secret-looking values", async () => {
     const bash = resolveBashForTest();
     if (!bash) {

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -241,7 +241,7 @@ async function validateSnapshot(
     shellArgs: opts.shellArgs,
     cwd: opts.cwd,
     env: buildTrustedSnapshotCaptureEnv(opts.env),
-    command: `. ${shQuote(snapshotPath)} >/dev/null 2>&1; :`,
+    command: `. ${shQuote(snapshotPath)} >/dev/null 2>&1`,
     timeoutMs: 2_000,
   });
   return result.status === 0;


### PR DESCRIPTION
## Summary

- fix shell snapshot validation so a failed `. snapshot` source status is not masked by a trailing no-op command
- add regression coverage for a fresh cached snapshot corrupted with the reported `--!(no-*)dir*` parse error

## Investigation

I rechecked live open PRs and issues for `shell-snapshot`, `shell snapshot`, `shell snapshots`, `OPENCLAW_EXEC_SHELL_SNAPSHOT`, `--!(no-*)dir`, and heartbeat/exec shell-error wording. I did not find an open PR that fixes this shell-snapshot validation path. The nearest heartbeat/exec search hit was #89073, which is about duplicate background sessions and not this snapshot cache/source validation failure.

The Discord reports match the same bug class: OpenClaw sources the cached snapshot before the real command, and validation previously ran `. snapshot >/dev/null 2>&1; :`, so a syntactically invalid snapshot could be treated as valid. The later real exec then emitted the shell syntax banner on stderr while still running the user command.

## Verification

- `node scripts/run-vitest.mjs src/agents/shell-snapshot.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)
