### PR TITLE
fix(agents): verify delegated write results

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -30,6 +30,7 @@ import {
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { verifyHostFile, writeAndVerifySandboxFile } from "./agent-tools.write-verification.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -948,7 +949,12 @@ function createSandboxEditOperations(params: SandboxToolParams) {
     readFile: (absolutePath: string) =>
       params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
     writeFile: (absolutePath: string, content: string) =>
-      params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content }),
+      writeAndVerifySandboxFile({
+        bridge: params.bridge,
+        root: params.root,
+        absolutePath,
+        content,
+      }),
     access: (absolutePath: string) => assertSandboxFileExists(params, absolutePath),
   } as const;
 }
@@ -973,6 +979,7 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = resolveHostPath(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
+  await verifyHostFile(resolved, content);
 }
 
 async function statHostFile(absolutePath: string) {
@@ -1004,6 +1011,7 @@ async function writeWorkspaceFile(
 ) {
   const relative = await toCanonicalRelativeWorkspacePath(root, absolutePath);
   await (await rootPromise).write(relative, content, { mkdir: true });
+  await verifyHostFile(path.resolve(root, relative), content);
 }
 
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {

--- a/src/agents/agent-tools.write-verification.test.ts
+++ b/src/agents/agent-tools.write-verification.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyHostFile, writeAndVerifySandboxFile } from "./agent-tools.write-verification.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { WriteVerificationError } from "./sessions/tools/write-verification.js";
+
+describe("agent-tools write verification", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it("rejects same-size stale host content", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-verify-"));
+    const filePath = path.join(tmpDir, "demo.txt");
+    await fs.writeFile(filePath, "stale content\n", "utf-8");
+
+    await expect(verifyHostFile(filePath, "fresh content\n")).rejects.toThrow(
+      WriteVerificationError,
+    );
+  });
+
+  it("rejects same-size stale sandbox content after a delegated write resolves", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-verify-"));
+    const filePath = path.join(tmpDir, "demo.txt");
+    const content = "fresh content\n";
+    const bridge: SandboxFsBridge = {
+      resolvePath: ({ filePath: inputPath }) => ({
+        hostPath: inputPath,
+        relativePath: path.relative(tmpDir, inputPath),
+        containerPath: inputPath,
+      }),
+      readFile: async () => Buffer.from("stale content\n"),
+      writeFile: async () => {},
+      mkdirp: async () => {},
+      remove: async () => {},
+      rename: async () => {},
+      stat: async () => ({
+        type: "file",
+        size: Buffer.byteLength(content, "utf8"),
+      }),
+    };
+
+    await expect(
+      writeAndVerifySandboxFile({
+        bridge,
+        root: tmpDir,
+        absolutePath: filePath,
+        content,
+      }),
+    ).rejects.toThrow(WriteVerificationError);
+  });
+});

