### PR TITLE
fix(auto-reply): guard tools status inventory reads

### DIFF
--- a/src/auto-reply/status.tools.test.ts
+++ b/src/auto-reply/status.tools.test.ts
@@ -106,6 +106,47 @@ describe("tools product copy", () => {
     expect(text).toContain('Add tools.alsoAllow: ["browser"].');
   });
 
+  it("omits unreadable tool inventory notices instead of failing the whole tools response", () => {
+    const text = buildToolsMessage({
+      agentId: "main",
+      profile: "coding",
+      groups: [
+        {
+          id: "core",
+          label: "Built-in tools",
+          source: "core",
+          tools: [
+            {
+              id: "exec",
+              label: "Exec",
+              description: "Run shell commands",
+              rawDescription: "Run shell commands",
+              source: "core",
+            },
+          ],
+        },
+      ],
+      notices: [
+        {
+          id: "healthy-notice",
+          severity: "info",
+          message: "Healthy notice",
+        },
+        {
+          id: "broken-notice",
+          severity: "warning",
+          get message(): string {
+            throw new Error("notice unavailable");
+          },
+        },
+      ],
+    });
+
+    expect(text).toContain("exec");
+    expect(text).toContain("Healthy notice");
+    expect(text).not.toContain("notice unavailable");
+  });
+
   it("keeps detailed descriptions in verbose mode", () => {
     const text = buildToolsMessage(
       {
@@ -136,6 +177,117 @@ describe("tools product copy", () => {
     expect(text).toContain("Exec - Run shell commands");
     expect(text).toContain("Tool availability depends on this agent's configuration.");
     expect(text).not.toContain("unavailable right now");
+  });
+
+  it("omits unreadable tool inventory entries instead of failing the whole tools response", () => {
+    const text = buildToolsMessage(
+      {
+        agentId: "main",
+        profile: "coding",
+        groups: [
+          {
+            id: "core",
+            label: "Built-in tools",
+            source: "core",
+            tools: [
+              {
+                id: "exec",
+                label: "Exec",
+                description: "Run shell commands",
+                rawDescription: "Run shell commands",
+                source: "core",
+              },
+              {
+                id: "broken",
+                get label(): string {
+                  throw new Error("descriptor unavailable");
+                },
+                description: "Broken descriptor",
+                rawDescription: "Broken descriptor",
+                source: "core",
+              },
+            ],
+          },
+        ],
+      },
+      { verbose: true },
+    );
+
+    expect(text).toContain("Exec - Run shell commands");
+    expect(text).not.toContain("descriptor unavailable");
+    expect(text).not.toContain("Broken descriptor");
+  });
+
+  it("omits unreadable tool inventory array slots instead of failing the whole tools response", () => {
+    const tools = [
+      {
+        id: "exec",
+        label: "Exec",
+        description: "Run shell commands",
+        rawDescription: "Run shell commands",
+        source: "core" as const,
+      },
+    ];
+    Object.defineProperty(tools, "1", {
+      get() {
+        throw new Error("tool slot unavailable");
+      },
+    });
+
+    const text = buildToolsMessage(
+      {
+        agentId: "main",
+        profile: "coding",
+        groups: [
+          {
+            id: "core",
+            label: "Built-in tools",
+            source: "core",
+            tools,
+          },
+        ],
+      },
+      { verbose: true },
+    );
+
+    expect(text).toContain("Exec - Run shell commands");
+    expect(text).not.toContain("tool slot unavailable");
+  });
+
+  it("omits unreadable tool inventory group slots instead of failing the whole tools response", () => {
+    const groups = [
+      {
+        id: "core" as const,
+        label: "Built-in tools",
+        source: "core" as const,
+        tools: [
+          {
+            id: "exec",
+            label: "Exec",
+            description: "Run shell commands",
+            rawDescription: "Run shell commands",
+            source: "core" as const,
+          },
+        ],
+      },
+    ];
+    Object.defineProperty(groups, "1", {
+      get() {
+        throw new Error("group slot unavailable");
+      },
+    });
+
+    const text = buildToolsMessage(
+      {
+        agentId: "main",
+        profile: "coding",
+        groups,
+      },
+      { verbose: true },
+    );
+
+    expect(text).toContain("Exec - Run shell commands");
+    expect(text).not.toContain("group slot unavailable");
   });
 
   it("trims verbose output before schema-like doc blocks", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -15,15 +15,118 @@ export {
   type StatusArgs,
 } from "../status/status-message.js";
 
+type ToolsInventoryGroup = EffectiveToolInventoryResult["groups"][number];
+type ToolsInventoryEntry = ToolsInventoryGroup["tools"][number];
+type ToolsInventorySource = ToolsInventoryGroup["source"];
+type ToolsInventoryNotice = NonNullable<EffectiveToolInventoryResult["notices"]>[number];
+
 type ToolsMessageItem = {
   id: string;
   name: string;
   description: string;
   rawDescription: string;
-  source: EffectiveToolInventoryResult["groups"][number]["source"];
+  source: ToolsInventorySource;
   pluginId?: string;
   channelId?: string;
 };
+
+type InventoryStringReadResult = { ok: true; value: string } | { ok: false };
+
+function readInventoryString(read: () => unknown): InventoryStringReadResult {
+  try {
+    const value = read();
+    return typeof value === "string" ? { ok: true, value } : { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readOptionalInventoryString(read: () => unknown): string | undefined {
+  const result = readInventoryString(read);
+  return result.ok ? result.value : undefined;
+}
+
+function readInventoryArrayLength(array: readonly unknown[]): number {
+  try {
+    return array.length;
+  } catch {
+    return 0;
+  }
+}
+
+function readInventoryArrayEntry<T>(array: readonly T[], index: number): T | null {
+  try {
+    return array[index] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isToolsInventorySource(value: unknown): value is ToolsInventorySource {
+  return value === "core" || value === "plugin" || value === "channel" || value === "mcp";
+}
+
+function readToolsInventorySource(tool: ToolsInventoryEntry): ToolsInventorySource {
+  try {
+    const source = tool.source;
+    return isToolsInventorySource(source) ? source : "core";
+  } catch {
+    return "core";
+  }
+}
+
+function readToolsInventoryEntries(group: ToolsInventoryGroup): ToolsInventoryEntry[] | null {
+  try {
+    return Array.isArray(group.tools) ? group.tools : null;
+  } catch {
+    return null;
+  }
+}
+
+function readToolsInventoryGroups(result: EffectiveToolInventoryResult): ToolsInventoryGroup[] {
+  try {
+    return Array.isArray(result.groups) ? result.groups : [];
+  } catch {
+    return [];
+  }
+}
+
+function readToolsInventoryNotices(result: EffectiveToolInventoryResult): ToolsInventoryNotice[] {
+  try {
+    return Array.isArray(result.notices) ? result.notices : [];
+  } catch {
+    return [];
+  }
+}
+
+function readToolsMessageItem(tool: ToolsInventoryEntry): ToolsMessageItem | null {
+  const rawId = readInventoryString(() => tool.id);
+  if (!rawId.ok) {
+    return null;
+  }
+  const id = normalizeToolName(rawId.value);
+  if (!id) {
+    return null;
+  }
+
+  const label = readInventoryString(() => tool.label);
+  const description = readInventoryString(() => tool.description);
+  const rawDescription = readInventoryString(() => tool.rawDescription);
+  if (!label.ok || !description.ok || !rawDescription.ok) {
+    return null;
+  }
+
+  const safeDescription = description.value || "Tool";
+  return {
+    id,
+    name: label.value || id,
+    description: safeDescription,
+    rawDescription: rawDescription.value || safeDescription,
+    source: readToolsInventorySource(tool),
+    pluginId: readOptionalInventoryString(() => tool.pluginId),
+    channelId: readOptionalInventoryString(() => tool.channelId),
+  };
+}
 
 function sortToolsMessageItems(items: ToolsMessageItem[]): ToolsMessageItem[] {
   return items.toSorted((a, b) => a.name.localeCompare(b.name));
@@ -46,26 +149,44 @@ function formatVerboseToolDescription(tool: ToolsMessageItem): string {
   });
 }
 
+function readToolsNoticeMessage(notice: ToolsInventoryNotice): string | null {
+  const message = readInventoryString(() => notice.message);
+  return message.ok && message.value ? message.value : null;
+}
+
 export function buildToolsMessage(
   result: EffectiveToolInventoryResult,
   options?: { verbose?: boolean },
 ): string {
   const groups: Array<{ label: string; tools: ToolsMessageItem[] }> = [];
-  for (const group of result.groups) {
+  const resultGroups = readToolsInventoryGroups(result);
+  const resultGroupsLength = readInventoryArrayLength(resultGroups);
+  for (let groupIndex = 0; groupIndex < resultGroupsLength; groupIndex++) {
+    const group = readInventoryArrayEntry(resultGroups, groupIndex);
+    if (!group) {
+      continue;
+    }
+    const groupTools = readToolsInventoryEntries(group);
+    if (!groupTools) {
+      continue;
+    }
     const tools: ToolsMessageItem[] = [];
-    for (const tool of group.tools) {
-      tools.push({
-        id: normalizeToolName(tool.id),
-        name: tool.label,
-        description: tool.description || "Tool",
-        rawDescription: tool.rawDescription || tool.description || "Tool",
-        source: tool.source,
-        pluginId: tool.pluginId,
-        channelId: tool.channelId,
-      });
+    const groupToolsLength = readInventoryArrayLength(groupTools);
+    for (let index = 0; index < groupToolsLength; index++) {
+      const tool = readInventoryArrayEntry(groupTools, index);
+      if (!tool) {
+        continue;
+      }
+      const item = readToolsMessageItem(tool);
+      if (item) {
+        tools.push(item);
+      }
     }
     if (tools.length > 0) {
-      groups.push({ label: group.label, tools: sortToolsMessageItems(tools) });
+      groups.push({
+        label: readOptionalInventoryString(() => group.label) || "Tools",
+        tools: sortToolsMessageItems(tools),
+      });
     }
   }
 
@@ -103,10 +224,19 @@ export function buildToolsMessage(
   } else {
     lines.push("", "Use /tools verbose for descriptions.");
   }
-  if (result.notices?.length) {
+  const notices = readToolsInventoryNotices(result);
+  if (notices.length) {
     lines.push("", "Notes");
-    for (const notice of result.notices) {
-      lines.push(`  ${notice.message}`);
+    const noticesLength = readInventoryArrayLength(notices);
+    for (let index = 0; index < noticesLength; index++) {
+      const notice = readInventoryArrayEntry(notices, index);
+      if (!notice) {
+        continue;
+      }
+      const message = readToolsNoticeMessage(notice);
+      if (message) {
+        lines.push(`  ${message}`);
+      }
     }
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary

- Guard `/tools` status inventory materialization so an unreadable group, tool entry, array slot, or notice cannot crash the whole tools response.
- Skip malformed entries with throwing required display fields while preserving healthy sibling tools and existing compact/verbose formatting.
- Add focused regressions for a throwing `label` getter beside a healthy tool, throwing group/tool array slots, and a throwing notice `message` getter beside a healthy notice.

## Verification

- Red repro:
  `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts -t "omits unreadable tool inventory entries" --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
  failed pre-patch with `descriptor unavailable`.
- Red notice repro:
  `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts -t "omits unreadable tool inventory notices" --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
  failed pre-patch with `notice unavailable`.
- Red array-slot repro:
  `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts -t "omits unreadable tool inventory array slots" --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
  failed pre-patch with `tool slot unavailable`.
- Red group-slot repro:
  `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts -t "omits unreadable tool inventory group slots" --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
  failed pre-patch with `group slot unavailable`.
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
  passed after the fix and again after rebasing; 1 file / 10 tests.
- `node_modules/.bin/oxfmt --check src/auto-reply/status.ts src/auto-reply/status.tools.test.ts`
  passed.
- `node_modules/.bin/oxlint --deny-warnings src/auto-reply/status.ts src/auto-reply/status.tools.test.ts`
  passed.
- `git diff --check origin/main..HEAD`
  passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  passed with no accepted/actionable findings.

Behavior addressed: `/tools` status rendering now omits unreadable effective inventory groups, entries, array slots, and notices instead of throwing before it can show healthy tools.

Real environment tested: Local linked GWT on macOS using the repo Vitest wrapper with the explicit `auto-reply-core` shard; AWS Crabbox and Blacksmith Testbox were not available from this environment.

Exact steps or command run after this patch: `nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-core.config.ts src/auto-reply/status.tools.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`

Evidence after fix: The full status tools file passed with 10/10 tests, including unreadable-entry, unreadable-array-slot, unreadable-group-slot, and unreadable-notice regressions.

Observed result after fix: The healthy `exec` tool and healthy notice remain in output, while malformed group/entry/slot/notice throw messages are absent.

What was not tested: `pnpm check:changed` could not be completed. `blacksmith testbox list --all` reported unauthenticated, and the AWS Crabbox changed-gate attempt failed before lease creation with coordinator `401 unauthorized`.
