### PR TITLE
fix(plugins): guard host cleanup extension metadata

### DIFF
--- a/src/plugins/host-hook-cleanup.config.test.ts
+++ b/src/plugins/host-hook-cleanup.config.test.ts
@@ -57,4 +57,53 @@ describe("plugin host cleanup config fallback", () => {
       },
     ]);
   });
+
+  it("continues cleanup after unreadable session extension metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    const runtimeCleanup = vi.fn();
+    const brokenExtension = {
+      pluginId: "broken-extension",
+      pluginName: "Broken Extension",
+      source: "test",
+    } as NonNullable<typeof registry.sessionExtensions>[number];
+    Object.defineProperty(brokenExtension, "extension", {
+      get() {
+        throw new Error("session extension getter exploded");
+      },
+    });
+    registry.sessionExtensions = [brokenExtension];
+    registry.runtimeLifecycles ??= [];
+    registry.runtimeLifecycles.push({
+      pluginId: "healthy-runtime",
+      pluginName: "Healthy Runtime",
+      source: "test",
+      lifecycle: {
+        id: "healthy-cleanup",
+        cleanup: runtimeCleanup,
+      },
+    });
+
+    const result = await runPluginHostCleanup({
+      cfg: {},
+      registry,
+      reason: "disable",
+    });
+
+    expect(runtimeCleanup.mock.calls).toEqual([
+      [
+        {
+          runId: undefined,
+          reason: "disable",
+          sessionKey: undefined,
+        },
+      ],
+    ]);
+    expect(result.cleanupCount).toBe(1);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      pluginId: "broken-extension",
+      hookId: "session:unknown",
+    });
+    expect(result.failures[0]?.error).toBeInstanceOf(Error);
+  });
 });

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -324,16 +324,20 @@ function collectSessionEntrySlotKeys(
 ): Set<string> {
   const slotKeys = new Set<string>();
   for (const registration of registry?.sessionExtensions ?? []) {
-    if (!shouldCleanPlugin(registration.pluginId, pluginId)) {
+    try {
+      if (!shouldCleanPlugin(registration.pluginId, pluginId)) {
+        continue;
+      }
+      const slotKey = registration.extension.sessionEntrySlotKey;
+      if (slotKey === undefined) {
+        continue;
+      }
+      const normalized = normalizeSessionEntrySlotKey(slotKey);
+      if (normalized.ok) {
+        slotKeys.add(normalized.key);
+      }
+    } catch {
       continue;
-    }
-    const slotKey = registration.extension.sessionEntrySlotKey;
-    if (slotKey === undefined) {
-      continue;
-    }
-    const normalized = normalizeSessionEntrySlotKey(slotKey);
-    if (normalized.ok) {
-      slotKeys.add(normalized.key);
     }
   }
   return slotKeys;
@@ -400,14 +404,35 @@ export async function runPluginHostCleanup(params: {
       if (!shouldCleanup()) {
         return { cleanupCount, failures };
       }
-      if (!shouldCleanPlugin(registration.pluginId, params.pluginId)) {
+      let pluginId: string;
+      let hookId: string;
+      let cleanup:
+        | ((params: {
+            reason: PluginHostCleanupReason;
+            sessionKey?: string;
+          }) => void | Promise<void>)
+        | undefined;
+      let failurePluginId = params.pluginId ?? "plugin-host";
+      try {
+        pluginId = registration.pluginId;
+        failurePluginId = pluginId;
+        if (!shouldCleanPlugin(pluginId, params.pluginId)) {
+          continue;
+        }
+        const extension = registration.extension;
+        cleanup = extension.cleanup;
+        hookId = `session:${extension.namespace}`;
+      } catch (error) {
+        failures.push({
+          pluginId: failurePluginId,
+          hookId: "session:unknown",
+          error,
+        });
         continue;
       }
-      const cleanup = registration.extension.cleanup;
       if (!cleanup) {
         continue;
       }
-      const hookId = `session:${registration.extension.namespace}`;
       try {
         await withPluginHostCleanupTimeout(hookId, () =>
           cleanup({
@@ -418,7 +443,7 @@ export async function runPluginHostCleanup(params: {
         cleanupCount += 1;
       } catch (error) {
         failures.push({
-          pluginId: registration.pluginId,
+          pluginId,
           hookId,
           error,
         });


### PR DESCRIPTION
## Summary

- guard plugin host cleanup slot-key discovery against unreadable session extension metadata
- record malformed session extension cleanup metadata as a cleanup failure instead of aborting the cleanup pass
- add a regression proving healthy runtime lifecycle cleanup still runs after a poisoned session extension row

## Verification

Behavior addressed: A stale or malformed plugin registry row with an unreadable session extension descriptor could throw during plugin host cleanup before healthy cleanup hooks ran.

Real environment tested: Local OpenClaw linked Codex worktree on Node 26 with branch `fuzz-tool-schema-next92-20260603` at `33ec4f273ef`.

Exact steps or command run after this patch:
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next92-rebase-focused node_modules/.bin/vitest run src/plugins/host-hook-cleanup.config.test.ts -t "continues cleanup after unreadable session extension metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next92-rebase-full node_modules/.bin/vitest run src/plugins/host-hook-cleanup.config.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `node_modules/.bin/oxfmt --check src/plugins/host-hook-cleanup.ts src/plugins/host-hook-cleanup.config.test.ts`
- `node_modules/.bin/oxlint src/plugins/host-hook-cleanup.ts src/plugins/host-hook-cleanup.config.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix: Focused Vitest passed the new regression; full touched test file passed 1 file / 2 tests. Format, lint, and diff whitespace checks passed. Branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.82)`.

Observed result after fix: `runPluginHostCleanup()` records the malformed `broken-extension` row as `session:unknown`, keeps the cleanup pass alive, and invokes the healthy `healthy-runtime` cleanup hook.

What was not tested: `pnpm check:changed` could not be run through maintainer remote gates from this shell: `blacksmith testbox list --all` reported unauthenticated, and AWS Crabbox failed before lease creation with coordinator `401 unauthorized`. `agent-transcript find` returned `[]`.
