### PR TITLE
fix(agents): surface explicit aborted flag in lifecycle end payload (#66534)

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2336,6 +2336,7 @@ export async function runEmbeddedAgent(
                 `livenessState=blocked suggestedAction=reset_or_new kind=${kind}`,
             );
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid: resolveReplayInvalidForAttempt(),
               livenessState: "blocked",
             });
@@ -2374,6 +2375,7 @@ export async function runEmbeddedAgent(
             const errorText = formatErrorMessage(promptError);
             const replayInvalid = resolveReplayInvalidForAttempt();
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid,
               livenessState: "blocked",
             });
@@ -2479,6 +2481,7 @@ export async function runEmbeddedAgent(
             // Handle role ordering errors with a user-friendly message
             if (/incorrect role information|roles must alternate/i.test(errorText)) {
               attempt.setTerminalLifecycleMeta?.({
+                aborted,
                 replayInvalid: resolveReplayInvalidForAttempt(),
                 livenessState: "blocked",
               });
@@ -2520,6 +2523,7 @@ export async function runEmbeddedAgent(
                 typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
               const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
               attempt.setTerminalLifecycleMeta?.({
+                aborted,
                 replayInvalid: resolveReplayInvalidForAttempt(),
                 livenessState: "blocked",
               });
@@ -3031,6 +3035,7 @@ export async function runEmbeddedAgent(
             const timeoutPhase = attempt.promptTimeoutOutcome?.timeoutPhase ?? "provider";
             const providerStarted = attempt.promptTimeoutOutcome?.providerStarted ?? true;
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid,
               livenessState,
               timeoutPhase,
@@ -3281,6 +3286,7 @@ export async function runEmbeddedAgent(
             const replayInvalid = resolveReplayInvalidForAttempt(null);
             const livenessState: EmbeddedRunLivenessState = "blocked";
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid,
               livenessState,
             });
@@ -3328,6 +3334,7 @@ export async function runEmbeddedAgent(
               incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
             });
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid,
               livenessState,
             });
@@ -3432,6 +3439,7 @@ export async function runEmbeddedAgent(
               incompleteTurnText,
             });
             attempt.setTerminalLifecycleMeta?.({
+              aborted,
               replayInvalid,
               livenessState,
             });
