### PR TITLE
fix(gateway): support Streamable HTTP MCP transport on loopback server

### DIFF
--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -111,6 +111,7 @@ export function validateMcpLoopbackRequest(params: {
   res: ServerResponse;
   ownerToken: string;
   nonOwnerToken: string;
+  onSseResponse?: (res: ServerResponse) => void;
 }): { senderIsOwner: boolean } | null {
   let url: URL;
   try {
@@ -164,6 +165,7 @@ export function validateMcpLoopbackRequest(params: {
     });
     params.res.flushHeaders();
     params.res.write(":\n\n");
+    params.onSseResponse?.(params.res);
     params.req.on("close", () => {
       if (!params.res.writableEnded) {
         params.res.end();

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -169,34 +169,13 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
-  if (params.req.method === "DELETE") {
-    const deleteAuthHeader = getHeader(params.req, "authorization") ?? "";
-    if (
-      !safeEqualSecret(deleteAuthHeader, `Bearer ${params.ownerToken}`) &&
-      !safeEqualSecret(deleteAuthHeader, `Bearer ${params.nonOwnerToken}`)
-    ) {
-      params.res.writeHead(401, { "Content-Type": "application/json" });
-      params.res.end(JSON.stringify({ error: "unauthorized" }));
-      return null;
-    }
-    if (rejectsBrowserLoopbackRequest(params.req)) {
-      params.res.writeHead(403, { "Content-Type": "application/json" });
-      params.res.end(JSON.stringify({ error: "forbidden" }));
-      return null;
-    }
-    logMcpLoopbackHttp("session-delete", { method: "DELETE", path: url.pathname });
-    params.res.writeHead(200);
-    params.res.end();
-    return null;
-  }
-
   if (params.req.method !== "POST") {
     logMcpLoopbackHttp("reject", {
       reason: "method_not_allowed",
       method: params.req.method ?? "",
       path: url.pathname,
     });
-    params.res.writeHead(405, { Allow: "POST, GET, DELETE" });
+    params.res.writeHead(405, { Allow: "GET, POST" });
     params.res.end();
     return null;
   }

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -154,6 +154,8 @@ export function validateMcpLoopbackRequest(params: {
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
     });
+    params.res.flushHeaders();
+    params.res.write(":\n\n");
     params.req.on("close", () => {
       if (!params.res.writableEnded) {
         params.res.end();
@@ -163,6 +165,20 @@ export function validateMcpLoopbackRequest(params: {
   }
 
   if (params.req.method === "DELETE") {
+    const deleteAuthHeader = getHeader(params.req, "authorization") ?? "";
+    if (
+      !safeEqualSecret(deleteAuthHeader, `Bearer ${params.ownerToken}`) &&
+      !safeEqualSecret(deleteAuthHeader, `Bearer ${params.nonOwnerToken}`)
+    ) {
+      params.res.writeHead(401, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "unauthorized" }));
+      return null;
+    }
+    if (rejectsBrowserLoopbackRequest(params.req)) {
+      params.res.writeHead(403, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "forbidden" }));
+      return null;
+    }
     logMcpLoopbackHttp("session-delete", { method: "DELETE", path: url.pathname });
     params.res.writeHead(200);
     params.res.end();

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -140,17 +140,20 @@ export function validateMcpLoopbackRequest(params: {
   }
 
   if (params.req.method === "GET") {
+    // Origin validation first (matches the POST path): a browser loopback request is
+    // rejected before bearer auth, so the local-loopback Origin boundary holds even for
+    // unauthenticated browser requests.
+    if (rejectsBrowserLoopbackRequest(params.req)) {
+      params.res.writeHead(403, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "forbidden" }));
+      return null;
+    }
     const authHeader = getHeader(params.req, "authorization") ?? "";
     const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
     const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
     if (!ownerTokenMatched && !nonOwnerTokenMatched) {
       params.res.writeHead(401, { "Content-Type": "application/json" });
       params.res.end(JSON.stringify({ error: "unauthorized" }));
-      return null;
-    }
-    if (rejectsBrowserLoopbackRequest(params.req)) {
-      params.res.writeHead(403, { "Content-Type": "application/json" });
-      params.res.end(JSON.stringify({ error: "forbidden" }));
       return null;
     }
     logMcpLoopbackHttp("sse-open", { method: "GET", path: url.pathname });
@@ -173,17 +176,18 @@ export function validateMcpLoopbackRequest(params: {
     // Streamable HTTP session teardown. The loopback server is stateless — it owns no
     // session lifecycle — so this is an auth-gated no-op acknowledgement: clients that
     // send DELETE when closing the transport get a clean 200 rather than a 405.
+    // Origin validation first (matches the POST/GET paths), before bearer auth.
+    if (rejectsBrowserLoopbackRequest(params.req)) {
+      params.res.writeHead(403, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "forbidden" }));
+      return null;
+    }
     const authHeader = getHeader(params.req, "authorization") ?? "";
     const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
     const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
     if (!ownerTokenMatched && !nonOwnerTokenMatched) {
       params.res.writeHead(401, { "Content-Type": "application/json" });
       params.res.end(JSON.stringify({ error: "unauthorized" }));
-      return null;
-    }
-    if (rejectsBrowserLoopbackRequest(params.req)) {
-      params.res.writeHead(403, { "Content-Type": "application/json" });
-      params.res.end(JSON.stringify({ error: "forbidden" }));
       return null;
     }
     logMcpLoopbackHttp("session-delete", { method: "DELETE", path: url.pathname });

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -169,13 +169,36 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
+  if (params.req.method === "DELETE") {
+    // Streamable HTTP session teardown. The loopback server is stateless — it owns no
+    // session lifecycle — so this is an auth-gated no-op acknowledgement: clients that
+    // send DELETE when closing the transport get a clean 200 rather than a 405.
+    const authHeader = getHeader(params.req, "authorization") ?? "";
+    const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
+    const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
+    if (!ownerTokenMatched && !nonOwnerTokenMatched) {
+      params.res.writeHead(401, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "unauthorized" }));
+      return null;
+    }
+    if (rejectsBrowserLoopbackRequest(params.req)) {
+      params.res.writeHead(403, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "forbidden" }));
+      return null;
+    }
+    logMcpLoopbackHttp("session-delete", { method: "DELETE", path: url.pathname });
+    params.res.writeHead(200, { "Content-Type": "application/json" });
+    params.res.end(JSON.stringify({ ok: true }));
+    return null;
+  }
+
   if (params.req.method !== "POST") {
     logMcpLoopbackHttp("reject", {
       reason: "method_not_allowed",
       method: params.req.method ?? "",
       path: url.pathname,
     });
-    params.res.writeHead(405, { Allow: "GET, POST" });
+    params.res.writeHead(405, { Allow: "GET, POST, DELETE" });
     params.res.end();
     return null;
   }

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -148,6 +148,11 @@ export function validateMcpLoopbackRequest(params: {
       params.res.end(JSON.stringify({ error: "unauthorized" }));
       return null;
     }
+    if (rejectsBrowserLoopbackRequest(params.req)) {
+      params.res.writeHead(403, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "forbidden" }));
+      return null;
+    }
     logMcpLoopbackHttp("sse-open", { method: "GET", path: url.pathname });
     params.res.writeHead(200, {
       "Content-Type": "text/event-stream",

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -139,13 +139,43 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
+  if (params.req.method === "GET") {
+    const authHeader = getHeader(params.req, "authorization") ?? "";
+    const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
+    const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
+    if (!ownerTokenMatched && !nonOwnerTokenMatched) {
+      params.res.writeHead(401, { "Content-Type": "application/json" });
+      params.res.end(JSON.stringify({ error: "unauthorized" }));
+      return null;
+    }
+    logMcpLoopbackHttp("sse-open", { method: "GET", path: url.pathname });
+    params.res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    params.req.on("close", () => {
+      if (!params.res.writableEnded) {
+        params.res.end();
+      }
+    });
+    return null;
+  }
+
+  if (params.req.method === "DELETE") {
+    logMcpLoopbackHttp("session-delete", { method: "DELETE", path: url.pathname });
+    params.res.writeHead(200);
+    params.res.end();
+    return null;
+  }
+
   if (params.req.method !== "POST") {
     logMcpLoopbackHttp("reject", {
       reason: "method_not_allowed",
       method: params.req.method ?? "",
       path: url.pathname,
     });
-    params.res.writeHead(405, { Allow: "POST" });
+    params.res.writeHead(405, { Allow: "POST, GET, DELETE" });
     params.res.end();
     return null;
   }

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -152,6 +152,28 @@ async function readStreamChunkWithTimeout(
   }
 }
 
+async function expectPromiseResolvesWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 async function readUntilInitialSseCommentFrame(
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): Promise<void> {
@@ -1229,6 +1251,32 @@ describe("createMcpLoopbackServerConfig", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/event-stream");
     await expectInitialSseCommentFrame(res);
+  });
+
+  it("closes active GET notification streams during loopback shutdown", async () => {
+    server = await startMcpLoopbackServer(0);
+    const token = getActiveMcpLoopbackRuntime()?.ownerToken;
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "GET",
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    expect(res.status).toBe(200);
+    const reader = res.body?.getReader();
+    if (!reader) {
+      throw new Error("expected SSE response body");
+    }
+
+    try {
+      await readUntilInitialSseCommentFrame(reader);
+      const closePromise = server.close();
+      server = undefined;
+      await expectPromiseResolvesWithin(closePromise, 500, "MCP loopback server close");
+      const closed = await readStreamChunkWithTimeout(reader);
+      expect(closed.done).toBe(true);
+    } finally {
+      await reader.cancel().catch(() => undefined);
+      reader.releaseLock();
+    }
   });
 
   it("rejects a GET notification channel without a bearer token (401)", async () => {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1148,4 +1148,76 @@ describe("createMcpLoopbackServerConfig", () => {
     );
     expect(config.mcpServers?.openclaw?.headers).not.toHaveProperty("x-openclaw-sender-is-owner");
   });
+
+  it("opens an auth-gated SSE stream on GET (Streamable HTTP notification channel)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "GET",
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    await res.body?.cancel();
+  });
+
+  it("rejects a GET notification channel without a bearer token (401)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, { method: "GET" });
+    expect(res.status).toBe(401);
+    await res.body?.cancel();
+  });
+
+  it("rejects a GET notification channel from a browser Origin (403)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "GET",
+      headers: {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        origin: "https://evil.example",
+      },
+    });
+    expect(res.status).toBe(403);
+    await res.body?.cancel();
+  });
+
+  it("acknowledges DELETE session teardown with 200 (stateless no-op)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "DELETE",
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects DELETE without a bearer token (401)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects unsupported methods with 405 advertising GET, POST, DELETE", async () => {
+    server = await startMcpLoopbackServer(0);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, { method: "PUT" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, POST, DELETE");
+  });
+
+  it("stays stateless: POST responses advertise no Mcp-Session-Id", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const res = await sendRaw({
+      port: server.port,
+      token: runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined,
+      headers: { "content-type": "application/json", "x-session-key": "agent:main:main" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("mcp-session-id")).toBeNull();
+  });
 });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1151,8 +1151,7 @@ describe("createMcpLoopbackServerConfig", () => {
 
   it("opens an auth-gated SSE stream on GET (Streamable HTTP notification channel)", async () => {
     server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
-    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const token = getActiveMcpLoopbackRuntime()?.ownerToken;
     const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
       method: "GET",
       headers: token ? { authorization: `Bearer ${token}` } : {},
@@ -1171,8 +1170,7 @@ describe("createMcpLoopbackServerConfig", () => {
 
   it("rejects a GET notification channel from a browser Origin (403)", async () => {
     server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
-    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const token = getActiveMcpLoopbackRuntime()?.ownerToken;
     const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
       method: "GET",
       headers: {
@@ -1186,8 +1184,7 @@ describe("createMcpLoopbackServerConfig", () => {
 
   it("acknowledges DELETE session teardown with 200 (stateless no-op)", async () => {
     server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
-    const token = runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined;
+    const token = getActiveMcpLoopbackRuntime()?.ownerToken;
     const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
       method: "DELETE",
       headers: token ? { authorization: `Bearer ${token}` } : {},
@@ -1210,14 +1207,32 @@ describe("createMcpLoopbackServerConfig", () => {
 
   it("stays stateless: POST responses advertise no Mcp-Session-Id", async () => {
     server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
     const res = await sendRaw({
       port: server.port,
-      token: runtime ? resolveMcpLoopbackBearerToken(runtime, false) : undefined,
+      token: getActiveMcpLoopbackRuntime()?.ownerToken,
       headers: { "content-type": "application/json", "x-session-key": "agent:main:main" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("mcp-session-id")).toBeNull();
+  });
+
+  it("rejects a browser-Origin GET before auth (403, no bearer)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "GET",
+      headers: { origin: "https://evil.example" },
+    });
+    expect(res.status).toBe(403);
+    await res.body?.cancel();
+  });
+
+  it("rejects a browser-Origin DELETE before auth (403, no bearer)", async () => {
+    server = await startMcpLoopbackServer(0);
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "DELETE",
+      headers: { origin: "https://evil.example" },
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -111,6 +111,7 @@ let server: Awaited<ReturnType<typeof startMcpLoopbackServer>> | undefined;
 
 const MAIN_SESSION_HEADER = { "x-session-key": "agent:main:main" };
 const ANGLE_NUMBER_PROPERTY = { type: "number" };
+const SSE_TEST_READ_TIMEOUT_MS = 100;
 
 async function sendRaw(params: {
   port: number;
@@ -126,6 +127,75 @@ async function sendRaw(params: {
     },
     body: params.body,
   });
+}
+
+async function readStreamChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  const timeoutResult = Symbol("sse-read-timeout");
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<typeof timeoutResult>((resolve) => {
+        timeout = setTimeout(() => resolve(timeoutResult), SSE_TEST_READ_TIMEOUT_MS);
+      }),
+    ]);
+    if (result === timeoutResult) {
+      throw new Error("timed out waiting for SSE response body");
+    }
+    return result;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function readUntilInitialSseCommentFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  let bodyPrefix = "";
+  while (!bodyPrefix.includes(":\n\n")) {
+    const chunk = await readStreamChunkWithTimeout(reader);
+    expect(chunk.done).toBe(false);
+    bodyPrefix += decoder.decode(chunk.value, { stream: true });
+    if (bodyPrefix.length > 64) {
+      throw new Error(`SSE response did not start with a comment frame: ${bodyPrefix}`);
+    }
+  }
+  expect(bodyPrefix.startsWith(":\n\n")).toBe(true);
+}
+
+async function expectInitialSseCommentFrame(res: Response): Promise<void> {
+  expect(res.body).toBeTruthy();
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new Error("expected SSE response body");
+  }
+  let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | undefined;
+  let closeTimeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await readUntilInitialSseCommentFrame(reader);
+
+    pendingRead = reader.read();
+    const immediateClose = Symbol("immediate-close");
+    const result = await Promise.race([
+      pendingRead,
+      new Promise<typeof immediateClose>((resolve) => {
+        closeTimeout = setTimeout(() => resolve(immediateClose), SSE_TEST_READ_TIMEOUT_MS);
+      }),
+    ]);
+    expect(result).toBe(immediateClose);
+  } finally {
+    if (closeTimeout) {
+      clearTimeout(closeTimeout);
+    }
+    await reader.cancel();
+    await pendingRead?.catch(() => undefined);
+    reader.releaseLock();
+  }
 }
 
 async function sendChunkedOversizedBody(params: {
@@ -1158,7 +1228,7 @@ describe("createMcpLoopbackServerConfig", () => {
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/event-stream");
-    await res.body?.cancel();
+    await expectInitialSseCommentFrame(res);
   });
 
   it("rejects a GET notification channel without a bearer token (401)", async () => {
@@ -1188,6 +1258,18 @@ describe("createMcpLoopbackServerConfig", () => {
     const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
       method: "DELETE",
       headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("ignores Mcp-Session-Id on DELETE because loopback teardown is stateless", async () => {
+    server = await startMcpLoopbackServer(0);
+    const token = getActiveMcpLoopbackRuntime()?.ownerToken;
+    const res = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+      method: "DELETE",
+      headers: token
+        ? { authorization: `Bearer ${token}`, "mcp-session-id": "ignored-loopback-session" }
+        : { "mcp-session-id": "ignored-loopback-session" },
     });
     expect(res.status).toBe(200);
   });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -143,9 +143,39 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
   const ownerToken = crypto.randomBytes(32).toString("hex");
   const nonOwnerToken = crypto.randomBytes(32).toString("hex");
   const toolCache = new McpLoopbackToolCache();
+  // GET notification streams are intentionally long-lived; shutdown must end
+  // them itself before waiting for httpServer.close() to drain active responses.
+  const activeSseResponses = new Set<ServerResponse>();
+
+  const trackSseResponse = (res: ServerResponse): void => {
+    activeSseResponses.add(res);
+    const cleanup = () => {
+      activeSseResponses.delete(res);
+      res.off("close", cleanup);
+      res.off("finish", cleanup);
+    };
+    res.once("close", cleanup);
+    res.once("finish", cleanup);
+  };
+
+  const closeActiveSseResponses = (): void => {
+    for (const res of [...activeSseResponses]) {
+      if (!res.destroyed && !res.writableEnded) {
+        const socket = res.socket;
+        res.end();
+        socket?.end();
+      }
+    }
+  };
 
   const httpServer = createHttpServer((req, res) => {
-    const auth = validateMcpLoopbackRequest({ req, res, ownerToken, nonOwnerToken });
+    const auth = validateMcpLoopbackRequest({
+      req,
+      res,
+      ownerToken,
+      nonOwnerToken,
+      onSseResponse: trackSseResponse,
+    });
     if (!auth) {
       return;
     }
@@ -292,6 +322,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           }
           resolve();
         });
+        closeActiveSseResponses();
       }),
   };
   return server;

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -142,7 +142,6 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
 }> {
   const ownerToken = crypto.randomBytes(32).toString("hex");
   const nonOwnerToken = crypto.randomBytes(32).toString("hex");
-  const mcpSessionId = crypto.randomUUID();
   const toolCache = new McpLoopbackToolCache();
 
   const httpServer = createHttpServer((req, res) => {
@@ -227,10 +226,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const payload = Array.isArray(parsed)
           ? JSON.stringify(responses)
           : JSON.stringify(responses[0]);
-        res.writeHead(200, {
-          "Content-Type": "application/json",
-          "Mcp-Session-Id": mcpSessionId,
-        });
+        res.writeHead(200, { "Content-Type": "application/json" });
         res.end(payload);
       } catch (error) {
         logWarn(`mcp loopback: request handling failed: ${formatErrorMessage(error)}`);

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -142,6 +142,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
 }> {
   const ownerToken = crypto.randomBytes(32).toString("hex");
   const nonOwnerToken = crypto.randomBytes(32).toString("hex");
+  const mcpSessionId = crypto.randomUUID();
   const toolCache = new McpLoopbackToolCache();
 
   const httpServer = createHttpServer((req, res) => {
@@ -226,7 +227,10 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const payload = Array.isArray(parsed)
           ? JSON.stringify(responses)
           : JSON.stringify(responses[0]);
-        res.writeHead(200, { "Content-Type": "application/json" });
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Mcp-Session-Id": mcpSessionId,
+        });
         res.end(payload);
       } catch (error) {
         logWarn(`mcp loopback: request handling failed: ${formatErrorMessage(error)}`);

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -159,7 +159,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
   };
 
   const closeActiveSseResponses = (): void => {
-    for (const res of [...activeSseResponses]) {
+    for (const res of activeSseResponses) {
       if (!res.destroyed && !res.writableEnded) {
         const socket = res.socket;
         res.end();


### PR DESCRIPTION
## Summary

The MCP loopback HTTP server generates a config with `"type": "http"` (Streamable HTTP transport), but only handled POST — a GET to `/mcp` returned 405. Claude Code's Streamable HTTP client opens an SSE notification channel by sending GET `/mcp` during initialization; the 405 left it hanging at "still connecting" indefinitely, so the agent got no OpenClaw MCP tools for the whole session.

This adds the missing transport surface, **kept stateless** (the loopback server owns no session lifecycle):

- **GET `/mcp` → 200 `text/event-stream`** — an auth-gated, browser-origin-rejected idle SSE notification channel (the actual fix for the hang). Closes cleanly when the client disconnects.
- **DELETE `/mcp` → 200** — auth-gated no-op acknowledgement of Streamable HTTP session teardown, so clients that send DELETE on close get a clean 200 rather than 405.
- **Stateless POST** — POST responses advertise **no** `Mcp-Session-Id`. The server processes each request independently; advertising a session id it never validates, expires, or owns would be misleading and push clients to echo a session the server ignores. (Per the spec, a stateless server simply omits the session id.)
- `Allow` now advertises `GET, POST, DELETE`; other methods still 405.

## Session semantics

Resolved the stateless-vs-sessionful question in favor of **stateless**: a single-purpose local loopback tool endpoint has no session state to manage, so it stays stateless rather than taking on a session lifecycle. (Maintainer can revisit if sessionful semantics are ever wanted.)

## Tests

`src/gateway/mcp-http.test.ts` — added focused gateway transport tests, all passing:
- GET valid bearer → 200 + `text/event-stream`
- GET no auth → 401; GET browser `Origin` → 403
- DELETE valid bearer → 200; DELETE no auth → 401
- unsupported method → 405 with `Allow: GET, POST, DELETE`
- POST stays stateless → no `Mcp-Session-Id` header

## Real behavior proof

- Behavior addressed: Streamable HTTP MCP clients now get the loopback notification channel they open during initialization. Before this patch, GET /mcp returned 405 even though OpenClaw generated an HTTP MCP server config, leaving clients stuck connecting without OpenClaw MCP tools.
- Real environment tested: Blacksmith Testbox through Crabbox, provider blacksmith-testbox, id tbx_01ktn2f64amve324y4w7fqn87c, GitHub Actions run 27179521692, Ubuntu runner with Node 24. The compiled smoke ran from the built OpenClaw dist output. The contributor also provided curl output from a built and running loopback MCP server.
- Exact steps or command run after this patch: Built the repo, started the compiled MCP loopback server from dist, hit the real HTTP endpoint with fetch/curl-equivalent requests for GET, DELETE, and unsupported methods, connected the official @modelcontextprotocol/sdk StreamableHTTPClientTransport client, called tools/list, opened an authenticated GET SSE stream, and closed the server while the SSE stream was active.
- Evidence after fix: Terminal output from the remote Testbox proof:

```text
compiled MCP loopback smoke passed {"port":38599,"sdkTools":28}
blacksmith run summary sync=delegated command=10m36.118s total=10m45.557s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01ktn2f64amve324y4w7fqn87c","slug":"brisk-krill","commandPhases":[{"name":"format","ms":584},{"name":"lint-core","ms":384218},{"name":"tsgo-core","ms":9933},{"name":"tsgo-core-test","ms":47245},{"name":"focused-vitest","ms":35406},{"name":"build","ms":111519},{"name":"compiled-e2e","ms":13749}],"exitCode":0}
```

Contributor curl proof from a built and running loopback MCP server also showed GET with a valid bearer returning 200 and Content-Type: text/event-stream, GET without auth returning 401, browser-Origin GET returning 403, authenticated DELETE returning 200, unauthenticated DELETE returning 401, and PUT returning 405 with Allow: GET, POST, DELETE.
- Observed result after fix: The compiled loopback server accepted authenticated GET /mcp as a live SSE channel, rejected missing/wrong bearer tokens, rejected browser Origin requests before auth, acknowledged authenticated DELETE without creating session state, kept POST stateless with no Mcp-Session-Id, returned 405 with the updated Allow header for unsupported methods, allowed the MCP SDK client to list 28 tools, and closed an active SSE stream cleanly during server shutdown.
- What was not tested: A live Claude Code interactive session with real user credentials was not run in this proof. The transport contract, compiled OpenClaw loopback runtime, official MCP SDK client path, auth/origin edges, shutdown behavior, focused gateway/agent tests, type checks, lint, and build were tested remotely.