### PR TITLE
fix(cron): prune isolated-target cron sessions without changing isCronRunSessionKey contract

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isIsolatedCronSessionKey } from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
 import { sweepCronRunSessions, resolveRetentionMs, resetReaperThrottle } from "./session-reaper.js";
 
@@ -61,6 +61,30 @@ describe("isCronRunSessionKey", () => {
   it("does not match non-canonical cron-like keys", () => {
     expect(isCronRunSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
     expect(isCronRunSessionKey("cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("isIsolatedCronSessionKey", () => {
+  it("matches isolated cron session keys", () => {
+    expect(isIsolatedCronSessionKey("agent:main:cron:abc-123")).toBe(true);
+    expect(isIsolatedCronSessionKey("agent:debugger:cron:249ecf82")).toBe(true);
+  });
+
+  it("does not match cron run session keys", () => {
+    expect(isIsolatedCronSessionKey("agent:main:cron:abc-123:run:def-456")).toBe(false);
+    expect(isIsolatedCronSessionKey("agent:main:cron:abc-123:run:def-456:subagent:worker")).toBe(
+      false,
+    );
+  });
+
+  it("does not match regular session keys", () => {
+    expect(isIsolatedCronSessionKey("agent:main:telegram:dm:123")).toBe(false);
+    expect(isIsolatedCronSessionKey("main")).toBe(false);
+  });
+
+  it("does not match heartbeat or other extended cron keys", () => {
+    expect(isIsolatedCronSessionKey("agent:main:cron:abc-123:heartbeat")).toBe(false);
+    expect(isIsolatedCronSessionKey("agent:main:cron:abc-123:heartbeat:run:uuid")).toBe(false);
   });
 });
 
@@ -128,6 +152,63 @@ describe("sweepCronRunSessions", () => {
       "agent:main:cron:job1:run:recent-run:thread:reply": {
         sessionId: "recent-run-thread",
         updatedAt: now - 1 * 3_600_000,
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-session",
+        updatedAt: now - 100 * 3_600_000,
+      },
+    });
+  });
+
+  it("prunes expired isolated-target cron sessions", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:isolated-job": {
+        sessionId: "isolated-session-old",
+        updatedAt: now - 25 * 3_600_000, // 25h ago — expired
+      },
+      "agent:main:cron:isolated-job:subagent:worker": {
+        sessionId: "isolated-subagent-old",
+        updatedAt: now - 25 * 3_600_000, // expired descendant — not matched by isolated key helper
+      },
+      "agent:main:cron:fresh-isolated-job": {
+        sessionId: "isolated-session-fresh",
+        updatedAt: now - 1 * 3_600_000, // 1h ago — not expired
+      },
+      "agent:main:cron:heartbeat-job:heartbeat": {
+        sessionId: "heartbeat-session-old",
+        updatedAt: now - 25 * 3_600_000, // old but heartbeat — not a cron session
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-session",
+        updatedAt: now - 100 * 3_600_000, // old but not a cron run
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      "agent:main:cron:isolated-job:subagent:worker": {
+        sessionId: "isolated-subagent-old",
+        updatedAt: now - 25 * 3_600_000,
+      },
+      "agent:main:cron:fresh-isolated-job": {
+        sessionId: "isolated-session-fresh",
+        updatedAt: now - 1 * 3_600_000,
+      },
+      "agent:main:cron:heartbeat-job:heartbeat": {
+        sessionId: "heartbeat-session-old",
+        updatedAt: now - 25 * 3_600_000,
       },
       "agent:main:telegram:dm:123": {
         sessionId: "regular-session",

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -3,7 +3,7 @@ import { loadSessionStore } from "../config/sessions/store-load.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isIsolatedCronSessionKey } from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
@@ -35,7 +35,8 @@ type ReaperResult = {
 };
 
 /**
- * Sweeps completed isolated cron run sessions while preserving base cron sessions.
+ * Sweeps completed cron run sessions and isolated cron sessions while
+ * preserving active base cron sessions.
  *
  * Must run outside the cron service `locked()` section because this acquires
  * the session-store file lock; reversing that order can deadlock timer ticks.
@@ -71,7 +72,7 @@ export async function sweepCronRunSessions(params: {
     await updateSessionStore(storePath, (store) => {
       const cutoff = now - retentionMs;
       for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
+        if (!isCronRunSessionKey(key) && !isIsolatedCronSessionKey(key)) {
           continue;
         }
         const entry = store[key];

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -266,6 +266,15 @@ export function isCronSessionKey(sessionKey: string | undefined | null): boolean
   return normalizeOptionalLowercaseString(parsed.rest)?.startsWith("cron:") === true;
 }
 
+/** Matches isolated cron session keys (`agent:*:cron:jobId` without `:run:`). */
+export function isIsolatedCronSessionKey(sessionKey: string | undefined | null): boolean {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return false;
+  }
+  return /^cron:[^:]+$/.test(parsed.rest);
+}
+
 export function isSubagentSessionKey(sessionKey: string | undefined | null): boolean {
   const raw = normalizeOptionalString(sessionKey);
   if (!raw) {


### PR DESCRIPTION
## Summary

Fixes #89666.

Isolated-target cron jobs generate session keys like `agent:${agentId}:cron:${jobId}` without a `:run:` segment. The session reaper `sweepCronRunSessions` currently only matches `isCronRunSessionKey`, which requires `:run:` in the key. As a result, isolated cron sessions never get pruned by `sessionRetention`.

## Approach

Instead of modifying `isCronRunSessionKey` (which is used in 10+ call sites across subagent delivery, tool routing, binding routing, gateway session utils, etc.), this PR adds a narrow helper `isIsolatedCronSessionKey` that matches exactly the `agent:*:cron:jobId` shape, and updates the reaper to prune both run sessions and isolated sessions.

This keeps the `isCronRunSessionKey` contract stable and avoids side effects on unrelated paths.

## Relation to #89719

PR #89719 proposes the same fix by changing the `isCronRunSessionKey` regex directly. While more concise, that approach changes a broadly-used predicate and may affect:
- `src/agents/subagent-announce-delivery.ts`
- `src/agents/openclaw-tools.ts`
- `src/routing/session-key.ts`
- `src/channels/plugins/binding-routing.ts`
- `src/gateway/session-utils.ts`
- `packages/memory-host-sdk/`

This PR offers a lower-risk alternative that scopes the change to the reaper only.

## Changes

- `src/sessions/session-key-utils.ts`: add `isIsolatedCronSessionKey`
- `src/cron/session-reaper.ts`: use both predicates in the reaper filter
- `src/cron/session-reaper.test.ts`: add regression tests

## Verification

- `pnpm test src/cron/session-reaper.test.ts` — 22 tests passed
- `pnpm test src/routing/session-key.test.ts` — 71 tests passed
- `pnpm format:check` on modified files — clean

## Real behavior proof

**Behavior addressed:** `sessionRetention` ignores isolated-target cron sessions because they lack the `:run:` segment.

**Real environment tested:** Node 22.19+ on Linux, repository `openclaw/openclaw`, branch `fix/cron-isolated-session-retention-89666` from a git worktree on latest `main`.

**Exact steps or command run after this patch:**

1. Verified the production source has the new helper and reaper change:

```bash
grep -n "isIsolatedCronSessionKey" src/sessions/session-key-utils.ts src/cron/session-reaper.ts
```

2. Ran the full session reaper test suite:

```bash
pnpm test src/cron/session-reaper.test.ts
```

3. Ran the routing session-key test suite:

```bash
pnpm test src/routing/session-key.test.ts
```

4. Verified formatting:

```bash
pnpm format:check src/cron/session-reaper.ts src/cron/session-reaper.test.ts src/sessions/session-key-utils.ts
```

**Evidence after fix:**

```text
$ pnpm test src/cron/session-reaper.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  7.37s

$ pnpm test src/routing/session-key.test.ts
 Test Files  1 passed (1)
      Tests  71 passed (71)
   Duration  400ms

$ pnpm format:check ...
All matched files use the correct format.
```

The new test `"prunes expired isolated-target cron sessions"` verifies that:
- `agent:main:cron:isolated-job` (25h old) → pruned
- `agent:main:cron:fresh-isolated-job` (1h old) → kept
- `agent:main:cron:heartbeat-job:heartbeat` (25h old) → kept (heartbeat excluded)
- `agent:main:telegram:dm:123` (100h old) → kept (not a cron session)

**Observed result after fix:** Both run sessions (`cron:jobId:run:uuid`) and isolated sessions (`cron:jobId`) are now correctly matched by the reaper and pruned when they exceed the retention period. The `isIsolatedCronSessionKey` helper intentionally excludes heartbeat keys (`cron:jobId:heartbeat`) to avoid interfering with the heartbeat runner cleanup logic.

**What was not tested:** Live gateway with isolated cron jobs running and observing session store pruning over 24h+.
