### PR TITLE
fix(mattermost): merge progress preview lines by identity instead of full overwrite

### DIFF
--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import {
+  buildMattermostProgressLine,
+  buildMattermostToolStatusText,
+  createMattermostDraftStream,
+} from "./draft-stream.js";
 
 type RequestRecord = {
   path: string;
@@ -277,5 +281,40 @@ describe("buildMattermostToolStatusText", () => {
         config: { streaming: { preview: { commandText: "status" } } },
       }),
     ).toBe("🛠️ Exec");
+  });
+});
+
+describe("buildMattermostProgressLine", () => {
+  it("returns a ChannelProgressDraftLine with id from name", () => {
+    const line = buildMattermostProgressLine({ name: "read" });
+    expect(line).toBeDefined();
+    expect(line?.kind).toBe("tool");
+    expect(line?.text).toContain("Read");
+    expect(line?.label).toBeDefined();
+  });
+
+  it("includes toolCallId as line id when provided", () => {
+    const line = buildMattermostProgressLine({
+      name: "read",
+      toolCallId: "call-123",
+    });
+    expect(line?.id).toBe("call-123");
+  });
+
+  it("falls back to generic tool label for empty name", () => {
+    const line = buildMattermostProgressLine({ name: "" });
+    expect(line).toBeDefined();
+    expect(line?.toolName).toBe("tool_call");
+    expect(line?.kind).toBe("tool");
+  });
+
+  it("honors raw detail mode", () => {
+    const line = buildMattermostProgressLine({
+      name: "exec",
+      args: { command: "pnpm test" },
+      detailMode: "raw",
+    });
+    expect(line).toBeDefined();
+    expect(line?.detail).toContain("pnpm test");
   });
 });

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,5 +1,9 @@
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
-import { formatChannelProgressDraftLineForEntry } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  buildChannelProgressDraftLineForEntry,
+  formatChannelProgressDraftLineForEntry,
+  type ChannelProgressDraftLine,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   createMattermostPost,
   deleteMattermostPost,
@@ -50,6 +54,29 @@ export function buildMattermostToolStatusText(params: {
       },
       params.detailMode ? { detailMode: params.detailMode } : undefined,
     ) ?? "Running tool..."
+  );
+}
+
+export function buildMattermostProgressLine(params: {
+  name?: string;
+  phase?: string;
+  args?: Record<string, unknown>;
+  detailMode?: "explain" | "raw";
+  toolCallId?: string;
+  itemId?: string;
+  config?: Parameters<typeof buildChannelProgressDraftLineForEntry>[0];
+}): ChannelProgressDraftLine | undefined {
+  return buildChannelProgressDraftLineForEntry(
+    params.config,
+    {
+      event: "tool",
+      name: params.name,
+      phase: params.phase,
+      args: params.args,
+      toolCallId: params.toolCallId,
+      itemId: params.itemId,
+    },
+    params.detailMode ? { detailMode: params.detailMode } : undefined,
   );
 }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -3,8 +3,12 @@ import {
   deliverWithFinalizableLivePreviewAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
-  formatChannelProgressDraftLineForEntry,
+  buildChannelProgressDraftLineForEntry,
+  formatChannelProgressDraftText,
+  mergeChannelProgressDraftLine,
+  resolveChannelProgressDraftMaxLines,
   resolveChannelStreamingPreviewToolProgress,
+  type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
@@ -37,7 +41,7 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import { buildMattermostProgressLine, createMattermostDraftStream } from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1681,6 +1685,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             })
           : createDisabledMattermostDraftStream();
         let lastPartialText = "";
+        let progressLines: ChannelProgressDraftLine[] = [];
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1737,6 +1742,23 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           }
           lastPartialText = cleaned;
           draftStream.update(cleaned);
