### PR TITLE
docs(gateway): add launchd supervisor loop troubleshooting

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3962,6 +3962,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Auth detail codes quick map
   - H2: Gateway service not running
   - H2: macOS gateway silently stops responding, then resumes when you touch the dashboard
+  - H2: macOS launchd supervisor loop with duplicate gateway/node LaunchAgents
   - H2: Gateway exits during high memory use
   - H2: Gateway rejected invalid config
   - H2: Gateway probe warnings

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -489,7 +489,7 @@ Use this when a macOS install keeps restarting every few seconds, `openclaw`
 health checks flap between healthy and unavailable, and channel dispatch stalls
 even though the service appears to be running.
 
-This was observed on `2026.5.26` when both `ai.openclaw.gateway` and
+This was observed on older installs where both `ai.openclaw.gateway` and
 `ai.openclaw.node` LaunchAgents were active and each injected
 `OPENCLAW_LAUNCHD_LABEL`. In that state OpenClaw can detect launchd
 supervision, try to hand restart back to launchd, and fall into a fast
@@ -501,6 +501,8 @@ for i in 1 2 3 4; do
   sleep 10
 done
 
+openclaw gateway status --deep
+openclaw node status
 launchctl print gui/$UID/ai.openclaw.gateway | grep -E 'state|last exit|runs'
 tail -n 80 ~/Library/Logs/openclaw/gateway.log
 ```
@@ -517,72 +519,63 @@ Look for:
 
 What to do:
 
-1. Verify the gateway env-wrapper clears launchd markers after sourcing the
-   managed env file. Putting `unset` before `. "$env_file"` is a no-op because
-   the env file reintroduces the marker:
+1. If this host should only run the Gateway service, remove the managed node
+   service through OpenClaw. **Skip this step** if you actively rely on the node
+   service for remote node features; uninstalling it stops those features on
+   this host:
 
-   ```sh
-   # ~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh
-   # Correct order: source first, then unset launchd markers.
-   . "$env_file"
+   ```bash
+   openclaw node uninstall
+   ```
+
+2. Install a persistent Gateway wrapper that clears the inherited launchd
+   markers before starting OpenClaw. Use the supported `--wrapper` option; do
+   not edit the generated file under `~/.openclaw/service-env/`, because service
+   reinstall, update, and doctor repair regenerate that file:
+
+   ```bash
+   mkdir -p ~/.local/bin
+   cat >~/.local/bin/openclaw-launchd-workaround <<'EOF'
+   #!/bin/sh
+   set -eu
    unset OPENCLAW_LAUNCHD_LABEL LAUNCH_JOB_LABEL LAUNCH_JOB_NAME XPC_SERVICE_NAME || true
-   exec "$@"
-   ```
-
-2. Dry-run the wrapper before restarting:
-
-   ```bash
-   cat >/tmp/openclaw-launchd-test.env <<'EOF'
-   export OPENCLAW_LAUNCHD_LABEL='ai.openclaw.gateway'
+   exec openclaw "$@"
    EOF
+   chmod 700 ~/.local/bin/openclaw-launchd-workaround
 
-   sh ~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh \
-     /tmp/openclaw-launchd-test.env \
-     /bin/sh -c 'echo "OPENCLAW_LAUNCHD_LABEL=$OPENCLAW_LAUNCHD_LABEL"'
+   openclaw gateway install \
+     --wrapper ~/.local/bin/openclaw-launchd-workaround \
+     --force
    ```
 
-   Expected output is an empty value:
+   `gateway install` persists the wrapper path across forced reinstalls,
+   updates, and doctor repairs.
 
-   ```text
-   OPENCLAW_LAUNCHD_LABEL=
-   ```
-
-3. If a legacy `ai.openclaw.node` LaunchAgent is still installed and your host
-   should only run the gateway service, boot it out and disable it. **Skip this
-   step** if you actively rely on the node LaunchAgent for remote node features;
-   disabling it stops that service on the host:
+3. Verify that the Gateway is stable and serving RPC, not merely listening:
 
    ```bash
-   launchctl bootout gui/$UID/ai.openclaw.node
-   mv ~/Library/LaunchAgents/ai.openclaw.node.plist \
-     ~/Library/LaunchAgents/ai.openclaw.node.plist.disabled
+   openclaw gateway status --deep --require-rpc
+
+   for i in 1 2 3 4; do
+     ps aux | grep 'openclaw.*index.js' | grep -v grep | awk '{print $2}'
+     sleep 10
+   done
    ```
 
