### PR TITLE
fix(gateway): guard node command policy metadata

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -5,10 +5,15 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type {
+  PluginNodeHostCommandRegistration,
+  PluginNodeInvokePolicyRegistration,
+} from "../plugins/registry-types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   isForegroundRestrictedPluginNodeCommand,
   isNodeCommandAllowed,
+  listDangerousPluginNodeCommands,
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
 } from "./node-command-policy.js";
@@ -18,9 +23,8 @@ describe("gateway/node-command-policy", () => {
     resetPluginRuntimeStateForTest();
   });
 
-  function installCanvasPluginDefaults() {
-    const registry = createEmptyPluginRegistry();
-    (registry.nodeInvokePolicies ??= []).push({
+  function createCanvasPolicyRegistration(): PluginNodeInvokePolicyRegistration {
+    return {
       pluginId: "canvas",
       pluginName: "Canvas",
       source: "/extensions/canvas/index.ts",
@@ -32,7 +36,110 @@ describe("gateway/node-command-policy", () => {
         foregroundRestrictedOnIos: true,
         handle: (ctx) => ctx.invokeNode(),
       },
-    });
+    };
+  }
+
+  function createUnreadablePolicyRegistration(): PluginNodeInvokePolicyRegistration {
+    return {
+      pluginId: "bad-policy",
+      source: "/extensions/bad/index.ts",
+      get policy() {
+        throw new Error("node command policy getter exploded");
+      },
+    };
+  }
+
+  function createUnreadableNodeHostCommandRegistration(): PluginNodeHostCommandRegistration {
+    return {
+      pluginId: "bad-command",
+      source: "/extensions/bad/index.ts",
+      get command() {
+        throw new Error("node command metadata getter exploded");
+      },
+    };
+  }
+
+  function createUnreadableDangerousPolicyRegistration(): PluginNodeInvokePolicyRegistration {
+    return {
+      pluginId: "dangerous-policy",
+      source: "/extensions/bad/index.ts",
+      policy: {
+        commands: ["dangerous.default"],
+        defaultPlatforms: ["windows"],
+        get dangerous() {
+          throw new Error("node policy dangerous getter exploded");
+        },
+        handle: (ctx) => ctx.invokeNode(),
+      },
+    };
+  }
+
+  function createDangerousPolicyWithUnreadableDefaults(): PluginNodeInvokePolicyRegistration {
+    return {
+      pluginId: "dangerous-policy",
+      source: "/extensions/bad/index.ts",
+      policy: {
+        commands: ["dangerous.default"],
+        get defaultPlatforms() {
+          throw new Error("node policy defaultPlatforms getter exploded");
+        },
+        dangerous: true,
+        handle: (ctx) => ctx.invokeNode(),
+      },
+    };
+  }
+
+  function createUnreadableDangerousNodeHostCommandRegistration(): PluginNodeHostCommandRegistration {
+    return {
+      pluginId: "dangerous-command",
+      source: "/extensions/bad/index.ts",
+      command: {
+        command: "plugin.exec",
+        get dangerous() {
+          throw new Error("node command dangerous getter exploded");
+        },
+        handle: async () => "{}",
+      },
+    };
+  }
+
+  function installCanvasPluginDefaults() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeInvokePolicies ??= []).push(createCanvasPolicyRegistration());
+    setActivePluginRegistry(registry);
+  }
+
+  function installUnreadableDangerousPolicy() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeInvokePolicies ??= []).push(createUnreadableDangerousPolicyRegistration());
+    setActivePluginRegistry(registry);
+  }
+
+  function installDangerousPolicyWithUnreadableDefaults() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeInvokePolicies ??= []).push(createDangerousPolicyWithUnreadableDefaults());
+    setActivePluginRegistry(registry);
+  }
+
+  function installUnreadableDangerousNodeHostCommand() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeHostCommands ??= []).push(createUnreadableDangerousNodeHostCommandRegistration());
+    setActivePluginRegistry(registry);
+  }
+
+  function installCanvasPluginDefaultsWithUnreadableSibling() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeInvokePolicies ??= []).push(
+      createUnreadablePolicyRegistration(),
+      createCanvasPolicyRegistration(),
+    );
+    setActivePluginRegistry(registry);
+  }
+
+  function installUnreadableNodeHostCommandSibling() {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeHostCommands ??= []).push(createUnreadableNodeHostCommandRegistration());
+    (registry.nodeInvokePolicies ??= []).push(createCanvasPolicyRegistration());
     setActivePluginRegistry(registry);
   }
 
