### PR TITLE
fix(plugins): guard tool result middleware metadata

### DIFF
--- a/src/plugins/agent-tool-result-middleware.test.ts
+++ b/src/plugins/agent-tool-result-middleware.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { normalizeAgentToolResultMiddlewareRuntimes } from "./agent-tool-result-middleware.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  listAgentToolResultMiddlewares,
+  normalizeAgentToolResultMiddlewareRuntimes,
+} from "./agent-tool-result-middleware.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 
-describe("normalizeAgentToolResultMiddlewareRuntimes", () => {
+describe("agent tool result middleware", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
   it("defaults omitted runtimes to every supported runtime", () => {
     expect(normalizeAgentToolResultMiddlewareRuntimes()).toEqual(["openclaw", "codex"]);
   });
@@ -23,5 +32,34 @@ describe("normalizeAgentToolResultMiddlewareRuntimes", () => {
         harnesses: ["codex-app-server"],
       }),
     ).toEqual(["codex"]);
+  });
+
+  it("keeps healthy middlewares after unreadable middleware metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    const healthy = vi.fn();
+    registry.agentToolResultMiddlewares.push(
+      Object.defineProperty(
+        {
+          pluginId: "stale",
+          source: "test",
+        },
+        "runtimes",
+        {
+          get() {
+            throw new Error("agent tool result middleware runtimes getter exploded");
+          },
+        },
+      ) as (typeof registry.agentToolResultMiddlewares)[number],
+      {
+        pluginId: "healthy",
+        rawHandler: healthy,
+        handler: healthy,
+        runtimes: ["codex"],
+        source: "test",
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    expect(listAgentToolResultMiddlewares("codex")).toEqual([healthy]);
   });
 });

--- a/src/plugins/agent-tool-result-middleware.ts
+++ b/src/plugins/agent-tool-result-middleware.ts
@@ -3,6 +3,7 @@ import type {
   AgentToolResultMiddlewareOptions,
   AgentToolResultMiddlewareRuntime,
 } from "./agent-tool-result-middleware-types.js";
+import type { PluginAgentToolResultMiddlewareRegistration } from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
 export const AGENT_TOOL_RESULT_MIDDLEWARE_RUNTIMES = [
@@ -71,12 +72,27 @@ export function normalizeAgentToolResultMiddlewareRuntimeIds(
   return normalized;
 }
 
+function readAgentToolResultMiddleware(
+  entry: PluginAgentToolResultMiddlewareRegistration,
+  runtime: AgentToolResultMiddlewareRuntime,
+): AgentToolResultMiddleware | null {
+  try {
+    if (!entry.runtimes.includes(runtime)) {
+      return null;
+    }
+    return typeof entry.handler === "function" ? entry.handler : null;
+  } catch {
+    return null;
+  }
+}
+
 export function listAgentToolResultMiddlewares(
   runtime: AgentToolResultMiddlewareRuntime,
 ): AgentToolResultMiddleware[] {
   return (
-    getActivePluginRegistry()
-      ?.agentToolResultMiddlewares?.filter((entry) => entry.runtimes.includes(runtime))
-      .map((entry) => entry.handler) ?? []
+    getActivePluginRegistry()?.agentToolResultMiddlewares?.flatMap((entry) => {
+      const handler = readAgentToolResultMiddleware(entry, runtime);
+      return handler ? [handler] : [];
+    }) ?? []
   );
 }


### PR DESCRIPTION
## Summary
- Guard active agent tool result middleware registration reads so one stale plugin row cannot abort middleware listing.
- Keep healthy middlewares available for the requested runtime after unreadable `runtimes` or `handler` metadata is skipped.
- Add a regression covering a poisoned middleware row before a healthy Codex middleware.

## Verification
- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next100-red node_modules/.bin/vitest run src/plugins/agent-tool-result-middleware.test.ts -t "keeps healthy middlewares after unreadable middleware metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `agent tool result middleware runtimes getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next100-focused node_modules/.bin/vitest run src/plugins/agent-tool-result-middleware.test.ts -t "keeps healthy middlewares after unreadable middleware metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next100-full2 node_modules/.bin/vitest run src/plugins/agent-tool-result-middleware.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 5 tests.
- `node_modules/.bin/oxfmt --check src/plugins/agent-tool-result-middleware.ts src/plugins/agent-tool-result-middleware.test.ts`
- `node_modules/.bin/oxlint src/plugins/agent-tool-result-middleware.ts src/plugins/agent-tool-result-middleware.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall 0.86.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall 0.83.
- Broad gate gap: `blacksmith testbox list --all` is blocked by missing Blacksmith auth; AWS Crabbox fallback `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` is blocked by coordinator 401 before lease.

Behavior addressed: malformed or stale agent tool result middleware registrations can no longer crash active middleware listing before healthy middlewares are returned.
Real environment tested: local sparse Codex worktree using linked repo install; plugins Vitest project.
Exact steps or command run after this patch: focused repro, full touched test file, oxfmt check, oxlint, git diff check, local and branch autoreview.
Evidence after fix: focused repro passes; full touched test file passes 5 tests.
Observed result after fix: unreadable middleware metadata rows are skipped and the healthy Codex middleware is still listed.
What was not tested: `pnpm check:changed`; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
