### PR TITLE
fix(gateway): guard node invoke plugin policies

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -116,6 +116,32 @@ function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegi
   };
 }
 
+function createUnreadablePolicyRegistration(): NodeInvokePolicyRegistration {
+  return {
+    pluginId: "bad-policy",
+    get policy() {
+      throw new Error("node invoke policy getter exploded");
+    },
+    pluginConfig: {},
+    source: "test",
+  } as NodeInvokePolicyRegistration;
+}
+
+function createReceiverSensitivePolicy(): NodeInvokePolicyRegistration {
+  const policy = {
+    commands: [DEMO_COMMAND],
+    receiverPayload: { fromReceiver: true },
+    handle(this: { receiverPayload: { fromReceiver: boolean } }) {
+      return { ok: true, payload: this.receiverPayload };
+    },
+  };
+  return {
+    pluginId: DEMO_PLUGIN_ID,
+    policy: policy as NodeInvokePolicyRegistration["policy"],
+    source: "test",
+  };
+}
+
 function createApprovalRequestPolicy(params?: {
   timeoutMs?: number;
 }): NodeInvokePolicyRegistration {
@@ -138,6 +164,47 @@ function setDangerousDemoCommandRegistry(policies: NodeInvokePolicyRegistration[
           command: DEMO_COMMAND,
           dangerous: true,
           handle: async () => "{}",
+        },
+        source: "test",
+      },
+    ],
+    nodeInvokePolicies: policies,
+  } as unknown as PluginRegistry;
+}
+
+function setDangerousDemoCommandRegistryWithUnreadableSibling(
+  policies: NodeInvokePolicyRegistration[] = [],
+) {
+  registryState.current = {
+    nodeHostCommands: [
+      {
+        pluginId: "bad-command",
+        get command() {
+          throw new Error("node host command getter exploded");
+        },
+        source: "test",
+      },
+      {
+        pluginId: DEMO_PLUGIN_ID,
+        command: {
+          command: DEMO_COMMAND,
+          dangerous: true,
+          handle: async () => "{}",
+        },
+        source: "test",
+      },
+    ],
+    nodeInvokePolicies: policies,
+  } as unknown as PluginRegistry;
+}
+
+function setUnreadableDemoCommandRegistry(policies: NodeInvokePolicyRegistration[] = []) {
+  registryState.current = {
+    nodeHostCommands: [
+      {
+        pluginId: "bad-command",
+        get command() {
+          throw new Error("node host command getter exploded");
         },
         source: "test",
       },
@@ -222,6 +289,81 @@ describe("applyPluginNodeInvokePolicy", () => {
       timeoutMs: undefined,
       idempotencyKey: undefined,
     });
+  });
+
+  it("skips unreadable sibling policies while preserving a matching plugin policy", async () => {
+    setDangerousDemoCommandRegistry([
+      createUnreadablePolicyRegistration(),
+      createDemoPolicy((ctx: OpenClawPluginNodeInvokePolicyContext) => ctx.invokeNode()),
+    ]);
+    const { context, invoke } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    expect(result).toStrictEqual({ ok: true, payload: { ok: true, value: 1 }, payloadJSON: null });
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when policy registration cannot be checked", async () => {
+    setDangerousDemoCommandRegistry([createUnreadablePolicyRegistration()]);
+    const { context, invoke } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    if (result === null) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.code).toBe("PLUGIN_POLICY_UNREADABLE");
+    expect(result.details).toStrictEqual({ pluginId: "bad-policy" });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original policy receiver when invoking handlers", async () => {
+    setDangerousDemoCommandRegistry([createReceiverSensitivePolicy()]);
+    const { context } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    expect(result).toStrictEqual({ ok: true, payload: { fromReceiver: true } });
+  });
+
+  it("skips unreadable dangerous command siblings while preserving missing-policy failures", async () => {
+    setDangerousDemoCommandRegistryWithUnreadableSibling();
+    const { context, invoke } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    if (result === null) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.code).toBe("PLUGIN_POLICY_MISSING");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when dangerous command registrations cannot be checked", async () => {
+    setUnreadableDemoCommandRegistry();
+    const { context, invoke } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    if (result === null) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected plugin policy failure");
+    }
+    expect(result.code).toBe("PLUGIN_COMMAND_UNREADABLE");
+    expect(result.details).toStrictEqual({ pluginId: "bad-command" });
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it("binds plugin policy approval requests to the invoking client", async () => {

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -3,9 +3,14 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
-import type { PluginRegistry } from "../plugins/registry-types.js";
+import type {
+  PluginNodeHostCommandRegistration,
+  PluginNodeInvokePolicyRegistration,
+  PluginRegistry,
+} from "../plugins/registry-types.js";
 import type {
   OpenClawPluginNodeInvokePolicyContext,
+  OpenClawPluginNodeInvokePolicy,
   OpenClawPluginNodeInvokePolicyResult,
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
@@ -30,17 +35,258 @@ function parsePayload(payloadJSON: string | null | undefined, payload: unknown):
   }
 }
 
-function findDangerousPluginNodeCommand(registry: PluginRegistry | null, command: string) {
-  const normalizedCommand = command.trim();
-  if (!normalizedCommand) {
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+type MatchedNodeInvokePolicy = {
+  commandList: string[];
+  handle: OpenClawPluginNodeInvokePolicy["handle"];
+  pluginId: string;
+  pluginConfig?: Record<string, unknown>;
+  policy: OpenClawPluginNodeInvokePolicy;
+};
+
+type PolicyReadResult =
+  | { ok: true; entry: MatchedNodeInvokePolicy }
+  | { ok: false; pluginId?: string };
+
+type PolicyLookupResult =
+  | { kind: "matched"; entry: MatchedNodeInvokePolicy }
+  | { kind: "blocked"; pluginId?: string }
+  | { kind: "none" };
+
+type DangerousCommandLookupResult =
+  | { kind: "matched"; pluginId: string }
+  | { kind: "blocked"; pluginId?: string }
+  | { kind: "none" };
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readArrayLength(value: readonly unknown[]): number | null {
+  const length = readField(() => value.length);
+  if (
+    !length.ok ||
+    typeof length.value !== "number" ||
+    !Number.isInteger(length.value) ||
+    length.value < 0
+  ) {
     return null;
   }
-  return (
-    registry?.nodeHostCommands?.find(
-      (entry) =>
-        entry.command.dangerous === true && entry.command.command.trim() === normalizedCommand,
-    ) ?? null
-  );
+  return length.value;
+}
+
+function stringArrayIncludes(values: readonly unknown[], target: string): boolean {
+  const length = readArrayLength(values);
+  if (length === null) {
+    return false;
+  }
+  let index = 0;
+  while (index < length) {
+    const value = readField(() => values[index]);
+    if (value.ok && value.value === target) {
+      return true;
+    }
+    index += 1;
+  }
+  return false;
+}
+
+function readStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const length = readArrayLength(value);
+  if (length === null) {
+    return null;
+  }
+  const out: string[] = [];
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => value[index]);
+    if (!entry.ok || typeof entry.value !== "string") {
+      return null;
+    }
+    out.push(entry.value);
+    index += 1;
+  }
+  return out;
+}
+
+function listNodeInvokePolicies(registry: PluginRegistry | null): ReadResult<readonly unknown[]> {
+  const policies = readField(() => registry?.nodeInvokePolicies);
+  if (!policies.ok) {
+    return { ok: false };
+  }
+  if (policies.value === undefined) {
+    return { ok: true, value: [] };
+  }
+  return Array.isArray(policies.value) ? { ok: true, value: policies.value } : { ok: false };
+}
+
+function listNodeHostCommands(registry: PluginRegistry | null): ReadResult<readonly unknown[]> {
+  const commands = readField(() => registry?.nodeHostCommands);
+  if (!commands.ok) {
+    return { ok: false };
+  }
+  if (commands.value === undefined) {
+    return { ok: true, value: [] };
+  }
+  return Array.isArray(commands.value) ? { ok: true, value: commands.value } : { ok: false };
+}
+
+function readPolicyPluginId(registration: unknown): string | undefined {
+  if (!isRecord(registration)) {
+    return undefined;
+  }
+  const typedRegistration = registration as PluginNodeInvokePolicyRegistration;
+  const pluginId = readField(() => typedRegistration.pluginId);
+  return pluginId.ok && typeof pluginId.value === "string" && pluginId.value.trim()
+    ? pluginId.value
+    : undefined;
+}
+
+function readNodeInvokePolicy(registration: unknown): PolicyReadResult {
+  if (!isRecord(registration)) {
+    return { ok: false };
+  }
+  const typedRegistration = registration as PluginNodeInvokePolicyRegistration;
+  const pluginId = readPolicyPluginId(registration);
+  if (!pluginId) {
+    return { ok: false };
+  }
+  const policy = readField(() => typedRegistration.policy);
+  if (!policy.ok || !isRecord(policy.value)) {
+    return { ok: false, pluginId };
+  }
+  const typedPolicy = policy.value as OpenClawPluginNodeInvokePolicy;
+  const commands = readField(() => typedPolicy.commands);
+  const commandList = commands.ok ? readStringArray(commands.value) : null;
+  if (!commandList) {
+    return { ok: false, pluginId };
+  }
+  const handle = readField(() => typedPolicy.handle);
+  if (!handle.ok || typeof handle.value !== "function") {
+    return { ok: false, pluginId };
+  }
+  const pluginConfig = readField(() => typedRegistration.pluginConfig);
+  return {
+    ok: true,
+    entry: {
+      commandList,
+      handle: handle.value,
+      pluginId,
+      policy: typedPolicy,
+      ...(pluginConfig.ok && isRecord(pluginConfig.value)
+        ? { pluginConfig: pluginConfig.value }
+        : {}),
+    },
+  };
+}
+
+function findMatchingPluginNodeInvokePolicy(
+  registry: PluginRegistry | null,
+  command: string,
+): PolicyLookupResult {
+  const policies = listNodeInvokePolicies(registry);
+  if (!policies.ok) {
+    return { kind: "blocked" };
+  }
+  const length = readArrayLength(policies.value);
+  if (length === null) {
+    return { kind: "blocked" };
+  }
+  let hasBlockedPolicy = false;
+  let blockedPluginId: string | undefined;
+  let index = 0;
+  while (index < length) {
+    const registration = readField(() => policies.value[index]);
+    const policy: PolicyReadResult = registration.ok
+      ? readNodeInvokePolicy(registration.value)
+      : { ok: false };
+    if (!policy.ok) {
+      hasBlockedPolicy = true;
+      blockedPluginId ??= policy.pluginId;
+      index += 1;
+      continue;
+    }
+    if (stringArrayIncludes(policy.entry.commandList, command)) {
+      return { kind: "matched", entry: policy.entry };
+    }
+    index += 1;
+  }
+  return hasBlockedPolicy ? { kind: "blocked", pluginId: blockedPluginId } : { kind: "none" };
+}
+
+function findDangerousPluginNodeCommand(
+  registry: PluginRegistry | null,
+  command: string,
+): DangerousCommandLookupResult {
+  const normalizedCommand = command.trim();
+  if (!normalizedCommand) {
+    return { kind: "none" };
+  }
+  const commands = listNodeHostCommands(registry);
+  if (!commands.ok) {
+    return { kind: "blocked" };
+  }
+  const length = readArrayLength(commands.value);
+  if (length === null) {
+    return { kind: "blocked" };
+  }
+  let hasBlockedCommand = false;
+  let blockedPluginId: string | undefined;
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => commands.value[index]);
+    if (!entry.ok || !isRecord(entry.value)) {
+      hasBlockedCommand = true;
+      index += 1;
+      continue;
+    }
+    const typedEntry = entry.value as PluginNodeHostCommandRegistration;
+    const pluginId = readField(() => typedEntry.pluginId);
+    const hostCommand = readField(() => typedEntry.command);
+    if (
+      !pluginId.ok ||
+      typeof pluginId.value !== "string" ||
+      !hostCommand.ok ||
+      !isRecord(hostCommand.value)
+    ) {
+      hasBlockedCommand = true;
+      if (pluginId.ok && typeof pluginId.value === "string" && pluginId.value.trim()) {
+        blockedPluginId ??= pluginId.value;
+      }
+      index += 1;
+      continue;
+    }
+    const typedCommand = hostCommand.value as PluginNodeHostCommandRegistration["command"];
+    const dangerous = readField(() => typedCommand.dangerous);
+    const commandValue = readField(() => typedCommand.command);
+    if (
+      dangerous.ok &&
+      dangerous.value === true &&
+      commandValue.ok &&
+      typeof commandValue.value === "string" &&
+      commandValue.value.trim() === normalizedCommand
+    ) {
+      return { kind: "matched", pluginId: pluginId.value };
+    }
+    if (!dangerous.ok || !commandValue.ok || typeof commandValue.value !== "string") {
+      hasBlockedCommand = true;
+      blockedPluginId ??= pluginId.value;
+    }
+    index += 1;
+  }
+  return hasBlockedCommand ? { kind: "blocked", pluginId: blockedPluginId } : { kind: "none" };
 }
 
 function createApprovalRuntime(params: {
@@ -120,12 +366,26 @@ export async function applyPluginNodeInvokePolicy(params: {
   idempotencyKey?: string;
 }): Promise<OpenClawPluginNodeInvokePolicyResult | null> {
   const registry = getActiveRuntimePluginRegistry();
-  const entry = registry?.nodeInvokePolicies?.find((candidate) =>
-    candidate.policy.commands.includes(params.command),
-  );
-  if (!entry) {
+  const policyLookup = findMatchingPluginNodeInvokePolicy(registry, params.command);
+  if (policyLookup.kind === "blocked") {
+    return {
+      ok: false,
+      code: "PLUGIN_POLICY_UNREADABLE",
+      message: `node.invoke ${params.command} cannot be checked because a plugin node.invoke policy registration is unreadable`,
+      details: { pluginId: policyLookup.pluginId ?? null },
+    };
+  }
+  if (policyLookup.kind === "none") {
     const dangerousCommand = findDangerousPluginNodeCommand(registry, params.command);
-    if (dangerousCommand) {
+    if (dangerousCommand.kind === "blocked") {
+      return {
+        ok: false,
+        code: "PLUGIN_COMMAND_UNREADABLE",
+        message: `node.invoke ${params.command} cannot be checked because a plugin node command registration is unreadable`,
+        details: { pluginId: dangerousCommand.pluginId ?? null },
+      };
+    }
+    if (dangerousCommand.kind === "matched") {
       return {
         ok: false,
         code: "PLUGIN_POLICY_MISSING",
@@ -134,6 +394,7 @@ export async function applyPluginNodeInvokePolicy(params: {
     }
     return null;
   }
+  const entry = policyLookup.entry;
 
   const invokeNode: OpenClawPluginNodeInvokePolicyContext["invokeNode"] = async (
     override = {},
@@ -160,7 +421,7 @@ export async function applyPluginNodeInvokePolicy(params: {
     };
   };
 
-  return await entry.policy.handle({
+  return await entry.handle.call(entry.policy, {
     nodeId: params.nodeSession.nodeId,
     command: params.command,
     params: params.params,


### PR DESCRIPTION
## Summary

- Harden `node.invoke` plugin policy dispatch against unreadable plugin policy and node command registrations.
- Preserve healthy matching policy dispatch, including method-style handler receivers, while failing closed when policy or dangerous-command metadata cannot be checked.
- Add focused gateway regressions for unreadable policy rows, unreadable dangerous-command rows, healthy sibling preservation, and original policy receiver semantics.

## Verification

Behavior addressed: unreadable plugin policy or dangerous node-command registrations could crash or bypass `node.invoke` policy checks instead of producing a controlled policy result.

Real environment tested: local linked OpenClaw worktree on Node via repo Vitest wrapper; Blacksmith Testbox and AWS Crabbox were attempted for broader changed-gate proof.

Exact steps or command run after this patch:
- `./node_modules/.bin/oxfmt --write src/gateway/node-invoke-plugin-policy.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `./node_modules/.bin/oxlint src/gateway/node-invoke-plugin-policy.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `git diff --check origin/main..HEAD`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/gateway/node-invoke-plugin-policy.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`

Evidence after fix:
- Focused gateway Vitest passed: 1 file, 10 tests.
- `oxfmt`, `oxlint`, and `git diff --check` passed.
- Branch autoreview passed with no accepted/actionable findings; `overall: patch is correct (0.86)`.
- Blacksmith Testbox reported unauthenticated.
- AWS Crabbox wrapper reached coordinator setup but failed before lease creation with HTTP 401 on `/v1/runs` and `/v1/leases`.

Observed result after fix: malformed or unreadable policy/command registry rows no longer throw through dispatch or allow ambiguous raw node invocation; healthy matching policy rows still invoke normally, and handler `this` semantics are preserved.

What was not tested: full `pnpm check:changed`, because Testbox auth was unavailable and AWS Crabbox coordinator rejected run/lease creation with 401.
