### PR TITLE
fix(status): render sub-1000 token counts as integers (#89735)

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,7 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { formatPromptCacheCompact, formatTokensCompact } from "./status.format.js";
+import {
+  formatKTokens,
+  formatPromptCacheCompact,
+  formatTokensCompact,
+} from "./status.format.js";
+
+describe("formatKTokens", () => {
+  it("renders sub-1000 values as plain integers so 999 does not look like 1k", () => {
+    expect(formatKTokens(0)).toBe("0");
+    expect(formatKTokens(420)).toBe("420");
+    expect(formatKTokens(999)).toBe("999");
+  });
+
+  it("keeps the existing fractional-k rendering for >=1000 values", () => {
+    expect(formatKTokens(1000)).toBe("1.0k");
+    expect(formatKTokens(9999)).toBe("10.0k");
+    expect(formatKTokens(12_000)).toBe("12k");
+  });
+});
 
 describe("status cache formatting", () => {
+  it("renders small-session token totals without the misleading k suffix", () => {
+    expect(
+      formatTokensCompact({
+        inputTokens: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 420,
+        contextTokens: 200_000,
+        percentUsed: 0,
+      }),
+    ).toBe("420/200k (0%)");
+  });
+
+  it("renders small-cache read/write counts as integers", () => {
+    expect(
+      formatPromptCacheCompact({
+        inputTokens: 9_000,
+        cacheRead: 12_000,
+        cacheWrite: 300,
+        totalTokens: 21_300,
+      }),
+    ).toBe("56% hit · read 12k · write 300");
+  });
+});
+
+describe("status cache formatting (legacy)", () => {
   it("formats explicit cache details for verbose status output", () => {
     expect(
       formatPromptCacheCompact({

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -5,8 +5,15 @@ import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
 import type { SessionStatus } from "./status.types.js";
 export { shortenText } from "./text-format.js";
 
-export const formatKTokens = (value: number) =>
-  `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+export const formatKTokens = (value: number) => {
+  // Sub-1000 counts must render as plain integers; otherwise 999 rounds across
+  // the boundary to "1.0k" and small caches/sessions look like they crossed
+  // into thousands. Matches the canonical formatTokenCount sub-1000 branch.
+  if (value < 1000) {
+    return String(Math.round(value));
+  }
+  return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+};
 
 export const formatDuration = (ms: number | null | undefined) => {
   if (ms == null || !Number.isFinite(ms)) {


### PR DESCRIPTION
## Summary

Fix [#89735](https://github.com/openclaw/openclaw/issues/89735).

`formatKTokens` in `src/commands/status.format.ts` always divides by 1000 and appends `k`, so sub-1000 values render as misleading fractional thousands. The worst case is `999 → "1.0k"` — rounding *up across the boundary* — but `420 → "0.4k"` and `cacheWrite: 300 → "0.3k"` show the same drift on small/fresh sessions and small cache lines.

This adds the `value < 1000` integer branch that the canonical `formatTokenCount` in `src/utils/usage-format.ts:97` already uses, leaving the existing `>= 1000` rendering untouched.

### Changes

- `src/commands/status.format.ts`: add `value < 1000` integer branch to `formatKTokens`; existing fractional/`k`/`>=10_000` branches unchanged.
- `src/commands/status.format.test.ts`: add `formatKTokens` regression block covering `0/420/999/1000/9999/12_000`; add small-session and small-cache integration cases on `formatTokensCompact` / `formatPromptCacheCompact`.

### Before / After

| value | before | after |
| ----- | ------ | ----- |
| 0     | `0.0k` | `0`   |
| 420   | `0.4k` | `420` |
| 999   | `1.0k` | `999` |
| 1000  | `1.0k` | `1.0k` |
| 9999  | `10.0k` | `10.0k` |
| 12000 | `12k`  | `12k` |

## Real behavior proof

- **Behavior addressed:** `openclaw status` (and `formatTokensCompact` / `formatPromptCacheCompact`) rendered sub-1000 token counts as fractional `k`, e.g. `999 → "1.0k"`, `420 → "0.4k"`, `cacheWrite: 300 → "0.3k"`. After this change they render as plain integers.
- **Real environment tested:** No — `pnpm test` / `node scripts/run-vitest.mjs` could not run on this contributor box (corepack could not reach `registry.npmjs.org` to materialize `pnpm@11.2.2`, and the local `node_modules` was not populated). Asserted via direct hand-evaluation of the new branch against the unchanged `(value / 1000).toFixed(...)` math, and via the new unit assertions, which encode the exact `before → after` values listed above. CI on this PR is the load-bearing proof.
- **Exact steps or command run after this patch:** Intended local command (blocked by the environment above):
  ```
  pnpm test src/commands/status.format.test.ts
  ```
- **Evidence after fix:** New regression block in `src/commands/status.format.test.ts` pins `formatKTokens(0|420|999|1000|9999|12_000)` and adds small-session / small-cache `formatTokensCompact` / `formatPromptCacheCompact` cases. The existing `read 2.0k / write 1.0k` legacy assertion is intentionally preserved (those values are `>= 1000` and not on the changed branch).
- **Observed result after fix:** Per the table above; `>= 1000` rendering is unchanged.
- **What was not tested:** Did not run `pnpm test` / `pnpm check:changed` / `pnpm tsgo*` locally (environment-blocked, see above). Did not exercise `openclaw status` end-to-end against a real session. CI on this PR should run the new unit cases; happy to follow up with any additional proof a maintainer requests.

## Notes

- Scope is intentionally narrow: only the sub-1000 branch is added; `>= 1000`, the `10_000` integer cutoff, and the `formatTokensCompact` / `formatPromptCacheCompact` callers are unchanged.
- Did not delegate to `formatTokenCount` directly because that helper also collapses `>= 1_000_000` into `m`, which would change the existing `>= 1000` rendering of `formatKTokens` (out of scope for this fix).
