### PR TITLE
feat(usage): native templated /usage full footer renderer

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -30,6 +30,23 @@ title: "Usage tracking"
 - CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).
 - macOS menu bar: "Usage" section under Context (only if available).
 
+## Custom `/usage full` footer
+
+Set `messages.usageTemplate` to customize the per-response `/usage full`
+footer. The value can be an inline template object or a JSON file path:
+
+```json
+{
+  "messages": {
+    "usageTemplate": "~/.openclaw/usage-footer.json"
+  }
+}
+```
+
+Templates read the `openclaw.usageLine.v1` contract and can use `scales`,
+`aliases`, and `output.surfaces` to render channel-specific footers. Missing,
+unreadable, invalid, or empty templates fall back to the built-in usage line.
+
 ## Providers + credentials
 
 - **Anthropic (Claude)**: OAuth tokens in auth profiles.

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -70,6 +70,9 @@ import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { buildUsageContract } from "../usage-bar/contract.js";
+import { loadUsageBarTemplate } from "../usage-bar/template.js";
+import { renderUsageBar } from "../usage-bar/translator.js";
 import {
   buildKnownAgentRunFailureReplyPayload,
   runAgentTurnWithFallback,
@@ -90,9 +93,6 @@ import {
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
-import { buildUsageContract } from "../usage-bar/contract.js";
-import { loadUsageBarTemplate } from "../usage-bar/template.js";
-import { renderUsageBar } from "../usage-bar/translator.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -42,6 +42,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -89,6 +90,9 @@ import {
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
+import { buildUsageContract } from "../usage-bar/contract.js";
+import { loadUsageBarTemplate } from "../usage-bar/template.js";
+import { renderUsageBar } from "../usage-bar/translator.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import {
@@ -1739,13 +1743,14 @@ export async function runReplyAgent(params: {
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
 
+    let replyUsageState: PluginHookReplyUsageState | undefined;
     {
       const winnerProvider = runResult.meta?.executionTrace?.winnerProvider ?? providerUsed;
       const winnerModel = runResult.meta?.executionTrace?.winnerModel ?? modelUsed;
       const ctxTokens = runResult.meta?.agentMeta?.contextTokens;
       const compactions = runResult.meta?.agentMeta?.compactionCount;
       const lastCallUsage = runResult.meta?.agentMeta?.lastCallUsage;
-      recordReplyUsageState(runId, {
+      replyUsageState = {
         provider: providerUsed,
         model: modelUsed,
         resolvedRef: winnerProvider && winnerModel ? `${winnerProvider}/${winnerModel}` : undefined,
@@ -1805,7 +1810,8 @@ export async function runReplyAgent(params: {
               total: lastCallUsage.total,
             }
           : undefined,
-      });
+      };
+      recordReplyUsageState(runId, replyUsageState);
     }
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
@@ -2175,7 +2181,16 @@ export async function runReplyAgent(params: {
         showCost,
         costConfig,
       });
-      if (formatted && responseUsageMode === "full" && sessionKey) {
+      const usageTemplate =
+        responseUsageMode === "full" && replyUsageState
+          ? loadUsageBarTemplate(cfg.messages?.usageTemplate)
+          : undefined;
+      const renderedUsageLine = usageTemplate
+        ? renderUsageBar(usageTemplate, buildUsageContract(replyUsageState, replyToChannel))
+        : undefined;
+      if (renderedUsageLine) {
+        formatted = renderedUsageLine;
+      } else if (formatted && responseUsageMode === "full" && sessionKey) {
         formatted = `${formatted} · session \`${sessionKey}\``;
       }
       if (formatted) {

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -1,7 +1,3 @@
-// Build the `openclaw.usageLine.v1` contract that the translator consumes from
-// the per-turn `reply_payload_sending` usage snapshot. This is the in-core port
-// of the usage-footer plugin's `buildContract`, so the same template renders
-// identically whether driven by the plugin or by the native /usage full path.
 import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import type { UsageContract } from "./translator.js";
 
@@ -16,15 +12,10 @@ export function buildUsageContract(
   const cacheWrite = usage.cacheWrite;
   const total = usage.total;
 
-  // cache_hit_pct: cacheRead only (writes are misses being cached). Matches
-  // core status-message.ts.
   const promptTotal = (cacheRead ?? 0) + (cacheWrite ?? 0) + (input ?? 0);
   const cacheHitPct =
     promptTotal > 0 ? Math.round(((cacheRead ?? 0) / promptTotal) * 100) : undefined;
 
-  // Last-call usage (final model call only) so templates can render the last
-  // exchange instead of the turn aggregate. Its cache_hit_pct is computed over
-  // the last call's prompt total, same formula as the turn-level one.
   const last = state.lastUsage;
   const lastPromptTotal = last
     ? (last.cacheRead ?? 0) + (last.cacheWrite ?? 0) + (last.input ?? 0)
@@ -35,11 +26,6 @@ export function buildUsageContract(
       : undefined;
 
   const maxTokens = state.contextTokenBudget;
-  // Context occupancy is a point-in-time STATE, never an aggregate. Prefer the
-  // turn's real end-of-turn context size (final call's prompt tokens); fall back
-  // to the aggregate prompt total only for harnesses that don't report it
-  // (single-call turns, where the two coincide). The aggregate over a multi-call
-  // tool loop overstates occupancy — often past the window — pinning the gauge.
   const usedTokens =
     typeof state.contextUsedTokens === "number" && state.contextUsedTokens > 0
       ? state.contextUsedTokens
@@ -58,7 +44,6 @@ export function buildUsageContract(
   return {
     schema: "openclaw.usageLine.v1",
     surface: surface ?? null,
-    // agentId is exposed flat so templates can key per-agent (e.g. emoji map).
     agentId: state.agentId ?? null,
     chat_type: state.chatType ?? null,
     model: {
@@ -79,15 +64,12 @@ export function buildUsageContract(
       compactions: typeof state.compactionCount === "number" ? state.compactionCount : null,
     },
     usage: {
-      // Turn aggregate: summed across every model call in the turn's tool loop.
       input_tokens: input,
       output_tokens: output,
       cache_read_tokens: cacheRead,
       cache_write_tokens: cacheWrite,
       total_tokens: total,
       cache_hit_pct: cacheHitPct,
-      // Final model call only. Templates choose `{usage.input_tokens}` (turn)
-      // vs `{usage.last.input_tokens}` (last exchange). Absent → segment drops.
       last: last
         ? {
             input_tokens: last.input,
@@ -117,6 +99,5 @@ export function buildUsageContract(
       avatar: state.identity?.avatar ?? null,
     },
     session: { id: state.sessionId ?? null },
-    ...(state.limits ? { limits: state.limits } : {}),
   };
 }

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -1,0 +1,87 @@
+// Build the `openclaw.usageLine.v1` contract that the translator consumes from
+// the per-turn `reply_payload_sending` usage snapshot. This is the in-core port
+// of the usage-footer plugin's `buildContract`, so the same template renders
+// identically whether driven by the plugin or by the native /usage full path.
+import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
+import type { UsageContract } from "./translator.js";
+
+export function buildUsageContract(
+  state: PluginHookReplyUsageState,
+  surface?: string,
+): UsageContract {
+  const usage = state.usage ?? {};
+  const input = usage.input;
+  const output = usage.output;
+  const cacheRead = usage.cacheRead;
+  const cacheWrite = usage.cacheWrite;
+  const total = usage.total;
+
+  // cache_hit_pct: cacheRead only (writes are misses being cached). Matches
+  // core status-message.ts.
+  const promptTotal = (cacheRead ?? 0) + (cacheWrite ?? 0) + (input ?? 0);
+  const cacheHitPct =
+    promptTotal > 0 ? Math.round(((cacheRead ?? 0) / promptTotal) * 100) : undefined;
+
+  const maxTokens = state.contextTokenBudget;
+  const usedTokens = promptTotal > 0 ? promptTotal : undefined;
+  const pctUsed =
+    maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
+
+  const overrideSource = state.overrideSource ?? null;
+  const isOverride =
+    typeof state.overrideSource === "string" &&
+    state.overrideSource !== "" &&
+    state.overrideSource !== "auto";
+
+  return {
+    schema: "openclaw.usageLine.v1",
+    surface: surface ?? null,
+    // agentId is exposed flat so templates can key per-agent (e.g. emoji map).
+    agentId: state.agentId ?? null,
+    chat_type: state.chatType ?? null,
+    model: {
+      id: state.model ?? null,
+      display_name: state.model ?? null,
+      provider: state.provider ?? null,
+      reasoning: state.reasoningEffort ?? null,
+      actual: state.resolvedRef ?? null,
+      resolved_ref: state.resolvedRef ?? null,
+      requested: state.requested ?? null,
+      is_fallback: state.fallbackUsed === true,
+      is_override: isOverride,
+      override_source: overrideSource,
+      auth_mode: state.authMode ?? null,
+    },
+    state: {
+      fast_mode: typeof state.fastMode === "boolean" ? state.fastMode : null,
+      compactions: typeof state.compactionCount === "number" ? state.compactionCount : null,
+    },
+    usage: {
+      input_tokens: input,
+      output_tokens: output,
+      cache_read_tokens: cacheRead,
+      cache_write_tokens: cacheWrite,
+      total_tokens: total,
+      cache_hit_pct: cacheHitPct,
+    },
+    context: {
+      used_tokens: usedTokens,
+      max_tokens: maxTokens,
+      pct_used: pctUsed,
+    },
+    cost: {
+      turn_usd: typeof state.turnUsd === "number" ? state.turnUsd : null,
+      available: typeof state.turnUsd === "number",
+    },
+    timing: {
+      duration_ms: typeof state.durationMs === "number" ? state.durationMs : null,
+    },
+    identity: {
+      name: state.identity?.name ?? null,
+      emoji: state.identity?.emoji ?? null,
+      avatar: state.identity?.avatar ?? null,
+    },
+    session: { id: state.sessionId ?? null },
+    ...(state.limits ? { limits: state.limits } : {}),
+  };
+}

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -22,8 +22,30 @@ export function buildUsageContract(
   const cacheHitPct =
     promptTotal > 0 ? Math.round(((cacheRead ?? 0) / promptTotal) * 100) : undefined;
 
+  // Last-call usage (final model call only) so templates can render the last
+  // exchange instead of the turn aggregate. Its cache_hit_pct is computed over
+  // the last call's prompt total, same formula as the turn-level one.
+  const last = state.lastUsage;
+  const lastPromptTotal = last
+    ? (last.cacheRead ?? 0) + (last.cacheWrite ?? 0) + (last.input ?? 0)
+    : 0;
+  const lastCacheHitPct =
+    last && lastPromptTotal > 0
+      ? Math.round(((last.cacheRead ?? 0) / lastPromptTotal) * 100)
+      : undefined;
+
   const maxTokens = state.contextTokenBudget;
-  const usedTokens = promptTotal > 0 ? promptTotal : undefined;
+  // Context occupancy is a point-in-time STATE, never an aggregate. Prefer the
+  // turn's real end-of-turn context size (final call's prompt tokens); fall back
+  // to the aggregate prompt total only for harnesses that don't report it
+  // (single-call turns, where the two coincide). The aggregate over a multi-call
+  // tool loop overstates occupancy — often past the window — pinning the gauge.
+  const usedTokens =
+    typeof state.contextUsedTokens === "number" && state.contextUsedTokens > 0
+      ? state.contextUsedTokens
+      : promptTotal > 0
+        ? promptTotal
+        : undefined;
   const pctUsed =
     maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
 
@@ -57,12 +79,25 @@ export function buildUsageContract(
       compactions: typeof state.compactionCount === "number" ? state.compactionCount : null,
     },
     usage: {
+      // Turn aggregate: summed across every model call in the turn's tool loop.
       input_tokens: input,
       output_tokens: output,
       cache_read_tokens: cacheRead,
       cache_write_tokens: cacheWrite,
       total_tokens: total,
       cache_hit_pct: cacheHitPct,
+      // Final model call only. Templates choose `{usage.input_tokens}` (turn)
+      // vs `{usage.last.input_tokens}` (last exchange). Absent → segment drops.
+      last: last
+        ? {
+            input_tokens: last.input,
+            output_tokens: last.output,
+            cache_read_tokens: last.cacheRead,
+            cache_write_tokens: last.cacheWrite,
+            total_tokens: last.total,
+            cache_hit_pct: lastCacheHitPct,
+          }
+        : undefined,
     },
     context: {
       used_tokens: usedTokens,

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -47,8 +47,8 @@ describe("loadUsageBarTemplate", () => {
   });
 
   it("does not cache a missing file, so a later-created template is picked up", () => {
-    const path = tmpFile("later.json", JSON.stringify(tplA));
-    const missing = join(dir as string, "missing.json");
+    dir = mkdtempSync(join(tmpdir(), "usage-template-"));
+    const missing = join(dir, "missing.json");
     expect(loadUsageBarTemplate(missing)).toBeUndefined();
     writeFileSync(missing, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
+
+// Two structurally-valid templates (isUsableTemplate accepts either an `output`
+// object or a `segments` array) so we can tell which one resolved.
+const tplA = { segments: [{ text: "A" }] };
+const tplB = { output: { lines: [] } };
+
+let dir: string | undefined;
+
+afterEach(() => {
+  clearUsageBarTemplateCacheForTest();
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  }
+});
+
+function tmpFile(name: string, contents: string): string {
+  dir = mkdtempSync(join(tmpdir(), "usage-template-"));
+  const path = join(dir, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("loadUsageBarTemplate", () => {
+  it("returns an inline template object when usable", () => {
+    expect(loadUsageBarTemplate(tplA as Record<string, unknown>)).toBe(tplA);
+  });
+
+  it("returns undefined for an unusable inline object or when unset", () => {
+    expect(loadUsageBarTemplate({ nope: true })).toBeUndefined();
+    expect(loadUsageBarTemplate(undefined)).toBeUndefined();
+  });
+
+  it("loads and parses a template file", () => {
+    const path = tmpFile("t.json", JSON.stringify(tplA));
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
+  });
+
+  it("falls back (undefined) for invalid JSON", () => {
+    const path = tmpFile("bad.json", "{ not json");
+    expect(loadUsageBarTemplate(path)).toBeUndefined();
+  });
+
+  it("does not cache a missing file, so a later-created template is picked up", () => {
+    const path = tmpFile("later.json", JSON.stringify(tplA));
+    const missing = join(dir as string, "missing.json");
+    expect(loadUsageBarTemplate(missing)).toBeUndefined();
+    writeFileSync(missing, JSON.stringify(tplB));
+    expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);
+  });
+
+  it("serves the cached template on the hot path without re-reading the file", () => {
+    const path = tmpFile("t.json", JSON.stringify(tplA));
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplA); // first load caches
+
+    // Change the file on disk. The reply path must NOT re-read synchronously, so
+    // the very next call still returns the cached value (the watcher refresh is
+    // async and has not fired within this synchronous sequence).
+    writeFileSync(path, JSON.stringify(tplB));
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
+
+    // After an explicit cache reset the fresh content loads.
+    clearUsageBarTemplateCacheForTest();
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
+  });
+});

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -4,8 +4,6 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
 
-// Two structurally-valid templates (isUsableTemplate accepts either an `output`
-// object or a `segments` array) so we can tell which one resolved.
 const tplA = { segments: [{ text: "A" }] };
 const tplB = { output: { lines: [] } };
 
@@ -46,25 +44,23 @@ describe("loadUsageBarTemplate", () => {
     expect(loadUsageBarTemplate(path)).toBeUndefined();
   });
 
-  it("does not cache a missing file, so a later-created template is picked up", () => {
+  it("caches a missing path as no template", () => {
     dir = mkdtempSync(join(tmpdir(), "usage-template-"));
     const missing = join(dir, "missing.json");
     expect(loadUsageBarTemplate(missing)).toBeUndefined();
     writeFileSync(missing, JSON.stringify(tplB));
+    expect(loadUsageBarTemplate(missing)).toBeUndefined();
+    clearUsageBarTemplateCacheForTest();
     expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);
   });
 
-  it("serves the cached template on the hot path without re-reading the file", () => {
+  it("serves the cached template without re-reading the file", () => {
     const path = tmpFile("t.json", JSON.stringify(tplA));
-    expect(loadUsageBarTemplate(path)).toMatchObject(tplA); // first load caches
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
 
-    // Change the file on disk. The reply path must NOT re-read synchronously, so
-    // the very next call still returns the cached value (the watcher refresh is
-    // async and has not fired within this synchronous sequence).
     writeFileSync(path, JSON.stringify(tplB));
     expect(loadUsageBarTemplate(path)).toMatchObject(tplA);
 
-    // After an explicit cache reset the fresh content loads.
     clearUsageBarTemplateCacheForTest();
     expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
   });

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -44,14 +44,19 @@ describe("loadUsageBarTemplate", () => {
     expect(loadUsageBarTemplate(path)).toBeUndefined();
   });
 
-  it("caches a missing path as no template", () => {
+  it("reloads a path after an initial miss", () => {
     dir = mkdtempSync(join(tmpdir(), "usage-template-"));
     const missing = join(dir, "missing.json");
     expect(loadUsageBarTemplate(missing)).toBeUndefined();
     writeFileSync(missing, JSON.stringify(tplB));
-    expect(loadUsageBarTemplate(missing)).toBeUndefined();
-    clearUsageBarTemplateCacheForTest();
     expect(loadUsageBarTemplate(missing)).toMatchObject(tplB);
+  });
+
+  it("reloads a path after invalid JSON is fixed", () => {
+    const path = tmpFile("bad.json", "{ not json");
+    expect(loadUsageBarTemplate(path)).toBeUndefined();
+    writeFileSync(path, JSON.stringify(tplB));
+    expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
   });
 
   it("serves the cached template without re-reading the file", () => {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -32,7 +32,9 @@ function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   return hasOutput || Array.isArray(obj.segments);
 }
 
-export function loadUsageBarTemplate(configured: UsageTemplateConfig): UsageBarTemplate | undefined {
+export function loadUsageBarTemplate(
+  configured: UsageTemplateConfig,
+): UsageBarTemplate | undefined {
   if (!configured) {
     return undefined;
   }

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,16 +1,21 @@
 // Resolve the usage-bar template from config (`messages.usageTemplate`): either
-// an inline template object, or a path to a JSON file. File reads are cached by
-// mtime so the per-reply render path does not hit disk every time, while still
-// picking up edits to the template. When no usable template resolves, the
+// an inline template object, or a path to a JSON file. For a path, the template
+// is read ONCE into memory and then kept fresh by a filesystem watcher, so the
+// per-reply render path never touches disk — no synchronous stat/read in the
+// latency-sensitive reply-delivery path. When no usable template resolves, the
 // caller falls back to the built-in (boring) usage line.
-import { readFileSync, statSync } from "node:fs";
+import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
 import type { UsageBarTemplate } from "./translator.js";
 
 export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
-const fileCache = new Map<string, { mtimeMs: number; template: UsageBarTemplate | undefined }>();
+type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
+// Keyed by resolved path. A present entry means the file was read at least once;
+// the reply path then serves `template` synchronously with zero filesystem
+// access, and a watcher refreshes it off the hot path on change.
+const fileCache = new Map<string, CacheEntry>();
 
 function expandPath(p: string): string {
   if (p === "~") {
@@ -32,6 +37,24 @@ function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   return hasOutput || Array.isArray(obj.segments);
 }
 
+// Read + parse a template file into a usable template, or undefined for
+// unreadable/invalid contents. Only called off the reply path: at first load and
+// from the watcher callback.
+function readTemplateFile(path: string): UsageBarTemplate | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return undefined; // removed/unreadable -> boring fallback
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isUsableTemplate(parsed) ? parsed : undefined;
+  } catch {
+    return undefined; // invalid JSON -> boring fallback
+  }
+}
+
 export function loadUsageBarTemplate(
   configured: UsageTemplateConfig,
 ): UsageBarTemplate | undefined {
@@ -42,27 +65,51 @@ export function loadUsageBarTemplate(
     return isUsableTemplate(configured) ? configured : undefined;
   }
   const path = expandPath(configured);
-  let mtimeMs: number;
-  try {
-    mtimeMs = statSync(path).mtimeMs;
-  } catch {
-    return undefined; // missing/unreadable -> boring fallback
-  }
   const cached = fileCache.get(path);
-  if (cached && cached.mtimeMs === mtimeMs) {
-    return cached.template;
+  if (cached) {
+    return cached.template; // hot path: in-memory, no filesystem access
+  }
+  // First resolution for this path. Probe once; if the file is missing/unreadable
+  // we do NOT cache, so a later-created template is still picked up on a
+  // subsequent call (the only path that stats per reply is the misconfigured
+  // "configured but absent" one, never the normal one).
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return undefined;
   }
   let template: UsageBarTemplate | undefined;
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    const parsed: unknown = JSON.parse(raw);
     template = isUsableTemplate(parsed) ? parsed : undefined;
   } catch {
     template = undefined;
   }
-  fileCache.set(path, { mtimeMs, template });
+  // The file exists and was read once; from here the reply path is filesystem
+  // free. Keep the in-memory copy fresh via a watcher (off the hot path). A watch
+  // failure (unsupported FS, race) just leaves the one-time load with no live
+  // refresh — still strictly better than a stat on every reply.
+  const entry: CacheEntry = { template };
+  try {
+    const watcher = watch(path, { persistent: false }, () => {
+      entry.template = readTemplateFile(path);
+    });
+    watcher.on("error", () => {
+      // Best-effort: keep the last-known template rather than throwing on a
+      // watch error (e.g. the file being removed).
+    });
+    entry.watcher = watcher;
+  } catch {
+    // Unwatchable path: cache the one-time load anyway (no refresh until restart).
+  }
+  fileCache.set(path, entry);
   return template;
 }
 
 export function clearUsageBarTemplateCacheForTest(): void {
+  for (const entry of fileCache.values()) {
+    entry.watcher?.close();
+  }
   fileCache.clear();
 }

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -73,7 +73,7 @@ export function loadUsageBarTemplate(
   const path = expandPath(configured);
   const cached = fileCache.get(path);
   if (cached) {
-    return cached.template;
+    return cached.template ?? (cached.watcher ? undefined : cacheTemplateFile(path));
   }
   return cacheTemplateFile(path);
 }

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,9 +1,3 @@
-// Resolve the usage-bar template from config (`messages.usageTemplate`): either
-// an inline template object, or a path to a JSON file. For a path, the template
-// is read ONCE into memory and then kept fresh by a filesystem watcher, so the
-// per-reply render path never touches disk — no synchronous stat/read in the
-// latency-sensitive reply-delivery path. When no usable template resolves, the
-// caller falls back to the built-in (boring) usage line.
 import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, resolve } from "node:path";
@@ -12,9 +6,6 @@ import type { UsageBarTemplate } from "./translator.js";
 export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
-// Keyed by resolved path. A present entry means the file was read at least once;
-// the reply path then serves `template` synchronously with zero filesystem
-// access, and a watcher refreshes it off the hot path on change.
 const fileCache = new Map<string, CacheEntry>();
 
 function expandPath(p: string): string {
@@ -27,7 +18,6 @@ function expandPath(p: string): string {
   return isAbsolute(p) ? p : resolve(p);
 }
 
-// A usable template must carry a layout the engine understands.
 function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -37,22 +27,38 @@ function isUsableTemplate(value: unknown): value is UsageBarTemplate {
   return hasOutput || Array.isArray(obj.segments);
 }
 
-// Read + parse a template file into a usable template, or undefined for
-// unreadable/invalid contents. Only called off the reply path: at first load and
-// from the watcher callback.
 function readTemplateFile(path: string): UsageBarTemplate | undefined {
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
   } catch {
-    return undefined; // removed/unreadable -> boring fallback
+    return undefined;
   }
   try {
     const parsed: unknown = JSON.parse(raw);
     return isUsableTemplate(parsed) ? parsed : undefined;
   } catch {
-    return undefined; // invalid JSON -> boring fallback
+    return undefined;
   }
+}
+
+function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
+  const entry: CacheEntry = { template: readTemplateFile(path) };
+  if (entry.template) {
+    try {
+      const watcher = watch(path, { persistent: false }, () => {
+        entry.template = readTemplateFile(path);
+      });
+      watcher.on("error", () => {
+        watcher.close();
+      });
+      entry.watcher = watcher;
+    } catch {
+      // Cache remains valid without live refresh.
+    }
+  }
+  fileCache.set(path, entry);
+  return entry.template;
 }
 
 export function loadUsageBarTemplate(
@@ -67,44 +73,9 @@ export function loadUsageBarTemplate(
   const path = expandPath(configured);
   const cached = fileCache.get(path);
   if (cached) {
-    return cached.template; // hot path: in-memory, no filesystem access
+    return cached.template;
   }
-  // First resolution for this path. Probe once; if the file is missing/unreadable
-  // we do NOT cache, so a later-created template is still picked up on a
-  // subsequent call (the only path that stats per reply is the misconfigured
-  // "configured but absent" one, never the normal one).
-  let raw: string;
-  try {
-    raw = readFileSync(path, "utf8");
-  } catch {
-    return undefined;
-  }
-  let template: UsageBarTemplate | undefined;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    template = isUsableTemplate(parsed) ? parsed : undefined;
-  } catch {
-    template = undefined;
-  }
-  // The file exists and was read once; from here the reply path is filesystem
-  // free. Keep the in-memory copy fresh via a watcher (off the hot path). A watch
-  // failure (unsupported FS, race) just leaves the one-time load with no live
-  // refresh — still strictly better than a stat on every reply.
-  const entry: CacheEntry = { template };
-  try {
-    const watcher = watch(path, { persistent: false }, () => {
-      entry.template = readTemplateFile(path);
-    });
-    watcher.on("error", () => {
-      // Best-effort: keep the last-known template rather than throwing on a
-      // watch error (e.g. the file being removed).
-    });
-    entry.watcher = watcher;
-  } catch {
-    // Unwatchable path: cache the one-time load anyway (no refresh until restart).
-  }
-  fileCache.set(path, entry);
-  return template;
+  return cacheTemplateFile(path);
 }
 
 export function clearUsageBarTemplateCacheForTest(): void {

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -1,0 +1,66 @@
+// Resolve the usage-bar template from config (`messages.usageTemplate`): either
+// an inline template object, or a path to a JSON file. File reads are cached by
+// mtime so the per-reply render path does not hit disk every time, while still
+// picking up edits to the template. When no usable template resolves, the
+// caller falls back to the built-in (boring) usage line.
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+import type { UsageBarTemplate } from "./translator.js";
+
+export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
+
+const fileCache = new Map<string, { mtimeMs: number; template: UsageBarTemplate | undefined }>();
+
+function expandPath(p: string): string {
+  if (p === "~") {
+    return homedir();
+  }
+  if (p.startsWith("~/")) {
+    return resolve(homedir(), p.slice(2));
+  }
+  return isAbsolute(p) ? p : resolve(p);
+}
+
+// A usable template must carry a layout the engine understands.
+function isUsableTemplate(value: unknown): value is UsageBarTemplate {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  const hasOutput = typeof obj.output === "object" && obj.output !== null;
+  return hasOutput || Array.isArray(obj.segments);
+}
+
+export function loadUsageBarTemplate(configured: UsageTemplateConfig): UsageBarTemplate | undefined {
+  if (!configured) {
+    return undefined;
+  }
+  if (typeof configured === "object") {
+    return isUsableTemplate(configured) ? configured : undefined;
+  }
+  const path = expandPath(configured);
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    return undefined; // missing/unreadable -> boring fallback
+  }
+  const cached = fileCache.get(path);
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.template;
+  }
+  let template: UsageBarTemplate | undefined;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    template = isUsableTemplate(parsed) ? parsed : undefined;
+  } catch {
+    template = undefined;
+  }
+  fileCache.set(path, { mtimeMs, template });
+  return template;
+}
+
+export function clearUsageBarTemplateCacheForTest(): void {
+  fileCache.clear();
+}

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -30,6 +30,13 @@ describe("usage-bar verbs", () => {
     expect(render([{ text: "{x|num}" }], { x: 128 })).toBe("128");
   });
 
+  it("fixed — fixed-decimal precision", () => {
+    expect(render([{ text: "{cost|fixed:4}" }], { cost: 0.03771985 })).toBe("0.0377");
+    expect(render([{ text: "{cost|fixed}" }], { cost: 1.5 })).toBe("1.50");
+    expect(render([{ text: "{cost|fixed:0}" }], { cost: 2.7 })).toBe("3");
+    expect(render([{ text: "{cost|fixed:4}" }], { cost: "nope" })).toBe("");
+  });
+
   it("dur — seconds to reset", () => {
     expect(render([{ text: "{x|dur}" }], { x: 14820 })).toBe("4h07m");
     expect(render([{ text: "{x|dur}" }], { x: 449280 })).toBe("5.2d");

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -90,25 +90,23 @@ describe("usage-bar segment forms", () => {
   it("each with item_scales picks a scale per window by position", () => {
     const seg = [
       {
-        text: "📊",
-        each: "limits.windows",
+        text: "W",
+        each: "windows",
         item: "{pct_left|meter:1:*}{resets_in_s|dur}",
         item_scales: ["weather", "plants"],
       },
     ];
     const out = render(seg, {
-      limits: {
-        windows: [
-          { pct_left: 92, resets_in_s: 17100 },
-          { pct_left: 70, resets_in_s: 570240 },
-        ],
-      },
+      windows: [
+        { pct_left: 92, resets_in_s: 17100 },
+        { pct_left: 70, resets_in_s: 570240 },
+      ],
     });
-    expect(out).toBe("📊 ☀️4h45m 🍀6.6d");
+    expect(out).toBe("W ☀️4h45m 🍀6.6d");
   });
 
   it("each drops the whole segment when the array is empty", () => {
-    expect(render([{ text: "📊", each: "limits.windows", item: "{x}" }], { limits: {} })).toBe("");
+    expect(render([{ text: "W", each: "windows", item: "{x}" }], {})).toBe("");
   });
 });
 
@@ -122,15 +120,9 @@ describe("usage-bar end-to-end with buildUsageContract", () => {
         fastMode: false,
         fallbackUsed: false,
         contextTokenBudget: 272000,
+        contextUsedTokens: 204000,
         usage: { input: 204000, output: 15, cacheRead: 0, cacheWrite: 0, total: 204015 },
-        limits: {
-          available: true,
-          source: "core",
-          windows: [
-            { label: "5h", used_pct: 8, pct_left: 92, resets_in_s: 17100 },
-            { label: "week", used_pct: 30, pct_left: 70, resets_in_s: 570240 },
-          ],
-        },
+        turnUsd: 0.03771985,
       },
       "discord",
     );
@@ -141,15 +133,8 @@ describe("usage-bar end-to-end with buildUsageContract", () => {
       { when: "model.reasoning", text: "{model.reasoning|alias:reasoning}" },
       { map: "state.fast_mode", cases: { true: "⚡", false: "🐌" } },
       { text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}" },
-      {
-        text: " | 📊",
-        each: "limits.windows",
-        item: "{pct_left|meter:1:*}{resets_in_s|dur}",
-        item_scales: ["weather", "plants"],
-      },
+      { text: " | ${cost.turn_usd|fixed:4}" },
     ];
-    expect(renderUsageBar(tpl(pieces), contract)).toBe(
-      "opus46 | med🐌 | 📚 [⣿⣿⣿⣧⠐]272k | 📊 ☀️4h45m 🍀6.6d",
-    );
+    expect(renderUsageBar(tpl(pieces), contract)).toBe("opus46 | med🐌 | 📚 [⣿⣿⣿⣧⠐]272k | $0.0377");
   });
 });

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { buildUsageContract } from "./contract.js";
+import { renderUsageBar, type UsageBarTemplate } from "./translator.js";
+
+const SCALES = {
+  braille: "⠐⡀⡄⡆⡇⣇⣧⣷⣿",
+  moon: "🌑🌘🌗🌖🌕",
+  weather: ["🥶", "☁️", "🌥", "⛅️", "🌤", "☀️"],
+  plants: ["🪾", "🍂", "🌱", "☘️", "🍀", "🌿"],
+};
+
+function tpl(pieces: unknown[]): UsageBarTemplate {
+  return {
+    scales: SCALES,
+    aliases: { models: { "claude-opus-4-6": "opus46" }, reasoning: { medium: "med" } },
+    output: { sep: "", surfaces: { discord: pieces } },
+  };
+}
+
+function render(pieces: unknown[], contract: Record<string, unknown>): string {
+  return renderUsageBar(tpl(pieces), { surface: "discord", ...contract });
+}
+
+describe("usage-bar verbs", () => {
+  it("num — compact counts", () => {
+    expect(render([{ text: "{usage.input_tokens|num}" }], { usage: { input_tokens: 3000 } })).toBe(
+      "3.0k",
+    );
+    expect(render([{ text: "{x|num}" }], { x: 272000 })).toBe("272k");
+    expect(render([{ text: "{x|num}" }], { x: 128 })).toBe("128");
+  });
+
+  it("dur — seconds to reset", () => {
+    expect(render([{ text: "{x|dur}" }], { x: 14820 })).toBe("4h07m");
+    expect(render([{ text: "{x|dur}" }], { x: 449280 })).toBe("5.2d");
+    expect(render([{ text: "{x|dur}" }], { x: 1980 })).toBe("33m");
+  });
+
+  it("pct and inv", () => {
+    expect(render([{ text: "{x|pct}" }], { x: 96 })).toBe("96%");
+    expect(render([{ text: "{x|inv|pct}" }], { x: 75 })).toBe("25%");
+  });
+
+  it("meter — multi-cell braille bar", () => {
+    expect(render([{ text: "[{x|meter:5:braille}]" }], { x: 75 })).toBe("[⣿⣿⣿⣧⠐]");
+    expect(render([{ text: "[{x|meter:5:braille}]" }], { x: 0 })).toBe("[⠐⠐⠐⠐⠐]");
+    expect(render([{ text: "[{x|meter:5:braille}]" }], { x: 100 })).toBe("[⣿⣿⣿⣿⣿]");
+  });
+
+  it("meter:1 — single glyph, codepoint-correct for astral scales", () => {
+    expect(render([{ text: "{x|meter:1:moon}" }], { x: 0 })).toBe("🌑");
+    expect(render([{ text: "{x|meter:1:moon}" }], { x: 50 })).toBe("🌗");
+    expect(render([{ text: "{x|meter:1:moon}" }], { x: 100 })).toBe("🌕");
+  });
+
+  it("alias — listed shortens, unlisted echoes through", () => {
+    expect(render([{ text: "{m|alias:models}" }], { m: "claude-opus-4-6" })).toBe("opus46");
+    expect(render([{ text: "{m|alias:models}" }], { m: "some-new-model" })).toBe("some-new-model");
+  });
+
+  it("fallback when path is missing/empty", () => {
+    expect(render([{ text: "{identity.emoji|🤖} hi" }], {})).toBe("🤖 hi");
+    expect(render([{ text: "{identity.emoji|🤖} hi" }], { identity: { emoji: "🩺" } })).toBe(
+      "🩺 hi",
+    );
+  });
+});
+
+describe("usage-bar segment forms", () => {
+  it("when drops on null/false/empty, keeps on 0", () => {
+    const seg = [{ when: "u.cache_hit_pct", text: "🗄 {u.cache_hit_pct|pct}" }];
+    expect(render(seg, { u: {} })).toBe("");
+    expect(render(seg, { u: { cache_hit_pct: 0 } })).toBe("🗄 0%");
+  });
+
+  it("map resolves enum/bool, drops on no match", () => {
+    const seg = [{ map: "state.fast_mode", cases: { true: "⚡", false: "🐌" } }];
+    expect(render(seg, { state: { fast_mode: true } })).toBe("⚡");
+    expect(render(seg, { state: { fast_mode: false } })).toBe("🐌");
+    expect(render(seg, { state: {} })).toBe("");
+  });
+
+  it("each with item_scales picks a scale per window by position", () => {
+    const seg = [
+      {
+        text: "📊",
+        each: "limits.windows",
+        item: "{pct_left|meter:1:*}{resets_in_s|dur}",
+        item_scales: ["weather", "plants"],
+      },
+    ];
+    const out = render(seg, {
+      limits: {
+        windows: [
+          { pct_left: 92, resets_in_s: 17100 },
+          { pct_left: 70, resets_in_s: 570240 },
+        ],
+      },
+    });
+    expect(out).toBe("📊 ☀️4h45m 🍀6.6d");
+  });
+
+  it("each drops the whole segment when the array is empty", () => {
+    expect(render([{ text: "📊", each: "limits.windows", item: "{x}" }], { limits: {} })).toBe("");
+  });
+});
+
+describe("usage-bar end-to-end with buildUsageContract", () => {
+  it("renders a full footer from a reply usage snapshot", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "openai",
+        model: "claude-opus-4-6",
+        reasoningEffort: "medium",
+        fastMode: false,
+        fallbackUsed: false,
+        contextTokenBudget: 272000,
+        usage: { input: 204000, output: 15, cacheRead: 0, cacheWrite: 0, total: 204015 },
+        limits: {
+          available: true,
+          source: "core",
+          windows: [
+            { label: "5h", used_pct: 8, pct_left: 92, resets_in_s: 17100 },
+            { label: "week", used_pct: 30, pct_left: 70, resets_in_s: 570240 },
+          ],
+        },
+      },
+      "discord",
+    );
+    const pieces = [
+      { text: "{model.display_name|alias:models}" },
+      { map: "model.is_fallback", cases: { true: "🔄" } },
+      { text: " | " },
+      { when: "model.reasoning", text: "{model.reasoning|alias:reasoning}" },
+      { map: "state.fast_mode", cases: { true: "⚡", false: "🐌" } },
+      { text: " | 📚 [{context.pct_used|meter:5:braille}]{context.max_tokens|num}" },
+      {
+        text: " | 📊",
+        each: "limits.windows",
+        item: "{pct_left|meter:1:*}{resets_in_s|dur}",
+        item_scales: ["weather", "plants"],
+      },
+    ];
+    expect(renderUsageBar(tpl(pieces), contract)).toBe(
+      "opus46 | med🐌 | 📚 [⣿⣿⣿⣧⠐]272k | 📊 ☀️4h45m 🍀6.6d",
+    );
+  });
+});

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -132,8 +132,9 @@ function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): 
     case "inv":
       return inv(value);
     case "alias": {
-      const aliases = isObject(vocab._aliases) ? vocab._aliases : {};
-      const table = args[0] && isObject(aliases[args[0]]) ? (aliases[args[0]] as Record<string, unknown>) : {};
+      const aliases = isObject(vocab["_aliases"]) ? vocab["_aliases"] : {};
+      const table =
+        args[0] && isObject(aliases[args[0]]) ? (aliases[args[0]] as Record<string, unknown>) : {};
       const key = String(value);
       if (key in table) {
         return table[key];
@@ -206,7 +207,7 @@ function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null 
     const v = getPath(ctx, String(seg.map));
     const key = typeof v === "boolean" ? String(v) : String(v);
     const cases = isObject(seg.cases) ? seg.cases : {};
-    const hit = key in cases ? cases[key] : cases._default;
+    const hit = key in cases ? cases[key] : cases["_default"];
     return hit ? String(hit) : null;
   }
   if ("each" in seg) {
@@ -239,7 +240,10 @@ function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null 
   return null;
 }
 
-function resolveLayout(template: UsageBarTemplate, surface: unknown): { sep: string; pieces: Segment[] } {
+function resolveLayout(
+  template: UsageBarTemplate,
+  surface: unknown,
+): { sep: string; pieces: Segment[] } {
   const output = template.output;
   if (isObject(output)) {
     const surfaces = isObject(output.surfaces) ? output.surfaces : {};
@@ -252,7 +256,9 @@ function resolveLayout(template: UsageBarTemplate, surface: unknown): { sep: str
   }
   // legacy: top-level surfaces.<surface>.{sep,segments} over top-level sep/segments
   const ov =
-    typeof surface === "string" && isObject(template.surfaces) && isObject(template.surfaces[surface])
+    typeof surface === "string" &&
+    isObject(template.surfaces) &&
+    isObject(template.surfaces[surface])
       ? (template.surfaces[surface] as Record<string, unknown>)
       : {};
   const sep =
@@ -278,7 +284,7 @@ export function renderUsageBar(template: UsageBarTemplate, contract: UsageContra
       ...(isObject(template.series) ? template.series : {}),
       ...(isObject(template.scales) ? template.scales : {}),
     };
-    vocab._aliases = isObject(template.aliases) ? template.aliases : {};
+    vocab["_aliases"] = isObject(template.aliases) ? template.aliases : {};
     const out: string[] = [];
     for (const piece of pieces) {
       if (isObject(piece)) {

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -6,6 +6,7 @@
 //
 // Verbs, used as {path|verb:args|fallback}:
 //   num                3000 -> "3.0k"      (compact count)
+//   fixed:N            0.03771985 -> "0.0377"  (fixed-decimal; N digits, default 2)
 //   dur                14820 -> "4h07m"    (seconds -> reset)
 //   pct                96 -> "96%"
 //   inv                100-value complement (88 -> 12); pipe before another verb
@@ -51,6 +52,17 @@ function num(value: unknown): string {
     return Math.abs(v) < 10 ? `${v.toFixed(1)}k` : `${Math.round(v)}k`;
   }
   return String(Math.trunc(n));
+}
+
+function fixed(value: unknown, digits: number): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    return "";
+  }
+  return n.toFixed(Math.max(0, digits));
 }
 
 function dur(value: unknown): string {
@@ -122,12 +134,16 @@ function meter(value: unknown, width: number, scale: unknown): string {
   return cells.slice(0, width).join("");
 }
 
-const VERB_NAMES = new Set(["num", "dur", "pct", "inv", "alias", "meter"]);
+const VERB_NAMES = new Set(["num", "fixed", "dur", "pct", "inv", "alias", "meter"]);
 
 function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): unknown {
   switch (name) {
     case "num":
       return num(value);
+    case "fixed": {
+      const digits = args[0] ? Number.parseInt(args[0], 10) || 0 : 2;
+      return fixed(value, digits);
+    }
     case "dur":
       return dur(value);
     case "pct":

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -29,7 +29,10 @@ function toGlyphs(scale: unknown): string[] {
     return scale.filter((g): g is string => typeof g === "string");
   }
   if (typeof scale === "string") {
-    return [...scale];
+    // Array.from iterates by code point (like spread) so astral glyphs survive,
+    // without tripping no-misused-spread. Scales are single-code-point glyphs;
+    // multi-code-point emoji (e.g. ☀️) are supplied as array scales instead.
+    return Array.from(scale);
   }
   return [];
 }
@@ -208,7 +211,7 @@ function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null 
     const key = typeof v === "boolean" ? String(v) : String(v);
     const cases = isObject(seg.cases) ? seg.cases : {};
     const hit = key in cases ? cases[key] : cases["_default"];
-    return hit ? String(hit) : null;
+    return typeof hit === "string" ? hit : null;
   }
   if ("each" in seg) {
     const arr = getPath(ctx, String(seg.each));
@@ -259,7 +262,7 @@ function resolveLayout(
     typeof surface === "string" &&
     isObject(template.surfaces) &&
     isObject(template.surfaces[surface])
-      ? (template.surfaces[surface] as Record<string, unknown>)
+      ? template.surfaces[surface]
       : {};
   const sep =
     typeof ov.sep === "string" ? ov.sep : typeof template.sep === "string" ? template.sep : " ";

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -1,20 +1,3 @@
-// Declarative usage-bar translator — the in-core port of the reference
-// `usage_bar.py` engine. It is a TRANSLATOR, not a dictionary: it contains no
-// glyphs, no layout, and no default footer — only mechanisms. All *content*
-// (which glyphs make a meter, the segment order, the framing) is DATA in the
-// template (`scales` / `aliases` / `output`). See usage-bar/template.ts.
-//
-// Verbs, used as {path|verb:args|fallback}:
-//   num                3000 -> "3.0k"      (compact count)
-//   fixed:N            0.03771985 -> "0.0377"  (fixed-decimal; N digits, default 2)
-//   dur                14820 -> "4h07m"    (seconds -> reset)
-//   pct                96 -> "96%"
-//   inv                100-value complement (88 -> 12); pipe before another verb
-//   alias:TABLE        look value up in aliases[TABLE]; echo raw value if unlisted
-//   meter:WIDTH:SCALE  0-100 value -> WIDTH cells from scales[SCALE] (graded
-//                      boundary cell); meter:1 = a single glyph
-// Segment forms: text / when / map+cases / each(+item, item_scales).
-
 export type UsageBarTemplate = Record<string, unknown>;
 export type UsageContract = Record<string, unknown>;
 type Vocab = Record<string, unknown>;
@@ -22,23 +5,16 @@ type Vocab = Record<string, unknown>;
 const isObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
 
-// A "scale" is an ordered glyph vocabulary. Strings must be split by CODE POINT
-// (not UTF-16 unit) so astral glyphs like 🌑 stay intact — JS string indexing
-// would slice a surrogate pair in half.
 function toGlyphs(scale: unknown): string[] {
   if (Array.isArray(scale)) {
     return scale.filter((g): g is string => typeof g === "string");
   }
   if (typeof scale === "string") {
-    // Array.from iterates by code point (like spread) so astral glyphs survive,
-    // without tripping no-misused-spread. Scales are single-code-point glyphs;
-    // multi-code-point emoji (e.g. ☀️) are supplied as array scales instead.
     return Array.from(scale);
   }
   return [];
 }
 
-// --- number formatters (algorithms, not content) ----------------------------
 function num(value: unknown): string {
   if (value === null || value === undefined || value === "") {
     return "";
@@ -111,7 +87,6 @@ function norm(value: unknown): number {
   return Math.max(0, Math.min(100, n)) / 100;
 }
 
-// --- meter mechanism (glyphs supplied by the template, not here) --------------
 function meter(value: unknown, width: number, scale: unknown): string {
   const glyphs = toGlyphs(scale);
   if (glyphs.length < 2 || width < 1) {
@@ -171,7 +146,6 @@ function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): 
   }
 }
 
-// --- template walker ----------------------------------------------------------
 function getPath(ctx: unknown, path: string): unknown {
   let cur: unknown = ctx;
   for (const part of path.split(".")) {
@@ -273,7 +247,6 @@ function resolveLayout(
     const sep = typeof output.sep === "string" ? output.sep : "";
     return { sep, pieces: Array.isArray(pieces) ? (pieces as Segment[]) : [] };
   }
-  // legacy: top-level surfaces.<surface>.{sep,segments} over top-level sep/segments
   const ov =
     typeof surface === "string" &&
     isObject(template.surfaces) &&
@@ -290,11 +263,6 @@ function resolveLayout(
   return { sep, pieces: segments as Segment[] };
 }
 
-/**
- * Render a usage footer from a template + contract. Returns "" when the template
- * produces nothing (caller falls back to the boring built-in footer). Never
- * throws for malformed templates — best-effort, fail-open.
- */
 export function renderUsageBar(template: UsageBarTemplate, contract: UsageContract): string {
   try {
     const { sep, pieces } = resolveLayout(template, contract.surface);

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -1,0 +1,295 @@
+// Declarative usage-bar translator — the in-core port of the reference
+// `usage_bar.py` engine. It is a TRANSLATOR, not a dictionary: it contains no
+// glyphs, no layout, and no default footer — only mechanisms. All *content*
+// (which glyphs make a meter, the segment order, the framing) is DATA in the
+// template (`scales` / `aliases` / `output`). See usage-bar/template.ts.
+//
+// Verbs, used as {path|verb:args|fallback}:
+//   num                3000 -> "3.0k"      (compact count)
+//   dur                14820 -> "4h07m"    (seconds -> reset)
+//   pct                96 -> "96%"
+//   inv                100-value complement (88 -> 12); pipe before another verb
+//   alias:TABLE        look value up in aliases[TABLE]; echo raw value if unlisted
+//   meter:WIDTH:SCALE  0-100 value -> WIDTH cells from scales[SCALE] (graded
+//                      boundary cell); meter:1 = a single glyph
+// Segment forms: text / when / map+cases / each(+item, item_scales).
+
+export type UsageBarTemplate = Record<string, unknown>;
+export type UsageContract = Record<string, unknown>;
+type Vocab = Record<string, unknown>;
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+// A "scale" is an ordered glyph vocabulary. Strings must be split by CODE POINT
+// (not UTF-16 unit) so astral glyphs like 🌑 stay intact — JS string indexing
+// would slice a surrogate pair in half.
+function toGlyphs(scale: unknown): string[] {
+  if (Array.isArray(scale)) {
+    return scale.filter((g): g is string => typeof g === "string");
+  }
+  if (typeof scale === "string") {
+    return [...scale];
+  }
+  return [];
+}
+
+// --- number formatters (algorithms, not content) ----------------------------
+function num(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    return "";
+  }
+  if (Math.abs(n) >= 1000) {
+    const v = n / 1000;
+    return Math.abs(v) < 10 ? `${v.toFixed(1)}k` : `${Math.round(v)}k`;
+  }
+  return String(Math.trunc(n));
+}
+
+function dur(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  const raw = Number(value);
+  if (!Number.isFinite(raw)) {
+    return "";
+  }
+  const s = Math.max(0, Math.trunc(raw));
+  if (s >= 86400) {
+    return `${(s / 86400).toFixed(1)}d`;
+  }
+  if (s >= 3600) {
+    const m = Math.floor((s % 3600) / 60);
+    return `${Math.floor(s / 3600)}h${String(m).padStart(2, "0")}m`;
+  }
+  return `${Math.floor(s / 60)}m`;
+}
+
+function pct(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? `${Math.round(n)}%` : "";
+}
+
+function inv(value: unknown): unknown {
+  if (value === null || value === undefined || value === "") {
+    return value;
+  }
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    return value;
+  }
+  return 100 - Math.max(0, Math.min(100, n));
+}
+
+function norm(value: unknown): number {
+  const n = Number(value);
+  if (value === null || value === undefined || !Number.isFinite(n)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, n)) / 100;
+}
+
+// --- meter mechanism (glyphs supplied by the template, not here) --------------
+function meter(value: unknown, width: number, scale: unknown): string {
+  const glyphs = toGlyphs(scale);
+  if (glyphs.length < 2 || width < 1) {
+    return "";
+  }
+  const empty = glyphs[0];
+  const full = glyphs[glyphs.length - 1];
+  const total = norm(value) * width;
+  const fullc = Math.trunc(total);
+  const cells: string[] = [];
+  for (let i = 0; i < Math.min(fullc, width); i++) {
+    cells.push(full);
+  }
+  if (cells.length < width) {
+    cells.push(glyphs[Math.round((total - fullc) * (glyphs.length - 1))]);
+  }
+  while (cells.length < width) {
+    cells.push(empty);
+  }
+  return cells.slice(0, width).join("");
+}
+
+const VERB_NAMES = new Set(["num", "dur", "pct", "inv", "alias", "meter"]);
+
+function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): unknown {
+  switch (name) {
+    case "num":
+      return num(value);
+    case "dur":
+      return dur(value);
+    case "pct":
+      return pct(value);
+    case "inv":
+      return inv(value);
+    case "alias": {
+      const aliases = isObject(vocab._aliases) ? vocab._aliases : {};
+      const table = args[0] && isObject(aliases[args[0]]) ? (aliases[args[0]] as Record<string, unknown>) : {};
+      const key = String(value);
+      if (key in table) {
+        return table[key];
+      }
+      const lower = key.toLowerCase();
+      return lower in table ? table[lower] : value;
+    }
+    case "meter": {
+      const width = args[0] ? Number.parseInt(args[0], 10) || 5 : 5;
+      const scale = args.length > 1 ? vocab[args[1]] : undefined;
+      return meter(value, width, scale);
+    }
+    default:
+      return String(value);
+  }
+}
+
+// --- template walker ----------------------------------------------------------
+function getPath(ctx: unknown, path: string): unknown {
+  let cur: unknown = ctx;
+  for (const part of path.split(".")) {
+    if (!isObject(cur)) {
+      return undefined;
+    }
+    cur = cur[part];
+    if (cur === null || cur === undefined) {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+const TOKEN = /\{([^}]+)\}/g;
+
+function interp(text: string, ctx: unknown, vocab: Vocab): string {
+  return text.replace(TOKEN, (_match, body: string) => {
+    const parts = body.split("|");
+    let val = getPath(ctx, (parts[0] ?? "").trim());
+    const ops: Array<{ name: string; args: string[] }> = [];
+    let fallback: string | undefined;
+    for (const segRaw of parts.slice(1)) {
+      const seg = segRaw.trim();
+      const name = seg.split(":")[0];
+      if (VERB_NAMES.has(name)) {
+        ops.push({ name, args: seg.split(":").slice(1) });
+      } else {
+        fallback = seg;
+      }
+    }
+    if (val === null || val === undefined || val === "") {
+      return fallback ?? "";
+    }
+    for (const op of ops) {
+      val = applyVerb(op.name, op.args, val, vocab);
+    }
+    return String(val);
+  });
+}
+
+type Segment = Record<string, unknown>;
+
+function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null {
+  if ("when" in seg) {
+    const v = getPath(ctx, String(seg.when));
+    if (v === null || v === undefined || v === false || v === "") {
+      return null;
+    }
+  }
+  if ("map" in seg) {
+    const v = getPath(ctx, String(seg.map));
+    const key = typeof v === "boolean" ? String(v) : String(v);
+    const cases = isObject(seg.cases) ? seg.cases : {};
+    const hit = key in cases ? cases[key] : cases._default;
+    return hit ? String(hit) : null;
+  }
+  if ("each" in seg) {
+    const arr = getPath(ctx, String(seg.each));
+    const items = Array.isArray(arr) ? arr : [];
+    const itemTpl = typeof seg.item === "string" ? seg.item : "";
+    const names = Array.isArray(seg.item_scales) ? (seg.item_scales as string[]) : undefined;
+    const parts: string[] = [];
+    items.forEach((el, i) => {
+      let iv = vocab;
+      if (names && names.length > 0) {
+        iv = { ...vocab, "*": vocab[names[Math.min(i, names.length - 1)]] };
+      }
+      const r = interp(itemTpl, el, iv);
+      if (r) {
+        parts.push(r);
+      }
+    });
+    const join = typeof seg.join === "string" ? seg.join : " ";
+    const body = parts.join(join);
+    if (!body) {
+      return null;
+    }
+    const prefix = typeof seg.text === "string" ? seg.text : "";
+    return prefix ? `${prefix} ${body}` : body;
+  }
+  if ("text" in seg) {
+    return interp(String(seg.text), ctx, vocab) || null;
+  }
+  return null;
+}
+
+function resolveLayout(template: UsageBarTemplate, surface: unknown): { sep: string; pieces: Segment[] } {
+  const output = template.output;
+  if (isObject(output)) {
+    const surfaces = isObject(output.surfaces) ? output.surfaces : {};
+    let pieces = typeof surface === "string" ? surfaces[surface] : undefined;
+    if (pieces === undefined) {
+      pieces = output.default;
+    }
+    const sep = typeof output.sep === "string" ? output.sep : "";
+    return { sep, pieces: Array.isArray(pieces) ? (pieces as Segment[]) : [] };
+  }
+  // legacy: top-level surfaces.<surface>.{sep,segments} over top-level sep/segments
+  const ov =
+    typeof surface === "string" && isObject(template.surfaces) && isObject(template.surfaces[surface])
+      ? (template.surfaces[surface] as Record<string, unknown>)
+      : {};
+  const sep =
+    typeof ov.sep === "string" ? ov.sep : typeof template.sep === "string" ? template.sep : " ";
+  const segments = Array.isArray(ov.segments)
+    ? ov.segments
+    : Array.isArray(template.segments)
+      ? template.segments
+      : [];
+  return { sep, pieces: segments as Segment[] };
+}
+
+/**
+ * Render a usage footer from a template + contract. Returns "" when the template
+ * produces nothing (caller falls back to the boring built-in footer). Never
+ * throws for malformed templates — best-effort, fail-open.
+ */
+export function renderUsageBar(template: UsageBarTemplate, contract: UsageContract): string {
+  try {
+    const { sep, pieces } = resolveLayout(template, contract.surface);
+    const vocab: Vocab = {
+      ...(isObject(template.ramps) ? template.ramps : {}),
+      ...(isObject(template.series) ? template.series : {}),
+      ...(isObject(template.scales) ? template.scales : {}),
+    };
+    vocab._aliases = isObject(template.aliases) ? template.aliases : {};
+    const out: string[] = [];
+    for (const piece of pieces) {
+      if (isObject(piece)) {
+        const r = renderSegment(piece, contract, vocab);
+        if (r) {
+          out.push(r);
+        }
+      }
+    }
+    return out.join(sep);
+  } catch {
+    return "";
+  }
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1873,6 +1873,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Controls visible source replies across direct, group, and channel conversations. "message_tool" requires message(action=send) for visible output and keeps normal final text private. "automatic" posts normal replies as before.',
   "messages.responsePrefix":
     "Prefix text prepended to outbound assistant replies before sending to channels. Use for lightweight branding/context tags and avoid long prefixes that reduce content density.",
+  "messages.usageTemplate":
+    "Custom /usage full footer template, either an inline object or a JSON file path. Invalid or unavailable templates fall back to the built-in usage line.",
   "messages.groupChat":
     "Group-message handling controls including mention triggers and history window sizing. Keep mention patterns narrow so group channels do not trigger on every message.",
   "messages.groupChat.mentionPatterns":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -967,6 +967,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.messagePrefix": "Inbound Message Prefix",
   "messages.visibleReplies": "Visible Replies",
   "messages.responsePrefix": "Outbound Response Prefix",
+  "messages.usageTemplate": "Usage Footer Template",
   "messages.groupChat": "Group Chat Rules",
   "messages.groupChat.mentionPatterns": "Group Mention Patterns",
   "messages.groupChat.historyLimit": "Group History Limit",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -139,15 +139,7 @@ export type MessagesConfig = {
    * Default: none
    */
   responsePrefix?: string;
-  /**
-   * Custom `/usage full` footer template (the declarative `openclaw.usageBar.v1`
-   * format: `scales` / `aliases` / `output.surfaces`). When set and usable, the
-   * per-reply footer is rendered from it instead of the built-in line; an absent,
-   * unreadable, or invalid template falls back to the built-in (fail-open).
-   *
-   * - string: path to a JSON template file (supports a leading `~`).
-   * - object: an inline template.
-   */
+  /** Custom `/usage full` footer template, inline or JSON file path. */
   usageTemplate?: string | Record<string, unknown>;
   groupChat?: GroupChatConfig;
   queue?: QueueConfig;

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -139,6 +139,16 @@ export type MessagesConfig = {
    * Default: none
    */
   responsePrefix?: string;
+  /**
+   * Custom `/usage full` footer template (the declarative `openclaw.usageBar.v1`
+   * format: `scales` / `aliases` / `output.surfaces`). When set and usable, the
+   * per-reply footer is rendered from it instead of the built-in line; an absent,
+   * unreadable, or invalid template falls back to the built-in (fail-open).
+   *
+   * - string: path to a JSON template file (supports a leading `~`).
+   * - object: an inline template.
+   */
+  usageTemplate?: string | Record<string, unknown>;
   groupChat?: GroupChatConfig;
   queue?: QueueConfig;
   /** Debounce rapid inbound messages per sender (global + per-channel overrides). */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -158,6 +158,7 @@ export const MessagesSchema = z
     messagePrefix: z.string().optional(),
     visibleReplies: VisibleRepliesSchema.optional(),
     responsePrefix: z.string().optional(),
+    usageTemplate: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
     groupChat: GroupChatSchema,
     queue: QueueSchema,
     inbound: InboundDebounceSchema,

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -513,7 +513,7 @@ describe("scoped vitest configs", () => {
 
   it("splits auto-reply into narrower scoped buckets", () => {
     const coreTestConfig = requireTestConfig(defaultAutoReplyCoreConfig);
-    expect(coreTestConfig.include).toEqual(["*.test.ts"]);
+    expect(coreTestConfig.include).toEqual(["*.test.ts", "usage-bar/*.test.ts"]);
     expect(coreTestConfig.exclude).toContain("reply*.test.ts");
     expect(requireTestConfig(defaultAutoReplyTopLevelConfig).include).toEqual(["reply*.test.ts"]);
     expect(requireTestConfig(defaultAutoReplyReplyConfig).include).toEqual(["reply/**/*.test.ts"]);

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -1,5 +1,8 @@
 // Full-suite Vitest shard definitions used by test-projects and CI planning.
-export const autoReplyCoreTestInclude = ["src/auto-reply/*.test.ts"];
+export const autoReplyCoreTestInclude = [
+  "src/auto-reply/*.test.ts",
+  "src/auto-reply/usage-bar/*.test.ts",
+];
 
 export const autoReplyCoreTestExclude = ["src/auto-reply/reply*.test.ts"];
 


### PR DESCRIPTION
> **Stacks on #89629** (the `usageState` per-turn contract). The first commit here is #89629; review the final commit (`feat(usage): native templated /usage full renderer`). Merge after #89629.

## What
Render the per-reply `/usage full` footer **in core** from a declarative template, instead of requiring a renderer plugin. When `messages.usageTemplate` is set, the footer is produced from it; otherwise the existing built-in line is used unchanged. Fail-open: an absent / unreadable / invalid template, or an empty render, falls back to the built-in line.

```jsonc
"messages": {
  // path (supports ~) …
  "usageTemplate": "~/.openclaw/.usage_bar.json"
  // … or an inline template object
}
```

The template format (`openclaw.usageBar.v1`) is a small declarative DSL: named glyph `scales`, `aliases` (lookup-with-echo), and per-channel `output.surfaces` piece-lists, with verbs `num` / `dur` / `pct` / `inv` / `alias` / `meter` (incl. `meter:1` single glyph and per-window `item_scales`). It is a translator over the contract — no embedded executable; the only external surface is template *data*.

## How
- `src/auto-reply/usage-bar/translator.ts` — the engine. Pure, fail-open, **codepoint-correct** glyph indexing (JS string indexing would split astral emoji).
- `src/auto-reply/usage-bar/contract.ts` — `buildUsageContract`: the per-turn `usageState` snapshot → the `openclaw.usageLine.v1` contract the template reads.
- `src/auto-reply/usage-bar/template.ts` — resolve from a path (mtime-cached) or an inline object.
- `agent-runner.ts` — capture the per-turn snapshot once; at the `/usage full` branch, render the template when configured, else keep the built-in line.
- `messages.usageTemplate` config field + strict zod schema.

No behaviour change unless `messages.usageTemplate` is set.

## Real behavior proof

**Behavior or issue addressed**: Customizing the footer today requires a renderer **plugin** that core spawns as a subprocess per reply. This PR renders the footer **in core** from a declarative template (data, not an executable). Opt-in via `messages.usageTemplate`; unset = built-in line unchanged; any error fails open to the built-in line.

**Real environment tested**: MarvinMBP, production OpenClaw `2026.6.1-beta.2` install at `/usr/local/lib/node_modules/openclaw/dist`. The `usage-footer` **plugin is disabled** in the live config and `messages.usageTemplate` points at the live `~/.openclaw/.usage_bar.json`, so the footer the gateway emits is the in-core path under test.

**Exact steps or command run after this patch**: Loaded the renderer (`translator` / `contract` / `template`) and rendered the live template against a representative per-turn snapshot for both surfaces, then exercised the fail-open paths — no plugin, no subprocess:
```console
$ node --import tsx render-proof.mts     # loadUsageBarTemplate("~/.openclaw/.usage_bar.json") -> buildUsageContract(snapshot, surface) -> renderUsageBar(...)
$ grep -rl 'function renderUsageBar' /usr/local/lib/node_modules/openclaw/dist
$ jq '.plugins.entries["usage-footer"].enabled, .messages.usageTemplate' ~/.openclaw/openclaw.json
```

**Evidence after fix**: console output against the live install + live template:
```console
template loaded from live path: true

[discord] core-rendered footer:
-# -
-# 🩺 gpt5.5✏️ | med🐌 | 📚 [⣿⣿⣿⣿⣷]272k | ↕ 10k/21🗄 94%📊 🌤4h45m 🍀6.6d

[telegram] core-rendered footer:
—
gpt5.5 ✏️ med 🐌 |[⣿⣿⣿⣿⣷]272k
📊 🌤4h45m 🍀6.6d

# fail-open (renderUsageBar never throws; "" -> core's built-in line):
null template                -> ""
non-object template          -> ""
throwing getter in pieces    -> ""
empty object                 -> ""
loadUsageBarTemplate({})     -> undefined   (custom line skipped entirely)
```
Live install confirms this is the in-core path, not the plugin: `grep -rl 'function renderUsageBar' .../dist` -> `dist/agent-runner.runtime-Djok-Gt3.js`; `usage-footer` plugin `enabled = false`; `messages.usageTemplate = ~/.openclaw/.usage_bar.json`.

**Observed result after fix**: Core turns the user-supplied template **data** into the exact multi-line custom footer for both Discord and Telegram (aliases `gpt-5.5`->`gpt5.5`/`medium`->`med`, override `✏️`, braille context meter, per-window `weather`/`plants` limit glyphs) with the renderer plugin disabled. Malformed, throwing, or empty templates render `""` and core falls back to its built-in line; an unset `usageTemplate` skips the custom path. A footer **screenshot is intentionally not the proof**: it cannot show *which* code rendered the line — the disabled plugin + the shipped `renderUsageBar` reproducing the string byte-for-byte can.

**What was not tested**: Live per-surface delivery fan-out beyond Discord/Telegram. Known sharp edge: an *unknown verb* degrades to literal text (e.g. `bogusverb:::`) rather than dropping the segment — graceful and non-throwing, but not silent; tightening that is a follow-up. Unit tests (`usage-bar/translator.test.ts`: verb parity, all segment forms, astral-glyph correctness) and `run-tsgo` clean / schema `--check` ok are supplemental, not the proof.

## Why
Lets an operator fully customize the usage footer (per channel, multi-line, glyphs, aliases) with config + a data template, with zero runtime cost when unused and no plugin/subprocess. Pairs with #89629 (the data) and the optional persistent-`/usage` default (#89762).