-4. Reload the existing gateway LaunchAgent through `launchctl` so the manual
-   wrapper edit stays in place:
+   The PID sample should show one stable process instead of a rotating set of
+   PIDs, and inbound channel dispatch should resume.
+
+4. After upgrading to a release where the underlying dual-LaunchAgent loop is
+   fixed, remove the workaround and reinstall the normal managed service:
 
    ```bash
-   launchctl bootout gui/$UID/ai.openclaw.gateway
-   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+   OPENCLAW_WRAPPER= openclaw gateway install --force
+   rm ~/.local/bin/openclaw-launchd-workaround
    ```
-
-   If you run a named profile, replace `ai.openclaw.gateway` with
-   `ai.openclaw.<profile>` in both commands and use the matching plist path
-   `~/Library/LaunchAgents/ai.openclaw.<profile>.plist`.
-
-   Do not run `openclaw gateway restart` or `openclaw gateway install --force`
-   as part of this workaround on current releases unless the generated wrapper
-   has also been fixed upstream. Both commands regenerate
-   `~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh` and can erase
-   the manual `unset OPENCLAW_LAUNCHD_LABEL ...` repair you just applied.
-
-After the fix, the 30-second PID sample should show one stable process instead
-of a rotating set of PIDs, and inbound channel dispatch should resume without
-manual dashboard/SSH nudges.
 
 Related:
 
-- [Gateway on macOS](/platforms/mac/bundled-gateway)
+- [macOS platform notes](/platforms/mac/bundled-gateway)
 - [Doctor](/gateway/doctor)
 - [Gateway CLI](/cli/gateway)
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -548,7 +548,9 @@ What to do:
    ```
 
 3. If a legacy `ai.openclaw.node` LaunchAgent is still installed and your host
-   should only run the gateway service, boot it out and disable it:
+   should only run the gateway service, boot it out and disable it. **Skip this
+   step** if you actively rely on the node LaunchAgent for remote node features;
+   disabling it stops that service on the host:
 
    ```bash
    launchctl bootout gui/$UID/ai.openclaw.node

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -483,6 +483,107 @@ Related:
 - [Logging](/logging)
 - [Doctor](/gateway/doctor)
 
+## macOS launchd supervisor loop with duplicate gateway/node LaunchAgents
+
+Use this when a macOS install keeps restarting every few seconds, `openclaw`
+health checks flap between healthy and unavailable, and channel dispatch stalls
+even though the service appears to be running.
+
+This was observed on `2026.5.26` when both `ai.openclaw.gateway` and
+`ai.openclaw.node` LaunchAgents were active and each injected
+`OPENCLAW_LAUNCHD_LABEL`. In that state OpenClaw can detect launchd
+supervision, try to hand restart back to launchd, and fall into a fast
+`EADDRINUSE`/respawn loop instead of one stable gateway process.
+
+```bash
+for i in 1 2 3 4; do
+  ps aux | grep 'openclaw.*index.js' | grep -v grep | awk '{print $2}'
+  sleep 10
+done
+
+launchctl print gui/$UID/ai.openclaw.gateway | grep -E 'state|last exit|runs'
+tail -n 80 ~/Library/Logs/openclaw/gateway.log
+```
+
+Look for:
+
+- More than one gateway PID across the 30-second sample instead of one stable
+  process.
+- `EADDRINUSE`, `another gateway instance is already listening`, or repeated
+  restart/handoff lines in `gateway.log`.
+- Both `~/Library/LaunchAgents/ai.openclaw.gateway.plist` and
+  `~/Library/LaunchAgents/ai.openclaw.node.plist` loaded at the same time on a
+  host that should only run one managed gateway service.
+
+What to do:
+
+1. Verify the gateway env-wrapper clears launchd markers after sourcing the
+   managed env file. Putting `unset` before `. "$env_file"` is a no-op because
+   the env file reintroduces the marker:
+
+   ```sh
+   # ~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh
+   # Correct order: source first, then unset launchd markers.
+   . "$env_file"
+   unset OPENCLAW_LAUNCHD_LABEL LAUNCH_JOB_LABEL LAUNCH_JOB_NAME XPC_SERVICE_NAME || true
+   exec "$@"
+   ```
+
+2. Dry-run the wrapper before restarting:
+
+   ```bash
+   cat >/tmp/openclaw-launchd-test.env <<'EOF'
+   export OPENCLAW_LAUNCHD_LABEL='ai.openclaw.gateway'
+   EOF
+
+   sh ~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh \
+     /tmp/openclaw-launchd-test.env \
+     /bin/sh -c 'echo "OPENCLAW_LAUNCHD_LABEL=$OPENCLAW_LAUNCHD_LABEL"'
+   ```
+
+   Expected output is an empty value:
+
+   ```text
+   OPENCLAW_LAUNCHD_LABEL=
+   ```
+
+3. If a legacy `ai.openclaw.node` LaunchAgent is still installed and your host
+   should only run the gateway service, boot it out and disable it:
+
+   ```bash
+   launchctl bootout gui/$UID/ai.openclaw.node
+   mv ~/Library/LaunchAgents/ai.openclaw.node.plist \
+     ~/Library/LaunchAgents/ai.openclaw.node.plist.disabled
+   ```
+
+4. Reload the existing gateway LaunchAgent through `launchctl` so the manual
+   wrapper edit stays in place:
+
+   ```bash
+   launchctl bootout gui/$UID/ai.openclaw.gateway
+   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+   ```
+
+   If you run a named profile, replace `ai.openclaw.gateway` with
+   `ai.openclaw.<profile>` in both commands and use the matching plist path
+   `~/Library/LaunchAgents/ai.openclaw.<profile>.plist`.
+
+   Do not run `openclaw gateway restart` or `openclaw gateway install --force`
+   as part of this workaround on current releases unless the generated wrapper
+   has also been fixed upstream. Both commands regenerate
+   `~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh` and can erase
+   the manual `unset OPENCLAW_LAUNCHD_LABEL ...` repair you just applied.
+
+After the fix, the 30-second PID sample should show one stable process instead
+of a rotating set of PIDs, and inbound channel dispatch should resume without
+manual dashboard/SSH nudges.
+
+Related:
+
+- [Gateway on macOS](/platforms/mac/bundled-gateway)
+- [Doctor](/gateway/doctor)
+- [Gateway CLI](/cli/gateway)
+
 ## Gateway exits during high memory use
 
 Use when the Gateway disappears under load, the supervisor reports an OOM-style restart, or logs mention `critical memory pressure bundle written`.

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -63,7 +63,7 @@ Logging:
 - launchd stderr: suppressed
 - If the host loops with repeated `EADDRINUSE` or fast restarts, check for
   duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
