### PR TITLE
fix(cli): skip compile cache on early Node 24.x to avoid startup deadlock

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -12,6 +12,7 @@ const MIN_NODE_MAJOR = 22;
 const MIN_NODE_MINOR = 19;
 const MIN_NODE_VERSION = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`;
 const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
+const COMPILE_CACHE_DISABLED_RESPAWNED_ENV = "OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED";
 
 const parseNodeVersion = (rawVersion) => {
   const [majorRaw = "0", minorRaw = "0"] = rawVersion.split(".");
@@ -204,10 +205,12 @@ const runRespawnedChild = (command, args, env) => {
 };
 
 const respawnWithoutCompileCacheIfNeeded = () => {
-  if (!isSourceCheckoutLauncher()) {
+  const needsDisabledCompileCacheRespawn =
+    isSourceCheckoutLauncher() || shouldSkipCompileCacheForWindowsNode24();
+  if (!needsDisabledCompileCacheRespawn) {
     return false;
   }
-  if (process.env.OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED === "1") {
+  if (process.env[COMPILE_CACHE_DISABLED_RESPAWNED_ENV] === "1") {
     return false;
   }
   if (!module.getCompileCacheDir?.() && !isNodeCompileCacheRequested()) {
@@ -216,7 +219,7 @@ const respawnWithoutCompileCacheIfNeeded = () => {
   const env = {
     ...process.env,
     NODE_DISABLE_COMPILE_CACHE: "1",
-    OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED: "1",
+    [COMPILE_CACHE_DISABLED_RESPAWNED_ENV]: "1",
   };
   delete env.NODE_COMPILE_CACHE;
   return runRespawnedChild(

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 const MIN_NODE_MAJOR = 22;
 const MIN_NODE_MINOR = 19;
 const MIN_NODE_VERSION = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`;
+const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
 
 const parseNodeVersion = (rawVersion) => {
   const [majorRaw = "0", minorRaw = "0"] = rawVersion.split(".");
@@ -23,6 +24,15 @@ const parseNodeVersion = (rawVersion) => {
 const isSupportedNodeVersion = (version) =>
   version.major > MIN_NODE_MAJOR ||
   (version.major === MIN_NODE_MAJOR && version.minor >= MIN_NODE_MINOR);
+
+const isNodeVersionAffectedByCompileCacheDeadlock = (rawVersion) => {
+  const version = parseNodeVersion(rawVersion);
+  return version.major === 24 && version.minor < MIN_COMPILE_CACHE_NODE_24_MINOR;
+};
+
+const shouldSkipCompileCacheForWindowsNode24 = () =>
+  process.platform === "win32" &&
+  isNodeVersionAffectedByCompileCacheDeadlock(process.versions.node);
 
 const ensureSupportedNodeVersion = () => {
   if (isSupportedNodeVersion(parseNodeVersion(process.versions.node))) {
@@ -217,7 +227,11 @@ const respawnWithoutCompileCacheIfNeeded = () => {
 };
 
 const respawnWithPackagedCompileCacheIfNeeded = () => {
-  if (isSourceCheckoutLauncher() || isNodeCompileCacheDisabled()) {
+  if (
+    isSourceCheckoutLauncher() ||
+    isNodeCompileCacheDisabled() ||
+    shouldSkipCompileCacheForWindowsNode24()
+  ) {
     return false;
   }
   if (process.env.OPENCLAW_PACKAGED_COMPILE_CACHE_RESPAWNED === "1") {
@@ -251,7 +265,8 @@ if (
   !waitingForCompileCacheRespawn &&
   module.enableCompileCache &&
   !isNodeCompileCacheDisabled() &&
-  !isSourceCheckoutLauncher()
+  !isSourceCheckoutLauncher() &&
+  !shouldSkipCompileCacheForWindowsNode24()
 ) {
   try {
     module.enableCompileCache(resolvePackagedCompileCacheDirectory());

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../test/helpers/temp-dir.js";
 import {
   buildOpenClawCompileCacheRespawnPlan,
+  isNodeVersionAffectedByCompileCacheDeadlock,
   isSourceCheckoutInstallRoot,
   resolveOpenClawCompileCacheDirectory,
   resolveEntryInstallRoot,
@@ -245,5 +246,73 @@ describe("entry compile cache", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("disables compile cache for early Node 24.x versions with known deadlock risk", () => {
+    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node24-");
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.1.0",
+      }),
+    ).toBe(false);
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.14.0",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps compile cache enabled for Node 24.15+ and other majors", () => {
+    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node2415-");
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.15.0",
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "22.22.0",
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "25.0.0",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isNodeVersionAffectedByCompileCacheDeadlock", () => {
+  it("flags Node 24.0 through 24.14 as affected", () => {
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("24.0.0")).toBe(true);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("24.1.0")).toBe(true);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("24.14.0")).toBe(true);
+  });
+
+  it("does not flag Node 24.15+", () => {
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("24.15.0")).toBe(false);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("24.20.1")).toBe(false);
+  });
+
+  it("does not flag other major versions", () => {
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("22.22.0")).toBe(false);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("23.11.0")).toBe(false);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("25.0.0")).toBe(false);
+  });
+
+  it("handles missing or invalid versions", () => {
+    expect(isNodeVersionAffectedByCompileCacheDeadlock(undefined)).toBe(false);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("")).toBe(false);
+    expect(isNodeVersionAffectedByCompileCacheDeadlock("not-a-version")).toBe(false);
   });
 });

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -59,11 +59,20 @@ describe("entry compile cache", () => {
   it("keeps compile cache enabled for packaged installs unless disabled by env", () => {
     const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-");
 
-    expect(shouldEnableOpenClawCompileCache({ env: {}, installRoot: root })).toBe(true);
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.15.0",
+        platform: "win32",
+      }),
+    ).toBe(true);
     expect(
       shouldEnableOpenClawCompileCache({
         env: { NODE_DISABLE_COMPILE_CACHE: "1" },
         installRoot: root,
+        nodeVersion: "24.15.0",
+        platform: "win32",
       }),
     ).toBe(false);
   });
