### PR TITLE
fix(agents): defense-in-depth direct-channel fallback when ACP subagent announce has no gateway scope

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1430,6 +1430,53 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  // #89718 — When `dispatchGatewayMethodInProcess` throws because no plugin
+  // runtime scope is active AND the fallback gateway context resolver returned
+  // nothing (gateway mid-shutdown / startup race / resolver disabled), the
+  // direct-announce catch must still route the completion via direct channel
+  // delivery so the user is not silently dropped.
+  it("directly delivers direct-message subagent text when in-process gateway dispatch has no scope", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error(
+        "In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.",
+      );
+    }) as unknown as typeof runtimeCallGateway;
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "direct completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        accountId: "acct-1",
+        to: "dm:U123",
+        content: "child completion output",
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
   it("uses in-process agent dispatch for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();
     const dispatchGatewayMethodInProcess = createInProcessGatewayMock({

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -397,6 +397,17 @@ function isIncompleteAnnounceAgentResultError(error: unknown): boolean {
   return /(?:incomplete terminal response|code=incomplete_result)\b/i.test(message);
 }
 
+// `dispatchGatewayMethodInProcess` throws this when the AsyncLocalStorage plugin
+// runtime scope is gone AND the fallback gateway context resolver yielded
+// nothing — typically when a subagent completes after its requester's gateway
+// request has ended and the gateway is mid-shutdown / startup race. The
+// announce path retries the dispatch a few times then surfaces here; without
+// a sibling fallback the user sees no reply at all (#89718).
+function isGatewayScopeUnavailableError(error: unknown): boolean {
+  const message = summarizeDeliveryError(error);
+  return /In-process gateway dispatch requires a gateway request scope/i.test(message);
+}
+
 function isSessionWriteLockAnnounceAgentError(error: unknown): boolean {
   if (isSessionWriteLockAcquireError(error)) {
     return true;
@@ -1437,7 +1448,7 @@ async function sendSubagentAnnounceDirectly(params: {
         params.expectsCompletionMessage &&
         (shouldDeliverAgentFinal || subagentDirectMessageCompletionRequiresMessageTool) &&
         isSubagentCompletion &&
-        isIncompleteAnnounceAgentResultError(err)
+        (isIncompleteAnnounceAgentResultError(err) || isGatewayScopeUnavailableError(err))
       ) {
         const textDelivery = await deliverTextCompletionDirect({
           cfg,


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89718 (Bug 2) reports that ACP subagent runs whose requester main session is fast (5–15s) but whose own runtime is slow (1–2 min) end with the user seeing no reply. Gateway log shows `[warn] Subagent completion direct announce failed for run <id>: In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.` repeated three times, followed by `Subagent announce give up (retry-limit)`. 100% delivery failure when the failure mode is reachable.
- **Root cause (investigated but NOT fixed by this PR)**: `dispatchGatewayMethodInProcessRaw` falls back to `getFallbackGatewayContext()` when the AsyncLocalStorage plugin runtime scope is absent (always the case for detached subagent-completion announces). The fallback resolver IS wired at gateway startup via `setFallbackGatewayContextResolver(() => gatewayRequestContext)` and that wire-up is present in `v2026.5.28`, so under normal operation the announce path resolves a usable context. The fallback state IS cleared by `clearFallbackGatewayContextForServer` on gateway close and on startup failure — the existing `server-plugins.lifecycle.test.ts` test "clears the fallback gateway context after server close" already asserts this exact error message reproduces post-close. The bug is reachable whenever the gateway is closed without restarting, OR when an in-process restart in `run-loop.ts` fails after its predecessor's close has already cleared the fallback (the loop's `catch` block keeps the process alive at "Process will stay alive; fix the issue and restart." with `server = null`). In that "alive but dead" window any detached ACP completion dispatch hits the throw. The structural root cause is that subagent-announce dispatches depend on ambient gateway-lifetime state that can be invalidated mid-flight by gateway lifecycle transitions; fixing that requires either threading a captured context through the subagent registry from spawn to announce, queuing announces across restarts, or coordinated shutdown that drains in-flight subagent announces before clearing fallback state. Each candidate touches owner-area gateway lifecycle or subagent registry persistence and is deliberately out of scope here.
- **Fix (defense-in-depth at the announce protocol layer, NOT a root-cause fix)**: Add a narrow `isGatewayScopeUnavailableError` matcher that recognizes the exact thrown text from `dispatchGatewayMethodInProcessRaw`, then OR it into the existing direct-announce catch branch so the same `deliverTextCompletionDirect` fallback that handles `isIncompleteAnnounceAgentResultError` also handles the No-Scope case. `deliverTextCompletionDirect` calls `sendMessage` directly without re-entering `dispatchGatewayMethodInProcess`, so the fallback cannot recurse into the same scope failure. This converts the user-visible silent message loss into a successful direct channel delivery on every code path where the gateway scope is unavailable, regardless of which gateway-lifetime path produced the loss. The underlying scope-resolver invalidation remains for a separate design-first PR.
- **What changed**:
  - `src/agents/subagent-announce-delivery.ts` — add `isGatewayScopeUnavailableError` matcher next to the existing classifier helpers; OR it into the catch-block fallback condition alongside `isIncompleteAnnounceAgentResultError`. The inline comment names the failure modes (mid-shutdown / startup race / resolver disabled) so the non-obvious "why" survives in source.
  - `src/agents/subagent-announce-delivery.test.ts` — add a regression case mirroring the existing incomplete-result Discord DM fixture but throwing the exact No-Scope error text the production catch sees. The test fails on `main` (`delivered: false`) and passes after this change.
- **What did NOT change (scope boundary)**:
  - Does NOT fix the structural root cause. The underlying gateway-lifetime context drift in `run-loop.ts`'s failed in-process restart path and the analogous post-close window remain reachable; only the user-visible failure mode (silent message loss) is closed off by the announce-protocol-layer fallback added here.
  - Does NOT modify Bug 1 from the same issue (the `acp-spawn-parent-stream` streamTo silent-stall). That is a separate timing concern where the `prompt_submitted` ACP event does not reach the relay in streamTo mode; it warrants its own diagnosis and PR.
  - No retry classification change: the No-Scope error stays out of both transient and permanent lists, so `runAnnounceDeliveryWithRetry` still runs three retries before the catch fires.
  - No config surface (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - No plugin surface (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - No gateway protocol changes.
  - No dependency, lockfile, or shrinkwrap changes.

### Reproduction

1. Spawn an ACP subagent from a channel session.
2. When the dispatch path's AsyncLocalStorage scope is absent (always the case for a detached subagent completion) AND the gateway fallback context resolver has been cleared (any of: gateway closed without restart, in-process restart failed and process is left at "alive but dead", an external test or process called the clear API), the announce path hits `dispatchGatewayMethodInProcess` and throws `In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.`
3. `runAnnounceDeliveryWithRetry` retries three times; each fails with the same error.
4. **Before this PR**: the catch block at the direct-announce path only falls through to `deliverTextCompletionDirect` when the error matches `isIncompleteAnnounceAgentResultError`. The No-Scope error is matched by neither that classifier nor the transient/permanent retry patterns, so the catch reaches its terminal `throw err` and `runSubagentAnnounceFlow` reports `Subagent announce give up (retry-limit)`. The user sees no reply.
5. **After this PR**: the catch block also matches the No-Scope error class and routes the completion via `deliverTextCompletionDirect` — the user receives the subagent result through the same channel/account/threadId the requester used.

Deterministic source reproduction (added as a regression test): inject a `callGateway` mock that throws the production No-Scope error string; the test harness auto-synthesizes the matching `dispatchGatewayMethodInProcess` proxy, so the error reaches the real catch block. Before the fix the test asserts `delivered: false`; after the fix it asserts `delivered: true / path: "direct"` with `sendMessage` invoked on the resolved delivery target.

### Real behavior proof

**Behavior addressed (#89718 Bug 2 — ACP subagent completion silent message loss when gateway scope is unavailable)**: the announce direct-call catch now routes No-Scope dispatch failures through `deliverTextCompletionDirect` instead of throwing through to the give-up branch, so the user sees the subagent result.

**Real environment tested (Linux Codex worktree, Node 22, Vitest against the synthesized `dispatchGatewayMethodInProcess` proxy)**: unit-level repro of the production catch path. The mock harness in `testing.setDepsForTest` proxies the throwing `callGateway` into the same `dispatchGatewayMethodInProcess` invocation that runs in production, so the test path is structurally identical to the runtime path that hits the No-Scope throw site in `server-plugins.ts`. A live ACP subagent run against a real gateway shutdown race was not exercised in this PR, and the structural root cause (gateway-lifetime context drift) is not addressed.

**Exact steps or command run after this patch (repo-root)**: `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce.capture-completion-reply.test.ts src/agents/subagent-announce-dispatch.test.ts` (108/108 passed across the three closest sibling suites); `node scripts/run-tsgo.mjs -p tsconfig.core.json` (clean); `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` (clean); `node scripts/run-oxlint.mjs src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts` (clean); `oxfmt --check` (clean); `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (reported `autoreview clean: no accepted/actionable findings reported / overall: patch is correct (0.84)`).

**Evidence after fix (Vitest output for the touched suite)**:

```text
 Test Files  3 passed (3)
      Tests  108 passed (108)
```

The new regression case `directly delivers direct-message subagent text when in-process gateway dispatch has no scope` asserts `{ delivered: true, path: "direct" }` and that `sendMessage` was invoked with the Discord DM target — both fail before the fix and pass after.

**Observed result after fix (catch block behavior)**: when `runAnnounceAgentCall` throws the No-Scope error and the existing gate conditions for the incomplete-result fallback hold (`expectsCompletionMessage`, `isSubagentCompletion`, and `shouldDeliverAgentFinal` or `subagentDirectMessageCompletionRequiresMessageTool`), `deliverTextCompletionDirect` runs and returns `{ delivered: true, path: "direct" }`. The user receives the subagent completion through the alternate delivery channel instead of the silent give-up the original code produced. The diagnostic trail (`runAnnounceDeliveryWithRetry` retry warnings + `Subagent completion direct announce failed for run <id>: <error>` log) still fires before the fallback runs, so the underlying scope-resolver issue remains visible to operators.

**What was not tested (live ACP runtime + real gateway lifecycle scenarios, AND the root cause itself)**: this PR does not include a live ACP subagent run against a real gateway across a close or failed-restart window. The regex was verified against the production-thrown string at the `dispatchGatewayMethodInProcessRaw` throw site in `src/gateway/server-plugins.ts`. The structural root cause (subagent-announce dispatches depending on ambient gateway-lifetime state) is not addressed: even after this PR, the underlying No-Scope error still surfaces in `runAnnounceDeliveryWithRetry` retry warnings, just no longer terminates in user-visible silent loss.

### Risk / Mitigation

- **Risk**: the new matcher could overmatch and swallow unrelated errors. **Mitigation**: the regex `/In-process gateway dispatch requires a gateway request scope/i` matches only the line at the No-Scope throw site in `server-plugins.ts`. The two adjacent error strings thrown a few lines below (`requires an authenticated plugin request scope`, `requires a scoped client`) intentionally do not match this classifier and remain in the rethrow path.
- **Risk**: the fallback may mask the underlying scope-resolver bug. **Mitigation**: `runAnnounceDeliveryWithRetry` still emits its retry warnings on every attempt before the catch runs, and the existing log line `Subagent completion direct announce failed for run <id>: <error>` still fires when the direct path reports an error — so the diagnostic trail leading to "No scope set and no fallback context available" remains visible in operator logs even when the fallback succeeds at delivery. The root-cause investigation will need to follow up in a separate design-first PR; this PR consciously stops short of that.
- **Risk**: Bug 1 from the same issue is still unresolved. **Mitigation**: marked `Refs #89718` (not `Closes`) to keep the issue open for Bug 1 AND for the structural root cause of Bug 2.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / tools

### Linked Issue/PR

Refs #89718 (defense-in-depth at announce protocol layer for Bug 2; Bug 1 streamTo silent-stall and the structural root cause both remain open for separate PRs)
