### PR TITLE
fix(status): render sub-1000 token counts as plain integers in formatKTokens

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { formatPromptCacheCompact, formatTokensCompact } from "./status.format.js";
+import { formatKTokens, formatPromptCacheCompact, formatTokensCompact } from "./status.format.js";
+
+describe("formatKTokens", () => {
+  it("renders sub-1000 values as plain integers", () => {
+    expect(formatKTokens(0)).toBe("0");
+    expect(formatKTokens(420)).toBe("420");
+    expect(formatKTokens(999)).toBe("999");
+  });
+
+  it("renders 1000+ values as before", () => {
+    expect(formatKTokens(1000)).toBe("1.0k");
+    expect(formatKTokens(1200)).toBe("1.2k");
+    expect(formatKTokens(10_000)).toBe("10k");
+    expect(formatKTokens(12_000)).toBe("12k");
+  });
+
+  it("no longer rounds 999 up to 1.0k", () => {
+    expect(formatKTokens(999)).not.toBe("1.0k");
+  });
+});
 
 describe("status cache formatting", () => {
   it("formats explicit cache details for verbose status output", () => {

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -5,8 +5,12 @@ import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
 import type { SessionStatus } from "./status.types.js";
 export { shortenText } from "./text-format.js";
 
-export const formatKTokens = (value: number) =>
-  `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+export const formatKTokens = (value: number) => {
+  if (value < 1000) {
+    return String(Math.round(value));
+  }
+  return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+};
 
 export const formatDuration = (ms: number | null | undefined) => {
   if (ms == null || !Number.isFinite(ms)) {


### PR DESCRIPTION
## Summary

Fixes #89735

`formatKTokens` in `src/commands/status.format.ts` was rendering sub-1000 token counts as misleading fractional k values:
- `formatKTokens(420)` → `"0.4k"` (should be `"420"`)
- `formatKTokens(999)` → `"1.0k"` (rounds 999 up to look like 1000)

## Changes

- Added a `value < 1000` guard in `formatKTokens` that returns `String(Math.round(value))` for small counts, mirroring the existing `formatTokenCount` behavior in `src/utils/usage-format.ts`
- Values >= 1000 keep existing behavior unchanged
- Added regression tests in `src/commands/status.format.test.ts` covering 0, 420, 999, 1000, 12000

## Test plan

- [x] Tests pass locally (vitest pre-commit hook confirmed)
- [ ] CI will validate on push