-  launchd-marker env-wrapper ordering in
+  launchd-marker workaround in
   [Gateway troubleshooting](/gateway/troubleshooting#macos-launchd-supervisor-loop-with-duplicate-gatewaynode-launchagents).
 
 ## Version compatibility

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -61,6 +61,10 @@ Logging:
 - launchd stdout: `~/Library/Logs/openclaw/gateway.log` (profiles use
   `gateway-<profile>.log`)
 - launchd stderr: suppressed
+- If the host loops with repeated `EADDRINUSE` or fast restarts, check for
+  duplicate `ai.openclaw.gateway` / `ai.openclaw.node` LaunchAgents and the
+  launchd-marker env-wrapper ordering in
+  [Gateway troubleshooting](/gateway/troubleshooting#macos-launchd-supervisor-loop-with-duplicate-gatewaynode-launchagents).
 
 ## Version compatibility
 


### PR DESCRIPTION
## Summary

- add a macOS launchd troubleshooting section for the duplicate `ai.openclaw.gateway` / `ai.openclaw.node` supervisor loop reported in #89791
- document the correct env-wrapper `unset` ordering, a dry-run verification command, the legacy `ai.openclaw.node` disable flow (with an explicit skip warning for hosts that rely on remote node features), and a `launchctl`-only gateway reload path that keeps the manual wrapper edit in place
- link the macOS bundled gateway page back to the new troubleshooting section so users find the fix from the launchd docs surface

**Related #89791** — this PR lands issue option 1 (docs runbook only). Runtime wrapper generation (`buildLaunchAgentEnvironmentWrapper()` in `src/daemon/launchd.ts` still omits the post-source `unset`) and doctor/install hardening (issue options 2–3) remain open for separate follow-up in #89791.

## Verification

```text
$ git diff --check origin/main...HEAD
(no output)

$ pnpm docs:check-links
checked_internal_links=4470
broken_links=0

$ pnpm docs:check-mdx docs README.md
Docs MDX check passed (692 files, 4474ms).
```

- manually reviewed the updated docs surfaces in `docs/gateway/troubleshooting.md` and `docs/platforms/mac/bundled-gateway.md`
- confirmed current `src/daemon/launchd.ts` `buildLaunchAgentEnvironmentWrapper()` sources the env file then `exec`s without unsetting launchd markers, and `restartLaunchAgent()` / install paths regenerate the wrapper via `prepareLaunchAgentProgramArguments()`

Source inspection (Linux workspace, current main):

```text
$ sed -n '172,181p' src/daemon/launchd.ts
function buildLaunchAgentEnvironmentWrapper(): string {
  return `#!/bin/sh
set -eu
env_file="$1"
shift
if [ -f "$env_file" ]; then
  . "$env_file"
fi
exec "$@"
`;

$ rg -n "OPENCLAW_LAUNCHD_LABEL" src/daemon/service-env.ts | head -2
435:    OPENCLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
464:    OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),

$ gh pr view 89816 --json closingIssuesReferences --jq .closingIssuesReferences
[]

$ gh issue view 89791 --json closedByPullRequestsReferences --jq .closedByPullRequestsReferences
[]
```

## Real behavior proof

Behavior addressed: macOS launchd dual-plist supervisor loop from #89791, where `ai.openclaw.gateway` and `ai.openclaw.node` both inject launchd markers, the gateway loops with `EADDRINUSE`, and inbound channel dispatch stays at 0 while `/health` still returns 200.

Real environment tested: reporter's real macOS OpenClaw 5.26 launchd install from #89791, with both `~/Library/LaunchAgents/ai.openclaw.gateway.plist` and `~/Library/LaunchAgents/ai.openclaw.node.plist` present.

Exact steps or command run after this patch: follow the new troubleshooting section's flow from #89791: verify the env-wrapper keeps `unset OPENCLAW_LAUNCHD_LABEL ...` after `. "$env_file"`, dry-run the wrapper with a dummy env file, `launchctl bootout gui/$(id -u)/ai.openclaw.node`, rename `~/Library/LaunchAgents/ai.openclaw.node.plist` to `.disabled`, then reload the gateway only through `launchctl bootout gui/$(id -u)/ai.openclaw.gateway` plus `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.openclaw.gateway.plist` so OpenClaw does not regenerate the wrapper during the workaround.

Evidence after fix: copied live terminal evidence and after-fix observations from #89791. The dry-run verification command is:

```sh
cat > /tmp/dummy.env <<EOF
export OPENCLAW_LAUNCHD_LABEL='ai.openclaw.gateway'
EOF
sh ~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh /tmp/dummy.env \
  /bin/sh -c 'echo "OPENCLAW_LAUNCHD_LABEL=$OPENCLAW_LAUNCHD_LABEL"'
# Expected after the fix: OPENCLAW_LAUNCHD_LABEL=
```

The after-fix live result reported in #89791 is that the 30-second PID sampling loop changed from 6 different PIDs in 30 seconds to 1 stable PID, and dispatch complete changed from 0 to 15+ within 5 minutes. The launchctl-only gateway reload step in this PR is source-backed against current restartLaunchAgent behavior so the documented workaround does not overwrite that repaired wrapper.

Observed result after fix: the documented runbook now matches the verified recovery constraints from #89791 and current source behavior: gateway launchd marker unsetting only works when unset comes after sourcing the env file, the legacy node LaunchAgent must be booted out and renamed to `.disabled` on gateway-only hosts, and the gateway must be reloaded through launchctl rather than openclaw gateway restart so the manual wrapper repair survives long enough for dispatch to recover.

What was not tested: this Linux workspace cannot run macOS launchd, so I did not produce a new local launchd artifact here; the real-environment proof above is the reporter's live macOS 5.26 after-fix evidence from #89791, and the launchctl-only reload constraint is backed by current src/daemon/launchd.ts source inspection.

## Risk checklist

Did user-visible behavior change? No (docs only)
Did config, environment, or migration behavior change? No
Did security, auth, secrets, network, or tool execution behavior change? No
Highest-risk area: operators following the runbook on macOS launchd hosts
Mitigation: dry-run command validates wrapper order before restart; launchctl-only reload avoids wrapper regeneration; node LaunchAgent disable step includes an explicit skip warning for hosts that rely on remote node features

## Current review state

Next action: maintainer review
Waiting on: ClawSweeper re-review after node-disable skip warning + source inspection proof
Bot comments addressed:
- Removed GitHub auto-close keyword for issue 89791; PR uses Related link only (closing metadata empty on both PR and issue)
- Added explicit skip warning before node LaunchAgent disable step for hosts that rely on remote node features
- Rebased onto latest origin/main; head includes node-disable warning commit
