### PR TITLE
perf(ui): label delayed chat sends in telemetry

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1814,6 +1814,8 @@ describe("handleSendChat", () => {
       client: { request } as unknown as ChatHost["client"],
       chatMessage: "wait for selected model",
       chatModelSwitchPromises: { "agent:main": switchUpdate.promise },
+      eventLogBuffer: [],
+      tab: "debug",
     });
 
     const send = handleSendChat(host);
@@ -1822,6 +1824,14 @@ describe("handleSendChat", () => {
       sendState: "waiting-model",
       text: "wait for selected model",
     });
+    expect(eventPayloads(host, "control-ui.chat.send")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "waiting-model",
+          sendState: "waiting-model",
+        }),
+      ]),
+    );
 
     await retryReconnectableQueuedChatSends(host);
     expect(request).not.toHaveBeenCalled();
@@ -2213,6 +2223,8 @@ describe("handleSendChat", () => {
       client: null,
       connected: false,
       chatMessage: "send after reconnect",
+      eventLogBuffer: [],
+      tab: "debug",
     });
 
     await handleSendChat(host);
@@ -2226,6 +2238,14 @@ describe("handleSendChat", () => {
       sessionKey: "agent:main",
     });
     expect(host.chatQueue[0]?.sendRunId).toEqual(expect.any(String));
+    expect(eventPayloads(host, "control-ui.chat.send")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "waiting-reconnect",
+          sendState: "waiting-reconnect",
+        }),
+      ]),
+    );
   });
 
   it("replays queued global sends under the originally selected agent", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -442,6 +442,9 @@ function enqueuePendingSendMessage(
   };
   host.chatQueue = [...host.chatQueue, pending];
   recordChatSendTiming(host, pending, "pending-visible", submittedAtMs);
+  if (sendState === "waiting-model" || sendState === "waiting-reconnect") {
+    recordChatSendTiming(host, pending, sendState, submittedAtMs);
+  }
   schedulePendingSendPaintTiming(host, pending, submittedAtMs);
   scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0], true, false, {
     source: "manual",


### PR DESCRIPTION
## Summary
- Record explicit `waiting-model` and `waiting-reconnect` phases for queued Control UI chat sends.
- Cover both delayed-send causes in `app-chat` unit tests so future perf telemetry keeps attribution.

## Verification
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- corepack pnpm test ui/src/ui/app-chat.test.ts -- --reporter=verbose` - `tbx_01kt6d6y1a4g6dd5s8xnv71cdw`, 81 tests passed
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` - `tbx_01kt6db1fpd0hmmmdj9s73ndq3`, lanes `core, coreTests`, exit 0
