### PR TITLE
fix(openai): guard responses tool payload names

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -480,6 +480,32 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("skips unreadable model payload tool names in debug summaries", () => {
+    const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+    process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "tools";
+    try {
+      const hostileTool = {
+        type: "function",
+        get function(): { name: string } {
+          throw new Error("responses debug tool function getter exploded");
+        },
+      };
+
+      expect(
+        testing.summarizeResponsesTools([
+          hostileTool,
+          { type: "function", function: { name: "wait" } },
+        ]),
+      ).toBe("count=2 names=wait");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
+      } else {
+        process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = previous;
+      }
+    }
+  });
+
   it("redacts full model payload debug summaries", () => {
     const previous = process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD;
     process.env.OPENCLAW_DEBUG_MODEL_PAYLOAD = "full-redacted";
@@ -508,6 +534,25 @@ describe("openai transport stream", () => {
       tools: [
         { type: "function", name: "exec" },
         { type: "web_search_preview" },
+        { type: "function", function: { name: "wait" } },
+      ],
+    };
+
+    testing.enforceCodeModeResponsesToolSurface(payload);
+    testing.assertCodeModeResponsesToolSurface(payload);
+    expect(payload.tools).toHaveLength(2);
+  });
+
+  it("skips unreadable code mode response payload tool names", () => {
+    const payload = {
+      tools: [
+        { type: "function", name: "exec" },
+        {
+          type: "function",
+          get function(): { name: string } {
+            throw new Error("responses code mode function getter exploded");
+          },
+        },
         { type: "function", function: { name: "wait" } },
       ],
     };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -342,19 +342,32 @@ function responseInputRoles(input: unknown): string {
   return [...roles].toSorted().join(",");
 }
 
+function readToolPayloadField(record: Record<string, unknown>, field: string): unknown {
+  try {
+    return record[field];
+  } catch {
+    return undefined;
+  }
+}
+
 function readResponsesToolDisplayName(tool: unknown): string {
   if (!tool || typeof tool !== "object") {
     return "";
   }
   const record = tool as Record<string, unknown>;
-  if (typeof record.name === "string") {
-    return record.name;
+  const name = readToolPayloadField(record, "name");
+  if (typeof name === "string") {
+    return name;
   }
-  const fn = record.function;
-  if (fn && typeof fn === "object" && typeof (fn as Record<string, unknown>).name === "string") {
-    return (fn as Record<string, unknown>).name as string;
+  const fn = readToolPayloadField(record, "function");
+  if (fn && typeof fn === "object") {
+    const fnName = readToolPayloadField(fn as Record<string, unknown>, "name");
+    if (typeof fnName === "string") {
+      return fnName;
+    }
   }
-  return typeof record.type === "string" ? record.type : "";
+  const type = readToolPayloadField(record, "type");
+  return typeof type === "string" && type !== "function" ? type : "";
 }
 
 function summarizeResponsesTools(tools: unknown): string {
@@ -373,11 +386,16 @@ function responsesPayloadToolName(tool: unknown): string | undefined {
   if (!isRecord(tool)) {
     return undefined;
   }
-  if (typeof tool.name === "string") {
-    return tool.name;
+  const name = readToolPayloadField(tool, "name");
+  if (typeof name === "string") {
+    return name;
   }
-  const fn = tool.function;
-  return isRecord(fn) && typeof fn.name === "string" ? fn.name : undefined;
+  const fn = readToolPayloadField(tool, "function");
+  if (!isRecord(fn)) {
+    return undefined;
+  }
+  const fnName = readToolPayloadField(fn, "name");
+  return typeof fnName === "string" ? fnName : undefined;
 }
 
 function enforceCodeModeResponsesToolSurface(payload: unknown): void {
@@ -2026,14 +2044,15 @@ function hasResponsesWebSearchTool(tools: unknown): boolean {
     if (!isRecord(tool)) {
       return false;
     }
-    if (tool.type === "web_search") {
+    const type = readToolPayloadField(tool, "type");
+    if (type === "web_search") {
       return true;
     }
-    if (tool.type === "function" && tool.name === "web_search") {
+    if (type === "function" && readToolPayloadField(tool, "name") === "web_search") {
       return true;
     }
-    const fn = tool.function;
-    return isRecord(fn) && fn.name === "web_search";
+    const fn = readToolPayloadField(tool, "function");
+    return isRecord(fn) && readToolPayloadField(fn, "name") === "web_search";
   });
 }
 


### PR DESCRIPTION
## Summary

- Guard OpenAI Responses tool payload field reads so accessor-backed `name`, `function`, or `type` fields cannot crash debug summaries, code-mode filtering, or web-search detection.
- Skip unreadable function tool names in payload summaries while preserving native non-function tool type labels.
- Add regressions for unreadable model-payload tool names in debug summaries and code-mode payload filtering.

## Verification

- Red repro before the fix: `CI=1 node scripts/run-vitest.mjs run src/agents/openai-transport-stream.test.ts -t "skips unreadable .*payload tool names" --reporter=verbose` failed with throwing `function` getters.
- `./node_modules/.bin/oxfmt --write src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `./node_modules/.bin/oxlint src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`
- `CI=1 node scripts/run-vitest.mjs run src/agents/openai-transport-stream.test.ts --reporter=verbose` (242 passed)
- Autoreview: `autoreview clean: no accepted/actionable findings reported`; `overall: patch is correct (0.84)`
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
  - provider: `aws`
  - run: `run_e07e36f593a2`
  - lease: `cbx_8b1a83ccd047`
  - type: `c7a.8xlarge`
  - lanes: `core`, `coreTests`
  - exit: `0`

## Real behavior proof

Behavior addressed: OpenAI Responses payload tools with throwing accessor-backed fields no longer crash model-payload debug summaries or code-mode tool filtering; valid `exec` and `wait` tools are preserved.

Real environment tested: Local Node/Vitest harness plus AWS Crabbox Linux remote changed gate.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/agents/openai-transport-stream.test.ts --reporter=verbose`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: The focused red repro now passes, the full touched test file passes 242 tests, and the AWS changed gate completed with exit 0.

Observed result after fix: The debug summary skips the unreadable function tool name and reports `count=2 names=wait`; code-mode filtering drops the unreadable tool and keeps `exec`/`wait`.

What was not tested: A live OpenAI provider call with a payload hook returning accessor-backed tool objects; the regression exercises the local outbound payload helpers directly.
