### PR TITLE
fix(agents): guard tool policy name reads

### DIFF
--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -35,6 +35,7 @@ import {
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import {
   mergeAlsoAllowPolicy,
+  normalizeReadableToolName,
   normalizeToolName,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
@@ -175,7 +176,10 @@ export function filterToolsByPolicy(tools: AnyAgentTool[], policy?: SandboxToolP
   if (!policy) {
     return tools;
   }
-  return tools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
+  return tools.filter((tool) => {
+    const name = normalizeReadableToolName(tool);
+    return name ? isToolAllowedByPolicyName(name, policy) : false;
+  });
 }
 
 type ToolPolicyConfig = {

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -1,7 +1,11 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
-import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
+import {
+  normalizeReadableToolName,
+  normalizeToolName,
+  type ToolPolicyLike,
+} from "./tool-policy.js";
 
 const MAX_AUDIT_TOOL_NAMES = 50;
 const MAX_AUDIT_FIELD_LENGTH = 160;
@@ -27,7 +31,7 @@ function toolPolicyRuleKind(policy: ToolPolicyLike): ToolPolicyRuleKind {
 }
 
 function normalizedToolNames(tools: readonly { name: string }[]): string[] {
-  return normalizeToolList(tools.map((tool) => tool.name));
+  return tools.map((tool, index) => normalizeReadableToolName(tool) || `tool[${index}]`);
 }
 
 function removedToolNamesByRule(params: {

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -274,6 +274,40 @@ describe("tool-policy-pipeline", () => {
     expect(filtered.map((t) => (t as unknown as DummyTool).name)).toEqual(["exec"]);
   });
 
+  test("quarantines tools with unreadable names during policy filtering", () => {
+    const hostileTool = {
+      get name(): string {
+        throw new Error("tool policy name getter exploded");
+      },
+    };
+    const tools = [{ name: "exec" }, hostileTool] as unknown as DummyTool[];
+
+    const filtered = applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["exec"] },
+          label: "tools.allow",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+
+    expect(filtered.map((t) => (t as unknown as DummyTool).name)).toEqual(["exec"]);
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via tools.allow: tool[1]",
+      {
+        rule: "tools.allow",
+        ruleKind: "allow",
+        removedToolCount: 1,
+        removedTools: ["tool[1]"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
+
   test("applies deny filtering after allow filtering", () => {
     const tools = [{ name: "exec" }, { name: "process" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -6,6 +6,7 @@ import {
   analyzeAllowlistByToolType,
   buildPluginToolGroups,
   expandPolicyWithPluginGroups,
+  normalizeReadableToolName,
   normalizeToolName,
   type ToolPolicyLike,
 } from "./tool-policy.js";
@@ -125,7 +126,7 @@ export function applyToolPolicyPipeline(params: {
   const coreToolNames = new Set(
     params.tools
       .filter((tool) => !params.toolMeta(tool))
-      .map((tool) => normalizeToolName(tool.name))
+      .map((tool) => normalizeReadableToolName(tool))
       .filter(Boolean),
   );
 

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -23,6 +23,19 @@ export function normalizeToolName(name: string) {
   return TOOL_NAME_ALIASES[normalized] ?? normalized;
 }
 
+export function readToolPolicyName(tool: { name: string }): string | undefined {
+  try {
+    return typeof tool.name === "string" ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeReadableToolName(tool: { name: string }): string {
+  const name = readToolPolicyName(tool);
+  return name ? normalizeToolName(name) : "";
+}
+
 export function couldNormalizeToolNamePrefixToAllowedTool(
   prefix: string,
   allowedToolNames: Set<string>,

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -1,12 +1,19 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { IMPLICIT_ALLOW_ALL_FROM_ALSO_ALLOW } from "./sandbox-tool-policy.js";
-import { expandToolGroups, normalizeToolList, normalizeToolName } from "./tool-policy-shared.js";
+import {
+  expandToolGroups,
+  normalizeReadableToolName,
+  normalizeToolList,
+  normalizeToolName,
+} from "./tool-policy-shared.js";
 export {
   couldNormalizeToolNamePrefixToAllowedTool,
   expandToolGroups,
+  normalizeReadableToolName,
   normalizeToolList,
   normalizeToolName,
+  readToolPolicyName,
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
@@ -52,7 +59,7 @@ export function replaceWithEffectiveToolAllowlist(
   target.length = 0;
   const seen = new Set<string>();
   for (const tool of tools) {
-    const normalized = normalizeToolName(tool.name);
+    const normalized = normalizeReadableToolName(tool);
     if (!normalized || seen.has(normalized)) {
       continue;
     }
@@ -116,7 +123,10 @@ export function buildPluginToolGroups<T extends { name: string }>(params: {
     if (!meta) {
       continue;
     }
-    const name = normalizeToolName(tool.name);
+    const name = normalizeReadableToolName(tool);
+    if (!name) {
+      continue;
+    }
     all.push(name);
     const pluginId = normalizeOptionalLowercaseString(meta.pluginId);
     if (!pluginId) {


### PR DESCRIPTION
## Summary

- Add a guarded tool-policy name reader and reuse it across policy grouping, filtering, effective allowlist replacement, and removal audits.
- Quarantine tools whose `name` getter throws during policy filtering instead of letting policy setup crash the assistant turn.
- Preserve audit visibility by reporting unreadable removed tools with stable `tool[index]` labels.

## Verification

- Red repro before the fix: `CI=1 node scripts/run-vitest.mjs run src/agents/tool-policy-pipeline.test.ts -t "quarantines tools with unreadable names" --reporter=verbose` failed with `tool policy name getter exploded`.
- `./node_modules/.bin/oxfmt --write src/agents/tool-policy-shared.ts src/agents/tool-policy.ts src/agents/tool-policy-pipeline.ts src/agents/agent-tools.policy.ts src/agents/tool-policy-audit.ts src/agents/tool-policy-pipeline.test.ts`
- `./node_modules/.bin/oxlint src/agents/tool-policy-shared.ts src/agents/tool-policy.ts src/agents/tool-policy-pipeline.ts src/agents/agent-tools.policy.ts src/agents/tool-policy-audit.ts src/agents/tool-policy-pipeline.test.ts`
- `git diff --check`
- `CI=1 node scripts/run-vitest.mjs run src/agents/tool-policy-pipeline.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts --reporter=verbose` (66 passed)
- Autoreview: `autoreview clean: no accepted/actionable findings reported`; `overall: patch is correct (0.86)`
- AWS Crabbox changed gate: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
  - provider: `aws`
  - run: `run_48594839c74b`
  - lease: `cbx_1347a3cafe5c`
  - type: `c7a.8xlarge`
  - lanes: `core`, `coreTests`
  - exit: `0`

## Real behavior proof

Behavior addressed: Active tool-policy filtering no longer crashes when a tool descriptor has an unreadable `name`; the bad tool is removed and healthy allowed tools remain usable.

Real environment tested: Local Node/Vitest harness plus AWS Crabbox Linux remote changed gate.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/agents/tool-policy-pipeline.test.ts src/agents/agent-tools.policy.test.ts src/agents/tool-policy.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts --reporter=verbose`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`.

Evidence after fix: The focused red repro now passes, adjacent policy coverage passes 66 tests, and the AWS changed gate completed with exit 0.

Observed result after fix: The unreadable-name tool is filtered out, the healthy `exec` tool remains, and the audit reports `tool policy removed 1 tool(s) via tools.allow: tool[1]`.

What was not tested: A live extension returning a getter-backed tool name through the full assistant startup path; the regression exercises the active policy filtering boundary directly.
