### PR TITLE
perf(ui): start chat refresh before bootstrap

### DIFF
--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -274,7 +274,7 @@ describe("connectGateway chat load startup work", () => {
     await vi.waitFor(() =>
       expect(refreshActiveTabMock).toHaveBeenCalledWith(host, { chatStartup: true }),
     );
-    expect(loadAgentsMock).toHaveBeenCalledWith(host);
+    await vi.waitFor(() => expect(loadAgentsMock).toHaveBeenCalledWith(host));
     expect(refreshActiveTabMock).toHaveBeenCalledTimes(1);
 
     agentsList.resolve();
@@ -304,21 +304,20 @@ describe("connectGateway chat load startup work", () => {
     expect(refreshActiveTabMock).toHaveBeenCalledTimes(1);
   });
 
-  it("waits for startup bootstrap before the first chat refresh", async () => {
+  it("does not let slow startup bootstrap block the first chat refresh", async () => {
     const bootstrap = createDeferred();
     const { host, client } = connectHost("chat");
     (host as typeof host & { controlUiBootstrapReady?: Promise<void> }).controlUiBootstrapReady =
       bootstrap.promise;
 
     client.emitHello();
-    await Promise.resolve();
 
-    expect(refreshActiveTabMock).not.toHaveBeenCalled();
-
-    bootstrap.resolve();
     await vi.waitFor(() =>
       expect(refreshActiveTabMock).toHaveBeenCalledWith(host, { chatStartup: true }),
     );
+    await vi.waitFor(() => expect(loadAgentsMock).toHaveBeenCalledWith(host));
+
+    bootstrap.resolve();
   });
 
   it("records connect timing through the Control UI performance buffer", () => {
@@ -347,7 +346,7 @@ describe("connectGateway chat load startup work", () => {
     await vi.waitFor(() =>
       expect(refreshActiveTabMock).toHaveBeenCalledWith(host, { chatStartup: true }),
     );
-    expect(loadAgentsMock).toHaveBeenCalledWith(host);
+    await vi.waitFor(() => expect(loadAgentsMock).toHaveBeenCalledWith(host));
 
     await vi.waitFor(() =>
       expect(loadControlUiBootstrapConfigMock).toHaveBeenCalledWith(host, {
@@ -384,7 +383,7 @@ describe("connectGateway chat load startup work", () => {
     await vi.waitFor(() =>
       expect(refreshActiveTabMock).toHaveBeenCalledWith(host, { chatStartup: true }),
     );
-    expect(loadAgentsMock).toHaveBeenCalledWith(host);
+    await vi.waitFor(() => expect(loadAgentsMock).toHaveBeenCalledWith(host));
     expect(refreshActiveTabMock).toHaveBeenCalledTimes(1);
 
     agentsList.resolve();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -685,11 +685,10 @@ async function loadAgentsThenRefreshActiveTab(host: GatewayHost) {
   }
 }
 
-async function loadAgentsThenRefreshActiveTabAfterBootstrap(
+async function loadAgentsThenRefreshActiveTabForClient(
   host: GatewayHost,
   client: GatewayBrowserClient,
 ) {
-  await host.controlUiBootstrapReady?.catch(() => undefined);
   if (host.client !== client) {
     return;
   }
@@ -822,7 +821,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         host as unknown as SessionsState & { sessionKey: string },
         { force: true },
       );
-      void loadAgentsThenRefreshActiveTabAfterBootstrap(host, client);
+      void loadAgentsThenRefreshActiveTabForClient(host, client);
       scheduleDeferredStartupWork(() => {
         if (host.client !== client) {
           return;

--- a/ui/src/ui/app-sidebar-full-message.test.ts
+++ b/ui/src/ui/app-sidebar-full-message.test.ts
@@ -9,6 +9,12 @@ describe("OpenClawApp full-message sidebar upgrade", () => {
     return document.createElement("openclaw-app") as import("./app.ts").OpenClawApp;
   }
 
+  it("defaults canvas embeds to strict sandbox before bootstrap config loads", async () => {
+    const app = await createApp();
+
+    expect(app.embedSandboxMode).toBe("strict");
+  });
+
   it("uses string content returned by chat.message.get", async () => {
     const content: SidebarContent = {
       kind: "markdown",

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -233,7 +233,7 @@ export class OpenClawApp extends LitElement {
   @state() userName = bootLocalUserIdentity.name;
   @state() userAvatar = bootLocalUserIdentity.avatar;
   @state() localMediaPreviewRoots: string[] = [];
-  @state() embedSandboxMode: "strict" | "scripts" | "trusted" = "scripts";
+  @state() embedSandboxMode: "strict" | "scripts" | "trusted" = "strict";
   @state() allowExternalEmbedUrls = false;
   @state() chatMessageMaxWidth: string | null = null;
   @state() serverVersion: string | null = null;

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -2270,6 +2270,46 @@ describe("grouped chat rendering", () => {
     expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-same-origin");
   });
 
+  it("recreates canvas preview iframes when the sandbox policy changes", () => {
+    const container = document.createElement("div");
+    const renderCanvas = (embedSandboxMode: "strict" | "scripts") =>
+      renderMessageGroups(
+        container,
+        [
+          createMessageGroup(
+            {
+              id: "assistant-canvas-inline-sandbox-change",
+              role: "assistant",
+              content: [
+                { type: "text", text: "Inline canvas result." },
+                createAssistantCanvasBlock({ suffix: "sandbox-change" }),
+              ],
+              timestamp: Date.now(),
+            },
+            "assistant",
+          ),
+        ],
+        { embedSandboxMode },
+      );
+
+    renderCanvas("strict");
+    const strictIframe = expectElement(
+      container,
+      ".chat-tool-card__preview-frame",
+      HTMLIFrameElement,
+    );
+    expect(strictIframe.getAttribute("sandbox")).toBe("");
+
+    renderCanvas("scripts");
+    const scriptsIframe = expectElement(
+      container,
+      ".chat-tool-card__preview-frame",
+      HTMLIFrameElement,
+    );
+    expect(scriptsIframe).not.toBe(strictIframe);
+    expect(scriptsIframe.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
   it("renders assistant_message canvas results in the assistant bubble even when tool rows are visible", () => {
     const container = document.createElement("div");
     renderMessageGroups(

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import { extractCanvasFromText } from "../../../../src/chat/canvas-render.js";
 import { t } from "../../i18n/index.ts";
 import { resolveCanvasIframeUrl } from "../canvas-url.ts";
@@ -412,15 +413,20 @@ function renderPreviewFrame(params: {
   height?: number;
   sandbox?: string;
 }) {
-  return html`
-    <iframe
-      class="chat-tool-card__preview-frame"
-      title=${params.title}
-      sandbox=${params.sandbox ?? ""}
-      src=${params.src ?? nothing}
-      style=${params.height ? `height:${params.height}px` : ""}
-    ></iframe>
-  `;
+  const sandbox = params.sandbox ?? "";
+  const src = params.src ?? "";
+  return keyed(
+    `${sandbox}\u0000${src}\u0000${params.height ?? ""}`,
+    html`
+      <iframe
+        class="chat-tool-card__preview-frame"
+        title=${params.title}
+        sandbox=${sandbox}
+        src=${src || nothing}
+        style=${params.height ? `height:${params.height}px` : ""}
+      ></iframe>
+    `,
+  );
 }
 
 export function renderToolPreview(

--- a/ui/src/ui/views/markdown-sidebar.ts
+++ b/ui/src/ui/views/markdown-sidebar.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { resolveCanvasIframeUrl } from "../canvas-url.ts";
 import { resolveEmbedSandbox, type EmbedSandboxMode } from "../embed-sandbox.ts";
@@ -29,6 +30,18 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
     content?.kind === "markdown" && content.content.trim()
       ? toSanitizedMarkdownHtml(content.content)
       : "";
+  const canvasSandbox =
+    content?.kind === "canvas"
+      ? resolveSidebarCanvasSandbox(content, props.embedSandboxMode ?? "scripts")
+      : "";
+  const canvasSrc =
+    content?.kind === "canvas"
+      ? resolveCanvasIframeUrl(
+          content.entryUrl,
+          props.canvasPluginSurfaceUrl,
+          props.allowExternalEmbedUrls ?? false,
+        )
+      : null;
   return html`
     <div class="sidebar-panel">
       <div class="sidebar-header">
@@ -71,22 +84,20 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
               ? html`
                   <div class="chat-tool-card__preview" data-kind="canvas">
                     <div class="chat-tool-card__preview-panel" data-side="front">
-                      <iframe
-                        class="chat-tool-card__preview-frame"
-                        title=${content.title?.trim() || "Render preview"}
-                        sandbox=${resolveSidebarCanvasSandbox(
-                          content,
-                          props.embedSandboxMode ?? "scripts",
-                        )}
-                        src=${resolveCanvasIframeUrl(
-                          content.entryUrl,
-                          props.canvasPluginSurfaceUrl,
-                          props.allowExternalEmbedUrls ?? false,
-                        ) ?? nothing}
-                        style=${content.preferredHeight
-                          ? `height:${content.preferredHeight}px`
-                          : ""}
-                      ></iframe>
+                      ${keyed(
+                        `${canvasSandbox}\u0000${canvasSrc ?? ""}\u0000${content.preferredHeight ?? ""}`,
+                        html`
+                          <iframe
+                            class="chat-tool-card__preview-frame"
+                            title=${content.title?.trim() || "Render preview"}
+                            sandbox=${canvasSandbox}
+                            src=${canvasSrc ?? nothing}
+                            style=${content.preferredHeight
+                              ? `height:${content.preferredHeight}px`
+                              : ""}
+                          ></iframe>
+                        `,
+                      )}
                     </div>
                     ${content.rawText?.trim()
                       ? html`


### PR DESCRIPTION
Summary:
- Start the active Control UI chat refresh after Gateway hello without waiting for the slower bootstrap fetch.
- Keep startup canvas embeds fail-closed with a strict sandbox until bootstrap config arrives.
- Recreate canvas preview iframes when sandbox/src policy changes so the relaxed policy is applied after bootstrap.

Verification:
- `git diff --check origin/main...HEAD`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- corepack pnpm test ui/src/ui/chat/grouped-render.test.ts ui/src/ui/markdown.test.ts ui/src/ui/chat/tool-cards.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-sidebar-full-message.test.ts ui/src/ui/app-lifecycle-connect.node.test.ts ui/src/ui/controllers/control-ui-bootstrap.test.ts -- --reporter=verbose` (`tbx_01kt6cbppk2fcgc9a7t03vrvq6`, 195 tests passed)
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts` (`tbx_01kt6cdn4w2p3xbrd79dghxzfz`, 12 tests passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean: no accepted/actionable findings)
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`tbx_01kt6cjdx9esjj60qfzxqc1d11`, lanes `core, coreTests`, exit 0)