@@ -3552,6 +3560,7 @@ export async function runEmbeddedAgent(
             ? [{ text: SILENT_REPLY_TOKEN }]
             : payloadsForTerminalPath;
           attempt.setTerminalLifecycleMeta?.({
+            aborted,
             replayInvalid,
             livenessState,
             stopReason,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -196,5 +196,6 @@ export type EmbeddedRunAttemptResult = {
     yielded?: boolean;
     timeoutPhase?: AgentRunTimeoutPhase;
     providerStarted?: boolean;
+    aborted?: boolean;
   }) => void;
 };

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -120,6 +120,50 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("forwards the runner's explicit aborted flag into the lifecycle end payload (#66534)", async () => {
+    emitAgentEventMock.mockClear();
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      { role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "partial" }] },
+      { onAgentEvent },
+    );
+    // The runner records this via setTerminalLifecycleMeta({ aborted }) on a user-cancelled
+    // run; it must reach the lifecycle:end payload so downstream consumers can distinguish a
+    // cancellation from a normal completion. #66534
+    ctx.state.terminalAborted = true;
+
+    await handleAgentEnd(ctx);
+
+    // Both the per-run callback and the global sink carry the explicit aborted flag.
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "lifecycle",
+        data: expect.objectContaining({ phase: "end", aborted: true }),
+      }),
+    );
+    expect(emitAgentEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "lifecycle",
+        data: expect.objectContaining({ aborted: true }),
+      }),
+    );
+  });
+
+  it("omits aborted from the lifecycle payload when the runner never recorded it (#66534)", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      { role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "done" }] },
+      { onAgentEvent },
+    );
+
+    // No terminalAborted recorded → no aborted key, so a normal completion is not mislabeled.
+    await handleAgentEnd(ctx);
+
+    for (const [event] of onAgentEvent.mock.calls) {
+      expect((event as { data?: Record<string, unknown> }).data).not.toHaveProperty("aborted");
+    }
+  });
+
   it("suppresses structured provider error messages in user-facing lifecycle events", async () => {
     const onAgentEvent = vi.fn();
     const rawError =

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -134,6 +134,9 @@ export function handleAgentEnd(
       ...(typeof ctx.state.providerStarted === "boolean"
         ? { providerStarted: ctx.state.providerStarted }
         : {}),
+      ...(typeof ctx.state.terminalAborted === "boolean"
+        ? { aborted: ctx.state.terminalAborted }
+        : {}),
     };
     if (isError) {
       emitAgentEvent({

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -142,6 +142,7 @@ export type EmbeddedAgentSubscribeState = {
   yielded?: boolean;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
+  terminalAborted?: boolean;
   hadDeterministicSideEffect?: boolean;
   pendingEventChain: Promise<void> | null;
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1343,6 +1343,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       yielded?: boolean;
       timeoutPhase?: AgentRunTimeoutPhase;
       providerStarted?: boolean;
+      aborted?: boolean;
     }) => {
       if (typeof meta.replayInvalid === "boolean") {
         state.replayState = { ...state.replayState, replayInvalid: meta.replayInvalid };
@@ -1361,6 +1362,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       }
       if (typeof meta.providerStarted === "boolean") {
         state.providerStarted = meta.providerStarted;
+      }
+      if (typeof meta.aborted === "boolean") {
+        state.terminalAborted = meta.aborted;
       }
     },
     isCompacting: () => state.compactionInFlight || state.pendingCompactionRetry > 0,


### PR DESCRIPTION
## Summary

When an embedded agent run ends, `handleAgentEnd` builds a `terminalMeta` that carries `stopReason` / `yielded` / `timeoutPhase` / `providerStarted` — but never the runner's explicit `aborted` boolean. So the emitted `lifecycle:end` payload omits `aborted`, even though downstream consumers already read it:

- `src/gateway/session-lifecycle-state.ts` keys run status off `data.aborted`
- `packages/sdk/src/normalize.ts` + `client.ts` consume `data.aborted`

A user-cancelled run is therefore indistinguishable from a normal completion at the lifecycle boundary.

### Fix

Forward the runner's **explicit** abort boolean (rather than re-inferring it from `stopReason`, which the earlier self-closed attempt #66574 did and ClawSweeper flagged as inferior):

- `setTerminalLifecycleMeta` gains an `aborted?: boolean` field that writes a new `state.terminalAborted` slot (`embedded-agent-subscribe.ts`, `handlers.types.ts`, `run/types.ts`).
- `handleAgentEnd` spreads `...(typeof ctx.state.terminalAborted === "boolean" ? { aborted: ctx.state.terminalAborted } : {})` into the single `terminalMeta` object, so it reaches both the global `emitAgentEvent` sink and the per-run `onAgentEvent` callback, on both the success (`end`) and `error` payloads.
- The runner already computes `aborted` at every `setTerminalLifecycleMeta` call site (`run.ts`), so the value is forwarded from there. (`stopReason` is already emitted today, so only the `aborted` half of the issue is genuinely missing.)

Fixes #66534

## Real behavior proof

**Behavior addressed**: The `lifecycle:end` payload now carries the runner's explicit `aborted` flag, so a user-cancelled run is distinguishable from a normal completion (and the existing `data.aborted` consumers in gateway/SDK receive it). When the runner never records an abort, no `aborted` key is added, so a normal completion is not mislabeled.

**Real environment tested**: vitest (`embedded-agent-subscribe.handlers.lifecycle.test.ts`) driving the real `handleAgentEnd` with `emitAgentEvent` mocked only at the event-sink boundary and a real per-run `onAgentEvent` callback capturing the payload; plus a standalone `node --import tsx` script importing the real `handleAgentEnd` from source (no build/service/credentials) and reading the emitted payload.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts`

**Evidence after fix**: `Test Files  1 passed (1)` / `Tests  34 passed (34)`, including two new #66534 cases (forwards `aborted:true`, and omits `aborted` when unset). Stashing only the source edits while keeping the tests flips exactly the "forwards aborted" case to failing (`Tests  1 failed | 33 passed`), proving the test binds the fix.

**Observed result after fix**: Driving the real `handleAgentEnd` via tsx — BEFORE the runner records an abort, the `end` payload has `aborted=undefined` with no `aborted` key; AFTER the runner records `terminalAborted=true`, the `end` payload carries `aborted=true` (same on the global `emitAgentEvent` sink and the `onAgentEvent` callback).

**What was not tested**: A full live agent run with a real user abort through the gateway socket — the change is in the lifecycle event-shaping layer, verified by driving the real `handleAgentEnd` and asserting the emitted payload; the upstream runner already computes the `aborted` boolean (covered by existing run-attempt tests) and the downstream `data.aborted` consumers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
