### PR TITLE
fix(security): guard plugin audit collector metadata

### DIFF
--- a/src/security/audit-plugin-readonly-scope.test.ts
+++ b/src/security/audit-plugin-readonly-scope.test.ts
@@ -174,6 +174,53 @@ describe("security audit read-only plugin scope", () => {
     expect(loadPluginMetadataRegistrySnapshotMock).not.toHaveBeenCalled();
   });
 
+  it("keeps healthy plugin security collectors after unreadable failure metadata", async () => {
+    const healthyFinding = {
+      checkId: "plugins.healthy.audit",
+      severity: "warn" as const,
+      title: "Healthy plugin audit",
+      detail: "healthy collector still ran",
+    };
+    getActivePluginRegistryMock.mockReturnValue({
+      securityAuditCollectors: [
+        Object.defineProperty(
+          {
+            collector() {
+              throw new Error("security audit collector exploded");
+            },
+            source: "test",
+          },
+          "pluginId",
+          {
+            get() {
+              throw new Error("security audit collector plugin id getter exploded");
+            },
+          },
+        ),
+        {
+          pluginId: "healthy",
+          collector: () => [healthyFinding],
+          source: "test",
+        },
+      ],
+    });
+
+    const findings = await collectPluginSecurityAuditFindings(
+      createAuditContext({
+        sourceConfig: {},
+        plugins: [],
+      }),
+    );
+
+    expect(findings).toContainEqual(healthyFinding);
+    expect(findings).toContainEqual({
+      checkId: "plugins.unknown.security_audit_failed",
+      severity: "warn",
+      title: "Plugin security audit collector failed",
+      detail: "unknown: Error: security audit collector exploded",
+    });
+  });
+
   it("keeps plain security audit off plugin collector runtime discovery by default", async () => {
     const sourceConfig = {
       plugins: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -33,6 +33,8 @@ import {
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
 import { normalizeTrustedSafeBinDirs } from "../infra/exec-safe-bin-trust.js";
+import type { PluginSecurityAuditCollectorRegistration } from "../plugins/registry-types.js";
+import type { OpenClawPluginSecurityAuditCollector } from "../plugins/types.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
 import { collectDeepProbeFindings } from "./audit-deep-probe-findings.js";
@@ -462,6 +464,44 @@ export function collectGatewayConfigFindings(
   });
 }
 
+type ReadablePluginSecurityAuditCollector = {
+  pluginId: string;
+  collector: OpenClawPluginSecurityAuditCollector;
+};
+
+function readPluginSecurityAuditCollector(
+  entry: PluginSecurityAuditCollectorRegistration,
+): ReadablePluginSecurityAuditCollector | null {
+  let collector: OpenClawPluginSecurityAuditCollector;
+  try {
+    collector = entry.collector;
+  } catch {
+    return null;
+  }
+  if (typeof collector !== "function") {
+    return null;
+  }
+  let pluginId = "unknown";
+  try {
+    pluginId = normalizeOptionalString(entry.pluginId) ?? "unknown";
+  } catch {
+    // Keep the collector runnable; the warning can fall back to an unknown owner.
+  }
+  return { pluginId, collector };
+}
+
+function createPluginSecurityAuditCollectorFailureFinding(params: {
+  pluginId: string;
+  err: unknown;
+}): SecurityAuditFinding {
+  return {
+    checkId: `plugins.${params.pluginId}.security_audit_failed`,
+    severity: "warn",
+    title: "Plugin security audit collector failed",
+    detail: `${params.pluginId}: ${String(params.err)}`,
+  };
+}
+
 export async function collectPluginSecurityAuditFindings(
   context: AuditExecutionContext,
 ): Promise<SecurityAuditFinding[]> {
@@ -531,8 +571,17 @@ export async function collectPluginSecurityAuditFindings(
   }
   const collectorResults = await Promise.all(
     collectors.map(async (entry) => {
+      const readable = readPluginSecurityAuditCollector(entry);
+      if (!readable) {
+        return [
+          createPluginSecurityAuditCollectorFailureFinding({
+            pluginId: "unknown",
+            err: new Error("plugin security audit collector metadata was unreadable"),
+          }),
+        ];
+      }
       try {
-        return await entry.collector({
+        return await readable.collector({
           config: context.cfg,
           sourceConfig: context.sourceConfig,
           env: context.env,
@@ -541,12 +590,7 @@ export async function collectPluginSecurityAuditFindings(
         });
       } catch (err) {
         return [
-          {
-            checkId: `plugins.${entry.pluginId}.security_audit_failed`,
-            severity: "warn" as const,
-            title: "Plugin security audit collector failed",
-            detail: `${entry.pluginId}: ${String(err)}`,
-          },
+          createPluginSecurityAuditCollectorFailureFinding({ pluginId: readable.pluginId, err }),
         ];
       }
     }),


### PR DESCRIPTION
## Summary
- Guard plugin security audit collector metadata before invoking collectors.
- Keep security audit/doctor collector execution alive when one stale plugin collector row has unreadable owner metadata.
- Add a regression covering a failed collector with unreadable plugin id followed by a healthy collector.

## Verification
- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next101-red node_modules/.bin/vitest run src/security/audit-plugin-readonly-scope.test.ts -t "keeps healthy plugin security collectors after unreadable failure metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed before the fix with `security audit collector plugin id getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next101-focused2 node_modules/.bin/vitest run src/security/audit-plugin-readonly-scope.test.ts -t "keeps healthy plugin security collectors after unreadable failure metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next101-full node_modules/.bin/vitest run src/security/audit-plugin-readonly-scope.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 5 tests.
- Post-rebase: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next101-rebase-full node_modules/.bin/vitest run src/security/audit-plugin-readonly-scope.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 5 tests.
- Post-second-rebase: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next101-rebase2-full node_modules/.bin/vitest run src/security/audit-plugin-readonly-scope.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` passed 5 tests.
- `node_modules/.bin/oxfmt --check src/security/audit.ts src/security/audit-plugin-readonly-scope.test.ts`
- `node_modules/.bin/oxlint src/security/audit.ts src/security/audit-plugin-readonly-scope.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall 0.86.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall 0.88.
- Broad gate gap: `blacksmith testbox list --all` is blocked by missing Blacksmith auth; AWS Crabbox fallback `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` is blocked by coordinator 401 before lease.

Behavior addressed: malformed or stale plugin security audit collector metadata can no longer crash security audit/doctor collector execution before healthy collectors run.
Real environment tested: local sparse Codex worktree using linked repo install; unit-fast Vitest project.
Exact steps or command run after this patch: focused repro, full touched test file, post-rebase full touched test file, post-second-rebase full touched test file, oxfmt check, oxlint, git diff check, local and branch autoreview.
Evidence after fix: focused repro passes; full touched test file passes 5 tests after both rebases.
Observed result after fix: unreadable collector owner metadata falls back to an `unknown` warning, the failed collector is contained as a finding, and the healthy collector still runs.
What was not tested: `pnpm check:changed`; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