@@ -104,6 +211,60 @@ describe("gateway/node-command-policy", () => {
 
     expect(allowlist.has("canvas.snapshot")).toBe(true);
     expect(allowlist.has("canvas.present")).toBe(true);
+  });
+
+  it("skips unreadable plugin policy siblings while preserving default commands", () => {
+    installCanvasPluginDefaultsWithUnreadableSibling();
+
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "windows",
+      deviceFamily: "Windows",
+    });
+
+    expect(allowlist.has("canvas.snapshot")).toBe(true);
+    expect(allowlist.has("canvas.present")).toBe(true);
+  });
+
+  it("skips unreadable dangerous command siblings while preserving default commands", () => {
+    installUnreadableNodeHostCommandSibling();
+
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "windows",
+      deviceFamily: "Windows",
+    });
+
+    expect(allowlist.has("canvas.snapshot")).toBe(true);
+    expect(allowlist.has("canvas.present")).toBe(true);
+  });
+
+  it("treats unreadable plugin policy dangerous metadata as dangerous", () => {
+    installUnreadableDangerousPolicy();
+
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "windows",
+      deviceFamily: "Windows",
+    });
+
+    expect(allowlist.has("dangerous.default")).toBe(false);
+    expect(listDangerousPluginNodeCommands()).toEqual(["dangerous.default"]);
+  });
+
+  it("keeps dangerous metadata when policy default platforms are unreadable", () => {
+    installDangerousPolicyWithUnreadableDefaults();
+
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "windows",
+      deviceFamily: "Windows",
+    });
+
+    expect(allowlist.has("dangerous.default")).toBe(false);
+    expect(listDangerousPluginNodeCommands()).toEqual(["dangerous.default"]);
+  });
+
+  it("treats unreadable node host command dangerous metadata as dangerous", () => {
+    installUnreadableDangerousNodeHostCommand();
+
+    expect(listDangerousPluginNodeCommands()).toEqual(["plugin.exec"]);
   });
 
   it("does not grant host command defaults for platform prefix aliases", () => {
@@ -247,5 +408,11 @@ describe("gateway/node-command-policy", () => {
 
     expect(isForegroundRestrictedPluginNodeCommand("canvas.snapshot")).toBe(true);
     expect(isForegroundRestrictedPluginNodeCommand("system.run")).toBe(false);
+  });
+
+  it("skips unreadable foreground restriction siblings while preserving matching metadata", () => {
+    installCanvasPluginDefaultsWithUnreadableSibling();
+
+    expect(isForegroundRestrictedPluginNodeCommand("canvas.snapshot")).toBe(true);
   });
 });

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -7,6 +7,11 @@ import {
   NODE_SYSTEM_RUN_COMMANDS,
 } from "../infra/node-commands.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
+import type {
+  PluginNodeHostCommandRegistration,
+  PluginNodeInvokePolicyRegistration,
+  PluginRegistry,
+} from "../plugins/registry-types.js";
 import { normalizeDeviceMetadataForPolicy } from "./device-metadata-normalization.js";
 import type { NodeSession } from "./node-registry.js";
 
