### PR TITLE
fix(agents): guard deferred follow-up tool descriptors

### DIFF
--- a/src/agents/agent-tools.deferred-followup-guidance.test.ts
+++ b/src/agents/agent-tools.deferred-followup-guidance.test.ts
@@ -41,4 +41,41 @@ describe("createOpenClawCodingTools deferred follow-up guidance", () => {
       "Manage running exec sessions for commands already started: list, poll, log, write, send-keys, submit, paste, kill. Use poll/log when you need status, logs, quiet-success confirmation, or completion confirmation when automatic completion wake is unavailable. Use poll/log also for input-wait hints. Use write/send-keys/submit/paste/kill for input or intervention.",
     );
   });
+
+  it("ignores unreadable tool names while describing healthy siblings", () => {
+    const badNameTool = {
+      get name(): string {
+        throw new Error("deferred follow-up tool name getter exploded");
+      },
+      description: "bad name",
+    } as AnyAgentTool;
+
+    const tools = applyDeferredFollowupToolDescriptions([
+      { name: "exec", description: "exec base" },
+      badNameTool,
+      { name: "process", description: "process base" },
+      { name: "cron", description: "cron base" },
+    ] as AnyAgentTool[]);
+
+    expect(tools[1]).toBe(badNameTool);
+    expect(tools[0]?.description).toContain("use cron instead");
+    expect(tools[2]?.description).toContain("scheduled follow-ups");
+  });
+
+  it("does not enumerate descriptors while adding deferred guidance", () => {
+    const execTool = Object.defineProperty({ name: "exec", description: "exec base" }, "poison", {
+      enumerable: true,
+      get() {
+        throw new Error("deferred follow-up descriptor getter exploded");
+      },
+    }) as AnyAgentTool;
+
+    const [updatedExec] = applyDeferredFollowupToolDescriptions([
+      execTool,
+      { name: "process", description: "process base" },
+    ] as AnyAgentTool[]);
+
+    expect(Object.is(updatedExec, execTool)).toBe(false);
+    expect(updatedExec?.description).toContain("otherwise use process to confirm completion");
+  });
 });

--- a/src/agents/agent-tools.deferred-followup.ts
+++ b/src/agents/agent-tools.deferred-followup.ts
@@ -5,20 +5,36 @@ export function applyDeferredFollowupToolDescriptions(
   tools: AnyAgentTool[],
   params?: { agentId?: string },
 ): AnyAgentTool[] {
-  const hasCronTool = tools.some((tool) => tool.name === "cron");
-  return tools.map((tool) => {
-    if (tool.name === "exec") {
-      return {
-        ...tool,
-        description: describeExecTool({ agentId: params?.agentId, hasCronTool }),
-      };
+  const toolNames = tools.map(readToolName);
+  const hasCronTool = toolNames.some((name) => name === "cron");
+  return tools.map((tool, index) => {
+    const name = toolNames[index];
+    if (name === "exec") {
+      return withToolDescription(tool, describeExecTool({ agentId: params?.agentId, hasCronTool }));
     }
-    if (tool.name === "process") {
-      return {
-        ...tool,
-        description: describeProcessTool({ hasCronTool }),
-      };
+    if (name === "process") {
+      return withToolDescription(tool, describeProcessTool({ hasCronTool }));
     }
     return tool;
   });
+}
+
+function readToolName(tool: AnyAgentTool): string | undefined {
+  try {
+    return typeof tool.name === "string" ? tool.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function withToolDescription(tool: AnyAgentTool, description: string): AnyAgentTool {
+  const clone = Object.create(Object.getPrototypeOf(tool)) as AnyAgentTool;
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(tool));
+  Object.defineProperty(clone, "description", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: description,
+  });
+  return clone;
 }


### PR DESCRIPTION
## Summary

- Guard deferred follow-up guidance setup against active tools whose `name` getter throws.
- Preserve unreadable-name tools in the returned list while still updating healthy `exec`/`process` siblings.
- Replace object-spread cloning with descriptor-preserving description replacement so poisoned enumerable fields are not invoked.

## Verification

- `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.deferred-followup-guidance.test.ts -t "ignores unreadable tool names" --reporter=verbose` failed pre-patch with `deferred follow-up tool name getter exploded`.
- `CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.deferred-followup-guidance.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --check src/agents/agent-tools.deferred-followup.ts src/agents/agent-tools.deferred-followup-guidance.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tools.deferred-followup.ts src/agents/agent-tools.deferred-followup-guidance.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.88)`

## Real behavior proof

Behavior addressed: Deferred follow-up tool guidance no longer aborts when a malformed active tool descriptor has an unreadable `name` or when a named tool has an unrelated poisoned enumerable descriptor field.

Real environment tested: Local linked Codex worktree on branch `fuzz-tool-schema-next73-20260603` at `b7bf4d31063e`; Crabbox remote changed gate attempted with provider `azure`.

Exact steps or command run after this patch:

```bash
CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.deferred-followup-guidance.test.ts -t "ignores unreadable tool names" --reporter=verbose
CI=1 node scripts/run-vitest.mjs run src/agents/agent-tools.deferred-followup-guidance.test.ts --reporter=verbose
./node_modules/.bin/oxfmt --check src/agents/agent-tools.deferred-followup.ts src/agents/agent-tools.deferred-followup-guidance.test.ts
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-tools.deferred-followup.ts src/agents/agent-tools.deferred-followup-guidance.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
node scripts/crabbox-wrapper.mjs run --label fuzz-tool-schema-next73-check-changed --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed
```

Evidence after fix: The focused deferred-followup guidance test file passed with 4 tests. Formatting, oxlint, whitespace checks, and branch-mode autoreview were clean.

Observed result after fix: Unreadable-name tools are ignored for guidance selection without being enumerated or dropped, healthy `exec`/`process` descriptions still receive the correct cron-aware guidance, and description replacement does not invoke unrelated descriptor getters.

What was not tested: Full remote `pnpm check:changed` did not run. Blacksmith Testbox was unauthenticated, and Crabbox failed before lease creation with coordinator `401 unauthorized`, so no remote run id or lease id was created.
