### PR TITLE
docs(web): document chat ACK timing metadata

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -180,7 +180,7 @@ Activity entries keep only sanitized summaries and redacted, truncated output pr
 
 <AccordionGroup>
   <Accordion title="Send and history semantics">
-    - `chat.send` is **non-blocking**: it acks immediately with `{ runId, status: "started" }` and the response streams via `chat` events.
+    - `chat.send` is **non-blocking**: it acks immediately with `{ runId, status: "started" }` and the response streams via `chat` events. Trusted Control UI clients may also receive optional ACK timing metadata for local diagnostics.
     - Chat uploads accept images plus non-video files. Images keep the native image path; other files are stored as managed media and shown in history as attachment links.
     - Re-sending with the same `idempotencyKey` returns `{ status: "in_flight" }` while running, and `{ status: "ok" }` after completion.
     - `chat.history` responses are size-bounded for UI safety. When transcript entries are too large, Gateway may truncate long text fields, omit heavy metadata blocks, and replace oversized messages with a placeholder (`[chat.history omitted: message too large]`).


### PR DESCRIPTION
Summary:
- Clarify that `chat.send` remains non-blocking while trusted Control UI clients may receive optional ACK timing metadata.
- Follow-up to the Control UI first-message timing work in https://github.com/openclaw/openclaw/pull/89801.

Verification:
- `git diff --check`
- `node scripts/docs-list.js`
- `node scripts/check-docs-mdx.mjs docs/web/control-ui.md`
