### PR TITLE
fix(providers): strip cache-boundary marker from non-Anthropic prompts

### DIFF
--- a/src/llm/providers/google-shared.test.ts
+++ b/src/llm/providers/google-shared.test.ts
@@ -1,6 +1,7 @@
 // Google shared provider tests cover response conversion and finish reasons.
 import { FinishReason, type GenerateContentResponse } from "@google/genai";
 import { describe, expect, it } from "vitest";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import type { AssistantMessage, Model } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import {
@@ -145,5 +146,15 @@ describe("buildGoogleGenerateContentParams", () => {
     );
 
     expect(params.config?.stopSequences).toEqual(["STOP"]);
+  });
+
+  it("strips the internal cache boundary marker from systemInstruction", () => {
+    const params = buildGoogleGenerateContentParams(model, {
+      systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+    });
+
+    expect(params.config?.systemInstruction).toBe("Stable\nDynamic");
+    expect(JSON.stringify(params)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -12,6 +12,7 @@ import {
   type Part,
   type ThinkingConfig,
 } from "@google/genai";
+import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
   Api,
@@ -500,7 +501,9 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
 
   const config: GenerateContentConfig = {
     ...(Object.keys(generationConfig).length > 0 && generationConfig),
-    ...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
+    ...(context.systemPrompt && {
+      systemInstruction: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
+    }),
     ...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
   };
 

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -1,5 +1,6 @@
 // Mistral provider tests cover request mapping and stream conversion.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import type { Context, Model } from "../types.js";
 
 const mistralMockState = vi.hoisted(() => ({
@@ -213,5 +214,25 @@ describe("Mistral provider", () => {
       type: "function",
       function: { name: "healthy_tool" },
     });
+  });
+
+  it("strips the internal cache boundary marker from the system message", async () => {
+    const stream = streamSimpleMistral(
+      makeMistralModel(),
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      { apiKey: "sk-mistral-provider" },
+    );
+
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const systemMessage = payload.messages.find((message) => message.role === "system");
+    expect(systemMessage?.content).toBe("Stable\nDynamic");
+    expect(JSON.stringify(payload)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
 });

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -7,6 +7,7 @@ import type {
   ContentChunk,
   FunctionTool,
 } from "@mistralai/mistralai/models/components";
+import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -309,7 +310,7 @@ function buildChatPayload(
   if (context.systemPrompt) {
     payload.messages.unshift({
       role: "system",
-      content: sanitizeSurrogates(context.systemPrompt),
+      content: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
     });
   }
 

--- a/src/llm/providers/openai-chatgpt-responses.test.ts
+++ b/src/llm/providers/openai-chatgpt-responses.test.ts
@@ -1,6 +1,7 @@
 // ChatGPT Responses provider tests cover stream handling and timeout behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import type { Context, Model } from "../types.js";
 import {
   extractOpenAICodexAccountId,
@@ -401,6 +402,60 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(sendMock).not.toHaveBeenCalled();
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Request timed out after 5ms");
+  });
+
+  it("strips the internal cache boundary marker from request instructions", async () => {
+    let capturedPayload: { instructions?: string } | undefined;
+    const stream = streamOpenAICodexResponses(
+      model,
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: createJwt({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acct-1",
+          },
+        }),
+        transport: "sse",
+        onPayload: (payload) => {
+          capturedPayload = payload as typeof capturedPayload;
+          throw new Error("stop after payload");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.instructions).toBe("Stable\nDynamic");
+    expect(JSON.stringify(capturedPayload)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+  });
+
+  it("falls back to the default instructions when no system prompt is set", async () => {
+    let capturedPayload: { instructions?: string } | undefined;
+    const stream = streamOpenAICodexResponses(
+      model,
+      { messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+      {
+        apiKey: createJwt({
+          "https://api.openai.com/auth": {
+            chatgpt_account_id: "acct-1",
+          },
+        }),
+        transport: "sse",
+        onPayload: (payload) => {
+          capturedPayload = payload as typeof capturedPayload;
+          throw new Error("stop after payload");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.instructions).toBe("You are a helpful assistant.");
   });
 
   it("prefers promptCacheKey over sessionId for request cache affinity", async () => {

--- a/src/llm/providers/openai-chatgpt-responses.ts
+++ b/src/llm/providers/openai-chatgpt-responses.ts
@@ -25,6 +25,7 @@ import {
   resolveTimerTimeoutMs,
   clampTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { clampThinkingLevel } from "../model-utils.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
@@ -488,7 +489,8 @@ function buildRequestBody(
     model: model.id,
     store: false,
     stream: true,
-    instructions: context.systemPrompt || "You are a helpful assistant.",
+    instructions:
+      stripSystemPromptCacheBoundary(context.systemPrompt ?? "") || "You are a helpful assistant.",
     input: messages,
     text: { verbosity: options?.textVerbosity || "low" },
     include: ["reasoning.encrypted_content"],

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -1,6 +1,7 @@
 // OpenAI Responses shared tests cover tool conversion and response item mapping.
 import type { Tool as OpenAIResponsesTool } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import {
@@ -260,6 +261,24 @@ describe("convertResponsesMessages", () => {
       role: "user",
       content: [{ type: "input_text", text: "hello" }],
     });
+  });
+
+  it("strips the internal cache boundary marker from the system prompt message", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+        messages: [],
+      } satisfies Context,
+      allowedToolCallProviders,
+    );
+
+    expect(input[0]).toMatchObject({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Stable\nDynamic" }],
+    });
+    expect(JSON.stringify(input)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
   });
 
   it("omits phase-tagged assistant replay ids without reasoning", () => {

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -13,6 +13,7 @@ import type {
   ResponseReasoningItem,
   ResponseStreamEvent,
 } from "openai/resources/responses/responses.js";
+import { stripSystemPromptCacheBoundary } from "../../agents/system-prompt-cache-boundary.js";
 import {
   AZURE_RESPONSES_TEXT_CONTENT_PART_TYPE,
   OPENAI_RESPONSES_OUTPUT_TEXT_CONTENT_PART_TYPE,
@@ -253,7 +254,12 @@ export function convertResponsesMessages<TApi extends Api>(
     messages.push({
       type: "message",
       role,
-      content: [{ type: "input_text", text: sanitizeSurrogates(context.systemPrompt) }],
+      content: [
+        {
+          type: "input_text",
+          text: sanitizeSurrogates(stripSystemPromptCacheBoundary(context.systemPrompt)),
+        },
+      ],
     });
   }
 


### PR DESCRIPTION
## Summary

- The internal `SYSTEM_PROMPT_CACHE_BOUNDARY` marker (`\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n`) is meant to stay private to OpenClaw's Anthropic prompt-cache split. It currently leaks verbatim into the system prompt sent to several **non-Anthropic** providers, so the model literally sees an `<!-- OPENCLAW_CACHE_BOUNDARY -->` HTML comment.
- This is a direct follow-up to #89386, which stripped the marker for `anthropic.ts` and `openai-completions.ts` but left the remaining non-Anthropic prompt paths untouched. Same root cause, the rest of the surface.
- Fix: apply the existing `stripSystemPromptCacheBoundary()` helper at the four remaining provider payload-build sites:
  - `google-shared.ts` — `systemInstruction` (covers `google` + `google-vertex`)
  - `mistral.ts` — system role message
  - `openai-responses-shared.ts` — system/developer message (covers `openai-responses` + `azure-openai-responses`)
  - `openai-chatgpt-responses.ts` — `instructions`
- **Intentionally out of scope:** `anthropic.ts` and `openai-completions.ts` (already handled by #89386, and the latter must *preserve* the marker on its Anthropic-family cache-control route). No token/cache performance claims — this is a correctness fix, not a perf change.
- **Success:** no non-Anthropic provider receives the marker; existing behavior (including the ChatGPT default-instructions fallback) is unchanged.

## Linked context

Related #89386 (preserve provider prompt cache boundaries — first half of this same root issue; this PR covers the remaining non-Anthropic provider prompt paths).

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** internal cache-boundary marker leaking into the system prompt sent to non-Anthropic providers (Google, Mistral, OpenAI Responses, OpenAI ChatGPT/Codex Responses).
- **Real environment tested:** local Node 22 runtime executing the production provider payload builders and stream entrypoints for all four affected providers (`buildGoogleGenerateContentParams`, `convertResponsesMessages`, `streamMistral`, `streamOpenAICodexResponses` — the real code that assembles the outbound request body, the Mistral and ChatGPT payloads captured through their `onPayload` hook before transport), driven via `node` (tsx) with a system prompt that contains the cache-boundary marker, capturing the stdout of the constructed payloads.
- **Exact steps or command run after this patch:** ran the production builders end to end with `node` (tsx):

  ```bash
  cat > ./.marker-leak-proof.mts <<'EOF'
  import { Buffer } from "node:buffer";
  import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./src/agents/system-prompt-cache-boundary.ts";
  import { buildGoogleGenerateContentParams } from "./src/llm/providers/google-shared.ts";
  import { convertResponsesMessages } from "./src/llm/providers/openai-responses-shared.ts";
  import { streamMistral } from "./src/llm/providers/mistral.ts";
  import { streamOpenAICodexResponses } from "./src/llm/providers/openai-chatgpt-responses.ts";
  const systemPrompt = `You are a helpful assistant.${SYSTEM_PROMPT_CACHE_BOUNDARY}Current task: summarize the thread.`;
  const ctx = { systemPrompt, messages: [{ role: "user", content: "hi", timestamp: 0 }] } as any;
  const has = (v: unknown) => JSON.stringify(v).includes("OPENCLAW_CACHE_BOUNDARY");
  const jwt = (p: Record<string, unknown>) => `${Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url")}.${Buffer.from(JSON.stringify(p)).toString("base64url")}.sig`;
  console.log("RAW (== pre-fix marked input):", JSON.stringify(systemPrompt), "| has marker:", has(systemPrompt));
  const g = buildGoogleGenerateContentParams({ id: "gemini", api: "google-generative-ai", provider: "google", reasoning: true, input: ["text"] } as any, ctx);
  console.log("Google systemInstruction:", JSON.stringify(g.config?.systemInstruction), "| has marker:", has(g));
  const r = convertResponsesMessages({ id: "gpt-5.5", api: "openai-responses", provider: "openai", reasoning: true, input: ["text"] } as any, ctx, new Set(["openai"])) as any[];
  const rs = r.find((m) => m.role === "developer" || m.role === "system");
  console.log("OpenAI Responses content:", JSON.stringify(rs?.content), "| has marker:", has(r));
  const mm = { id: "mistral-large-latest", api: "mistral-conversations", provider: "mistral", reasoning: false, input: ["text"], baseUrl: "https://api.mistral.ai", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 128000, maxTokens: 8192 } as any;
  try { await streamMistral(mm, ctx, { apiKey: "sk-x", onPayload: (p: any) => { const sys = p.messages.find((m: any) => m.role === "system"); console.log("Mistral system content:", JSON.stringify(sys?.content), "| has marker:", has(p)); throw new Error("stop"); } } as any).result(); } catch {}
  const cm = { id: "gpt-5.5", api: "openai-chatgpt-responses", provider: "openai", reasoning: true, input: ["text"], baseUrl: "https://chatgpt.test/backend-api", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 128000, maxTokens: 16000 } as any;
  try { await streamOpenAICodexResponses(cm, ctx, { apiKey: jwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" } }), transport: "sse", onPayload: (bo: any) => { console.log("ChatGPT instructions:", JSON.stringify(bo.instructions), "| has marker:", has(bo)); throw new Error("stop"); } } as any).result(); } catch {}
  EOF
  ./node_modules/.bin/tsx ./.marker-leak-proof.mts; rm -f ./.marker-leak-proof.mts
  ```

- **Evidence after fix:** local `node` (tsx) stdout from the production payload builders/entrypoints; the Mistral and ChatGPT request bodies are captured via the production `onPayload` hook before transport:

  ```
  RAW (== pre-fix marked input): "You are a helpful assistant.\n<!-- OPENCLAW_CACHE_BOUNDARY -->\nCurrent task: summarize the thread." | has marker: true
  Google systemInstruction: "You are a helpful assistant.\nCurrent task: summarize the thread." | has marker: false
  OpenAI Responses content: "You are a helpful assistant.\nCurrent task: summarize the thread." | has marker: false
  Mistral system content: "You are a helpful assistant.\nCurrent task: summarize the thread." | has marker: false
  ChatGPT instructions: "You are a helpful assistant.\nCurrent task: summarize the thread." | has marker: false
  ```

- **Observed result after fix:** in the captured stdout, the outbound Google `systemInstruction`, the OpenAI Responses system message, the Mistral system message, and the ChatGPT/Codex `instructions` field are all `"You are a helpful assistant.\nCurrent task: summarize the thread."` with `has marker: false`, while the raw pre-fix input on the first line still prints `has marker: true`. The internal `<!-- OPENCLAW_CACHE_BOUNDARY -->` comment no longer reaches the provider payload; the boundary collapses to a single newline, matching the already-shipped `anthropic.ts` / `openai-completions.ts` behavior.
- **What was not tested:** a live network round-trip to Google / Mistral / OpenAI (no third-party API credentials available); the proof is captured at the payload-construction boundary — the exact string handed to each provider SDK's request object before transport. All four provider paths (Google, Mistral, OpenAI Responses, ChatGPT/Codex) appear in the stdout above; the regression tests under Tests and validation assert the same invariant.
- **Proof limitations or environment constraints:** marker absence is asserted on the serialized outbound payload produced by the real builder code, not captured from the provider's server-side receipt.
- **Before evidence:** pre-fix, these four sites forwarded `context.systemPrompt` without stripping, so the first stdout line — the raw marked input with `has marker: true` — is the string that would have been embedded verbatim in those provider fields before this change.

## Tests and validation

- `node scripts/run-vitest.mjs` on the four provider test files → **27 passed**.
- `oxfmt --check`, `oxlint`, `tsgo:core`, and `tsgo:test:src` all clean.
- Added per-provider regression tests that pass `Stable + <cache boundary> + Dynamic` and assert the **sent** payload (`JSON.stringify(payload)`) does **not** contain `OPENCLAW_CACHE_BOUNDARY` and equals `Stable\nDynamic`. The ChatGPT path also gets a regression test for the no-system-prompt default-instructions fallback.
- What failed before: the marker survived into the outbound system prompt for all four providers (the four new assertions would fail on `main`).

## Risk checklist

- **Did user-visible behavior change?** Yes (intended): non-Anthropic models no longer see the internal `<!-- OPENCLAW_CACHE_BOUNDARY -->` comment in their system prompt.
- **Did config, environment, or migration behavior change?** No.
- **Did security, auth, secrets, network, or tool execution behavior change?** No.
- **Highest-risk area:** the ChatGPT `instructions` field, which is unconditional (unlike the other three sites guarded by `if (context.systemPrompt)`). `context.systemPrompt` can be `undefined` there.
- **How is that risk mitigated:** `stripSystemPromptCacheBoundary(context.systemPrompt ?? "") || "You are a helpful assistant."` preserves the original `context.systemPrompt || "..."` fallback exactly, plus a dedicated regression test covers the no-system-prompt path.

## Current review state

- **Next action:** maintainer review.
- **Waiting on:** nothing from the author; CI.
- **Bot/reviewer comments addressed:** reworked the Real behavior proof section to lead with `node` (tsx) stdout of the production payload builders/entrypoints (all four providers, Mistral/ChatGPT captured via the `onPayload` hook before transport) as the after-fix evidence; the unit/regression tests are kept under Tests and validation as supplemental.

