### PR TITLE
fix(media): guard document extractor metadata

### DIFF
--- a/src/media/document-extractors.runtime.test.ts
+++ b/src/media/document-extractors.runtime.test.ts
@@ -84,4 +84,51 @@ describe("extractDocumentContent", () => {
     expect(extractionError.message).toBe("Document extraction failed for application/pdf");
     expect(extractionError.cause).toBe(cause);
   });
+
+  it("keeps trying healthy document extractors after unreadable metadata", async () => {
+    const extract = vi.fn(function (this: { prefix: string }) {
+      return Promise.resolve({ text: `${this.prefix} text`, images: [] });
+    });
+    const brokenExtractor = {
+      id: "broken",
+      pluginId: "broken-doc",
+      label: "Broken",
+      extract: vi.fn(),
+    };
+    Object.defineProperty(brokenExtractor, "mimeTypes", {
+      get() {
+        throw new Error("document extractor mimeTypes getter exploded");
+      },
+    });
+    resolvePluginDocumentExtractorsMock.mockReturnValue([
+      brokenExtractor,
+      {
+        id: "pdf",
+        pluginId: "document-extract",
+        label: "PDF",
+        prefix: "pdf",
+        mimeTypes: ["application/pdf"],
+        extract,
+      },
+    ]);
+
+    await expect(
+      extractDocumentContent({
+        buffer: Buffer.from("pdf"),
+        mimeType: "application/pdf",
+        maxPages: 1,
+        maxPixels: 100,
+        minTextChars: 10,
+        config: {
+          env: {
+            vars: {
+              TEST_CASE: "unreadable-document-extractor-metadata",
+            },
+          },
+        },
+      }),
+    ).resolves.toStrictEqual({ text: "pdf text", images: [], extractor: "pdf" });
+
+    expect(extract).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/media/document-extractors.runtime.ts
+++ b/src/media/document-extractors.runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   DocumentExtractionRequest,
   DocumentExtractionResult,
+  PluginDocumentExtractorEntry,
 } from "../plugins/document-extractor-types.js";
 import { resolvePluginDocumentExtractors } from "../plugins/document-extractors.runtime.js";
 import { createConfigScopedPromiseLoader } from "../plugins/plugin-cache-primitives.js";
@@ -10,6 +11,31 @@ import { createConfigScopedPromiseLoader } from "../plugins/plugin-cache-primiti
 const documentExtractorLoader = createConfigScopedPromiseLoader((config?: OpenClawConfig) =>
   resolvePluginDocumentExtractors(config ? { config } : undefined),
 );
+
+type ReadableDocumentExtractor = {
+  id: string;
+  mimeTypes: string[];
+  extract: PluginDocumentExtractorEntry["extract"];
+  receiver: unknown;
+};
+
+function readDocumentExtractor(entry: unknown): ReadableDocumentExtractor | undefined {
+  try {
+    const extractor = entry as Partial<PluginDocumentExtractorEntry>;
+    const id = typeof extractor.id === "string" && extractor.id.trim() ? extractor.id.trim() : "";
+    if (!id || !Array.isArray(extractor.mimeTypes) || typeof extractor.extract !== "function") {
+      return undefined;
+    }
+    return {
+      id,
+      mimeTypes: extractor.mimeTypes.map((mimeType) => normalizeLowercaseStringOrEmpty(mimeType)),
+      extract: extractor.extract,
+      receiver: entry,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 export async function extractDocumentContent(
   params: DocumentExtractionRequest & {
@@ -33,17 +59,16 @@ export async function extractDocumentContent(
   const errors: unknown[] = [];
 
   for (const extractor of extractors) {
-    if (
-      !extractor.mimeTypes.map((entry) => normalizeLowercaseStringOrEmpty(entry)).includes(mimeType)
-    ) {
+    const readableExtractor = readDocumentExtractor(extractor);
+    if (!readableExtractor?.mimeTypes.includes(mimeType)) {
       continue;
     }
     try {
-      const result = await extractor.extract(request);
+      const result = await readableExtractor.extract.call(readableExtractor.receiver, request);
       if (result) {
         return {
           ...result,
-          extractor: extractor.id,
+          extractor: readableExtractor.id,
         };
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

- Guard document extractor metadata reads before MIME matching and extraction.
- Skip malformed/unreadable extractor rows instead of letting one bad plugin entry prevent later healthy extractors.
- Preserve method-style extractor `this` binding when invoking valid extractors.

## Verification

- Red repro before the fix: focused Vitest failed with `document extractor mimeTypes getter exploded` before the healthy PDF extractor ran.
- `node_modules/.bin/oxfmt --check src/media/document-extractors.runtime.ts src/media/document-extractors.runtime.test.ts`
- `node_modules/.bin/oxlint src/media/document-extractors.runtime.ts src/media/document-extractors.runtime.test.ts`
- `git diff --check`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next90 node_modules/.bin/vitest run src/media/document-extractors.runtime.test.ts -t "keeps trying healthy document extractors after unreadable metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 1 file / 1 test, 2 skipped
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next90 node_modules/.bin/vitest run src/media/document-extractors.runtime.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 1 file / 3 tests
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

Behavior addressed: malformed document extractor metadata no longer crashes document extraction before healthy plugin extractors can run.
Real environment tested: local macOS worktree on branch `fuzz-tool-schema-next90-20260603`, direct Vitest binary with one fork for the focused and full document-extractor runtime tests.
Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next90 node_modules/.bin/vitest run src/media/document-extractors.runtime.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1`.
Evidence after fix: full `src/media/document-extractors.runtime.test.ts` passed with 1 file / 3 tests; focused regression passed with 1 file / 1 test, 2 skipped.
Observed result after fix: unreadable extractor metadata is skipped, the healthy PDF extractor still runs, and method-style extractor receiver binding is preserved.
What was not tested: full `pnpm check:changed`; Blacksmith Testbox is unauthenticated locally, and AWS Crabbox changed-gate setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
