### PR TITLE
fix(plugins): guard agent event subscription metadata

### DIFF
--- a/src/plugins/contracts/run-context-lifecycle.contract.test.ts
+++ b/src/plugins/contracts/run-context-lifecycle.contract.test.ts
@@ -857,4 +857,50 @@ describe("plugin run context lifecycle", () => {
       }),
     ).toBe(false);
   });
+
+  it("keeps dispatching healthy agent event subscriptions after unreadable metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    const healthyHandle = vi.fn();
+    const brokenRegistration = {
+      pluginId: "broken-event-subscription",
+      pluginName: "Broken Event Subscription",
+      source: "test",
+    } as NonNullable<typeof registry.agentEventSubscriptions>[number];
+    Object.defineProperty(brokenRegistration, "subscription", {
+      get() {
+        throw new Error("agent event subscription getter exploded");
+      },
+    });
+    registry.agentEventSubscriptions = [
+      brokenRegistration,
+      {
+        pluginId: "healthy-event-subscription",
+        pluginName: "Healthy Event Subscription",
+        source: "test",
+        subscription: {
+          id: "healthy-events",
+          streams: ["status"],
+          handle: healthyHandle,
+        },
+      },
+    ];
+
+    dispatchPluginAgentEventSubscriptions({
+      registry,
+      event: {
+        runId: "run-agent-event",
+        seq: 1,
+        stream: "status",
+        ts: Date.now(),
+        data: { phase: "running" },
+      },
+    });
+    await waitForPluginEventHandlers();
+
+    expect(healthyHandle).toHaveBeenCalledTimes(1);
+    expect(healthyHandle.mock.calls[0]?.[0]).toMatchObject({
+      runId: "run-agent-event",
+      stream: "status",
+    });
+  });
 });

--- a/src/plugins/host-hook-runtime.ts
+++ b/src/plugins/host-hook-runtime.ts
@@ -5,6 +5,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { withPluginHostCleanupTimeout } from "./host-hook-cleanup-timeout.js";
 import {
   isPluginJsonValue,
+  type PluginAgentEventSubscriptionRegistration,
   type PluginHostCleanupReason,
   type PluginJsonValue,
   type PluginRunContextGetParams,
@@ -296,11 +297,33 @@ export function dispatchPluginAgentEventSubscriptions(params: {
   const pendingHandlers: Promise<void>[] = [];
   const isTerminalEvent = isTerminalAgentRunEvent(params.event);
   for (const registration of subscriptions) {
-    const streams = registration.subscription.streams;
-    if (streams && streams.length > 0 && !streams.includes(params.event.stream)) {
+    let pluginId = "plugin-host";
+    let subscriptionId = "unknown";
+    let handler: PluginAgentEventSubscriptionRegistration["handle"] | undefined;
+    try {
+      pluginId = registration.pluginId;
+      const subscription = registration.subscription;
+      subscriptionId = normalizeOptionalString(subscription.id) ?? "unknown";
+      const streams = Array.isArray(subscription.streams) ? subscription.streams : undefined;
+      if (streams && streams.length > 0 && !streams.includes(params.event.stream)) {
+        continue;
+      }
+      handler = subscription.handle;
+      if (typeof handler !== "function") {
+        continue;
+      }
+    } catch (error) {
+      logAgentEventSubscriptionFailure({
+        pluginId,
+        subscriptionId,
+        error,
+      });
       continue;
     }
-    const pluginId = registration.pluginId;
+    const activeHandler = handler;
+    if (!activeHandler) {
+      continue;
+    }
     const runId = params.event.runId;
     let handlerActive = true;
     const ctx = {
@@ -319,13 +342,11 @@ export function dispatchPluginAgentEventSubscriptions(params: {
       },
     };
     try {
-      const pending = Promise.resolve(
-        registration.subscription.handle(structuredClone(params.event), ctx),
-      )
+      const pending = Promise.resolve(activeHandler(structuredClone(params.event), ctx))
         .catch((error: unknown) => {
           logAgentEventSubscriptionFailure({
             pluginId,
-            subscriptionId: registration.subscription.id,
+            subscriptionId,
             error,
           });
         })
@@ -338,7 +359,7 @@ export function dispatchPluginAgentEventSubscriptions(params: {
       handlerActive = false;
       logAgentEventSubscriptionFailure({
         pluginId,
-        subscriptionId: registration.subscription.id,
+        subscriptionId,
         error,
       });
     }


### PR DESCRIPTION
## Summary

- guard agent event subscription dispatch against unreadable plugin-owned subscription metadata
- avoid re-reading fragile subscription fields while logging handler failures
- add a regression proving healthy agent event subscribers still run after a poisoned subscription row

## Verification

Behavior addressed: A stale or malformed plugin registry row with an unreadable agent event subscription descriptor could throw during event dispatch before healthy subscribers ran.

Real environment tested: Local OpenClaw linked Codex worktree on Node 26 with branch `fuzz-tool-schema-next93-20260603` at `a106c4fe709`.

Exact steps or command run after this patch:
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next93-rebase-focused node_modules/.bin/vitest run src/plugins/contracts/run-context-lifecycle.contract.test.ts -t "keeps dispatching healthy agent event subscriptions after unreadable metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next93-rebase-full node_modules/.bin/vitest run src/plugins/contracts/run-context-lifecycle.contract.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1`
- `node_modules/.bin/oxfmt --check src/plugins/host-hook-runtime.ts src/plugins/contracts/run-context-lifecycle.contract.test.ts`
- `node_modules/.bin/oxlint src/plugins/host-hook-runtime.ts src/plugins/contracts/run-context-lifecycle.contract.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix: Focused Vitest passed the new regression; full touched contract file passed 1 file / 16 tests. Format, lint, and diff whitespace checks passed. Branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.87)`.

Observed result after fix: `dispatchPluginAgentEventSubscriptions()` logs/skips the malformed `broken-event-subscription` row and still invokes the healthy `healthy-event-subscription` handler for the event.

What was not tested: `pnpm check:changed` could not be run through maintainer remote gates from this shell: `blacksmith testbox list --all` reported unauthenticated, and AWS Crabbox failed before lease creation with coordinator `401 unauthorized`. `agent-transcript find` returned `[]`.
