### PR TITLE
fix(telegram): avoid duplicate dm chat window context

### DIFF
--- a/extensions/telegram/src/bot-message-context.prompt-context.test.ts
+++ b/extensions/telegram/src/bot-message-context.prompt-context.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import type { TelegramPromptContextEntry } from "./bot-message-context.types.js";
+
+const telegramChatWindowContext: TelegramPromptContextEntry = {
+  label: "Conversation context",
+  source: "telegram",
+  type: "chat_window",
+  payload: {
+    order: "chronological",
+    relation: "selected_for_current_message",
+    messages: [
+      {
+        message_id: "10",
+        sender: "Pat",
+        timestamp_ms: 1_700_000_000_000,
+        body: "Earlier DM turn already in the transcript",
+      },
+    ],
+  },
+};
+
+describe("buildTelegramMessageContext prompt context", () => {
+  it("omits Telegram chat-window context for existing unthreaded private DM sessions", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "continue",
+      },
+      promptContext: [telegramChatWindowContext],
+      sessionRuntime: {
+        readSessionUpdatedAt: ({ sessionKey }) =>
+          sessionKey === "agent:main:main" ? 1_700_000_000_000 : undefined,
+      },
+    });
+
+    expect(ctx?.ctxPayload.SessionKey).toBe("agent:main:main");
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toBeUndefined();
+  });
+
+  it("keeps Telegram chat-window context for fresh private DM sessions", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "start",
+      },
+      promptContext: [telegramChatWindowContext],
+    });
+
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toEqual([telegramChatWindowContext]);
+  });
+
+  it("keeps Telegram chat-window context for existing private DM replies", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 1234, type: "private", first_name: "Pat" },
+        from: { id: 1234, first_name: "Pat" },
+        text: "replying with context",
+        reply_to_message: {
+          chat: { id: 1234, type: "private", first_name: "Pat" },
+          from: { id: 1234, first_name: "Pat" },
+          text: "older referenced turn",
+          date: 1_700_000_000,
+          message_id: 10,
+        },
+      },
+      promptContext: [telegramChatWindowContext],
+      sessionRuntime: {
+        readSessionUpdatedAt: ({ sessionKey }) =>
+          sessionKey === "agent:main:main" ? 1_700_000_000_000 : undefined,
+      },
+    });
+
+    expect(ctx?.ctxPayload.UntrustedStructuredContext).toEqual([telegramChatWindowContext]);
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -101,6 +101,10 @@ export async function resolveTelegramMessageContextStorePath(params: {
   });
 }
 
+function isTelegramChatWindowPromptContext(entry: TelegramPromptContextEntry): boolean {
+  return entry.source === "telegram" && entry.type === "chat_window";
+}
+
 function replyTargetToChainEntry(replyTarget: TelegramReplyTarget): TelegramReplyChainEntry {
   return {
     ...(replyTarget.id ? { messageId: replyTarget.id } : {}),
@@ -361,6 +365,17 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: route.sessionKey,
   });
+  const shouldSuppressPersistedDmChatWindowContext =
+    !isGroup &&
+    previousTimestamp !== undefined &&
+    dmThreadId == null &&
+    visibleReplyChain.length === 0 &&
+    !visibleReplyTarget;
+  // Existing plain DMs already carry their history through the persistent
+  // transcript. Keep chat windows for fresh DMs, topics, replies, and groups.
+  const visiblePromptContext = shouldSuppressPersistedDmChatWindowContext
+    ? promptContext.filter((entry) => !isTelegramChatWindowPromptContext(entry))
+    : promptContext;
   const body = formatInboundEnvelope({
     channel: "Telegram",
     from: conversationLabel,
@@ -530,7 +545,7 @@ export async function buildTelegramInboundContextPayload(params: {
           }
         : undefined,
       groupSystemPrompt: isGroup || (!isGroup && groupConfig) ? groupSystemPrompt : undefined,
-      untrustedContext: promptContext.length > 0 ? promptContext : undefined,
+      untrustedContext: visiblePromptContext.length > 0 ? visiblePromptContext : undefined,
     },
     contextVisibility: contextVisibilityMode,
     extra: {

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -22,6 +22,7 @@ type BuildTelegramMessageContextForTestParams = {
   message: Record<string, unknown>;
   me?: Record<string, unknown>;
   allMedia?: TelegramMediaRef[];
+  promptContext?: BuildTelegramMessageContextParams["promptContext"];
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
@@ -111,6 +112,7 @@ export async function buildTelegramMessageContextForTest(
       me: { id: 7, username: "bot", ...params.me },
     } as never,
     allMedia: params.allMedia ?? [],
+    promptContext: params.promptContext ?? [],
     storeAllowFrom: [],
     options: params.options ?? {},
     bot: {


### PR DESCRIPTION
## Summary

Telegram private DMs already route into a persistent OpenClaw session transcript, but the inbound prompt also injected the recent Telegram `chat_window` context on every plain DM turn. That duplicated prior messages inside each new user message and increased token usage for ongoing DM conversations.

This patch filters Telegram `chat_window` prompt context only for existing unthreaded private DM sessions. Fresh DMs still receive the bootstrap chat window, and replies/topics/groups keep their contextual windows because those surfaces need explicit surrounding context.

Fixes #87566.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Existing Telegram private DM sessions no longer duplicate recent Telegram chat-window context when the persistent OpenClaw transcript already contains the prior conversation.
- Real environment tested: Local macOS OpenClaw checkout rebased on current `openclaw/openclaw` `main`, Node 22, running the current Telegram inbound message-context construction path from this branch.
- Exact steps or command run after this patch: `NO_COLOR=1 node --import tsx --input-type=module -` from the repo root. The command built one existing private DM turn and one fresh private DM turn with the same Telegram `chat_window` prompt-context entry, then counted the `source=telegram,type=chat_window` entries present in the emitted inbound context payload.
- Evidence after fix: Copied terminal output from the local OpenClaw runtime command:
  ```text
  existing DM sessionKey: agent:main:main
  existing DM chat_window context count: 0
  fresh DM sessionKey: agent:main:main
  fresh DM chat_window context count: 1
  ```
- Observed result after fix: The existing persistent private DM turn emits zero Telegram chat-window prompt-context entries, while the fresh private DM turn still emits one chat-window entry.
- What was not tested: A live Telegram Bot API roundtrip was not run from this machine.
- Proof limitations or environment constraints: No live Telegram bot credentials are available in this checkout; the copied output above is from the local OpenClaw runtime path that constructs Telegram inbound context payloads before dispatch.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.prompt-context.test.ts --reporter=dot` -> 1 file / 3 tests passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts --reporter=dot` -> 2 files / 18 tests passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts --reporter=dot -t "adds live chat and reply-target windows"` -> 1 passed / 74 skipped.
- `npx oxfmt --check extensions/telegram/src/bot-message-context.session.ts extensions/telegram/src/bot-message-context.test-harness.ts extensions/telegram/src/bot-message-context.prompt-context.test.ts` -> clean.
- `node scripts/run-oxlint.mjs extensions/telegram/src/bot-message-context.session.ts extensions/telegram/src/bot-message-context.test-harness.ts extensions/telegram/src/bot-message-context.prompt-context.test.ts` -> exit 0.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` -> exit 0.
- `git diff --check` -> exit 0.

## Risk

The filter is deliberately narrow: it only removes `source: "telegram"` + `type: "chat_window"` entries when the route is an existing unthreaded private DM without a visible reply target or reply chain. Group chats, topics, reply-context turns, and fresh DMs keep the existing context behavior.