--- a/src/agents/agent-tools.write-verification.test.ts
+++ b/src/agents/agent-tools.write-verification.test.ts
@@ -44,6 +44,7 @@ describe("agent-tools write verification", () => {
       stat: async () => ({
         type: "file",
         size: Buffer.byteLength(content, "utf8"),
+        mtimeMs: Date.now(),
       }),
     };
 

--- a/src/agents/agent-tools.write-verification.ts
+++ b/src/agents/agent-tools.write-verification.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import type { SandboxFsBridge, SandboxFsStat } from "./sandbox/fs-bridge.js";
+import { verifyWrittenContent, verifyWrittenStat } from "./sessions/tools/write-verification.js";
+
+export async function verifyHostFile(absolutePath: string, content: string): Promise<void> {
+  let stat: { type: "file" | "directory" | "other"; size: number } | null = null;
+  try {
+    const fileStat = await fs.stat(absolutePath);
+    stat = {
+      type: fileStat.isFile() ? "file" : fileStat.isDirectory() ? "directory" : "other",
+      size: fileStat.size,
+    };
+  } catch {
+    stat = null;
+  }
+
+  verifyWrittenStat({ absolutePath, content, stat });
+  const readback = await fs.readFile(absolutePath).catch(() => undefined);
+  verifyWrittenContent({ absolutePath, content, readback });
+}
+
+export async function writeAndVerifySandboxFile(params: {
+  bridge: SandboxFsBridge;
+  root: string;
+  absolutePath: string;
+  content: string;
+}): Promise<void> {
+  await params.bridge.writeFile({
+    filePath: params.absolutePath,
+    cwd: params.root,
+    data: params.content,
+  });
+  const stat: Pick<SandboxFsStat, "type" | "size"> | null = await params.bridge.stat({
+    filePath: params.absolutePath,
+    cwd: params.root,
+  });
+  verifyWrittenStat({ absolutePath: params.absolutePath, content: params.content, stat });
+  const readback = await params.bridge
+    .readFile({ filePath: params.absolutePath, cwd: params.root })
+    .catch(() => undefined);
+  verifyWrittenContent({
+    absolutePath: params.absolutePath,
+    content: params.content,
+    readback,
+  });
+}

--- a/src/agents/agent-tools.write-verification.ts
+++ b/src/agents/agent-tools.write-verification.ts
@@ -3,7 +3,7 @@ import type { SandboxFsBridge, SandboxFsStat } from "./sandbox/fs-bridge.js";
 import { verifyWrittenContent, verifyWrittenStat } from "./sessions/tools/write-verification.js";
 
 export async function verifyHostFile(absolutePath: string, content: string): Promise<void> {
-  let stat: { type: "file" | "directory" | "other"; size: number } | null = null;
+  let stat: { type: "file" | "directory" | "other"; size: number } | null;
   try {
     const fileStat = await fs.stat(absolutePath);
     stat = {

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -167,6 +167,7 @@ describe("models-config", () => {
               openai: {
                 baseUrl: "   ",
                 apiKey: "OPENAI_API_KEY",
+                models: [],
               },
             },
           },

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
 import { createEditTool, createEditToolDefinition, type EditOperations } from "./edit.js";
+import { WriteVerificationError } from "./write-verification.js";
 
 const testTheme = {
   bg: (_name: string, text: string) => text,
@@ -103,6 +104,29 @@ describe("edit tool", () => {
         undefined,
       ),
     ).rejects.toThrow("Simulated write failure");
+  });
+
+  it("does not recover write verification failures as edit success", async () => {
+    const filePath = await createTempFile("before old text after\n");
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile: (absolutePath) => fs.readFile(absolutePath),
+      writeFile: async (absolutePath, content) => {
+        await fs.writeFile(absolutePath, content, "utf-8");
+        throw new WriteVerificationError(
+          `Write verification failed: file does not exist after write (${absolutePath})`,
+        );
+      },
+    };
+    const tool = createEditTool(tmpDir, { operations });
+
+    await expect(
+      tool.execute(
+        "call-1",
+        { path: filePath, edits: [{ oldText: "old text", newText: "new text" }] },
+        undefined,
+      ),
+    ).rejects.toThrow(WriteVerificationError);
   });
 
   it("recovers multi-edit post-write failures", async () => {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -32,6 +32,7 @@ import { resolveToCwd } from "./path-utils.js";
 import { invalidArgText, shortenPath, str } from "./render-utils.js";
 import type { EditToolDetails, EditToolInput } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
+import { isWriteVerificationError } from "./write-verification.js";
 
 type EditPreview = EditDiffResult | EditDiffError;
 
@@ -436,6 +437,9 @@ export function createEditToolDefinition(
             },
           };
         } catch (error: unknown) {
+          if (isWriteVerificationError(error)) {
+            throw error;
+          }
           const normalizedError = error instanceof Error ? error : new Error(String(error));
           const currentContent = await ops
             .readFile(absolutePath)

--- a/src/agents/sessions/tools/write-verification.ts
+++ b/src/agents/sessions/tools/write-verification.ts
@@ -1,0 +1,53 @@
+export class WriteVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WriteVerificationError";
+  }
+}
+
+export function isWriteVerificationError(error: unknown): error is WriteVerificationError {
+  return error instanceof WriteVerificationError;
+}
+
+type WrittenStat = {
+  type: "file" | "directory" | "other";
+  size: number;
+};
+
+export function verifyWrittenStat(params: {
+  absolutePath: string;
+  content: string;
+  stat: WrittenStat | null;
+}): void {
+  if (!params.stat) {
+    throw new WriteVerificationError(
+      `Write verification failed: file does not exist after write (${params.absolutePath})`,
+    );
+  }
+  if (params.stat.type !== "file") {
+    throw new WriteVerificationError(
+      `Write verification failed: path is not a file after write (${params.absolutePath})`,
+    );
+  }
+  const expectedSize = Buffer.byteLength(params.content, "utf8");
+  if (params.stat.size !== expectedSize) {
+    throw new WriteVerificationError(
+      `Write verification failed: expected ${expectedSize} bytes but file has ${params.stat.size} bytes (${params.absolutePath})`,
+    );
+  }
+}
+
+export function verifyWrittenContent(params: {
+  absolutePath: string;
+  content: string;
+  readback: Buffer | string | undefined;
+}): void {
+  const currentContent = Buffer.isBuffer(params.readback)
+    ? params.readback.toString("utf8")
+    : params.readback;
+  if (currentContent !== params.content) {
+    throw new WriteVerificationError(
+      `Write verification failed: readback did not match requested content (${params.absolutePath})`,
+    );
+  }
+}

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { WriteVerificationError } from "./write-verification.js";
 import { createWriteTool, type WriteOperations } from "./write.js";
 
 describe("write tool", () => {
@@ -108,6 +109,36 @@ describe("write tool", () => {
     );
 
     expect(result.content[0]?.type).toBe("text");
+  });
+
+  it("does not report success when a delegated write resolves without creating the file", async () => {
+    const filePath = await createTempPath();
+    const tool = createWriteTool(tmpDir, {
+      operations: {
+        mkdir: async () => {},
+        writeFile: async () => {},
+        readFile: async () => Buffer.from(""),
+        statFile: async () => null,
+      },
+    });
+
+    await expect(
+      tool.execute("call-1", { path: filePath, content: "expected content" }, undefined),
+    ).rejects.toThrow(WriteVerificationError);
+    await expect(fs.access(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not report success when same-size stale content remains after write", async () => {
+    const filePath = await createTempPath();
+    await fs.writeFile(filePath, "stale content\n", "utf-8");
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(async () => {}),
+    });
+
+    await expect(
+      tool.execute("call-1", { path: filePath, content: "fresh content\n" }, undefined),
+    ).rejects.toThrow(WriteVerificationError);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("stale content\n");
   });
 
   it("writes file URL paths through the shared session path resolver", async () => {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -26,6 +26,7 @@ import {
   str,
 } from "./render-utils.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
+import { verifyWrittenContent, verifyWrittenStat } from "./write-verification.js";
 
 const writeSchema = Type.Object({
   path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
@@ -318,6 +319,24 @@ async function didWriteMetadataChange(
   return afterStat.size !== beforeStat.size || afterStat.mtimeMs !== beforeStat.mtimeMs;
 }
 
+async function verifyWriteResult(
+  absolutePath: string,
+  content: string,
+  ops: WriteOperations,
+): Promise<void> {
+  if (ops.statFile) {
+    const stat = await ops.statFile(absolutePath).catch(() => null);
+    verifyWrittenStat({ absolutePath, content, stat });
+  }
+
+  if (!ops.readFile) {
+    return;
+  }
+
+  const readback = await ops.readFile(absolutePath).catch(() => undefined);
+  verifyWrittenContent({ absolutePath, content, readback });
+}
+
 function isWriteRecoveryCandidate(error: unknown, signal: AbortSignal | undefined): boolean {
   if (signal?.aborted) {
     return true;
@@ -402,6 +421,7 @@ export function createWriteToolDefinition(
             throw new Error("Operation aborted");
           }
           await ops.writeFile(absolutePath, content);
+          await verifyWriteResult(absolutePath, content, ops);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }


### PR DESCRIPTION
## Summary
- fixes #67136 by verifying delegated write results before reporting success
- adds shared write verification for missing files, non-file paths, byte-size mismatches, and stale same-size content
- keeps edit recovery from converting write-verification failures into successful edit output

## Verification
- `docker run --rm -v /tmp/openclaw-67136:/work -w /work -e OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node:22-bookworm bash -lc 'corepack enable && pnpm test src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts src/agents/agent-tools.write-verification.test.ts src/agents/agent-tools.read.host-edit-access.test.ts'`
- `docker run --rm -v /tmp/openclaw-67136:/work -w /work -e OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node:22-bookworm bash -lc 'corepack enable && pnpm test src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts src/agents/agent-tools.write-verification.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/agent-tools.workspace-paths.test.ts src/agents/agent-tools.read.host-tilde-expansion.test.ts src/agents/agent-tools.read.host-edit-access.test.ts'`
- `docker run --rm -v /tmp/openclaw-67136:/work -w /work -e OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree ubuntu:24.04 bash -lc 'set -euo pipefail; apt-get update >/dev/null; DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl xz-utils >/dev/null; curl -fsSL https://nodejs.org/dist/v22.19.0/node-v22.19.0-linux-x64.tar.xz -o /tmp/node.tar.xz; tar -C /usr/local --strip-components=1 -xf /tmp/node.tar.xz; corepack enable; node --version; pnpm --version; pnpm test src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts'`
- `git diff --check`
- `docker run --rm -v /tmp/openclaw-67136:/work -w /work -e OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node:22-bookworm bash -lc 'corepack enable && pnpm exec oxfmt --check --threads=1 src/agents/agent-tools.read.ts src/agents/agent-tools.write-verification.ts src/agents/agent-tools.write-verification.test.ts src/agents/sessions/tools/write.ts src/agents/sessions/tools/write-verification.ts src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.ts src/agents/sessions/tools/edit.test.ts src/agents/agent-tools.read.host-edit-access.test.ts'`

## Real behavior proof
behavior:
The write tool could report a successful byte count after a delegated write resolved, even when the target file was not created or when stale same-size content remained.

environment:
OpenClaw branch `fix/write-tool-verified-success` at `199d0d56be5573e39ff96f87bf109561d4ec02bc`, rebased on current `main`. Focused proof ran in Docker `node:22-bookworm` and Ubuntu 24.04 with Node `v22.19.0`.

steps:
1. Reproduced the false-success class with a delegated write operation that resolves without creating the target file.
2. Added shared write-result verification for the session write tool and host/sandbox edit write adapters.
3. Added readback verification when readback is available, so same-size stale content cannot pass size-only verification.
4. Reran focused write/edit/verification regression tests plus adjacent agent-tools workspace/path coverage on the fixed branch.
5. Reran the direct write/edit proof in an Ubuntu 24.04 container with Node 22.19.

evidence:
Before the fix, the regression failed because the tool returned `Successfully wrote 16 bytes...` while the target file was missing.

After the fix, `src/agents/sessions/tools/write.test.ts`, `src/agents/sessions/tools/edit.test.ts`, `src/agents/agent-tools.write-verification.test.ts`, and `src/agents/agent-tools.read.host-edit-access.test.ts` passed with 15 tests. Adjacent agent-tools coverage passed with 51 tests. Ubuntu 24.04 + Node 22.19 proof also passed the direct write/edit lane with 11 tests.

observedResult:
Delegated writes now fail with `WriteVerificationError` when the file is missing, not a file, has the wrong byte size, or reads back different content. Edit recovery rethrows verification failures instead of reporting a recovered success.

notTested:
I did not replay the original DeepSeek webchat session because that requires the reporter's provider/session setup. The Ubuntu 24.04 source proof and focused adapter/session tests cover the write-tool false-success path.
