### PR TITLE
fix(plugins): guard codex app extension factories

### DIFF
--- a/src/plugins/codex-app-server-extension-factory.test.ts
+++ b/src/plugins/codex-app-server-extension-factory.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { listCodexAppServerExtensionFactories } from "./codex-app-server-extension-factory.js";
+import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginCodexAppServerExtensionFactoryRegistration } from "./registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
+
+describe("listCodexAppServerExtensionFactories", () => {
+  it("skips unreadable factory siblings while preserving healthy factories", () => {
+    const registry = createEmptyPluginRegistry();
+    const factory: CodexAppServerExtensionFactory = () => undefined;
+    registry.codexAppServerExtensionFactories = [
+      {
+        pluginId: "broken-codex-ext",
+        source: "test",
+        get factory() {
+          throw new Error("codex app factory getter exploded");
+        },
+      } as PluginCodexAppServerExtensionFactoryRegistration,
+      {
+        pluginId: "healthy-codex-ext",
+        source: "test",
+        rawFactory: factory,
+        factory,
+      } as PluginCodexAppServerExtensionFactoryRegistration,
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listCodexAppServerExtensionFactories()).toEqual([factory]);
+  });
+});

--- a/src/plugins/codex-app-server-extension-factory.ts
+++ b/src/plugins/codex-app-server-extension-factory.ts
@@ -1,9 +1,44 @@
+import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
+import type {
+  PluginCodexAppServerExtensionFactoryRegistration,
+  PluginRegistry,
+} from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
 export const CODEX_APP_SERVER_EXTENSION_RUNTIME_ID = "codex-app-server";
 
-export function listCodexAppServerExtensionFactories() {
-  return (
-    getActivePluginRegistry()?.codexAppServerExtensionFactories?.map((entry) => entry.factory) ?? []
-  );
+function listActiveCodexAppServerExtensionFactoryRegistrations(): readonly PluginCodexAppServerExtensionFactoryRegistration[] {
+  const registry = getActivePluginRegistry() as PluginRegistry | null | undefined;
+  if (!registry) {
+    return [];
+  }
+  try {
+    return Array.isArray(registry.codexAppServerExtensionFactories)
+      ? registry.codexAppServerExtensionFactories
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function readCodexAppServerExtensionFactory(
+  entry: PluginCodexAppServerExtensionFactoryRegistration,
+): CodexAppServerExtensionFactory | undefined {
+  try {
+    const { factory } = entry;
+    return typeof factory === "function" ? factory : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function listCodexAppServerExtensionFactories(): CodexAppServerExtensionFactory[] {
+  const factories: CodexAppServerExtensionFactory[] = [];
+  for (const entry of listActiveCodexAppServerExtensionFactoryRegistrations()) {
+    const factory = readCodexAppServerExtensionFactory(entry);
+    if (factory) {
+      factories.push(factory);
+    }
+  }
+  return factories;
 }


### PR DESCRIPTION
Summary
- Guard Codex app-server extension factory listing against unreadable active-registry entries.
- Skip malformed/non-function factory rows while preserving healthy factories in order.
- Add focused coverage for an unreadable factory sibling.

Verification
- ./node_modules/.bin/oxfmt --check src/plugins/codex-app-server-extension-factory.ts src/plugins/codex-app-server-extension-factory.test.ts
- ./node_modules/.bin/oxlint src/plugins/codex-app-server-extension-factory.ts src/plugins/codex-app-server-extension-factory.test.ts
- git diff --check
- CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=60000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 nodenv exec node scripts/run-vitest.mjs run src/plugins/codex-app-server-extension-factory.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000
- .agents/skills/autoreview/scripts/autoreview --mode local
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Behavior addressed: Codex app-server extension factory discovery no longer crashes when an active plugin registry contains an unreadable sibling factory registration.
Real environment tested: Local sparse Codex worktree on Node via nodenv, with repo symlinked node_modules; remote broad gates attempted but auth-blocked.
Exact steps or command run after this patch: The formatting, lint, diff-check, focused Vitest, local autoreview, and branch autoreview commands listed above were run after the final patch and rebase.
Evidence after fix: Focused Vitest passed src/plugins/codex-app-server-extension-factory.test.ts with the unreadable sibling regression; both autoreview passes reported no accepted/actionable findings.
Observed result after fix: listCodexAppServerExtensionFactories() skips the unreadable sibling registration and returns the healthy factory in order.
What was not tested: pnpm check:changed was not completed because Blacksmith Testbox reported not authenticated and AWS Crabbox coordinator requests returned HTTP 401 unauthorized.
