### PR TITLE
fix(agents): guard message provider tool name reads

### DIFF
--- a/src/agents/agent-tools.message-provider-policy.test.ts
+++ b/src/agents/agent-tools.message-provider-policy.test.ts
@@ -4,7 +4,10 @@
  * unsafe or redundant for the active channel.
  */
 import { describe, expect, it } from "vitest";
-import { filterToolNamesByMessageProvider } from "./agent-tools.message-provider-policy.js";
+import {
+  filterToolNamesByMessageProvider,
+  filterToolsByMessageProvider,
+} from "./agent-tools.message-provider-policy.js";
 
 const DEFAULT_TOOL_NAMES = ["read", "write", "tts", "web_search"];
 
@@ -20,5 +23,33 @@ describe("createOpenClawCodingTools message provider policy", () => {
   it("keeps tts tool for non-voice providers", () => {
     const names = new Set(filterToolNamesByMessageProvider(DEFAULT_TOOL_NAMES, "guildchat"));
     expect(names.has("tts")).toBe(true);
+  });
+
+  it("omits unreadable tool names while applying provider policy", () => {
+    const readTool = { name: "read" };
+    const malformedTool = {
+      get name(): string {
+        throw new Error("fuzzed unreadable tool name");
+      },
+    };
+    const ttsTool = { name: "tts" };
+
+    expect(filterToolsByMessageProvider([readTool, malformedTool, ttsTool], "voice")).toEqual([
+      readTool,
+    ]);
+  });
+
+  it("does not read tool names when no provider policy applies", () => {
+    const readTool = { name: "read" };
+    const malformedTool = {
+      get name(): string {
+        throw new Error("fuzzed unreadable tool name");
+      },
+    };
+
+    expect(filterToolsByMessageProvider([readTool, malformedTool], "guildchat")).toEqual([
+      readTool,
+      malformedTool,
+    ]);
   });
 });

--- a/src/agents/agent-tools.message-provider-policy.ts
+++ b/src/agents/agent-tools.message-provider-policy.ts
@@ -14,6 +14,19 @@ const TOOL_ALLOW_BY_MESSAGE_PROVIDER: Readonly<Record<string, readonly string[]>
   node: ["canvas", "image", "pdf", "tts", "web_fetch", "web_search"],
 };
 
