### PR TITLE
fix(gateway): guard plugin UI descriptors

### DIFF
--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -11,6 +11,7 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isPluginJsonValue } from "../../plugins/host-hooks.js";
+import type { PluginControlUiDescriptorRegistryRegistration } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   validateJsonSchemaValue,
@@ -24,6 +25,38 @@ const log = createSubsystemLogger("gateway/plugin-host-hooks");
 
 function formatSessionActionPayloadSchemaErrors(errors: JsonSchemaValidationError[]): string {
   return errors.map((error) => error.text).join("; ");
+}
+
+function listPluginControlUiDescriptors(): Record<string, unknown>[] {
+  let registrations: PluginControlUiDescriptorRegistryRegistration[];
+  try {
+    const candidate = getActivePluginRegistry()?.controlUiDescriptors;
+    registrations = Array.isArray(candidate) ? candidate : [];
+  } catch {
+    registrations = [];
+  }
+
+  const descriptors: Record<string, unknown>[] = [];
+  for (const entry of registrations) {
+    try {
+      const descriptor = entry.descriptor;
+      const pluginId = normalizeOptionalString(entry.pluginId);
+      const pluginName = normalizeOptionalString(entry.pluginName);
+      if (!isRecord(descriptor) || !pluginId) {
+        continue;
+      }
+      descriptors.push(
+        Object.assign(
+          {},
+          descriptor,
+          pluginName ? { pluginId, pluginName } : { pluginId },
+        ) as Record<string, unknown>,
+      );
+    } catch {
+      continue;
+    }
+  }
+  return descriptors;
 }
 
 /** Ensures plugin action result extension fields stay JSON-compatible on the wire. */
@@ -52,12 +85,7 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const descriptors = (getActivePluginRegistry()?.controlUiDescriptors ?? []).map((entry) =>
-      Object.assign({}, entry.descriptor, {
-        pluginId: entry.pluginId,
-        pluginName: entry.pluginName,
-      }),
-    );
+    const descriptors = listPluginControlUiDescriptors();
     respond(true, { ok: true, descriptors }, undefined);
   },
   "plugins.sessionAction": async ({ params, client, respond }) => {

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -52,6 +52,25 @@ async function callPluginSessionActionForTest(params: {
   return response ?? { ok: false, error: new Error("handler did not respond") };
 }
 
+async function callPluginUiDescriptorsForTest(): Promise<HookResponse> {
+  let response: HookResponse | undefined;
+  const respond: RespondFn = (ok, payload, error) => {
+    response = { ok, payload, error };
+  };
+  await pluginHostHookHandlers["plugins.uiDescriptors"]({
+    req: { id: "test", type: "req", method: "plugins.uiDescriptors", params: {} },
+    params: {},
+    client: {
+      connId: "test-client",
+      connect: { scopes: [READ_SCOPE] },
+    } as GatewayClient,
+    isWebchatConnect: () => false,
+    respond,
+    context: {} as never,
+  });
+  return response ?? { ok: false, error: new Error("handler did not respond") };
+}
+
 async function callRegisteredSessionActionForTest(params: {
   pluginId: string;
   actionId: string;
@@ -148,6 +167,52 @@ describe("plugin session actions", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     resetAgentEventsForTest();
+  });
+
+  it("keeps returning healthy UI descriptors after unreadable registrations", async () => {
+    const registry = createEmptyPluginRegistry();
+    const brokenRegistration = {
+      pluginId: "broken-ui",
+      pluginName: "Broken UI",
+      source: "/plugins/broken-ui/index.ts",
+      rootDir: "/plugins/broken-ui",
+    } as NonNullable<typeof registry.controlUiDescriptors>[number];
+    Object.defineProperty(brokenRegistration, "descriptor", {
+      get() {
+        throw new Error("control UI descriptor getter exploded");
+      },
+    });
+    registry.controlUiDescriptors = [
+      brokenRegistration,
+      {
+        pluginId: "healthy-ui",
+        pluginName: "Healthy UI",
+        descriptor: {
+          id: "healthy-panel",
+          surface: "session",
+          label: "Healthy panel",
+        },
+        source: "/plugins/healthy-ui/index.ts",
+        rootDir: "/plugins/healthy-ui",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    const response = await callPluginUiDescriptorsForTest();
+
+    expect(response.ok).toBe(true);
+    expect(response.payload).toEqual({
+      ok: true,
+      descriptors: [
+        {
+          id: "healthy-panel",
+          surface: "session",
+          label: "Healthy panel",
+          pluginId: "healthy-ui",
+          pluginName: "Healthy UI",
+        },
+      ],
+    });
   });
 
   it("initializes and registers typed session actions", () => {


### PR DESCRIPTION
## Summary

- guard `plugins.uiDescriptors` descriptor projection so one malformed Control UI registration cannot crash the whole gateway response
- skip unreadable or malformed UI descriptor rows while preserving healthy plugin descriptors
- add a contract regression for an unreadable descriptor getter next to a healthy descriptor

## Verification

Behavior addressed: A plugin registration with an unreadable `descriptor` getter could throw inside `plugins.uiDescriptors`, preventing healthy plugin UI descriptors from being returned.

Real environment tested: Local OpenClaw linked Codex worktree on Node 26 with the rebased branch `fuzz-tool-schema-next91-20260603` at `21e5ba12fff`.

Exact steps or command run after this patch:
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next91-rebase-focused node_modules/.bin/vitest run src/plugins/contracts/session-actions.contract.test.ts -t "keeps returning healthy UI descriptors after unreadable registrations" --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next91-rebase-full node_modules/.bin/vitest run src/plugins/contracts/session-actions.contract.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `node_modules/.bin/oxfmt --check src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `node_modules/.bin/oxlint src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix: Focused Vitest passed 1 test; full contract file passed 1 file / 11 tests. Format, lint, and diff whitespace checks passed. Branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.88)`.

Observed result after fix: The gateway returns the healthy `healthy-ui` descriptor and skips the unreadable `broken-ui` registration instead of throwing `control UI descriptor getter exploded`.

What was not tested: `pnpm check:changed` could not be run through maintainer remote gates from this shell: `blacksmith testbox list --all` reported unauthenticated, and AWS Crabbox failed before lease creation with coordinator `401 unauthorized`. `agent-transcript find` returned `[]`.
