### PR TITLE
fix(control-ui): clear stale composer replays after send

### DIFF
--- a/ui/src/ui/e2e/chat-composer-stale-replay-89466.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-composer-stale-replay-89466.e2e.test.ts
@@ -1,0 +1,129 @@
+// Real-browser proof + regression for #89466: after send clears the Control UI
+// composer, a stale *native* InputEvent replay of the just-submitted text must
+// not reappear in the textarea, while a deliberate same-text re-entry still
+// works. Screenshots go to the ignored .artifacts/ tree.
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const describeE2e = chromiumAvailable ? describe : describe.skip;
+
+const composerSelector = ".agent-chat__composer-combobox textarea";
+const submitted = "submitted message";
+const artifactDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/chat-composer-stale-replay-89466",
+);
+
+let server: ControlUiE2eServer;
+
+async function openChat(): Promise<{ browser: Browser; context: BrowserContext; page: Page }> {
+  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  let context: BrowserContext | undefined;
+  let page: Page | undefined;
+  try {
+    context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    page = await context.newPage();
+    page.setDefaultTimeout(15_000);
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Ready for the stale-replay check.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    // First navigation can trigger a cold Vite dev-server compile; allow headroom.
+    await page.goto(`${server.baseUrl}chat`, { timeout: 60_000, waitUntil: "domcontentloaded" });
+    return { browser, context, page };
+  } catch (error) {
+    await page?.close().catch(() => {});
+    await context?.close().catch(() => {});
+    await browser.close().catch(() => {});
+    throw error;
+  }
+}
+
+async function closeChat(fixture: {
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+}): Promise<void> {
+  await fixture.page.close().catch(() => {});
+  await fixture.context.close().catch(() => {});
+  await fixture.browser.close().catch(() => {});
+}
+
+describeE2e("Control UI #89466 composer stale native replay (mocked Gateway E2E)", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("clears after send, suppresses a stale native InputEvent replay, and accepts re-entry", async () => {
+    const fixture = await openChat();
+    const { page } = fixture;
+    const composer = page.locator(composerSelector);
+    try {
+      // First load can sit on a cold Vite dev-server compile; wait it out.
+      await page.getByText("Ready for the stale-replay check.").waitFor({ timeout: 90_000 });
+      await composer.waitFor({ state: "visible", timeout: 90_000 });
+
+      // 1. Type (real per-character native input) and send through the real
+      //    GUI; the composer clears after send.
+      await composer.click();
+      await composer.pressSequentially(submitted, { delay: 20 });
+      await expect.poll(() => composer.inputValue(), { timeout: 10_000 }).toBe(submitted);
+      await page.getByRole("button", { name: "Send message" }).click();
+      await expect.poll(() => composer.inputValue(), { timeout: 10_000 }).toBe("");
+      const afterSend = await composer.inputValue();
+      await page.screenshot({ path: path.join(artifactDir, "01-cleared-after-send.png") });
+
+      // 2. Replay the submitted value through a *native* InputEvent (the exact
+      //    path the previous guard skipped). It must stay suppressed.
+      await composer.evaluate((el, text) => {
+        const textarea = el as HTMLTextAreaElement;
+        textarea.value = text;
+        textarea.dispatchEvent(
+          new InputEvent("input", { bubbles: true, data: text, inputType: "insertText" }),
+        );
+      }, submitted);
+      // Give the handler a frame; the value must not reappear.
+      await page.waitForTimeout(250);
+      const afterReplay = await composer.inputValue();
+      await page.screenshot({ path: path.join(artifactDir, "02-stale-replay-suppressed.png") });
+
+      // 3. A deliberate same-text re-entry via real keyboard typing is accepted.
+      await composer.click();
+      await page.keyboard.type(submitted);
+      await expect.poll(() => composer.inputValue(), { timeout: 10_000 }).toBe(submitted);
+      const afterReentry = await composer.inputValue();
+      await page.screenshot({ path: path.join(artifactDir, "03-same-text-reentry.png") });
+
+      expect({ afterReentry, afterReplay, afterSend }).toEqual({
+        afterReentry: submitted,
+        afterReplay: "",
+        afterSend: "",
+      });
+    } finally {
+      await closeChat(fixture);
+    }
+  });
+});

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2006,6 +2006,45 @@ describe("chat slash menu accessibility", () => {
     ).toHaveLength(1);
   });
 
