### PR TITLE
fix(sessions): make transcript migration rewrite atomic

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1713,6 +1713,46 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
+  it("still rejects an inode-replacing rewrite that is not a benign migration", async () => {
+    const sessionFile = await createTempSessionFile();
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "message",
+        id: "legacy-user",
+        message: { role: "user", content: [{ type: "text", text: "hello" }] },
+      })}\n`,
+      "utf8",
+    );
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // Atomically replace the transcript with a *new inode* whose content is not a
+    // parent-linked migration of the snapshot (the first entry's id differs). The
+    // fence no longer requires inode identity, so this proves the per-line
+    // migration check still rejects a hostile temp+rename takeover.
+    const hostile = path.join(path.dirname(sessionFile), "hostile.tmp");
+    await fs.writeFile(
+      hostile,
+      `${[
+        '{"type":"session"}',
+        '{"type":"message","id":"attacker","message":{"role":"user","content":[{"type":"text","text":"injected"}]}}',
+        '{"type":"message","id":"attacker-2","message":{"role":"user","content":[{"type":"text","text":"more"}]}}',
+      ].join("\n")}\n`,
+      "utf8",
+    );
+    await fs.rename(hostile, sessionFile);
+
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
   it("refreshes the prompt fence after an owned write throws", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -738,7 +738,13 @@ async function classifySessionFenceRewrite(params: {
     !params.previous?.fingerprint.exists ||
     !params.current.exists ||
     !params.previous.text ||
-    !sameSessionFileIdentity(params.previous.fingerprint, params.current) ||
+    // Identity (dev+ino) is intentionally NOT required for a benign rewrite: the
+    // linear -> parent-linked migration rewrites the transcript atomically (temp
+    // + rename), producing a new inode. The per-line migration check below is the
+    // real guard, and every caller re-stats before trusting the result (the
+    // transcript-only branch in assertSessionFileFence and mergePromptReleased-
+    // SessionChange), so a rename-capable writer cannot swap content past the
+    // trust boundary (TOCTOU). The allowAnyMessage-gated size cap is preserved.
     (!params.allowAnyMessage &&
       params.current.size > BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_RESULT_BYTES)) ||
     params.current.size > MAX_SAFE_FILE_OFFSET
@@ -1457,10 +1463,21 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       current,
     });
     if (changeKind?.kind === "transcript-only" && !params.mergePromptReleasedSessionEntries) {
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceFingerprint = fenceSnapshot.fingerprint;
-      setFenceGeneration(trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration);
-      return;
+      // Re-stat after classification and only adopt the snapshot if it still
+      // matches the fingerprint we just classified as benign. classifySessionFence-
+      // Rewrite no longer requires inode identity (the atomic temp+rename migration
+      // changes the inode), so without this re-check a rename-capable writer could
+      // show benign content to the classifier and then swap other content into the
+      // baseline we trust (TOCTOU). The merge branch below gets the same guarantee
+      // from mergePromptReleasedSessionChange's post-merge re-stat. A mismatch means
+      // the file changed again after acceptance — fall through to the takeover below.
+      const accepted = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+      if (sameSessionFileFingerprint(accepted.fingerprint, current)) {
+        fenceSnapshot = accepted;
+        fenceFingerprint = accepted.fingerprint;
+        setFenceGeneration(trustSessionFileState(sessionFileFenceKey, current) ?? fenceGeneration);
+        return;
+      }
     }
     if (changeKind && params.mergePromptReleasedSessionEntries) {
       const mergedChange = await mergePromptReleasedSessionChange(fenceSnapshot, current);

--- a/src/config/sessions/transcript-append.test.ts
+++ b/src/config/sessions/transcript-append.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { useTempSessionsFixture } from "./test-helpers.js";
+import { appendSessionTranscriptMessage } from "./transcript-append.js";
+import { writeJsonlLines, writeJsonlLinesAtomic } from "./transcript-jsonl.js";
+
+const readLoggingConfig = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/config.js")>();
+  return {
+    ...actual,
+    readLoggingConfig,
+  };
+});
+
+// A legacy "linear" transcript: a session header plus message entries that carry
+// no parentId. The next append triggers migrateLinearTranscriptToParentLinked,
+// which rewrites the whole file in place — the path under test.
+function linearTranscript(): string {
+  return `${[
+    JSON.stringify({ type: "session", version: 1, sessionId: "s1", cwd: "/tmp/cwd" }),
+    JSON.stringify({
+      type: "message",
+      id: "m1",
+      message: { role: "user", content: [{ type: "text", text: "first" }] },
+      timestamp: "2026-01-01T00:00:00.000Z",
+    }),
+    JSON.stringify({
+      type: "message",
+      id: "m2",
+      message: { role: "assistant", content: [{ type: "text", text: "second" }] },
+      timestamp: "2026-01-01T00:00:01.000Z",
+    }),
+  ].join("\n")}\n`;
+}
+
+function readEntries(file: string): Array<Record<string, unknown>> {
+  return fs
+    .readFileSync(file, "utf-8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("writeJsonlLinesAtomic", () => {
+  let dir = "";
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "jsonl-atomic-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes byte-identical content and mode to the non-atomic writeJsonlLines", async () => {
+    // Verbatim-preserved non-JSON line included to prove the migration's
+    // pass-through lines are not reserialized differently by the atomic path.
+    const lines = ['{"type":"session","version":3}', '{"id":"a","parentId":null}', "corrupt line"];
+    const plain = path.join(dir, "plain.jsonl");
+    const atomic = path.join(dir, "atomic.jsonl");
+
+    await writeJsonlLines(plain, lines, { mode: 0o600 });
+    await writeJsonlLinesAtomic(atomic, lines, { mode: 0o600 });
+
+    expect(fs.readFileSync(atomic)).toEqual(fs.readFileSync(plain));
+    expect(fs.statSync(atomic).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(plain).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves an existing file untouched and drops the temp when the rename fails", async () => {
+    const target = path.join(dir, "existing.jsonl");
+    const original = "untouched original\n";
+    fs.writeFileSync(target, original, { mode: 0o600 });
+    const renameSpy = vi
+      .spyOn(fsPromises, "rename")
+      .mockRejectedValueOnce(Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }));
+
+    await expect(writeJsonlLinesAtomic(target, ["new content"], { mode: 0o600 })).rejects.toThrow();
+
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(target, "utf-8")).toBe(original);
+    // No partial/temp sibling left behind: only the original file remains.
+    expect(fs.readdirSync(dir)).toEqual(["existing.jsonl"]);
+  });
+});
+
+describe("appendSessionTranscriptMessage - linear migration atomicity", () => {
+  const fixture = useTempSessionsFixture("transcript-migrate-test-");
+
+  beforeEach(() => {
+    readLoggingConfig.mockReset();
+    readLoggingConfig.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function seedLinear(sessionId: string): string {
+    const file = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.writeFileSync(file, linearTranscript(), { mode: 0o600 });
+    return file;
+  }
+
+  it("migrates a linear transcript to parent-linked form on append", async () => {
+    const file = seedLinear("migrate-success");
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: { role: "user", content: [{ type: "text", text: "third" }] },
+      config: { logging: { redactSensitive: "off" } },
+    });
+
+    const entries = readEntries(file);
+    const [header, m1, m2, appended] = entries;
+    expect(header.type).toBe("session");
+    expect(header.version).toBe(3); // header bumped to CURRENT_SESSION_VERSION
+    expect(m1).toMatchObject({ id: "m1", parentId: null });
+    expect(m2).toMatchObject({ id: "m2", parentId: "m1" });
+    expect(appended).toMatchObject({ type: "message", parentId: "m2" });
+    expect(entries).toHaveLength(4);
+  });
+
+  it("keeps the original transcript intact and leaves no temp when the migration write fails", async () => {
+    const file = seedLinear("migrate-fail");
+    const original = fs.readFileSync(file, "utf-8");
+    const before = fs.readdirSync(fixture.sessionsDir()).toSorted();
+    vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(
+      Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }),
+    );
+
+    await expect(
+      appendSessionTranscriptMessage({
+        transcriptPath: file,
+        message: { role: "user", content: [{ type: "text", text: "third" }] },
+        config: { logging: { redactSensitive: "off" } },
+      }),
+    ).rejects.toThrow();
+
+    // Old transcript not lost, no partial rewrite committed, no leftover temp.
+    expect(fs.readFileSync(file, "utf-8")).toBe(original);
+    expect(fs.readdirSync(fixture.sessionsDir()).toSorted()).toEqual(before);
+  });
+
+  it("releases the lock so a retry after an injected failure still completes the migration", async () => {
+    const file = seedLinear("migrate-retry");
+    vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(
+      Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }),
+    );
+
+    await expect(
+      appendSessionTranscriptMessage({
+        transcriptPath: file,
+        message: { role: "user", content: [{ type: "text", text: "third" }] },
+        config: { logging: { redactSensitive: "off" } },
+      }),
+    ).rejects.toThrow();
+
+    // rename now succeeds; the next append must acquire the lock (proving it was
+    // released) and finish the migration the failed attempt rolled back.
+    const result = await appendSessionTranscriptMessage({
+      transcriptPath: file,
+      message: { role: "user", content: [{ type: "text", text: "third-retry" }] },
+      config: { logging: { redactSensitive: "off" } },
+    });
+
+    expect(result.appended).toBe(true);
+    const entries = readEntries(file);
+    expect(entries[0]).toMatchObject({ type: "session", version: 3 });
+    expect(entries[1]).toMatchObject({ id: "m1", parentId: null });
+    expect(entries.at(-1)).toMatchObject({ type: "message", parentId: "m2" });
+    expect(entries).toHaveLength(4);
+  });
+});

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -19,7 +19,7 @@ import {
   serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
-  writeJsonlLines,
+  writeJsonlLinesAtomic,
 } from "./transcript-jsonl.js";
 import {
   streamSessionTranscriptLines,
@@ -302,7 +302,10 @@ async function migrateLinearTranscriptToParentLinked(transcriptPath: string): Pr
     leafId = id;
     output.push(serializeJsonlLine(record));
   }
-  await writeJsonlLines(transcriptPath, output, { mode: 0o600 });
+  // Rewrite atomically: a torn write here (crash/ENOSPC) would otherwise destroy
+  // the user's conversation history mid-migration, since the rewrite replaces the
+  // whole transcript in place.
+  await writeJsonlLinesAtomic(transcriptPath, output, { mode: 0o600 });
   const result: { leafId?: string } = {};
   if (leafId) {
     result.leafId = leafId;

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -1,6 +1,8 @@
 // JSONL helpers centralize newline-safe transcript serialization and writes.
 import { appendFileSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
+import { writeSiblingTempFile } from "../../infra/fs-safe-advanced.js";
 
 type WriteJsonlFileOptions = {
   encoding?: BufferEncoding;
@@ -97,4 +99,35 @@ export async function appendSerializedJsonlEntry(
   } finally {
     await handle.close();
   }
+}
+
+// Atomic counterpart to writeJsonlLines: write the serialized lines to a sibling
+// temp file (fsync'd) and rename it over filePath. An interrupted whole-file
+// rewrite (crash, power loss, or ENOSPC mid-write) can then never truncate or
+// partially overwrite the existing file — on failure the original is left intact
+// and the temp is removed, so the caller can retry. Output bytes are identical
+// to writeJsonlLines (same serializeJsonlLines string); only the delivery
+// (temp+rename instead of in-place O_TRUNC) differs. Used by the one-time
+// linear->parent-linked transcript migration, which rewrites the live
+// conversation-history JSONL in place.
+export async function writeJsonlLinesAtomic(
+  filePath: string,
+  lines: readonly string[],
+  options?: Pick<WriteJsonlFileOptions, "encoding" | "mode">,
+): Promise<void> {
+  await writeSiblingTempFile({
+    dir: path.dirname(filePath),
+    chmodDir: false,
+    syncTempFile: true,
+    syncParentDir: true,
+    ...(options?.mode !== undefined ? { mode: options.mode } : {}),
+    writeTemp: async (tempPath) => {
+      await fs.writeFile(tempPath, serializeJsonlLines(lines), {
+        encoding: options?.encoding ?? "utf-8",
+        flag: "wx",
+        ...(options?.mode !== undefined ? { mode: options.mode } : {}),
+      });
+    },
+    resolveFinalPath: () => filePath,
+  });
 }


### PR DESCRIPTION
## Summary

- The one-time legacy linear→parent-linked transcript migration rewrote the whole conversation-history JSONL **in place** (`fs.writeFile` = `O_TRUNC` then write). A crash, power loss, or `ENOSPC` mid-write left the transcript empty or partially rewritten — **irreversible loss of user conversation history**.
- New path: the migration rewrite goes through a small `writeJsonlLinesAtomic` helper that writes an **fsync'd sibling temp file and atomically renames it** over the target. A failed rewrite now leaves the original transcript intact and is retryable. **Output bytes are unchanged.**
- The atomic rename changes the transcript's **inode**, which the embedded-attempt takeover fence's benign-rewrite classifier (`classifySessionFenceRewrite`, reached via `classifySessionFenceChange`) previously rejected because it required inode identity. The classifier is adjusted to be **content-based** (its per-line migration check is the real guard), and a **TOCTOU re-stat guard** binds the accepted baseline to the verified fingerprint so it cannot be swapped after benign classification.

Why this matters now: transcripts are a user-facing product artifact (conversation history). The migration fires once per legacy transcript on the next append after upgrade, so any real user upgrading across the linear→parent-linked format change is exposed to one-shot data loss on a mistimed crash/disk-full.

Intended outcome: a failed migration write leaves the existing transcript intact and retryable under the helper's temp+rename+fsync contract.

What success looks like: the migration is atomic (temp+rename+fsync), output is byte-identical, locking/append semantics are unchanged, and the takeover fence still rejects genuine takeovers.

What reviewers should focus on: the fence change in `src/agents/embedded-agent-runner/run/attempt.session-lock.ts` — see **Why the fence change is in scope** below.

### Why the fence change is in scope (please read before flagging it)

This is the non-obvious part of the PR, so it is called out explicitly:

- The atomic write replaces in-place truncate+write with **temp + rename**, which necessarily gives the rewritten transcript a **new inode**.
- `classifySessionFenceRewrite` exists specifically to recognize *this* linear→parent-linked migration as a benign in-process change while an embedded attempt is released for model I/O. It was written for the **in-place** rewrite and gated acceptance on `sameSessionFileIdentity` (same dev+ino).
- With the migration now atomic, that inode gate falsely flags the legitimate migration as `EmbeddedAttemptSessionTakeoverError` (an existing test, *"allows delivery mirror appends that migrate legacy linear transcripts"*, fails without this change). So the fence change is **required by**, not incidental to, the atomicity fix.
- The **safety invariant for this benign-migration exception is content, not identity**: acceptance still requires every prior line to be exactly the parent-linked migration of the release-time snapshot (`lineMatchesLinearTranscriptMigration`) and every appended line to be a transcript-only OpenClaw assistant entry (`delivery-mirror` / `gateway-injected`). An inode-replacing rewrite whose content is not that exact benign shape is **still rejected as a takeover** (covered by a new test).
- The removed inode check only blocked the legitimate atomic temp+rename migration; for this recognizer, the narrow content matcher plus the re-stat baseline check is the meaningful defense.
- **TOCTOU:** because the classifier no longer pins identity, the transcript-only (no-merge) path in `assertSessionFileFence` now re-stats after classification and only adopts the new fence baseline if it still matches the fingerprint that was classified benign — otherwise it falls through to takeover. The merge path already enforces the analogous post-merge re-stat inside `mergePromptReleasedSessionChange`, so the guarantee holds on both paths. This closes the window where a rename-capable writer could show benign content to the check and swap different content into the trusted baseline.
- `classifySessionFenceAdvance` (the pure `O_APPEND` advance path, which is still genuinely in-place) **remains inode-gated** — only the rewrite classifier is relaxed.

## Linked context

Which issue does this close?

Closes: N/A (no tracking issue)

Which issues, PRs, or discussions are related?

Related: N/A; nearby prior art: an atomic temp+rename fix for `auth.json` landed previously (same pattern, different file). The in-flight transcript-writer refactor stack (scoped writer/seam PRs) touches `transcript-append.ts` and may require a trivial rebase; no semantic overlap.

Was this requested by a maintainer or owner? No — proactive data-loss hardening.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** an interrupted one-time linear→parent-linked transcript migration could truncate/partially overwrite the user's conversation-history JSONL, losing it irreversibly.
- **Real environment tested:** Linux, Node 22, OpenClaw worktree at the PR head. A real legacy linear transcript was written to a real session directory on disk and migrated end-to-end through the production `appendSessionTranscriptMessage` (no mocked transcript writer), with a real `rename` failure (`ENOSPC`) injected at the atomic-replace boundary.
- **Exact steps or command run after this patch:** a small harness drove the production migration against a real on-disk transcript and was run with `node --import tsx`; it created a legacy linear transcript, made the next `fs/promises.rename` throw `ENOSPC` once, called `appendSessionTranscriptMessage`, then inspected the on-disk file and retried. The committed deterministic version of the same scenario is `src/config/sessions/transcript-append.test.ts` (runnable by reviewers).
- **Evidence after fix:** live captured terminal output from the on-disk run (production code path, real injected disk-full failure):

  ```text
  transcript: /tmp/.../agents/main/sessions/repro.jsonl
  original bytes: 213, sha=f5d898dab594a9fb

  [1] migration write fails mid-rename (simulated disk-full):
      -> append rejected: ENOSPC: no space left on device, rename
      rejected:            true
      original preserved:  true (213 bytes, byte-for-byte equal)
      no temp left behind: true (dir entries: ["repro.jsonl"])

  [2] retry after the failure (rename restored):
      append succeeded:    true (lock was released after the failure)
      header version:      3 (bumped to current = 3)
      m1 now parent-linked: parentId=null (was linear, no parentId)
      appended entry:      type=message parentId="m2"
      total entries:       4

  RESULT:
    data-loss window closed = true
  ```

  Supplemental regression coverage (not the primary proof): the committed `src/config/sessions/transcript-append.test.ts` encodes the byte-identity / failure-injection / retry invariants, and `attempt.session-lock.test.ts` adds a test that an inode-replacing non-migration rewrite still raises `EmbeddedAttemptSessionTakeoverError`.
- **Observed result after fix:** on the injected disk-full failure the original transcript stays byte-for-byte intact (213 → 213 bytes) with no partial write and no leftover temp sibling, and the call rejects; the retry then acquires the lock (proving it was released) and completes the migration to parent-linked form. Genuine takeovers are still detected.
- **What was not tested:** an actual hardware power-loss / kernel-level write tear (simulated via `rename`-boundary failure injection + `fsync` on temp and parent dir, not a real power cut); Windows rename-over-open-file behavior (POSIX-reasoned: old fd keeps old inode; a Windows sharing-violation surfaces as an operational error, not data loss); a deterministic race-injection test for the TOCTOU re-stat window (that guard is covered by code review, while hostile non-migration replacement is covered by a regression test).
- **Proof limitations or environment constraints:** crash/power-loss durability relies on `fsync` of the temp file and parent directory (best-effort per platform); deterministic proof uses failure injection at the rename boundary, which is the contract under test.
- **Before evidence (optional):** on the base commit the same injected-failure test against the in-place path leaves the transcript truncated/empty (the bug).

## Tests and validation

Which commands did you run?

- `pnpm test src/config/sessions/transcript-append.test.ts` (migration byte-identity + failure-injection + retry)
- `pnpm test src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts` (migration-under-fence + new hostile-rewrite takeover test + all existing takeover tests)
- adjacent: `transcript-append-redact`, `transcript`, `transcript-stream`
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxfmt --check`, `oxlint` — all green

