### PR TITLE
fix(media): guard hosted media resolver metadata

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -365,6 +365,24 @@ describe("loadWebMedia", () => {
     expect(result.buffer.length).toBeGreaterThan(0);
   });
 
+  it("ignores unreadable hosted media resolver registries", async () => {
+    const registry = createEmptyPluginRegistry();
+    Object.defineProperty(registry, "hostedMediaResolvers", {
+      get() {
+        throw new Error("hosted media resolver registry exploded");
+      },
+    });
+    setActivePluginRegistry(registry);
+
+    const result = await loadWebMedia(tinyPngFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+    });
+
+    expect(result.kind).toBe("image");
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
   it("surfaces Rastermill decode failures when image optimization cannot produce a JPEG", async () => {
     await expect(optimizeImageToJpeg(Buffer.from("not an image"), 8)).rejects.toThrow(
       /Unable to determine image dimensions/,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -17,6 +17,7 @@ import { FsSafeError, readLocalFileSafely } from "../infra/fs-safe.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
 import type { PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import type { PluginHostedMediaResolverRegistration } from "../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { readRemoteMediaBuffer } from "./fetch.js";
@@ -94,9 +95,44 @@ async function resolveMediaStoreUriToPath(mediaUrl: string): Promise<string | nu
   }
 }
 
-async function resolveHostedPluginMediaUrl(mediaUrl: string): Promise<string | null> {
+type HostedMediaResolverEntry = {
+  pluginId?: string;
+  resolver: PluginHostedMediaResolverRegistration["resolver"];
+};
+
+function listHostedMediaResolvers(): HostedMediaResolverEntry[] {
   const registry = getActivePluginRegistry();
-  for (const entry of registry?.hostedMediaResolvers ?? []) {
+  let registrations: unknown;
+  try {
+    registrations = registry?.hostedMediaResolvers;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(registrations)) {
+    return [];
+  }
+  const resolvers: HostedMediaResolverEntry[] = [];
+  for (const registration of registrations) {
+    try {
+      const entry = registration as Partial<PluginHostedMediaResolverRegistration>;
+      const resolver = entry.resolver;
+      if (typeof resolver !== "function") {
+        continue;
+      }
+      const pluginId =
+        typeof entry.pluginId === "string" && entry.pluginId.trim()
+          ? entry.pluginId.trim()
+          : undefined;
+      resolvers.push(pluginId ? { pluginId, resolver } : { resolver });
+    } catch {
+      continue;
+    }
+  }
+  return resolvers;
+}
+
+async function resolveHostedPluginMediaUrl(mediaUrl: string): Promise<string | null> {
+  for (const entry of listHostedMediaResolvers()) {
     try {
       const resolved = await entry.resolver(mediaUrl);
       if (typeof resolved === "string" && resolved.trim()) {


### PR DESCRIPTION
## Summary

- Guard hosted media resolver registry reads before media URL resolution.
- Skip unreadable/non-array hosted resolver lists and malformed resolver rows instead of crashing media loads.
- Add a regression test for an unreadable `hostedMediaResolvers` registry while preserving normal local media loading.

## Verification

- Red repro before the fix: direct `loadWebMedia` repro with an active registry whose `hostedMediaResolvers` getter throws failed with `hosted media resolver registry exploded`.
- `node_modules/.bin/oxfmt --check src/media/web-media.ts src/media/web-media.test.ts`
- `node_modules/.bin/oxlint src/media/web-media.ts src/media/web-media.test.ts`
- `git diff --check`
- `nodenv exec node --import tsx --input-type=module -e '<direct loadWebMedia unreadable hostedMediaResolvers repro>'` -> `image:true`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next88 node_modules/.bin/vitest run src/media/web-media.test.ts -t "ignores unreadable hosted media resolver registries" --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 1 file / 1 test, 73 skipped
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Behavior addressed: malformed hosted media resolver registry metadata no longer crashes `loadWebMedia` before normal media handling can continue.
Real environment tested: local macOS worktree on branch `fuzz-tool-schema-next88-20260603`, Node through `nodenv exec` where used, direct Vitest binary for the focused media test.
Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next88 node_modules/.bin/vitest run src/media/web-media.test.ts -t "ignores unreadable hosted media resolver registries" --pool=forks --maxWorkers=1 --maxConcurrency=1`.
Evidence after fix: focused Vitest passed with 1 file / 1 test, 73 skipped; direct repro returned `image:true` instead of throwing `hosted media resolver registry exploded`.
Observed result after fix: unreadable hosted resolver registry is ignored and the explicitly allowed local PNG loads as image media.
What was not tested: full `pnpm check:changed`; Blacksmith Testbox is unauthenticated locally, and AWS Crabbox changed-gate setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
