### PR TITLE
fix(plugins): guard command spec projections

### DIFF
--- a/src/plugins/command-specs.test.ts
+++ b/src/plugins/command-specs.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPluginCommandEntrySpecsFromRegistrations,
+  listProviderPluginCommandSpecsFromRegistrations,
+} from "./command-specs.js";
+import type { PluginCommandRegistration } from "./registry-types.js";
+import type { OpenClawPluginCommandDefinition } from "./types.js";
+
+function command(
+  params: Partial<OpenClawPluginCommandDefinition> & {
+    name: string;
+    description: string;
+  },
+): OpenClawPluginCommandDefinition {
+  return {
+    handler: async () => ({ text: "ok" }),
+    ...params,
+  };
+}
+
+function registration(
+  commandDefinition: OpenClawPluginCommandDefinition,
+): PluginCommandRegistration {
+  return {
+    pluginId: "demo",
+    command: commandDefinition,
+    pluginName: "Demo",
+    source: "test",
+  };
+}
+
+function unreadableCommandRegistration(): PluginCommandRegistration {
+  return Object.defineProperty(
+    {
+      pluginId: "bad",
+      pluginName: "Bad",
+    },
+    "command",
+    {
+      enumerable: true,
+      get() {
+        throw new Error("command registration getter exploded");
+      },
+    },
+  ) as PluginCommandRegistration;
+}
+
+describe("plugin command specs", () => {
+  it("skips unreadable command registrations while preserving healthy specs", () => {
+    const badNameCommand = Object.defineProperty(
+      command({ name: "bad", description: "Bad command" }),
+      "name",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("command name getter exploded");
+        },
+      },
+    ) as OpenClawPluginCommandDefinition;
+
+    const specs = getPluginCommandEntrySpecsFromRegistrations([
+      unreadableCommandRegistration(),
+      registration(badNameCommand),
+      registration(
+        command({
+          name: "voice",
+          description: "Voice command",
+          acceptsArgs: true,
+        }),
+      ),
+    ]);
+
+    expect(specs).toEqual([
+      {
+        name: "voice",
+        nativeName: "voice",
+        description: "Voice command",
+        acceptsArgs: true,
+      },
+    ]);
+  });
+
+  it("skips unreadable provider filters while preserving healthy provider specs", () => {
+    const malformedChannelsCommand = command({
+      name: "malformed",
+      description: "Malformed command",
+      channels: [123 as unknown as string],
+    });
+    const unreadableChannelArray = ["discord"];
+    Object.defineProperty(unreadableChannelArray, "0", {
+      enumerable: true,
+      get() {
+        throw new Error("command channel entry getter exploded");
+      },
+    });
+    const unreadableChannelEntryCommand = command({
+      name: "unreadable_entry",
+      description: "Unreadable channel entry command",
+      channels: unreadableChannelArray,
+    });
+    const badChannelsCommand = Object.defineProperty(
+      command({ name: "bad", description: "Bad command" }),
+      "channels",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("command channels getter exploded");
+        },
+      },
+    ) as OpenClawPluginCommandDefinition;
+
+    const specs = listProviderPluginCommandSpecsFromRegistrations(
+      [
+        registration(malformedChannelsCommand),
+        registration(unreadableChannelEntryCommand),
+        registration(badChannelsCommand),
+        registration(
+          command({
+            name: "voice",
+            description: "Voice command",
+            acceptsArgs: true,
+            nativeNames: { discord: "discord_voice" },
+            channels: ["discord"],
+            descriptionLocalizations: { ko: "Voice command ko" },
+          }),
+        ),
+      ],
+      "discord",
+    );
+
+    expect(specs).toEqual([
+      {
+        name: "discord_voice",
+        description: "Voice command",
+        descriptionLocalizations: { ko: "Voice command ko" },
+        acceptsArgs: true,
+      },
+    ]);
+  });
+});

--- a/src/plugins/command-specs.ts
+++ b/src/plugins/command-specs.ts
@@ -2,7 +2,6 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import { resolveReadOnlyChannelCommandDefaults } from "../channels/plugins/read-only-command-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { pluginCommandSupportsChannel } from "./command-registration.js";
 import { pluginCommands } from "./command-registry-state.js";
 import type { PluginCommandRegistration } from "./registry-types.js";
 import type { OpenClawPluginCommandDefinition } from "./types.js";
@@ -21,10 +20,125 @@ export type PluginCommandEntrySpec = {
   nativeName?: string;
 };
 
