### PR TITLE
fix(agents): guard lean tool name reads

### DIFF
--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -36,6 +36,33 @@ describe("local model lean tool filtering", () => {
     ).toEqual(["read", "exec"]);
   });
 
+  it("omits unreadable tool names while lean filtering stays active", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+    const readTool = { name: "read" } as AnyAgentTool;
+    const unreadableTool = {} as AnyAgentTool;
+    Object.defineProperty(unreadableTool, "name", {
+      get() {
+        throw new Error("local model lean tool name getter exploded");
+      },
+    });
+    const execTool = { name: "exec" } as AnyAgentTool;
+
+    expect(
+      filterLocalModelLeanTools({
+        tools: [readTool, unreadableTool, { name: "cron" } as AnyAgentTool, execTool],
+        config: cfg,
+      }),
+    ).toEqual([readTool, execTool]);
+  });
+
   it("keeps explicitly preserved tools when lean mode is enabled", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -17,6 +17,14 @@ function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>): Set<
   );
 }
 
+function readNormalizedLocalModelLeanToolName(tool: AnyAgentTool): string | undefined {
+  try {
+    return normalizeToolName(tool.name) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveLocalModelLeanPreserveToolNames(params?: {
   toolNames?: Iterable<string>;
   forceMessageTool?: boolean;
@@ -74,7 +82,10 @@ export function filterLocalModelLeanTools(params: {
   }
   const preservedToolNames = resolvePreservedLocalModelLeanToolNames(params.preserveToolNames);
   return params.tools.filter((tool) => {
-    const normalizedName = normalizeToolName(tool.name);
+    const normalizedName = readNormalizedLocalModelLeanToolName(tool);
+    if (!normalizedName) {
+      return false;
+    }
     return (
       preservedToolNames.has(normalizedName) ||
       !LOCAL_MODEL_LEAN_DENY_TOOL_NAMES.has(normalizedName)


### PR DESCRIPTION
Summary
- Catch-bound local-model lean tool name normalization so unreadable descriptors cannot crash lean filtering.
- Drop malformed or empty-name descriptors only while lean filtering is active; disabled lean mode still returns the original tool array.
- Add a regression covering an unreadable `name` getter while preserving healthy `read` / `exec` siblings and filtering `cron`.

Verification
- Red repro before the fix: `CI=1 node scripts/run-vitest.mjs run src/agents/local-model-lean.test.ts -t "omits unreadable tool names" --reporter=verbose` failed with `local model lean tool name getter exploded` from `src/agents/local-model-lean.ts`.
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs run src/agents/local-model-lean.test.ts -t "omits unreadable tool names" --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs run src/agents/local-model-lean.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `node --run format:check -- src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/agents/local-model-lean.ts src/agents/local-model-lean.test.ts`
- `git diff --check origin/main..HEAD`
- added-line private-data scrub
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed: local-model lean filtering no longer aborts the assistant tool surface when a malformed descriptor has an unreadable `name` getter.

Real environment tested: local focused Vitest and repo wrapper checks on the rebased OpenClaw branch.

Exact steps or command run after this patch: ran the focused regression, the full `src/agents/local-model-lean.test.ts` file, format check, scoped oxlint, diff check, private-data scrub, local autoreview, and branch autoreview.

Evidence after fix: focused Vitest passed 1 file / 10 tests after rebase; format, scoped oxlint, and diff check passed; local and branch autoreview reported no accepted/actionable findings.

Observed result after fix: malformed unreadable-name tools are omitted during active lean filtering, healthy `read` and `exec` tools remain visible, and denied heavyweight tools are still removed.

What was not tested: full `pnpm check:changed` did not run. The AWS Crabbox changed-gate wrapper failed before lease creation because the local sparse-sync cache had less than the required 1 GiB free even after `agent-worktree-maintain --force`; Blacksmith Testbox is not authenticated in this environment. The plain oxlint wrapper was also blocked before lint by unrelated Discord boundary dts errors, so scoped oxlint was run with `OPENCLAW_OXLINT_SKIP_PREPARE=1` on the touched files.
