### PR TITLE
fix(plugins): guard binding resolved callbacks

### DIFF
--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -744,6 +744,56 @@ describe("plugin conversation binding approvals", () => {
     await expectResolutionCallback(testCase);
   });
 
+  it("keeps dispatching resolved callbacks after an unreadable registration", async () => {
+    const onResolved = vi.fn(async () => undefined);
+    const registry = createEmptyPluginRegistry();
+    const brokenRegistration = {
+      pluginRoot: "/plugins/callback-guard",
+      handler: async () => undefined,
+      source: "/plugins/callback-guard/index.ts",
+      rootDir: "/plugins/callback-guard",
+    } as PluginRegistry["conversationBindingResolvedHandlers"][number];
+    Object.defineProperty(brokenRegistration, "pluginId", {
+      get() {
+        throw new Error("binding resolved plugin id getter exploded");
+      },
+    });
+    registry.conversationBindingResolvedHandlers.push(brokenRegistration, {
+      pluginId: "codex",
+      pluginRoot: "/plugins/callback-guard",
+      handler: onResolved,
+      source: "/plugins/callback-guard/index.ts",
+      rootDir: "/plugins/callback-guard",
+    });
+    setActivePluginRegistry(registry);
+
+    const request = await requestPluginConversationBinding({
+      pluginId: "codex",
+      pluginName: "Codex App Server",
+      pluginRoot: "/plugins/callback-guard",
+      requestedBySenderId: "user-1",
+      conversation: {
+        channel: "discord",
+        accountId: "isolated",
+        conversationId: "channel:callback-guard",
+      },
+      binding: { summary: "Bind this conversation despite a bad callback sibling." },
+    });
+    expect(request.status).toBe("pending");
+    if (request.status !== "pending") {
+      throw new Error("expected pending bind request");
+    }
+
+    await resolvePluginConversationBindingApproval({
+      approvalId: request.approvalId,
+      decision: "allow-once",
+      senderId: "user-1",
+    });
+
+    await flushMicrotasks();
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     {
       name: "does not wait for an approved bind callback before returning",

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -25,6 +25,7 @@ import type {
   PluginConversationBindingRequestParams,
   PluginConversationBindingRequestResult,
 } from "./conversation-binding.types.js";
+import type { PluginConversationBindingResolvedHandlerRegistration } from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
 const log = createSubsystemLogger("plugins/binding");
@@ -952,21 +953,65 @@ function dispatchPluginConversationBindingResolved(params: {
   });
 }
 
+type ConversationBindingResolvedHandlerEntry = {
+  pluginId: string;
+  pluginRoot?: string;
+  handler: PluginConversationBindingResolvedHandlerRegistration["handler"];
+};
+
+function listConversationBindingResolvedHandlers(params: {
+  pluginId: string;
+  pluginRoot: string;
+}): ConversationBindingResolvedHandlerEntry[] {
+  let registrations: unknown;
+  try {
+    registrations = getActivePluginRegistry()?.conversationBindingResolvedHandlers;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(registrations)) {
+    return [];
+  }
+  const handlers: ConversationBindingResolvedHandlerEntry[] = [];
+  for (const registration of registrations) {
+    try {
+      const entry = registration as Partial<PluginConversationBindingResolvedHandlerRegistration>;
+      if (entry.pluginId !== params.pluginId) {
+        continue;
+      }
+      const registeredRoot =
+        typeof entry.pluginRoot === "string" && entry.pluginRoot.trim()
+          ? entry.pluginRoot.trim()
+          : undefined;
+      if (registeredRoot && registeredRoot !== params.pluginRoot) {
+        continue;
+      }
+      if (typeof entry.handler !== "function") {
+        continue;
+      }
+      handlers.push(
+        registeredRoot
+          ? { pluginId: entry.pluginId, pluginRoot: registeredRoot, handler: entry.handler }
+          : { pluginId: entry.pluginId, handler: entry.handler },
+      );
+    } catch {
+      continue;
+    }
+  }
+  return handlers;
+}
+
 async function notifyPluginConversationBindingResolved(params: {
   status: "approved" | "denied";
   binding?: PluginConversationBinding;
   decision: PluginConversationBindingResolutionDecision;
   request: PendingPluginBindingRequest;
 }): Promise<void> {
-  const registrations = getActivePluginRegistry()?.conversationBindingResolvedHandlers ?? [];
+  const registrations = listConversationBindingResolvedHandlers({
+    pluginId: params.request.pluginId,
+    pluginRoot: params.request.pluginRoot,
+  });
   for (const registration of registrations) {
-    if (registration.pluginId !== params.request.pluginId) {
-      continue;
-    }
-    const registeredRoot = registration.pluginRoot?.trim();
-    if (registeredRoot && registeredRoot !== params.request.pluginRoot) {
-      continue;
-    }
     try {
       const event: PluginConversationBindingResolvedEvent = {
         status: params.status,


### PR DESCRIPTION
## Summary

- Guard conversation-binding resolved callback registry reads before dispatch.
- Skip malformed/unreadable callback registrations instead of letting one bad sibling prevent healthy callbacks.
- Add a regression test where an unreadable callback registration precedes a healthy `codex` callback.

## Verification

- Red repro before the fix: focused Vitest failed because the healthy callback was called 0 times after an unreadable sibling registration.
- `node_modules/.bin/oxfmt --check src/plugins/conversation-binding.ts src/plugins/conversation-binding.test.ts`
- `node_modules/.bin/oxlint src/plugins/conversation-binding.ts src/plugins/conversation-binding.test.ts`
- `git diff --check`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next89 node_modules/.bin/vitest run src/plugins/conversation-binding.test.ts -t "keeps dispatching resolved callbacks after an unreadable registration" --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 1 file / 1 test, 16 skipped
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next89 node_modules/.bin/vitest run src/plugins/conversation-binding.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 1 file / 17 tests
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Behavior addressed: malformed conversation-binding resolved callback metadata no longer prevents later healthy plugin callbacks from receiving approval/denial resolution events.
Real environment tested: local macOS worktree on branch `fuzz-tool-schema-next89-20260603`, direct Vitest binary with one fork for the focused and full conversation-binding file tests.
Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next89 node_modules/.bin/vitest run src/plugins/conversation-binding.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1`.
Evidence after fix: full `src/plugins/conversation-binding.test.ts` passed with 1 file / 17 tests; focused regression passed with 1 file / 1 test, 16 skipped.
Observed result after fix: unreadable callback registrations are skipped and the healthy matching callback is invoked once after approval resolution.
What was not tested: full `pnpm check:changed`; Blacksmith Testbox is unauthenticated locally, and AWS Crabbox changed-gate setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
