### PR TITLE
perf(ui): surface chat ACK server timing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
@@ -211,6 +212,38 @@ type PreRegisteredAgentRun = {
 };
 
 type ChatHistoryMethod = "chat.history" | "chat.startup";
+
+type ChatSendAckServerTiming = {
+  receivedToAckMs: number;
+  loadSessionMs: number;
+  prepareAttachmentsMs?: number;
+};
+
+function roundedChatSendTimingMs(value: number): number {
+  return Math.max(0, Math.round(value * 1000) / 1000);
+}
+
+function chatSendAckServerTimingAttributes(
+  timing: ChatSendAckServerTiming | undefined,
+): Record<string, number> {
+  if (!timing) {
+    return {};
+  }
+  return {
+    serverReceivedToAckMs: timing.receivedToAckMs,
+    serverLoadSessionMs: timing.loadSessionMs,
+    ...(timing.prepareAttachmentsMs !== undefined
+      ? { serverPrepareAttachmentsMs: timing.prepareAttachmentsMs }
+      : {}),
+  };
+}
+
+function shouldIncludeChatSendAckServerTiming(client?: {
+  id?: string | null;
+  mode?: string | null;
+}): boolean {
+  return isOperatorUiClient(client);
+}
 
 async function handleChatMetadataRequest({
   params,
@@ -2956,6 +2989,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     });
   },
   "chat.send": async ({ params, respond, context, client }) => {
+    const chatSendReceivedAtMs = performance.now();
     if (!validateChatSendParams(params)) {
       respond(
         false,
@@ -3053,11 +3087,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: agentIdOverride,
     });
     const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-    const {
-      cfg,
-      entry,
-      canonicalKey: sessionKey,
-    } = measureDiagnosticsTimelineSpanSync(
+    const sessionLoadStartedAtMs = performance.now();
+    const sessionLoadResult = measureDiagnosticsTimelineSpanSync(
       "gateway.chat_send.load_session",
       () => loadSessionEntry(rawSessionKey, sessionLoadOptions),
       {
@@ -3069,6 +3100,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         },
       },
     );
+    const sessionLoadMs = roundedChatSendTimingMs(performance.now() - sessionLoadStartedAtMs);
+    const { cfg, entry, canonicalKey: sessionKey } = sessionLoadResult;
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: rawSessionKey,
@@ -3218,7 +3251,9 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
+    let prepareAttachmentsMs: number | undefined;
     if (normalizedAttachments.length > 0) {
+      const prepareAttachmentsStartedAtMs = performance.now();
       try {
         await measureDiagnosticsTimelineSpan(
           "gateway.chat_send.prepare_attachments",
@@ -3280,6 +3315,9 @@ export const chatHandlers: GatewayRequestHandlers = {
             },
           },
         );
+        prepareAttachmentsMs = roundedChatSendTimingMs(
+          performance.now() - prepareAttachmentsStartedAtMs,
+        );
       } catch (err) {
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
         respond(
@@ -3328,9 +3366,17 @@ export const chatHandlers: GatewayRequestHandlers = {
         agentId: selectedAgent.agentId,
         clientRunId,
       });
+      const serverTiming = shouldIncludeChatSendAckServerTiming(clientInfo)
+        ? {
+            receivedToAckMs: roundedChatSendTimingMs(performance.now() - chatSendReceivedAtMs),
+            loadSessionMs: sessionLoadMs,
+            ...(prepareAttachmentsMs !== undefined ? { prepareAttachmentsMs } : {}),
+          }
+        : undefined;
       const ackPayload = {
         runId: clientRunId,
         status: "started" as const,
+        ...(serverTiming ? { serverTiming } : {}),
       };
       emitDiagnosticsTimelineEvent(
         {
@@ -3340,6 +3386,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           attributes: {
             ...chatSendTraceAttributes,
             ackStatus: ackPayload.status,
+            ...chatSendAckServerTimingAttributes(serverTiming),
           },
         },
         { config: cfg },

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -66,9 +66,10 @@ function createDeferred<T>() {
 
 async function withGatewayChatHarness(
   run: (ctx: { ws: GatewaySocket; createSessionDir: () => Promise<string> }) => Promise<void>,
+  options?: { headers?: Record<string, string> },
 ) {
   const tempDirs: string[] = [];
-  const ws = await harness.openWs();
+  const ws = await harness.openWs(options?.headers);
   const createSessionDir = async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     tempDirs.push(sessionDir);
@@ -865,7 +866,14 @@ describe("gateway server chat", () => {
           {
             id: "first",
             ok: true,
-            payload: { runId: "idem-active-a", status: "started" },
+            payload: expect.objectContaining({
+              runId: "idem-active-a",
+              status: "started",
+              serverTiming: {
+                receivedToAckMs: expect.any(Number),
+                loadSessionMs: expect.any(Number),
+              },
+            }),
             error: undefined,
           },
         ]);
@@ -877,7 +885,14 @@ describe("gateway server chat", () => {
         {
           id: "first",
           ok: true,
-          payload: { runId: "idem-active-a", status: "started" },
+          payload: expect.objectContaining({
+            runId: "idem-active-a",
+            status: "started",
+            serverTiming: {
+              receivedToAckMs: expect.any(Number),
+              loadSessionMs: expect.any(Number),
+            },
+          }),
           error: undefined,
         },
         {
@@ -993,13 +1008,27 @@ describe("gateway server chat", () => {
         {
           id: "first",
           ok: true,
-          payload: { runId: "idem-sequential-a", status: "started" },
+          payload: expect.objectContaining({
+            runId: "idem-sequential-a",
+            status: "started",
+            serverTiming: {
+              receivedToAckMs: expect.any(Number),
+              loadSessionMs: expect.any(Number),
+            },
+          }),
           error: undefined,
         },
         {
           id: "second",
           ok: true,
-          payload: { runId: "idem-sequential-b", status: "started" },
+          payload: expect.objectContaining({
+            runId: "idem-sequential-b",
+            status: "started",
+            serverTiming: {
+              receivedToAckMs: expect.any(Number),
+              loadSessionMs: expect.any(Number),
+            },
+          }),
           error: undefined,
         },
       ]);
@@ -1326,47 +1355,70 @@ describe("gateway server chat", () => {
     process.env.OPENCLAW_DIAGNOSTICS = "timeline";
     process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
     try {
-      await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
-        const spy = getReplyFromConfig;
-        await connectOk(ws);
-
-        await createSessionDir();
-        await writeMainSessionStore();
-        mockGetReplyFromConfigOnce(async () => undefined);
-
-        const sendRes = await rpcReq(ws, "chat.send", {
-          sessionKey: "main",
-          message: "hello",
-          idempotencyKey: "idem-timeline",
-        });
-        expect(sendRes.ok).toBe(true);
-
-        await vi.waitFor(() => {
-          expect(spy.mock.calls.length).toBeGreaterThan(0);
-        }, FAST_WAIT_OPTS);
-        await vi.waitFor(async () => {
-          const events = await readTimelineEvents(timelinePath);
-          const ackReady = events.find(
-            (event) =>
-              event.type === "mark" &&
-              event.name === "gateway.chat_send.ack_ready" &&
-              (event.attributes as Record<string, unknown> | undefined)?.runId === "idem-timeline",
-          );
-          expect(ackReady?.attributes).toMatchObject({
-            runId: "idem-timeline",
-            ackStatus: "started",
+      await withGatewayChatHarness(
+        async ({ ws, createSessionDir }) => {
+          const spy = getReplyFromConfig;
+          await connectOk(ws, {
+            client: {
+              id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+              version: "1.0.0",
+              platform: "web",
+              mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+            },
           });
-          expect(
-            events.some(
+
+          await createSessionDir();
+          await writeMainSessionStore();
+          mockGetReplyFromConfigOnce(async () => undefined);
+
+          const sendRes = await rpcReq(ws, "chat.send", {
+            sessionKey: "main",
+            message: "hello",
+            idempotencyKey: "idem-timeline",
+          });
+          expect(sendRes.ok).toBe(true);
+          expect(sendRes.payload).toMatchObject({
+            runId: "idem-timeline",
+            status: "started",
+            serverTiming: {
+              receivedToAckMs: expect.any(Number),
+              loadSessionMs: expect.any(Number),
+            },
+          });
+
+          await vi.waitFor(() => {
+            expect(spy.mock.calls.length).toBeGreaterThan(0);
+          }, FAST_WAIT_OPTS);
+          await vi.waitFor(async () => {
+            const events = await readTimelineEvents(timelinePath);
+            const ackReady = events.find(
               (event) =>
-                event.type === "span.end" &&
-                event.name === "gateway.chat_send.dispatch_inbound" &&
+                event.type === "mark" &&
+                event.name === "gateway.chat_send.ack_ready" &&
                 (event.attributes as Record<string, unknown> | undefined)?.runId ===
                   "idem-timeline",
-            ),
-          ).toBe(true);
-        }, FAST_WAIT_OPTS);
-      });
+            );
+            expect(ackReady?.attributes).toMatchObject({
+              runId: "idem-timeline",
+              ackStatus: "started",
+              serverReceivedToAckMs: expect.any(Number),
+              serverLoadSessionMs: expect.any(Number),
+            });
+            expect(
+              events.some(
+                (event) =>
+                  event.type === "span.end" &&
+                  event.name === "gateway.chat_send.dispatch_inbound" &&
+                  (event.attributes as Record<string, unknown> | undefined)?.runId ===
+                    "idem-timeline",
+              ),
+            ).toBe(true);
+          }, FAST_WAIT_OPTS);
+        },
+        {
+          headers: { origin: `http://127.0.0.1:${harness.port}` },
+        },
+      );
     } finally {
       if (previousDiagnostics === undefined) {
         delete process.env.OPENCLAW_DIAGNOSTICS;
@@ -1380,6 +1432,43 @@ describe("gateway server chat", () => {
       }
       await fs.rm(timelineDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
     }
+  });
+
+  test("chat.send omits ACK server timing for public WebChat clients", async () => {
+    await withGatewayChatHarness(
+      async ({ ws, createSessionDir }) => {
+        await connectOk(ws, {
+          client: {
+            id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+            version: "1.0.0",
+            platform: "web",
+            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+          },
+        });
+
+        await createSessionDir();
+        await writeMainSessionStore();
+        mockGetReplyFromConfigOnce(async () => undefined);
+
+        const sendRes = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "hello",
+          idempotencyKey: "idem-public-webchat",
+        });
+
+        expect(sendRes.ok).toBe(true);
+        expect(sendRes.payload).toMatchObject({
+          runId: "idem-public-webchat",
+          status: "started",
+        });
+        expect(
+          (sendRes.payload as { serverTiming?: unknown } | undefined)?.serverTiming,
+        ).toBeUndefined();
+      },
+      {
+        headers: { origin: `http://127.0.0.1:${harness.port}` },
+      },
+    );
   });
 
   test("chat.history hard-caps single oversized nested payloads", async () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1335,7 +1335,14 @@ describe("handleSendChat", () => {
   it("records visible send timing phases for a normal chat send", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {
-        return { status: "started" };
+        return {
+          status: "started",
+          serverTiming: {
+            receivedToAckMs: 17,
+            loadSessionMs: 4,
+            prepareAttachmentsMs: 0.5,
+          },
+        };
       }
       throw new Error(`Unexpected request: ${method}`);
     });
@@ -1360,6 +1367,11 @@ describe("handleSendChat", () => {
     });
     expect(ack?.durationMs).toEqual(expect.any(Number));
     expect(ack?.requestDurationMs).toEqual(expect.any(Number));
+    expect(ack).toMatchObject({
+      serverReceivedToAckMs: 17,
+      serverLoadSessionMs: 4,
+      serverPrepareAttachmentsMs: 0.5,
+    });
   });
 
   it("records pending send paint timing before a delayed chat.send ACK", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -711,6 +711,21 @@ function updateChatSendAckTiming(
   entries.set(ack.runId, next);
 }
 
+function chatSendAckServerTimingEventFields(ack: ChatSendAck): Record<string, number> {
+  const timing = ack.serverTiming;
+  return {
+    ...(typeof timing?.receivedToAckMs === "number"
+      ? { serverReceivedToAckMs: timing.receivedToAckMs }
+      : {}),
+    ...(typeof timing?.loadSessionMs === "number"
+      ? { serverLoadSessionMs: timing.loadSessionMs }
+      : {}),
+    ...(typeof timing?.prepareAttachmentsMs === "number"
+      ? { serverPrepareAttachmentsMs: timing.prepareAttachmentsMs }
+      : {}),
+  };
+}
+
 function chatEventHasVisibleTerminalPayload(payload: ChatEventPayload): boolean {
   if (payload.state === "error" && payload.errorMessage?.trim()) {
     return true;
@@ -920,6 +935,7 @@ async function sendQueuedChatMessage(
     recordChatSendTiming(host, sendingItem, "ack", sendingItem.sendSubmittedAtMs, {
       ackStatus: ack.status,
       requestDurationMs: roundedControlUiDurationMs(controlUiNowMs() - requestStartedAtMs),
+      ...chatSendAckServerTimingEventFields(ack),
     });
     removeQueuedMessageWithoutReleasing(host, id, sessionKey);
     if (isVisibleSession()) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1798,6 +1798,38 @@ describe("sendChatMessage", () => {
     expect(sendParams.sessionId).toBeUndefined();
   });
 
+  it("preserves optional Gateway ACK server timing metadata", async () => {
+    const request = vi.fn().mockResolvedValue({
+      runId: "run-timed",
+      status: "started",
+      serverTiming: {
+        receivedToAckMs: 18.25,
+        loadSessionMs: 4.5,
+        prepareAttachmentsMs: 9,
+        ignored: "nope",
+      },
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await requestChatSend(state, {
+      message: "queued",
+      runId: "run-timed",
+    });
+
+    expect(result).toEqual({
+      runId: "run-timed",
+      status: "started",
+      serverTiming: {
+        receivedToAckMs: 18.25,
+        loadSessionMs: 4.5,
+        prepareAttachmentsMs: 9,
+      },
+    });
+  });
+
   it("omits literal global send agentId until selected/default agent is known", async () => {
     const request = vi.fn().mockResolvedValue({ runId: "run-global", status: "started" });
     const state = createState({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -865,10 +865,37 @@ function buildApiAttachments(attachments?: ChatAttachment[]) {
 
 export type ChatSendAckStatus = "started" | "in_flight" | "ok";
 
+export type ChatSendAckServerTiming = {
+  receivedToAckMs?: number;
+  loadSessionMs?: number;
+  prepareAttachmentsMs?: number;
+};
+
 export type ChatSendAck = {
   runId: string;
   status: ChatSendAckStatus;
+  serverTiming?: ChatSendAckServerTiming;
 };
+
+function normalizeAckTimingValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeChatSendAckServerTiming(value: unknown): ChatSendAckServerTiming | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const receivedToAckMs = normalizeAckTimingValue(record.receivedToAckMs);
+  const loadSessionMs = normalizeAckTimingValue(record.loadSessionMs);
+  const prepareAttachmentsMs = normalizeAckTimingValue(record.prepareAttachmentsMs);
+  const timing: ChatSendAckServerTiming = {
+    ...(receivedToAckMs !== undefined ? { receivedToAckMs } : {}),
+    ...(loadSessionMs !== undefined ? { loadSessionMs } : {}),
+    ...(prepareAttachmentsMs !== undefined ? { prepareAttachmentsMs } : {}),
+  };
+  return Object.keys(timing).length > 0 ? timing : undefined;
+}
 
 function normalizeChatSendAck(payload: unknown, fallbackRunId: string): ChatSendAck {
   if (!payload || typeof payload !== "object") {
@@ -878,9 +905,11 @@ function normalizeChatSendAck(payload: unknown, fallbackRunId: string): ChatSend
   const runId =
     typeof record.runId === "string" && record.runId.trim() ? record.runId.trim() : fallbackRunId;
   const status = record.status;
+  const serverTiming = normalizeChatSendAckServerTiming(record.serverTiming);
   return {
     runId,
     status: status === "in_flight" || status === "ok" ? status : "started",
+    ...(serverTiming ? { serverTiming } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds optional `chat.send` ACK server timing for operator UI clients so Control UI can separate server pre-ACK time from browser/request time on first sends.
- Preserves public WebChat behavior by omitting the new ACK timing payload for non-operator WebChat clients.
- Normalizes the optional timing payload in the Control UI controller and records the flattened values in existing `control-ui.chat.send` ACK timing events.
- Out of scope: changing send scheduling, model dispatch, transport auth, or visible chat rendering.

## Linked context

Maintainer-requested follow-up for Control WebUI clean first-message slowness discovery.

## Real behavior proof

- Behavior or issue addressed: Control UI first-send telemetry could not distinguish browser/network request duration from server-side pre-ACK work.
- Real environment tested: OpenClaw local linked worktree plus Blacksmith Testbox via Crabbox.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run src/gateway/server.chat.gateway-server-chat-b.test.ts -- --reporter=verbose`
  - `node scripts/run-vitest.mjs run ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts -- --reporter=verbose`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -- --reporter=verbose`
  - `git diff --check`
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat-b.test.ts ui/src/ui/controllers/chat.ts ui/src/ui/app-chat.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-chat.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label control-first-message-next-rebased-check --idle-timeout 90m -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- Evidence after fix: Gateway test passes with Control UI `mode=webchat` receiving `serverTiming`; public `webchat-ui` regression verifies the field is omitted. Testbox `tbx_01kt6jcjzh9esd723hvjnjvekh` passed `check:changed` with `lanes=core, coreTests`.
- Observed result after fix: Control UI ACK timing events include `serverReceivedToAckMs`, `serverLoadSessionMs`, and optional `serverPrepareAttachmentsMs` when the Gateway provides them.
- What was not tested: live provider latency on a real user account.
- Proof limitations or environment constraints: mocked UI E2E validates the browser flow and gateway traffic shape; live provider runtime timing still needs field observation once merged.

## Tests and validation

- Gateway focused: 31 tests passed.
- Control UI unit focused: 197 tests passed.
- Control UI mocked browser E2E: 12 tests passed.
- Static: `git diff --check`, targeted oxlint clean.
- Remote changed gate: Blacksmith Testbox through Crabbox passed on `tbx_01kt6jcjzh9esd723hvjnjvekh`.
- Autoreview: clean, no accepted/actionable findings.

## Risk checklist

- Did user-visible behavior change? `No`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- Highest-risk area: accidentally exposing operator-only timing metadata to public WebChat clients.
- Mitigation: server gate uses operator UI identity, and regression coverage asserts public WebChat clients do not receive `serverTiming`.

## Current review state

- Next action: wait for PR checks, then squash merge if clean.
- Waiting on: GitHub PR checks after push.
- Bot or reviewer comments addressed: local autoreview initially caught the Control UI `mode=webchat` gating bug; the fix and regression coverage are included.
