### PR TITLE
fix(agents): avoid enumerating wrapped tool descriptors

### DIFF
--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -2,6 +2,7 @@ import { copyPluginToolMeta } from "../plugins/tools.js";
 import { bindAbortRelay } from "../utils/fetch-timeout.js";
 import { copyBeforeToolCallHookMarker } from "./agent-tools.before-tool-call.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { createWrappedAgentToolDescriptor } from "./agent-tools.wrapper-descriptor.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 
 function throwAbortError(): never {
@@ -57,16 +58,16 @@ export function wrapToolWithAbortSignal(
   if (!execute) {
     return tool;
   }
-  const wrappedTool: AnyAgentTool = {
-    ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+  const wrappedTool = createWrappedAgentToolDescriptor(
+    tool,
+    async (toolCallId, params, signal, onUpdate) => {
       const combined = combineAbortSignals(signal, abortSignal);
       if (combined?.aborted) {
         throwAbortError();
       }
       return await execute(toolCallId, params, combined, onUpdate);
     },
-  };
+  );
   copyPluginToolMeta(tool, wrappedTool);
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   copyBeforeToolCallHookMarker(tool, wrappedTool);

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -47,6 +47,7 @@ import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { resolveSkillWorkshopToolApproval } from "../skills/workshop/policy.js";
 import { isPlainObject } from "../utils.js";
 import { adjustedParamsByToolCallId } from "./agent-tools.before-tool-call.state.js";
+import { createWrappedAgentToolDescriptor } from "./agent-tools.wrapper-descriptor.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -1103,9 +1104,9 @@ export function wrapToolWithBeforeToolCallHook(
     ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
     emitDiagnostics: options.emitDiagnostics !== false,
   };
-  const wrappedTool: AnyAgentTool = {
-    ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+  const wrappedTool = createWrappedAgentToolDescriptor(
+    tool,
+    async (toolCallId, params, signal, onUpdate) => {
       const prepare = (tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
       const preparedParams = prepare
         ? await prepare(params, {
@@ -1250,7 +1251,7 @@ export function wrapToolWithBeforeToolCallHook(
         throw err;
       }
     },
-  };
+  );
   copyPluginToolMeta(tool, wrappedTool);
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {

--- a/src/agents/agent-tools.wrapper-descriptor.ts
+++ b/src/agents/agent-tools.wrapper-descriptor.ts
@@ -1,0 +1,46 @@
+import type { AnyAgentTool } from "./agent-tools.types.js";
+
+function readOptionalToolField<K extends keyof AnyAgentTool>(
+  tool: AnyAgentTool,
+  key: K,
+): AnyAgentTool[K] | undefined {
+  try {
+    return tool[key];
+  } catch {
+    return undefined;
+  }
+}
+
+export function createWrappedAgentToolDescriptor(
+  tool: AnyAgentTool,
+  execute: AnyAgentTool["execute"],
+): AnyAgentTool {
+  const wrapped: AnyAgentTool = {
+    name: tool.name,
+    label: tool.label,
+    description: tool.description,
+    parameters: tool.parameters,
+    execute,
+  };
+  const prepareArguments = readOptionalToolField(tool, "prepareArguments");
+  if (prepareArguments) {
+    wrapped.prepareArguments = prepareArguments;
+  }
+  const executionMode = readOptionalToolField(tool, "executionMode");
+  if (executionMode) {
+    wrapped.executionMode = executionMode;
+  }
+  const displaySummary = readOptionalToolField(tool, "displaySummary");
+  if (displaySummary !== undefined) {
+    wrapped.displaySummary = displaySummary;
+  }
+  const prepareBeforeToolCallParams = readOptionalToolField(tool, "prepareBeforeToolCallParams");
+  if (prepareBeforeToolCallParams) {
+    wrapped.prepareBeforeToolCallParams = prepareBeforeToolCallParams;
+  }
+  const finalizeBeforeToolCallParams = readOptionalToolField(tool, "finalizeBeforeToolCallParams");
+  if (finalizeBeforeToolCallParams) {
+    wrapped.finalizeBeforeToolCallParams = finalizeBeforeToolCallParams;
+  }
+  return wrapped;
+}

--- a/src/agents/agent-tools.wrappers.test.ts
+++ b/src/agents/agent-tools.wrappers.test.ts
@@ -1,0 +1,57 @@
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+
+function createPoisonedTool(): AnyAgentTool & { poison?: unknown } {
+  const tool: AnyAgentTool & { poison?: unknown } = {
+    name: "safe_tool",
+    label: "Safe Tool",
+    description: "A healthy tool with one hostile non-contract field.",
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: { ok: true },
+    })),
+  };
+  Object.defineProperty(tool, "poison", {
+    enumerable: true,
+    get() {
+      throw new Error("non-contract tool field getter exploded");
+    },
+  });
+  return tool;
+}
+
+describe("agent tool wrappers", () => {
+  it("does not read non-contract tool fields when adding before-tool-call hooks", () => {
+    const wrapped = wrapToolWithBeforeToolCallHook(createPoisonedTool());
+
+    expect(wrapped.name).toBe("safe_tool");
+    expect(wrapped.description).toBe("A healthy tool with one hostile non-contract field.");
+  });
+
+  it("does not read non-contract tool fields when adding abort signals", async () => {
+    const wrapped = wrapToolWithAbortSignal(createPoisonedTool(), new AbortController().signal);
+
+    await expect(wrapped.execute("call-1", {})).resolves.toMatchObject({
+      details: { ok: true },
+    });
+  });
+
+  it("ignores unreadable optional wrapper metadata", () => {
+    const tool = createPoisonedTool();
+    Object.defineProperty(tool, "displaySummary", {
+      enumerable: true,
+      get() {
+        throw new Error("display summary getter exploded");
+      },
+    });
+
+    const wrapped = wrapToolWithAbortSignal(tool, new AbortController().signal);
+
+    expect(wrapped.displaySummary).toBeUndefined();
+    expect(wrapped.name).toBe("safe_tool");
+  });
+});


### PR DESCRIPTION
## Summary

- Stop before-tool-call and abort wrappers from spreading arbitrary active tool descriptors.
- Add a shared wrapper descriptor copier that preserves the `AgentTool` contract fields plus wrapper-relevant optional metadata without enumerating hostile plugin/tool fields.
- Cover descriptors with throwing non-contract getters and unreadable optional display metadata.

## Verification

- Red repro before fix:
  - `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.wrappers.test.ts --reporter=verbose`
  - Failed with `non-contract tool field getter exploded` from `wrapToolWithBeforeToolCallHook` and `wrapToolWithAbortSignal`.
- Focused local proof after fix:
  - `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.wrappers.test.ts --reporter=verbose`
  - `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.wrappers.test.ts src/agents/tool-search.test.ts -t "agent tool wrappers|does not re-wrap abort-wrapped tools that already have before_tool_call hooks" --reporter=verbose`
  - `CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts -t "fires hook exactly once when tool goes through wrap \\+ abort \\+ toToolDefinitions|preserves the hook marker when abort wrapping a hooked tool|normalizes outer code-mode exec hook params when a wrapper owns the hook" --reporter=verbose`
  - `./node_modules/.bin/oxfmt --check src/agents/agent-tools.abort.ts src/agents/agent-tools.before-tool-call.ts src/agents/agent-tools.wrapper-descriptor.ts src/agents/agent-tools.wrappers.test.ts`
  - `./node_modules/.bin/oxlint src/agents/agent-tools.abort.ts src/agents/agent-tools.before-tool-call.ts src/agents/agent-tools.wrapper-descriptor.ts src/agents/agent-tools.wrappers.test.ts`
  - `git diff --check origin/main..HEAD`
- Autoreview:
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - Clean: no accepted/actionable findings.
- Remote/broad proof:
  - AWS Crabbox `pnpm check:changed` run `run_1cdcddfdbd34`, lease `cbx_a7fdff5e57bd`, type `c7a.8xlarge`, lanes `core, coreTests`.
  - That pre-amend run failed only in `typecheck core tests` on the new test's `"text"` literal inference; the test was fixed and local focused proof reran.
  - Rerunning AWS Crabbox on the amended head was blocked before lease creation by coordinator `401 unauthorized`; Blacksmith Testbox is also unavailable locally because `blacksmith testbox list --all` reports unauthenticated.
  - A local fallback for the exact failed core-test typecheck phase was blocked by sparse checkout inputs.
  - PR check rollup after creation: `mergeStateStatus=CLEAN`, active/failing checks 0.

## Real behavior proof

Behavior addressed: A plugin/tool descriptor with a throwing extra getter can no longer crash assistant tool wrapping before content.

Real environment tested: Local Codex worktree with targeted Vitest wrapper and before-tool-call integration coverage; AWS Crabbox attempted for broad changed-gate proof.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.wrappers.test.ts src/agents/tool-search.test.ts -t "agent tool wrappers|does not re-wrap abort-wrapped tools that already have before_tool_call hooks" --reporter=verbose`

Evidence after fix: 4 Vitest project files passed, 8 tests passed, 48 skipped; e2e wrapper composition target passed 3 tests with 16 skipped.

Observed result after fix: before-tool-call and abort wrappers keep the healthy tool descriptor and execution path while ignoring hostile non-contract fields and unreadable optional display metadata.

What was not tested: Full `pnpm check:changed` on the amended head under Crabbox/Testbox; the AWS rerun was blocked by coordinator auth, Blacksmith was unauthenticated, and local sparse checkout cannot run the changed-gate core-test typecheck. GitHub PR checks settled clean after push.