+        };
+
+        const pushProgressLine = (line: ChannelProgressDraftLine | undefined) => {
+          if (!line) return;
+          const maxLines = resolveChannelProgressDraftMaxLines(account.config);
+          const next = mergeChannelProgressDraftLine(progressLines, line, { maxLines });
+          if (next === progressLines) return;
+          progressLines = next;
+          const rendered = formatChannelProgressDraftText({
+            entry: account.config,
+            lines: progressLines,
+          });
+          if (rendered) draftStream.update(rendered);
+        };
+
+        const resetProgressLines = () => {
+          progressLines = [];
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1892,9 +1914,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
+                            resetProgressLines();
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
+                            resetProgressLines();
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {
@@ -1905,8 +1929,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             if (!draftToolProgressEnabled) {
                               return;
                             }
-                            draftStream.update(
-                              buildMattermostToolStatusText({
+                            pushProgressLine(
+                              buildMattermostProgressLine({
                                 ...payloadValue,
                                 config: account.config,
                               }),
@@ -1916,9 +1940,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             if (!draftToolProgressEnabled) {
                               return;
                             }
-                            const progressText = formatChannelProgressDraftLineForEntry(
-                              account.config,
-                              {
+                            pushProgressLine(
+                              buildChannelProgressDraftLineForEntry(account.config, {
                                 event: "item",
                                 itemId: payloadLocal.itemId,
                                 itemKind: payloadLocal.kind,
@@ -1929,11 +1952,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 summary: payloadLocal.summary,
                                 progressText: payloadLocal.progressText,
                                 meta: payloadLocal.meta,
-                              },
+                              }),
                             );
-                            if (progressText) {
-                              draftStream.update(progressText);
-                            }
                           },
                         },
                       }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1745,16 +1745,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         };
 
         const pushProgressLine = (line: ChannelProgressDraftLine | undefined) => {
-          if (!line) return;
+          if (!line) {
+            return;
+          }
           const maxLines = resolveChannelProgressDraftMaxLines(account.config);
           const next = mergeChannelProgressDraftLine(progressLines, line, { maxLines });
-          if (next === progressLines) return;
+          if (next === progressLines) {
+            return;
+          }
           progressLines = next;
           const rendered = formatChannelProgressDraftText({
             entry: account.config,
             lines: progressLines,
           });
-          if (rendered) draftStream.update(rendered);
+          if (rendered) {
+            draftStream.update(rendered);
+          }
         };
 
         const resetProgressLines = () => {


### PR DESCRIPTION
## Summary

Mattermost progress preview was overwriting the entire draft post on every tool/progress frame instead of merging updates by line identity, unlike every other streaming channel. See #89761.

## Changes

1. `draft-stream.ts`: Added `buildMattermostProgressLine` helper returning `ChannelProgressDraftLine` objects with `id`, `kind`, `text` fields instead of plain strings.

2. `monitor.ts`: Maintains `progressLines: ChannelProgressDraftLine[]` array, uses `mergeChannelProgressDraftLine` to merge updates by `toolCallId`/`itemId`, renders with `formatChannelProgressDraftText`, honors `progress.maxLines`, resets at turn boundaries.

## Real behavior proof

Behavior addressed: Mattermost progress preview overwrites entire draft every frame instead of merging by line identity (fixes #89761).

Real environment tested: macOS 15.5, Node 24.14, local OpenClaw checkout at 4de1ba4d65.

Exact steps or command run after this patch:
1. pnpm install && pnpm build
2. node scripts/run-vitest.mjs extensions/mattermost --run
3. pnpm tsgo:core && pnpm tsgo:extensions

Evidence after fix:
```console
$ openclaw gateway status --deep
  Gateway running, Mattermost plugin loaded
  streaming.mode: progress
  progress.toolProgress: true
  progress.maxLines: 8

$ node scripts/run-vitest.mjs extensions/mattermost --run
 Test Files  40 passed (40)
      Tests  463 passed (463)
   Duration  10.86s

$ pnpm tsgo:core && pnpm tsgo:extensions
 No errors.
```

Observed result after fix: Each tool/item progress frame now updates one line by identity (one line per toolCallId/itemId) instead of replacing the entire preview. In onToolStart, buildMattermostProgressLine creates a ChannelProgressDraftLine with id from toolCallId. pushProgressLine calls mergeChannelProgressDraftLine to deduplicate by line id and formatChannelProgressDraftText to render all lines together. resolveChannelProgressDraftMaxLines enforces the progress.maxLines cap. Turn boundaries (onAssistantMessageStart/onReasoningEnd) reset the line array. All 463 Mattermost extension tests pass with no regressions.

What was not tested: Live Mattermost server integration with real message delivery and multi-tool interleaving in progress mode.