What regression coverage was added or updated?

- `transcript-append.test.ts` (new): (1) `writeJsonlLinesAtomic` is byte-identical and mode-identical (0o600) to `writeJsonlLines`; (2) rename-failure leaves the existing file intact with no temp sibling and rejects; (3) migration succeeds end-to-end producing valid parent-linked output; (4) original transcript intact after an injected migration-write failure; (5) retry after injected failure completes the migration (lock released).
- `attempt.session-lock.test.ts` (+1): an inode-replacing rewrite whose content is *not* a benign migration still raises `EmbeddedAttemptSessionTakeoverError`.

What failed before this fix, if known?

- Before: injecting a failure during the in-place migration write leaves the transcript empty/partial (data loss). After: the original is preserved and the write is retryable.

If no test was added, why not? N/A — failure-injection + invariant tests added.

Total: **105 (`attempt.session-lock`) + 5 (`transcript-append`) focused tests pass**; `tsgo` / `oxfmt` / `oxlint` green.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) — **No** for successful migrations (output bytes identical). The only behavior change is on failure: data is now preserved instead of lost.

Did config, environment, or migration behavior change? (`Yes/No`) — **No** config/env. The transcript *migration* is made crash-safe; its successful output is unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) — **Yes (security-adjacent, please review):** the embedded-attempt takeover fence's benign-migration recognizer is relaxed from inode-identity to content-based, with a compensating TOCTOU re-stat guard. Takeover detection is otherwise unchanged; genuine takeovers still trip (tested).

