### PR TITLE
fix(plugins): guard tool result middleware metadata

### DIFF
--- a/src/plugins/agent-tool-result-middleware.test.ts
+++ b/src/plugins/agent-tool-result-middleware.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { normalizeAgentToolResultMiddlewareRuntimes } from "./agent-tool-result-middleware.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listAgentToolResultMiddlewares,
+  normalizeAgentToolResultMiddlewareRuntimes,
+} from "./agent-tool-result-middleware.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginAgentToolResultMiddlewareRegistration } from "./registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
 
 describe("normalizeAgentToolResultMiddlewareRuntimes", () => {
   it("defaults omitted runtimes to every supported runtime", () => {
@@ -23,5 +33,31 @@ describe("normalizeAgentToolResultMiddlewareRuntimes", () => {
         harnesses: ["codex-app-server"],
       }),
     ).toEqual(["codex"]);
+  });
+});
+
+describe("listAgentToolResultMiddlewares", () => {
+  it("skips unreadable middleware siblings while preserving healthy handlers", () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = () => undefined;
+    registry.agentToolResultMiddlewares = [
+      {
+        pluginId: "broken-middleware",
+        source: "test",
+        get runtimes() {
+          throw new Error("middleware runtimes getter exploded");
+        },
+        handler: () => undefined,
+      } as PluginAgentToolResultMiddlewareRegistration,
+      {
+        pluginId: "healthy-middleware",
+        source: "test",
+        runtimes: ["codex"],
+        handler,
+      } as PluginAgentToolResultMiddlewareRegistration,
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listAgentToolResultMiddlewares("codex")).toEqual([handler]);
   });
 });

--- a/src/plugins/agent-tool-result-middleware.ts
+++ b/src/plugins/agent-tool-result-middleware.ts
@@ -3,6 +3,10 @@ import type {
   AgentToolResultMiddlewareOptions,
   AgentToolResultMiddlewareRuntime,
 } from "./agent-tool-result-middleware-types.js";
+import type {
+  PluginAgentToolResultMiddlewareRegistration,
+  PluginRegistry,
+} from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
 export const AGENT_TOOL_RESULT_MIDDLEWARE_RUNTIMES = [
@@ -71,12 +75,53 @@ export function normalizeAgentToolResultMiddlewareRuntimeIds(
   return normalized;
 }
 
+type MiddlewareSnapshot =
+  | {
+      ok: true;
+      handler: AgentToolResultMiddleware;
+      runtimes: readonly AgentToolResultMiddlewareRuntime[];
+    }
+  | {
+      ok: false;
+    };
+
+function listActiveMiddlewareRegistrations(): readonly PluginAgentToolResultMiddlewareRegistration[] {
+  const registry = getActivePluginRegistry() as PluginRegistry | null | undefined;
+  if (!registry) {
+    return [];
+  }
+  try {
+    return Array.isArray(registry.agentToolResultMiddlewares)
+      ? registry.agentToolResultMiddlewares
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function snapshotMiddlewareRegistration(
+  entry: PluginAgentToolResultMiddlewareRegistration,
+): MiddlewareSnapshot {
+  try {
+    const { runtimes, handler } = entry;
+    if (!Array.isArray(runtimes) || typeof handler !== "function") {
+      return { ok: false };
+    }
+    return { ok: true, runtimes, handler };
+  } catch {
+    return { ok: false };
+  }
+}
+
 export function listAgentToolResultMiddlewares(
   runtime: AgentToolResultMiddlewareRuntime,
 ): AgentToolResultMiddleware[] {
-  return (
-    getActivePluginRegistry()
-      ?.agentToolResultMiddlewares?.filter((entry) => entry.runtimes.includes(runtime))
-      .map((entry) => entry.handler) ?? []
-  );
+  const handlers: AgentToolResultMiddleware[] = [];
+  for (const entry of listActiveMiddlewareRegistrations()) {
+    const registration = snapshotMiddlewareRegistration(entry);
+    if (registration.ok && registration.runtimes.includes(runtime)) {
+      handlers.push(registration.handler);
+    }
+  }
+  return handlers;
 }


### PR DESCRIPTION
Summary
- Guard active plugin tool-result middleware registration reads so malformed sibling metadata cannot crash middleware discovery.
- Skip unreadable/non-array runtime metadata and non-function handlers while preserving healthy middleware ordering.
- Add focused coverage for unreadable middleware siblings.

Verification
- ./node_modules/.bin/oxfmt --check src/plugins/agent-tool-result-middleware.ts src/plugins/agent-tool-result-middleware.test.ts
- ./node_modules/.bin/oxlint src/plugins/agent-tool-result-middleware.ts src/plugins/agent-tool-result-middleware.test.ts
- git diff --check
- CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/plugins/agent-tool-result-middleware.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000
- .agents/skills/autoreview/scripts/autoreview --mode local
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Behavior addressed: Active plugin tool-result middleware discovery no longer crashes when a sibling middleware registration has unreadable runtime metadata.
Real environment tested: Local sparse Codex worktree on Node via nodenv, with repo symlinked node_modules; remote broad gates attempted but auth-blocked.
Exact steps or command run after this patch: The formatting, lint, diff-check, focused Vitest, local autoreview, and branch autoreview commands listed above were run after the final patch and rebase.
Evidence after fix: Focused Vitest passed src/plugins/agent-tool-result-middleware.test.ts with 5 tests, including the unreadable sibling regression; both autoreview passes reported no accepted/actionable findings.
Observed result after fix: listAgentToolResultMiddlewares("codex") skips the unreadable sibling registration and returns the healthy handler in order.
What was not tested: pnpm check:changed was not completed because Blacksmith Testbox reported not authenticated and AWS Crabbox coordinator requests returned HTTP 401 unauthorized.
