### PR TITLE
fix: trim trailing whitespace from final text-chunking chunk

### DIFF
--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -66,7 +66,10 @@ export function chunkTextForOutbound(text: string, limit: number): string[] {
     remaining = remaining.slice(breakAt).trimStart();
   }
   if (remaining.length > 0 || text.length === 0) {
-    chunks.push(remaining);
+    const finalChunk = remaining.trimEnd();
+    if (finalChunk.length > 0 || text.length === 0) {
+      chunks.push(finalChunk);
+    }
   }
   return chunks;
 }

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -56,6 +56,12 @@ export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 export type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 
 export function chunkTextForOutbound(text: string, limit: number): string[] {
+  if (!text) {
+    return [];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
   const chunks: string[] = [];
   let remaining = text;
   while (remaining.length > limit) {
@@ -65,9 +71,9 @@ export function chunkTextForOutbound(text: string, limit: number): string[] {
     chunks.push(remaining.slice(0, breakAt).trimEnd());
     remaining = remaining.slice(breakAt).trimStart();
   }
-  if (remaining.length > 0 || text.length === 0) {
+  if (remaining.length > 0) {
     const finalChunk = remaining.trimEnd();
-    if (finalChunk.length > 0 || text.length === 0) {
+    if (finalChunk.length > 0) {
       chunks.push(finalChunk);
     }
   }

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -56,9 +56,6 @@ export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 export type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 
 export function chunkTextForOutbound(text: string, limit: number): string[] {
-  if (!text) {
-    return [];
-  }
   if (limit <= 0 || text.length <= limit) {
     return [text];
   }

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -153,7 +153,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";',
     'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";',
     'export type { WizardPrompter } from "openclaw/plugin-sdk/setup";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0 || text.length === 0) { chunks.push(finalChunk); } } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -153,7 +153,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";',
     'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";',
     'export type { WizardPrompter } from "openclaw/plugin-sdk/setup";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0 || text.length === 0) { chunks.push(finalChunk); } } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { if (!text) { return []; } if (limit <= 0 || text.length <= limit) { return [text]; } const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0) { const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0) { chunks.push(finalChunk); } } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -153,7 +153,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";',
     'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";',
     'export type { WizardPrompter } from "openclaw/plugin-sdk/setup";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { if (!text) { return []; } if (limit <= 0 || text.length <= limit) { return [text]; } const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0) { const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0) { chunks.push(finalChunk); } } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { if (limit <= 0 || text.length <= limit) { return [text]; } const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0) { const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0) { chunks.push(finalChunk); } } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -37,4 +37,25 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final chunk", () => {
+    // Issue #64036: final chunk was not trimmed like in-loop chunks
+    expect(chunkTextByBreakResolver("  ! ", 2, (w) => w.lastIndexOf(" ") || w.length)).toEqual([
+      "!",
+    ]);
+    expect(chunkTextByBreakResolver("a b ", 2, (w) => w.lastIndexOf(" ") || w.length)).toEqual([
+      "a",
+      "b",
+    ]);
+    // "abc   " with limit 6 fits in one chunk; not the same code path.
+    // Use a multi-chunk case instead:
+    expect(chunkTextByBreakResolver("abc   def ", 6, (w) => w.lastIndexOf(" "))).toEqual([
+      "abc",
+      "def",
+    ]);
+  });
+
+  it("skips empty final chunk after trimEnd", () => {
+    expect(chunkTextByBreakResolver("   ", 2, (w) => w.lastIndexOf(" ") || w.length)).toEqual([]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -31,7 +31,10 @@ export function chunkTextByBreakResolver(
     remaining = remaining.slice(nextStart).trimStart();
   }
   if (remaining.length) {
-    chunks.push(remaining);
+    const finalChunk = remaining.trimEnd();
+    if (finalChunk.length > 0) {
+      chunks.push(finalChunk);
+    }
   }
   return chunks;
 }


### PR DESCRIPTION
Fixes #64036. The final chunk emitted after the chunking loop was not trimmed with `trimEnd()`, unlike in-loop chunks. Also fix the same bug in Matrix's inline `chunkTextForOutbound` copy and update the guardrail test that hardcodes its source.

## Problem

`chunkTextByBreakResolver` in `src/shared/text-chunking.ts` was inconsistent: chunks emitted inside the loop were trimmed via `trimEnd()`, but the final chunk pushed after the loop preserved trailing whitespace. Matrix's inline `chunkTextForOutbound` in `extensions/matrix/runtime-api.ts` had the same bug.

## Changes

- **`src/shared/text-chunking.ts`**: Apply `trimEnd()` to the final `remaining` chunk and skip pushing when trimmed result is empty.
- **`extensions/matrix/runtime-api.ts`**: Same post-loop trim for the Matrix inline copy. Added under-limit early return (`limit <= 0 || text.length <= limit → [text]`) to match shared helper semantics and preserve the empty-string contract (`chunkTextForOutbound("", 10)` → `[""]`).
- **`src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`**: Update hardcoded Matrix source string to match the fixed implementation.
- **`src/shared/text-chunking.test.ts`**: Add regression tests for final-chunk trailing whitespace and empty-after-trim cases.

## What previous PRs missed

| Gap | #64054 | #64079 | #72491 | #82421 | This PR |
|---|---|---|---|---|---|
| Shared `text-chunking.ts` final chunk trim | ✅ | ✅ | ✅ | ✅ | ✅ |
| Matrix `runtime-api.ts` inline copy | ❌ | ❌ | ✅ | ✅ | ✅ |
| Guardrail test update | ❌ | ❌ | ✅ | ✅ | ✅ |
| Preserve Matrix empty-string contract | ❌ | ❌ | ❌ | ❌ | ✅ |
| Preserve Matrix under-limit contract | ❌ | ❌ | ❌ | ❌ | ✅ |
| No unnecessary Markdown IR scope creep | ✅ | ✅ | ❌ | ❌ | ✅ |

## Real behavior proof

After-fix evidence from a real local setup (Node 22, Bun runtime, macOS ARM64):

**Shared `chunkTextByBreakResolver` — after-fix:**

```
chunkTextByBreakResolver("", 10, () => 5)
=> []

chunkTextByBreakResolver("  ! ", 2, w => w.lastIndexOf(" ") || w.length)
=> ["!"]

chunkTextByBreakResolver("a b ", 2, w => w.lastIndexOf(" ") || w.length)
=> ["a","b"]

chunkTextByBreakResolver("abc   def ", 6, w => w.lastIndexOf(" "))
=> ["abc","def"]

chunkTextByBreakResolver("   ", 2, w => w.lastIndexOf(" ") || w.length)
=> []

chunkTextByBreakResolver("alpha beta gamma", 10, w => w.lastIndexOf(" "))
=> ["alpha","beta gamma"]
```

**Matrix `chunkTextForOutbound` — after-fix:**

```
# Empty string — contract preserved from current main
chunkTextForOutbound("", 10)
=> [""]

# Under-limit trailing whitespace — preserved (text.length <= limit)
chunkTextForOutbound("hello ", 10)
=> ["hello "]

# Zero limit — preserved
chunkTextForOutbound("hello", 0)
=> ["hello"]

# Post-loop residual trailing whitespace — trimmed (the bug fix)
chunkTextForOutbound("alpha beta ", 8)
=> ["alpha","beta"]

# Normal multi-chunk
chunkTextForOutbound("hello world", 5)
=> ["hello","world"]

# Code-block-like content
chunkTextForOutbound("line1\nline2\nline3 ", 10)
=> ["line1","line2","line3"]
```

**Test suite:**

```
pnpm test src/shared/text-chunking.test.ts src/plugin-sdk/text-chunking.test.ts \
  src/auto-reply/chunk.test.ts \
  src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts \
  extensions/matrix/src/outbound.test.ts

→ All 88 tests pass across 4 shards
```
