### PR TITLE
fix(agents): guard tool inventory metadata

### DIFF
--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -3,7 +3,9 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginToolMetadataRegistration } from "../plugins/host-hooks.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import type { PluginToolMetadataRegistryRegistration } from "../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.js";
 import { getChannelAgentToolMeta } from "./channel-tools.js";
@@ -153,18 +155,101 @@ function disambiguateLabels(entries: EffectiveToolInventoryEntry[]): EffectiveTo
   });
 }
 
+function readPluginToolMetadataArray(): readonly PluginToolMetadataRegistryRegistration[] {
+  const registry = getActivePluginRegistry();
+  if (!registry) {
+    return [];
+  }
+  try {
+    return Array.isArray(registry.toolMetadata) ? registry.toolMetadata : [];
+  } catch {
+    return [];
+  }
+}
+
+function readOptionalPluginToolMetadataString(
+  metadata: PluginToolMetadataRegistration,
+  key: "displayName" | "description",
+): string | undefined {
+  try {
+    const value = metadata[key];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalPluginToolMetadataRisk(
+  metadata: PluginToolMetadataRegistration,
+): PluginToolMetadataRegistration["risk"] | undefined {
+  try {
+    const value = metadata.risk;
+    return value === "low" || value === "medium" || value === "high" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOptionalPluginToolMetadataTags(
+  metadata: PluginToolMetadataRegistration,
+): string[] | undefined {
+  try {
+    return Array.isArray(metadata.tags) ? [...metadata.tags] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function snapshotPluginToolMetadata(
+  entry: PluginToolMetadataRegistryRegistration,
+): [string, PluginToolMetadataRegistration] | null {
+  try {
+    const { pluginId, metadata } = entry;
+    const toolName = metadata.toolName;
+    if (typeof pluginId !== "string" || typeof toolName !== "string" || !toolName.trim()) {
+      return null;
+    }
+    const snapshot: PluginToolMetadataRegistration = { toolName };
+    const displayName = readOptionalPluginToolMetadataString(metadata, "displayName");
+    if (displayName !== undefined) {
+      snapshot.displayName = displayName;
+    }
+    const description = readOptionalPluginToolMetadataString(metadata, "description");
+    if (description !== undefined) {
+      snapshot.description = description;
+    }
+    const risk = readOptionalPluginToolMetadataRisk(metadata);
+    if (risk !== undefined) {
+      snapshot.risk = risk;
+    }
+    const tags = readOptionalPluginToolMetadataTags(metadata);
+    if (tags !== undefined) {
+      snapshot.tags = tags;
+    }
+    return [buildPluginToolMetadataKey(pluginId, toolName), snapshot];
+  } catch {
+    return null;
+  }
+}
+
+function buildPluginToolMetadataMap(): ReadonlyMap<string, PluginToolMetadataRegistration> {
+  const metadataByTool = new Map<string, PluginToolMetadataRegistration>();
+  for (const entry of readPluginToolMetadataArray()) {
+    const snapshot = snapshotPluginToolMetadata(entry);
+    if (snapshot) {
+      metadataByTool.set(snapshot[0], snapshot[1]);
+    }
+  }
+  return metadataByTool;
+}
+
 export function buildEffectiveToolInventoryEntries(
   tools: readonly AnyAgentTool[],
   rawToolsByName: ReadonlyMap<string, AnyAgentTool> = new Map(),
 ): EffectiveToolInventoryEntry[] {
   // Key metadata by plugin ownership and tool name so only the owning plugin can
   // project display/risk metadata for its own tool.
-  const pluginToolMetadata = new Map(
-    (getActivePluginRegistry()?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
-  );
+  const pluginToolMetadata = buildPluginToolMetadataMap();
 
   return disambiguateLabels(
     tools

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -838,6 +838,42 @@ describe("resolveEffectiveToolInventory", () => {
     });
   });
 
+  it("skips unreadable plugin tool metadata while building effective inventory", async () => {
+    const registry = createEmptyPluginRegistry();
+    const metadata = {};
+    Object.defineProperty(metadata, "toolName", {
+      enumerable: true,
+      get() {
+        throw new Error("metadata toolName getter exploded");
+      },
+    });
+    registry.toolMetadata = [
+      {
+        pluginId: "docs",
+        pluginName: "Docs",
+        source: "fixture",
+        metadata,
+      } as never,
+    ];
+    setActivePluginRegistry(registry);
+    const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryScoped } =
+      await loadHarness({
+        tools: [mockTool({ name: "docs_lookup", label: "Lookup", description: "Search docs" })],
+        pluginMeta: { docs_lookup: { pluginId: "docs" } },
+      });
+
+    const result = resolveEffectiveToolInventoryScoped({ cfg: {} });
+
+    expect(result.groups[0]?.tools[0]).toEqual({
+      id: "docs_lookup",
+      label: "Lookup",
+      description: "Search docs",
+      rawDescription: "Search docs",
+      source: "plugin",
+      pluginId: "docs",
+    });
+  });
+
   it("prefers displaySummary over raw description", async () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryItem } = await loadHarness({
       tools: [


### PR DESCRIPTION
Summary
- Guard effective tool inventory projection against unreadable plugin tool metadata rows.
- Snapshot readable plugin-owned metadata before projection so malformed rows fall back to plain tool labels/descriptions.
- Add focused coverage for an unreadable plugin metadata toolName getter.

Verification
- ./node_modules/.bin/oxfmt --check src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts
- ./node_modules/.bin/oxlint src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts
- git diff --check
- CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/agents/tools-effective-inventory.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000
- .agents/skills/autoreview/scripts/autoreview --mode local
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Behavior addressed: tools.effective inventory construction no longer crashes when active plugin tool metadata contains unreadable fields.
Real environment tested: Local sparse Codex worktree on Node via nodenv, with repo symlinked node_modules; remote broad gates attempted but auth-blocked.
Exact steps or command run after this patch: The formatting, lint, diff-check, focused Vitest, local autoreview, and branch autoreview commands listed above were run after the final patch and rebase.
Evidence after fix: Focused Vitest passed src/agents/tools-effective-inventory.test.ts with 21 tests, including the unreadable plugin metadata regression; both autoreview passes reported no accepted/actionable findings.
Observed result after fix: The inventory builder skips the unreadable plugin metadata row and returns the plugin tool with its normal label, description, rawDescription, source, and pluginId.
What was not tested: pnpm check:changed was not completed because Blacksmith Testbox reported not authenticated and AWS Crabbox coordinator requests returned HTTP 401 unauthorized.
