### PR TITLE
fix(providers): forward stop sequences in bundled Anthropic transports

### DIFF
--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
@@ -176,6 +176,34 @@ describe("createMantleAnthropicStreamFn", () => {
     expect(streamOptions.effort).toBe("low");
   });
 
+  it("forwards stop sequences to the shared Anthropic stream", () => {
+    const model = createTestModel();
+    const context = { messages: [] };
+    const deps = createTestDeps();
+    deps.stream.mockReturnValue({ kind: "anthropic-stream" } as never);
+
+    void createMantleAnthropicStreamFn(deps)(model, context, {
+      apiKey: "bedrock-bearer-token",
+      stop: ["</tool>", "\n\nObservation:"],
+    });
+
+    // The shared Anthropic provider maps options.stop to the native stop_sequences field.
+    expect(firstStreamOptions(deps).stop).toEqual(["</tool>", "\n\nObservation:"]);
+  });
+
+  it("omits stop sequences when none are requested", () => {
+    const model = createTestModel();
+    const context = { messages: [] };
+    const deps = createTestDeps();
+    deps.stream.mockReturnValue({ kind: "anthropic-stream" } as never);
+
+    void createMantleAnthropicStreamFn(deps)(model, context, {
+      apiKey: "bedrock-bearer-token",
+    });
+
+    expect(firstStreamOptions(deps).stop).toBeUndefined();
+  });
+
   it("normalizes Mantle provider URLs to the Anthropic endpoint", () => {
     expect(resolveMantleAnthropicBaseUrl("https://bedrock-mantle.us-east-1.api.aws/v1")).toBe(
       "https://bedrock-mantle.us-east-1.api.aws/anthropic",

--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
@@ -78,6 +78,7 @@ function buildMantleAnthropicBaseOptions(
     temperature: requiresDefaultSampling(model.id) ? undefined : options?.temperature,
     maxTokens: options?.maxTokens || Math.min(model.maxTokens, 32_000),
     signal: options?.signal,
+    stop: options?.stop,
     apiKey,
     cacheRetention: options?.cacheRetention,
     sessionId: options?.sessionId,

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -166,6 +166,87 @@ describe("Bedrock profile endpoint resolution", () => {
   });
 });
 
+describe("Bedrock inferenceConfig stop sequences", () => {
+  function stopContext() {
+    return {
+      messages: [{ role: "user", content: "Reply briefly.", timestamp: 0 }],
+    } as never;
+  }
+
+  function adaptiveFableModel() {
+    return bedrockModel({
+      id: "production-fable",
+      name: "Production deployment",
+      reasoning: false,
+      params: { canonicalModelId: "claude-fable-5" },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
+  }
+
+  // Capture the real pre-send Converse command payload (mock SDK send) to prove
+  // stop forwarding through the actual request-build path, not a helper in isolation.
+  async function captureInferenceConfig(
+    model: ReturnType<typeof bedrockModel>,
+    options: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: "end_turn" } },
+      ]),
+    } as never);
+    const stream = streamBedrock(model, stopContext(), options as never);
+    await stream.result();
+    const command = send.mock.calls[0]?.[0] as {
+      input?: { inferenceConfig?: Record<string, unknown> };
+    };
+    return command.input?.inferenceConfig ?? {};
+  }
+
+  it("forwards stop sequences to the native stopSequences field", async () => {
+    const inferenceConfig = await captureInferenceConfig(bedrockModel({ reasoning: false }), {
+      maxTokens: 1024,
+      temperature: 0.4,
+      stop: ["</tool>", "\n\nObservation:"],
+    });
+    expect(inferenceConfig).toMatchObject({
+      maxTokens: 1024,
+      temperature: 0.4,
+      stopSequences: ["</tool>", "\n\nObservation:"],
+    });
+  });
+
+  it("keeps stopSequences without reintroducing temperature under adaptive thinking", async () => {
+    const inferenceConfig = await captureInferenceConfig(adaptiveFableModel(), {
+      reasoning: "high",
+      temperature: 0.2,
+      stop: ["STOP"],
+    });
+    // Adaptive-thinking requests omit temperature; stop forwarding must not
+    // reintroduce it (this is the compatibility guard the rebase preserves).
+    expect(inferenceConfig.stopSequences).toEqual(["STOP"]);
+    expect(Object.hasOwn(inferenceConfig, "temperature")).toBe(false);
+  });
+
+  it("omits stopSequences when stop is undefined", async () => {
+    const inferenceConfig = await captureInferenceConfig(bedrockModel({ reasoning: false }), {
+      maxTokens: 1024,
+      temperature: 0.7,
+    });
+    expect(Object.hasOwn(inferenceConfig, "stopSequences")).toBe(false);
+  });
+
+  it("omits stopSequences for an empty stop array", async () => {
+    const inferenceConfig = await captureInferenceConfig(bedrockModel({ reasoning: false }), {
+      maxTokens: 1024,
+      stop: [],
+    });
+    expect(Object.hasOwn(inferenceConfig, "stopSequences")).toBe(false);
+  });
+});
+
 describe("Bedrock thinking effort mapping", () => {
   it("does not force adaptive thinking for optional Claude models when callers omit reasoning", () => {
     const model = bedrockModel({

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -214,6 +214,11 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
           ...(options.maxTokens !== undefined && { maxTokens: options.maxTokens }),
           ...(options.temperature !== undefined &&
             !sendsAdaptiveThinking && { temperature: options.temperature }),
+          // Forward the contract stop sequences to Bedrock Converse's native
+          // stopSequences. Empty/undefined stop omits the field so unset requests
+          // stay byte-identical to before.
+          ...(options.stop !== undefined &&
+            options.stop.length > 0 && { stopSequences: options.stop }),
         },
         toolConfig: convertToolConfig(
           context.tools,

--- a/extensions/anthropic-vertex/stream-runtime.test.ts
+++ b/extensions/anthropic-vertex/stream-runtime.test.ts
@@ -391,6 +391,30 @@ describe("createAnthropicVertexStreamFn", () => {
     expect(transportPayloadHook).toBeUndefined();
   });
 
+  it("forwards stop sequences to the shared Anthropic transport", () => {
+    const { deps, streamAnthropicMock } = createStreamDeps();
+    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
+    const model = makeModel({ id: "claude-sonnet-4-6", maxTokens: 128000 });
+
+    void streamFn(model, { messages: [] }, { stop: ["</tool>", "\n\nObservation:"] });
+
+    // The shared Anthropic provider maps this to `stop_sequences` (anthropic.ts:970).
+    expect(streamTransportOptions(streamAnthropicMock).stop).toEqual([
+      "</tool>",
+      "\n\nObservation:",
+    ]);
+  });
+
+  it("omits stop sequences when none are requested", () => {
+    const { deps, streamAnthropicMock } = createStreamDeps();
+    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);
+    const model = makeModel({ id: "claude-sonnet-4-6", maxTokens: 128000 });
+
+    void streamFn(model, { messages: [] }, {});
+
+    expect(streamTransportOptions(streamAnthropicMock).stop).toBeUndefined();
+  });
+
   it("omits maxTokens when neither the model nor request provide a finite limit", () => {
     const { deps, streamAnthropicMock } = createStreamDeps();
     const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5", undefined, deps);

--- a/extensions/anthropic-vertex/stream-runtime.ts
+++ b/extensions/anthropic-vertex/stream-runtime.ts
@@ -163,6 +163,7 @@ export function createAnthropicVertexStreamFn(
       ...(temperature !== undefined ? { temperature } : {}),
       ...(maxTokens !== undefined ? { maxTokens } : {}),
       signal: options?.signal,
+      stop: options?.stop,
       cacheRetention: options?.cacheRetention,
       sessionId: options?.sessionId,
       headers: options?.headers,


### PR DESCRIPTION
## Summary

- Forwards `stop` sequences through the remaining **bundled Anthropic-family transports** that build their own request payload: Anthropic Vertex, Amazon Bedrock, and Amazon Bedrock Mantle. Each dropped the contractually-forwardable `stop` field (`packages/llm-core/src/types.ts` `stop?: string[]`).
- **Preserves existing behavior when stop sequences are unset**: every path is guarded so empty/undefined `stop` emits no field — unset requests are byte-identical to before.
- **Completes the same-root provider payload forwarding pattern** from the recent shared/agent fix (`fe3c3ac5cd`, refs #87920) and the bundled Google transport fix (`generationConfig.stopSequences`). Those covered the shared providers and the one Google bundled transport; these three bundled Anthropic-family transports were the remaining own-payload builders that still dropped `stop`.

What is intentionally out of scope?

- The OpenAI **Responses-API** transports (`openai-responses`, `openai-chatgpt-responses`, `azure-openai-responses`) are **out-of-scope follow-up**: the `/v1/responses` request shape has no `stop` field, so mapping it has unclear semantics and needs live-API + docs confirmation. No behavior is changed for them here.
- Providers that already forward `stop` (shared `anthropic.ts`, `google-shared.ts`, `mistral.ts`, `openai-completions.ts`, the core agent transports, and `extensions/google/transport-stream.ts`) are untouched.

What should reviewers focus on?

- Bedrock: the extracted `buildInferenceConfig(options)` helper and its guarded `stopSequences` spread (`@aws-sdk/client-bedrock-runtime` `InferenceConfiguration.stopSequences?: string[]`).
- Vertex / Mantle: both delegate to the shared Anthropic provider, which maps `stop` → `stop_sequences` behind its existing `length > 0` guard (`src/llm/providers/anthropic.ts`), so forwarding `stop` through the transport option bag is sufficient.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #87920 (shared/agent stop forwarding, `fe3c3ac5cd`) and the bundled Google transport stop fix (`4bb86877e2`). This PR is the same-root completeness follow-up for the remaining bundled Anthropic-family transports.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Anthropic Vertex, Amazon Bedrock, and Amazon Bedrock Mantle transports silently dropped caller-provided `stop` sequences; the provider request never received `stop_sequences` (Anthropic) / `inferenceConfig.stopSequences` (Bedrock). After this patch the field is forwarded when set and omitted when unset.
- Real environment tested: node/tsx stdout captured from the production provider payload builders themselves — `createAnthropicVertexStreamFn` and `createMantleAnthropicStreamFn` (both via the shared `streamAnthropic` payload builder, which sets `stop_sequences`), and `streamBedrock` (via its own `buildInferenceConfig`, which sets `inferenceConfig.stopSequences`). The actual request payload object is captured at the runtime `onPayload` seam — after the production code constructs it and **before** the transport/API send — and the harness then throws so each transport aborts before reaching any provider send. No live Bedrock/Vertex/Mantle API round-trip, no network send, and no credentials/prompts are used.
- Exact steps or command run after this patch: from a normal repo checkout (deps installed), `node --import tsx proof-stop-sequences.mts` — a local harness (not part of the diff; full source in the collapsed section below) that imports the three production stream factories, drives them with a redacted input prompt and `stop = ["</tool>", "\n\nObservation:"]`, and prints the captured request payload's stop field for the set, empty, and unset cases.
- Evidence after fix (redacted terminal stdout from the production payload builders, captured before transport/API send):

```
=== raw setup ===
stop sequences input: ["</tool>","\n\nObservation:"]

=== Anthropic Vertex payload (captured before transport send) ===
  stop_sequences (set)   : ["</tool>","\n\nObservation:"]
  stop_sequences (unset) : null (omitted)

=== Amazon Bedrock payload (captured before client.send) ===
  inferenceConfig.stopSequences (set)   : ["</tool>","\n\nObservation:"]
  inferenceConfig.stopSequences (empty) : null (omitted)
  inferenceConfig.stopSequences (unset) : null (omitted)

=== Amazon Bedrock Mantle payload (captured before transport send) ===
  stop_sequences (set)   : ["</tool>","\n\nObservation:"]
  stop_sequences (unset) : null (omitted)

=== result summary ===
  all providers carry expected stop field when set : true
  stop field omitted when empty/undefined           : true
  RESULT: PASS
```

- Observed result after fix: Each provider's request payload, captured before the transport/API send, carries the native stop field when stop sequences are provided — Anthropic Vertex `stop_sequences`, Amazon Bedrock `inferenceConfig.stopSequences`, Amazon Bedrock Mantle `stop_sequences` — with the exact provided array, and omits the field entirely for empty/undefined stop sequences. The harness summary line is `RESULT: PASS` (all-present-when-set `true`, omitted-when-unset `true`).
- What was not tested: No live provider API round-trip — the network send is intentionally short-circuited after the request payload is captured. Whether the stop field is forwarded is fully determined at payload-construction time, which this capture exercises against the production builders directly. Colocated transport tests are supplemental.
- Proof limitations or environment constraints: No live Amazon Bedrock / Anthropic Vertex / Bedrock Mantle account is available, so the proof captures the actual request payload produced by the production builders at the point just before the SDK send — which is exactly where the stop field is added. `stop_sequences` (Anthropic) and `inferenceConfig.stopSequences` (Bedrock Converse) are documented, stable `string[]` request fields. ClawBench is not applicable: this is a request-payload correctness fix, not a latency/throughput change.
- Before evidence (optional but encouraged): On current `main` the same three builders omit `stop_sequences` / `inferenceConfig.stopSequences` even when stop sequences are provided (the dropped-field defect this PR fixes), verified by source inspection of the pre-patch option bags / `inferenceConfig`.

<details>
<summary>Proof harness used (local, not part of the diff) — <code>proof-stop-sequences.mts</code></summary>

Vertex and Mantle are driven with an in-memory fake Anthropic client; Bedrock constructs the production `BedrockRuntimeClient` but the harness throws at `onPayload`, so it aborts before `client.send`. The request payload is captured at the `onPayload` seam (after the production builder constructs it, before any send). No network send occurs for any of the three. Run from a normal repo checkout with `node --import tsx proof-stop-sequences.mts`.

```ts
// Redacted proof harness: drives the PRODUCTION provider payload builders for the
// three bundled Anthropic-family transports and captures the request payload via
// the `onPayload` seam, which runs BEFORE any transport/API send. No live provider
// call, no credentials, no prompts printed — only the stop-sequence fields.
import { streamAnthropic } from "./src/llm/providers/anthropic.ts";
import { createAnthropicVertexStreamFn } from "./extensions/anthropic-vertex/stream-runtime.ts";
import { createMantleAnthropicStreamFn } from "./extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts";
import { streamBedrock } from "./extensions/amazon-bedrock/stream.runtime.ts";

const STOP = ["</tool>", "\n\nObservation:"];
const CTX = { messages: [{ role: "user", content: "redacted-prompt" }] } as never;

// Fake client: onPayload fires before this is reached, so we never touch the network.
const fakeMessages = {
  create() {
    throw new Error("payload captured before send (no network)");
  },
};
function fakeAnthropicClient() {
  return { messages: fakeMessages } as never;
}

function capture() {
  let resolve!: (p: unknown) => void;
  const captured = new Promise<unknown>((r) => (resolve = r));
  // Record the request payload the production code just built, then throw so the
  // transport aborts BEFORE reaching any provider send. Works for all three:
  // shared streamAnthropic (Vertex/Mantle) calls onPayload before client.messages.create;
  // streamBedrock calls onPayload before client.send. The throw lands in each
  // transport's own try/catch (surfaced as a stream error event we ignore).
  const onPayload = async (payload: unknown) => {
    resolve(payload);
    throw new Error("payload captured; aborting before any send");
  };
  return { onPayload, captured };
}

async function grab(run: (onPayload: (p: unknown) => Promise<unknown>) => void): Promise<any> {
  const { onPayload, captured } = capture();
  run(onPayload);
  const timeout = new Promise((_, rej) => setTimeout(() => rej(new Error("no payload")), 4000));
  return Promise.race([captured, timeout]);
}

function present(v: unknown): boolean {
  return Array.isArray(v) && v.length > 0;
}

const common = {
  reasoning: false,
  input: ["text"],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 200_000,
};
const vertexModel = {
  ...common,
  id: "claude-sonnet-4-6",
  name: "Claude Sonnet 4.6",
  api: "anthropic-messages",
  provider: "anthropic-vertex",
  baseUrl: "https://us-east5-aiplatform.googleapis.com/v1",
  maxTokens: 64000,
} as never;
const mantleModel = {
  ...common,
  id: "anthropic.claude-opus-4-7",
  name: "Claude Opus 4.7",
  api: "anthropic-messages",
  provider: "amazon-bedrock-mantle",
  baseUrl: "https://bedrock-mantle.example/v1",
  maxTokens: 128000,
} as never;
const bedrockModel = {
  ...common,
  id: "anthropic.claude-sonnet-4-6-v1:0",
  api: "bedrock-converse-stream",
  provider: "amazon-bedrock",
  name: "Claude Sonnet 4.6",
  maxTokens: 4096,
  baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
} as never;

function vertexFn(stop: string[] | undefined) {
  const fn = createAnthropicVertexStreamFn("redacted-project", "us-east5", undefined, {
    AnthropicVertex: function () {
      return fakeAnthropicClient();
    } as never,
    streamAnthropic,
  });
  return (onPayload: never) => void fn(vertexModel, CTX, { stop, onPayload } as never);
}

function mantleFn(stop: string[] | undefined) {
  const fn = createMantleAnthropicStreamFn({
    createClient: () => fakeAnthropicClient(),
    stream: streamAnthropic,
  });
  return (onPayload: never) =>
    void fn(mantleModel, CTX, { apiKey: "redacted", stop, onPayload } as never);
}

function bedrockFn(stop: string[] | undefined) {
  return (onPayload: never) =>
    void streamBedrock(bedrockModel, CTX, { maxTokens: 1024, stop, onPayload } as never);
}

console.log("=== raw setup ===");
console.log("stop sequences input:", JSON.stringify(STOP));
console.log("");

const vSet = await grab(vertexFn(STOP));
const vUnset = await grab(vertexFn(undefined));
console.log("=== Anthropic Vertex payload (captured before transport send) ===");
console.log("  stop_sequences (set)   :", JSON.stringify(vSet.stop_sequences));
console.log("  stop_sequences (unset) :", JSON.stringify(vUnset.stop_sequences ?? null), "(omitted)");
console.log("");

const bSet = await grab(bedrockFn(STOP));
const bEmpty = await grab(bedrockFn([]));
const bUnset = await grab(bedrockFn(undefined));
console.log("=== Amazon Bedrock payload (captured before client.send) ===");
console.log("  inferenceConfig.stopSequences (set)   :", JSON.stringify(bSet.inferenceConfig?.stopSequences));
console.log("  inferenceConfig.stopSequences (empty) :", JSON.stringify(bEmpty.inferenceConfig?.stopSequences ?? null), "(omitted)");
console.log("  inferenceConfig.stopSequences (unset) :", JSON.stringify(bUnset.inferenceConfig?.stopSequences ?? null), "(omitted)");
console.log("");

const mSet = await grab(mantleFn(STOP));
const mUnset = await grab(mantleFn(undefined));
console.log("=== Amazon Bedrock Mantle payload (captured before transport send) ===");
console.log("  stop_sequences (set)   :", JSON.stringify(mSet.stop_sequences));
console.log("  stop_sequences (unset) :", JSON.stringify(mUnset.stop_sequences ?? null), "(omitted)");
console.log("");

const allSetPresent =
  present(vSet.stop_sequences) &&
  present(bSet.inferenceConfig?.stopSequences) &&
  present(mSet.stop_sequences);
const allUnsetOmitted =
  vUnset.stop_sequences === undefined &&
  bEmpty.inferenceConfig?.stopSequences === undefined &&
  bUnset.inferenceConfig?.stopSequences === undefined &&
  mUnset.stop_sequences === undefined;

console.log("=== result summary ===");
console.log("  all providers carry expected stop field when set :", allSetPresent);
console.log("  stop field omitted when empty/undefined           :", allUnsetOmitted);
console.log("  RESULT:", allSetPresent && allUnsetOmitted ? "PASS" : "FAIL");
```

</details>

## Tests and validation

Which commands did you run?

- `node --import tsx proof-stop-sequences.mts` → captured the production request payloads before transport/API send (see Real behavior proof above); `RESULT: PASS`.
- Supplemental: `node scripts/run-vitest.mjs extensions/anthropic-vertex/stream-runtime.test.ts extensions/amazon-bedrock/stream.runtime.test.ts extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts` → 3 files / 32 tests passed
- Supplemental: `pnpm exec oxfmt --check` (6 touched files) → clean; `node scripts/run-oxlint.mjs` (6 touched files) → no findings; `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` → pass

What regression coverage was added or updated?

- 7 new tests across the three transports covering: stop forwarded when provided; native field omitted for empty `[]` and undefined; existing maxTokens/temperature/effort paths unchanged.

What failed before this fix, if known?

- Before the fix, caller-provided `stop` sequences were never sent to these three providers (no `stop_sequences` / `stopSequences` in the request).

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes — `stop` sequences are now honored on these three providers when callers set them. No change when `stop` is unset.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area? Emitting an unexpected request field on the unset path.

How is that risk mitigated? Every path guards on `stop !== undefined && stop.length > 0` (Bedrock locally; Vertex/Mantle via the shared Anthropic provider's existing guard), so unset/empty requests are byte-identical to before. Verified by the empty/undefined tests.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? Nothing from the author; awaiting review/CI.

Which bot or reviewer comments were addressed? None yet (initial submission).
