### PR TITLE
fix(agents): resolve webchat current session status

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -573,6 +573,43 @@ describe("session_status tool", () => {
     });
   });
 
+  it("resolves whitespace-decorated webchat sessionKey=current to the full requester main key (#89800)", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-fallback-main",
+        updatedAt: 5,
+        thinkingLevel: "high",
+      },
+      "agent:admin:main": {
+        sessionId: "s-admin-main",
+        updatedAt: 10,
+        thinkingLevel: "low",
+      },
+    });
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:admin:main",
+      activeDeliveryContext: {
+        channel: "webchat",
+        to: "control-ui-conversation",
+      },
+      config: mockConfig as never,
+    });
+
+    const result = await tool.execute("call-current-webchat-main-spaced", {
+      sessionKey: " current ",
+    });
+    const details = result.details as { ok?: boolean; sessionKey?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:admin:main");
+
+    const statusArg = mockCallArg(buildStatusMessageMock) as Record<string, unknown>;
+    expectRecordFields(statusArg.sessionEntry, {
+      sessionId: "s-admin-main",
+      thinkingLevel: "low",
+    });
+  });
+
   it("synthesizes webchat sessionKey=current from the full requester main key (#89773)", async () => {
     resetSessionStore({});
 

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -538,6 +538,62 @@ describe("session_status tool", () => {
     expect(details.sessionKey).toBe("main");
   });
 
+  it("resolves webchat sessionKey=current to the full requester main key (#89773)", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-fallback-main",
+        updatedAt: 5,
+        thinkingLevel: "high",
+      },
+      "agent:admin:main": {
+        sessionId: "s-admin-main",
+        updatedAt: 10,
+        thinkingLevel: "low",
+      },
+    });
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:admin:main",
+      activeDeliveryContext: {
+        channel: "webchat",
+        to: "control-ui-conversation",
+      },
+      config: mockConfig as never,
+    });
+
+    const result = await tool.execute("call-current-webchat-main", { sessionKey: "current" });
+    const details = result.details as { ok?: boolean; sessionKey?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:admin:main");
+
+    const statusArg = mockCallArg(buildStatusMessageMock) as Record<string, unknown>;
+    expectRecordFields(statusArg.sessionEntry, {
+      sessionId: "s-admin-main",
+      thinkingLevel: "low",
+    });
+  });
+
+  it("synthesizes webchat sessionKey=current from the full requester main key (#89773)", async () => {
+    resetSessionStore({});
+
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:admin:main",
+      activeDeliveryContext: {
+        channel: "webchat",
+        to: "control-ui-conversation",
+      },
+      config: mockConfig as never,
+    });
+
+    const result = await tool.execute("call-current-webchat-main-unpersisted", {
+      sessionKey: "current",
+    });
+    const details = result.details as { ok?: boolean; sessionKey?: string; statusText?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:admin:main");
+    expect(details.statusText).toContain("OpenClaw");
+  });
+
   it("uses runSessionKey thinking level for implicit no-arg status lookups (#82669)", async () => {
     resetSessionStore({
       "agent:main:telegram:default:direct:1234": {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -574,15 +574,16 @@ export function createSessionStatusTool(opts?: {
       if (isImplicitRunSessionStatus) {
         requestedKeyRaw = opts?.runSessionKey;
       }
+      let requestedKeyInput = requestedKeyRaw?.trim() ?? "";
 
       // Track whether this is a semantic-current request (literal "current" or a
       // current-client alias) BEFORE any rewrite, so visibility treats it as self.
       const isSemanticCurrentRequest =
-        requestedKeyRaw === "current" ||
+        requestedKeyInput === "current" ||
         isImplicitRunSessionStatus ||
         Boolean(
           resolveCurrentSessionClientAlias({
-            key: requestedKeyRaw ?? "",
+            key: requestedKeyInput,
             requesterInternalKey: effectiveRequesterKey,
           }),
         );
@@ -590,24 +591,26 @@ export function createSessionStatusTool(opts?: {
       // Resolve semantic "current" to the live run session key for lookup purposes (#76708).
       // In sandboxed channel runs there may be no separate runSessionKey because the sandbox
       // key already is the live requester; avoid probing literal "current" through the gateway.
-      if (requestedKeyRaw === "current" && (opts?.runSessionKey || opts?.sandboxed === true)) {
+      if (requestedKeyInput === "current" && (opts?.runSessionKey || opts?.sandboxed === true)) {
         requestedKeyRaw = opts.runSessionKey ?? effectiveRequesterKey;
+        requestedKeyInput = requestedKeyRaw?.trim() ?? "";
       }
 
       const currentSessionAlias = resolveCurrentSessionClientAlias({
-        key: requestedKeyRaw ?? "",
+        key: requestedKeyInput,
         requesterInternalKey: effectiveRequesterKey,
       });
       if (currentSessionAlias) {
         requestedKeyRaw = opts?.runSessionKey ?? currentSessionAlias;
+        requestedKeyInput = requestedKeyRaw?.trim() ?? "";
       }
-      const requestedKeyInput = requestedKeyRaw?.trim() ?? "";
       const effectiveRequesterLookupKey = effectiveRequesterKey.trim();
       let resolvedViaSessionId = false;
       let resolvedViaImplicitCurrentFallback = false;
-      if (!requestedKeyRaw?.trim()) {
+      if (!requestedKeyInput) {
         throw new Error("sessionKey required");
       }
+      requestedKeyRaw = requestedKeyInput;
       const ensureAgentAccess = (targetAgentId: string) => {
         if (targetAgentId === requesterAgentId) {
           return;
@@ -623,20 +626,20 @@ export function createSessionStatusTool(opts?: {
         }
       };
 
-      if (requestedKeyRaw.startsWith("agent:") && !isSemanticCurrentRequest) {
-        const requestedAgentId = resolveAgentIdFromSessionKey(requestedKeyRaw);
+      if (requestedKeyInput.startsWith("agent:") && !isSemanticCurrentRequest) {
+        const requestedAgentId = resolveAgentIdFromSessionKey(requestedKeyInput);
         ensureAgentAccess(requestedAgentId);
         const access = visibilityGuard.check(
-          normalizeVisibilityTargetSessionKey(requestedKeyRaw, requestedAgentId),
+          normalizeVisibilityTargetSessionKey(requestedKeyInput, requestedAgentId),
         );
         if (!access.allowed) {
           throw new Error(access.error);
         }
       }
 
-      const isExplicitAgentKey = requestedKeyRaw.startsWith("agent:");
+      const isExplicitAgentKey = requestedKeyInput.startsWith("agent:");
       let agentId = isExplicitAgentKey
-        ? resolveAgentIdFromSessionKey(requestedKeyRaw)
+        ? resolveAgentIdFromSessionKey(requestedKeyInput)
         : requesterAgentId;
       let storePath = resolveStorePath(cfg.session?.store, { agentId });
       let store = loadSessionStore(storePath);
@@ -653,15 +656,15 @@ export function createSessionStatusTool(opts?: {
         alias,
         mainKey,
         requesterInternalKey: storeScopedRequesterKey,
-        includeAliasFallback: requestedKeyRaw !== "current",
+        includeAliasFallback: requestedKeyInput !== "current",
       });
 
       if (
         !resolved &&
-        (requestedKeyRaw === "current" || shouldResolveSessionIdInput(requestedKeyRaw))
+        (requestedKeyInput === "current" || shouldResolveSessionIdInput(requestedKeyInput))
       ) {
         const resolvedSession = await resolveSessionReference({
-          sessionKey: requestedKeyRaw,
+          sessionKey: requestedKeyInput,
           alias,
           mainKey,
           requesterInternalKey: effectiveRequesterKey,
@@ -672,7 +675,7 @@ export function createSessionStatusTool(opts?: {
             resolvedSession,
             requesterSessionKey: effectiveRequesterKey,
             restrictToSpawned: opts?.sandboxed === true,
-            visibilitySessionKey: requestedKeyRaw,
+            visibilitySessionKey: requestedKeyInput,
           });
           if (!visibleSession.ok) {
             throw new Error("Session status visibility is restricted to the current session tree.");
@@ -681,6 +684,7 @@ export function createSessionStatusTool(opts?: {
           ensureAgentAccess(resolveAgentIdFromSessionKey(visibleSession.key));
           resolvedViaSessionId = true;
           requestedKeyRaw = visibleSession.key;
+          requestedKeyInput = requestedKeyRaw.trim();
           agentId = resolveAgentIdFromSessionKey(visibleSession.key);
           storePath = resolveStorePath(cfg.session?.store, { agentId });
           store = loadSessionStore(storePath);
@@ -701,7 +705,7 @@ export function createSessionStatusTool(opts?: {
         }
       }
 
-      if (!resolved && requestedKeyRaw === "current" && effectiveRequesterLookupKey) {
+      if (!resolved && requestedKeyInput === "current" && effectiveRequesterLookupKey) {
         resolved = resolveSessionEntry({
           store,
           keyRaw: effectiveRequesterLookupKey,
@@ -712,7 +716,7 @@ export function createSessionStatusTool(opts?: {
         });
       }
 
-      if (!resolved && requestedKeyRaw === "current") {
+      if (!resolved && requestedKeyInput === "current") {
         resolved = resolveSessionEntry({
           store,
           keyRaw: requestedKeyRaw,
@@ -761,8 +765,8 @@ export function createSessionStatusTool(opts?: {
       }
 
       if (!resolved) {
-        const kind = shouldResolveSessionIdInput(requestedKeyRaw) ? "sessionId" : "sessionKey";
-        throw new Error(`Unknown ${kind}: ${requestedKeyRaw}`);
+        const kind = shouldResolveSessionIdInput(requestedKeyInput) ? "sessionId" : "sessionKey";
+        throw new Error(`Unknown ${kind}: ${requestedKeyInput}`);
       }
 
       // Preserve caller-scoped raw-key/current lookups as "self" for visibility checks.

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -602,6 +602,7 @@ export function createSessionStatusTool(opts?: {
         requestedKeyRaw = opts?.runSessionKey ?? currentSessionAlias;
       }
       const requestedKeyInput = requestedKeyRaw?.trim() ?? "";
+      const effectiveRequesterLookupKey = effectiveRequesterKey.trim();
       let resolvedViaSessionId = false;
       let resolvedViaImplicitCurrentFallback = false;
       if (!requestedKeyRaw?.trim()) {
@@ -700,6 +701,17 @@ export function createSessionStatusTool(opts?: {
         }
       }
 
+      if (!resolved && requestedKeyRaw === "current" && effectiveRequesterLookupKey) {
+        resolved = resolveSessionEntry({
+          store,
+          keyRaw: effectiveRequesterLookupKey,
+          alias,
+          mainKey,
+          requesterInternalKey: storeScopedRequesterKey,
+          includeAliasFallback: false,
+        });
+      }
+
       if (!resolved && requestedKeyRaw === "current") {
         resolved = resolveSessionEntry({
           store,
@@ -732,12 +744,15 @@ export function createSessionStatusTool(opts?: {
       }
 
       if (!resolved) {
+        const runSessionFallbackKey = opts?.runSessionKey?.trim();
         const fallback = resolveImplicitCurrentSessionFallback({
           allowFallback: isSemanticCurrentRequest || requestedKeyParam === undefined,
           fallbackKey:
-            (isSemanticCurrentRequest || isImplicitRunSessionStatus) && opts?.runSessionKey
-              ? opts.runSessionKey
-              : storeScopedRequesterKey,
+            (isSemanticCurrentRequest || isImplicitRunSessionStatus) && runSessionFallbackKey
+              ? runSessionFallbackKey
+              : isSemanticCurrentRequest
+                ? effectiveRequesterLookupKey
+                : storeScopedRequesterKey,
         });
         if (fallback) {
           resolved = fallback;


### PR DESCRIPTION
## Summary

- Resolve semantic `session_status({ sessionKey: "current" })` against the full effective requester key before alias fallback.
- Use the full requester key when synthesizing an unpersisted semantic-current fallback without `runSessionKey`.
- Add WebChat regressions for both persisted and unpersisted `agent:admin:main` current-session lookups.

Fixes #89773

## Red test

Before the production change, the new WebChat regression failed with:

```text
AssertionError: expected 'main' to be 'agent:admin:main'
```

## Real behavior proof

- Behavior or issue addressed: WebChat `session_status({ sessionKey: "current" })` no longer resolves the active `agent:admin:main` requester to the fallback `main` session.
- Real environment tested: Local macOS source checkout at PR head `a1c8e3aeab7cf76451572acb91dd4ce95b5a86a8`, Node via `node --import tsx`, using the actual `createSessionStatusTool` runtime and a real temporary `sessions.json` store on disk.
- Exact steps or command run after this patch: Ran a local runtime probe that wrote both a fallback `main` session and the active WebChat requester session `agent:admin:main` with different model markers, then invoked `session_status({ sessionKey: "current" })` with `agentSessionKey: "agent:admin:main"` and active WebChat delivery context.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output from the runtime probe:

  ```text
  $ node --import tsx - <<'EOF'
  ...writes temp sessions.json with main=claude-fallback-main and agent:admin:main=gpt-5.4-admin-main, then executes createSessionStatusTool(...).execute("proof-webchat-current", { sessionKey: "current" })...
  EOF
  proof store: /var/folders/tr/xv22vnms42d9b2w8d5mnv2w80000gn/T/openclaw-89773-proof-XE8IgQ/sessions.json
  resolved sessionKey: agent:admin:main
  status mentions admin model: true
  status mentions fallback model: false
  fallback main avoided: true
  ```

- Observed result after fix: The semantic `current` lookup resolved to `agent:admin:main`; the rendered status used the admin session model marker and did not include the fallback `main` marker.
- What was not tested: No browser UI click-through or live WebChat server was run; this proof exercises the runtime `session_status` tool with WebChat delivery context and persisted session-store data.
- Proof limitations or environment constraints: The probe uses a redacted temporary local store instead of a user transcript so no private conversation data is exposed.
- Before evidence (optional but encouraged): Before the production change, the added regression resolved `current` to `main` and failed with `expected 'main' to be 'agent:admin:main'`.

## Validation

- `node scripts/run-vitest.mjs src/agents/openclaw-tools.session-status.test.ts --reporter=dot` -> 62 passed
- `node scripts/run-vitest.mjs src/agents/tools/sessions-resolution.test.ts --reporter=dot` -> 18 passed
- `npx oxfmt --check src/agents/openclaw-tools.session-status.test.ts src/agents/tools/session-status-tool.ts` -> passed
- `node scripts/run-oxlint.mjs src/agents/openclaw-tools.session-status.test.ts src/agents/tools/session-status-tool.ts` -> passed
- `git diff --check` -> passed