+type ReadableToolName<TTool> = {
+  readonly name: string;
+  readonly tool: TTool;
+};
+
+function readToolName(tool: { name: string }): string | undefined {
+  try {
+    return tool.name;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Filters tool names by the active message-provider allow/deny policy. */
 export function filterToolNamesByMessageProvider(
   toolNames: readonly string[],
@@ -41,22 +54,36 @@ export function filterToolsByMessageProvider<TTool extends { name: string }>(
   tools: readonly TTool[],
   messageProvider?: string,
 ): TTool[] {
+  const normalizedProvider = normalizeOptionalLowercaseString(messageProvider);
+  if (!normalizedProvider) {
+    return [...tools];
+  }
+  const allowedTools = TOOL_ALLOW_BY_MESSAGE_PROVIDER[normalizedProvider];
+  const deniedTools = TOOL_DENY_BY_MESSAGE_PROVIDER[normalizedProvider];
+  if ((!allowedTools || allowedTools.length === 0) && (!deniedTools || deniedTools.length === 0)) {
+    return [...tools];
+  }
+  const readableTools: ReadableToolName<TTool>[] = [];
+  for (const tool of tools) {
+    const name = readToolName(tool);
+    if (name) {
+      readableTools.push({ name, tool });
+    }
+  }
   const filteredToolNames = filterToolNamesByMessageProvider(
-    tools.map((tool) => tool.name),
-    messageProvider,
+    readableTools.map((tool) => tool.name),
+    normalizedProvider,
   );
   const remainingCounts = new Map<string, number>();
   for (const toolName of filteredToolNames) {
     remainingCounts.set(toolName, (remainingCounts.get(toolName) ?? 0) + 1);
   }
-  return tools.filter((tool) => {
-    // Counted matching preserves the original order and duplicate instances
-    // after name-level policy filtering.
-    const remaining = remainingCounts.get(tool.name) ?? 0;
+  return readableTools.flatMap(({ name, tool }) => {
+    const remaining = remainingCounts.get(name) ?? 0;
     if (remaining <= 0) {
-      return false;
+      return [];
     }
-    remainingCounts.set(tool.name, remaining - 1);
-    return true;
+    remainingCounts.set(name, remaining - 1);
+    return [tool];
   });
 }


### PR DESCRIPTION
## Summary
- Guard `filterToolsByMessageProvider()` against tool descriptors whose `name` getter throws while provider allow/deny policy is applied.
- Avoid reading descriptor names when no message-provider policy exists, preserving the original tool list for providers such as `guildchat`.
- Preserve current-main normalized provider coverage while adding focused regression coverage for unreadable names in the voice-policy path and the no-policy path.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Ongoing tool/schema fuzzing hardening work.

## Real behavior proof (required for external PRs)

- Behavior addressed: Message-provider tool policy filtering no longer crashes when a malformed tool descriptor has an unreadable `name` getter; provider policy filtering omits that malformed descriptor and keeps healthy allowed siblings.
- Real environment tested: Local linked OpenClaw worktree rebased onto current `origin/main` (`f60943717ef57412872233a45f2b61e4f95f4c2a`), branch `fuzz-tool-schema-next75-20260603`, commit `2170cb49380768dace3cd0fa2dde3670a82bd44f`.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next75-rebased2 node scripts/run-vitest.mjs run src/agents/agent-tools.message-provider-policy.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-tools.message-provider-policy.ts src/agents/agent-tools.message-provider-policy.test.ts`; `node scripts/run-oxlint.mjs src/agents/agent-tools.message-provider-policy.ts src/agents/agent-tools.message-provider-policy.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `git push --force-with-lease origin fuzz-tool-schema-next75-20260603`.
- Evidence after fix: The focused Vitest file passed 1 file / 9 tests; scoped `oxfmt --check` passed; scoped `run-oxlint.mjs` passed; whitespace diff check passed; branch autoreview reported `autoreview clean: no accepted/actionable findings reported` with `overall: patch is correct (0.87)`.
- Observed result after fix: The synthetic unreadable-name descriptor is dropped only when a provider policy must inspect names, `tts` is still denied for normalized voice providers, and providers without a policy return the original tool descriptors without reading names.
- What was not tested: Full `pnpm check:changed` did not complete because maintainer remote runners are not authenticated in this environment.
- Proof limitations or environment constraints: `blacksmith testbox list --all` failed with `not authenticated`; AWS Crabbox reported provider `aws` but failed coordinator `/v1/runs` and `/v1/leases` with HTTP 401 `unauthorized`; delegated `blacksmith-testbox` Crabbox failed at `blacksmith testbox warmup` with `not authenticated`.
- Before evidence: The focused repro added in this PR failed before the fix with `fuzzed unreadable tool name` when the message-provider policy path read the tool `name` getter.

## Tests and validation

Which commands did you run?

- `git fetch origin main fuzz-tool-schema-next75-20260603 --prune`
- `git rebase origin/main` (conflict resolved in `src/agents/agent-tools.message-provider-policy.ts` to combine current-main normalized provider tests with guarded descriptor reads)
- `./node_modules/.bin/oxfmt --write --threads=1 src/agents/agent-tools.message-provider-policy.ts src/agents/agent-tools.message-provider-policy.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next75-rebased2 node scripts/run-vitest.mjs run src/agents/agent-tools.message-provider-policy.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/agent-tools.message-provider-policy.ts src/agents/agent-tools.message-provider-policy.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-tools.message-provider-policy.ts src/agents/agent-tools.message-provider-policy.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` (blocked: not authenticated)
- `node scripts/crabbox-wrapper.mjs run --provider aws --label fuzz-tool-schema-next75-check --shell -- "pnpm check:changed"` (blocked: coordinator HTTP 401 unauthorized)
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label fuzz-tool-schema-next75-check --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` (blocked: Blacksmith not authenticated)

What regression coverage was added or updated?

- Added coverage that `filterToolsByMessageProvider()` skips unreadable tool-name descriptors when an active provider policy must inspect names.
- Added coverage that the no-policy path returns the original descriptors without reading their `name` fields.
- Preserved current-main normalized voice-provider coverage.

What failed before this fix, if known?

- The new focused repro failed before the fix with `fuzzed unreadable tool name`.

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed tool descriptors are omitted from provider-policy-filtered tool lists instead of crashing the turn before model content.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

A malformed descriptor with an unreadable name is now dropped when a message-provider allow/deny policy applies.

How is that risk mitigated?

The no-policy fast path still returns original descriptors without reading names, healthy sibling tools are preserved, duplicate readable names are still counted, and provider allow/deny semantics are unchanged.

## Current review state

What is the next action?

Maintainer review and normal PR CI.

What is still waiting on author, maintainer, CI, or external proof?

Full `pnpm check:changed` needs authenticated Blacksmith Testbox or Crabbox coordinator access.

Which bot or reviewer comments were addressed?

Branch autoreview passed clean after the current-main rebase and lint cleanup.
