### PR TITLE
perf(gateway): overlap chat catalog startup

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2540,6 +2540,14 @@ async function handleChatHistoryRequest({
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));
     return;
   }
+  const modelCatalogPromise = measureDiagnosticsTimelineSpan(
+    `gateway.${method}.model_catalog`,
+    () => loadOptionalServerMethodModelCatalog(context, method),
+    {
+      config: cfg,
+      phase: method,
+    },
+  );
   const sessionId = entry?.sessionId;
   const sessionAgentId = resolveSessionAgentId({
     sessionKey,
@@ -2620,14 +2628,7 @@ async function handleChatHistoryRequest({
       `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
     );
   }
-  const modelCatalog = await measureDiagnosticsTimelineSpan(
-    `gateway.${method}.model_catalog`,
-    () => loadOptionalServerMethodModelCatalog(context, method),
-    {
-      config: cfg,
-      phase: method,
-    },
-  );
+  const modelCatalog = await modelCatalogPromise;
   const sessionInfo = buildGatewaySessionInfo({
     cfg,
     storePath,


### PR DESCRIPTION
## Summary
- start the optional model catalog load earlier during `chat.history` / `chat.startup`
- keep the existing 750ms optional catalog timeout and still await catalog metadata before building `sessionInfo`, defaults, and startup `agentsList`

## Verification
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (accepted finding on short timeout metadata regression; fixed by switching to overlap-only approach)
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- corepack pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/controllers/sessions.test.ts -- --reporter=verbose` (`tbx_01kt6edf5d328vqr43epy0cs0b`, exit 0)
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` (clean)
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` (`tbx_01kt6eh4fk409g4ar1kpa0edhz`, lanes `core, coreTests`, exit 0)
