### PR TITLE
fix(gateway): guard discovery service metadata

### DIFF
--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -186,6 +186,71 @@ describe("startGatewayDiscovery", () => {
     expect(stopped).toEqual(["peer", "bonjour"]);
   });
 
+  it("continues local discovery after unreadable discovery service metadata", async () => {
+    useDevelopmentDiscoveryEnv();
+
+    const healthyStop = vi.fn();
+    const healthy = makeDiscoveryService({
+      id: "healthy-discovery",
+      pluginId: "healthy-plugin",
+      stop: healthyStop,
+    });
+    const broken = {
+      pluginId: "broken-plugin",
+      pluginName: "Broken Plugin",
+      source: "test",
+      get service() {
+        throw new Error("gateway discovery service getter exploded");
+      },
+    } as PluginGatewayDiscoveryServiceRegistration;
+    const logs = makeLogs();
+
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "serve",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [broken, healthy],
+      logDiscovery: logs,
+    });
+
+    expect(healthy.service.advertise).toHaveBeenCalledTimes(1);
+    expect(result.bonjourStop).toBeTypeOf("function");
+    expect(logs.warn.mock.calls).toEqual([
+      [
+        "gateway discovery service failed (unknown-discovery-service, plugin=broken-plugin): Error: gateway discovery service getter exploded",
+      ],
+    ]);
+
+    await result.bonjourStop?.();
+    expect(healthyStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows unknown-discovery-service as an explicit discovery service id", async () => {
+    useDevelopmentDiscoveryEnv();
+
+    const service = makeDiscoveryService({
+      id: "unknown-discovery-service",
+      pluginId: "custom-discovery-plugin",
+    });
+    const logs = makeLogs();
+
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "serve",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [service],
+      logDiscovery: logs,
+    });
+
+    expect(service.service.advertise).toHaveBeenCalledTimes(1);
+    expect(logs.warn).not.toHaveBeenCalled();
+    await result.bonjourStop?.();
+  });
+
   it("omits invalid SSH discovery ports", async () => {
     await expectSshPortOmitted("2222abc");
   });

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -4,6 +4,10 @@ import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { resolveWideAreaDiscoveryDomain, writeWideAreaGatewayZone } from "../infra/widearea-dns.js";
 import type { PluginGatewayDiscoveryServiceRegistration } from "../plugins/registry-types.js";
+import type {
+  OpenClawGatewayDiscoveryAdvertiseContext,
+  OpenClawGatewayDiscoveryService,
+} from "../plugins/types.js";
 import {
   formatBonjourInstanceName,
   resolveBonjourCliPath,
@@ -11,6 +15,102 @@ import {
 } from "./server-discovery.js";
 
 const DEFAULT_DISCOVERY_ADVERTISE_TIMEOUT_MS = 5_000;
+const UNKNOWN_DISCOVERY_SERVICE_ID = "unknown-discovery-service";
+const UNKNOWN_DISCOVERY_PLUGIN_ID = "unknown-plugin";
+
+type PreparedGatewayDiscoveryServiceRegistration =
+  | {
+      ok: true;
+      pluginId: string;
+      serviceId: string;
+      advertise: (
+        context: OpenClawGatewayDiscoveryAdvertiseContext,
+      ) => ReturnType<OpenClawGatewayDiscoveryService["advertise"]>;
+    }
+  | {
+      ok: false;
+      pluginId: string;
+      serviceId: string;
+      error: unknown;
+    };
+
+function readStringField(
+  read: () => unknown,
+  fallback: string,
+): { value: string; usedFallback: boolean; error?: unknown } {
+  try {
+    const value = read();
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { value, usedFallback: false };
+    }
+    return { value: fallback, usedFallback: true };
+  } catch (error) {
+    return { value: fallback, usedFallback: true, error };
+  }
+}
+
+function readGatewayDiscoveryServiceRegistration(
+  entry: PluginGatewayDiscoveryServiceRegistration,
+): PreparedGatewayDiscoveryServiceRegistration {
+  const pluginId = readStringField(() => entry.pluginId, UNKNOWN_DISCOVERY_PLUGIN_ID).value;
+
+  let service: OpenClawGatewayDiscoveryService;
+  try {
+    service = entry.service;
+  } catch (error) {
+    return {
+      ok: false,
+      pluginId,
+      serviceId: UNKNOWN_DISCOVERY_SERVICE_ID,
+      error,
+    };
+  }
+
+  const serviceId = readStringField(() => service.id, UNKNOWN_DISCOVERY_SERVICE_ID);
+  if (serviceId.error) {
+    return {
+      ok: false,
+      pluginId,
+      serviceId: serviceId.value,
+      error: serviceId.error,
+    };
+  }
+  if (serviceId.usedFallback) {
+    return {
+      ok: false,
+      pluginId,
+      serviceId: serviceId.value,
+      error: new Error("gateway discovery service id must be a non-empty string"),
+    };
+  }
+
+  let advertise: OpenClawGatewayDiscoveryService["advertise"];
+  try {
+    advertise = service.advertise;
+  } catch (error) {
+    return {
+      ok: false,
+      pluginId,
+      serviceId: serviceId.value,
+      error,
+    };
+  }
+  if (typeof advertise !== "function") {
+    return {
+      ok: false,
+      pluginId,
+      serviceId: serviceId.value,
+      error: new Error("gateway discovery service advertise must be a function"),
+    };
+  }
+
+  return {
+    ok: true,
+    pluginId,
+    serviceId: serviceId.value,
+    advertise: (context) => advertise.call(service, context),
+  };
+}
 
 function resolveDiscoveryAdvertiseTimeoutMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_GATEWAY_DISCOVERY_ADVERTISE_TIMEOUT_MS?.trim();