@@ -248,13 +257,14 @@ describe("entry compile cache", () => {
     }
   });
 
-  it("disables compile cache for early Node 24.x versions with known deadlock risk", () => {
+  it("disables compile cache for early Node 24.x versions on Windows", () => {
     const root = makeTempDir(tempDirs, "openclaw-compile-cache-node24-");
     expect(
       shouldEnableOpenClawCompileCache({
         env: {},
         installRoot: root,
         nodeVersion: "24.1.0",
+        platform: "win32",
       }),
     ).toBe(false);
     expect(
@@ -262,17 +272,39 @@ describe("entry compile cache", () => {
         env: {},
         installRoot: root,
         nodeVersion: "24.14.0",
+        platform: "win32",
       }),
     ).toBe(false);
   });
 
-  it("keeps compile cache enabled for Node 24.15+ and other majors", () => {
+  it("keeps compile cache enabled for early Node 24.x on non-Windows packaged installs", () => {
+    const root = makeTempDir(tempDirs, "openclaw-compile-cache-node24-nonwin-");
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.1.0",
+        platform: "linux",
+      }),
+    ).toBe(true);
+    expect(
+      shouldEnableOpenClawCompileCache({
+        env: {},
+        installRoot: root,
+        nodeVersion: "24.14.0",
+        platform: "darwin",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps compile cache enabled for Node 24.15+ and other majors on Windows", () => {
     const root = makeTempDir(tempDirs, "openclaw-compile-cache-node2415-");
     expect(
       shouldEnableOpenClawCompileCache({
         env: {},
         installRoot: root,
         nodeVersion: "24.15.0",
+        platform: "win32",
       }),
     ).toBe(true);
     expect(
@@ -280,6 +312,7 @@ describe("entry compile cache", () => {
         env: {},
         installRoot: root,
         nodeVersion: "22.22.0",
+        platform: "win32",
       }),
     ).toBe(true);
     expect(
@@ -287,6 +320,7 @@ describe("entry compile cache", () => {
         env: {},
         installRoot: root,
         nodeVersion: "25.0.0",
+        platform: "win32",
       }),
     ).toBe(true);
   });

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -124,6 +124,8 @@ describe("entry compile cache", () => {
         currentFile: path.join(root, "dist", "entry.js"),
         env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
         installRoot: root,
+        nodeVersion: "24.1.0",
+        platform: "linux",
       }),
     ).toBeUndefined();
   });

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -111,12 +111,12 @@ describe("entry compile cache", () => {
       args: ["--no-warnings", path.join(root, "dist", "entry.js"), "status", "--json"],
       env: {
         NODE_DISABLE_COMPILE_CACHE: "1",
-        OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED: "1",
+        OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED: "1",
       },
     });
   });
 
