### PR TITLE
fix(memory): add EPERM fallback for atomic reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -4,8 +4,10 @@ import fs from "node:fs/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 
 type MemoryIndexFileOps = {
+  copyFile: typeof fs.copyFile;
   rename: typeof fs.rename;
   rm: typeof fs.rm;
+  unlink: typeof fs.unlink;
   wait: (ms: number) => Promise<void>;
 };
 
@@ -20,8 +22,10 @@ type MemoryIndexFileOptions = {
 type ResolvedMemoryIndexFileOptions = Required<MemoryIndexFileOptions>;
 
 const defaultFileOps: MemoryIndexFileOps = {
+  copyFile: fs.copyFile,
   rename: fs.rename,
   rm: fs.rm,
+  unlink: fs.unlink,
   wait: sleep,
 };
 
@@ -33,6 +37,10 @@ const defaultRemoveRetryDelayMs = 50;
 
 function isTransientFileError(err: unknown): boolean {
   return transientFileErrorCodes.has((err as NodeJS.ErrnoException).code ?? "");
+}
+
+function isFileErrorCode(err: unknown, code: string): boolean {
+  return (err as NodeJS.ErrnoException).code === code;
 }
 
 function resolveMemoryIndexFileOptions(
@@ -62,6 +70,11 @@ async function renameWithRetry(
         return;
       }
       if (!isTransientFileError(err) || attempt === options.maxRenameAttempts) {
+        if (isFileErrorCode(err, "EPERM")) {
+          await options.fileOps.copyFile(source, target);
+          await options.fileOps.unlink(source);
+          return;
+        }
         throw err;
       }
       await options.fileOps.wait(options.renameRetryDelayMs * attempt);

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -94,7 +94,7 @@ describe("memory manager atomic reindex", () => {
     const wait = vi.fn().mockResolvedValue(undefined);
 
     await moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
-      fileOps: { rename, rm: fs.rm, wait },
+      fileOps: { copyFile: fs.copyFile, rename, rm: fs.rm, unlink: fs.unlink, wait },
       maxRenameAttempts: 3,
       renameRetryDelayMs: 10,
     });
@@ -110,7 +110,7 @@ describe("memory manager atomic reindex", () => {
 
     await expectRejectCode(
       moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
-        fileOps: { rename, rm: fs.rm, wait },
+        fileOps: { copyFile: fs.copyFile, rename, rm: fs.rm, unlink: fs.unlink, wait },
         maxRenameAttempts: 3,
         renameRetryDelayMs: 10,
       }),
@@ -123,6 +123,30 @@ describe("memory manager atomic reindex", () => {
     expect(wait).toHaveBeenNthCalledWith(2, 20);
   });
 
+  it("falls back to copy and unlink after persistent EPERM rename failures", async () => {
+    const rename = vi.fn().mockRejectedValue(Object.assign(new Error("locked"), { code: "EPERM" }));
+    const copyFile = vi.fn().mockResolvedValue(undefined);
+    const unlink = vi.fn().mockResolvedValue(undefined);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
+      fileOps: { copyFile, rename, rm: fs.rm, unlink, wait },
+      maxRenameAttempts: 3,
+      renameRetryDelayMs: 10,
+    });
+
+    expect(rename).toHaveBeenCalledTimes(9);
+    expect(wait).toHaveBeenCalledTimes(6);
+    expect(copyFile).toHaveBeenCalledTimes(3);
+    expect(copyFile).toHaveBeenNthCalledWith(1, "index.sqlite.tmp", "index.sqlite");
+    expect(copyFile).toHaveBeenNthCalledWith(2, "index.sqlite.tmp-wal", "index.sqlite-wal");
+    expect(copyFile).toHaveBeenNthCalledWith(3, "index.sqlite.tmp-shm", "index.sqlite-shm");
+    expect(unlink).toHaveBeenCalledTimes(3);
+    expect(unlink).toHaveBeenNthCalledWith(1, "index.sqlite.tmp");
+    expect(unlink).toHaveBeenNthCalledWith(2, "index.sqlite.tmp-wal");
+    expect(unlink).toHaveBeenNthCalledWith(3, "index.sqlite.tmp-shm");
+  });
+
   it("does not retry missing optional sqlite sidecar files", async () => {
     const rename = vi
       .fn()
@@ -132,7 +156,7 @@ describe("memory manager atomic reindex", () => {
     const wait = vi.fn().mockResolvedValue(undefined);
 
     await moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
-      fileOps: { rename, rm: fs.rm, wait },
+      fileOps: { copyFile: fs.copyFile, rename, rm: fs.rm, unlink: fs.unlink, wait },
       maxRenameAttempts: 3,
       renameRetryDelayMs: 10,
     });
@@ -168,7 +192,7 @@ describe("memory manager atomic reindex", () => {
 
     await expectRejectCode(
       moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
-        fileOps: { rename, rm: fs.rm, wait },
+        fileOps: { copyFile: fs.copyFile, rename, rm: fs.rm, unlink: fs.unlink, wait },
         maxRenameAttempts: 3,
         renameRetryDelayMs: 10,
       }),
@@ -192,7 +216,7 @@ describe("memory manager atomic reindex", () => {
       const wait = vi.fn().mockResolvedValue(undefined);
 
       await removeMemoryIndexFiles("index.sqlite.tmp", {
-        fileOps: { rename: fs.rename, rm, wait },
+        fileOps: { copyFile: fs.copyFile, rename: fs.rename, rm, unlink: fs.unlink, wait },
         maxRemoveAttempts: 3,
         removeRetryDelayMs: 10,
       });
@@ -214,7 +238,7 @@ describe("memory manager atomic reindex", () => {
 
     await expectRejectCode(
       removeMemoryIndexFiles("index.sqlite.tmp", {
-        fileOps: { rename: fs.rename, rm, wait },
+        fileOps: { copyFile: fs.copyFile, rename: fs.rename, rm, unlink: fs.unlink, wait },
         maxRemoveAttempts: 3,
         removeRetryDelayMs: 10,
       }),
@@ -233,7 +257,7 @@ describe("memory manager atomic reindex", () => {
 
     await expectRejectCode(
       removeMemoryIndexFiles("index.sqlite.tmp", {
-        fileOps: { rename: fs.rename, rm, wait },
+        fileOps: { copyFile: fs.copyFile, rename: fs.rename, rm, unlink: fs.unlink, wait },
         maxRemoveAttempts: 3,
         removeRetryDelayMs: 10,
       }),
@@ -260,7 +284,13 @@ describe("memory manager atomic reindex", () => {
           tempClosed = true;
         },
         fileOptions: {
-          fileOps: { rename: fs.rename, rm, wait: vi.fn().mockResolvedValue(undefined) },
+          fileOps: {
+            copyFile: fs.copyFile,
+            rename: fs.rename,
+            rm,
+            unlink: fs.unlink,
+            wait: vi.fn().mockResolvedValue(undefined),
+          },
         },
         build: async () => {
           throw new Error("embedding failure");

--- a/package.json
+++ b/package.json
@@ -1838,7 +1838,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/plugins/import-specifier.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/check-windows-memory-index-proof.mjs && node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/plugins/import-specifier.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/scripts/check-windows-memory-index-proof.mjs
+++ b/scripts/check-windows-memory-index-proof.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const repoRoot = process.cwd();
+
+function runPnpmOpenClaw(args, env) {
+  const npmExecPath = process.env.npm_execpath;
+  const commandArgs = ["openclaw", ...args];
+  let command = "pnpm";
+  let finalArgs = commandArgs;
+
+  if (npmExecPath && fs.existsSync(npmExecPath)) {
+    command = process.execPath;
+    finalArgs = [npmExecPath, ...commandArgs];
+  } else if (process.platform === "win32") {
+    command = process.env.ComSpec || "cmd.exe";
+    finalArgs = ["/d", "/s", "/c", `pnpm ${commandArgs.join(" ")}`];
+  }
+
+  return spawnSync(command, finalArgs, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 120_000,
+  });
+}
+
+function sqliteCount(db, table) {
+  return db.prepare(`SELECT count(*) AS count FROM ${table}`).get().count;
+}
+
+async function main() {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-windows-memory-proof-"));
+  const home = path.join(root, "home");
+  const stateDir = path.join(root, "state");
+  const workspaceDir = path.join(root, "workspace");
+  const configPath = path.join(root, "openclaw.json");
+  const indexPath = path.join(workspaceDir, "index.sqlite");
+  await fsp.mkdir(workspaceDir, { recursive: true });
+  await fsp.mkdir(home, { recursive: true });
+  await fsp.writeFile(
+    path.join(workspaceDir, "MEMORY.md"),
+    ["# Windows memory index proof", "", "A durable note for the real CLI index command."].join(
+      "\n",
+    ),
+    "utf8",
+  );
+  await fsp.writeFile(
+    configPath,
+    `${JSON.stringify({
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "none",
+            store: { path: indexPath, vector: { enabled: false } },
+            sync: { watch: false, onSearch: false, onSessionStart: false },
+          },
+        },
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+      memory: { backend: "builtin" },
+    })}\n`,
+    "utf8",
+  );
+
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, ".config"),
+    XDG_DATA_HOME: path.join(home, ".local", "share"),
+    XDG_CACHE_HOME: path.join(home, ".cache"),
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_NO_RESPAWN: "1",
+  };
+
+  console.log("[windows-memory-proof] command: pnpm openclaw memory index --force");
+  console.log(`[windows-memory-proof] platform: ${process.platform}`);
+  console.log(`[windows-memory-proof] workspace: ${workspaceDir}`);
+  console.log(`[windows-memory-proof] index: ${indexPath}`);
+
+  const result = runPnpmOpenClaw(["memory", "index", "--force"], env);
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.status !== 0) {
+    throw new Error(`memory index command failed with exit code ${result.status ?? "null"}`);
+  }
+
+  const db = new DatabaseSync(indexPath, { readOnly: true });
+  try {
+    const chunks = sqliteCount(db, "chunks");
+    const ftsChunks = sqliteCount(db, "chunks_fts");
+    const meta = sqliteCount(db, "meta");
+    if (chunks < 1 || ftsChunks < 1 || meta < 1) {
+      throw new Error(
+        `expected readable populated memory index, got chunks=${chunks}, chunks_fts=${ftsChunks}, meta=${meta}`,
+      );
+    }
+    console.log(
+      `[windows-memory-proof] readable sqlite index: chunks=${chunks} chunks_fts=${ftsChunks} meta=${meta}`,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+main().catch(
+  /**
+   * @param {unknown} err
+   */
+  (err) => {
+    console.error(err instanceof Error ? err.stack || err.message : String(err));
+    process.exitCode = 1;
+  },
+);

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -140,4 +140,10 @@ describe("package scripts", () => {
       "test/scripts/run-with-env.test.ts",
     );
   });
+
+  it("runs real memory index proof in Windows CI", () => {
+    expect(readPackageJson().scripts["test:windows:ci"]).toContain(
+      "scripts/check-windows-memory-index-proof.mjs",
+    );
+  });
 });


### PR DESCRIPTION
Fixes #78640

## Summary

What problem does this PR solve?

Memory atomic reindex could still fail on Windows after exhausting the existing `EPERM` rename retry loop, leaving `openclaw memory index --force` unable to replace the sqlite index files.

Why does this matter now?

Issue #78640 reports that retrying `fs.rename` is not enough for persistent Windows `EPERM` failures during the memory index swap. The failed swap blocks forced memory reindexing for affected users.

What is the intended outcome?

After the bounded retry loop is exhausted for `EPERM`, the atomic reindex move path falls back to `copyFile` followed by `unlink` for the sqlite file and optional `-wal`/`-shm` sidecars.

What should reviewers focus on?

- The exhausted-`EPERM` fallback in `extensions/memory-core/src/memory/manager-atomic-reindex.ts`.
- The deterministic persistent-`EPERM` regression in `extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`.
- The Windows CI proof script wired into `test:windows:ci`.

## Linked context

Which issue does this close?

Closes #78640.

Was this requested by a maintainer or owner?

No direct maintainer request beyond the open issue classification.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: memory atomic reindex no longer throws after a persistent `EPERM` from `rename`; once configured attempts are exhausted, the move path copies the source index file to the target and unlinks the source.
- Real environment tested: GitHub Actions Windows runner in `checks-windows-node-test` on PR head `0c82c7e4aa48a13c7c7c6db20d23dcc1b7cf82c6`, plus local contributor checkout `/Users/andy/openclaw-78640` for focused regression/lint validation.
- Exact steps or command run after this patch: Windows CI ran `node scripts/check-windows-memory-index-proof.mjs` before the existing Windows test list. That script invokes `pnpm openclaw memory index --force`, then opens the resulting sqlite index read-only and verifies `chunks`, `chunks_fts`, and `meta` rows.
- Evidence after fix (copied from Windows CI job `checks-windows-node-test`, run `26871184669`, job `79246687209`):

```text
$ node scripts/check-windows-memory-index-proof.mjs && node scripts/test-projects.mjs ...
[windows-memory-proof] command: pnpm openclaw memory index --force
[windows-memory-proof] platform: win32
[windows-memory-proof] workspace: C:\Users\RUNNER~1\AppData\Local\Temp\openclaw-windows-memory-proof-h4DH8v\workspace
[windows-memory-proof] index: C:\Users\RUNNER~1\AppData\Local\Temp\openclaw-windows-memory-proof-h4DH8v\workspace\index.sqlite
$ node scripts/run-node.mjs "memory" "index" "--force"
Memory index updated (main).
[windows-memory-proof] readable sqlite index: chunks=1 chunks_fts=1 meta=1
```

- Observed result after fix: the Windows CI proof command completed successfully on `win32`; `openclaw memory index --force` updated the memory index, and the script opened the resulting sqlite database and verified readable indexed content.
- What was not tested: I did not reproduce the original locked-handle `EPERM` from a user machine; the PR combines real Windows CLI/index-readability proof with deterministic source-level coverage of persistent `EPERM` fallback behavior.
- Proof limitations or environment constraints: GitHub Actions proves the documented memory indexing path works on Windows after this patch, while the focused regression test injects persistent `EPERM` to force the exact fallback branch.
- Before evidence (optional but encouraged): before this patch, the same persistent `EPERM` path would exhaust the rename attempts and throw the original `EPERM` instead of copying and unlinking the index files.

## Tests and validation

Which commands did you run?

- `pnpm exec vitest run extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`
- `node scripts/check-windows-memory-index-proof.mjs`
- `node scripts/run-vitest.mjs test/package-scripts.test.ts --reporter=dot`
- `pnpm exec oxfmt --check --threads=1 scripts/check-windows-memory-index-proof.mjs package.json test/package-scripts.test.ts`
- `pnpm exec oxlint scripts/check-windows-memory-index-proof.mjs test/package-scripts.test.ts`
- `pnpm lint --threads=8`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

What regression coverage was added or updated?

Added a deterministic unit regression that forces persistent `EPERM` from rename and asserts the fallback copies and unlinks the base sqlite file plus `-wal`/`-shm` sidecars. Added a Windows CI proof script and package-script coverage to keep `test:windows:ci` exercising the memory index CLI proof.

What failed before this fix, if known?

With persistent `EPERM`, `renameWithRetry` exhausted the retry limit and threw instead of falling back to copy/unlink.

If no test was added, why not?

Focused regression and Windows CLI proof coverage were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Index swap behavior when rename fails for reasons other than the reported persistent Windows `EPERM`.

How is that risk mitigated?

The fallback only runs for `EPERM` after the existing bounded retry loop is exhausted; `ENOENT`, non-transient errors, and non-`EPERM` transient exhaustion keep their previous behavior. Windows CI also verifies the documented memory reindex command completes and leaves a readable sqlite index.

## Current review state

What is the next action?

Ready for ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI is green on the current head, including `check-lint`, `check-test-types`, and `checks-windows-node-test`. Waiting on ClawSweeper to re-review the new Windows proof.
