### PR TITLE
fix(gateway): guard plugin method scope metadata

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -175,6 +175,44 @@ describe("method scope resolution", () => {
     ).toEqual({ allowed: false, missingScope: "operator.approvals" });
   });
 
+  it("skips unreadable plugin session action siblings while preserving registered scopes", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.sessionActions = [
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        get action() {
+          throw new Error("session action getter exploded");
+        },
+      } as NonNullable<typeof registry.sessionActions>[number],
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        action: {
+          id: "approve",
+          requiredScopes: ["operator.approvals"],
+          handler: () => ({ result: { ok: true } }),
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual(["operator.approvals"]);
+    expect(
+      authorizeOperatorScopesForMethod("plugins.sessionAction", ["operator.write"], {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual({ allowed: false, missingScope: "operator.approvals" });
+  });
+
   it("falls back to broad operator scopes when a dynamic session action is not locally registered", () => {
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {
@@ -201,6 +239,30 @@ describe("method scope resolution", () => {
     const registry = createEmptyPluginRegistry();
     registry.gatewayHandlers["browser.request"] = pluginHandler;
     registry.gatewayMethodDescriptors.push(
+      createPluginGatewayMethodDescriptor({
+        pluginId: "browser",
+        name: "browser.request",
+        handler: pluginHandler,
+        scope: "operator.admin",
+      }),
+    );
+    setActivePluginRegistry(registry);
+
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("browser.request")).toEqual([
+      "operator.admin",
+    ]);
+  });
+
+  it("skips unreadable plugin gateway method descriptor siblings", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["browser.request"] = pluginHandler;
+    registry.gatewayMethodDescriptors.push(
+      {
+        get name() {
+          throw new Error("gateway method descriptor getter exploded");
+        },
+        scope: "operator.read",
+      } as ReturnType<typeof createPluginGatewayMethodDescriptor>,
       createPluginGatewayMethodDescriptor({
         pluginId: "browser",
         name: "browser.request",

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -1,4 +1,8 @@
 import { normalizeOptionalString as normalizeSessionActionParam } from "@openclaw/normalization-core/string-coerce";
+import type {
+  PluginRegistry,
+  PluginSessionActionRegistryRegistration,
+} from "../plugins/registry-types.js";
 import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import { resolveReservedGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import {
@@ -7,6 +11,7 @@ import {
   isDynamicOperatorGatewayMethod,
   resolveCoreOperatorGatewayMethodScope,
 } from "./methods/core-descriptors.js";
+import type { GatewayMethodDescriptor } from "./methods/descriptor.js";
 import {
   ADMIN_SCOPE,
   APPROVALS_SCOPE,
@@ -38,6 +43,92 @@ export const CLI_DEFAULT_OPERATOR_SCOPES: OperatorScope[] = [
   TALK_SECRETS_SCOPE,
 ];
 
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readRegistryArray(
+  registry: PluginRegistry | null | undefined,
+  read: (registry: PluginRegistry) => unknown,
+): readonly unknown[] {
+  if (!registry) {
+    return [];
+  }
+  const value = readField(() => read(registry));
+  return value.ok && Array.isArray(value.value) ? value.value : [];
+}
+
+function readArrayLength(value: readonly unknown[]): number | null {
+  const length = readField(() => value.length);
+  return length.ok && Number.isInteger(length.value) && length.value >= 0 ? length.value : null;
+}
+
+function findPluginGatewayMethodDescriptor(
+  registry: PluginRegistry | null | undefined,
+  method: string,
+): GatewayMethodDescriptor | undefined {
+  const descriptors = readRegistryArray(registry, (value) => value.gatewayMethodDescriptors);
+  const length = readArrayLength(descriptors);
+  if (length === null) {
+    return undefined;
+  }
+  let index = 0;
+  while (index < length) {
+    const descriptor = readField(() => descriptors[index] as GatewayMethodDescriptor);
+    const name: ReadResult<string> = descriptor.ok
+      ? readField(() => descriptor.value.name)
+      : { ok: false };
+    if (name.ok && name.value === method) {
+      return descriptor.value;
+    }
+    index += 1;
+  }
+  return undefined;
+}
+
+function findPluginSessionActionRegistration(params: {
+  actionId: string;
+  pluginId: string;
+  registry: PluginRegistry | null | undefined;
+}): PluginSessionActionRegistryRegistration | undefined {
+  const registrations = readRegistryArray(params.registry, (value) => value.sessionActions);
+  const length = readArrayLength(registrations);
+  if (length === null) {
+    return undefined;
+  }
+  let index = 0;
+  while (index < length) {
+    const registration = readField(
+      () => registrations[index] as PluginSessionActionRegistryRegistration,
+    );
+    const pluginId: ReadResult<string> = registration.ok
+      ? readField(() => registration.value.pluginId)
+      : { ok: false };
+    const action: ReadResult<PluginSessionActionRegistryRegistration["action"]> = registration.ok
+      ? readField(() => registration.value.action)
+      : { ok: false };
+    const actionId: ReadResult<string> = action.ok
+      ? readField(() => action.value.id)
+      : { ok: false };
+    if (
+      pluginId.ok &&
+      pluginId.value === params.pluginId &&
+      actionId.ok &&
+      actionId.value === params.actionId
+    ) {
+      return registration.value;
+    }
+    index += 1;
+  }
+  return undefined;
+}
+
 function resolveScopedMethod(method: string): OperatorScope | undefined {
   // Core descriptors are authoritative, then reserved namespace policy, then active plugin
   // descriptors. Node/dynamic sentinels are intentionally excluded from operator scopes.
@@ -49,8 +140,9 @@ function resolveScopedMethod(method: string): OperatorScope | undefined {
   if (reservedScope) {
     return reservedScope;
   }
-  const pluginDescriptor = getPluginRegistryState()?.activeRegistry?.gatewayMethodDescriptors?.find(
-    (descriptor) => descriptor.name === method,
+  const pluginDescriptor = findPluginGatewayMethodDescriptor(
+    getPluginRegistryState()?.activeRegistry,
+    method,
   );
   const pluginScope = pluginDescriptor?.scope;
   return pluginScope === "node" || pluginScope === "dynamic" ? undefined : pluginScope;
@@ -100,9 +192,11 @@ function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] 
   if (!pluginId || !actionId) {
     return undefined;
   }
-  const registration = getPluginRegistryState()?.activeRegistry?.sessionActions?.find(
-    (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-  );
+  const registration = findPluginSessionActionRegistration({
+    actionId,
+    pluginId,
+    registry: getPluginRegistryState()?.activeRegistry,
+  });
   if (!registration) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Harden plugin gateway method descriptor and session-action scope lookups against unreadable sibling registrations.
- Preserve core/reserved method precedence, healthy plugin scope resolution, and broad CLI fallback behavior for unmatched dynamic actions.
- Add focused method-scope regressions for unreadable descriptor and session-action siblings.

## Verification

Behavior addressed: unreadable plugin gateway method descriptors or plugin session-action registrations could crash operator scope resolution/authorization before healthy sibling metadata was considered.

Real environment tested: local linked OpenClaw worktree on Node via repo Vitest wrapper; Blacksmith Testbox and AWS Crabbox were attempted for broader changed-gate proof.

Exact steps or command run after this patch:
- `./node_modules/.bin/oxfmt --check src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts`
- `./node_modules/.bin/oxlint src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts`
- `git diff --check origin/main..HEAD`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/gateway/method-scopes.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`

Evidence after fix:
- Focused gateway Vitest passed: 1 file, 77 tests.
- `oxfmt`, `oxlint`, and `git diff --check` passed.
- Branch autoreview passed with no accepted/actionable findings; `overall: patch is correct (0.82)`.
- Blacksmith Testbox reported unauthenticated.
- AWS Crabbox wrapper reached coordinator setup but failed before lease creation with HTTP 401 on `/v1/runs` and `/v1/leases`.

Observed result after fix: unreadable plugin method/session-action metadata no longer throws through scope resolution; healthy sibling metadata still controls the required operator scope.

What was not tested: full `pnpm check:changed`, because Testbox auth was unavailable and AWS Crabbox coordinator rejected run/lease creation with 401.
