### PR TITLE
feat(workboard): polish drag feedback

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -330,7 +330,8 @@ the template id is stored as card metadata.
    optional linked session - or open Sessions and choose **Add to Workboard**
    for an existing session.
 3. Drag the card between columns, or focus its compact status control and use
-   the menu or ArrowLeft/ArrowRight.
+   the menu or ArrowLeft/ArrowRight. During a drag, the source card dims and
+   available drop columns gain an outline.
 4. Start work from the card to create or reuse a dashboard session.
 5. Open the linked session from the card while the agent works.
 6. Let lifecycle sync move running work into `review`/`blocked`, then manually

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -422,6 +422,49 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-health")?.textContent).toContain("running");
   });
 
+  it("distinguishes the dragged card from its available drop columns", () => {
+    const host = {};
+    const state = getWorkboardState(host);
+    state.loaded = true;
+    state.cards = [
+      {
+        id: "card-1",
+        title: "Drag feedback",
+        status: "todo",
+        priority: "normal",
+        labels: [],
+        position: 1000,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    state.draggedCardId = "card-1";
+    const container = document.createElement("div");
+    const props: WorkboardRenderProps = {
+      host,
+      client: null,
+      connected: true,
+      canWrite: true,
+      pluginEnabled: true,
+      agentsList: null,
+      sessions: [],
+      onOpenSession: () => undefined,
+    };
+
+    renderInto(container, props);
+
+    expect(container.querySelector(".workboard-card")?.classList).toContain(
+      "workboard-card--dragging",
+    );
+    expect(container.querySelectorAll(".workboard-column--drop")).toHaveLength(9);
+
+    state.draggedCardId = null;
+    renderInto(container, props);
+
+    expect(container.querySelector(".workboard-card--dragging")).toBeNull();
+    expect(container.querySelector(".workboard-column--drop")).toBeNull();
+  });
+
   it("hides cached card mutation controls until a lifecycle teardown reload succeeds", async () => {
     const host = {};
     const state = getWorkboardState(host);

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -1787,6 +1787,7 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     archived,
   } = cardActions;
   const syncing = state.syncingCardIds.has(card.id);
+  const dragging = state.draggedCardId === card.id;
   const healthHighlighted = state.activeHealthHighlight
     ? workboardCardMatchesHealthKey(card, state.activeHealthHighlight, props.sessions, task)
     : false;
@@ -1829,7 +1830,9 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     <article
       class="workboard-card priority-${card.priority} ${busy
         ? "workboard-card--busy"
-        : ""} ${archived ? "workboard-card--archived" : ""} ${healthHighlighted
+        : ""} ${archived ? "workboard-card--archived" : ""} ${dragging
+        ? "workboard-card--dragging"
+        : ""} ${healthHighlighted
         ? `workboard-card--health-highlight workboard-card--health-highlight-${state.activeHealthHighlight}`
         : ""} workboard-card--openable"
       role="button"

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -598,7 +598,6 @@ function getCardActionState(props: WorkboardProps, card: WorkboardCard) {
   return {
     state,
     task,
-    session,
     busy,
     activeTask,
     live,
@@ -1787,7 +1786,6 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     archived,
   } = cardActions;
   const syncing = state.syncingCardIds.has(card.id);
-  const dragging = state.draggedCardId === card.id;
   const healthHighlighted = state.activeHealthHighlight
     ? workboardCardMatchesHealthKey(card, state.activeHealthHighlight, props.sessions, task)
     : false;
@@ -1830,9 +1828,8 @@ function renderCard(props: WorkboardProps, card: WorkboardCard) {
     <article
       class="workboard-card priority-${card.priority} ${busy
         ? "workboard-card--busy"
-        : ""} ${archived ? "workboard-card--archived" : ""} ${dragging
-        ? "workboard-card--dragging"
-        : ""} ${healthHighlighted
+        : ""} ${archived ? "workboard-card--archived" : ""}
+      ${state.draggedCardId === card.id ? "workboard-card--dragging" : ""} ${healthHighlighted
         ? `workboard-card--health-highlight workboard-card--health-highlight-${state.activeHealthHighlight}`
         : ""} workboard-card--openable"
       role="button"

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -532,7 +532,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
         .poll(() => dragSource.getAttribute("class"))
         .toContain("workboard-card--dragging");
       await expect
-        .poll(() => dragSource.evaluate((card) => window.getComputedStyle(card).opacity))
+        .poll(() => dragSource.evaluate((element) => window.getComputedStyle(element).opacity))
         .toBe("0.45");
       expect(await writable.page.locator(".workboard-column--drop").count()).toBe(9);
       await captureScreenshot(writable.page, artifacts, "06-drag-feedback");

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -526,8 +526,23 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       await details.locator('button[aria-label="Cancel"]').click();
 
       await writableGateway.deferNext("workboard.cards.move");
+      const dragSource = cardInColumn(writable.page, "Todo", editedCard.title);
+      await dragSource.dispatchEvent("dragstart");
+      await expect
+        .poll(() => dragSource.getAttribute("class"))
+        .toContain("workboard-card--dragging");
+      await expect
+        .poll(() => dragSource.evaluate((card) => window.getComputedStyle(card).opacity))
+        .toBe("0.45");
+      expect(await writable.page.locator(".workboard-column--drop").count()).toBe(9);
+      await captureScreenshot(writable.page, artifacts, "06-drag-feedback");
+      await dragSource.dispatchEvent("dragend");
+      await expect
+        .poll(() => dragSource.getAttribute("class"))
+        .not.toContain("workboard-card--dragging");
+
       const moveBefore = (await writableGateway.getRequests("workboard.cards.move")).length;
-      await cardInColumn(writable.page, "Todo", editedCard.title).dragTo(
+      await dragSource.dragTo(
         statusColumn(writable.page, "Running").locator(".workboard-column__cards"),
       );
       const moveRequest = await waitForNextRequest(
@@ -543,7 +558,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       await cardInColumn(writable.page, "Running", editedCard.title).waitFor({
         state: "visible",
       });
-      await captureScreenshot(writable.page, artifacts, "06-moved-running");
+      await captureScreenshot(writable.page, artifacts, "07-moved-running");
 
       await writableGateway.deferNext("workboard.cards.update");
       const syncBefore = (await writableGateway.getRequests("workboard.cards.update")).length;
@@ -583,7 +598,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       await writable.page.locator(".workboard-detail").getByText("Moved to Review").waitFor({
         state: "visible",
       });
-      await captureScreenshot(writable.page, artifacts, "07-lifecycle-review");
+      await captureScreenshot(writable.page, artifacts, "08-lifecycle-review");
       await details.locator('button[aria-label="Cancel"]').click();
       await details.waitFor({ state: "hidden" });
 
@@ -636,7 +651,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       await writable.page
         .getByText("Acceptance: live Gateway invalidation refreshed this card")
         .waitFor({ state: "visible" });
-      await captureScreenshot(writable.page, artifacts, "08-reloaded-review");
+      await captureScreenshot(writable.page, artifacts, "09-reloaded-review");
     } finally {
       await closeRecordedPage(writable, artifacts, "workboard-writable");
     }

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -694,6 +694,16 @@
   opacity: 0.72;
 }
 
+.workboard-card.workboard-card--dragging {
+  opacity: 0.45;
+  border-color: color-mix(in srgb, var(--accent) 70%, var(--border-strong));
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--accent) 34%, transparent),
+    0 8px 22px color-mix(in srgb, #000 18%, transparent);
+  transform: scale(0.985);
+  cursor: grabbing;
+}
+
 .workboard-card h3 {
   margin: 0;
   color: var(--text-strong);


### PR DESCRIPTION
## What Problem This Solves

Workboard already supports native card drag-and-drop, but the dragged source card did not visibly enter a drag state. Operators received weak feedback about which card was moving and which columns were valid targets.

## Why This Change Was Made

This maintainer rewrite narrows the original mixed-scope PR to the Workboard behavior it identified. The existing drag state now drives one explicit source-card class, while the existing drop-target state continues to mark every permitted status column. Styling stays inside the Workboard owner surface; no global keyboard or application-shell policy is added.

The browser test exercises the real HTML5 drag path, checks computed styling and all valid drop targets, verifies cleanup after `dragend`, and then proves the actual drop still persists the card move.

## User Impact

Dragging a Workboard card now dims, outlines, and slightly lifts the source card while valid destination columns remain visibly marked. Ending or completing the drag removes the transient feedback without changing card movement or permission behavior.

## Evidence

- Exact final content: 68 focused Workboard unit tests, the UI TypeScript gate, and the TypeScript LOC ratchet passed in Testbox `tbx_01kxggwpzrypqjfd6nync5x1hs` ([run](https://github.com/openclaw/openclaw/actions/runs/29341569537)).
- All 3 Chromium Workboard E2E scenarios passed in that same run, including computed drag styling, all 9 valid drop targets, drag cleanup, persisted movement, and the newly landed board-filter behavior.
- Exact final head: targeted oxlint and all 3 Chromium Workboard E2E scenarios passed after the lint cleanup ([run](https://github.com/openclaw/openclaw/actions/runs/29342260335)).
- Exact final head `6b2e4b4707f17379991ebe424a21b138cab61bc0`: full hosted CI passed ([run](https://github.com/openclaw/openclaw/actions/runs/29342591113)).
- Screenshot artifact visually confirms a ghosted source card and clearly outlined valid columns without layout movement.
- Fresh maintainer autoreview: no accepted or actionable findings.

This rewrite preserves original contributor credit through the commit co-author trailer. Release note: Workboard card dragging now shows clearer source-card and drop-target feedback. Thanks @BunsDev for identifying the missing feedback.