@@ -64,6 +164,13 @@ export async function startGatewayDiscovery(params: {
     let stoppedLocalDiscovery = false;
     for (const entry of params.gatewayDiscoveryServices ?? []) {
       attemptedLocalDiscovery = true;
+      const registration = readGatewayDiscoveryServiceRegistration(entry);
+      if (!registration.ok) {
+        params.logDiscovery.warn(
+          `gateway discovery service failed (${registration.serviceId}, plugin=${registration.pluginId}): ${String(registration.error)}`,
+        );
+        continue;
+      }
       try {
         let timer: ReturnType<typeof setTimeout> | undefined;
         let timedOut = false;
@@ -80,7 +187,7 @@ export async function startGatewayDiscovery(params: {
           minimal: mdnsMinimal,
         };
         const advertisePromise = Promise.resolve()
-          .then(() => entry.service.advertise(context))
+          .then(() => registration.advertise(context))
           .then(
             async (started) => {
               if (timedOut) {
@@ -96,14 +203,14 @@ export async function startGatewayDiscovery(params: {
                   }
                 }
                 params.logDiscovery.warn(
-                  `gateway discovery service completed after startup timeout (${entry.service.id}, plugin=${entry.pluginId})`,
+                  `gateway discovery service completed after startup timeout (${registration.serviceId}, plugin=${registration.pluginId})`,
                 );
               }
               return started;
             },
             (err: unknown) => {
               params.logDiscovery.warn(
-                `gateway discovery service failed${timedOut ? " after startup timeout" : ""} (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
+                `gateway discovery service failed${timedOut ? " after startup timeout" : ""} (${registration.serviceId}, plugin=${registration.pluginId}): ${String(err)}`,
               );
               return undefined;
             },
@@ -112,7 +219,7 @@ export async function startGatewayDiscovery(params: {
           timer = setTimeout(() => {
             timedOut = true;
             params.logDiscovery.warn(
-              `gateway discovery service timed out after ${advertiseTimeoutMs}ms (${entry.service.id}, plugin=${entry.pluginId}); continuing startup`,
+              `gateway discovery service timed out after ${advertiseTimeoutMs}ms (${registration.serviceId}, plugin=${registration.pluginId}); continuing startup`,
             );
             resolve(undefined);
           }, advertiseTimeoutMs);
@@ -127,7 +234,7 @@ export async function startGatewayDiscovery(params: {
         }
       } catch (err) {
         params.logDiscovery.warn(
-          `gateway discovery service failed (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
+          `gateway discovery service failed (${registration.serviceId}, plugin=${registration.pluginId}): ${String(err)}`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- Snapshot plugin gateway discovery service metadata before advertising so malformed registrations can be logged and skipped without aborting local discovery startup.
- Reuse the sanitized service/plugin ids for failure, timeout, and late-completion logging.
- Add regressions for unreadable service metadata and an explicit `unknown-discovery-service` id so the fallback label is not treated as reserved.

## Verification

- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next96-red node_modules/.bin/vitest run src/gateway/server-discovery-runtime.test.ts -t "continues local discovery after unreadable discovery service metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `gateway discovery service getter exploded`.
- Focused: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next96-focused node_modules/.bin/vitest run src/gateway/server-discovery-runtime.test.ts -t "continues local discovery after unreadable discovery service metadata|allows unknown-discovery-service as an explicit discovery service id" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 2 tests, 10 skipped.
- Full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next96-full node_modules/.bin/vitest run src/gateway/server-discovery-runtime.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 12 tests.
- Post-rebase full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next96-rebase-full node_modules/.bin/vitest run src/gateway/server-discovery-runtime.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 12 tests.
- `node_modules/.bin/oxfmt --check src/gateway/server-discovery-runtime.ts src/gateway/server-discovery-runtime.test.ts`
- `node_modules/.bin/oxlint src/gateway/server-discovery-runtime.ts src/gateway/server-discovery-runtime.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean; overall `patch is correct (0.86)`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean; overall `patch is correct (0.86)`.
- Broad changed gate blocked: `blacksmith testbox list --all` returned `not authenticated`; AWS Crabbox changed gate returned coordinator `POST /v1/leases: http 401` before lease.
- `agent-transcript find` returned `[]`.

Behavior addressed: A plugin gateway discovery registration with an unreadable `service` getter could throw out of `startGatewayDiscovery()` before healthy discovery services advertised.
Real environment tested: Local Codex worktree on Node/Vitest using the gateway-server project runner, plus attempted maintainer remote gate auth checks.
Exact steps or command run after this patch: Post-rebase full touched-file Vitest command, focused regression command, oxfmt, oxlint, diff-check, and autoreview commands listed above.
Evidence after fix: The poisoned metadata regression logs and skips the broken registration while the healthy discovery service advertises and later stops; the full touched test file passes 12/12.
Observed result after fix: Local discovery startup continues after malformed plugin discovery metadata instead of aborting the gateway discovery startup path.
What was not tested: `pnpm check:changed` through Testbox/Crabbox because Blacksmith is unauthenticated locally and the AWS Crabbox coordinator returned 401 before allocating a lease.
