### PR TITLE
fix(gateway): guard plugin session action dispatch

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -1,4 +1,8 @@
 import { normalizeOptionalString as normalizeSessionActionParam } from "@openclaw/normalization-core/string-coerce";
+import type {
+  PluginRegistry,
+  PluginSessionActionRegistryRegistration,
+} from "../plugins/registry-types.js";
 import { getPluginRegistryState } from "../plugins/runtime-state.js";
 import { resolveReservedGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import {
@@ -37,6 +41,82 @@ export const CLI_DEFAULT_OPERATOR_SCOPES: OperatorScope[] = [
   PAIRING_SCOPE,
   TALK_SECRETS_SCOPE,
 ];
+
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readArrayLength(value: readonly unknown[]): number | null {
+  const length = readField(() => value.length);
+  return length.ok && Number.isInteger(length.value) && length.value >= 0 ? length.value : null;
+}
+
+function listSessionActionRegistrations(
+  registry: PluginRegistry | null | undefined,
+): readonly unknown[] {
+  const entries = readField(() => registry?.sessionActions);
+  return entries.ok && Array.isArray(entries.value) ? entries.value : [];
+}
+
+function findSessionActionRegistration(params: {
+  actionId: string;
+  pluginId: string;
+  registry: PluginRegistry | null | undefined;
+}): PluginSessionActionRegistryRegistration | undefined {
+  const entries = listSessionActionRegistrations(params.registry);
+  const length = readArrayLength(entries);
+  if (length === null) {
+    return undefined;
+  }
+  let index = 0;
+  while (index < length) {
+    const registration = readField(() => entries[index] as PluginSessionActionRegistryRegistration);
+    const pluginId: ReadResult<string> = registration.ok
+      ? readField(() => registration.value.pluginId)
+      : { ok: false };
+    const action: ReadResult<PluginSessionActionRegistryRegistration["action"]> = registration.ok
+      ? readField(() => registration.value.action)
+      : { ok: false };
+    const actionId: ReadResult<string> = action.ok
+      ? readField(() => action.value.id)
+      : { ok: false };
+    if (
+      pluginId.ok &&
+      pluginId.value === params.pluginId &&
+      actionId.ok &&
+      actionId.value === params.actionId
+    ) {
+      return registration.value;
+    }
+    index += 1;
+  }
+  return undefined;
+}
+
+function resolveSessionActionRequiredScopes(
+  registration: PluginSessionActionRegistryRegistration,
+): OperatorScope[] {
+  const action = readField(() => registration.action);
+  const requiredScopes: ReadResult<unknown> = action.ok
+    ? readField(() => action.value.requiredScopes)
+    : { ok: false };
+  if (!requiredScopes.ok || requiredScopes.value === undefined) {
+    return [WRITE_SCOPE];
+  }
+  if (!Array.isArray(requiredScopes.value) || requiredScopes.value.length === 0) {
+    return [WRITE_SCOPE];
+  }
+  const scopes = requiredScopes.value.filter((scope): scope is OperatorScope =>
+    isOperatorScope(scope),
+  );
+  return scopes.length > 0 ? scopes : [WRITE_SCOPE];
+}
 
 function resolveScopedMethod(method: string): OperatorScope | undefined {
   // Core descriptors are authoritative, then reserved namespace policy, then active plugin
@@ -100,14 +180,15 @@ function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] 
   if (!pluginId || !actionId) {
     return undefined;
   }
-  const registration = getPluginRegistryState()?.activeRegistry?.sessionActions?.find(
-    (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-  );
+  const registration = findSessionActionRegistration({
+    actionId,
+    pluginId,
+    registry: getPluginRegistryState()?.activeRegistry,
+  });
   if (!registration) {
     return undefined;
   }
-  const requiredScopes = registration.action.requiredScopes;
-  return requiredScopes && requiredScopes.length > 0 ? [...requiredScopes] : [WRITE_SCOPE];
+  return resolveSessionActionRequiredScopes(registration);
 }
 
 function resolveSessionActionLeastPrivilegeScopes(params: unknown): OperatorScope[] {

--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -11,6 +11,10 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isPluginJsonValue } from "../../plugins/host-hooks.js";
+import type {
+  PluginRegistry,
+  PluginSessionActionRegistryRegistration,
+} from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   validateJsonSchemaValue,
@@ -21,6 +25,108 @@ import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 const log = createSubsystemLogger("gateway/plugin-host-hooks");
+
+type ReadResult<T> = { ok: true; value: T } | { ok: false };
+
+type MatchedSessionAction = {
+  action: PluginSessionActionRegistryRegistration["action"];
+  handler: PluginSessionActionRegistryRegistration["action"]["handler"];
+  requiredScopes: string[] | null;
+  schema: PluginSessionActionRegistryRegistration["action"]["schema"];
+};
+
+function readField<T>(read: () => T): ReadResult<T> {
+  try {
+    return { ok: true, value: read() };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readArrayLength(value: readonly unknown[]): number | null {
+  const length = readField(() => value.length);
+  return length.ok && Number.isInteger(length.value) && length.value >= 0 ? length.value : null;
+}
+
+function listSessionActionRegistrations(registry: PluginRegistry | null): readonly unknown[] {
+  const entries = readField(() => registry?.sessionActions);
+  return entries.ok && Array.isArray(entries.value) ? entries.value : [];
+}
+
+function readRequiredScopes(
+  action: PluginSessionActionRegistryRegistration["action"],
+): string[] | null {
+  const requiredScopes = readField(() => action.requiredScopes);
+  if (!requiredScopes.ok) {
+    return null;
+  }
+  if (requiredScopes.value === undefined) {
+    return [WRITE_SCOPE];
+  }
+  if (!Array.isArray(requiredScopes.value)) {
+    return null;
+  }
+  const length = readArrayLength(requiredScopes.value);
+  if (length === null) {
+    return null;
+  }
+  const scopes: string[] = [];
+  let index = 0;
+  while (index < length) {
+    const scope = readField(() => requiredScopes.value?.[index]);
+    if (!scope.ok || typeof scope.value !== "string") {
+      return null;
+    }
+    scopes.push(scope.value);
+    index += 1;
+  }
+  return scopes.length > 0 ? scopes : [WRITE_SCOPE];
+}
+
+function findSessionActionRegistration(params: {
+  actionId: string;
+  pluginId: string;
+  registry: PluginRegistry | null;
+}): MatchedSessionAction | null {
+  const entries = listSessionActionRegistrations(params.registry);
+  const length = readArrayLength(entries);
+  if (length === null) {
+    return null;
+  }
+  let index = 0;
+  while (index < length) {
+    const entry = readField(() => entries[index] as PluginSessionActionRegistryRegistration);
+    const pluginId: ReadResult<string> = entry.ok
+      ? readField(() => entry.value.pluginId)
+      : { ok: false };
+    const action: ReadResult<PluginSessionActionRegistryRegistration["action"]> = entry.ok
+      ? readField(() => entry.value.action)
+      : { ok: false };
+    const actionId: ReadResult<string> = action.ok
+      ? readField(() => action.value.id)
+      : { ok: false };
+    if (
+      pluginId.ok &&
+      pluginId.value === params.pluginId &&
+      action.ok &&
+      actionId.ok &&
+      actionId.value === params.actionId
+    ) {
+      const handler = readField(() => action.value.handler);
+      const schema = readField(() => action.value.schema);
+      return handler.ok && schema.ok
+        ? {
+            action: action.value,
+            handler: handler.value,
+            requiredScopes: readRequiredScopes(action.value),
+            schema: schema.value,
+          }
+        : null;
+    }
+    index += 1;
+  }
+  return null;
+}
 
 function formatSessionActionPayloadSchemaErrors(errors: JsonSchemaValidationError[]): string {
   return errors.map((error) => error.text).join("; ");
@@ -90,9 +196,7 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
     const pluginLoaded = Boolean(
       registry?.plugins.some((plugin) => plugin.id === pluginId && plugin.status === "loaded"),
     );
-    const registration = (registry?.sessionActions ?? []).find(
-      (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-    );
+    const registration = findSessionActionRegistration({ actionId, pluginId, registry });
     if (!registration || !pluginLoaded) {
       respond(
         false,
@@ -106,10 +210,15 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
     }
     const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
     const hasAdmin = scopes.includes(ADMIN_SCOPE);
-    const requiredScopes =
-      registration.action.requiredScopes && registration.action.requiredScopes.length > 0
-        ? registration.action.requiredScopes
-        : [WRITE_SCOPE];
+    const requiredScopes = registration.requiredScopes;
+    if (!requiredScopes) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "plugin session action metadata unavailable"),
+      );
+      return;
+    }
     // Plugin actions default to write access, while read-only actions can opt
     // down. Admin bypasses all checks and write includes read for UI callers.
     const missingScope = requiredScopes.find(
@@ -138,11 +247,8 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      if (registration.action.schema !== undefined) {
-        if (
-          typeof registration.action.schema !== "boolean" &&
-          !isRecord(registration.action.schema)
-        ) {
+      if (registration.schema !== undefined) {
+        if (typeof registration.schema !== "boolean" && !isRecord(registration.schema)) {
           respond(
             false,
             undefined,
@@ -156,7 +262,7 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
         // Schemas are plugin-provided data; validate their shape before passing
         // them into the shared schema evaluator so malformed plugins fail cleanly.
         const validation = validateJsonSchemaValue({
-          schema: registration.action.schema as JsonSchemaValue,
+          schema: registration.schema as JsonSchemaValue,
           cacheKey: `plugin-session-action:${pluginId}:${actionId}`,
           value: params.payload,
         });
@@ -172,16 +278,18 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
           return;
         }
       }
-      const result = await registration.action.handler({
-        pluginId,
-        actionId,
-        ...(sessionKey ? { sessionKey } : {}),
-        ...(params.payload !== undefined ? { payload: params.payload } : {}),
-        client: {
-          ...(client?.connId ? { connId: client.connId } : {}),
-          scopes: [...scopes],
+      const result = await Reflect.apply(registration.handler, registration.action, [
+        {
+          pluginId,
+          actionId,
+          ...(sessionKey ? { sessionKey } : {}),
+          ...(params.payload !== undefined ? { payload: params.payload } : {}),
+          client: {
+            ...(client?.connId ? { connId: client.connId } : {}),
+            scopes: [...scopes],
+          },
         },
-      });
+      ]);
       if (result !== undefined && !isRecord(result)) {
         respond(
           false,

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -651,6 +651,139 @@ describe("plugin session actions", () => {
     expect(originalScopes).toEqual([READ_SCOPE]);
   });
 
+  it("skips unreadable session action siblings while dispatching a healthy match", async () => {
+    const handler = vi.fn(() => ({ result: { ok: true } }));
+    const registry = createEmptyPluginRegistry();
+    registry.sessionActions = [
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+        get action() {
+          throw new Error("session action getter exploded");
+        },
+      } as NonNullable<typeof registry.sessionActions>[number],
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+        action: {
+          id: "healthy",
+          requiredScopes: [READ_SCOPE],
+          handler,
+        },
+      },
+    ];
+    registry.plugins = [
+      createPluginRecord({
+        id: "session-action-fixture",
+        name: "Session Action Fixture",
+        status: "loaded",
+      }),
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      callPluginSessionActionThroughGatewayForTest({
+        body: {
+          pluginId: "session-action-fixture",
+          actionId: "healthy",
+        },
+        scopes: [READ_SCOPE],
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      payload: { ok: true, result: { ok: true } },
+      error: undefined,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when matching session action required scopes are unreadable", async () => {
+    const handler = vi.fn(() => ({ result: { ok: true } }));
+    const registry = createEmptyPluginRegistry();
+    registry.sessionActions = [
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+        action: {
+          id: "unreadable-scope",
+          get requiredScopes() {
+            throw new Error("session action scopes getter exploded");
+          },
+          handler,
+        },
+      },
+    ];
+    registry.plugins = [
+      createPluginRecord({
+        id: "session-action-fixture",
+        name: "Session Action Fixture",
+        status: "loaded",
+      }),
+    ];
+    setActivePluginRegistry(registry);
+
+    const response = await callPluginSessionActionThroughGatewayForTest({
+      body: {
+        pluginId: "session-action-fixture",
+        actionId: "unreadable-scope",
+      },
+      scopes: [WRITE_SCOPE],
+    });
+    const error = requireHookError(response);
+    expect(error.code).toBe("UNAVAILABLE");
+    expect(error.message).toBe("plugin session action metadata unavailable");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("preserves method-style session action handler receivers", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = function (this: { receiverPayload: { ok: boolean } }) {
+      return { result: this.receiverPayload };
+    };
+    Object.defineProperty(handler, "call", {
+      value: () => {
+        throw new Error("handler call property should not be used");
+      },
+    });
+    registry.sessionActions = [
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+        action: {
+          id: "receiver",
+          receiverPayload: { ok: true },
+          handler,
+        },
+      } as NonNullable<typeof registry.sessionActions>[number],
+    ];
+    registry.plugins = [
+      createPluginRecord({
+        id: "session-action-fixture",
+        name: "Session Action Fixture",
+        status: "loaded",
+      }),
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      callPluginSessionActionForTest({
+        body: {
+          pluginId: "session-action-fixture",
+          actionId: "receiver",
+        },
+        scopes: [WRITE_SCOPE],
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      payload: { ok: true, result: { ok: true } },
+      error: undefined,
+    });
+  });
+
   it("does not dispatch session actions for plugins that are not loaded", async () => {
     const handler = vi.fn(() => ({ result: { stale: true } }));
     const registry = createEmptyPluginRegistry();


### PR DESCRIPTION
Summary
- Guard plugin session action registry traversal in the gateway auth and dispatch paths so unreadable sibling action metadata cannot crash request handling.
- Fail closed when the matching session action required scope metadata is unreadable, without invoking the plugin handler.
- Preserve method-style handler receivers with Reflect.apply while avoiding plugin-controlled handler.call lookups.

Verification
- ./node_modules/.bin/oxfmt --check src/gateway/method-scopes.ts src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts
- ./node_modules/.bin/oxlint src/gateway/method-scopes.ts src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts
- git diff --check
- CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/gateway/method-scopes.test.ts src/plugins/contracts/session-actions.contract.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000
- .agents/skills/autoreview/scripts/autoreview --mode local
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Behavior addressed: Plugin session-action gateway requests no longer crash when the active registry contains unreadable sibling session action metadata, and matching actions with unreadable required scope metadata fail closed before handler dispatch.
Real environment tested: Local sparse Codex worktree on Node via nodenv, with repo symlinked node_modules; remote broad gates attempted but auth-blocked.
Exact steps or command run after this patch: The formatting, lint, diff-check, focused Vitest, local autoreview, and branch autoreview commands listed above were run after the final patch and rebase.
Evidence after fix: Focused Vitest passed 2 shards covering src/plugins/contracts/session-actions.contract.test.ts and src/gateway/method-scopes.test.ts, including 13 plugin contract tests and 75 gateway method-scope tests; both autoreview passes reported no accepted/actionable findings.
Observed result after fix: Healthy session action dispatch skips unreadable sibling entries, unreadable matching requiredScopes returns UNAVAILABLE with no handler call, and method-style handler receivers still work even when the handler has its own call property.
What was not tested: pnpm check:changed was not completed because Blacksmith Testbox reported not authenticated and AWS Crabbox coordinator requests returned HTTP 401 unauthorized.
