### PR TITLE
fix(feishu): avoid axios interceptor internals

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -7,6 +7,17 @@ type CreateFeishuWSClient = typeof import("./client.js").createFeishuWSClient;
 type ClearClientCache = typeof import("./client.js").clearClientCache;
 type SetFeishuClientRuntimeForTest = typeof import("./client.js").setFeishuClientRuntimeForTest;
 
+const requestInterceptorState = vi.hoisted(() => {
+  let registered: ((req: unknown) => unknown) | undefined;
+  return {
+    get registered() {
+      return registered;
+    },
+    use: vi.fn((fn: (req: unknown) => unknown) => {
+      registered = fn;
+    }),
+  };
+});
 const clientCtorMock = vi.hoisted(() =>
   vi.fn(function clientCtor() {
     return { connected: true };
@@ -22,16 +33,31 @@ const proxyAgentCtorMock = vi.hoisted(() =>
     return { proxied: true };
   }),
 );
-const mockBaseHttpInstance = vi.hoisted(() => ({
-  request: vi.fn().mockResolvedValue({}),
-  get: vi.fn().mockResolvedValue({}),
-  post: vi.fn().mockResolvedValue({}),
-  put: vi.fn().mockResolvedValue({}),
-  patch: vi.fn().mockResolvedValue({}),
-  delete: vi.fn().mockResolvedValue({}),
-  head: vi.fn().mockResolvedValue({}),
-  options: vi.fn().mockResolvedValue({}),
-}));
+const mockBaseHttpInstance = vi.hoisted(() => {
+  const requestInterceptors = { use: requestInterceptorState.use };
+  Object.defineProperty(requestInterceptors, "handlers", {
+    configurable: true,
+    get() {
+      throw new Error("Do not read axios private interceptor handlers");
+    },
+    set() {
+      throw new Error("Do not write axios private interceptor handlers");
+    },
+  });
+  return {
+    request: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockResolvedValue({}),
+    post: vi.fn().mockResolvedValue({}),
+    put: vi.fn().mockResolvedValue({}),
+    patch: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    head: vi.fn().mockResolvedValue({}),
+    options: vi.fn().mockResolvedValue({}),
+    interceptors: {
+      request: requestInterceptors,
+    },
+  };
+});
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
 const registerFeishuDocToolsMock = vi.hoisted(() => vi.fn());
@@ -51,6 +77,7 @@ let setFeishuClientRuntimeForTest: SetFeishuClientRuntimeForTest;
 let FEISHU_HTTP_TIMEOUT_MS: number;
 let FEISHU_HTTP_TIMEOUT_MAX_MS: number;
 let FEISHU_HTTP_TIMEOUT_ENV_VAR: string;
+let FEISHU_USER_AGENT: string;
 
 let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
 let priorFeishuTimeoutEnv: string | undefined;
@@ -178,6 +205,7 @@ beforeAll(async () => {
     FEISHU_HTTP_TIMEOUT_MS,
     FEISHU_HTTP_TIMEOUT_MAX_MS,
     FEISHU_HTTP_TIMEOUT_ENV_VAR,
+    FEISHU_USER_AGENT,
   } = await import("./client.js"));
 });
 
