### PR TITLE
fix(gateway): guard plugin session action lookups

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginSessionActionRegistryRegistration } from "../plugins/registry-types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
   authorizeOperatorScopesForMethod,
@@ -189,6 +190,47 @@ describe("method scope resolution", () => {
       "operator.pairing",
       "operator.talk.secrets",
     ]);
+  });
+
+  it("keeps healthy plugin session action scopes after unreadable action metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    const staleAction = {
+      pluginId: "scope-plugin",
+      pluginName: "Scope Plugin",
+      source: "test",
+    } as PluginSessionActionRegistryRegistration;
+    Object.defineProperty(staleAction, "action", {
+      get() {
+        throw new Error("plugin session action metadata getter exploded");
+      },
+    });
+    registry.sessionActions = [
+      staleAction,
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        action: {
+          id: "approve",
+          requiredScopes: ["operator.approvals"],
+          handler: () => ({ result: { ok: true } }),
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual(["operator.approvals"]);
+    expect(
+      authorizeOperatorScopesForMethod("plugins.sessionAction", ["operator.approvals"], {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual({ allowed: true });
   });
 
   it("returns empty scopes for unknown methods", () => {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -100,14 +100,19 @@ function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] 
   if (!pluginId || !actionId) {
     return undefined;
   }
-  const registration = getPluginRegistryState()?.activeRegistry?.sessionActions?.find(
-    (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-  );
-  if (!registration) {
-    return undefined;
+  for (const entry of getPluginRegistryState()?.activeRegistry?.sessionActions ?? []) {
+    try {
+      const action = entry.action;
+      if (entry.pluginId === pluginId && action.id === actionId) {
+        const requiredScopes = action.requiredScopes;
+        return requiredScopes && requiredScopes.length > 0 ? [...requiredScopes] : [WRITE_SCOPE];
+      }
+    } catch {
+      // Stale plugin rows must not block least-privilege checks for healthy registrations.
+      continue;
+    }
   }
-  const requiredScopes = registration.action.requiredScopes;
-  return requiredScopes && requiredScopes.length > 0 ? [...requiredScopes] : [WRITE_SCOPE];
+  return undefined;
 }
 
 function resolveSessionActionLeastPrivilegeScopes(params: unknown): OperatorScope[] {

--- a/src/gateway/server-methods/plugin-host-hooks.test.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginSessionActionRegistryRegistration } from "../../plugins/registry-types.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { pluginHostHookHandlers } from "./plugin-host-hooks.js";
+
+afterEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
+describe("plugin host hook gateway handlers", () => {
+  it("dispatches healthy plugin session actions after unreadable action metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({ id: "scope-plugin", status: "loaded" } as never);
+    const staleAction = {
+      pluginId: "scope-plugin",
+      pluginName: "Scope Plugin",
+      source: "test",
+    } as PluginSessionActionRegistryRegistration;
+    Object.defineProperty(staleAction, "action", {
+      get() {
+        throw new Error("plugin session action metadata getter exploded");
+      },
+    });
+    registry.sessionActions = [
+      staleAction,
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        action: {
+          id: "approve",
+          requiredScopes: ["operator.approvals"],
+          handler: () => ({ result: { dispatched: true } }),
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    const responses: Array<{ ok: boolean; payload?: unknown; error?: { code: string } }> = [];
+    await pluginHostHookHandlers["plugins.sessionAction"]({
+      params: { pluginId: "scope-plugin", actionId: "approve" },
+      client: { connect: { scopes: ["operator.approvals"] } } as never,
+      respond: (ok, payload, error) => responses.push({ ok, payload, error }),
+      req: { id: 1, method: "plugins.sessionAction" } as never,
+      context: {} as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(responses).toEqual([
+      { ok: true, payload: { ok: true, result: { dispatched: true } }, error: undefined },
+    ]);
+  });
+
+  it("returns unavailable when no healthy plugin session action matches", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({ id: "scope-plugin", status: "loaded" } as never);
+    const staleAction = {
+      pluginId: "scope-plugin",
+      pluginName: "Scope Plugin",
+      source: "test",
+    } as PluginSessionActionRegistryRegistration;
+    Object.defineProperty(staleAction, "action", {
+      get() {
+        throw new Error("plugin session action metadata getter exploded");
+      },
+    });
+    registry.sessionActions = [staleAction];
+    setActivePluginRegistry(registry);
+
+    const responses: Array<{ ok: boolean; payload?: unknown; error?: { code: string } }> = [];
+    await pluginHostHookHandlers["plugins.sessionAction"]({
+      params: { pluginId: "scope-plugin", actionId: "missing" },
+      client: { connect: { scopes: ["operator.approvals"] } } as never,
+      respond: (ok, payload, error) => responses.push({ ok, payload, error }),
+      req: { id: 1, method: "plugins.sessionAction" } as never,
+      context: {} as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.ok).toBe(false);
+    expect(responses[0]?.error?.code).toBe(ErrorCodes.UNAVAILABLE);
+  });
+});

--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -11,6 +11,7 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isPluginJsonValue } from "../../plugins/host-hooks.js";
+import type { PluginSessionActionRegistryRegistration } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   validateJsonSchemaValue,
@@ -24,6 +25,24 @@ const log = createSubsystemLogger("gateway/plugin-host-hooks");
 
 function formatSessionActionPayloadSchemaErrors(errors: JsonSchemaValidationError[]): string {
   return errors.map((error) => error.text).join("; ");
+}
+
+function findPluginSessionActionRegistration(
+  registrations: readonly PluginSessionActionRegistryRegistration[],
+  pluginId: string,
+  actionId: string,
+): PluginSessionActionRegistryRegistration | undefined {
+  for (const entry of registrations) {
+    try {
+      if (entry.pluginId === pluginId && entry.action.id === actionId) {
+        return entry;
+      }
+    } catch {
+      // Stale plugin rows must not block dispatch for a healthy later registration.
+      continue;
+    }
+  }
+  return undefined;
 }
 
 /** Ensures plugin action result extension fields stay JSON-compatible on the wire. */
@@ -90,8 +109,10 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
     const pluginLoaded = Boolean(
       registry?.plugins.some((plugin) => plugin.id === pluginId && plugin.status === "loaded"),
     );
-    const registration = (registry?.sessionActions ?? []).find(
-      (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
+    const registration = findPluginSessionActionRegistration(
+      registry?.sessionActions ?? [],
+      pluginId,
+      actionId,
     );
     if (!registration || !pluginLoaded) {
       respond(


### PR DESCRIPTION
## Summary

- Guard plugin session action registry lookup during least-privilege scope resolution so unreadable stale rows do not block later healthy registrations.
- Guard the matching `plugins.sessionAction` dispatch lookup for the same stale-row case.
- Add gateway regressions for scope/authorization and dispatch behavior after unreadable action metadata.

## Verification

- Red scope repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next102-red node_modules/.bin/vitest run src/gateway/method-scopes.test.ts -t "keeps healthy plugin session action scopes after unreadable action metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed pre-patch with `plugin session action metadata getter exploded`.
- Red dispatch repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next102-dispatch-red node_modules/.bin/vitest run src/gateway/server-methods/plugin-host-hooks.test.ts -t "dispatches healthy plugin session actions after unreadable action metadata" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed pre-patch with `plugin session action metadata getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next102-rebase2-both node_modules/.bin/vitest run src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=dot` passed: 5 files, 232 tests.
- `node_modules/.bin/oxfmt --check src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.ts src/gateway/server-methods/plugin-host-hooks.test.ts` passed.
- `node_modules/.bin/oxlint src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.ts src/gateway/server-methods/plugin-host-hooks.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings, overall `patch is correct (0.86)`.
- `blacksmith testbox list --all` blocked: not authenticated.
- `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` blocked before lease creation with coordinator `401 unauthorized`.
- `.agents/skills/agent-transcript/scripts/agent-transcript find` returned `[]`.

## Real behavior proof

Behavior addressed: stale or malformed plugin session action registry rows with unreadable `action` metadata no longer crash scope resolution or gateway dispatch before a later healthy registration can be used.

Real environment tested: local Codex worktree on Node/Vitest with the gateway projects selected by the touched test files; Testbox and Crabbox broad gates were attempted but blocked by auth.

Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next102-rebase2-both node_modules/.bin/vitest run src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=dot`.

Evidence after fix: the post-rebase touched test command passed 5 files and 232 tests; focused red repros failed before the implementation with `plugin session action metadata getter exploded`.

Observed result after fix: scope resolution returns the healthy registration's required scopes, authorization accepts the matching approvals scope, and `plugins.sessionAction` dispatch reaches the healthy handler after skipping the stale row.

What was not tested: `pnpm check:changed` did not run because Blacksmith Testbox was unauthenticated and the AWS Crabbox coordinator returned `401 unauthorized` before lease creation.