+  it("ignores a stale native InputEvent replay after send cleared the host draft", () => {
+    for (const inputType of ["insertText", "insertReplacementText", ""]) {
+      let draft = "";
+      const container = document.createElement("div");
+      const onDraftChange = vi.fn((next: string) => {
+        draft = next;
+      });
+      const onSend = vi.fn(() => {
+        draft = "";
+      });
+      const renderWithDraft = () => {
+        render(
+          renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+          container,
+        );
+      };
+
+      renderWithDraft();
+      inputDraft(container, "submitted message");
+      container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+      const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+      expect(textarea?.value).toBe("");
+
+      // The real composer replays the submitted value through a native
+      // InputEvent, not a generic Event; it must still be suppressed.
+      textarea!.value = "submitted message";
+      textarea!.dispatchEvent(
+        new InputEvent("input", { bubbles: true, data: "submitted message", inputType }),
+      );
+
+      expect(draft).toBe("");
+      expect(textarea?.value).toBe("");
+      expect(
+        onDraftChange.mock.calls.filter(([value]) => value === "submitted message"),
+      ).toHaveLength(1);
+    }
+  });
+
   it("accepts same-text re-entry from a real InputEvent", () => {
     let draft = "";
     const container = document.createElement("div");

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1973,6 +1973,99 @@ describe("chat slash menu accessibility", () => {
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("");
   });
 
+  it("ignores a stale input replay after send already cleared the host draft", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.value).toBe("");
+
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(draft).toBe("");
+    expect(textarea?.value).toBe("");
+    expect(
+      onDraftChange.mock.calls.filter(([value]) => value === "submitted message"),
+    ).toHaveLength(1);
+  });
+
+  it("accepts same-text re-entry from a real InputEvent", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "submitted message");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    textarea!.value = "submitted message";
+    textarea!.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "submitted message",
+        inputType: "insertFromPaste",
+      }),
+    );
+
+    expect(textarea?.value).toBe("submitted message");
+    expect(draft).toBe("");
+  });
+
+  it("accepts a later host prefill even when it matches the last submitted draft", () => {
+    let draft = "";
+    const container = document.createElement("div");
+    const onDraftChange = vi.fn((next: string) => {
+      draft = next;
+    });
+    const onSend = vi.fn(() => {
+      draft = "";
+    });
+    const renderWithDraft = () => {
+      render(
+        renderChat(createChatProps({ draft, getDraft: () => draft, onDraftChange, onSend })),
+        container,
+      );
+    };
+
+    renderWithDraft();
+    inputDraft(container, "/status ");
+    container.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    draft = "/status ";
+    renderWithDraft();
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("/status ");
+  });
+
   it("commits local draft input before Enter sends", () => {
     const onDraftChange = vi.fn();
     const onSend = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -33,13 +33,13 @@ import { CHAT_HISTORY_RENDER_LIMIT } from "../chat/history-limits.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../chat/input-history.ts";
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
-import type { RealtimeTalkConversationEntry } from "../chat/realtime-talk-conversation.ts";
 import {
   REALTIME_TALK_FALLBACK_PROVIDERS,
   listSelectableRealtimeTalkProviders,
   resolveControlUiRealtimeTalkProviderTransports,
   type RealtimeTalkCatalogProvider,
 } from "../chat/realtime-talk-catalog.ts";
+import type { RealtimeTalkConversationEntry } from "../chat/realtime-talk-conversation.ts";
 import type { RealtimeTalkStatus } from "../chat/realtime-talk.ts";
 import { renderChatRunControls } from "../chat/run-controls.ts";
 import type { ChatRunUiStatus } from "../chat/run-lifecycle.ts";
@@ -623,6 +623,30 @@ function shouldIgnoreClearedSubmittedDraftReplay(
     mirror.hostDraft === "" &&
     pending.text === value &&
     pending.inputVersion === mirror.inputVersion
+  );
+}
+
+// A stale composer replay re-delivers the just-submitted text through a native
+// `input`/`InputEvent` after send already cleared the host draft (observed on
+// Windows Chrome/Edge). Deliberate same-text re-entry instead arrives as an
+// explicit paste/drop insertion — fresh typing advances `inputVersion`, so it is
+// never confused with a replay. Only those user-initiated insertions are exempt
+// from stale-replay suppression; every other input (including native
+// `InputEvent` replays with `insertText`/`insertReplacementText`/empty
+// `inputType`) stays eligible so the submitted text cannot reappear.
+const DELIBERATE_COMPOSER_REENTRY_INPUT_TYPES = new Set([
+  "insertFromPaste",
+  "insertFromPasteAsQuotation",
+  "insertFromDrop",
+  "insertFromYank",
+]);
+
+function isDeliberateComposerReentry(e: Event): boolean {
+  return (
+    typeof InputEvent !== "undefined" &&
+    e instanceof InputEvent &&
+    typeof e.inputType === "string" &&
+    DELIBERATE_COMPOSER_REENTRY_INPUT_TYPES.has(e.inputType)
   );
 }
 
@@ -2475,9 +2499,12 @@ export function renderChat(props: ChatProps) {
   };
   const handleInput = (e: Event) => {
     const target = e.target as HTMLTextAreaElement;
-    const staleReplayEvent = typeof InputEvent !== "undefined" ? !(e instanceof InputEvent) : false;
+    const isCompositionInput =
+      vs.composerComposing ||
+      (typeof InputEvent !== "undefined" && e instanceof InputEvent && e.isComposing);
     if (
-      staleReplayEvent &&
+      !isCompositionInput &&
+      !isDeliberateComposerReentry(e) &&
       shouldIgnoreClearedSubmittedDraftReplay(props, target.value, draftMirror)
     ) {
       draftMirror.pendingClearedSubmittedDraft = null;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -567,6 +567,11 @@ type CachedChatItems = {
 type ComposerDraftMirror = {
   hostDraft: string;
   value: string;
+  inputVersion: number;
+  pendingClearedSubmittedDraft: {
+    text: string;
+    inputVersion: number;
+  } | null;
 };
 
 const chatItemsBySession = new Map<string, CachedChatItems>();
@@ -583,23 +588,60 @@ function getComposerDraftMirror(props: ChatProps): ComposerDraftMirror {
     () => ({
       hostDraft: props.draft,
       value: props.draft,
+      inputVersion: 0,
+      pendingClearedSubmittedDraft: null,
     }),
   );
   if (mirror.hostDraft !== props.draft) {
     mirror.hostDraft = props.draft;
     mirror.value = props.draft;
+    mirror.pendingClearedSubmittedDraft = null;
   }
   return mirror;
 }
 
 function commitComposerDraft(props: ChatProps, value: string): void {
   const mirror = getComposerDraftMirror(props);
+  mirror.pendingClearedSubmittedDraft = null;
   mirror.value = value;
   if (mirror.hostDraft === value) {
     return;
   }
   mirror.hostDraft = value;
   props.onDraftChange(value);
+}
+
+function shouldIgnoreClearedSubmittedDraftReplay(
+  props: ChatProps,
+  value: string,
+  mirror: ComposerDraftMirror,
+): boolean {
+  const pending = mirror.pendingClearedSubmittedDraft;
+  return (
+    pending !== null &&
+    props.getDraft?.() === "" &&
+    mirror.hostDraft === "" &&
+    pending.text === value &&
+    pending.inputVersion === mirror.inputVersion
+  );
+}
+
+function commitComposerTextareaDraft(
+  props: ChatProps,
+  value: string,
+  target?: HTMLTextAreaElement | null,
+): void {
+  const mirror = getComposerDraftMirror(props);
+  if (shouldIgnoreClearedSubmittedDraftReplay(props, value, mirror)) {
+    mirror.pendingClearedSubmittedDraft = null;
+    mirror.value = "";
+    if (target && target.value !== "") {
+      target.value = "";
+      adjustTextareaHeight(target);
+    }
+    return;
+  }
+  commitComposerDraft(props, value);
 }
 
 function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsProps): boolean {
@@ -2258,13 +2300,23 @@ export function renderChat(props: ChatProps) {
     </div>
   `;
 
-  const syncComposerDraftAfterSend = (target: HTMLTextAreaElement | null) => {
+  const syncComposerDraftAfterSend = (
+    target: HTMLTextAreaElement | null,
+    submittedDraft: string,
+  ) => {
     const hostDraft = props.getDraft?.();
     if (typeof hostDraft !== "string") {
       return;
     }
     // Sends can clear the host draft synchronously before Lit rerenders; keep
     // the local mirror aligned so the submitted text does not stay editable.
+    draftMirror.pendingClearedSubmittedDraft =
+      hostDraft === "" && submittedDraft.length > 0
+        ? {
+            text: submittedDraft,
+            inputVersion: draftMirror.inputVersion,
+          }
+        : null;
     draftMirror.hostDraft = hostDraft;
     draftMirror.value = hostDraft;
     if (target && target.value !== hostDraft) {
@@ -2350,7 +2402,7 @@ export function renderChat(props: ChatProps) {
 
     if ((e.key === "ArrowUp" || e.key === "ArrowDown") && props.onHistoryKeydown) {
       const target = e.target as HTMLTextAreaElement;
-      commitComposerDraft(props, target.value);
+      commitComposerTextareaDraft(props, target.value, target);
       const result = props.onHistoryKeydown({
         key: e.key,
         selectionStart: target.selectionStart,
@@ -2393,9 +2445,10 @@ export function renderChat(props: ChatProps) {
       e.preventDefault();
       if (canCompose) {
         const target = e.target as HTMLTextAreaElement;
-        commitComposerDraft(props, target.value);
+        const submittedDraft = target.value;
+        commitComposerTextareaDraft(props, submittedDraft, target);
         props.onSend();
-        syncComposerDraftAfterSend(target);
+        syncComposerDraftAfterSend(target, submittedDraft);
       }
     }
   };
@@ -2405,6 +2458,9 @@ export function renderChat(props: ChatProps) {
     options: { forceCommit?: boolean } = {},
   ) => {
     adjustTextareaHeight(target);
+    if (draftMirror.value !== target.value) {
+      draftMirror.inputVersion += 1;
+    }
     draftMirror.value = target.value;
     const hostDraftNeeded = isBusy || showAbortableUi || props.queue.length > 0;
     if (
@@ -2417,9 +2473,23 @@ export function renderChat(props: ChatProps) {
     }
     updateSlashMenu(target.value, requestUpdate, props, {}, () => target.value);
   };
-  const handleInput = (e: InputEvent) => {
+  const handleInput = (e: Event) => {
     const target = e.target as HTMLTextAreaElement;
-    if (vs.composerComposing || e.isComposing) {
+    const staleReplayEvent = typeof InputEvent !== "undefined" ? !(e instanceof InputEvent) : false;
+    if (
+      staleReplayEvent &&
+      shouldIgnoreClearedSubmittedDraftReplay(props, target.value, draftMirror)
+    ) {
+      draftMirror.pendingClearedSubmittedDraft = null;
+      draftMirror.value = "";
+      if (target.value !== "") {
+        target.value = "";
+      }
+      adjustTextareaHeight(target);
+      updateSlashMenu("", requestUpdate);
+      return;
+    }
+    if (e instanceof InputEvent && (vs.composerComposing || e.isComposing)) {
       // Skip adjustTextareaHeight during IME composition — each pinyin
       // keystroke fires `input` and the height read/write forces a
       // synchronous reflow that blocks the composition thread.
@@ -2435,12 +2505,13 @@ export function renderChat(props: ChatProps) {
   };
   const handleBlur = (e: FocusEvent) => {
     const target = e.target as HTMLTextAreaElement;
-    commitComposerDraft(props, target.value);
+    commitComposerTextareaDraft(props, target.value, target);
   };
   const handleSend = () => {
-    commitComposerDraft(props, draftMirror.value);
+    const submittedDraft = draftMirror.value;
+    commitComposerTextareaDraft(props, submittedDraft, composerTextarea);
     props.onSend();
-    syncComposerDraftAfterSend(composerTextarea);
+    syncComposerDraftAfterSend(composerTextarea, submittedDraft);
   };
   const slashMenuVisible = isSlashMenuVisible();
   const activeSlashMenuOptionId = getActiveSlashMenuOptionId();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2513,7 +2513,7 @@ export function renderChat(props: ChatProps) {
         target.value = "";
       }
       adjustTextareaHeight(target);
-      updateSlashMenu("", requestUpdate);
+      updateSlashMenu("", requestUpdate, props);
       return;
     }
     if (e instanceof InputEvent && (vs.composerComposing || e.isComposing)) {


### PR DESCRIPTION
## Summary

- After sending a message, the Control UI composer clears the draft. A stale `input` event can replay the just-submitted text back into the textarea, making it look like the message was never sent (Windows Chrome/Edge, #89466).
- **Root-cause fix (this round):** the stale-replay guard previously only treated **non-`InputEvent`** events as replays (`!(e instanceof InputEvent)`). The real composer replays the submitted value through a **native `InputEvent`**, so it slipped past the guard into `syncComposerValue` and restored the text. The guard now discriminates on the cleared-submitted-draft state (matching text + empty host draft + unchanged `inputVersion`) for **any** event, exempting only deliberate paste/drop insertions and IME composition.
- Deliberate same-text re-entry still works: a paste/drop carries an explicit `inputType`, and fresh typing advances `inputVersion` before the stale check.
- What did **not** change: send path, host draft ownership, IME composition handling, slash-menu behavior.

## Linked context

Closes #89466.
Related #94901 (alternative app-chat-marker approach) — thanks for the shared analysis; this PR keeps the composer-boundary guard and adds native-replay coverage + real-browser proof.

## Real behavior proof

**Behavior or issue addressed:** After send clears the Control UI composer, a stale **native `InputEvent`** replay of the submitted text no longer reappears in the textarea, while a deliberate same-text re-entry is still accepted.

**Real environment tested:** Real Chromium (Playwright) driving the Control UI Vite app with the repo's mocked Gateway harness (`ui/src/test-helpers/control-ui-e2e.ts`), on Windows 10 + Node 22, patched branch head `ce16136921ac`.

**Exact steps or command run after this patch:**

```bash
# Real-browser e2e (new): types + sends, replays a native InputEvent, re-enters text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/ui/e2e/chat-composer-stale-replay-89466.e2e.test.ts

# Focused unit regression incl. native InputEvent inputType variants
pnpm test ui/src/ui/views/chat.test.ts
```

**Evidence after fix:**

Real-browser e2e run (Chromium):

```text
 ✓ |ui-e2e| ui/src/ui/e2e/chat-composer-stale-replay-89466.e2e.test.ts (1 test) 
   ✓ clears after send, suppresses a stale native InputEvent replay, and accepts re-entry
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

In-browser captured values: `afterSend = ""`, `afterReplay = ""` (native `InputEvent` with `inputType: "insertText"` replaying the submitted text), `afterReentry = "submitted message"`.

Screenshots captured under `.artifacts/control-ui-e2e/chat-composer-stale-replay-89466/`:
- `01-cleared-after-send.png` — composer empty (placeholder shown) after send; "submitted message" appears as a sent chat bubble.
- `02-stale-replay-suppressed.png` — after the native `InputEvent` replay, the composer is still empty (placeholder); the submitted text did not reappear.
- `03-same-text-reentry.png` — after deliberate keyboard re-entry, the composer shows "submitted message" again.

Unit regression (jsdom), native `InputEvent` path now covered:

```text
$ pnpm test ui/src/ui/views/chat.test.ts
 Test Files  1 passed (1)
      Tests  114 passed (114)
```

**Observed result after fix:** The real browser composer clears after send, ignores the stale **native** replay, and still accepts a deliberate same-text re-entry.

**What was not tested:** A live remote Gateway/provider session. The browser proof uses the repo's deterministic mocked Gateway harness. The exact Chrome/Edge timing quirk that emits the stale replay is reproduced by dispatching the native `InputEvent` the real composer would deliver.

## Tests and validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-composer-stale-replay-89466.e2e.test.ts` — new real-browser e2e (1 passed).
- `pnpm test ui/src/ui/views/chat.test.ts` — 114 passed, including the new `ignores a stale native InputEvent replay after send cleared the host draft` test (covers `insertText`/`insertReplacementText`/empty `inputType`) plus the existing deliberate-paste and host-prefill cases.

## Risk checklist

Did user-visible behavior change? Yes — the composer no longer restores submitted text after send when a native replay fires; deliberate re-entry is unchanged.
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
Highest-risk area (`merge-risk: message-delivery`): the composer state path that decides whether submitted text is cleared/retained/replayed. Mitigation: the guard only suppresses when the text matches the just-submitted draft AND the host draft is empty AND `inputVersion` is unchanged since send; deliberate paste/drop and IME composition are explicitly exempted, and both real-browser + unit tests lock the contract.

## Current review state

Next action: ClawSweeper re-review on head `ce16136921ac`, then maintainer merge.
Waiting on: `proof: sufficient` / `ready for maintainer look`.
Bot comments addressed (June 19 review):
- [P2 / "patch is incorrect"] Native `InputEvent` replays are now suppressed — the guard no longer keys off `!(e instanceof InputEvent)`; it uses the cleared-submitted-draft + `inputVersion` discriminator and exempts only deliberate paste/drop and IME.
- [P1 proof] Replaced the generic `Event("input")` evidence with a real-browser e2e that replays a native `InputEvent` and with a unit regression covering native `inputType` variants; pasted run output above.
- [P1 test] Added `ignores a stale native InputEvent replay after send cleared the host draft`.
- Competing-PR note: reviewed #94901; kept the smaller composer-boundary fix and added the native-replay coverage it and this PR both need.
