### PR TITLE
fix(openai): add session affinity header

### DIFF
--- a/extensions/openai/transport-policy.test.ts
+++ b/extensions/openai/transport-policy.test.ts
@@ -37,6 +37,7 @@ describe("openai transport policy", () => {
       transport: "websocket",
     });
     expect(state?.headers?.["x-client-request-id"]).toBe("session-123");
+    expect(state?.headers?.["x-session-affinity"]).toBe("session-123");
     expect(state?.headers?.["x-openclaw-session-id"]).toBe("session-123");
     expect(state?.headers?.["x-openclaw-turn-id"]).toBe("turn-123");
     expect(state?.headers?.["x-openclaw-turn-attempt"]).toBe("2");
@@ -76,6 +77,7 @@ describe("openai transport policy", () => {
       transport: "stream",
     });
     expect(state?.headers?.["x-client-request-id"]).toBe("session-123");
+    expect(state?.headers?.["x-session-affinity"]).toBe("session-123");
     expect(state?.headers?.["x-openclaw-session-id"]).toBe("session-123");
     expect(state?.headers?.["x-openclaw-turn-id"]).toBe("turn-123");
     expect(state?.headers?.["x-openclaw-turn-attempt"]).toBe("2");
@@ -89,6 +91,7 @@ describe("openai transport policy", () => {
       sessionId: "session-123",
     });
     expect(policy?.headers?.["x-client-request-id"]).toBe("session-123");
+    expect(policy?.headers?.["x-session-affinity"]).toBe("session-123");
     expect(policy?.headers?.["x-openclaw-session-id"]).toBe("session-123");
     expect(policy?.degradeCooldownMs).toBe(60_000);
   });
@@ -105,6 +108,7 @@ describe("openai transport policy", () => {
       sessionId: "session-123",
     });
     expect(policy?.headers?.["x-client-request-id"]).toBe("session-123");
+    expect(policy?.headers?.["x-session-affinity"]).toBe("session-123");
     expect(policy?.headers?.["x-openclaw-session-id"]).toBe("session-123");
     expect(policy?.degradeCooldownMs).toBe(60_000);
   });
@@ -122,6 +126,7 @@ describe("openai transport policy", () => {
       sessionId: "session-123",
     });
     expect(policy?.headers?.["x-client-request-id"]).toBe("session-123");
+    expect(policy?.headers?.["x-session-affinity"]).toBe("session-123");
     expect(policy?.headers?.["x-openclaw-session-id"]).toBe("session-123");
     expect(policy?.degradeCooldownMs).toBe(60_000);
   });

