### PR TITLE
fix(diagnostic): gate stuck-session fallback on fresh progress

### DIFF
--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -154,6 +154,40 @@ describe("classifySessionAttention", () => {
         recoveryEligible: false,
       },
     },
+    {
+      // External-runtime streams (e.g. claude-cli) emit run.progress but do not
+      // register an embedded run handle, so activeWorkKind stays undefined.
+      // Fresh progress must still rule out stuck recovery, otherwise an actively
+      // streaming run is force-recovered while it is still healthy.
+      name: "fresh progress without active work kind is long_running, not stuck",
+      state: "processing" as const,
+      queueDepth: 1,
+      activity: {
+        lastProgressAgeMs: 0,
+        lastProgressReason: "cli_live:stream_progress",
+      },
+      expected: {
+        eventType: "session.long_running",
+        reason: "queued_behind_untracked_active_progress",
+        classification: "long_running",
+        recoveryEligible: false,
+      },
+    },
+    {
+      name: "fresh progress without active work kind or queued work is long_running",
+      state: "processing" as const,
+      queueDepth: 0,
+      activity: {
+        lastProgressAgeMs: 0,
+        lastProgressReason: "cli_live:stream_progress",
+      },
+      expected: {
+        eventType: "session.long_running",
+        reason: "untracked_active_progress",
+        classification: "long_running",
+        recoveryEligible: false,
+      },
+    },
   ])("$name", ({ activity, expected, queueDepth, state }) => {
     expect(
       classifySessionAttention({

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -92,11 +92,9 @@ export function classifySessionAttention(params: {
     };
   }
 
-  // External runtimes (e.g. claude-cli) emit run.progress but do not register
-  // an embedded run handle, so activity.activeWorkKind stays undefined. Fresh
-  // progress is the authoritative signal that the session is still healthy;
-  // skipping this check would force-recover an actively streaming run while
-  // its lane has no command-queue task to release (released=0 no-op).
+  // External runtimes emit run.progress without registering an embedded run
+  // handle, leaving activeWorkKind undefined; without this gate an actively
+  // streaming session is force-recovered while its lane has nothing to reclaim.
   const lastProgressAgeMs = params.activity.lastProgressAgeMs;
   if (typeof lastProgressAgeMs === "number" && lastProgressAgeMs <= params.staleMs) {
     return {

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -92,6 +92,23 @@ export function classifySessionAttention(params: {
     };
   }
 
+  // External runtimes (e.g. claude-cli) emit run.progress but do not register
+  // an embedded run handle, so activity.activeWorkKind stays undefined. Fresh
+  // progress is the authoritative signal that the session is still healthy;
+  // skipping this check would force-recover an actively streaming run while
+  // its lane has no command-queue task to release (released=0 no-op).
+  const lastProgressAgeMs = params.activity.lastProgressAgeMs;
+  if (typeof lastProgressAgeMs === "number" && lastProgressAgeMs <= params.staleMs) {
+    return {
+      eventType: "session.long_running",
+      reason:
+        params.queueDepth > 0
+          ? "queued_behind_untracked_active_progress"
+          : "untracked_active_progress",
+      classification: "long_running",
+      recoveryEligible: false,
+    };
+  }
   return {
     eventType: "session.stuck",
     reason: params.queueDepth > 0 ? "queued_work_without_active_run" : "stale_session_state",


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89766 reports that long-running gateways running cron `sessionTarget: isolated` jobs on the `claude-cli` backend repeatedly emit `[diagnostic] stuck session: ... reason=queued_work_without_active_run ... lastProgress=cli_live:stream_progress lastProgressAge=0s recovery=checking` followed by `action=release_lane ... released=0` while the cli child is actively streaming. The classifier declares a healthy streaming session as stuck and the recovery path then mutates diagnostic state (flips lane idle, bumps generation, clears queueDepth) on a session whose run is still running. The reporter's downstream lane-occupation theory is mechanically off — cli runs never enqueue in `session:agent:main:cron:<jobId>:run:<runId>`, so `resetCommandLane` returning `released=0` is the normal no-op shape, not a leak — but the classifier-altitude misclassification it documents is real and reproducible from current source.
- **Root Cause**: Diagnostic activity has three tracked work kinds (`tool_call`, `model_call`, `embedded_run`) and `getDiagnosticSessionActivitySnapshot` derives `activeWorkKind` only from those (`src/logging/diagnostic-run-activity.ts:580-587`). The cron isolated executor routes claude-cli jobs through `runCliAgent` (`src/cron/isolated-agent/run-executor.ts:220-256`), which goes to `runClaudeLiveSessionTurn` and emits `cli_live:stream_progress` via `markDiagnosticRunProgress` (`src/agents/cli-runner/claude-live-session.ts:494-500,682`) but never calls `setActiveEmbeddedRun` (only `src/agents/embedded-agent-runner/run/attempt.ts:3340` does that, and only `runEmbeddedAgent` reaches it). So for cli sessions `activity.activeWorkKind` stays `undefined` while `lastProgressAt` is fresh. `classifySessionAttention`'s fall-through (`src/logging/diagnostic-session-attention.ts:95-100` on main) returns `session.stuck` reason `queued_work_without_active_run` with `recoveryEligible: true` regardless of `lastProgressAgeMs`, and the heartbeat sweep (`src/logging/diagnostic.ts:1247-1280`) then drives `requestStuckSessionRecovery`. The same file's first branch (`:38-50`) already gates the analogous idle-orphaned-activity case on `lastProgressAgeMs > staleMs`; the fall-through is the only branch missing the freshness check.
- **Fix**: Apply the same freshness gate to the `activeWorkKind === undefined` fall-through. When `typeof lastProgressAgeMs === "number" && lastProgressAgeMs <= staleMs`, return `session.long_running` with reason `untracked_active_progress` (or `queued_behind_untracked_active_progress` when `queueDepth > 0`) and `recoveryEligible: false`. Stale or missing progress still falls through to the existing `session.stuck` path so genuinely abandoned sessions remain recoverable.
- **What changed**:
  - `src/logging/diagnostic-session-attention.ts` — add the `lastProgressAgeMs <= staleMs` gate immediately before the existing fall-through; introduce two new reason strings (`untracked_active_progress`, `queued_behind_untracked_active_progress`) that are local to this classifier and emit through the existing `reason: string` field on `DiagnosticSessionAttentionBaseEvent`.
  - `src/logging/diagnostic-session-attention.test.ts` — add two table-driven cases covering the fresh-progress + no-`activeWorkKind` path: queued (`queueDepth: 1`) and non-queued (`queueDepth: 0`), both with `state: "processing"` and `lastProgressReason: "cli_live:stream_progress"`.
- **What did NOT change (scope boundary)**:
  - The eight pre-existing classifier branches (idle-orphaned-stuck, blocked tool, queued-behind-terminal, active-work-without-progress, long-running active, queued-behind-active, stale-no-queue, queued-stale) are unchanged; the new gate is reached only when the `activeWorkKind`-set block falls through.
  - `classifySessionAttention`'s existing `session.stuck` fall-through still handles stale/missing progress; `recoveryEligible: true` for genuinely abandoned cli sessions (when `lastProgressAgeMs > staleMs`) is preserved.
  - `recoverStuckDiagnosticSession`, `applyRecoveryOutcomeToDiagnosticState`, `clearDiagnosticEmbeddedRunActivityForSession`, and `isIdleQueuedRecoverableSessionStall` are unchanged.
  - The cli-runner, cron service, embedded-agent-runner, command queue, MCP loopback singleton, and plugin runtime loader are unchanged; no new `activeWorkKind` registration for cli runs is introduced (that is a broader taxonomy decision worth its own design discussion).
  - The `DiagnosticSessionAttentionClassification` discriminated union, `DiagnosticSessionAttentionBaseEvent`, `session.long_running` / `session.stuck` event types, and all existing reason strings (`queued_work_without_active_run`, `stale_session_state`, `queued_behind_active_work`, `active_work`, `active_work_without_progress`, `queued_behind_terminal_active_work`, `blocked_tool_call`) are preserved.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - No dependency changes (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `npm-shrinkwrap.json` all unchanged).

### Reproduction

1. Run an isolated cron job (`sessionTarget: isolated`) with an `agentRuntime: claude-cli` model on a gateway with `cron.maxConcurrentRuns >= 1` and let the cli child stream output for longer than `stuckSessionWarnMs` (default 30s).
2. The diagnostic heartbeat sweep iterates `diagnosticSessionStates`, finds the cron session in `state === "processing"` with `ageMs > stuckSessionWarnMs`, and calls `logSessionAttention`.
3. `getDiagnosticSessionActivitySnapshot` returns `{ lastProgressAgeMs: <small>, lastProgressReason: "cli_live:stream_progress" }` with `activeWorkKind` undefined.
4. **Before this PR**: `classifySessionAttention` falls through to `session.stuck` reason `queued_work_without_active_run` with `recoveryEligible: true`; the heartbeat dispatches `requestStuckSessionRecovery` against the live streaming session; `recoverStuckDiagnosticSession` finds no embedded run handle, calls `resetCommandLane(session:agent:main:cron:<jobId>:run:<runId>)` which returns `released=0` because cli runs never enqueue there; `applyRecoveryOutcomeToDiagnosticState` flips the diagnostic state to `idle`, bumps the generation, and clears `queueDepth` while the cli child is still streaming. Logs match the reporter's `[diagnostic] stuck session ... reason=queued_work_without_active_run ... lastProgressAge=0s ... action=release_lane ... released=0` chain.
5. **After this PR**: the classifier returns `session.long_running` reason `untracked_active_progress` (or `queued_behind_untracked_active_progress` when `queueDepth > 0`) with `recoveryEligible: false`; the heartbeat does not dispatch recovery; the streaming session is not interfered with; once progress goes stale (`lastProgressAgeMs > staleMs`) or absent, the existing `session.stuck` fall-through still applies.

### Real behavior proof

**Behavior addressed (#89766)**: cron isolated claude-cli sessions emitting fresh `cli_live:stream_progress` are no longer classified as `session.stuck` while progress is within `staleMs`; the recovery coordinator no longer mutates `state.state`, `state.generation`, or `state.queueDepth` against a live streaming session. The reporter's "lane-occupation → leak → runtime-plugins stall" theory is not the source-confirmed cascade — `resetCommandLane` on an empty lane is a no-op by design — but the classifier misclassification that produces the literal `queued_work_without_active_run` warnings and false recovery dispatches IS addressed at the classifier altitude.

**Real environment tested (Linux, Node 22 — Vitest against the production `classifySessionAttention`, with adjacent suites exercising the recovery coordinator and heartbeat sweep)**: classifier-level reproduction of the reporter's exact snapshot fields; full adjacency check on the heartbeat + stuck-recovery runtime to prove no regression of the non-cli paths.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/logging/diagnostic-session-attention.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`; `./node_modules/.bin/oxlint src/logging/diagnostic-session-attention.ts src/logging/diagnostic-session-attention.test.ts`; `./node_modules/.bin/oxfmt --check src/logging/diagnostic-session-attention.ts src/logging/diagnostic-session-attention.test.ts`; `./node_modules/.bin/tsgo --noEmit -p tsconfig.json`.

**Evidence after fix (Vitest output for the touched test files)**:

```text
 diagnostic-session-attention.test.ts                Tests  12 passed (12)
 diagnostic.test.ts + diagnostic-stuck-session-recovery.runtime.test.ts   Tests  88 passed (88)
```

The new cases — `fresh progress without active work kind is long_running, not stuck` and `fresh progress without active work kind or queued work is long_running` — assert both `queueDepth` branches with `state: "processing"` and `lastProgressReason: "cli_live:stream_progress"`. Both fail on `main` with `{ eventType: 'session.stuck', reason: 'stale_session_state' / 'queued_work_without_active_run', classification: 'stale_session_state', recoveryEligible: true }` and pass after this patch with `session.long_running` / `untracked_active_progress` / `queued_behind_untracked_active_progress` / `recoveryEligible: false`.

**Observed result after fix**: the classifier returns `session.long_running` for fresh-progress sessions without `activeWorkKind`; the heartbeat dispatch never reaches `requestStuckSessionRecovery` for those sessions; the recovery coordinator's `applyRecoveryOutcomeToDiagnosticState` is not invoked, so `state.state`, `state.generation`, and `state.queueDepth` are not mutated mid-stream. Stale/missing progress still falls through to `session.stuck` so genuinely abandoned cli sessions remain recoverable.

**What was not tested**: the multi-hour gateway uptime reproduction that produces the reporter's downstream `stalled before execution start (last phase: runtime-plugins)` symptom on subsequent isolated runs. The classifier misclassification, recovery dispatch, and diagnostic state mutation are source-confirmed and covered deterministically; whether eliminating the false recovery also eliminates the reporter's downstream runtime-plugins stall is an open question that requires a live gateway repro. This PR is intentionally scoped to the classifier-altitude bug the reporter's logs literally show (`queued_work_without_active_run` + `lastProgressAge=0s`); any remaining runtime-plugins stall is a separate investigation.

**Repro confirmation**: each new classifier case fails on `main` (verified locally pre-patch) and passes after the gate, exercising the exact `activity` shape the cli streaming path produces. The existing classifier tests (`stale state without queued work`, `queued stale state without active work`, `processing session with orphaned activity is not recoverable`, etc.) continue to pass because their `activity` snapshots either omit `lastProgressAgeMs` (typeof guard skips the gate) or have `activeWorkKind` set (gate is in the `undefined` branch only).

### Risk / Mitigation

- **Risk**: A genuinely abandoned cli session that emitted one fresh progress marker just before going silent could stay `long_running` for an extra `staleMs` window. **Mitigation**: the gate is `lastProgressAgeMs <= staleMs`; anything past the threshold still falls through to `session.stuck`. The bounded delay (≤ one `staleMs` cycle) matches the existing idle-branch policy on `:38-50`, which uses the same `lastProgressAgeMs > staleMs` predicate.
- **Risk**: New reason strings (`untracked_active_progress`, `queued_behind_untracked_active_progress`) could break a downstream consumer. **Mitigation**: `git grep` of `src/` confirms only `classifySessionAttention` and the heartbeat emitter in `src/logging/diagnostic.ts` consume `reason`; the field is typed `string` in `DiagnosticSessionAttentionBaseEvent` (`src/infra/diagnostic-events.ts:201`) with no enum constraint; `classification: "long_running"` is already a valid event variant.
- **Risk**: Missing the broader architectural fix (registering cli runs as a new `DiagnosticSessionActiveWorkKind`). **Mitigation**: this PR is intentionally bounded to the classifier. Broadening the `activeWorkKind` taxonomy to cover external runtimes would cross into cli-runner / activity-tracker / event-schema and is worth its own design discussion. The fall-through gate is generic — any future external runtime emitting `run.progress` without participating in `activeWorkKind` is protected.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Diagnostics / logging
- [x] Sessions / storage

### Linked Issue/PR

Refs #89766
