### PR TITLE
fix: allowlist pending agent sqlite scaffold

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -2,6 +2,13 @@
 // generated/build inputs, manifest-discovered plugin surfaces, live-test
 // helpers, or package bridge files that static production scanning cannot see.
 export const KNIP_UNUSED_FILE_ALLOWLIST = [
+  // Per-agent SQLite scaffold is intentionally ahead of mainline runtime callers.
+  // The pending SQLite session/runtime branch wires these files into production.
+  "src/agents/cache/agent-cache-store.sqlite.ts",
+  "src/agents/cache/agent-cache-store.ts",
+  "src/state/openclaw-agent-db.paths.ts",
+  "src/state/openclaw-agent-db.ts",
+  "src/state/openclaw-agent-schema.generated.ts",
 ];
 
 // Knip can disagree across supported local/CI platforms for files that are


### PR DESCRIPTION
## Summary

Fixes the unrelated `check-dependencies` CI failure from https://github.com/openclaw/openclaw/actions/runs/26864214240/job/79224291792?pr=89701.

The failing step was `pnpm deadcode:unused-files`. The agent-local SQLite cache/database scaffold is intentionally unused on current `main`, but it is still needed by the pending SQLite session/runtime branch, where `src/agents/runtime-worker.entry.ts` wires `createSqliteAgentCacheStore` into production. This PR restores the Knip unused-file allowlist entries instead of deleting the scaffold, so current main CI is green without dropping tests/files that the pending runtime migration depends on.

Provenance checked:

- `fc50f949d48` / PR `#88349` added the per-agent SQLite cache scaffold and originally allowlisted it as intentionally ahead of runtime callers.
- `85633eb615` removed those allowlist entries while the scaffold files remained on main, which exposed the current `deadcode:unused-files` failure.
- `origin/josh/transcript-sqlite-migration` still contains the cache tests and production runtime callers for this scaffold.

## Verification

- `pnpm deadcode:unused-files`
- `git diff --check origin/main...HEAD`
