### PR TITLE
Bound WhatsApp outbound send duration

### DIFF
--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -5,7 +5,7 @@ import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage } from 
 import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveWhatsAppOutboundMentions } from "./outbound-mentions.js";
-import { createWebSendApi } from "./send-api.js";
+import { createWebSendApi, WHATSAPP_SEND_TIMEOUT_MS } from "./send-api.js";
 
 const recordChannelActivity = vi.hoisted(() => vi.fn());
 const imageOps = vi.hoisted(() => ({
@@ -68,12 +68,17 @@ describe("createWebSendApi", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     imageOps.getImageMetadata.mockResolvedValue(null);
     imageOps.resizeToJpeg.mockRejectedValue(new Error("unexpected thumbnail generation"));
     api = createWebSendApi({
       sock: { sendMessage, sendPresenceUpdate },
       defaultAccountId: "main",
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
@@ -454,6 +459,32 @@ describe("createWebSendApi", () => {
       providerAccepted: false,
     });
     expect(res.receipt ? listMessageReceiptPlatformIds(res.receipt) : []).toStrictEqual([]);
+  });
+
+  it("times out stalled socket message sends", async () => {
+    vi.useFakeTimers();
+    const neverSettles = new Promise<WAMessage | undefined>(() => {
+      // Keep the provider send pending so the timeout path fires.
+    });
+    sendMessage.mockImplementationOnce(() => neverSettles);
+
+    const pending = api.sendMessage("+1555", "hello");
+    const expectation = expect(pending).rejects.toThrow(
+      `WhatsApp sendMessage timed out after ${WHATSAPP_SEND_TIMEOUT_MS}ms`,
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(WHATSAPP_SEND_TIMEOUT_MS);
+
+    await expectation;
+    expect(recordChannelActivity).not.toHaveBeenCalled();
+  });
+
+  it("clears the socket send timeout after successful sends", async () => {
+    vi.useFakeTimers();
+
+    await api.sendMessage("+1555", "hello");
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("keeps direct-chat reactions without a participant key", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -21,6 +21,8 @@ import {
 } from "./send-result.js";
 import type { ActiveWebSendOptions } from "./types.js";
 
+export const WHATSAPP_SEND_TIMEOUT_MS = 30_000;
+
 function recordWhatsAppOutbound(accountId: string) {
   recordChannelActivity({
     channel: "whatsapp",
@@ -31,6 +33,30 @@ function recordWhatsAppOutbound(accountId: string) {
 
 function supportsForcedDocumentMediaType(mediaType: string): boolean {
   return mediaType.startsWith("image/") || mediaType.startsWith("video/");
+}
+
+function createWhatsAppSendTimeoutError(operation: string): Error {
+  const error = new Error(`${operation} timed out after ${WHATSAPP_SEND_TIMEOUT_MS}ms`);
+  error.name = "WhatsAppSendTimeoutError";
+  return error;
+}
+
+async function withWhatsAppSendTimeout<T>(operation: string, promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(createWhatsAppSendTimeoutError(operation));
+        }, WHATSAPP_SEND_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 export function createWebSendApi(params: {
@@ -57,6 +83,21 @@ export function createWebSendApi(params: {
     params.authDir
       ? toWhatsappJidWithLid(recipient, { authDir: params.authDir })
       : toWhatsappJid(recipient);
+  const sendSocketMessage = async (
+    jid: string,
+    content: AnyMessageContent,
+    options?: MiscMessageGenerationOptions,
+  ): Promise<WAMessage | undefined> => {
+    const sendPromise = options
+      ? params.sock.sendMessage(jid, content, options)
+      : params.sock.sendMessage(jid, content);
+    return await withWhatsAppSendTimeout("WhatsApp sendMessage", sendPromise);
+  };
+  const sendSocketPresenceUpdate = async (presence: WAPresence, jid?: string): Promise<unknown> =>
+    await withWhatsAppSendTimeout(
+      "WhatsApp sendPresenceUpdate",
+      params.sock.sendPresenceUpdate(presence, jid),
+    );
   const resolveMentions = async (
     jid: string,
     text: string,
@@ -136,9 +177,7 @@ export function createWebSendApi(params: {
         participant: sendOptions?.quotedMessageKey?.participant,
         messageText: sendOptions?.quotedMessageKey?.messageText,
       });
-      const result = quotedOpts
-        ? await params.sock.sendMessage(jid, payload, quotedOpts)
-        : await params.sock.sendMessage(jid, payload);
+      const result = await sendSocketMessage(jid, payload, quotedOpts);
       const results = [normalizeWhatsAppSendResult(result, mediaBuffer ? "media" : "text")];
       if (shouldSendAudioText) {
         const resolvedAudioText = await resolveMentions(jid, text);
@@ -146,9 +185,7 @@ export function createWebSendApi(params: {
           { text: resolvedAudioText.text },
           resolvedAudioText.mentionedJids,
         );
-        const textResult = quotedOpts
-          ? await params.sock.sendMessage(jid, textPayload, quotedOpts)
-          : await params.sock.sendMessage(jid, textPayload);
+        const textResult = await sendSocketMessage(jid, textPayload, quotedOpts);
         results.push(normalizeWhatsAppSendResult(textResult, "text"));
       }
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
@@ -160,7 +197,7 @@ export function createWebSendApi(params: {
       poll: { question: string; options: string[]; maxSelections?: number },
     ): Promise<WhatsAppSendResult> => {
       const jid = resolveOutboundJid(to);
-      const result = await params.sock.sendMessage(jid, {
+      const result = await sendSocketMessage(jid, {
         poll: {
           name: poll.question,
           values: poll.options,
@@ -180,7 +217,7 @@ export function createWebSendApi(params: {
       // Resolve DM targets through the same LID-aware path as normal sends so
       // reactions land on the delivered WhatsApp message key.
       const jid = resolveOutboundJid(chatJid);
-      const result = await params.sock.sendMessage(jid, {
+      const result = await sendSocketMessage(jid, {
         react: {
           text: emoji,
           key: {
@@ -198,7 +235,7 @@ export function createWebSendApi(params: {
       if (isWhatsAppNewsletterJid(jid)) {
         return;
       }
-      await params.sock.sendPresenceUpdate("composing", jid);
+      await sendSocketPresenceUpdate("composing", jid);
     },
   } as const;
 }


### PR DESCRIPTION
## Summary
- add a bounded timeout around WhatsApp Web socket send operations
- fail stalled provider sends with a clear timeout error instead of waiting indefinitely
- cover the timeout path with focused send API tests

## Tests
- pnpm exec vitest run extensions/whatsapp/src/inbound/send-api.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/inbound/send-api.ts extensions/whatsapp/src/inbound/send-api.test.ts
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/whatsapp/src/inbound/send-api.ts extensions/whatsapp/src/inbound/send-api.test.ts
- pnpm exec tsc --noEmit --project tsconfig.extensions.json
