### PR TITLE
fix(plugin-sdk): guard plain text tool name reads

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -238,6 +238,51 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     ]);
   });
 
+  it("skips unreadable context tool names while promoting healthy text tool calls", async () => {
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: '[tool:read] {"path":"/tmp/file.txt"}',
+          },
+        },
+      ]);
+    const unreadableTool = Object.defineProperty({}, "name", {
+      enumerable: true,
+      get() {
+        throw new Error("plain text tool name getter exploded");
+      },
+    });
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [unreadableTool, { name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => (event as { type?: string }).type)).toEqual([
+      "toolcall_start",
+      "toolcall_delta",
+      "done",
+    ]);
+    const done = events.at(-1) as { message?: { content?: unknown; stopReason?: unknown } };
+    expect(done.message?.stopReason).toBe("toolUse");
+    expect(done.message?.content).toEqual([
+      expect.objectContaining({
+        type: "toolCall",
+        name: "read",
+        arguments: { path: "/tmp/file.txt" },
+      }),
+    ]);
+  });
+
   it("promotes complete under-cap text tool calls for non-stop terminal reasons", async () => {
     const rawToolText = '[tool:read] {"path":"/tmp/file.txt"}';
     const baseStreamFn: StreamFn = () =>

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import {
   extractStandalonePlainTextToolCallText,
   normalizePlainTextToolCallStreamEvents,
@@ -11,7 +12,6 @@ import type { StreamFn } from "../agents/runtime/index.js";
 import { streamWithPayloadPatch } from "../llm/providers/stream-wrappers/stream-payload-utils.js";
 import { streamSimple } from "../llm/stream.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
-import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import type { ProviderWrapStreamFnContext } from "./plugin-entry.js";
 
 export type ProviderStreamWrapperFactory =
@@ -34,17 +34,22 @@ function toRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
+function readContextToolName(tool: unknown): string | undefined {
+  const record = toRecord(tool);
+  try {
+    const name = record?.name;
+    return typeof name === "string" && name.trim() ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveContextToolNames(context: Parameters<StreamFn>[1]): Set<string> {
   const tools = (context as { tools?: unknown }).tools;
   if (!Array.isArray(tools)) {
     return new Set();
   }
-  const names = tools
-    .map((tool) => {
-      const record = toRecord(tool);
-      return typeof record?.name === "string" && record.name.trim() ? record.name : undefined;
-    })
-    .filter((name): name is string => Boolean(name));
+  const names = tools.map(readContextToolName).filter((name): name is string => Boolean(name));
   return new Set(names);
 }
 


### PR DESCRIPTION
## Summary

- Guard plain-text tool-call compatibility against unreadable tool `name` accessors in provider stream context.
- Skip only malformed/unreadable context tool entries while preserving healthy sibling tool-call promotion.
- Add regression coverage for a hostile sibling tool and a healthy `[tool:read]` text call.

## Verification

- `CI=1 node scripts/run-vitest.mjs run src/plugin-sdk/provider-stream-shared.test.ts -t "skips unreadable context tool names" --reporter=verbose`
- `CI=1 node scripts/run-vitest.mjs run src/plugin-sdk/provider-stream-shared.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

## Real behavior proof

Behavior addressed: a provider stream wrapper could abort plain-text tool-call repair when any `context.tools` entry exposed an unreadable `name`, preventing healthy sibling tools from being promoted.

Real environment tested: local linked OpenClaw worktree on Node/Vitest through `scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs run src/plugin-sdk/provider-stream-shared.test.ts --reporter=dot`.

Evidence after fix: the full `provider-stream-shared.test.ts` file passed, including the new hostile descriptor regression.

Observed result after fix: unreadable tool-name access is contained and the healthy `read` text call is still emitted as `toolcall_start`, `toolcall_delta`, and `done` with `stopReason: "toolUse"`.

What was not tested: `pnpm check:changed` could not run remotely because the coordinator rejected lease creation with HTTP 401 before executing the command.