--- a/extensions/openai/transport-policy.ts
+++ b/extensions/openai/transport-policy.ts
@@ -56,6 +56,7 @@ function resolveSessionHeaders(params: {
   }
   return {
     "x-client-request-id": sessionId,
+    "x-session-affinity": sessionId,
     "x-openclaw-session-id": sessionId,
   };
 }

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -504,6 +504,7 @@ export async function runBtwSideQuestion(
     currentStreamFn: streamSimple,
     providerStreamFn,
     sessionId,
+    sessionKey: params.sessionKey,
     signal: params.opts?.abortSignal,
     model: runtimeModel,
     resolvedApiKey: apiKey,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -191,6 +191,7 @@ function prepareCompactionSessionAgent(params: {
   session: { agent: { streamFn?: unknown } };
   providerStreamFn: unknown;
   sessionId: string;
+  sessionKey?: string;
   signal: AbortSignal;
   effectiveModel: ProviderRuntimeModel;
   resolvedApiKey?: string;
@@ -208,6 +209,7 @@ function prepareCompactionSessionAgent(params: {
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
     providerStreamFn: params.providerStreamFn as never,
     sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
     signal: params.signal,
     model: params.effectiveModel,
     resolvedApiKey: params.resolvedApiKey,
@@ -1223,6 +1225,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
             session,
             providerStreamFn,
             sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
             signal: runAbortController.signal,
             effectiveModel,
             resolvedApiKey: hasRuntimeAuthExchange ? undefined : apiKeyInfo?.apiKey,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2536,6 +2536,7 @@ export async function runEmbeddedAttempt(
         currentStreamFn: defaultSessionStreamFn,
         providerStreamFn,
         sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
         promptCacheKey: params.promptCacheKey,
         signal: runAbortController.signal,
         model: params.model,

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -153,6 +153,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const streamFn = resolveEmbeddedAgentStreamFn({
       currentStreamFn: undefined,
       sessionId: "session-1",
+      sessionKey: "agent:main:codex",
       model: {
         api: "openai-chatgpt-responses",
         provider: "openai",
@@ -172,7 +173,35 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     );
     expect(requireRecord(result.context, "codex native context").systemPrompt).toBe("intro\ntail");
     expect(requireRecord(result.options, "codex native options").apiKey).toBe("oauth-bearer-token");
+    expect(requireRecord(result.options, "codex native options").sessionId).toBe("session-1");
+    expect(requireRecord(result.options, "codex native options").sessionKey).toBe(
+      "agent:main:codex",
+    );
     expect(nativeStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the session key as the provider session id for OpenAI transports", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      sessionId: "run-session",
+      sessionKey: "agent:main:discord:channel:c1",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4",
+      } as never,
+    });
+
+    const result = await expectStreamResultRecord(
+      streamFn({ provider: "openai", id: "gpt-5.4" } as never, {} as never, {}),
+      "openai transport session result",
+    );
+    expect(result.sessionKey).toBe("agent:main:discord:channel:c1");
+    expect(result.sessionId).toBeUndefined();
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
   });
 
   it("routes GitHub Copilot fallbacks through boundary-aware transports", () => {

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -12,6 +12,7 @@ let openClawNativeCodexResponsesStreamFnForTest: StreamFn | undefined;
 type EmbeddedStreamOptions = Parameters<StreamFn>[2] & {
   authProfileId?: string;
   promptCacheKey?: string;
+  sessionKey?: string;
 };
 
 export function resolveEmbeddedAgentBaseStreamFn(params: {
@@ -51,6 +52,30 @@ function hasResolvedRuntimeApiKey(apiKey: string | undefined): boolean {
 
 function isOpenAICodexResponsesModel(model: EmbeddedRunAttemptParams["model"]): boolean {
   return model.provider === "openai" && model.api === "openai-chatgpt-responses";
+}
+
+function resolveOpenAITransportSessionKey(params: {
+  model: EmbeddedRunAttemptParams["model"];
+  sessionKey?: string;
+}): string | undefined {
+  const provider = String(params.model.provider).trim().toLowerCase();
+  if (
+    provider !== "openai" &&
+    provider !== "azure-openai" &&
+    provider !== "azure-openai-responses"
+  ) {
+    return undefined;
+  }
+  const api = String(params.model.api).trim();
+  if (
+    api !== "openai-responses" &&
+    api !== "openai-chatgpt-responses" &&
+    api !== "openai-completions" &&
+    api !== "azure-openai-responses"
+  ) {
+    return undefined;
+  }
+  return params.sessionKey?.trim() || undefined;
 }
 
 function resolveOpenClawNativeCodexResponsesStreamFn(params: {
@@ -116,6 +141,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   currentStreamFn: StreamFn | undefined;
   providerStreamFn?: StreamFn;
   sessionId: string;
+  sessionKey?: string;
   promptCacheKey?: string;
   signal?: AbortSignal;
   model: EmbeddedRunAttemptParams["model"];
@@ -123,6 +149,10 @@ export function resolveEmbeddedAgentStreamFn(params: {
   authProfileId?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
+  const openAITransportSessionKey = resolveOpenAITransportSessionKey({
+    model: params.model,
+    sessionKey: params.sessionKey,
+  });
   if (params.providerStreamFn) {
     return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
       runSignal: params.signal,
@@ -130,6 +160,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       authProfileId: params.authProfileId,
       authStorage: params.authStorage,
       providerId: params.model.provider,
+      sessionKey: openAITransportSessionKey,
       promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
@@ -158,6 +189,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       authStorage: params.authStorage,
       providerId: params.model.provider,
       sessionId: params.sessionId,
+      sessionKey: openAITransportSessionKey,
       promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
@@ -190,6 +222,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
         authProfileId: params.authProfileId,
         authStorage: params.authStorage,
         providerId: params.model.provider,
+        sessionKey: openAITransportSessionKey,
         promptCacheKey: params.promptCacheKey,
       });
     }
@@ -227,6 +260,7 @@ function wrapEmbeddedAgentStreamFn(
     authStorage: { getApiKey(provider: string): Promise<string | undefined> } | undefined;
     providerId: string;
     sessionId?: string;
+    sessionKey?: string;
     promptCacheKey?: string;
     transformContext?: (context: Parameters<StreamFn>[1]) => Parameters<StreamFn>[1];
   },
@@ -240,6 +274,10 @@ function wrapEmbeddedAgentStreamFn(
       params.sessionId && !embeddedOptions?.sessionId
         ? { ...embeddedOptions, sessionId: params.sessionId }
         : embeddedOptions;
+    const sessionKey = params.sessionKey?.trim();
+    if (sessionKey && !merged?.sessionKey) {
+      merged = { ...merged, sessionKey };
+    }
     const promptCacheKey = params.promptCacheKey?.trim();
     if (promptCacheKey && !merged?.promptCacheKey) {
       merged = { ...merged, promptCacheKey };

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2783,6 +2783,40 @@ describe("openai transport stream", () => {
     expect(params.prompt_cache_key).toBe("cron-cache-key");
   });
 
+  it("uses sessionKey only for transport identity, not prompt-cache affinity", () => {
+    expect(
+      testing.resolveTransportSessionId({
+        sessionId: "run-session",
+        sessionKey: "agent:main:discord:channel:c1",
+      }),
+    ).toBe("agent:main:discord:channel:c1");
+
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        sessionKey: "agent:main:discord:channel:c1",
+      },
+    ) as { prompt_cache_key?: string };
+
+    expect(params.prompt_cache_key).toBeUndefined();
+  });
+
   it("clamps Responses promptCacheKey before sending it upstream", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -123,6 +123,7 @@ type BaseStreamOptions = {
   apiKey?: string;
   cacheRetention?: "none" | "short" | "long";
   sessionId?: string;
+  sessionKey?: string;
   promptCacheKey?: string;
   authProfileId?: string;
   onPayload?: (payload: unknown, model: Model) => unknown;
@@ -1828,6 +1829,12 @@ function resolveProviderTransportTurnState(
   });
 }
 
+function resolveTransportSessionId(
+  options: Pick<BaseStreamOptions, "sessionId" | "sessionKey"> | undefined,
+): string | undefined {
+  return options?.sessionKey?.trim() || options?.sessionId;
+}
+
 function resolveOpenAISdkTimeoutMs(model: Model): number | undefined {
   return resolveModelRequestTimeoutMs(model, undefined);
 }
@@ -1894,7 +1901,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
         const turnState = resolveProviderTransportTurnState(model, {
-          sessionId: options?.sessionId,
+          sessionId: resolveTransportSessionId(options),
           turnId: randomUUID(),
           attempt: 1,
           transport: "stream",
@@ -2328,7 +2335,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
         const turnState = resolveProviderTransportTurnState(model, {
-          sessionId: options?.sessionId,
+          sessionId: resolveTransportSessionId(options),
           turnId: randomUUID(),
           attempt: 1,
           transport: "stream",
@@ -4295,6 +4302,7 @@ export const testing = {
   buildOpenAIResponsesReasoningReplayMetadata,
   normalizeResponsesFailedEvent,
   prepareOpenAIResponsesReasoningItemForReplay,
+  resolveTransportSessionId,
   stripResponsesRequestEncryptedContent,
   tagOpenAIResponsesReasoningReplayItem,
   summarizeResponsesFailedNoDetailsObservation,


### PR DESCRIPTION
## Summary

- Add `x-session-affinity` to OpenAI-family native transport session headers.
- Pass the embedded runner `sessionKey` through OpenAI-family transports as an internal transport identity key, while preserving existing `sessionId` and prompt-cache behavior.
- Cover direct OpenAI policy headers, embedded stream option wiring, and prompt-cache separation.

## Verification

- `node scripts/run-vitest.mjs extensions/openai/transport-policy.test.ts src/agents/embedded-agent-runner/stream-resolution.test.ts src/agents/btw.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "sessionKey only for transport identity|promptCacheKey|prompt_cache_key"`
- `npm exec --yes --package oxfmt@0.52.0 -- oxfmt --check extensions/openai/transport-policy.ts extensions/openai/transport-policy.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/stream-resolution.ts src/agents/embedded-agent-runner/stream-resolution.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/compact.ts src/agents/btw.ts`
- `git diff --check`

## Known local gap

- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts` has 5 local failures in existing loopback chat-completions request-capture tests where the loopback capture variables remain unset. The focused prompt-cache/OpenAI transport subset above passes.