-  it("does not respawn packaged installs when NODE_COMPILE_CACHE is configured", () => {
+  it("does not respawn unaffected packaged installs when NODE_COMPILE_CACHE is configured", () => {
     const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-respawn-");
 
     expect(
@@ -126,6 +126,31 @@ describe("entry compile cache", () => {
         installRoot: root,
       }),
     ).toBeUndefined();
+  });
+
+  it("builds a no-cache respawn plan for affected Windows packaged installs", () => {
+    const root = makeTempDir(tempDirs, "openclaw-compile-cache-package-win24-");
+    const entryFile = path.join(root, "dist", "entry.js");
+
+    const plan = buildOpenClawCompileCacheRespawnPlan({
+      currentFile: entryFile,
+      env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
+      execArgv: ["--no-warnings"],
+      execPath: "/usr/bin/node",
+      installRoot: root,
+      argv: ["/usr/bin/node", entryFile, "doctor", "--fix", "--non-interactive"],
+      nodeVersion: "24.1.0",
+      platform: "win32",
+    });
+
+    expect(plan).toEqual({
+      command: "/usr/bin/node",
+      args: ["--no-warnings", entryFile, "doctor", "--fix", "--non-interactive"],
+      env: {
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED: "1",
+      },
+    });
   });
 
   it("does not respawn source checkouts twice", async () => {
@@ -138,7 +163,7 @@ describe("entry compile cache", () => {
         currentFile: path.join(root, "dist", "entry.js"),
         env: {
           NODE_COMPILE_CACHE: "/tmp/openclaw-cache",
-          OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED: "1",
+          OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED: "1",
         },
         installRoot: root,
       }),

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -12,8 +12,7 @@ import {
 } from "./process/respawn-child-runner.js";
 
 // Node 24.0–24.14 can deadlock during ESM module loading when compile cache is
-// enabled on Windows npm-global installs. The release CI pins 24.15+ and has
-// not reproduced the hang. Skip compile cache on affected versions.
+// enabled on Windows npm-global installs. Keep the skip scoped to that platform.
 const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
 
 export function resolveEntryInstallRoot(entryFile: string): string {
@@ -59,11 +58,15 @@ export function shouldEnableOpenClawCompileCache(params: {
   env?: NodeJS.ProcessEnv;
   installRoot: string;
   nodeVersion?: string;
+  platform?: NodeJS.Platform;
 }): boolean {
   if (isNodeCompileCacheDisabled(params.env)) {
     return false;
   }
-  if (isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node)) {
+  if (
+    (params.platform ?? process.platform) === "win32" &&
+    isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node)
+  ) {
     return false;
   }
   return !isSourceCheckoutInstallRoot(params.installRoot);

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -14,6 +14,7 @@ import {
 // Node 24.0–24.14 can deadlock during ESM module loading when compile cache is
 // enabled on Windows npm-global installs. Keep the skip scoped to that platform.
 const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
+const COMPILE_CACHE_DISABLED_RESPAWNED_ENV = "OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED";
 
 export function resolveEntryInstallRoot(entryFile: string): string {
   const entryDir = path.dirname(entryFile);
@@ -139,12 +140,18 @@ export function buildOpenClawCompileCacheRespawnPlan(params: {
   installRoot: string;
   argv?: string[];
   compileCacheDir?: string;
+  nodeVersion?: string;
+  platform?: NodeJS.Platform;
 }): OpenClawCompileCacheRespawnPlan | undefined {
   const env = params.env ?? process.env;
-  if (!isSourceCheckoutInstallRoot(params.installRoot)) {
+  const needsDisabledCompileCacheRespawn =
+    isSourceCheckoutInstallRoot(params.installRoot) ||
+    ((params.platform ?? process.platform) === "win32" &&
+      isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node));
+  if (!needsDisabledCompileCacheRespawn) {
     return undefined;
   }
-  if (env.OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED === "1") {
+  if (env[COMPILE_CACHE_DISABLED_RESPAWNED_ENV] === "1") {
     return undefined;
   }
   if (!params.compileCacheDir && !isNodeCompileCacheRequested(env)) {
@@ -153,7 +160,7 @@ export function buildOpenClawCompileCacheRespawnPlan(params: {
   const nextEnv: NodeJS.ProcessEnv = {
     ...env,
     NODE_DISABLE_COMPILE_CACHE: "1",
-    OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED: "1",
+    [COMPILE_CACHE_DISABLED_RESPAWNED_ENV]: "1",
   };
   delete nextEnv.NODE_COMPILE_CACHE;
   return {

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -4,11 +4,17 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { enableCompileCache, getCompileCacheDir } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 import {
   runRespawnChildWithSignalBridge,
   type RespawnChildRuntime,
 } from "./process/respawn-child-runner.js";
+
+// Node 24.0–24.14 can deadlock during ESM module loading when compile cache is
+// enabled on Windows npm-global installs. The release CI pins 24.15+ and has
+// not reproduced the hang. Skip compile cache on affected versions.
+const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
 
 export function resolveEntryInstallRoot(entryFile: string): string {
   const entryDir = path.dirname(entryFile);
@@ -31,11 +37,33 @@ function isNodeCompileCacheRequested(env: NodeJS.ProcessEnv | undefined): boolea
   return env?.NODE_COMPILE_CACHE !== undefined && !isNodeCompileCacheDisabled(env);
 }
 
+export function isNodeVersionAffectedByCompileCacheDeadlock(
+  nodeVersion: string | undefined,
+): boolean {
+  if (!nodeVersion) {
+    return false;
+  }
+  const match = nodeVersion.match(/^(\d+)\.(\d+)/);
+  if (!match) {
+    return false;
+  }
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  if (major !== 24) {
+    return false;
+  }
+  return minor < MIN_COMPILE_CACHE_NODE_24_MINOR;
+}
+
 export function shouldEnableOpenClawCompileCache(params: {
   env?: NodeJS.ProcessEnv;
   installRoot: string;
+  nodeVersion?: string;
 }): boolean {
   if (isNodeCompileCacheDisabled(params.env)) {
+    return false;
+  }
+  if (isNodeVersionAffectedByCompileCacheDeadlock(params.nodeVersion ?? process.versions.node)) {
     return false;
   }
   return !isSourceCheckoutInstallRoot(params.installRoot);

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -11,7 +11,7 @@ import {
   type RespawnChildRuntime,
 } from "./process/respawn-child-runner.js";
 
-// Node 24.0–24.14 can deadlock during ESM module loading when compile cache is
+// Node 24.0-24.14 can deadlock during ESM module loading when compile cache is
 // enabled on Windows npm-global installs. Keep the skip scoped to that platform.
 const MIN_COMPILE_CACHE_NODE_24_MINOR = 15;
 const COMPILE_CACHE_DISABLED_RESPAWNED_ENV = "OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED";

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -58,6 +58,26 @@ async function addCompileCacheProbe(fixtureRoot: string): Promise<void> {
   );
 }
 
+async function addLauncherRuntimeMock(
+  fixtureRoot: string,
+  params: { nodeVersion: string; platform: NodeJS.Platform },
+): Promise<string> {
+  const mockPath = path.join(fixtureRoot, "mock-launcher-runtime.mjs");
+  await fs.writeFile(
+    mockPath,
+    [
+      "Object.defineProperty(process, 'platform', {",
+      `  value: ${JSON.stringify(params.platform)},`,
+      "});",
+      "Object.defineProperty(process.versions, 'node', {",
+      `  value: ${JSON.stringify(params.nodeVersion)},`,
+      "});",
+    ].join("\n"),
+    "utf8",
+  );
+  return mockPath;
+}
+
 async function waitForJsonFile<T>(filePath: string, timeoutMs: number): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
@@ -854,6 +874,67 @@ describe("openclaw launcher", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain(path.join("node-compile-cache", "openclaw", "2026.4.29"));
     expect(result.stdout).not.toContain(path.join(runCwd, "openclaw"));
+  });
+
+  it("skips compile cache for Windows packaged launchers on early Node 24.x", async () => {
+    for (const nodeVersion of ["24.1.0", "24.14.0"]) {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      const tmpRoot = makeTempDir(fixtureRoots, "openclaw-launcher-tmp-");
+      const mockRuntime = await addLauncherRuntimeMock(fixtureRoot, {
+        nodeVersion,
+        platform: "win32",
+      });
+      await addCompileCacheProbe(fixtureRoot);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", mockRuntime, path.join(fixtureRoot, "openclaw.mjs")],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({
+            TMP: tmpRoot,
+            TEMP: tmpRoot,
+            TMPDIR: tmpRoot,
+          }),
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("cache:disabled;respawn:0");
+    }
+  });
+
+  it("keeps compile cache enabled for unaffected packaged launcher runtimes", async () => {
+    const cases: Array<{ nodeVersion: string; platform: NodeJS.Platform }> = [
+      { nodeVersion: "24.15.0", platform: "win32" },
+      { nodeVersion: "24.1.0", platform: "linux" },
+      { nodeVersion: "24.14.0", platform: "darwin" },
+    ];
+
+    for (const runtime of cases) {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      const tmpRoot = makeTempDir(fixtureRoots, "openclaw-launcher-tmp-");
+      const mockRuntime = await addLauncherRuntimeMock(fixtureRoot, runtime);
+      await addCompileCacheProbe(fixtureRoot);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", mockRuntime, path.join(fixtureRoot, "openclaw.mjs")],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({
+            TMP: tmpRoot,
+            TEMP: tmpRoot,
+            TMPDIR: tmpRoot,
+          }),
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("cache:enabled;respawn:0");
+    }
   });
 
   it("enables compile cache for packaged launchers", async () => {

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -51,7 +51,7 @@ async function addCompileCacheProbe(fixtureRoot: string): Promise<void> {
     [
       'import module from "node:module";',
       "process.stdout.write(",
-      '  `${module.getCompileCacheDir?.() ? "cache:enabled" : "cache:disabled"};respawn:${process.env.OPENCLAW_SOURCE_COMPILE_CACHE_RESPAWNED ?? "0"}`',
+      '  `${module.getCompileCacheDir?.() ? "cache:enabled" : "cache:disabled"};respawn:${process.env.OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED ?? "0"}`',
       ");",
     ].join("\n"),
     "utf8",
@@ -902,6 +902,36 @@ describe("openclaw launcher", () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout).toBe("cache:disabled;respawn:0");
+    }
+  });
+
+  it("respawns Windows early Node 24 packaged launchers without inherited NODE_COMPILE_CACHE", async () => {
+    for (const nodeVersion of ["24.1.0", "24.14.0"]) {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      const tmpRoot = makeTempDir(fixtureRoots, "openclaw-launcher-tmp-");
+      const mockRuntime = await addLauncherRuntimeMock(fixtureRoot, {
+        nodeVersion,
+        platform: "win32",
+      });
+      await addCompileCacheProbe(fixtureRoot);
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", mockRuntime, path.join(fixtureRoot, "openclaw.mjs")],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({
+            NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+            TMP: tmpRoot,
+            TEMP: tmpRoot,
+            TMPDIR: tmpRoot,
+          }),
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("cache:disabled;respawn:1");
     }
   });
 


### PR DESCRIPTION
## Summary

Disable Node compile cache for Windows packaged startup on early Node 24.x versions (`24.0`-`24.14`), including the case where the packaged launcher or entry helper inherits `NODE_COMPILE_CACHE` from the parent environment.

This applies the same no-cache startup boundary to both the TypeScript packaged entry decision and the `openclaw.mjs` packaged launcher path, while keeping compile cache enabled for non-Windows packaged installs on Node `24.0`-`24.14`, for Windows packaged installs on Node `24.15+`, and for other Node majors.

This update also fixes the focused compile-cache regression test so its "unaffected packaged install" case explicitly runs as Linux Node 24.1 instead of inheriting the native Windows Node 24.1 proof runner environment.

Fixes #86550

## Maintainer-ready summary

- **Why it matters / User impact:** Affected Windows npm-global users on early Node 24.x can hang before basic CLI commands (`openclaw --version`, `openclaw doctor --fix --non-interactive`, `openclaw gateway start`) produce output or exit. This patch removes the startup-level compile-cache trigger for that Windows/Node range while preserving compile-cache behavior outside that boundary.
- **Maintainer-ready confidence:** High for the source boundary, focused regression test, native Windows npm-global CLI proof, gateway proof, and the exact Node `24.15+` re-enable boundary. The previous evidence gap is now closed with native Windows side-by-side proof using the same packed OpenClaw artifact on `node@24.14.0` and `node@24.15.0`.
- **Compatibility stance:** Do not disable compile cache for all Windows Node 24.x. The proof supports the narrower behavior: Windows Node `24.0`-`24.14` takes the protected no-cache path; Windows Node `24.15+` keeps compile cache enabled.

## Real behavior proof

- **Behavior or issue addressed:** Native Windows npm-global CLI startup can hang on early Node 24.x when Node compile cache is active before the CLI import path. The code fix applies to Windows packaged startup on Node `24.0`-`24.14`, including inherited `NODE_COMPILE_CACHE`.
- **Real environment tested:** Native Windows 10 / Git Bash, packed current PR head `563dcf592ec695bf34cf7fd4ba9aee141843fe6a`, isolated npm-global prefixes, isolated OpenClaw home/state/config paths, inherited `NODE_COMPILE_CACHE`, and explicit proof ports (`19114` for Node 24.14, `19115` for Node 24.15).
- **Same artifact for the cutoff comparison:** `npm pack` produced `openclaw-2026.6.2.tgz`; that same packed artifact was installed and tested under both `node@24.14.0` and `node@24.15.0`.
- **Exact steps or command run after this patch:** `node@24.14.0 node_modules/vitest/vitest.mjs run src/entry.compile-cache.test.ts`; `node@24.15.0 node_modules/vitest/vitest.mjs run src/entry.compile-cache.test.ts`; `scripts/build-all.mjs`; `npm pack`; `npm install -g --prefix <isolated-prefix> openclaw-2026.6.2.tgz` for each runtime; with inherited `NODE_COMPILE_CACHE`, run `openclaw --version` and `openclaw gateway install/start/status/stop/uninstall --json` for both Node 24.14 and Node 24.15; instrument `openclaw.mjs gateway status --json` with `--import compile-cache-proof-logger.mjs` to capture the actual process/env transition.
- **Evidence after fix:** Maintainer-readable proof summary: focused startup-decision tests passed on native Windows `node@24.14.0` and `node@24.15.0`; the current PR head built and packed successfully; the same packed tarball installed in isolated npm-global prefixes under both runtimes; `openclaw --version` and gateway install/start/status/stop/uninstall completed successfully for both runtimes; instrumentation showed Node 24.14 takes the no-cache respawn path while Node 24.15 keeps compile cache enabled through the packaged cache path.
- **Observed result after fix:** Focused compile-cache tests passed 19/19 on both native Windows `node@24.14.0` and `node@24.15.0`; build and pack completed; the same packed artifact installed in isolated npm-global prefixes under both runtimes; both runtime proof scripts completed `openclaw --version` and gateway install/start/status/stop/uninstall with `PROOF_RC=0` and gateway RPC `ok: true`; the Node 24.14 process log proves the no-cache respawn (`NODE_DISABLE_COMPILE_CACHE=1`, `OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED=1`, inherited `NODE_COMPILE_CACHE` removed); the Node 24.15 process log proves compile cache remains enabled by repointing `NODE_COMPILE_CACHE` to the packaged OpenClaw cache path, without the no-cache respawn marker.
- **What was not tested:** I did not find an upstream Node release note, issue, or PR explicitly saying a Windows module-compile-cache deadlock was fixed in Node 24.15. The upstream evidence supports Node 24.15 as the official module-compile-cache stability boundary, while the OpenClaw-specific cutoff is now supported by direct native Windows side-by-side packed-CLI proof. I am not citing the newest `doctor --fix --non-interactive` comparison attempt as passing proof because it timed out after printing normal doctor output. Full-file `test/openclaw-launcher.e2e.test.ts` was previously attempted under native Windows Node 24.1 but is not cited as passing proof due unrelated local fixture/runtime behavior.
- **Fix classification:** Root-cause startup fix plus test portability fix for the native-Windows proof runner.

### Current-head validation

- `node@24.14.0`: `node_modules/vitest/vitest.mjs run src/entry.compile-cache.test.ts` passed 19/19 focused tests.
- `node@24.15.0`: `node_modules/vitest/vitest.mjs run src/entry.compile-cache.test.ts` passed 19/19 focused tests.
- `scripts/build-all.mjs` completed successfully before packing the current PR artifact.
- `npm pack` generated `openclaw-2026.6.2.tgz` for the native comparison proof.
- Isolated npm-global installs from that tarball succeeded under both `node@24.14.0` and `node@24.15.0`.

### Native Windows side-by-side cutoff proof

- **Node `24.14.0` affected side:** With inherited `NODE_COMPILE_CACHE`, the instrumented process log shows the launcher respawned into the protected no-cache path: the child process had `NODE_DISABLE_COMPILE_CACHE=1`, `OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED=1`, and no inherited `NODE_COMPILE_CACHE`. The packed CLI then completed `openclaw --version` and `gateway install/start/status/stop/uninstall --json` successfully; gateway status showed the listener running and RPC `ok: true`. The proof script exited `PROOF_RC=0`.
- **Node `24.15.0` re-enabled side:** With inherited `NODE_COMPILE_CACHE`, the instrumented process log shows the launcher did **not** take the no-cache respawn path. Instead, it kept compile cache enabled and repointed `NODE_COMPILE_CACHE` to the packaged OpenClaw cache directory (`.../openclaw/2026.6.2/...`), with no `NODE_DISABLE_COMPILE_CACHE` and no `OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED`. The packed CLI then completed `openclaw --version` and `gateway install/start/status/stop/uninstall --json` successfully; gateway status showed the listener running and RPC `ok: true`. The proof script exited `PROOF_RC=0`.

### Public evidence summary

The validation is summarized here as maintainer-readable commands and observed outcomes, not as local artifact paths:

1. **Focused startup-decision regression test**
   - Command shape: `node_modules/vitest/vitest.mjs run src/entry.compile-cache.test.ts`
   - Native Windows `node@24.14.0`: 19/19 tests passed.
   - Native Windows `node@24.15.0`: 19/19 tests passed.
   - Covered boundary: Windows Node `24.0`-`24.14` disables compile cache / no-cache respawns when inherited cache is active; Windows Node `24.15+` keeps compile cache enabled; non-Windows Node `24.0`-`24.14` keeps compile cache enabled.

2. **Same packed artifact tested on both runtimes**
   - `scripts/build-all.mjs` completed.
   - `npm pack` produced `openclaw-2026.6.2.tgz`.
   - That same tarball installed successfully into isolated npm-global prefixes under both `node@24.14.0` and `node@24.15.0`.

3. **Native Windows packed CLI/gateway lifecycle**
   - Command shape for both runtimes: `openclaw --version`, then `openclaw gateway install --json`, `gateway start --json`, `gateway status --json`, `gateway stop --json`, `gateway uninstall --json`.
   - Node `24.14.0`: proof script ended `PROOF_RC=0`; gateway status showed listener `127.0.0.1:19114`, server version `2026.6.2`, and RPC `ok: true`.
   - Node `24.15.0`: proof script ended `PROOF_RC=0`; gateway status showed listener `127.0.0.1:19115`, server version `2026.6.2`, and RPC `ok: true`.

4. **Instrumented compile-cache behavior at the cutoff**
   - Node `24.14.0` started with inherited `NODE_COMPILE_CACHE`, then respawned with `NODE_DISABLE_COMPILE_CACHE=1` and `OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED=1`; inherited `NODE_COMPILE_CACHE` was removed before the CLI import path.
   - Node `24.15.0` started with inherited `NODE_COMPILE_CACHE`, did **not** set `NODE_DISABLE_COMPILE_CACHE`, did **not** set `OPENCLAW_COMPILE_CACHE_DISABLED_RESPAWNED`, and continued with `NODE_COMPILE_CACHE` pointed at the packaged OpenClaw cache directory under `openclaw/2026.6.2/...`.

This is why the final scope is narrow: protect Windows packaged startup on Node `24.0`-`24.14`, while keeping compile cache enabled for non-Windows installs and Windows Node `24.15+`.

### What was not claimed

- I did not find an upstream Node release note, issue, or PR that explicitly says a Windows module-compile-cache deadlock was fixed in Node 24.15. The upstream evidence supports Node 24.15 as the official module-compile-cache stability boundary (`nodejs/node#60971`); the direct reason to keep `24.15+` enabled in this PR is now the native Windows side-by-side OpenClaw proof above.
- I am not citing the newest `doctor --fix --non-interactive` comparison attempt as passing proof because that command timed out after printing normal doctor output. The current-head native comparison proof instead uses `openclaw --version` and the gateway lifecycle, both of which completed with `PROOF_RC=0` for Node 24.14 and Node 24.15.
- Full-file `test/openclaw-launcher.e2e.test.ts` was previously attempted under native Windows Node 24.1 but is not cited as passing proof because local Windows fixture/runtime behavior caused unrelated failures; the source boundary is covered by the focused regression test plus packed CLI proof.

## Review findings addressed

- RF-001 / RF-003 / RF-004 / RF-008: Addressed with fresh native Windows npm-global proof. The packed PR package ran visible CLI startup and gateway lifecycle commands, observed live listeners/RPC, and cleaned up with stop/uninstall.
- RF-002 / RF-006: Addressed by focused regression tests plus the new side-by-side native Windows proof. Windows Node `24.14.0` takes the no-cache respawn path; Windows Node `24.15.0` keeps compile cache enabled through the packaged cache path.
- RF-005: The compatibility/performance tradeoff is explicitly scoped. Compile cache is disabled only for Windows packaged startup on Node `24.0`-`24.14`; non-Windows packaged installs and Windows Node `24.15+` keep compile cache enabled.
- RF-007: The manual acceptance point is no longer an untested cutoff. There is still no Windows-deadlock-specific upstream Node note, but the PR now contains direct Windows packed-CLI proof at the exact `24.14` / `24.15` boundary.
- RF-009: Addressed with current-head focused verification and native packed CLI/gateway behavior proof.

## Regression Test Plan

- **Target test file:** `src/entry.compile-cache.test.ts`; launcher startup behavior is additionally covered by native packed npm-global proof.
- **Scenario locked in:** Early Node 24.x disables compile cache on Windows packaged installs and on the packaged launcher; inherited `NODE_COMPILE_CACHE` triggers a one-shot no-cache respawn for affected Windows packaged startup; compile cache stays enabled for early Node 24.x on Linux/macOS packaged startup and for Node `24.15+` / Node 22 / Node 25 on Windows packaged startup.
- **Why this is the smallest reliable guardrail:** The changed behavior is a startup decision before command execution. Injecting `nodeVersion` and `platform` directly proves the decision boundary, while the native npm-global proof covers the reported Windows packaged-startup class and the exact cutoff behavior.

## Root Cause

- **Root cause:** OpenClaw enables or inherits Node's compile cache during packaged CLI startup before importing the full CLI. The linked issue reports a startup hang on native Windows npm-global with early Node 24.x at that entry stage. The source of the failure is the startup-level compile-cache state before command dispatch, not gateway, plugin, channel, provider, or command-specific code.
- **Why this is root-cause fix:** The patch blocks OpenClaw's compile-cache API use for Windows packaged startup on Node `24.0`-`24.14` and respawns affected packaged startup when `NODE_COMPILE_CACHE` was inherited, setting `NODE_DISABLE_COMPILE_CACHE=1` and removing `NODE_COMPILE_CACHE` before the runtime entry import. That removes the reported entry-level deadlock trigger for the affected Windows packaged startup class while preserving the existing compile-cache contract outside that boundary.

## Scope and architecture

- What did NOT change: No unrelated gateway behavior, plugin/channel/provider code, config surface, dependency, lockfile, docs, or unrelated startup path changed. The only behavior change is the compile-cache startup default and inherited-cache respawn for Windows packaged Node `24.0`-`24.14`; unrelated CLI startup hangs remain out of scope.
- Architecture / source-of-truth check: The source-of-truth boundary is split by runtime artifact: `src/entry.compile-cache.ts` is the canonical typed entry helper, and `openclaw.mjs` is the canonical packaged launcher pre-import compile-cache path. Both now apply the same Windows Node `24.0`-`24.14` contract before calling `enableCompileCache(...)`, inheriting compile cache, or respawning for packaged compile cache.
- Compatibility / related open PR scan: The compatibility-sensitive surface is packaged CLI startup defaulting, and this patch keeps the behavior change scoped to affected Windows early-Node-24 packaged startup. `check-upstream-fixed` reported current `origin/main` does not already cover this PR.

## Patch quality notes

- Patch quality notes: The no-cache respawn is intentionally limited to source checkouts that already needed inherited-cache cleanup and to Windows packaged Node `24.0`-`24.14`, where inherited compile cache can preserve the startup hang. The default for every other packaged runtime remains the existing compile-cache-enabled path. The added `return false` branches are explicit guard exits for unavailable/malformed version input or already-disabled compile-cache state; they are not silent product fallbacks and they preserve the previous default behavior outside the affected boundary. No new dependencies, config knobs, fallback stacks, or runtime shims were added.
- Test quality notes: The added explicit platform/runtime cases keep the focused test valid when run from native Windows Node 24.x and verify both sides of the cutoff.

## Merge risk

- Risk labels considered: `merge-risk: availability`, `merge-risk: compatibility`.
- Risk explanation: Availability risk is the reported Windows startup hang. Compatibility/performance risk is changing packaged startup compile-cache behavior.
- Why acceptable: Compile cache is a startup optimization, while the reported failure prevents the CLI from starting at all. The patch preserves compile cache outside the Windows early-Node-24 boundary, and the new native Windows side-by-side proof shows the exact `24.14` / `24.15` cutoff behaves as intended.
