### PR TITLE
fix(fireworks): optimize caching with x-session-affinity

### DIFF
--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -40,6 +40,9 @@
             "input": ["text", "image"],
             "contextWindow": 262144,
             "maxTokens": 262144,
+            "compat": {
+              "sendSessionAffinityHeaders": true
+            },
             "cost": {
               "input": 0.95,
               "output": 4,
@@ -54,7 +57,8 @@
             "contextWindow": 256000,
             "maxTokens": 256000,
             "compat": {
-              "unsupportedToolSchemaKeywords": ["not"]
+              "unsupportedToolSchemaKeywords": ["not"],
+              "sendSessionAffinityHeaders": true
             },
             "cost": {
               "input": 0,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1768,11 +1768,17 @@ function readResponsesOutputMessageText(item: Record<string, unknown>): string {
     .join("");
 }
 
+function isFireworksProvider(model: Model): boolean {
+  const normalized = model.provider?.trim().toLowerCase();
+  return normalized === "fireworks" || normalized === "fireworks-ai";
+}
+
 function buildOpenAIClientHeaders(
   model: Model,
   context: Context,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  sessionId?: string,
 ): Record<string, string> {
   const providerHeaders = { ...model.headers };
   if (model.provider === "github-copilot") {
@@ -1785,6 +1791,13 @@ function buildOpenAIClientHeaders(
     );
   }
   const callerHeaders = { ...optionHeaders, ...turnHeaders };
+  const shouldSendSessionAffinity =
+    sessionId && (model.compat?.sendSessionAffinityHeaders ?? isFireworksProvider(model));
+  if (shouldSendSessionAffinity) {
+    callerHeaders["x-session-affinity"] = sessionId!;
+    callerHeaders["x-client-request-id"] = sessionId!;
+    callerHeaders["session_id"] = sessionId!;
+  }
   const headers = resolveProviderRequestPolicyConfig({
     provider: model.provider,
     api: model.api,
@@ -1857,12 +1870,13 @@ function createOpenAIResponsesClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  sessionId?: string,
 ) {
   return new OpenAI({
     apiKey,
     baseURL: model.baseUrl,
     dangerouslyAllowBrowser: true,
-    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
+    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, sessionId),
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
@@ -1905,6 +1919,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          options?.sessionId,
         );
         let params = buildOpenAIResponsesParams(
           model,
@@ -2339,6 +2354,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          options?.sessionId,
         );
         const deploymentName = resolveAzureDeploymentName(model);
         let params = buildAzureOpenAIResponsesParams(
@@ -2430,12 +2446,13 @@ function createAzureOpenAIClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  sessionId?: string,
 ) {
   return new AzureOpenAI({
     apiKey,
     apiVersion: resolveAzureOpenAIApiVersion(),
     dangerouslyAllowBrowser: true,
-    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
+    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, sessionId),
     baseURL: normalizeAzureBaseUrl(model.baseUrl),
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
@@ -2481,8 +2498,9 @@ function createOpenAICompletionsClient(
   context: Context,
   apiKey: string,
   optionHeaders?: Record<string, string>,
+  sessionId?: string,
 ) {
-  const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders);
+  const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders, sessionId);
   return new OpenAI({
     apiKey,
     baseURL: clientConfig.baseURL,
@@ -2506,12 +2524,13 @@ function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
   optionHeaders?: Record<string, string>,
+  sessionId?: string,
 ): {
   baseURL: string;
   defaultHeaders: Record<string, string>;
   defaultQuery?: Record<string, string>;
 } {
-  const headers = buildOpenAIClientHeaders(model, context, optionHeaders);
+  const headers = buildOpenAIClientHeaders(model, context, optionHeaders, undefined, sessionId);
   const defaultQuery: Record<string, string> = {};
   let baseURL = model.baseUrl;
   let isAzureHost = false;
@@ -2574,7 +2593,13 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       };
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        const client = createOpenAICompletionsClient(
+          model,
+          context,
+          apiKey,
+          options?.headers,
+          options?.sessionId,
+        );
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -1242,6 +1242,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
   const baseUrl = model.baseUrl;
 
   const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
+  const isFireworks = provider === "fireworks" || provider === "fireworks-ai";
   const isTogether =
     provider === "together" ||
     baseUrl.includes("api.together.ai") ||
@@ -1301,7 +1302,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     zaiToolStream: false,
     supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway,
     cacheControlFormat,
-    sendSessionAffinityHeaders: false,
+    sendSessionAffinityHeaders: isFireworks,
     supportsPromptCacheKey: false,
     supportsLongCacheRetention: !(isTogether || isCloudflareWorkersAI || isCloudflareAiGateway),
   };

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -563,6 +563,16 @@ function createClient(
   if (optionsHeaders) {
     Object.assign(headers, optionsHeaders);
   }
+  console.error(
+    "[fw-cache-proof:request] " +
+      JSON.stringify({
+        provider: model.provider,
+        model: model.id,
+        xSessionAffinity: headers["x-session-affinity"]
+          ? String(headers["x-session-affinity"]).slice(0, 12) + "...redacted"
+          : null,
+      }),
+  );
 
   const defaultHeaders =
     model.provider === "cloudflare-ai-gateway"


### PR DESCRIPTION
## Summary

* Enable Fireworks models to send session-affinity headers.
* Why now: the bundled Fireworks catalog currently does not opt into OpenClaw’s existing session-affinity header path. There is a similar functionality but it seems misplaced as Fireworks is not routed via Anthropic because its models are `"api": "openai-completions"`.
[src/llm/providers/anthropic.ts:174-186](https://github.com/openclaw/openclaw/blob/main/src/llm/providers/anthropic.ts#L174-L186)
[extensions/fireworks/openclaw.plugin.json:31-35](https://github.com/openclaw/openclaw/blob/main/extensions/fireworks/openclaw.plugin.json#L31-L35)

* Success looks like: Fireworks catalog-derived requests include `x-session-affinity` when OpenClaw has a session identifier, without changing behavior for other OpenAI-compatible providers.
* Reviewers should focus on the Fireworks catalog compat flag, stream wrapper routing, and whether the change remains isolated from shared OpenAI-compatible provider behavior.

## Linked context

Closes: N/A

Related:

* Fireworks prompt caching documentation: 
- human https://docs.fireworks.ai/guides/prompt-caching 
- agents https://docs.fireworks.ai/guides/prompt-caching.md

Was this requested by a maintainer or owner?

No maintainer request yet. This follows Fireworks prompt-caching documentation that recommends `x-session-affinity` for routing repeated session traffic to the same replica.
