### PR TITLE
fix: rebuild persisted plugins when policy refresh loses install rows

### DIFF
--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -594,6 +594,60 @@ describe("installed plugin index persistence", () => {
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
   });
 
+  it("falls back to a source rebuild when persisted plugins omit an installed plugin", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "plugins", "demo");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const candidate = createCandidate(pluginDir);
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const initial = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [candidate],
+      env,
+      installRecords: {
+        demo: {
+          source: "path",
+          installPath: pluginDir,
+        },
+      },
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...initial,
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      env,
+      config: {
+        plugins: {
+          entries: {
+            demo: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    });
+
+    expectPluginIds(refreshed, ["demo"]);
+    expectPluginFields(refreshed, "demo", { enabled: false });
+    expectInstallRecord(refreshed, "demo", {
+      source: "path",
+      installPath: pluginDir,
+    });
+  });
+
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();
     await writePersistedInstalledPluginIndex(

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -427,6 +427,15 @@ function hasPolicyRefreshTargets(
   return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
 }
 
+function hasPersistedPluginRecordsForInstallRecords(persisted: InstalledPluginIndex): boolean {
+  const installRecordPluginIds = Object.keys(persisted.installRecords ?? {});
+  if (installRecordPluginIds.length === 0) {
+    return true;
+  }
+  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  return installRecordPluginIds.every((pluginId) => pluginIds.has(pluginId));
+}
+
 function canRefreshPersistedPolicyState(
   persisted: InstalledPluginIndex | null,
   params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
@@ -450,7 +459,10 @@ function canRefreshPersistedPolicyState(
   ) {
     return false;
   }
-  return hasPolicyRefreshTargets(persisted, params.policyPluginIds);
+  return (
+    hasPolicyRefreshTargets(persisted, params.policyPluginIds) &&
+    hasPersistedPluginRecordsForInstallRecords(persisted)
+  );
 }
 
 function refreshPersistedPolicyState(


### PR DESCRIPTION
## Summary

- When `refreshPersistedInstalledPluginIndex` runs with `reason: "policy-changed"`, the `canRefreshPersistedPolicyState` guard only checked `hasPolicyRefreshTargets()`. If the persisted index had all the right plugin IDs but the `plugins[]` array was empty (e.g. from a stale or corrupted persist), the guard passed through without rebuilding.
- This caused path/npm-origin plugins to silently disappear from the registry after a policy refresh.
- Added `hasPersistedPluginRecordsForInstallRecords()` so that when install records reference plugins missing from the persisted `plugins[]` array, the guard returns false and forces a full source rebuild.

## Verification

- Added test "falls back to a source rebuild when persisted plugins omit an installed plugin" — persists an index with `plugins: []` while install records reference a plugin, then verifies policy refresh rebuilds from source.
- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts`

## Real behavior proof

Behavior addressed: A `policy-changed` refresh no longer silently drops installed plugins when install records exist but the persisted `plugins[]` view is empty.

Real environment tested: Real filesystem + SQLite state DB + actual `refreshPluginRegistryAfterConfigMutation()` runtime path on Linux.

Exact steps or command run after this patch: Created a real plugin directory with `index.ts` and `openclaw.plugin.json`, built an installed-plugin index with an install record for `demo`, persisted a corrupted view by rewriting the same index with `plugins: []` while keeping `installRecords.demo`, called the real `refreshPluginRegistryAfterConfigMutation({ reason: "policy-changed" })` path, and read the persisted installed-plugin index back from SQLite.

Evidence after fix: Terminal output from the real runtime proof plus the persisted SQLite summary artifact:

```text
Before refresh:
- beforePluginIds = []
- beforeInstallRecordIds = ["demo"]

After refresh:
- afterPluginIds includes "demo"
- afterEnabled = false
- afterInstallRecordIds = ["demo"]
- warnings = []
- sqlitePath = /home/0668000855/3_AI/github-opelclaw/openclaw/.artifacts/plugin-policy-refresh-proof/state-root/state/openclaw.sqlite
```

Observed result after fix: The policy refresh rebuilt from source, restored the missing plugin record into `plugins[]`, preserved the install record, and applied the disabled policy state.

What was not tested: A live ClawHub/Gateway event source. The proof exercised the real persistence and registry refresh runtime locally without external manifests or network events.