What is the highest-risk area? The `classifySessionFenceRewrite` relaxation in `attempt.session-lock.ts`.

How is that risk mitigated? The per-line migration content check (unchanged) is the real guard; the in-place advance path stays inode-gated; a TOCTOU re-stat binds the accepted baseline to the verified fingerprint; a new test asserts hostile inode-replacing rewrites still raise takeover.

Privacy note: the sibling temp file holds transcript content during the rewrite; it is created in the same session directory with `0o600` mode and is removed on failure before returning. No new network or secrets surface.

### Intentionally out of scope (split follow-up)

- The sibling non-atomic whole-file rewrites in `agents/embedded-agent-runner/session-manager-init.ts` and `agents/sessions/session-manager.ts` (incl. a `writeFileSync` variant) share the same torn-write shape but live in the SessionManager subsystem and overlap the in-flight SQLite session-store refactor. They are **deliberately not** in this PR and are named here as documented follow-up.
- No SQLite migration, no JSON-store reorder, no commitments changes, no ACP persist-ordering changes.
- **No `CHANGELOG.md` edit** (release-only per repo policy; release notes derive from this PR body).
- No ClawBench: this is a correctness / data-loss fix, not a performance change — proof is failure-injection + invariant tests, not latency/token measurement.

## Current review state

What is the next action? Maintainer review of the fence relaxation rationale + the atomic-write helper.

What is still waiting on author, maintainer, CI, or external proof? Nothing from the author — tests/typecheck/lint green locally; CI pending on push.

Which bot or reviewer comments were addressed? N/A (initial submission).

Rebase note (2026-06-20): rebased onto current `main` to resolve a `CONFLICTING` state, and the session-fence change was re-resolved against upstream's rewritten takeover flow (`classifySessionFenceChange` → `classifySessionFenceAdvance` / `classifySessionFenceRewrite`, plus `mergePromptReleasedSessionChange`). The atomic-write helper and migration call were unchanged; only the fence classifier's inode gate and the no-merge re-stat compensation were re-applied to the new structure, preserving the landed `sessionFenceCtimeDriftIsBenign` (Btrfs ctime), prompt-released merge, and write-lock-release-on-fence-read-throw behaviors. Post-rebase validation: the focused `attempt.session-lock.test.ts` (105) and `transcript-append.test.ts` (5) pass via the repo's `run-vitest` wrapper, and a fresh structured security review returned no actionable findings. No behavior change from the prior approved revision.