-function resolvePluginNativeName(
+type ProjectablePluginCommand = {
+  name: string;
+  description: string;
+  acceptsArgs: boolean;
+  nativeNames?: Record<string, string>;
+  descriptionLocalizations?: Record<string, string>;
+  channels?: string[];
+};
+
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecordLike(value)) {
+    return undefined;
+  }
+  const entries = readField(() => Object.entries(value));
+  if (!entries.ok) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, raw] of entries.value) {
+    if (typeof raw === "string") {
+      out[key] = raw;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function readStringArray(value: unknown): string[] | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const out: string[] = [];
+  let index = 0;
+  while (index < value.length) {
+    const entry = readField(() => value[index]);
+    if (!entry.ok || typeof entry.value !== "string") {
+      return null;
+    }
+    out.push(entry.value);
+    index += 1;
+  }
+  return out;
+}
+
+function snapshotPluginCommandForSpecs(
   command: OpenClawPluginCommandDefinition,
-  provider?: string,
-): string {
+): ProjectablePluginCommand | null {
+  const name = readField(() => command.name);
+  if (!name.ok || typeof name.value !== "string" || !name.value.trim()) {
+    return null;
+  }
+  const description = readField(() => command.description);
+  if (!description.ok || typeof description.value !== "string" || !description.value.trim()) {
+    return null;
+  }
+  const channels = readField(() => command.channels);
+  if (!channels.ok) {
+    return null;
+  }
+  const normalizedChannels = readStringArray(channels.value);
+  if (channels.value !== undefined && normalizedChannels == null) {
+    return null;
+  }
+  const acceptsArgs = readField(() => command.acceptsArgs);
+  const nativeNames = readField(() => command.nativeNames);
+  const descriptionLocalizations = readField(() => command.descriptionLocalizations);
+  const nativeNamesValue = nativeNames.ok ? readStringRecord(nativeNames.value) : undefined;
+  const descriptionLocalizationsValue = descriptionLocalizations.ok
+    ? readStringRecord(descriptionLocalizations.value)
+    : undefined;
+  return {
+    name: name.value,
+    description: description.value,
+    acceptsArgs: acceptsArgs.ok ? acceptsArgs.value === true : false,
+    ...(nativeNamesValue ? { nativeNames: nativeNamesValue } : {}),
+    ...(descriptionLocalizationsValue
+      ? { descriptionLocalizations: descriptionLocalizationsValue }
+      : {}),
+    ...(normalizedChannels !== undefined ? { channels: normalizedChannels } : {}),
+  };
+}
+
+function snapshotPluginCommandRegistration(
+  registration: PluginCommandRegistration,
+): ProjectablePluginCommand | null {
+  const command = readField(() => registration.command);
+  return command.ok ? snapshotPluginCommandForSpecs(command.value) : null;
+}
+
+function pluginCommandSupportsChannelSnapshot(
+  command: ProjectablePluginCommand,
+  channel?: string,
+): boolean {
+  if (!command.channels || command.channels.length === 0 || !channel) {
+    return true;
+  }
+  const normalizedChannel = normalizeOptionalLowercaseString(channel) ?? "";
+  return command.channels.some(
+    (entry) => (normalizeOptionalLowercaseString(entry) ?? "") === normalizedChannel,
+  );
+}
+
+function resolvePluginNativeName(command: ProjectablePluginCommand, provider?: string): string {
   const providerName = normalizeOptionalLowercaseString(provider);
   const providerOverride = providerName ? command.nativeNames?.[providerName] : undefined;
   if (typeof providerOverride === "string" && providerOverride.trim()) {
@@ -38,7 +152,7 @@ function resolvePluginNativeName(
   return fallbackName || command.name;
 }
 
-function resolvePluginTextName(command: OpenClawPluginCommandDefinition): string {
+function resolvePluginTextName(command: ProjectablePluginCommand): string {
   const name = command.name.trim();
   return name || command.name;
 }
@@ -102,6 +216,8 @@ export function getPluginCommandEntrySpecs(
   const providerName = normalizeOptionalLowercaseString(provider);
   const nativeCommandsEnabled = pluginNativeCommandsEnabled(providerName, options);
   return Array.from(pluginCommands.values())
+    .map(snapshotPluginCommandForSpecs)
+    .filter((cmd): cmd is ProjectablePluginCommand => cmd !== null)
     .map((cmd) => serializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled))
     .filter((spec): spec is PluginCommandEntrySpec => spec !== null);
 }
@@ -114,9 +230,9 @@ export function getPluginCommandEntrySpecsFromRegistrations(
   const providerName = normalizeOptionalLowercaseString(provider);
   const nativeCommandsEnabled = pluginNativeCommandsEnabled(providerName, options);
   return commands
-    .map((entry) =>
-      serializePluginCommandEntrySpec(entry.command, providerName, nativeCommandsEnabled),
-    )
+    .map(snapshotPluginCommandRegistration)
+    .filter((cmd): cmd is ProjectablePluginCommand => cmd !== null)
+    .map((cmd) => serializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled))
     .filter((spec): spec is PluginCommandEntrySpec => spec !== null);
 }
 
@@ -128,7 +244,9 @@ export function listProviderPluginCommandSpecs(provider?: string): Array<{
   acceptsArgs: boolean;
 }> {
   return Array.from(pluginCommands.values())
-    .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
+    .map(snapshotPluginCommandForSpecs)
+    .filter((cmd): cmd is ProjectablePluginCommand => cmd !== null)
+    .filter((cmd) => pluginCommandSupportsChannelSnapshot(cmd, provider))
     .map((cmd) => serializePluginCommandSpec(cmd, provider));
 }
 
@@ -142,13 +260,14 @@ export function listProviderPluginCommandSpecsFromRegistrations(
   acceptsArgs: boolean;
 }> {
   return commands
-    .map((entry) => entry.command)
-    .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
+    .map(snapshotPluginCommandRegistration)
+    .filter((cmd): cmd is ProjectablePluginCommand => cmd !== null)
+    .filter((cmd) => pluginCommandSupportsChannelSnapshot(cmd, provider))
     .map((cmd) => serializePluginCommandSpec(cmd, provider));
 }
 
 function serializePluginCommandSpec(
-  cmd: OpenClawPluginCommandDefinition,
+  cmd: ProjectablePluginCommand,
   provider?: string,
 ): {
   name: string;
@@ -173,11 +292,11 @@ function serializePluginCommandSpec(
 }
 
 function serializePluginCommandEntrySpec(
-  cmd: OpenClawPluginCommandDefinition,
+  cmd: ProjectablePluginCommand,
   provider: string | undefined,
   nativeCommandsEnabled: boolean,
 ): PluginCommandEntrySpec | null {
-  if (!pluginCommandSupportsChannel(cmd, provider)) {
+  if (!pluginCommandSupportsChannelSnapshot(cmd, provider)) {
     return null;
   }
   const nativeName = nativeCommandsEnabled ? resolvePluginNativeName(cmd, provider) : undefined;


### PR DESCRIPTION
## Summary
- Snapshot plugin command registrations before building command specs for `commands.list` and provider-native command surfaces.
- Skip unreadable or malformed command registrations/fields instead of letting one bad plugin command crash projection or fall open to every provider.
- Add focused regressions for unreadable command registrations, unreadable names, unreadable channel filters, unreadable channel entries, and malformed channel filters while preserving healthy sibling command specs.

## Verification
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/plugins/command-specs.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000` (red pre-fix: command registration/name/channel getters escaped; green post-fix)
- `./node_modules/.bin/oxfmt --write src/plugins/command-specs.ts src/plugins/command-specs.test.ts`
- `./node_modules/.bin/oxlint src/plugins/command-specs.ts src/plugins/command-specs.test.ts`
- `git diff --check origin/main..HEAD`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/plugins/command-specs.test.ts src/gateway/server-methods/commands.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000` (2 files / 27 tests)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (final rerun clean, no accepted/actionable findings)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean, no accepted/actionable findings)

Behavior addressed: plugin command spec projection now isolates unreadable/malformed runtime command registrations instead of crashing `commands.list` or widening malformed channel filters.
Real environment tested: local linked Codex worktree on Node via `nodenv exec node`; Testbox unavailable because `blacksmith testbox list --all` returned unauthenticated; AWS Crabbox changed gate unavailable because coordinator `/v1/runs` and `/v1/leases` returned HTTP 401 unauthorized.
Exact steps or command run after this patch: focused Vitest for `src/plugins/command-specs.test.ts`, combined Vitest for `src/plugins/command-specs.test.ts src/gateway/server-methods/commands.test.ts`, oxfmt, oxlint, `git diff --check`, local autoreview, branch autoreview.
Evidence after fix: unreadable command registration/name/channel getters and malformed channel arrays are skipped while the healthy `voice` command remains listed; existing `commands.list` tests still pass.
Observed result after fix: all focused tests passed and both autoreview runs reported no accepted/actionable findings.
What was not tested: `pnpm check:changed` broad gate was not run because Testbox auth is missing and Crabbox coordinator auth currently returns 401.
