### PR TITLE
Share channel progress draft compositor

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f3e0379cbe0e584a8c9658253d4a808356fe80fb5ec775bbee9e968e8d815380  plugin-sdk-api-baseline.json
-601b55acafbd1e00b850c9b0c15d587029050906960071d448d37538b223e226  plugin-sdk-api-baseline.jsonl
+a9501e226bb26befb02072cf5e60c3dc124cbd5dc0b16eb281789d0843f72f71  plugin-sdk-api-baseline.json
+b106090dc12bf7e46beac4ed160f0cff0ef8039291f24172b693e8d8b752d571  plugin-sdk-api-baseline.jsonl

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,15 +1,8 @@
-import { EmbeddedBlockChunker, formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
+import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
-  createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
-  formatChannelProgressDraftText,
-  isChannelProgressDraftWorkToolName,
-  mergeChannelProgressDraftLine,
-  normalizeChannelProgressDraftLineIdentity,
-  resolveChannelProgressDraftMaxLineChars,
-  resolveChannelProgressDraftMaxLines,
+  createChannelProgressDraftCompositor,
   resolveChannelStreamingBlockEnabled,
-  resolveChannelStreamingProgressCommentary,
   resolveChannelStreamingPreviewToolProgress,
   resolveChannelStreamingSuppressDefaultToolProgressMessages,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -79,86 +72,48 @@ export function createDiscordDraftPreviewController(params: {
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
-  let finalReplyStarted = false;
   let finalReplyDelivered = false;
   const previewToolProgressEnabled =
     Boolean(draftStream) && resolveChannelStreamingPreviewToolProgress(params.discordConfig);
-  const commentaryProgressEnabled =
-    Boolean(draftStream) && resolveChannelStreamingProgressCommentary(params.discordConfig);
   const suppressDefaultToolProgressMessages =
     Boolean(draftStream) &&
     resolveChannelStreamingSuppressDefaultToolProgressMessages(params.discordConfig, {
       draftStreamActive: true,
       previewToolProgressEnabled,
     });
-  let previewToolProgressSuppressed = false;
-  let previewToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
-  let reasoningProgressRawText = "";
-  let lastReasoningProgressLine: string | undefined;
   const progressSeed = `${params.accountId}:${params.deliverChannelId}`;
-
-  const renderProgressDraft = async (options?: { flush?: boolean }) => {
-    if (!draftStream || discordStreamMode !== "progress") {
-      return;
-    }
-    const previewText = formatChannelProgressDraftText({
-      entry: params.discordConfig,
-      lines: previewToolProgressLines,
-      seed: progressSeed,
-    });
-    if (!previewText || previewText === lastPartialText) {
-      return;
-    }
-    lastPartialText = previewText;
-    draftText = previewText;
-    hasStreamedMessage = true;
-    draftChunker?.reset();
-    draftStream.update(previewText);
-    if (options?.flush) {
-      await draftStream.flush();
-    }
-  };
-
-  const progressDraftGate = createChannelProgressDraftGate({
-    onStart: () => renderProgressDraft({ flush: true }),
+  const progressDraft = createChannelProgressDraftCompositor({
+    entry: params.discordConfig,
+    mode: discordStreamMode,
+    active: Boolean(draftStream),
+    seed: progressSeed,
+    update: async (previewText, options) => {
+      lastPartialText = previewText;
+      draftText = previewText;
+      hasStreamedMessage = true;
+      draftChunker?.reset();
+      draftStream?.update(previewText);
+      if (options?.flush) {
+        await draftStream?.flush();
+      }
+    },
+    deleteCurrent: async () => {
+      lastPartialText = "";
+      draftText = "";
+      hasStreamedMessage = false;
+      if (draftStream?.messageId()) {
+        await draftStream.deleteCurrentMessage();
+      }
+    },
+    isEmptyLine: isEmptyDiscordProgressLine,
+    shouldStartNow: shouldStartDiscordProgressDraftNow,
   });
-
-  const clearProgressDraftLine = async (lineId: string) => {
-    const nextLines = previewToolProgressLines.filter(
-      (line) => typeof line !== "object" || line.id?.trim() !== lineId,
-    );
-    if (nextLines.length === previewToolProgressLines.length) {
-      return;
-    }
-    previewToolProgressLines = nextLines;
-    if (!progressDraftGate.hasStarted) {
-      return;
-    }
-    const previewText = formatChannelProgressDraftText({
-      entry: params.discordConfig,
-      lines: previewToolProgressLines,
-      seed: progressSeed,
-    });
-    if (previewText) {
-      await renderProgressDraft();
-      return;
-    }
-    lastPartialText = "";
-    draftText = "";
-    hasStreamedMessage = false;
-    if (draftStream?.messageId()) {
-      await draftStream.deleteCurrentMessage();
-    }
-  };
 
   const resetProgressState = () => {
     lastPartialText = "";
     draftText = "";
     draftChunker?.reset();
-    previewToolProgressSuppressed = false;
-    previewToolProgressLines = [];
-    reasoningProgressRawText = "";
-    lastReasoningProgressLine = undefined;
+    progressDraft.reset();
   };
 
   const forceNewMessageIfNeeded = () => {
@@ -172,22 +127,23 @@ export function createDiscordDraftPreviewController(params: {
   return {
     draftStream,
     previewToolProgressEnabled,
-    commentaryProgressEnabled,
+    commentaryProgressEnabled: progressDraft.commentaryProgressEnabled,
     suppressDefaultToolProgressMessages,
     get isProgressMode() {
       return discordStreamMode === "progress";
     },
     get hasProgressDraftStarted() {
-      return progressDraftGate.hasStarted;
+      return progressDraft.hasStarted;
     },
     get finalizedViaPreviewMessage() {
       return finalizedViaPreviewMessage;
     },
     markFinalReplyStarted() {
-      finalReplyStarted = true;
+      progressDraft.markFinalReplyStarted();
     },
     markFinalReplyDelivered() {
       finalReplyDelivered = true;
+      progressDraft.markFinalReplyDelivered();
     },
     markPreviewFinalized() {
       finalizedViaPreviewMessage = true;
@@ -197,149 +153,19 @@ export function createDiscordDraftPreviewController(params: {
       if (!draftStream || discordStreamMode !== "progress") {
         return;
       }
-      await progressDraftGate.startNow();
+      await progressDraft.start();
     },
     async pushToolProgress(
       line?: string | ChannelProgressDraftLine,
       options?: { toolName?: string },
     ) {
-      if (!draftStream) {
-        return;
-      }
-      if (finalReplyStarted || finalReplyDelivered) {
-        return;
-      }
-      if (
-        options?.toolName !== undefined &&
-        !isChannelProgressDraftWorkToolName(options.toolName)
-      ) {
-        return;
-      }
-      if (isEmptyDiscordProgressLine(line)) {
-        return;
-      }
-      const normalized = normalizeChannelProgressDraftLineIdentity(line);
-      if (!normalized) {
-        return;
-      }
-      const progressLine: string | ChannelProgressDraftLine =
-        typeof line === "object" && line !== undefined ? line : normalized;
-      if (discordStreamMode !== "progress") {
-        if (!previewToolProgressEnabled || previewToolProgressSuppressed) {
-          return;
-        }
-        const nextLines = mergeChannelProgressDraftLine(previewToolProgressLines, progressLine, {
-          maxLines: resolveChannelProgressDraftMaxLines(params.discordConfig),
-        });
-        if (nextLines === previewToolProgressLines) {
-          return;
-        }
-        previewToolProgressLines = nextLines;
-        const previewText = formatChannelProgressDraftText({
-          entry: params.discordConfig,
-          lines: previewToolProgressLines,
-          seed: progressSeed,
-        });
-        lastPartialText = previewText;
-        draftText = previewText;
-        hasStreamedMessage = true;
-        draftChunker?.reset();
-        draftStream.update(previewText);
-        return;
-      }
-      if (previewToolProgressEnabled && !previewToolProgressSuppressed && normalized) {
-        previewToolProgressLines = mergeChannelProgressDraftLine(
-          previewToolProgressLines,
-          progressLine,
-          {
-            maxLines: resolveChannelProgressDraftMaxLines(params.discordConfig),
-          },
-        );
-      }
-      const alreadyStarted = progressDraftGate.hasStarted;
-      let progressActive;
-      if (shouldStartDiscordProgressDraftNow(line)) {
-        await progressDraftGate.startNow();
-        progressActive = progressDraftGate.hasStarted;
-      } else {
-        progressActive = await progressDraftGate.noteWork();
-      }
-      if ((alreadyStarted || progressActive) && progressDraftGate.hasStarted) {
-        await renderProgressDraft();
-      }
+      await progressDraft.pushToolProgress(line, options);
     },
     async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
-      if (!draftStream || discordStreamMode !== "progress" || !text) {
-        return;
-      }
-      if (finalReplyDelivered) {
-        return;
-      }
-      reasoningProgressRawText = mergeReasoningProgressText(reasoningProgressRawText, text, {
-        snapshot: options?.snapshot === true,
-      });
-      const normalized = normalizeReasoningProgressLine(reasoningProgressRawText);
-      if (!normalized) {
-        return;
-      }
-      const displayLine = formatReasoningProgressDisplayLine(
-        normalized,
-        resolveChannelProgressDraftMaxLineChars(params.discordConfig),
-      );
-      if (!displayLine) {
-        return;
-      }
-      if (previewToolProgressEnabled && !previewToolProgressSuppressed) {
-        const priorIndex =
-          lastReasoningProgressLine === undefined
-            ? -1
-            : previewToolProgressLines.lastIndexOf(lastReasoningProgressLine);
-        if (priorIndex >= 0) {
-          previewToolProgressLines = [...previewToolProgressLines];
-          previewToolProgressLines[priorIndex] = displayLine;
-        } else {
-          previewToolProgressLines = [...previewToolProgressLines, displayLine].slice(
-            -resolveChannelProgressDraftMaxLines(params.discordConfig),
-          );
-        }
-        lastReasoningProgressLine = displayLine;
-      }
-      const progressActive = await progressDraftGate.noteWork();
-      if (progressActive && progressDraftGate.hasStarted) {
-        await renderProgressDraft();
-      }
+      await progressDraft.pushReasoningProgress(text, options);
     },
     async pushCommentaryProgress(text?: string, options?: { itemId?: string }) {
-      if (!draftStream || discordStreamMode !== "progress" || !commentaryProgressEnabled) {
-        return;
-      }
-      if (finalReplyStarted || finalReplyDelivered) {
-        return;
-      }
-      const itemId = options?.itemId?.trim();
-      if (!text && !itemId) {
-        return;
-      }
-      const normalized = normalizeCommentaryProgressText(text ?? "");
-      const lineId = itemId ? `commentary:${itemId}` : normalized ? `commentary:${normalized}` : "";
-      if (!normalized) {
-        if (lineId) {
-          await clearProgressDraftLine(lineId);
-        }
-        return;
-      }
-      const line: ChannelProgressDraftLine = {
-        id: lineId,
-        kind: "item",
-        text: normalized,
-        label: "Commentary",
-        prefix: false,
-      };
-      previewToolProgressLines = mergeChannelProgressDraftLine(previewToolProgressLines, line, {
-        maxLines: resolveChannelProgressDraftMaxLines(params.discordConfig),
-      });
-      await progressDraftGate.startNow();
-      await renderProgressDraft();
+      await progressDraft.pushCommentaryProgress(text, options);
     },
     resolvePreviewFinalText(text?: string) {
       if (typeof text !== "string") {
@@ -390,8 +216,7 @@ export function createDiscordDraftPreviewController(params: {
       if (discordStreamMode === "progress") {
         return;
       }
-      previewToolProgressSuppressed = true;
-      previewToolProgressLines = [];
+      progressDraft.suppress();
       hasStreamedMessage = true;
       if (discordStreamMode === "partial") {
         if (
@@ -457,7 +282,7 @@ export function createDiscordDraftPreviewController(params: {
     },
     async cleanup() {
       try {
-        progressDraftGate.cancel();
+        progressDraft.cancel();
         if (!finalReplyDelivered) {
           await draftStream?.discardPending();
         }
@@ -469,106 +294,6 @@ export function createDiscordDraftPreviewController(params: {
       }
     },
   };
-}
-
-function normalizeReasoningProgressLine(text: string): string {
-  return text
-    .replace(
-      /^\s*(?:>\s*)?(?:Reasoning:\s*(?:\r?\n|\r)\s*|Thinking\.{0,3}\s*(?:\r?\n|\r)\s*(?:\r?\n|\r)\s*)/i,
-      "",
-    )
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function normalizeReasoningProgressInput(text: string): string {
-  const normalized = normalizeReasoningProgressLine(text);
-  const italic = normalized.match(/^_(.*)_$/u);
-  return (italic?.[1] ?? normalized).trim();
-}
-
-function formatReasoningProgressDisplayLine(text: string, maxChars: number): string {
-  const normalizedText = normalizeReasoningProgressInput(text);
-  const formatted = normalizeReasoningProgressLine(formatReasoningMessage(normalizedText));
-  if (!formatted) {
-    return "";
-  }
-  if (Array.from(formatted).length <= maxChars) {
-    return formatted;
-  }
-  const italic = formatted.match(/^_(.*)_$/u);
-  if (!italic) {
-    return compactReasoningProgressDisplayLine(formatted, maxChars);
-  }
-  const body = compactReasoningProgressDisplayLine(italic[1] ?? "", Math.max(1, maxChars - 2));
-  return body ? `_${body}_` : "";
-}
-
-function compactReasoningProgressDisplayLine(text: string, maxChars: number): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  const chars = Array.from(normalized);
-  if (chars.length <= maxChars) {
-    return normalized;
-  }
-  if (maxChars <= 1) {
-    return "…";
-  }
-  const head = chars
-    .slice(0, maxChars - 1)
-    .join("")
-    .trimEnd();
-  const boundary = head.search(/\s+\S*$/u);
-  if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
-  }
-  return `${head}…`;
-}
-
-function normalizeCommentaryProgressText(text: string): string {
-  const cleaned = stripInlineDirectiveTagsForDelivery(text).text.trim();
-  if (!cleaned || isSilentCommentaryProgressText(cleaned)) {
-    return "";
-  }
-  return cleaned
-    .split(/\r?\n/u)
-    .map((line) => line.replace(/\s+/g, " ").trim())
-    .filter(Boolean)
-    .map((line) => `_${line}_`)
-    .join("\n");
-}
-
-function isSilentCommentaryProgressText(text: string): boolean {
-  const normalized = text.replace(/^[\s*_`~]+|[\s*_`~]+$/gu, "").trim();
-  return /^NO_REPLY$/iu.test(normalized);
-}
-
-function mergeReasoningProgressText(
-  current: string,
-  incoming: string,
-  options?: { snapshot?: boolean },
-): string {
-  if (!current) {
-    return incoming;
-  }
-  const normalizedCurrent = normalizeReasoningProgressLine(current);
-  const normalizedIncoming = normalizeReasoningProgressLine(incoming);
-  if (!normalizedIncoming || normalizedIncoming === normalizedCurrent) {
-    return current;
-  }
-  if (
-    options?.snapshot === true ||
-    isReasoningSnapshotText(incoming) ||
-    normalizedIncoming.startsWith(normalizedCurrent)
-  ) {
-    return incoming;
-  }
-  return `${current}${incoming}`;
-}
-
-function isReasoningSnapshotText(text: string): boolean {
-  return /^\s*(?:>\s*)?(?:Reasoning:\s*(?:\r?\n|\r)\s*|Thinking\.{0,3}\s*(?:\r?\n|\r)\s*(?:\r?\n|\r)\s*)/i.test(
-    text,
-  );
 }
 
 function isEmptyDiscordProgressLine(line: string | ChannelProgressDraftLine | undefined): boolean {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2317,6 +2317,27 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
+  it("composes streamed reasoning with tool progress in Telegram progress drafts", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onReasoningStream?.({ text: "<think>Checking files</think>" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`\n• _Checking files_");
+  });
+
   it("keeps the progress draft label when tool progress lines are hidden", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -24,14 +24,10 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildChannelProgressDraftLineForEntry,
-  createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
+  createChannelProgressDraftCompositor,
   formatChannelProgressDraftLine,
   formatChannelProgressDraftLineForEntry,
-  formatChannelProgressDraftText,
-  isChannelProgressDraftWorkToolName,
-  mergeChannelProgressDraftLine,
-  resolveChannelProgressDraftMaxLines,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewNativeToolProgress,
   resolveChannelStreamingPreviewNativeToolProgressAllowFrom,
@@ -406,6 +402,13 @@ function sanitizeProgressMarkdownText(text: string): string {
 function formatProgressAsMarkdownCode(text: string): string {
   const clipped = clipProgressMarkdownText(text);
   return `\`${sanitizeProgressMarkdownText(clipped)}\``;
+}
+
+function formatTelegramProgressLine(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.startsWith("_") && trimmed.endsWith("_")
+    ? trimmed
+    : formatProgressAsMarkdownCode(text);
 }
 
 function normalizeTelegramThreadId(value: unknown): number | undefined {
@@ -873,7 +876,10 @@ export const dispatchTelegramMessage = async ({
     !hasTelegramQuoteReply &&
     !accountBlockStreamingEnabled &&
     !forceBlockStreamingForReasoning;
-  const canStreamReasoningDraft = !isRoomEvent && streamReasoningDraft;
+  const streamReasoningInProgressDraft =
+    streamReasoningDraft && streamMode === "progress" && canStreamAnswerDraft;
+  const canStreamReasoningDraft =
+    !isRoomEvent && streamReasoningDraft && !streamReasoningInProgressDraft;
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number"
       ? (replyQuoteMessageId ?? msg.message_id)
@@ -936,8 +942,6 @@ export const dispatchTelegramMessage = async ({
           log: logVerbose,
         })
       : undefined;
-  let streamToolProgressSuppressed = false;
-  let streamToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
   function resetAnswerToolProgressDraft() {
@@ -952,33 +956,25 @@ export const dispatchTelegramMessage = async ({
     }
     activeAnswerDraftIsToolProgressOnly = true;
   }
-  const renderProgressDraft = async (options?: { flush?: boolean }): Promise<boolean> => {
-    if (!answerLane.stream || streamMode !== "progress") {
-      return false;
-    }
-    const streamText = formatChannelProgressDraftText({
-      entry: telegramCfg,
-      lines: streamToolProgressLines,
-      seed: progressSeed,
-      formatLine: formatProgressAsMarkdownCode,
-    });
-    if (!streamText || streamText === answerLane.lastPartialText) {
-      return false;
-    }
-    await prepareAnswerLaneForToolProgress();
-    answerLane.lastPartialText = streamText;
-    answerLane.hasStreamedMessage = true;
-    answerLane.finalized = false;
-    answerLane.stream.update(streamText);
-    if (options?.flush) {
-      await answerLane.stream.flush();
-    }
-    return true;
-  };
-  const progressDraftGate = createChannelProgressDraftGate({
-    onStart: async () => {
-      await renderProgressDraft({ flush: true });
+  const progressDraft = createChannelProgressDraftCompositor({
+    entry: telegramCfg,
+    mode: streamMode,
+    active: Boolean(answerLane.stream),
+    seed: progressSeed,
+    formatLine: formatTelegramProgressLine,
+    update: async (streamText, options) => {
+      await prepareAnswerLaneForToolProgress();
+      answerLane.lastPartialText = streamText;
+      answerLane.hasStreamedMessage = true;
+      answerLane.finalized = false;
+      answerLane.stream?.update(streamText);
+      if (options?.flush) {
+        await answerLane.stream?.flush();
+      }
     },
+    tryNativeUpdate: nativeToolProgressDraft
+      ? async (streamText) => await nativeToolProgressDraft.update(streamText)
+      : undefined,
   });
   let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
@@ -986,80 +982,37 @@ export const dispatchTelegramMessage = async ({
     line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string; startImmediately?: boolean },
   ) => {
-    if (!answerLane.stream) {
+    if (
+      !answerLane.stream ||
+      answerLane.finalized ||
+      finalAnswerDeliveryStarted ||
+      finalAnswerDelivered
+    ) {
       return false;
     }
-    if (answerLane.finalized || finalAnswerDeliveryStarted || finalAnswerDelivered) {
-      return false;
-    }
-    if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
-      return false;
-    }
-    const rawText = typeof line === "string" ? line : line?.text;
-    const normalized = sanitizeProgressMarkdownText(rawText?.replace(/\s+/g, " ").trim() ?? "");
-    if (streamToolProgressSuppressed) {
-      return false;
-    }
-    if (streamMode !== "progress" && !streamToolProgressEnabled) {
-      return false;
-    }
-    const shouldUpdateProgressLines =
-      streamToolProgressEnabled && !streamToolProgressSuppressed && Boolean(normalized);
-    if (!shouldUpdateProgressLines && streamMode !== "progress") {
-      return false;
-    }
-    const progressLine =
-      typeof line === "object" && line !== undefined ? { ...line, text: normalized } : normalized;
-    const nextLines = shouldUpdateProgressLines
-      ? mergeChannelProgressDraftLine(streamToolProgressLines, progressLine, {
-          maxLines: resolveChannelProgressDraftMaxLines(telegramCfg),
-        })
-      : streamToolProgressLines;
-    if (shouldUpdateProgressLines && nextLines === streamToolProgressLines) {
-      return false;
-    }
-    if (nativeToolProgressDraft && shouldUpdateProgressLines) {
-      const streamText = formatChannelProgressDraftText({
-        entry: telegramCfg,
-        lines: nextLines,
-        seed: progressSeed,
-      });
-      if (streamText && (await nativeToolProgressDraft.update(streamText))) {
-        streamToolProgressLines = nextLines;
-        return true;
-      }
-    }
-    if (streamMode !== "progress") {
-      streamToolProgressLines = nextLines;
-      const streamText = formatChannelProgressDraftText({
-        entry: telegramCfg,
-        lines: streamToolProgressLines,
-        seed: progressSeed,
-        formatLine: formatProgressAsMarkdownCode,
-      });
-      await prepareAnswerLaneForToolProgress();
-      answerLane.lastPartialText = streamText;
-      answerLane.hasStreamedMessage = true;
-      answerLane.finalized = false;
-      answerLane.stream.update(streamText);
-      return true;
-    }
-    streamToolProgressLines = nextLines;
-    if (options?.startImmediately) {
-      await progressDraftGate.startNow();
-      if (progressDraftGate.hasStarted) {
-        await renderProgressDraft();
-        return true;
-      }
-      return progressDraftGate.hasStarted;
-    }
-    const alreadyStarted = progressDraftGate.hasStarted;
-    const progressActive = await progressDraftGate.noteWork();
-    if ((alreadyStarted || progressActive) && progressDraftGate.hasStarted) {
-      await renderProgressDraft();
-      return true;
-    }
-    return false;
+    return await progressDraft.pushToolProgress(line, options);
+  };
+  const pushStreamReasoningProgress = async (payload: {
+    text?: string;
+    isReasoningSnapshot?: boolean;
+  }) => {
+    return await progressDraft.pushReasoningProgress(payload.text, {
+      snapshot: payload.isReasoningSnapshot === true,
+    });
+  };
+  const markProgressFinalStarted = () => {
+    finalAnswerDeliveryStarted = true;
+    progressDraft.markFinalReplyStarted();
+  };
+  const markProgressFinalDelivered = () => {
+    finalAnswerDelivered = true;
+    progressDraft.markFinalReplyDelivered();
+  };
+  const resetProgressDraftState = () => {
+    progressDraft.reset();
+  };
+  const suppressProgressDraftState = () => {
+    progressDraft.suppress();
   };
   let splitReasoningOnNextStream = false;
   let draftLaneEventQueue = Promise.resolve();
@@ -1143,8 +1096,7 @@ export const dispatchTelegramMessage = async ({
     await answerLane.stream?.clear();
     answerLane.stream?.forceNewMessage();
     resetDraftLaneState(answerLane);
-    streamToolProgressSuppressed = true;
-    streamToolProgressLines = [];
+    suppressProgressDraftState();
     return true;
   };
   const prepareAnswerLaneForText = async () => {
@@ -1172,8 +1124,7 @@ export const dispatchTelegramMessage = async ({
         return;
       }
       resetAnswerToolProgressDraft();
-      streamToolProgressSuppressed = true;
-      streamToolProgressLines = [];
+      suppressProgressDraftState();
     }
     lane.hasStreamedMessage = true;
     lane.finalized = false;
@@ -1587,7 +1538,7 @@ export const dispatchTelegramMessage = async ({
         return { kind: "skipped" };
       }
       answerLane.finalized = true;
-      finalAnswerDelivered = true;
+      markProgressFinalDelivered();
       return { kind: "sent" };
     };
     const resolveTranscriptBackedFinalText = async (text: string): Promise<string> =>
@@ -1702,7 +1653,7 @@ export const dispatchTelegramMessage = async ({
                     const segments = split.segments;
                     const reply = resolveSendableOutboundReplyParts(effectivePayload);
                     if (info.kind === "final" && (reply.text.length > 0 || reply.hasMedia)) {
-                      finalAnswerDeliveryStarted = true;
+                      markProgressFinalStarted();
                     }
                     if (info.kind === "final") {
                       await enqueueDraftLaneEvent(async () => {});
@@ -1734,7 +1685,7 @@ export const dispatchTelegramMessage = async ({
                         buttons,
                       });
                       if (result.kind !== "skipped") {
-                        finalAnswerDelivered = true;
+                        markProgressFinalDelivered();
                       }
                       return result;
                     };
@@ -1849,7 +1800,7 @@ export const dispatchTelegramMessage = async ({
                         });
                       }
                       if (info.kind === "final" && delivered) {
-                        finalAnswerDelivered = true;
+                        markProgressFinalDelivered();
                       }
                       if (info.kind === "final") {
                         await flushBufferedFinalAnswer();
@@ -1875,7 +1826,7 @@ export const dispatchTelegramMessage = async ({
                       durable: info.kind === "final",
                     });
                     if (info.kind === "final" && delivered) {
-                      finalAnswerDelivered = true;
+                      markProgressFinalDelivered();
                     }
                     if (info.kind === "final") {
                       await flushBufferedFinalAnswer();
@@ -1957,13 +1908,19 @@ export const dispatchTelegramMessage = async ({
                           }
                           await ingestDraftLaneSegments(payload, true);
                         })
-                    : undefined,
+                    : streamReasoningInProgressDraft
+                      ? (payload) =>
+                          enqueueDraftLaneEvent(async () => {
+                            await pushStreamReasoningProgress(payload);
+                          })
+                      : undefined,
                   onAssistantMessageStart: answerLane.stream
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
                           reasoningStepState.resetForNextStep();
-                          streamToolProgressSuppressed = false;
-                          streamToolProgressLines = [];
+                          if (streamMode !== "progress") {
+                            resetProgressDraftState();
+                          }
                           if (answerLane.finalized) {
                             await rotateLaneForNewMessage(answerLane);
                           }
@@ -1973,8 +1930,7 @@ export const dispatchTelegramMessage = async ({
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
                           splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
-                          streamToolProgressSuppressed = false;
-                          streamToolProgressLines = [];
+                          resetProgressDraftState();
                         })
                     : undefined,
                   suppressDefaultToolProgressMessages:
@@ -2106,7 +2062,7 @@ export const dispatchTelegramMessage = async ({
       dispatchError = err;
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
     } finally {
-      progressDraftGate.cancel();
+      progressDraft.cancel();
       await draftLaneEventQueue;
       nativeToolProgressDraft?.stop();
       const lanesToCleanup: Array<{ laneName: LaneName; lane: DraftLaneState }> = [

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelProgressDraftCompositor } from "./progress-draft-compositor.js";
+
+describe("createChannelProgressDraftCompositor", () => {
+  it("keeps the progress label visible when tool lines are hidden", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: "Shelling", toolProgress: false } },
+      },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+
+    expect(update).toHaveBeenCalledWith("Shelling", { flush: true });
+  });
+
+  it("keeps reasoning details hidden when tool progress lines are hidden", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: "Shelling", toolProgress: false } },
+      },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+    await progress.pushReasoningProgress("Reading files");
+
+    expect(update).toHaveBeenCalledWith("Shelling", { flush: true });
+    expect(update).not.toHaveBeenCalledWith(expect.stringContaining("Reading"), undefined);
+  });
+
+  it("does not resurrect progress after suppression", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    progress.suppress();
+    await progress.pushReasoningProgress("Reading files");
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("composes reasoning deltas with tool progress", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+    await progress.pushReasoningProgress("Reading");
+    await progress.pushReasoningProgress(" files");
+
+    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n• _Reading files_", undefined);
+  });
+
+  it("preserves tagged reasoning content without leaking tags", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+    await progress.pushReasoningProgress("<think>Checking files</think>");
+
+    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n• _Checking files_", undefined);
+  });
+
+  it("replaces repeated formatted reasoning snapshots", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushToolProgress("🛠️ Exec", { startImmediately: true });
+    await progress.pushReasoningProgress("Thinking\n\n_Reading_");
+    await progress.pushReasoningProgress("Thinking\n\n_Reading files_");
+
+    expect(update).toHaveBeenLastCalledWith("Shelling\n\n🛠️ Exec\n• _Reading files_", undefined);
+  });
+});

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -1,0 +1,387 @@
+import { formatReasoningMessage } from "../agents/embedded-agent-utils.js";
+import { stripInlineDirectiveTagsForDelivery } from "../utils/directive-tags.js";
+import {
+  createChannelProgressDraftGate,
+  type ChannelProgressDraftLine,
+  formatChannelProgressDraftText,
+  isChannelProgressDraftWorkToolName,
+  mergeChannelProgressDraftLine,
+  normalizeChannelProgressDraftLineIdentity,
+  resolveChannelProgressDraftMaxLineChars,
+  resolveChannelProgressDraftMaxLines,
+  resolveChannelStreamingProgressCommentary,
+  resolveChannelStreamingPreviewToolProgress,
+  resolveChannelStreamingSuppressDefaultToolProgressMessages,
+  type StreamingCompatEntry,
+  type StreamingMode,
+} from "./streaming.js";
+
+export type ChannelProgressDraftMode = StreamingMode;
+
+export type ChannelProgressDraftCompositor = ReturnType<
+  typeof createChannelProgressDraftCompositor
+>;
+type ProgressDraftLine = string | ChannelProgressDraftLine;
+
+export function createChannelProgressDraftCompositor(params: {
+  entry: StreamingCompatEntry | null | undefined;
+  mode: ChannelProgressDraftMode;
+  active: boolean;
+  seed: string;
+  update: (text: string, options?: { flush?: boolean }) => Promise<void> | void;
+  deleteCurrent?: () => Promise<void> | void;
+  tryNativeUpdate?: (text: string) => Promise<boolean> | boolean;
+  formatLine?: (line: string) => string;
+  isEmptyLine?: (line: ProgressDraftLine | undefined) => boolean;
+  shouldStartNow?: (line: ProgressDraftLine | undefined) => boolean;
+}) {
+  const previewToolProgressEnabled =
+    params.active && resolveChannelStreamingPreviewToolProgress(params.entry);
+  const commentaryProgressEnabled =
+    params.active && resolveChannelStreamingProgressCommentary(params.entry);
+  const suppressDefaultToolProgressMessages =
+    params.active &&
+    resolveChannelStreamingSuppressDefaultToolProgressMessages(params.entry, {
+      draftStreamActive: true,
+      previewToolProgressEnabled,
+    });
+  let progressSuppressed = false;
+  let lines: ProgressDraftLine[] = [];
+  let lastRenderedText = "";
+  let reasoningRawText = "";
+  let lastReasoningLine: string | undefined;
+  let finalReplyStarted = false;
+  let finalReplyDelivered = false;
+
+  const formatDraftText = (draftLines = lines, options?: { formatted?: boolean }) =>
+    formatChannelProgressDraftText({
+      entry: params.entry,
+      lines: draftLines,
+      seed: params.seed,
+      formatLine: options?.formatted === false ? undefined : params.formatLine,
+    });
+
+  const clearProgressState = (suppressed: boolean) => {
+    progressSuppressed = suppressed;
+    lines = [];
+    lastRenderedText = "";
+    reasoningRawText = "";
+    lastReasoningLine = undefined;
+  };
+
+  const render = async (options?: { flush?: boolean }): Promise<boolean> => {
+    if (!params.active || params.mode !== "progress") {
+      return false;
+    }
+    const text = formatDraftText();
+    if (!text || text === lastRenderedText) {
+      return false;
+    }
+    lastRenderedText = text;
+    await params.update(text, options);
+    return true;
+  };
+
+  const gate = createChannelProgressDraftGate({
+    onStart: async () => {
+      await render({ flush: true });
+    },
+  });
+
+  const clearLine = async (lineId: string) => {
+    const nextLines = lines.filter(
+      (line) => typeof line !== "object" || line.id?.trim() !== lineId,
+    );
+    if (nextLines.length === lines.length) {
+      return;
+    }
+    lines = nextLines;
+    if (!gate.hasStarted) {
+      return;
+    }
+    const text = formatDraftText();
+    if (text) {
+      await render();
+      return;
+    }
+    lastRenderedText = "";
+    await params.deleteCurrent?.();
+  };
+
+  const noteProgress = async (
+    line?: ProgressDraftLine,
+    options?: { toolName?: string; startImmediately?: boolean },
+  ) => {
+    if (!params.active || finalReplyStarted || finalReplyDelivered) {
+      return false;
+    }
+    if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
+      return false;
+    }
+    if (params.isEmptyLine?.(line)) {
+      return false;
+    }
+    const normalized = normalizeChannelProgressDraftLineIdentity(line);
+    if (!normalized || progressSuppressed) {
+      return false;
+    }
+    if (params.mode !== "progress" && !previewToolProgressEnabled) {
+      return false;
+    }
+    const progressLine = typeof line === "object" && line !== undefined ? line : normalized;
+    const shouldStoreLine = previewToolProgressEnabled;
+    const nextLines = shouldStoreLine
+      ? mergeChannelProgressDraftLine(lines, progressLine, {
+          maxLines: resolveChannelProgressDraftMaxLines(params.entry),
+        })
+      : lines;
+    if (shouldStoreLine && nextLines === lines) {
+      return false;
+    }
+    if (shouldStoreLine && params.tryNativeUpdate) {
+      const text = formatDraftText(nextLines, { formatted: false });
+      if (text && (await params.tryNativeUpdate(text))) {
+        lines = nextLines;
+        lastRenderedText = text;
+        return true;
+      }
+    }
+    lines = nextLines;
+    if (params.mode !== "progress") {
+      if (!shouldStoreLine) {
+        return false;
+      }
+      const text = formatDraftText();
+      if (!text || text === lastRenderedText) {
+        return false;
+      }
+      lastRenderedText = text;
+      await params.update(text);
+      return true;
+    }
+    if (options?.startImmediately || params.shouldStartNow?.(line)) {
+      await gate.startNow();
+      return gate.hasStarted ? await render() : false;
+    }
+    const alreadyStarted = gate.hasStarted;
+    const progressActive = await gate.noteWork();
+    if ((alreadyStarted || progressActive) && gate.hasStarted) {
+      return await render();
+    }
+    return false;
+  };
+
+  return {
+    get previewToolProgressEnabled() {
+      return previewToolProgressEnabled;
+    },
+    get commentaryProgressEnabled() {
+      return commentaryProgressEnabled;
+    },
+    get suppressDefaultToolProgressMessages() {
+      return suppressDefaultToolProgressMessages;
+    },
+    get hasStarted() {
+      return gate.hasStarted;
+    },
+    markFinalReplyStarted() {
+      finalReplyStarted = true;
+    },
+    markFinalReplyDelivered() {
+      finalReplyDelivered = true;
+    },
+    reset() {
+      clearProgressState(false);
+    },
+    suppress() {
+      clearProgressState(true);
+    },
+    cancel() {
+      gate.cancel();
+    },
+    start() {
+      return gate.startNow();
+    },
+    pushToolProgress: noteProgress,
+    async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
+      if (
+        !params.active ||
+        params.mode !== "progress" ||
+        !text ||
+        progressSuppressed ||
+        finalReplyDelivered
+      ) {
+        return false;
+      }
+      reasoningRawText = mergeReasoningProgressText(reasoningRawText, text, {
+        snapshot: options?.snapshot === true,
+      });
+      const normalized = normalizeReasoningProgressLine(reasoningRawText);
+      if (!normalized) {
+        return false;
+      }
+      const displayLine = formatReasoningProgressDisplayLine(
+        normalized,
+        resolveChannelProgressDraftMaxLineChars(params.entry),
+      );
+      if (!displayLine) {
+        return false;
+      }
+      if (previewToolProgressEnabled) {
+        const priorIndex =
+          lastReasoningLine === undefined ? -1 : lines.lastIndexOf(lastReasoningLine);
+        if (priorIndex >= 0) {
+          lines = [...lines];
+          lines[priorIndex] = displayLine;
+        } else {
+          lines = [...lines, displayLine].slice(-resolveChannelProgressDraftMaxLines(params.entry));
+        }
+        lastReasoningLine = displayLine;
+      }
+      const progressActive = await gate.noteWork();
+      if (progressActive && gate.hasStarted) {
+        return await render();
+      }
+      return false;
+    },
+    async pushCommentaryProgress(text?: string, options?: { itemId?: string }) {
+      if (!params.active || params.mode !== "progress" || !commentaryProgressEnabled) {
+        return false;
+      }
+      if (finalReplyStarted || finalReplyDelivered) {
+        return false;
+      }
+      const itemId = options?.itemId?.trim();
+      if (!text && !itemId) {
+        return false;
+      }
+      const normalized = normalizeCommentaryProgressText(text ?? "");
+      const lineId = itemId ? `commentary:${itemId}` : normalized ? `commentary:${normalized}` : "";
+      if (!normalized) {
+        if (lineId) {
+          await clearLine(lineId);
+        }
+        return false;
+      }
+      const line: ChannelProgressDraftLine = {
+        id: lineId,
+        kind: "item",
+        text: normalized,
+        label: "Commentary",
+        prefix: false,
+      };
+      lines = mergeChannelProgressDraftLine(lines, line, {
+        maxLines: resolveChannelProgressDraftMaxLines(params.entry),
+      });
+      await gate.startNow();
+      return await render();
+    },
+  };
+}
+
+function normalizeReasoningProgressLine(text: string): string {
+  return stripReasoningProgressTags(text)
+    .replace(
+      /^\s*(?:>\s*)?(?:Reasoning:\s*(?:\r?\n|\r)\s*|Thinking\.{0,3}\s*(?:\r?\n|\r)\s*(?:\r?\n|\r)\s*)/i,
+      "",
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripReasoningProgressTags(text: string): string {
+  return text.replace(
+    /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/giu,
+    "",
+  );
+}
+
+function normalizeReasoningProgressInput(text: string): string {
+  const normalized = normalizeReasoningProgressLine(text);
+  const italic = normalized.match(/^_(.*)_$/u);
+  return (italic?.[1] ?? normalized).trim();
+}
+
+function formatReasoningProgressDisplayLine(text: string, maxChars: number): string {
+  const normalizedText = normalizeReasoningProgressInput(text);
+  const formatted = normalizeReasoningProgressLine(formatReasoningMessage(normalizedText));
+  if (!formatted) {
+    return "";
+  }
+  if (Array.from(formatted).length <= maxChars) {
+    return formatted;
+  }
+  const italic = formatted.match(/^_(.*)_$/u);
+  if (!italic) {
+    return compactReasoningProgressDisplayLine(formatted, maxChars);
+  }
+  const body = compactReasoningProgressDisplayLine(italic[1] ?? "", Math.max(1, maxChars - 2));
+  return body ? `_${body}_` : "";
+}
+
+function compactReasoningProgressDisplayLine(text: string, maxChars: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const chars = Array.from(normalized);
+  if (chars.length <= maxChars) {
+    return normalized;
+  }
+  if (maxChars <= 1) {
+    return "…";
+  }
+  const head = chars
+    .slice(0, maxChars - 1)
+    .join("")
+    .trimEnd();
+  const boundary = head.search(/\s+\S*$/u);
+  if (boundary > Math.floor(maxChars * 0.6)) {
+    return `${head.slice(0, boundary).trimEnd()}…`;
+  }
+  return `${head}…`;
+}
+
+function normalizeCommentaryProgressText(text: string): string {
+  const cleaned = stripInlineDirectiveTagsForDelivery(text).text.trim();
+  if (!cleaned || isSilentCommentaryProgressText(cleaned)) {
+    return "";
+  }
+  return cleaned
+    .split(/\r?\n/u)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .map((line) => `_${line}_`)
+    .join("\n");
+}
+
+function isSilentCommentaryProgressText(text: string): boolean {
+  const normalized = text.replace(/^[\s*_`~]+|[\s*_`~]+$/gu, "").trim();
+  return /^NO_REPLY$/iu.test(normalized);
+}
+
+function mergeReasoningProgressText(
+  current: string,
+  incoming: string,
+  options?: { snapshot?: boolean },
+): string {
+  if (!current) {
+    return incoming;
+  }
+  const normalizedCurrent = normalizeReasoningProgressInput(current);
+  const normalizedIncoming = normalizeReasoningProgressInput(incoming);
+  if (!normalizedIncoming || normalizedIncoming === normalizedCurrent) {
+    return current;
+  }
+  if (
+    options?.snapshot === true ||
+    isReasoningSnapshotText(incoming) ||
+    normalizedIncoming.startsWith(normalizedCurrent)
+  ) {
+    return incoming;
+  }
+  return `${current}${incoming}`;
+}
+
+function isReasoningSnapshotText(text: string): boolean {
+  return /^\s*(?:>\s*)?(?:Reasoning:\s*(?:\r?\n|\r)\s*|Thinking\.{0,3}\s*(?:\r?\n|\r)\s*(?:\r?\n|\r)\s*)/i.test(
+    text,
+  );
+}

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -26,7 +26,7 @@ export type {
 } from "../config/types.base.js";
 export type { SlackChannelStreamingConfig } from "../config/types.slack.js";
 
-type StreamingCompatEntry = {
+export type StreamingCompatEntry = {
   streaming?: unknown;
   streamMode?: unknown;
   chunkMode?: unknown;

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -75,6 +75,7 @@ export type { OutboundSendDeps } from "../infra/outbound/send-deps.js";
 export { sanitizeForPlainText } from "../infra/outbound/sanitize-text.js";
 export { logAckFailure, logTypingFailure } from "../channels/logging.js";
 export * from "../channels/streaming.js";
+export * from "../channels/progress-draft-compositor.js";
 export {
   classifyDurableSendRecoveryState,
   createChannelMessageAdapterFromOutbound,


### PR DESCRIPTION
Summary:
- Add a shared channel progress draft compositor for tool, commentary, and reasoning progress.
- Move Discord to the shared compositor and wire Telegram progress drafts through the same path.
- Add regressions for hidden progress details, suppressed drafts, tagged reasoning, and repeated reasoning snapshots.

Verification:
- node scripts/run-vitest.mjs src/channels/progress-draft-compositor.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/telegram/src/bot-message-dispatch.test.ts
- pnpm plugin-sdk:api:check
- pnpm build
- Real Codex probe from code: spawned `codex exec --json`, observed command_execution + final agent_message, and verified the compositor rendered tool + commentary + reasoning progress without leaking <think> tags.
- Testbox changed gate: provider=blacksmith-testbox id=tbx_01kt5wpcb29zrh5cmn5cx6ayvw, exit=0
- .agents/skills/autoreview/scripts/autoreview --mode local --base origin/main: clean
