### PR TITLE
fix(gateway): guard plugin reload metadata

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -1,9 +1,11 @@
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import type { PluginReloadRegistration } from "../plugins/registry-types.js";
 import {
   getActivePluginChannelRegistryVersion,
   getActivePluginRegistry,
   getActivePluginRegistryVersion,
 } from "../plugins/runtime.js";
+import type { OpenClawPluginReloadRegistration } from "../plugins/types.js";
 import { isPlainObject } from "../utils.js";
 
 export type ChannelKind = ChannelId;
@@ -142,6 +144,45 @@ let cachedRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
 let cachedActiveRegistryVersion = -1;
 let cachedChannelRegistryVersion = -1;
 
+type PreparedPluginReloadRegistration = {
+  restartPrefixes: string[];
+  hotPrefixes: string[];
+  noopPrefixes: string[];
+};
+
+function readReloadPrefixes(read: () => unknown): string[] {
+  try {
+    const value = read();
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter(
+      (prefix): prefix is string => typeof prefix === "string" && prefix.length > 0,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function readPluginReloadRegistration(
+  entry: PluginReloadRegistration,
+): PreparedPluginReloadRegistration | null {
+  let registration: OpenClawPluginReloadRegistration;
+  try {
+    registration = entry.registration;
+  } catch {
+    return null;
+  }
+  if (!registration || typeof registration !== "object") {
+    return null;
+  }
+  return {
+    restartPrefixes: readReloadPrefixes(() => registration.restartPrefixes),
+    hotPrefixes: readReloadPrefixes(() => registration.hotPrefixes),
+    noopPrefixes: readReloadPrefixes(() => registration.noopPrefixes),
+  };
+}
+
 function listReloadRules(): ReloadRule[] {
   const registry = getActivePluginRegistry();
   const activeRegistryVersion = getActivePluginRegistryVersion();
@@ -189,8 +230,12 @@ function listReloadRules(): ReloadRule[] {
       ],
     },
   ]);
-  const pluginReloadRules: ReloadRule[] = (registry?.reloads ?? []).flatMap((entry) =>
-    (entry.registration.restartPrefixes ?? [])
+  const pluginReloadRules: ReloadRule[] = (registry?.reloads ?? []).flatMap((entry) => {
+    const registration = readPluginReloadRegistration(entry);
+    if (!registration) {
+      return [];
+    }
+    return registration.restartPrefixes
       .map(
         (prefix): ReloadRule => ({
           prefix,
@@ -198,20 +243,20 @@ function listReloadRules(): ReloadRule[] {
         }),
       )
       .concat(
-        (entry.registration.hotPrefixes ?? []).map(
+        registration.hotPrefixes.map(
           (prefix): ReloadRule => ({
             prefix,
             kind: "hot",
           }),
         ),
-        (entry.registration.noopPrefixes ?? []).map(
+        registration.noopPrefixes.map(
           (prefix): ReloadRule => ({
             prefix,
             kind: "none",
           }),
         ),
-      ),
-  );
+      );
+  });
   const rules = [
     ...BASE_RELOAD_RULES,
     ...pluginReloadRules,

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -8,6 +8,7 @@ import type {
   OpenClawConfig,
 } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { PluginReloadRegistration } from "../plugins/registry-types.js";
 import {
   pinActivePluginChannelRegistry,
   resetPluginRuntimeStateForTest,
@@ -193,6 +194,36 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(true);
     expect(plan.restartReasons).toContain("browser.enabled");
     expect(plan.hotReasons).toStrictEqual([]);
+  });
+
+  it("keeps healthy plugin reload rules after unreadable reload metadata", () => {
+    const poisonedRegistry = createTestRegistry([
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+    ]);
+    poisonedRegistry.reloads = [
+      {
+        pluginId: "broken",
+        pluginName: "Broken",
+        source: "test",
+        get registration() {
+          throw new Error("plugin reload registration getter exploded");
+        },
+      } as PluginReloadRegistration,
+      {
+        pluginId: "browser",
+        pluginName: "Browser",
+        registration: { restartPrefixes: ["browser"] },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(poisonedRegistry);
+
+    const plan = buildGatewayReloadPlan(["browser.enabled"]);
+
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("browser.enabled");
+    expect(resolveConfigReloadMetadata("browser.enabled").kind).toBe("restart");
   });
 
   it("restarts the Gmail watcher for hooks.gmail changes", () => {


### PR DESCRIPTION
## Summary

- Snapshot plugin reload registration metadata before building gateway config reload rules.
- Skip malformed reload registrations so one stale plugin row cannot abort reload planning.
- Keep healthy plugin reload rules active after unreadable plugin reload metadata.

## Verification

- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next98-red node_modules/.bin/vitest run src/gateway/config-reload.test.ts -t "keeps healthy plugin reload rules after unreadable reload metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix in all 3 gateway projects with `plugin reload registration getter exploded`.
- Focused: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next98-focused node_modules/.bin/vitest run src/gateway/config-reload.test.ts -t "keeps healthy plugin reload rules after unreadable reload metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 3 tests, 234 skipped.
- Full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next98-full node_modules/.bin/vitest run src/gateway/config-reload.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 237 tests.
- Post-rebase full touched file: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next98-rebase-full node_modules/.bin/vitest run src/gateway/config-reload.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 237 tests.
- `node_modules/.bin/oxfmt --check src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts`
- `node_modules/.bin/oxlint src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean; overall `patch is correct (0.87)`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean; overall `patch is correct (0.78)`.
- Broad changed gate blocked: `blacksmith testbox list --all` returned `not authenticated`; AWS Crabbox changed gate returned coordinator `POST /v1/leases: http 401` before lease.
- `agent-transcript find` returned `[]`.

Behavior addressed: A plugin reload registration with an unreadable `registration` getter could throw while building gateway config reload rules, preventing healthy plugin reload rules from being applied.
Real environment tested: Local Codex worktree on Node/Vitest using gateway-core, gateway-server, and gateway-client projects, plus attempted maintainer remote gate auth checks.
Exact steps or command run after this patch: Post-rebase full touched-file Vitest command, focused regression command, oxfmt, oxlint, diff-check, and autoreview commands listed above.
Evidence after fix: The poisoned reload metadata regression skips the broken registration while the healthy `browser` restart rule still marks `browser.enabled` as restart-backed.
Observed result after fix: Gateway config reload planning continues after malformed plugin reload metadata instead of aborting on the stale row.
What was not tested: `pnpm check:changed` through Testbox/Crabbox because Blacksmith is unauthenticated locally and the AWS Crabbox coordinator returned 401 before allocating a lease.
