### PR TITLE
fix(agents): guard code mode catalog tool names

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -702,6 +702,42 @@ describe("Code Mode", () => {
     expect(compacted.catalogToolCount).toBe(1);
   });
 
+  it("skips unreadable catalog tool names while keeping healthy code mode siblings", () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const badNameTool = {
+      get name(): string {
+        throw new Error("code mode tool name getter exploded");
+      },
+      label: "Bad Name",
+      description: "bad",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      execute: vi.fn(async () => jsonResult({ ok: true })),
+    } satisfies AnyAgentTool;
+
+    const compacted = applyCodeModeCatalog({
+      tools: [
+        ...codeModeTools,
+        badNameTool,
+        pluginTool("fake_create_ticket", "Create a fake ticket"),
+      ],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    expect(compacted.tools.map((tool) => tool.name)).toEqual([
+      CODE_MODE_EXEC_TOOL_NAME,
+      CODE_MODE_WAIT_TOOL_NAME,
+    ]);
+    expect(compacted.catalogToolCount).toBe(1);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_create_ticket"]);
+  });
+
   it("accepts command as an exec-compatible code alias", async () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     applyCodeModeCatalog({

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1200,14 +1200,13 @@ export function applyCodeModeCatalog(params: {
       isVisibleControlTool: isCodeModeControlTool,
     });
   }
-  const tools = params.tools.filter(
-    (tool) =>
-      isCodeModeControlTool(tool) ||
-      (tool.name !== TOOL_SEARCH_CODE_MODE_TOOL_NAME &&
-        tool.name !== TOOL_SEARCH_RAW_TOOL_NAME &&
-        tool.name !== TOOL_DESCRIBE_RAW_TOOL_NAME &&
-        tool.name !== TOOL_CALL_RAW_TOOL_NAME),
-  );
+  const tools = params.tools.filter((tool) => {
+    if (isCodeModeControlTool(tool)) {
+      return true;
+    }
+    const toolName = readCodeModeCatalogToolName(tool);
+    return Boolean(toolName && !isLegacyToolSearchControlToolName(toolName));
+  });
   const compacted = applyToolCatalogCompaction({
     ...params,
     tools,
@@ -1217,7 +1216,7 @@ export function applyCodeModeCatalog(params: {
   });
   const visibleCatalog = params.catalogRef?.current?.entries ?? [];
   for (const tool of compacted.tools) {
-    if (tool.name === CODE_MODE_EXEC_TOOL_NAME) {
+    if (readCodeModeCatalogToolName(tool) === CODE_MODE_EXEC_TOOL_NAME) {
       tool.description = createCodeModeExecDescription(
         {
           config: params.config,
@@ -1233,6 +1232,24 @@ export function applyCodeModeCatalog(params: {
     }
   }
   return compacted;
+}
+
+function readCodeModeCatalogToolName(tool: AnyAgentTool): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" && name.trim() ? name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isLegacyToolSearchControlToolName(name: string): boolean {
+  return (
+    name === TOOL_SEARCH_CODE_MODE_TOOL_NAME ||
+    name === TOOL_SEARCH_RAW_TOOL_NAME ||
+    name === TOOL_DESCRIBE_RAW_TOOL_NAME ||
+    name === TOOL_CALL_RAW_TOOL_NAME
+  );
 }
 
 export function addClientToolsToCodeModeCatalog(params: {


### PR DESCRIPTION
## Summary

- Guard Code Mode catalog filtering against tools whose `name` getter throws before the shared Tool Search catalog compaction path runs.
- Keep marked Code Mode control tools visible, drop unreadable/empty candidate names, and preserve existing legacy Tool Search control removal.
- Add a focused regression proving a bad-name tool does not block a healthy sibling from being cataloged behind `exec`/`wait`.

## Verification

- `CI=1 node scripts/run-vitest.mjs run src/agents/code-mode.test.ts -t "skips unreadable catalog tool names" --reporter=verbose`
- `CI=1 node scripts/run-vitest.mjs run src/agents/code-mode.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check src/agents/code-mode.ts src/agents/code-mode.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/code-mode.ts src/agents/code-mode.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.86)`

## Real behavior proof

Behavior addressed: Code Mode catalog setup no longer aborts when a malformed tool descriptor has an unreadable `name`; healthy sibling tools still move into the Code Mode catalog behind `exec`/`wait`.

Real environment tested: Local linked Codex worktree on branch `fuzz-tool-schema-next72-20260603` at `74cf55f1178b`; Crabbox remote changed gate attempted with provider `azure`.

Exact steps or command run after this patch:

```bash
CI=1 node scripts/run-vitest.mjs run src/agents/code-mode.test.ts -t "skips unreadable catalog tool names" --reporter=verbose
CI=1 node scripts/run-vitest.mjs run src/agents/code-mode.test.ts --reporter=dot
./node_modules/.bin/oxfmt --check src/agents/code-mode.ts src/agents/code-mode.test.ts
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/code-mode.ts src/agents/code-mode.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
node scripts/crabbox-wrapper.mjs run --label fuzz-tool-schema-next72-check-changed --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
```

Evidence after fix: The focused regression passed in both agent projects; the full `src/agents/code-mode.test.ts` file passed with 54 tests. Formatting, oxlint, whitespace checks, and branch-mode autoreview were clean.

Observed result after fix: The bad-name descriptor is skipped before catalog compaction, `exec`/`wait` remain the visible Code Mode tools, and the healthy sibling appears in the catalog.

What was not tested: Full remote `pnpm check:changed` did not run. Blacksmith Testbox was unauthenticated, and Crabbox failed before lease creation with coordinator `401 unauthorized`, so no remote run id or lease id was created.
