### PR TITLE
fix(gateway): guard plugin node policy metadata

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -106,6 +106,47 @@ describe("gateway/node-command-policy", () => {
     expect(allowlist.has("canvas.present")).toBe(true);
   });
 
+  it("keeps healthy plugin node defaults after unreadable policy metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    (registry.nodeInvokePolicies ??= []).push(
+      Object.defineProperty(
+        {
+          pluginId: "stale",
+          source: "test",
+          pluginConfig: {},
+        },
+        "policy",
+        {
+          get() {
+            throw new Error("plugin node policy getter exploded");
+          },
+        },
+      ) as NonNullable<typeof registry.nodeInvokePolicies>[number],
+      {
+        pluginId: "canvas",
+        pluginName: "Canvas",
+        source: "/extensions/canvas/index.ts",
+        rootDir: "/extensions/canvas",
+        pluginConfig: {},
+        policy: {
+          commands: ["canvas.snapshot"],
+          defaultPlatforms: ["windows"],
+          foregroundRestrictedOnIos: true,
+          handle: (ctx) => ctx.invokeNode(),
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "windows",
+      deviceFamily: "Windows",
+    });
+
+    expect(allowlist.has("canvas.snapshot")).toBe(true);
+    expect(isForegroundRestrictedPluginNodeCommand("canvas.snapshot")).toBe(true);
+  });
+
   it("does not grant host command defaults for platform prefix aliases", () => {
     const cfg = {} as OpenClawConfig;
     const cases = [

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -9,6 +9,10 @@ import {
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import { normalizeDeviceMetadataForPolicy } from "./device-metadata-normalization.js";
 import type { NodeSession } from "./node-registry.js";
+import {
+  readPluginNodeHostCommandRegistration,
+  readPluginNodeInvokePolicyRegistration,
+} from "./plugin-node-command-policy-registrations.js";
 
 const CAMERA_COMMANDS = ["camera.list"];
 const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
@@ -224,12 +228,14 @@ export function listDangerousPluginNodeCommands(): string[] {
     return [];
   }
   const commands = [
-    ...(registry.nodeHostCommands ?? [])
-      .filter((entry) => entry.command.dangerous === true)
-      .map((entry) => entry.command.command),
-    ...(registry.nodeInvokePolicies ?? [])
-      .filter((entry) => entry.policy.dangerous === true)
-      .flatMap((entry) => entry.policy.commands),
+    ...(registry.nodeHostCommands ?? []).flatMap((entry) => {
+      const readable = readPluginNodeHostCommandRegistration(entry);
+      return readable?.dangerous === true ? [readable.command] : [];
+    }),
+    ...(registry.nodeInvokePolicies ?? []).flatMap((entry) => {
+      const readable = readPluginNodeInvokePolicyRegistration(entry);
+      return readable?.dangerous === true ? readable.commands : [];
+    }),
   ];
   return normalizeUniqueStringEntries(commands);
 }
@@ -239,12 +245,28 @@ function listDefaultPluginNodeCommands(platformId: PlatformId): string[] {
   if (!registry) {
     return [];
   }
+  const commands = (registry.nodeInvokePolicies ?? [])
+    .map(readPluginNodeInvokePolicyRegistration)
+    .flatMap((entry) => {
+      if (!entry || entry.dangerous === true) {
+        return [];
+      }
+      return entry.defaultPlatforms.includes(platformId) ? entry.commands : [];
+    });
+  return normalizeUniqueStringEntries(commands);
+}
+
+function listForegroundRestrictedPluginNodeCommands(): string[] {
+  const registry = getActiveRuntimePluginRegistry();
+  if (!registry) {
+    return [];
+  }
   const commands = (registry.nodeInvokePolicies ?? []).flatMap((entry) => {
-    if (entry.policy.dangerous === true) {
+    const readable = readPluginNodeInvokePolicyRegistration(entry);
+    if (!readable?.foregroundRestrictedOnIos) {
       return [];
     }
-    const defaults = entry.policy.defaultPlatforms ?? [];
-    return defaults.includes(platformId) ? entry.policy.commands : [];
+    return readable.commands;
   });
   return normalizeUniqueStringEntries(commands);
 }
@@ -258,10 +280,8 @@ export function isForegroundRestrictedPluginNodeCommand(command: string): boolea
   if (!normalized) {
     return false;
   }
-  return (registry.nodeInvokePolicies ?? []).some(
-    (entry) =>
-      entry.policy.foregroundRestrictedOnIos === true &&
-      entry.policy.commands.some((policyCommand) => policyCommand.trim() === normalized),
+  return listForegroundRestrictedPluginNodeCommands().some(
+    (policyCommand) => policyCommand.trim() === normalized,
   );
 }
 

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -301,4 +301,44 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     expect(result).toBeNull();
   });
+
+  it("keeps healthy plugin node policies after unreadable metadata", async () => {
+    registryState.current = {
+      nodeHostCommands: [
+        Object.defineProperty(
+          {
+            pluginId: "stale",
+            source: "test",
+          },
+          "command",
+          {
+            get() {
+              throw new Error("plugin node command getter exploded");
+            },
+          },
+        ),
+      ],
+      nodeInvokePolicies: [
+        Object.defineProperty(
+          {
+            pluginId: "stale",
+            source: "test",
+          },
+          "policy",
+          {
+            get() {
+              throw new Error("plugin node policy getter exploded");
+            },
+          },
+        ),
+        createDemoPolicy((ctx: OpenClawPluginNodeInvokePolicyContext) => ctx.invokeNode()),
+      ],
+    } as unknown as PluginRegistry;
+    const { context, invoke } = createContext();
+
+    const result = await invokeDemoPolicy(context);
+
+    expect(result).toStrictEqual({ ok: true, payload: { ok: true, value: 1 }, payloadJSON: null });
+    expect(invoke).toHaveBeenCalledOnce();
+  });
 });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -10,6 +10,10 @@ import type {
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
 import type { NodeSession } from "./node-registry.js";
+import {
+  readPluginNodeHostCommandRegistration,
+  readPluginNodeInvokePolicyRegistration,
+} from "./plugin-node-command-policy-registrations.js";
 import { resolveApprovalRequestRecipientConnIds } from "./server-methods/approval-shared.js";
 import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";
 
@@ -36,10 +40,10 @@ function findDangerousPluginNodeCommand(registry: PluginRegistry | null, command
     return null;
   }
   return (
-    registry?.nodeHostCommands?.find(
-      (entry) =>
-        entry.command.dangerous === true && entry.command.command.trim() === normalizedCommand,
-    ) ?? null
+    registry?.nodeHostCommands
+      ?.map(readPluginNodeHostCommandRegistration)
+      .find((entry) => entry?.dangerous === true && entry.command.trim() === normalizedCommand) ??
+    null
   );
 }
 