@@ -237,6 +265,26 @@ afterAll(() => {
   vi.doUnmock("@larksuiteoapi/node-sdk");
   vi.doUnmock("@openclaw/proxyline");
   vi.resetModules();
+});
+
+describe("Feishu default User-Agent interceptor", () => {
+  it("registers through the public interceptor API and overrides the SDK User-Agent", () => {
+    expect(requestInterceptorState.registered).toBeTypeOf("function");
+
+    const req = { headers: { "User-Agent": "oapi-node-sdk/1.0.0" } };
+    expect(requestInterceptorState.registered?.(req)).toBe(req);
+
+    expect(req.headers["User-Agent"]).toBe(FEISHU_USER_AGENT);
+  });
+
+  it("sets the User-Agent on AxiosHeaders-like request headers", () => {
+    const headers = { set: vi.fn() };
+    const req = { headers };
+
+    expect(requestInterceptorState.registered?.(req)).toBe(req);
+
+    expect(headers.set).toHaveBeenCalledWith("User-Agent", FEISHU_USER_AGENT);
+  });
 });
 
 describe("createFeishuClient HTTP timeout", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -54,33 +54,40 @@ const defaultFeishuClientSdk: FeishuClientSdk = {
 
 let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
 
-// Override the SDK's default User-Agent interceptor.
-// The Lark SDK registers an axios request interceptor that sets
-// 'oapi-node-sdk/1.0.0'. Axios request interceptors execute in LIFO order
-// (last-registered runs first), so simply appending ours doesn't work — the
-// SDK's interceptor would run last and overwrite our UA. We must clear
-// handlers[] first, then register our own as the sole interceptor.
-//
-// Risk is low: the SDK only registers one interceptor (UA) at init time, and
-// we clear it at module load before any other code can register handlers.
-// If a future SDK version adds more interceptors, the upgrade will need
-// compatibility verification regardless.
-{
-  const inst = Lark.defaultHttpInstance as {
-    interceptors?: {
-      request: { handlers: unknown[]; use: (fn: (req: unknown) => unknown) => void };
-    };
+type RequestInterceptorApi = {
+  use: (fn: (req: unknown) => unknown) => unknown;
+};
+
+type FeishuDefaultHttpInstanceWithInterceptors = {
+  interceptors?: {
+    request?: RequestInterceptorApi;
   };
-  if (inst.interceptors?.request) {
-    inst.interceptors.request.handlers = [];
-    inst.interceptors.request.use((req: unknown) => {
-      const r = req as { headers?: Record<string, string> };
-      if (r.headers) {
-        r.headers["User-Agent"] = getFeishuUserAgent();
-      }
-      return req;
-    });
+};
+
+function setRequestUserAgent(req: unknown) {
+  const request = req as { headers?: unknown };
+  const headers = request.headers;
+  if (!headers) {
+    request.headers = { "User-Agent": getFeishuUserAgent() };
+    return req;
   }
+
+  const maybeAxiosHeaders = headers as { set?: unknown };
+  if (typeof maybeAxiosHeaders.set === "function") {
+    maybeAxiosHeaders.set("User-Agent", getFeishuUserAgent());
+    return req;
+  }
+
+  (headers as Record<string, string>)["User-Agent"] = getFeishuUserAgent();
+  return req;
+}
+
+// Override the SDK's default User-Agent through the public interceptor API.
+// The SDK fallback interceptor only fills User-Agent when it is absent, so this
+// interceptor can preserve the rest of the SDK's request interceptor stack.
+{
+  const inst = Lark.defaultHttpInstance as FeishuDefaultHttpInstanceWithInterceptors;
+  inst.interceptors?.request?.use(setRequestUserAgent);
 }
 
 export { FEISHU_HTTP_TIMEOUT_ENV_VAR, FEISHU_HTTP_TIMEOUT_MAX_MS, FEISHU_HTTP_TIMEOUT_MS };


### PR DESCRIPTION
## Summary

- Stop clearing `Lark.defaultHttpInstance.interceptors.request.handlers` at module load.
- Register the Feishu User-Agent override through the public `request.use(...)` interceptor API.
- Cover the import-time regression with a mocked interceptor that throws if private `handlers` is read or written.

Fixes #83913

## Red test

Before the production change, the new `extensions/feishu/src/client.test.ts` import-time regression failed with:

```text
Error: Do not write axios private interceptor handlers
- extensions/feishu/src/client.ts:75:31
```

## Real behavior proof

- Behavior or issue addressed: The Feishu client no longer reads or writes the undocumented axios `interceptors.request.handlers` array during import, and registers its User-Agent override through the public interceptor API.
- Real environment tested: Local macOS source checkout at PR head `b87083193b84f304af0eeebf92c582ed355bdb24`, Node via `node --import tsx`, real bundled `@larksuiteoapi/node-sdk` default HTTP instance.
- Exact steps or command run after this patch: Replaced only the public `request.use` boundary with a counter, made the private `handlers` property throw on direct read/write, then imported `extensions/feishu/src/client.ts` through tsx.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output from the runtime import probe:

  ```text
  $ node --import tsx - <<'EOF'
  import * as Lark from "@larksuiteoapi/node-sdk";

  const requestInterceptors = Lark.defaultHttpInstance.interceptors.request;
  let publicUseCalls = 0;
  let registeredInterceptorType = "missing";
  requestInterceptors.use = ((fn) => {
    publicUseCalls += 1;
    registeredInterceptorType = typeof fn;
    return publicUseCalls;
  });
  Object.defineProperty(requestInterceptors, "handlers", {
    configurable: true,
    get() {
      throw new Error("proof failed: OpenClaw read private axios handlers");
    },
    set() {
      throw new Error("proof failed: OpenClaw wrote private axios handlers");
    },
  });

  const moduleUrl = new URL("./extensions/feishu/src/client.ts?proof=" + Date.now(), import.meta.url);
  const feishuClient = await import(moduleUrl.href);
  console.log(`Feishu UA: ${feishuClient.getFeishuUserAgent()}`);
  console.log(`public request.use calls during import: ${publicUseCalls}`);
  console.log(`registered interceptor type: ${registeredInterceptorType}`);
  console.log("private axios handlers touched by OpenClaw import: no");
  EOF
  Feishu UA: openclaw-feishu-builtin/2026.6.2/darwin
  public request.use calls during import: 1
  registered interceptor type: function
  private axios handlers touched by OpenClaw import: no
  ```

- Observed result after fix: Importing the Feishu client succeeded, exactly one public `request.use` interceptor was registered, the registered callback was a function, and the throwing private `handlers` accessor was never touched by OpenClaw import code.
- What was not tested: No live Feishu/Lark network request was sent; this proof verifies the import-time interceptor registration boundary that issue #83913 reported.
- Proof limitations or environment constraints: The probe intentionally avoids credentials and network calls; it uses the real SDK object but instruments the interceptor boundary locally.
- Before evidence (optional but encouraged): Before the production change, the added regression failed at `extensions/feishu/src/client.ts:75:31` with `Do not write axios private interceptor handlers`.

## Validation

- `node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts --reporter=dot` -> 18 passed
- `npx oxfmt --check extensions/feishu/src/client.ts extensions/feishu/src/client.test.ts` -> passed
- `node scripts/run-oxlint.mjs extensions/feishu/src/client.ts extensions/feishu/src/client.test.ts` -> passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` -> passed
- `git diff --check` -> passed
