### PR TITLE
fix(plugins): guard plugin service metadata

### DIFF
--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -167,6 +167,63 @@ describe("startPluginServices", () => {
     expectServiceLifecycleState({ starts, stops, contexts, config });
   });
 
+  it("continues starting healthy services after unreadable service metadata", async () => {
+    const starts: string[] = [];
+    const stops: string[] = [];
+    const registry = createRegistry([createTrackingService("service-a", { starts, stops })]);
+    registry.services.unshift({
+      pluginId: "broken-service-plugin",
+      pluginName: "Broken Service Plugin",
+      get service() {
+        throw new Error("service getter exploded");
+      },
+      source: "test",
+      origin: "workspace",
+      rootDir: "/plugins/broken-service",
+    } as (typeof registry.services)[number]);
+
+    const handle = await startPluginServices({
+      registry,
+      config: createServiceConfig(),
+    });
+    await handle.stop();
+
+    expect(starts).toEqual(["a"]);
+    expect(stops).toEqual(["a"]);
+    expect(mockedLogger.error.mock.calls).toEqual([
+      [
+        "plugin service failed (unknown-service, plugin=broken-service-plugin, root=/plugins/broken-service): service getter exploded",
+      ],
+    ]);
+  });
+
+  it("allows unknown-service as an explicit service id", async () => {
+    const starts: string[] = [];
+    await startTrackingServices({
+      services: [createTrackingService("unknown-service", { starts })],
+    });
+
+    expect(starts).toEqual(["e"]);
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("tracks stop handlers installed during service startup", async () => {
+    const stop = vi.fn();
+    const service: OpenClawPluginService = {
+      id: "dynamic-stop-service",
+      start() {
+        service.stop = stop;
+      },
+    };
+
+    const handle = await startTrackingServices({
+      services: [service],
+    });
+    await handle.stop();
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("registers dynamic HTTP routes into the service registry scope", async () => {
     const serviceRegistry = createRegistry([
       {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -9,7 +9,7 @@ import { withPluginHttpRouteRegistry } from "./http-registry.js";
 import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
 import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
-import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
+import type { OpenClawPluginService, OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
 function createPluginLogger(): PluginLogger {
@@ -25,15 +25,15 @@ function createServiceContext(params: {
   config: OpenClawConfig;
   startupTrace?: PluginServiceStartupTrace;
   workspaceDir?: string;
-  service: PluginServiceRegistration;
+  service: PreparedPluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   const isDiagnosticsExporter =
-    params.service?.pluginId === params.service?.service.id &&
-    (params.service?.service.id === "diagnostics-otel" ||
-      params.service?.service.id === "diagnostics-prometheus");
+    params.service.pluginId === params.service.serviceId &&
+    (params.service.serviceId === "diagnostics-otel" ||
+      params.service.serviceId === "diagnostics-prometheus");
   const grantsInternalDiagnostics =
     isDiagnosticsExporter &&
-    (params.service?.origin === "bundled" || params.service?.trustedOfficialInstall === true);
+    (params.service.origin === "bundled" || params.service.trustedOfficialInstall === true);
 
   return {
     config: params.config,
@@ -59,8 +59,142 @@ function createServiceContext(params: {
   };
 }
 
-function createPluginServiceTraceName(entry: PluginServiceRegistration): string {
-  return `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.service.id)}`;
+type PreparedPluginServiceRegistration = Omit<PluginServiceRegistration, "service"> & {
+  service: OpenClawPluginService;
+  serviceId: string;
+  start: OpenClawPluginService["start"];
+};
+
+type PluginServiceRegistrationReadResult =
+  | { ok: true; registration: PreparedPluginServiceRegistration }
+  | {
+      ok: false;
+      error: unknown;
+      pluginId: string;
+      rootDir?: string;
+      serviceId: string;
+    };
+
+function readStringField(
+  read: () => unknown,
+  fallback: string,
+):
+  | { ok: true; usedFallback: boolean; value: string }
+  | { ok: false; error: unknown; value: string } {
+  try {
+    const value = read();
+    return typeof value === "string" && value.length > 0
+      ? { ok: true, usedFallback: false, value }
+      : { ok: true, usedFallback: true, value: fallback };
+  } catch (error) {
+    return { ok: false, error, value: fallback };
+  }
+}
+
+function formatServiceError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readOptionalField<T>(read: () => T): T | undefined {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
+function readPluginServiceRegistration(
+  entry: PluginServiceRegistration,
+): PluginServiceRegistrationReadResult {
+  const pluginId = readStringField(() => entry.pluginId, "unknown-plugin").value;
+  const rootDirResult = readStringField(() => entry.rootDir, "unknown");
+  const rootDir = rootDirResult.value;
+  let service: OpenClawPluginService;
+  try {
+    service = entry.service;
+  } catch (error) {
+    return { ok: false, error, pluginId, rootDir, serviceId: "unknown-service" };
+  }
+
+  const serviceIdResult = readStringField(() => service.id, "unknown-service");
+  if (!serviceIdResult.ok || serviceIdResult.usedFallback) {
+    return {
+      ok: false,
+      error: serviceIdResult.ok
+        ? new Error("service registration missing id")
+        : serviceIdResult.error,
+      pluginId,
+      rootDir,
+      serviceId: serviceIdResult.value,
+    };
+  }
+
+  let start: OpenClawPluginService["start"];
+  try {
+    start = service.start;
+  } catch (error) {
+    return { ok: false, error, pluginId, rootDir, serviceId: serviceIdResult.value };
+  }
+  if (typeof start !== "function") {
+    return {
+      ok: false,
+      error: new Error("service registration missing start handler"),
+      pluginId,
+      rootDir,
+      serviceId: serviceIdResult.value,
+    };
+  }
+
+  return {
+    ok: true,
+    registration: {
+      pluginId,
+      pluginName: readStringField(() => entry.pluginName, pluginId).value,
+      service,
+      serviceId: serviceIdResult.value,
+      start: (ctx) => start.call(service, ctx),
+      source: readStringField(() => entry.source, "unknown").value,
+      origin: readOptionalField(() => entry.origin) ?? "workspace",
+      trustedOfficialInstall: readOptionalField(() => entry.trustedOfficialInstall),
+      rootDir,
+    },
+  };
+}
+
+function createPluginServiceTraceName(entry: PreparedPluginServiceRegistration): string {
+  return `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.serviceId)}`;
+}
+
+function readPluginServiceStop(
+  entry: PreparedPluginServiceRegistration,
+): { ok: true; hasStop: boolean } | { ok: false; error: unknown } {
+  try {
+    const stop = entry.service.stop;
+    if (stop == null) {
+      return { ok: true, hasStop: false };
+    }
+    return typeof stop === "function"
+      ? { ok: true, hasStop: true }
+      : { ok: false, error: new Error("service stop handler is not a function") };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function createPluginServiceStop(
+  entry: PreparedPluginServiceRegistration,
+  serviceContext: OpenClawPluginServiceContext,
+): () => void | Promise<void> {
+  return () => {
+    const stop = entry.service.stop;
+    if (stop == null) {
+      return;
+    }
+    if (typeof stop !== "function") {
+      throw new Error("service stop handler is not a function");
+    }
+    return stop.call(entry.service, serviceContext);
+  };
 }
 
 function createScopedPluginServiceStartupTrace(
@@ -102,8 +236,16 @@ export async function startPluginServices(params: {
     stop?: () => void | Promise<void>;
   }> = [];
   let failedCount = 0;
-  for (const entry of params.registry.services) {
-    const service = entry.service;
+  for (const rawEntry of params.registry.services) {
+    const readResult = readPluginServiceRegistration(rawEntry);
+    if (!readResult.ok) {
+      failedCount += 1;
+      log.error(
+        `plugin service failed (${readResult.serviceId}, plugin=${readResult.pluginId}, root=${readResult.rootDir ?? "unknown"}): ${formatServiceError(readResult.error)}`,
+      );
+      continue;
+    }
+    const entry = readResult.registration;
     const traceName = createPluginServiceTraceName(entry);
     const serviceContext = createServiceContext({
       config: params.config,
@@ -113,21 +255,28 @@ export async function startPluginServices(params: {
     });
     try {
       const startService = () =>
-        withPluginHttpRouteRegistry(params.registry, () => service.start(serviceContext));
+        withPluginHttpRouteRegistry(params.registry, () => entry.start(serviceContext));
       if (params.startupTrace) {
         await params.startupTrace.measure(traceName, startService);
       } else {
         await startService();
       }
+      const stopReadResult = readPluginServiceStop(entry);
+      if (!stopReadResult.ok) {
+        failedCount += 1;
+        log.error(
+          `plugin service failed (${entry.serviceId}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${formatServiceError(stopReadResult.error)}`,
+        );
+        continue;
+      }
       running.push({
-        id: service.id,
-        stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
+        id: entry.serviceId,
+        stop: stopReadResult.hasStop ? createPluginServiceStop(entry, serviceContext) : undefined,
       });
     } catch (err) {
       failedCount += 1;
-      const error = err as Error;
       log.error(
-        `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
+        `plugin service failed (${entry.serviceId}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${formatServiceError(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- Guard plugin service metadata before service startup so a malformed registry row cannot abort the whole service loop.
- Log and skip unreadable service registrations while preserving valid service lifecycle behavior.
- Preserve service ids such as `unknown-service` and stop handlers installed during startup.

## Verification

- Red repro:
  `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next95-red node_modules/.bin/vitest run src/plugins/services.test.ts -t "continues starting healthy services after unreadable service metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
  failed pre-patch with `service getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next95-focused3 node_modules/.bin/vitest run src/plugins/services.test.ts -t "continues starting healthy services after unreadable service metadata|allows unknown-service as an explicit service id|tracks stop handlers installed during service startup" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next95-rebase-full node_modules/.bin/vitest run src/plugins/services.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `node_modules/.bin/oxfmt --check src/plugins/services.ts src/plugins/services.test.ts`
- `node_modules/.bin/oxlint src/plugins/services.ts src/plugins/services.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Broad changed gate blocked: `blacksmith testbox list --all` reported unauthenticated; AWS Crabbox `check:changed` failed before lease creation with coordinator `401 unauthorized`.

Behavior addressed: malformed plugin service metadata no longer aborts plugin service startup before healthy services can start.
Real environment tested: local Codex worktree on macOS with the OpenClaw plugin Vitest lane.
Exact steps or command run after this patch: full touched test file, focused regression tests, formatter, linter, diff check, and branch autoreview listed above.
Evidence after fix: focused regression passed 3 tests; full `src/plugins/services.test.ts` passed 10 tests; branch autoreview reported no accepted/actionable findings.
Observed result after fix: unreadable service metadata is logged as a plugin service failure, healthy services still start and stop, `unknown-service` remains valid, and stop handlers installed during startup still run.
What was not tested: broad `pnpm check:changed`; Testbox auth and Crabbox coordinator auth were unavailable locally.