@@ -120,10 +124,10 @@ export async function applyPluginNodeInvokePolicy(params: {
   idempotencyKey?: string;
 }): Promise<OpenClawPluginNodeInvokePolicyResult | null> {
   const registry = getActiveRuntimePluginRegistry();
-  const entry = registry?.nodeInvokePolicies?.find((candidate) =>
-    candidate.policy.commands.includes(params.command),
-  );
-  if (!entry) {
+  const policy = registry?.nodeInvokePolicies
+    ?.map(readPluginNodeInvokePolicyRegistration)
+    .find((candidate) => candidate?.commands.includes(params.command));
+  if (!policy) {
     const dangerousCommand = findDangerousPluginNodeCommand(registry, params.command);
     if (dangerousCommand) {
       return {
@@ -160,14 +164,14 @@ export async function applyPluginNodeInvokePolicy(params: {
     };
   };
 
-  return await entry.policy.handle({
+  return await policy.handle({
     nodeId: params.nodeSession.nodeId,
     command: params.command,
     params: params.params,
     timeoutMs: params.timeoutMs,
     idempotencyKey: params.idempotencyKey,
     config: params.context.getRuntimeConfig(),
-    pluginConfig: entry.pluginConfig,
+    pluginConfig: policy.pluginConfig,
     node: {
       nodeId: params.nodeSession.nodeId,
       displayName: params.nodeSession.displayName,
@@ -184,7 +188,7 @@ export async function applyPluginNodeInvokePolicy(params: {
     approvals: createApprovalRuntime({
       context: params.context,
       client: params.client,
-      pluginId: entry.pluginId,
+      pluginId: policy.pluginId,
     }),
     invokeNode,
   });

--- a/src/gateway/plugin-node-command-policy-registrations.ts
+++ b/src/gateway/plugin-node-command-policy-registrations.ts
@@ -1,0 +1,73 @@
+import type {
+  PluginNodeHostCommandRegistration,
+  PluginNodeInvokePolicyRegistration,
+} from "../plugins/registry-types.js";
+import type { OpenClawPluginNodeInvokePolicy } from "../plugins/types.js";
+
+export type ReadablePluginNodeHostCommandRegistration = {
+  pluginId: string;
+  command: string;
+  dangerous: boolean;
+};
+
+export type ReadablePluginNodeInvokePolicyRegistration = {
+  pluginId: string;
+  pluginConfig?: Record<string, unknown>;
+  commands: string[];
+  defaultPlatforms: string[];
+  dangerous: boolean;
+  foregroundRestrictedOnIos: boolean;
+  handle: OpenClawPluginNodeInvokePolicy["handle"];
+};
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function readPluginId(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function readPluginNodeHostCommandRegistration(
+  entry: PluginNodeHostCommandRegistration,
+): ReadablePluginNodeHostCommandRegistration | null {
+  try {
+    const pluginId = readPluginId(entry.pluginId);
+    const command = entry.command;
+    if (!pluginId || typeof command.command !== "string") {
+      return null;
+    }
+    return {
+      pluginId,
+      command: command.command,
+      dangerous: command.dangerous === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function readPluginNodeInvokePolicyRegistration(
+  entry: PluginNodeInvokePolicyRegistration,
+): ReadablePluginNodeInvokePolicyRegistration | null {
+  try {
+    const pluginId = readPluginId(entry.pluginId);
+    const policy = entry.policy;
+    if (!pluginId || typeof policy.handle !== "function") {
+      return null;
+    }
+    return {
+      pluginId,
+      ...(entry.pluginConfig ? { pluginConfig: entry.pluginConfig } : {}),
+      commands: readStringArray(policy.commands),
+      defaultPlatforms: readStringArray(policy.defaultPlatforms),
+      dangerous: policy.dangerous === true,
+      foregroundRestrictedOnIos: policy.foregroundRestrictedOnIos === true,
+      handle: policy.handle,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add guarded snapshots for plugin node host command and node.invoke policy metadata.
- Keep healthy plugin node defaults, foreground restriction metadata, dangerous-command gating, and invoke policy handlers available when a stale plugin registration has unreadable metadata.
- Add regressions for unreadable plugin node policy rows in gateway allowlist and invoke-policy paths.

## Verification
- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-red-a node_modules/.bin/vitest run src/gateway/node-command-policy.test.ts -t "keeps healthy plugin node defaults after unreadable policy metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `plugin node policy getter exploded` in gateway core/server/client.
- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-red-b node_modules/.bin/vitest run src/gateway/node-invoke-plugin-policy.test.ts -t "keeps healthy plugin node policies after unreadable metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `plugin node policy getter exploded` in gateway core/server/client.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-focused-a node_modules/.bin/vitest run src/gateway/node-command-policy.test.ts -t "keeps healthy plugin node defaults after unreadable policy metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-focused-b node_modules/.bin/vitest run src/gateway/node-invoke-plugin-policy.test.ts -t "keeps healthy plugin node policies after unreadable metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-full node_modules/.bin/vitest run src/gateway/node-command-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 60 tests across gateway core/server/client.
- Post-rebase: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next99-rebase-full node_modules/.bin/vitest run src/gateway/node-command-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 60 tests across gateway core/server/client.
- `node_modules/.bin/oxfmt --check src/gateway/plugin-node-command-policy-registrations.ts src/gateway/node-command-policy.ts src/gateway/node-invoke-plugin-policy.ts src/gateway/node-command-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `node_modules/.bin/oxlint src/gateway/plugin-node-command-policy-registrations.ts src/gateway/node-command-policy.ts src/gateway/node-invoke-plugin-policy.ts src/gateway/node-command-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall 0.84.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall 0.86.
- Broad gate gap: `blacksmith testbox list --all` is blocked by missing Blacksmith auth; AWS Crabbox fallback `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` is blocked by coordinator 401 before lease.

Behavior addressed: malformed or stale plugin node command/policy registrations can no longer crash gateway node command policy evaluation before healthy plugin policy rows are considered.
Real environment tested: local sparse Codex worktree using linked repo install; gateway core/server/client Vitest projects.
Exact steps or command run after this patch: post-rebase full affected test command, oxfmt check, oxlint, git diff check, local and branch autoreview.
Evidence after fix: focused repros pass; full affected test files pass 60 tests across gateway core/server/client.
Observed result after fix: healthy plugin node defaults, foreground restriction metadata, dangerous-command gating, and invoke policy handling continue after unreadable stale plugin metadata rows are skipped.
What was not tested: `pnpm check:changed`; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
