### PR TITLE
fix(gateway): allow macOS app platform version refresh without re-pairing

### DIFF
--- a/src/gateway/device-authz.test-helpers.ts
+++ b/src/gateway/device-authz.test-helpers.ts
@@ -42,6 +42,8 @@ export async function pairDeviceIdentity(params: {
   scopes: string[];
   clientId?: string;
   clientMode?: string;
+  platform?: string;
+  deviceFamily?: string;
 }): Promise<{
   identityPath: string;
   identity: DeviceIdentity;
@@ -55,6 +57,8 @@ export async function pairDeviceIdentity(params: {
     scopes: params.scopes,
     clientId: params.clientId,
     clientMode: params.clientMode,
+    platform: params.platform,
+    deviceFamily: params.deviceFamily,
   });
   await approveDevicePairing(request.request.requestId, {
     callerScopes: params.scopes,

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -2,7 +2,12 @@
 // command scopes, and gateway enforcement around node client identity.
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
-import { approveDevicePairing, requestDevicePairing } from "../infra/device-pairing.js";
+import {
+  approveDevicePairing,
+  getPairedDevice,
+  listDevicePairing,
+  requestDevicePairing,
+} from "../infra/device-pairing.js";
 import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -55,16 +60,19 @@ async function connectNodeClient(params: {
   port: number;
   deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
   commands: string[];
+  clientName?: string;
+  platform?: string;
+  deviceFamily?: string;
 }) {
   return await connectGatewayClient({
     url: `ws://127.0.0.1:${params.port}`,
     token: "secret",
     role: "node",
-    clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.NODE_HOST,
     clientDisplayName: "node-command-pin",
     clientVersion: "1.0.0",
-    platform: "macos",
-    deviceFamily: "Mac",
+    platform: params.platform ?? "macos",
+    deviceFamily: params.deviceFamily ?? "Mac",
     mode: GATEWAY_CLIENT_MODES.NODE,
     scopes: [],
     commands: params.commands,
@@ -652,6 +660,51 @@ describe("gateway node pairing authorization", () => {
           ),
         ).toBe(false);
       });
+    });
+
+    test("refreshes a paired macOS app node version without a repair request", async () => {
+      const started = getStarted();
+      const pairedNode = await pairDeviceIdentity({
+        name: "macos-version-refresh",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.MACOS_APP,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+        platform: "macOS 26.5.1",
+        deviceFamily: "Mac",
+      });
+      const nodeRequest = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        platform: "macOS 26.5.1",
+        deviceFamily: "Mac",
+        commands: ["system.info"],
+      });
+      requireApprovedPairing(
+        await approveNodePairing(nodeRequest.request.requestId, {
+          callerScopes: ["operator.pairing", "operator.write", "operator.admin"],
+        }),
+      );
+
+      const nodeClient = await connectNodeClient({
+        port: started.port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["system.info"],
+        clientName: GATEWAY_CLIENT_NAMES.MACOS_APP,
+        platform: "macOS 26.5.2",
+        deviceFamily: "Mac",
+      });
+      try {
+        await vi.waitFor(async () => {
+          const pairedDevice = await getPairedDevice(pairedNode.identity.deviceId);
+          expect(pairedDevice?.platform).toBe("macOS 26.5.2");
+        });
+        const devicePairing = await listDevicePairing();
+        expect(
+          devicePairing.pending.find((entry) => entry.deviceId === pairedNode.identity.deviceId),
+        ).toBeUndefined();
+      } finally {
+        await nodeClient.stopAndWait();
+      }
     });
 
     test("requests re-pairing when a paired node reconnects with upgraded commands", async () => {

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -10,7 +10,11 @@ import {
 } from "../infra/device-pairing.js";
 import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  type GatewayClientName,
+} from "../utils/message-channel.js";
 import { callGateway } from "./call.js";
 import {
   loadDeviceIdentity,
@@ -60,7 +64,7 @@ async function connectNodeClient(params: {
   port: number;
   deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
   commands: string[];
-  clientName?: string;
+  clientName?: GatewayClientName;
   platform?: string;
   deviceFamily?: string;
 }) {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -925,8 +925,8 @@ describe("resolvePinnedClientMetadata", () => {
     ["openclaw-ios", "iPadOS 26.5.0", "iPadOS 26.4.2", "iPad"],
     ["openclaw-ios", "iPadOS 26.5.0", "iOS 26.4.2", "iPad"],
     ["openclaw-android", "Android 16", "Android 15", "Android"],
-    ["openclaw-macos", "macos 26.5.1", "macos 26.5.0", "Mac"],
-    ["openclaw-macos", "macos 27.0.0", "macos 26.5.1", "Mac"],
+    ["openclaw-macos", "macOS 26.5.1", "macOS 26.5.0", "Mac"],
+    ["openclaw-macos", "macOS 27.0.0", "macOS 26.5.1", "Mac"],
   ])(
     "allows %s platform version refresh without metadata-upgrade approval",
     (clientId, claimedPlatform, pairedPlatform, deviceFamily) => {
@@ -949,6 +949,25 @@ describe("resolvePinnedClientMetadata", () => {
     },
   );
 
+  it.each(["node", "ui"])("allows a macOS platform version refresh in %s mode", (clientMode) => {
+    expect(
+      testing.resolvePinnedClientMetadata({
+        clientId: "openclaw-macos",
+        clientMode,
+        claimedPlatform: "macOS 26.5.2",
+        claimedDeviceFamily: "Mac",
+        pairedPlatform: "macOS 26.5.1",
+        pairedDeviceFamily: "Mac",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: false,
+      pinnedPlatform: "macOS 26.5.2",
+      pinnedDeviceFamily: "Mac",
+      refreshPairedPlatform: "macOS 26.5.2",
+    });
+  });
+
   it("still requires approval when an iOS device family changes", () => {
     expect(
       testing.resolvePinnedClientMetadata({
@@ -967,6 +986,48 @@ describe("resolvePinnedClientMetadata", () => {
       refreshPairedPlatform: "iOS 26.5.0",
     });
   });
+
+  it("still requires approval when a macOS device family changes", () => {
+    expect(
+      testing.resolvePinnedClientMetadata({
+        clientId: "openclaw-macos",
+        clientMode: "node",
+        claimedPlatform: "macOS 26.5.2",
+        claimedDeviceFamily: "VirtualMac",
+        pairedPlatform: "macOS 26.5.1",
+        pairedDeviceFamily: "Mac",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: true,
+      pinnedPlatform: "macOS 26.5.2",
+      pinnedDeviceFamily: "Mac",
+      refreshPairedPlatform: "macOS 26.5.2",
+    });
+  });
+
+  it.each([
+    ["node-host", "macOS 26.5.2", "macOS 26.5.1"],
+    ["openclaw-macos", "macOS anything", "macOS previous"],
+  ])(
+    "keeps non-version macOS platform changes approval-bound for %s",
+    (clientId, claimed, paired) => {
+      expect(
+        testing.resolvePinnedClientMetadata({
+          clientId,
+          clientMode: "node",
+          claimedPlatform: claimed,
+          claimedDeviceFamily: "Mac",
+          pairedPlatform: paired,
+          pairedDeviceFamily: "Mac",
+        }),
+      ).toMatchObject({
+        platformMismatch: true,
+        deviceFamilyMismatch: false,
+        pinnedPlatform: undefined,
+      });
+    },
+  );
 
   it("keeps non-native-app platform version changes approval-bound", () => {
     expect(

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -925,6 +925,8 @@ describe("resolvePinnedClientMetadata", () => {
     ["openclaw-ios", "iPadOS 26.5.0", "iPadOS 26.4.2", "iPad"],
     ["openclaw-ios", "iPadOS 26.5.0", "iOS 26.4.2", "iPad"],
     ["openclaw-android", "Android 16", "Android 15", "Android"],
+    ["openclaw-macos", "macos 26.5.1", "macos 26.5.0", "Mac"],
+    ["openclaw-macos", "macos 27.0.0", "macos 26.5.1", "Mac"],
   ])(
     "allows %s platform version refresh without metadata-upgrade approval",
     (clientId, claimedPlatform, pairedPlatform, deviceFamily) => {
@@ -966,7 +968,7 @@ describe("resolvePinnedClientMetadata", () => {
     });
   });
 
-  it("keeps non-mobile platform version changes approval-bound", () => {
+  it("keeps non-native-app platform version changes approval-bound", () => {
     expect(
       testing.resolvePinnedClientMetadata({
         clientId: "node-host",

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -1009,6 +1009,7 @@ describe("resolvePinnedClientMetadata", () => {
   it.each([
     ["node-host", "macOS 26.5.2", "macOS 26.5.1"],
     ["openclaw-macos", "macOS anything", "macOS previous"],
+    ["openclaw-macos", "macOS", "macOS 26.5.1"],
   ])(
     "keeps non-version macOS platform changes approval-bound for %s",
     (clientId, claimed, paired) => {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -443,12 +443,15 @@ function resolvePinnedClientMetadata(params: {
     }
   }
 
-  function normalizeMobileAppPlatformPin(clientId: string | undefined, value: string): string {
+  function normalizeNativeAppPlatformPin(clientId: string | undefined, value: string): string {
     if (clientId === GATEWAY_CLIENT_IDS.IOS_APP && /^(?:ios|ipados)(?:\s|$)/.test(value)) {
       return "ios-family";
     }
     if (clientId === GATEWAY_CLIENT_IDS.ANDROID_APP && /^android(?:\s|$)/.test(value)) {
       return "android";
+    }
+    if (clientId === GATEWAY_CLIENT_IDS.MACOS_APP && /^macos(?:\s|$)/.test(value)) {
+      return "macos";
     }
     return value;
   }
@@ -466,24 +469,24 @@ function resolvePinnedClientMetadata(params: {
     claimedPlatform !== "" &&
     normalizeLegacyNodeHostPlatformPin(claimedPlatform) ===
       normalizeLegacyNodeHostPlatformPin(pairedPlatform);
-  const isMobileAppPlatformVersionRefresh =
+  const isNativeAppPlatformVersionRefresh =
     hasPinnedPlatform &&
     claimedPlatform !== "" &&
     claimedPlatform !== pairedPlatform &&
-    normalizeMobileAppPlatformPin(params.clientId, claimedPlatform) ===
-      normalizeMobileAppPlatformPin(params.clientId, pairedPlatform);
+    normalizeNativeAppPlatformPin(params.clientId, claimedPlatform) ===
+      normalizeNativeAppPlatformPin(params.clientId, pairedPlatform);
   const platformMismatch =
     hasPinnedPlatform &&
     claimedPlatform !== pairedPlatform &&
     !isLegacyNodeHostPlatformPin &&
-    !isMobileAppPlatformVersionRefresh;
+    !isNativeAppPlatformVersionRefresh;
   const deviceFamilyMismatch = hasPinnedDeviceFamily && claimedDeviceFamily !== pairedDeviceFamily;
   const pinnedPlatform =
     claimedPlatform === pairedPlatform
       ? params.pairedPlatform
       : isLegacyNodeHostPlatformPin
         ? normalizeLegacyNodeHostPlatformPin(pairedPlatform)
-        : isMobileAppPlatformVersionRefresh
+        : isNativeAppPlatformVersionRefresh
           ? params.claimedPlatform
           : undefined;
   return {
@@ -491,7 +494,7 @@ function resolvePinnedClientMetadata(params: {
     deviceFamilyMismatch,
     pinnedPlatform: hasPinnedPlatform ? pinnedPlatform : undefined,
     pinnedDeviceFamily: hasPinnedDeviceFamily ? params.pairedDeviceFamily : undefined,
-    ...(isMobileAppPlatformVersionRefresh ? { refreshPairedPlatform: params.claimedPlatform } : {}),
+    ...(isNativeAppPlatformVersionRefresh ? { refreshPairedPlatform: params.claimedPlatform } : {}),
   };
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -450,7 +450,7 @@ function resolvePinnedClientMetadata(params: {
     if (clientId === GATEWAY_CLIENT_IDS.ANDROID_APP && /^android(?:\s|$)/.test(value)) {
       return "android";
     }
-    if (clientId === GATEWAY_CLIENT_IDS.MACOS_APP && /^macos(?:\s|$)/.test(value)) {
+    if (clientId === GATEWAY_CLIENT_IDS.MACOS_APP && /^macos \d+(?:\.\d+){0,2}$/.test(value)) {
       return "macos";
     }
     return value;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -443,7 +443,10 @@ function resolvePinnedClientMetadata(params: {
     }
   }
 
-  function normalizeNativeAppPlatformPin(clientId: string | undefined, value: string): string {
+  function resolveNativeAppPlatformFamily(
+    clientId: string | undefined,
+    value: string,
+  ): string | undefined {
     if (clientId === GATEWAY_CLIENT_IDS.IOS_APP && /^(?:ios|ipados)(?:\s|$)/.test(value)) {
       return "ios-family";
     }
@@ -453,7 +456,7 @@ function resolvePinnedClientMetadata(params: {
     if (clientId === GATEWAY_CLIENT_IDS.MACOS_APP && /^macos \d+(?:\.\d+){0,2}$/.test(value)) {
       return "macos";
     }
-    return value;
+    return undefined;
   }
 
   const claimedPlatform = normalizeDeviceMetadataForAuth(params.claimedPlatform);
@@ -469,12 +472,20 @@ function resolvePinnedClientMetadata(params: {
     claimedPlatform !== "" &&
     normalizeLegacyNodeHostPlatformPin(claimedPlatform) ===
       normalizeLegacyNodeHostPlatformPin(pairedPlatform);
+  const claimedNativeAppPlatformFamily = resolveNativeAppPlatformFamily(
+    params.clientId,
+    claimedPlatform,
+  );
+  const pairedNativeAppPlatformFamily = resolveNativeAppPlatformFamily(
+    params.clientId,
+    pairedPlatform,
+  );
   const isNativeAppPlatformVersionRefresh =
     hasPinnedPlatform &&
     claimedPlatform !== "" &&
     claimedPlatform !== pairedPlatform &&
-    normalizeNativeAppPlatformPin(params.clientId, claimedPlatform) ===
-      normalizeNativeAppPlatformPin(params.clientId, pairedPlatform);
+    claimedNativeAppPlatformFamily !== undefined &&
+    claimedNativeAppPlatformFamily === pairedNativeAppPlatformFamily;
   const platformMismatch =
     hasPinnedPlatform &&
     claimedPlatform !== pairedPlatform &&


### PR DESCRIPTION
## What Problem This Solves

After a macOS update, the Mac app can report a new native platform version while retaining the same device identity. The Gateway treated that safe version-only change as a metadata mismatch, requested repair pairing, and could leave the app in a repeated approval loop.

Fixes #92768.

## Why This Change Was Made

The paired-client metadata resolver now handles a valid native `macOS <version>` change like the existing iOS and Android version refreshes. Maintainer hardening limits the exception to the native Mac app, the same Mac device family, and the native macOS version grammar. Client changes, family changes, malformed labels, bare `macOS`, roles, scopes, and other metadata changes remain approval-bound.

This is the correct owner boundary: the Gateway owns comparison and persistence of paired-device metadata. Suppressing the prompt in the app would leave the false mismatch in place.

## User Impact

Updating macOS no longer forces an already-approved Mac app node through repair pairing. The stored platform version refreshes on reconnect while the existing identity, approval timestamps, node capabilities, and permissions remain intact.

## Evidence

- Exact PR head: `236da42d15e29f4345632dec8cb111bbdd1ba123`.
- Blacksmith Testbox: 144 post-rebase tests across six Gateway projects, then 124 focused tests across four projects after the marker-collision repair.
- Blacksmith Testbox `tbx_01kx93ja7q8aschcx4xmv9wyp1`: `pnpm tsgo:core:test` passed after the final test-helper typing repair.
- Fresh autoreview: no accepted or actionable findings.
- Exact-head hosted CI: green.
- Signed-app live proof on clawmac: the 2026.7.2 Mac app connected to the runtime-identical patched Gateway, completed device and node approval, and successfully invoked `system.which`.
- Regression proof: after changing only the stored platform from `macOS 26.5.2` to `macOS 26.5.1`, the same device reconnected, silently restored `macOS 26.5.2`, preserved the original approval timestamps, created zero pending device repair requests, remained an approved connected node, and successfully invoked `system.which` again.

---

AI-assisted. The contributor supplied the original fix and reproduction; maintainers hardened the platform grammar, expanded Gateway coverage, added full reconnect persistence proof, and ran live signed-app validation.
