### PR TITLE
fix: backport gateway health credential handling

### DIFF
--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -61,12 +61,15 @@ const buildGatewayConnectionDetailsMock = vi.fn(() => ({
   message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
 }));
 const formatGatewayTransportErrorJsonMock = vi.fn();
+const isGatewayCredentialsRequiredErrorMock = vi.fn(() => false);
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
   buildGatewayConnectionDetails: (...args: [unknown, ...unknown[]]) =>
     Reflect.apply(buildGatewayConnectionDetailsMock, undefined, args),
   formatGatewayTransportErrorJson: (...args: unknown[]) =>
     formatGatewayTransportErrorJsonMock(...args),
+  isGatewayCredentialsRequiredError: (...args: unknown[]) =>
+    isGatewayCredentialsRequiredErrorMock(...args),
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
@@ -104,6 +107,7 @@ describe("healthCommand", () => {
       message: "Gateway mode: local\nGateway target: ws://127.0.0.1:18789",
     });
     formatGatewayTransportErrorJsonMock.mockReturnValue(null);
+    isGatewayCredentialsRequiredErrorMock.mockReturnValue(false);
   });
 
   it("outputs JSON from gateway", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -21,6 +21,7 @@ import {
   buildGatewayConnectionDetails,
   callGateway,
   formatGatewayTransportErrorJson,
+  isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -647,6 +648,19 @@ export async function healthCommand(
         }),
     );
   } catch (error) {
+    if (isGatewayCredentialsRequiredError(error)) {
+      const message = formatErrorMessage(error);
+      if (opts.json) {
+        writeRuntimeJson(runtime, {
+          ok: false,
+          error: { type: "gateway_credentials_required", message },
+        });
+      } else {
+        runtime.error(message);
+      }
+      runtime.exit(1);
+      return;
+    }
     if (opts.json) {
       const payload = formatGatewayTransportErrorJson(error);
       if (payload) {


### PR DESCRIPTION
## Summary

- Backport the minimal gateway health credentials fix from `b859c97796a0fe5be8e613db671d7409efc4b24f` onto `release/2026.6.1`.
- Keep the release-branch change intentionally small: `openclaw health` catches the credentials-required guard and returns a normal failed health result instead of leaking the raw exception.

## Context

This is the backportable slice from #89337 for #89711. The broader diagnostic cleanup remains on the mainline PR; this release branch PR only carries the minimal behavior fix.

## Verification

- `node scripts/run-vitest.mjs src/commands/health.test.ts`
- `git diff --check`
