### PR TITLE
fix(node-host): guard plugin command metadata

### DIFF
--- a/src/node-host/plugin-node-host.test.ts
+++ b/src/node-host/plugin-node-host.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginNodeHostCommandRegistration } from "../plugins/registry-types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   invokeRegisteredNodeHostCommand,
@@ -74,6 +75,41 @@ describe("plugin node-host registry", () => {
       '{"ok":true}',
     );
     await expect(invokeRegisteredNodeHostCommand("missing.command", null)).resolves.toBeNull();
+    expect(handle).toHaveBeenCalledWith('{"ok":true}');
+  });
+
+  it("keeps healthy node-host commands available after unreadable command metadata", async () => {
+    const handle = vi.fn(async (paramsJSON?: string | null) => paramsJSON ?? "");
+    const registry = createEmptyPluginRegistry();
+    registry.nodeHostCommands = [
+      {
+        pluginId: "broken",
+        pluginName: "Broken",
+        source: "test",
+        get command() {
+          throw new Error("node host command getter exploded");
+        },
+      } as PluginNodeHostCommandRegistration,
+      {
+        pluginId: "browser",
+        pluginName: "Browser",
+        command: {
+          command: "browser.proxy",
+          cap: "browser",
+          handle,
+        },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listRegisteredNodeHostCapsAndCommands()).toEqual({
+      caps: ["browser"],
+      commands: ["browser.proxy"],
+    });
+    await expect(invokeRegisteredNodeHostCommand("browser.proxy", '{"ok":true}')).resolves.toBe(
+      '{"ok":true}',
+    );
     expect(handle).toHaveBeenCalledWith('{"ok":true}');
   });
 });

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -1,5 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginNodeHostCommandRegistration } from "../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import type { OpenClawPluginNodeHostCommand } from "../plugins/types.js";
 
 let pluginRegistryLoaderModulePromise:
   | Promise<typeof import("../plugins/runtime/runtime-registry-loader.js")>
@@ -8,6 +10,72 @@ let pluginRegistryLoaderModulePromise:
 async function loadPluginRegistryLoaderModule() {
   pluginRegistryLoaderModulePromise ??= import("../plugins/runtime/runtime-registry-loader.js");
   return await pluginRegistryLoaderModulePromise;
+}
+
+type PreparedNodeHostCommand = {
+  command: string;
+  cap?: string;
+  handle: OpenClawPluginNodeHostCommand["handle"];
+};
+
+function readNodeHostCommandRegistration(
+  entry: PluginNodeHostCommandRegistration,
+): PreparedNodeHostCommand | null {
+  let commandRegistration: OpenClawPluginNodeHostCommand;
+  try {
+    commandRegistration = entry.command;
+  } catch {
+    return null;
+  }
+
+  let command: string;
+  try {
+    const value = commandRegistration.command;
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return null;
+    }
+    command = value;
+  } catch {
+    return null;
+  }
+
+  let handle: OpenClawPluginNodeHostCommand["handle"];
+  try {
+    handle = commandRegistration.handle;
+  } catch {
+    return null;
+  }
+  if (typeof handle !== "function") {
+    return null;
+  }
+
+  let cap: string | undefined;
+  try {
+    const value = commandRegistration.cap;
+    if (typeof value === "string" && value.trim().length > 0) {
+      cap = value;
+    }
+  } catch {
+    cap = undefined;
+  }
+
+  return {
+    command,
+    cap,
+    handle: (paramsJSON) => handle.call(commandRegistration, paramsJSON),
+  };
+}
+
+function readRegisteredNodeHostCommands(): PreparedNodeHostCommand[] {
+  const registry = getActivePluginRegistry();
+  const commands: PreparedNodeHostCommand[] = [];
+  for (const entry of registry?.nodeHostCommands ?? []) {
+    const command = readNodeHostCommandRegistration(entry);
+    if (command) {
+      commands.push(command);
+    }
+  }
+  return commands;
 }
 
 export async function ensureNodeHostPluginRegistry(params: {
@@ -26,14 +94,13 @@ export function listRegisteredNodeHostCapsAndCommands(): {
   caps: string[];
   commands: string[];
 } {
-  const registry = getActivePluginRegistry();
   const caps = new Set<string>();
   const commands = new Set<string>();
-  for (const entry of registry?.nodeHostCommands ?? []) {
-    if (entry.command.cap) {
-      caps.add(entry.command.cap);
+  for (const entry of readRegisteredNodeHostCommands()) {
+    if (entry.cap) {
+      caps.add(entry.cap);
     }
-    commands.add(entry.command.command);
+    commands.add(entry.command);
   }
   return {
     caps: [...caps].toSorted((left, right) => left.localeCompare(right)),
@@ -45,12 +112,9 @@ export async function invokeRegisteredNodeHostCommand(
   command: string,
   paramsJSON?: string | null,
 ): Promise<string | null> {
-  const registry = getActivePluginRegistry();
-  const match = (registry?.nodeHostCommands ?? []).find(
-    (entry) => entry.command.command === command,
-  );
+  const match = readRegisteredNodeHostCommands().find((entry) => entry.command === command);
   if (!match) {
     return null;
   }
-  return await match.command.handle(paramsJSON);
+  return await match.handle(paramsJSON);
 }


### PR DESCRIPTION
## Summary

- Snapshot plugin node-host command registration metadata before listing or dispatching commands.
- Skip malformed command rows so one stale plugin registration cannot hide healthy node-host commands.
- Preserve handler receiver context for valid commands while keeping handler execution errors visible.

## Verification

- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next97-red node_modules/.bin/vitest run src/node-host/plugin-node-host.test.ts -t "keeps healthy node-host commands available after unreadable command metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `node host command getter exploded`.
- Focused: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next97-focused node_modules/.bin/vitest run src/node-host/plugin-node-host.test.ts -t "keeps healthy node-host commands available after unreadable command metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 1 test, 2 skipped.
- Full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next97-full node_modules/.bin/vitest run src/node-host/plugin-node-host.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 3 tests.
- Post-rebase full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next97-rebase-full node_modules/.bin/vitest run src/node-host/plugin-node-host.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 3 tests.
- `node_modules/.bin/oxfmt --check src/node-host/plugin-node-host.ts src/node-host/plugin-node-host.test.ts`
- `node_modules/.bin/oxlint src/node-host/plugin-node-host.ts src/node-host/plugin-node-host.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean; overall `patch is correct (0.86)`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean; overall `patch is correct (0.86)`.
- Broad changed gate blocked: `blacksmith testbox list --all` returned `not authenticated`; AWS Crabbox changed gate returned coordinator `POST /v1/leases: http 401` before lease.
- `agent-transcript find` returned `[]`.

Behavior addressed: A plugin node-host command registration with an unreadable `command` getter could throw while listing registered caps/commands or searching for a healthy command to invoke.
Real environment tested: Local Codex worktree on Node/Vitest using the unit-fast project runner, plus attempted maintainer remote gate auth checks.
Exact steps or command run after this patch: Post-rebase full touched-file Vitest command, focused regression command, oxfmt, oxlint, diff-check, and autoreview commands listed above.
Evidence after fix: The poisoned metadata regression skips the broken registration while the healthy `browser.proxy` command remains listed and invokable.
Observed result after fix: Node-host command listing and dispatch continue after malformed plugin command metadata instead of aborting on the stale row.
What was not tested: `pnpm check:changed` through Testbox/Crabbox because Blacksmith is unauthenticated locally and the AWS Crabbox coordinator returned 401 before allocating a lease.
