### PR TITLE
test(cron): cover cron base-session preservation during reaper sweep

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -168,6 +168,45 @@ describe("sweepCronRunSessions", () => {
     expect(result).toEqual({ swept: true, pruned: 1 });
   });
 
+  it("preserves stable isolated cron base sessions while pruning expired run descendants", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:job-isolated-expired": {
+        sessionId: "isolated-expired",
+        updatedAt: now - 25 * 3_600_000, // old but stable base row — preserve
+      },
+      "agent:main:cron:job-isolated-recent": {
+        sessionId: "isolated-recent",
+        updatedAt: now - 1 * 3_600_000, // recent stable base row — preserve
+      },
+      "agent:main:cron:job-main-target": {
+        sessionId: "main-target-base",
+        updatedAt: now,
+      },
+      "agent:main:cron:job-main-target:run:run-123": {
+        sessionId: "main-target-run",
+        updatedAt: now - 25 * 3_600_000, // expired run descendant — prune
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:cron:job-isolated-expired"]).toBeDefined();
+    expect(updated["agent:main:cron:job-isolated-recent"]).toBeDefined();
+    expect(updated["agent:main:cron:job-main-target"]).toBeDefined();
+    expect(updated["agent:main:cron:job-main-target:run:run-123"]).toBeUndefined();
+  });
+
   it("preserves expired continuation rows while generated media is pending", async () => {
     const now = Date.now();
     const sessionKey = "agent:main:cron:job1:run:pending-run";

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -88,7 +88,7 @@ describe("sweepCronRunSessions", () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:cron:job1": {
         sessionId: "base-session",
-        updatedAt: now,
+        updatedAt: now - 25 * 3_600_000, // stale base row — preserve
       },
       "agent:main:cron:job1:run:old-run": {
         sessionId: "old-run",
@@ -132,7 +132,7 @@ describe("sweepCronRunSessions", () => {
     ]);
     expect(updated["agent:main:cron:job1"]).toMatchObject({
       sessionId: "base-session",
-      updatedAt: now,
+      updatedAt: now - 25 * 3_600_000,
     });
     expect(updated["agent:main:cron:job1:run:recent-run"]).toMatchObject({
       sessionId: "recent-run",
@@ -166,45 +166,6 @@ describe("sweepCronRunSessions", () => {
     });
 
     expect(result).toEqual({ swept: true, pruned: 1 });
-  });
-
-  it("preserves stable isolated cron base sessions while pruning expired run descendants", async () => {
-    const now = Date.now();
-    const store: Record<string, { sessionId: string; updatedAt: number }> = {
-      "agent:main:cron:job-isolated-expired": {
-        sessionId: "isolated-expired",
-        updatedAt: now - 25 * 3_600_000, // old but stable base row — preserve
-      },
-      "agent:main:cron:job-isolated-recent": {
-        sessionId: "isolated-recent",
-        updatedAt: now - 1 * 3_600_000, // recent stable base row — preserve
-      },
-      "agent:main:cron:job-main-target": {
-        sessionId: "main-target-base",
-        updatedAt: now,
-      },
-      "agent:main:cron:job-main-target:run:run-123": {
-        sessionId: "main-target-run",
-        updatedAt: now - 25 * 3_600_000, // expired run descendant — prune
-      },
-    };
-    fs.writeFileSync(storePath, JSON.stringify(store));
-
-    const result = await sweepCronRunSessions({
-      sessionStorePath: storePath,
-      nowMs: now,
-      log,
-      force: true,
-    });
-
-    expect(result.swept).toBe(true);
-    expect(result.pruned).toBe(1);
-
-    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
-    expect(updated["agent:main:cron:job-isolated-expired"]).toBeDefined();
-    expect(updated["agent:main:cron:job-isolated-recent"]).toBeDefined();
-    expect(updated["agent:main:cron:job-main-target"]).toBeDefined();
-    expect(updated["agent:main:cron:job-main-target:run:run-123"]).toBeUndefined();
   });
 
   it("preserves expired continuation rows while generated media is pending", async () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for the current cron session reaper boundary: expired canonical `agent:<id>:cron:<jobId>:run:<runId>` run-session descendants are pruned, while stable `agent:<id>:cron:<jobId>` base rows are preserved.

This PR is now intentionally test-only. The earlier runtime implementation attempt was removed after review; current `main` already preserves base cron rows and prunes only run descendants. This PR keeps that behavior covered so it does not regress.

## Changes

- Add a regression test in `src/cron/session-reaper.test.ts` verifying that old stable cron base rows are preserved while expired run descendants are pruned.
- No runtime code changes.

## Real behavior proof

Behavior or issue addressed: After the fix, cron session retention only prunes expired canonical `agent:<id>:cron:<jobId>:run:<runId>` run-session descendants and preserves stable `agent:<id>:cron:<jobId>` base rows, avoiding accidental deletion of carried base-session metadata unless a separate maintainer-approved lifecycle cleanup is introduced.
Real environment tested: Repository `openclaw/openclaw`, branch `fix/cron-isolated-session-pruning`, commit `057bba37c605`, refreshed against current `origin/main` in worktree `/datad/github/openclaw-pr89721`; proof used a copied real OpenClaw agent session-store directory under `/root/.openclaw/agents` and production SQLite session-store APIs, with redacted injected cron rows in the copy only.
Exact steps or command run after this patch:
```shell
git diff --check
pnpm exec oxlint src/cron/session-reaper.ts src/cron/session-reaper.test.ts
OPENCLAW_TEST_FAST=1 node scripts/test-projects.mjs src/cron/session-reaper.test.ts
./node_modules/.bin/tsx /tmp/openclaw-89721-real-store-proof.ts | tee /tmp/openclaw-89721-real-store-proof.json
```
Evidence after fix: Verification output:
```text
=== diff --check ===
=== oxlint ===
Found 0 warnings and 0 errors.
Finished in 49ms on 2 files with 208 rules using 8 threads.
=== targeted test ===
src/cron/session-reaper.test.ts: 18 tests passed
[test] passed 1 Vitest shard in 39.49s

Real/copied store proof summary:
{
  "realStoreRoot": "/root/.openclaw/agents",
  "selectedAgent": "head-of-operations",
  "realEntryCountBeforeInjection": 0,
  "injectedBefore": {
    "stableBasePresent": true,
    "activeBasePresent": true,
    "oldRunPresent": true,
    "recentRunPresent": true
  },
  "sweepResult": { "swept": true, "pruned": 1 },
  "injectedAfter": {
    "stableBasePresent": true,
    "activeBasePresent": true,
    "oldRunPresent": false,
    "recentRunPresent": true
  },
  "afterEntryCount": 3,
  "warningCount": 0
}
```
Observed result after fix: The expired run descendant was pruned, the old stable base cron row remained present, the recent run row remained present, and the reaper reported one pruned row with no warnings. This directly verifies the review-requested boundary: base rows are not age-pruned by `cron.sessionRetention`.
What was not tested: Full repository test suite and a live production gateway cron run were not executed. The proof copied a real local session-store directory and injected redacted cron rows into the copy because the currently readable local stores had no pre-existing cron rows to mutate safely.

## Test Plan

- `node scripts/test-projects.mjs src/cron/session-reaper.test.ts` — 18 tests pass (existing + regression coverage for base-row preservation).
- `pnpm exec oxlint src/cron/session-reaper.ts src/cron/session-reaper.test.ts` — 0 errors.
- `git diff --check` — clean.

## Risk

Minimal. This is a test-only change with no runtime impact. The test documents and protects the existing retention boundary: stable cron base rows are preserved, while expired run descendants are pruned.

Related to #89666. This PR now provides regression coverage for the current base-row preservation behavior rather than introducing a runtime pruning change.