@@ -147,6 +152,159 @@ const DEVICE_FAMILY_TOKEN_RULES: ReadonlyArray<{
   { id: "linux", tokens: ["linux"] },
 ] as const;
 
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+type PluginNodePolicySnapshot = {
+  commands: string[];
+  defaultPlatforms: string[] | null;
+  dangerous: boolean;
+  foregroundRestrictedOnIos: boolean;
+};
+
+type PluginNodeHostCommandSnapshot = {
+  command: string;
+  dangerous: boolean;
+};
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readArrayLength(value: readonly unknown[]): number | null {
+  const length = readField(() => value.length);
+  return length.ok && Number.isInteger(length.value) && length.value >= 0 ? length.value : null;
+}
+
+function readRegistryArray(
+  registry: PluginRegistry | null,
+  read: (registry: PluginRegistry) => unknown,
+): readonly unknown[] {
+  if (!registry) {
+    return [];
+  }
+  const value = readField(() => read(registry));
+  return value.ok && Array.isArray(value.value) ? value.value : [];
+}
+
+function readStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const length = readArrayLength(value);
+  if (length === null) {
+    return null;
+  }
+  const out: string[] = [];
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => value[index]);
+    if (!entry.ok || typeof entry.value !== "string") {
+      return null;
+    }
+    out.push(entry.value);
+    index += 1;
+  }
+  return out;
+}
+
+function readPluginNodePolicy(entry: unknown): PluginNodePolicySnapshot | null {
+  if (!isRecord(entry)) {
+    return null;
+  }
+  const registration = entry as PluginNodeInvokePolicyRegistration;
+  const policy = readField(() => registration.policy);
+  if (!policy.ok || !isRecord(policy.value)) {
+    return null;
+  }
+  const commands = readField(() => policy.value.commands);
+  const commandList = commands.ok ? readStringArray(commands.value) : null;
+  if (!commandList) {
+    return null;
+  }
+  const defaultPlatforms = readField(() => policy.value.defaultPlatforms);
+  const defaultPlatformList =
+    defaultPlatforms.ok && defaultPlatforms.value !== undefined
+      ? readStringArray(defaultPlatforms.value)
+      : [];
+  const dangerous = readField(() => policy.value.dangerous);
+  const foregroundRestrictedOnIos = readField(() => policy.value.foregroundRestrictedOnIos);
+  return {
+    commands: commandList,
+    defaultPlatforms: defaultPlatformList,
+    dangerous: !dangerous.ok || dangerous.value === true,
+    foregroundRestrictedOnIos:
+      foregroundRestrictedOnIos.ok && foregroundRestrictedOnIos.value === true,
+  };
+}
+
+function readPluginNodeHostCommand(entry: unknown): PluginNodeHostCommandSnapshot | null {
+  if (!isRecord(entry)) {
+    return null;
+  }
+  const registration = entry as PluginNodeHostCommandRegistration;
+  const command = readField(() => registration.command);
+  if (!command.ok || !isRecord(command.value)) {
+    return null;
+  }
+  const commandValue = readField(() => command.value.command);
+  if (!commandValue.ok || typeof commandValue.value !== "string") {
+    return null;
+  }
+  const dangerous = readField(() => command.value.dangerous);
+  return {
+    command: commandValue.value,
+    dangerous: !dangerous.ok || dangerous.value === true,
+  };
+}
+
+function listPluginNodePolicies(registry: PluginRegistry | null): PluginNodePolicySnapshot[] {
+  const entries = readRegistryArray(registry, (value) => value.nodeInvokePolicies);
+  const length = readArrayLength(entries);
+  if (length === null) {
+    return [];
+  }
+  const policies: PluginNodePolicySnapshot[] = [];
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => entries[index]);
+    const policy = entry.ok ? readPluginNodePolicy(entry.value) : null;
+    if (policy) {
+      policies.push(policy);
+    }
+    index += 1;
+  }
+  return policies;
+}
+
+function listPluginNodeHostCommands(
+  registry: PluginRegistry | null,
+): PluginNodeHostCommandSnapshot[] {
+  const entries = readRegistryArray(registry, (value) => value.nodeHostCommands);
+  const length = readArrayLength(entries);
+  if (length === null) {
+    return [];
+  }
+  const commands: PluginNodeHostCommandSnapshot[] = [];
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => entries[index]);
+    const command = entry.ok ? readPluginNodeHostCommand(entry.value) : null;
+    if (command) {
+      commands.push(command);
+    }
+    index += 1;
+  }
+  return commands;
+}
+
 function resolvePlatformIdByExactMatch(value: string): Exclude<PlatformId, "unknown"> | undefined {
   if (CANONICAL_PLATFORM_IDS.has(value as Exclude<PlatformId, "unknown">)) {
     return value as Exclude<PlatformId, "unknown">;
@@ -224,12 +382,12 @@ export function listDangerousPluginNodeCommands(): string[] {
     return [];
   }
   const commands = [
-    ...(registry.nodeHostCommands ?? [])
-      .filter((entry) => entry.command.dangerous === true)
-      .map((entry) => entry.command.command),
-    ...(registry.nodeInvokePolicies ?? [])
-      .filter((entry) => entry.policy.dangerous === true)
-      .flatMap((entry) => entry.policy.commands),
+    ...listPluginNodeHostCommands(registry)
+      .filter((entry) => entry.dangerous)
+      .map((entry) => entry.command),
+    ...listPluginNodePolicies(registry)
+      .filter((entry) => entry.dangerous)
+      .flatMap((entry) => entry.commands),
   ];
   return normalizeUniqueStringEntries(commands);
 }
@@ -239,12 +397,11 @@ function listDefaultPluginNodeCommands(platformId: PlatformId): string[] {
   if (!registry) {
     return [];
   }
-  const commands = (registry.nodeInvokePolicies ?? []).flatMap((entry) => {
-    if (entry.policy.dangerous === true) {
+  const commands = listPluginNodePolicies(registry).flatMap((entry) => {
+    if (entry.dangerous) {
       return [];
     }
-    const defaults = entry.policy.defaultPlatforms ?? [];
-    return defaults.includes(platformId) ? entry.policy.commands : [];
+    return entry.defaultPlatforms?.includes(platformId) ? entry.commands : [];
   });
   return normalizeUniqueStringEntries(commands);
 }
@@ -258,10 +415,10 @@ export function isForegroundRestrictedPluginNodeCommand(command: string): boolea
   if (!normalized) {
     return false;
   }
-  return (registry.nodeInvokePolicies ?? []).some(
+  return listPluginNodePolicies(registry).some(
     (entry) =>
-      entry.policy.foregroundRestrictedOnIos === true &&
-      entry.policy.commands.some((policyCommand) => policyCommand.trim() === normalized),
+      entry.foregroundRestrictedOnIos &&
+      entry.commands.some((policyCommand) => policyCommand.trim() === normalized),
   );
 }
 


### PR DESCRIPTION
## Summary

- Harden plugin-backed node command policy projection against unreadable plugin policy and node command metadata.
- Preserve valid plugin default command, dangerous command, and foreground-restriction behavior while treating unreadable `dangerous` flags conservatively.
- Add focused regressions for unreadable sibling metadata, unreadable dangerous flags, and malformed default-platform metadata that must not hide dangerous commands.

## Verification

Behavior addressed: unreadable plugin node policy or node host command metadata could crash allowlist/default-command projection, dangerous-command listing, or foreground restriction checks.

Real environment tested: local linked OpenClaw worktree on Node via repo Vitest wrapper; Blacksmith Testbox and AWS Crabbox were attempted for broader changed-gate proof.

Exact steps or command run after this patch:
- `./node_modules/.bin/oxfmt --check src/gateway/node-command-policy.ts src/gateway/node-command-policy.test.ts`
- `./node_modules/.bin/oxlint src/gateway/node-command-policy.ts src/gateway/node-command-policy.test.ts`
- `git diff --check origin/main..HEAD`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/gateway/node-command-policy.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`

Evidence after fix:
- Focused gateway Vitest passed: 1 file, 19 tests.
- `oxfmt`, `oxlint`, and `git diff --check` passed.
- Branch autoreview passed with no accepted/actionable findings; `overall: patch is correct (0.86)`.
- Blacksmith Testbox reported unauthenticated.
- AWS Crabbox wrapper reached coordinator setup but failed before lease creation with HTTP 401 on `/v1/runs` and `/v1/leases`.

Observed result after fix: malformed or unreadable plugin metadata no longer crashes node command policy projection; valid sibling metadata still contributes defaults/restrictions, and unreadable dangerous flags are treated as dangerous rather than safe.

What was not tested: full `pnpm check:changed`, because Testbox auth was unavailable and AWS Crabbox coordinator rejected run/lease creation with 401.
