### PR TITLE
fix(plugins): guard typed hook metadata

### DIFF
--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -229,6 +229,24 @@ describe("before_agent_run hook", () => {
     );
   });
 
+  it("fails closed when matching hook handler metadata is unreadable", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "unreadable-handler-plugin",
+        hookName: "before_agent_run",
+        get handler() {
+          throw new Error("hook handler getter exploded");
+        },
+        source: "test",
+      } as unknown as PluginHookRegistration,
+    ]);
+    const runner = createHookRunner(registry);
+
+    await expect(runner.runBeforeAgentRun({ prompt: "test", messages: [] }, ctx)).rejects.toThrow(
+      "before_agent_run handler from unreadable-handler-plugin failed: hook handler getter exploded",
+    );
+  });
+
   it("fails closed when handlers exceed the default timeout", async () => {
     vi.useFakeTimers();
     const registry = makeRegistry([

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -219,4 +219,35 @@ describe("before_agent_start hook merger", () => {
 
     expect(capturedCtx).toBe(stubCtx);
   });
+
+  it("skips unreadable typed hook metadata before dispatching healthy hooks", async () => {
+    registry.typedHooks.push({
+      pluginId: "poisoned-hook",
+      get hookName() {
+        throw new Error("typed hook name getter exploded");
+      },
+      get handler() {
+        throw new Error("typed hook handler getter exploded");
+      },
+      get priority() {
+        throw new Error("typed hook priority getter exploded");
+      },
+      source: "test",
+    } as unknown as PluginHookRegistration);
+    addBeforeAgentStartHook(
+      registry,
+      "healthy-hook",
+      () => ({ prependContext: "healthy hook ran" }),
+      5,
+    );
+
+    const runner = createHookRunner(registry);
+
+    expect(runner.hasHooks("before_agent_start")).toBe(true);
+    expect(runner.getHookCount("before_agent_start")).toBe(1);
+    await expect(runner.runBeforeAgentStart({ prompt: "test" }, stubCtx)).resolves.toEqual({
+      ...EMPTY_BEFORE_AGENT_START_RESULT,
+      prependContext: "healthy hook ran",
+    });
+  });
 });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -269,6 +269,81 @@ type SyncHookEvent<K extends SyncHookName> = Parameters<SyncHookHandler<K>>[0];
 type SyncHookContext<K extends SyncHookName> = Parameters<SyncHookHandler<K>>[1];
 type SyncHookResult<K extends SyncHookName> = ReturnType<SyncHookHandler<K>>;
 
+function normalizeOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readTypedHookRegistration<K extends PluginHookName>(
+  registration: PluginHookRegistration,
+  hookName: K,
+): PluginHookRegistration<K> | undefined {
+  try {
+    if (registration.hookName !== hookName) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  let handler: unknown;
+  try {
+    handler = registration.handler;
+  } catch (error) {
+    handler = () => {
+      throw error;
+    };
+  }
+  if (typeof handler !== "function") {
+    handler = () => {
+      throw new Error("plugin hook handler is not a function");
+    };
+  }
+
+  let pluginId = "unknown-plugin";
+  try {
+    const rawPluginId = registration.pluginId;
+    if (typeof rawPluginId === "string" && rawPluginId.trim()) {
+      pluginId = rawPluginId.trim();
+    }
+  } catch {
+    // Keep a stable owner label for error reporting while skipping only fields
+    // needed to select and invoke a hook.
+  }
+
+  let source = "runtime";
+  try {
+    const rawSource = registration.source;
+    if (typeof rawSource === "string" && rawSource.trim()) {
+      source = rawSource;
+    }
+  } catch {
+    // Source is diagnostic metadata only.
+  }
+
+  let priority: number | undefined;
+  try {
+    priority = normalizeOptionalNumber(registration.priority);
+  } catch {
+    // Bad priority metadata should not block the hook itself.
+  }
+
+  let timeoutMs: number | undefined;
+  try {
+    timeoutMs = normalizeOptionalNumber(registration.timeoutMs);
+  } catch {
+    // Bad timeout metadata falls back to the runner default.
+  }
+
+  return {
+    pluginId,
+    hookName,
+    handler: handler as PluginHookRegistration<K>["handler"],
+    ...(priority !== undefined ? { priority } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    source,
+  };
+}
+
 /**
  * Get hooks for a specific hook name, sorted by priority (higher first).
  */
@@ -276,8 +351,9 @@ function getHooksForName<K extends PluginHookName>(
   registry: HookRunnerRegistry,
   hookName: K,
 ): PluginHookRegistration<K>[] {
-  return (registry.typedHooks as PluginHookRegistration<K>[])
-    .filter((h) => h.hookName === hookName)
+  return registry.typedHooks
+    .map((hook) => readTypedHookRegistration(hook, hookName))
+    .filter((hook): hook is PluginHookRegistration<K> => hook !== undefined)
     .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 }
 
@@ -1611,14 +1687,14 @@ export function createHookRunner(
   // =========================================================================
 
   function hasHooks(hookName: PluginHookName): boolean {
-    return registry.typedHooks.some((h) => h.hookName === hookName);
+    return getHooksForName(registry, hookName).length > 0;
   }
 
   /**
    * Get count of registered hooks for a given hook name.
    */
   function getHookCount(hookName: PluginHookName): number {
-    return registry.typedHooks.filter((h) => h.hookName === hookName).length;
+    return getHooksForName(registry, hookName).length;
   }
 
   return {


### PR DESCRIPTION
## Summary

- Guard typed plugin hook registration selection against unreadable hook metadata so a malformed row cannot crash hook checks or dispatch before healthy hooks run.
- Preserve fail-closed behavior for matching safety hooks whose handler metadata is unreadable by routing that failure through the existing hook error policy.
- Add regressions for fail-open `before_agent_start` dispatch and fail-closed `before_agent_run` gate behavior.

## Verification

- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next94-red-raw node_modules/.bin/vitest run src/plugins/hooks.before-agent-start.test.ts -t "skips unreadable typed hook metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed pre-patch with `typed hook name getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next94-rebase-full node_modules/.bin/vitest run src/plugins/hooks.before-agent-start.test.ts src/plugins/hook-lifecycle-gates.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 2 files / 30 tests after rebase.
- `node_modules/.bin/oxfmt --check src/plugins/hooks.ts src/plugins/hooks.before-agent-start.test.ts src/plugins/hook-lifecycle-gates.test.ts` passed.
- `node_modules/.bin/oxlint src/plugins/hooks.ts src/plugins/hooks.before-agent-start.test.ts src/plugins/hook-lifecycle-gates.test.ts` passed.
- `git diff --check origin/main..HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings; `overall: patch is correct (0.82)`.
- Broad changed gate not completed: `blacksmith testbox list --all` reported unauthenticated, and `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` failed before lease creation with coordinator `401 unauthorized`.

Behavior addressed: malformed typed plugin hook metadata no longer crashes hook enumeration or dispatch before healthy hooks can run; matching fail-closed hook handler failures still block.
Real environment tested: local linked OpenClaw worktree on Node/Vitest with branch rebased onto current `origin/main`.
Exact steps or command run after this patch: focused red/green Vitest, full touched hook test files, oxfmt, oxlint, git diff check, and branch autoreview; remote `check:changed` attempted through Testbox/Crabbox paths.
Evidence after fix: healthy `before_agent_start` hook still runs after an unreadable sibling row; unreadable `before_agent_run` handler metadata rejects through the existing fail-closed error path.
Observed result after fix: focused and full touched-file tests passed after rebase; static checks and autoreview were clean.
What was not tested: full `pnpm check:changed` because local Blacksmith auth is missing and the Crabbox coordinator returned `401 unauthorized` before creating a lease.
