### PR TITLE
fix(plugins): guard runtime lifecycle cleanup metadata

### DIFF
--- a/src/plugins/host-hook-cleanup.config.test.ts
+++ b/src/plugins/host-hook-cleanup.config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runPluginHostCleanup } from "./host-hook-cleanup.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRuntimeLifecycleRegistryRegistration } from "./registry-types.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(),
@@ -56,5 +57,88 @@ describe("plugin host cleanup config fallback", () => {
         hookId: "session-store",
       },
     ]);
+  });
+
+  it("records unreadable runtime lifecycle metadata while continuing cleanup", async () => {
+    const registry = createEmptyPluginRegistry();
+    const cleanup = vi.fn();
+    const staleLifecycle = {
+      pluginId: "cleanup-plugin",
+      pluginName: "Cleanup Plugin",
+      source: "test",
+    } as PluginRuntimeLifecycleRegistryRegistration;
+    Object.defineProperty(staleLifecycle, "lifecycle", {
+      get() {
+        throw new Error("plugin runtime lifecycle metadata getter exploded");
+      },
+    });
+    registry.runtimeLifecycles = [
+      staleLifecycle,
+      {
+        pluginId: "cleanup-plugin",
+        pluginName: "Cleanup Plugin",
+        source: "test",
+        lifecycle: {
+          id: "runtime-cleanup",
+          cleanup,
+        },
+      },
+    ];
+
+    const result = await runPluginHostCleanup({
+      registry,
+      pluginId: "cleanup-plugin",
+      reason: "disable",
+      sessionStorePaths: [],
+    });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(result.cleanupCount).toBe(1);
+    expect(result.failures).toEqual([
+      {
+        error: expect.objectContaining({
+          message: "plugin runtime lifecycle metadata getter exploded",
+        }),
+        pluginId: "cleanup-plugin",
+        hookId: "runtime:<unreadable>",
+      },
+    ]);
+  });
+
+  it("ignores unreadable runtime lifecycle metadata outside targeted cleanup", async () => {
+    const registry = createEmptyPluginRegistry();
+    const cleanup = vi.fn();
+    const staleLifecycle = {
+      pluginId: "other-plugin",
+      pluginName: "Other Plugin",
+      source: "test",
+    } as PluginRuntimeLifecycleRegistryRegistration;
+    Object.defineProperty(staleLifecycle, "lifecycle", {
+      get() {
+        throw new Error("other plugin runtime lifecycle metadata getter exploded");
+      },
+    });
+    registry.runtimeLifecycles = [
+      staleLifecycle,
+      {
+        pluginId: "cleanup-plugin",
+        pluginName: "Cleanup Plugin",
+        source: "test",
+        lifecycle: {
+          id: "runtime-cleanup",
+          cleanup,
+        },
+      },
+    ];
+
+    const result = await runPluginHostCleanup({
+      registry,
+      pluginId: "cleanup-plugin",
+      reason: "disable",
+      sessionStorePaths: [],
+    });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(result).toEqual({ cleanupCount: 1, failures: [] });
   });
 });

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -12,7 +12,10 @@ import {
   makePluginSessionSchedulerJobKey,
 } from "./host-hook-runtime.js";
 import type { PluginHostCleanupReason } from "./host-hooks.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type {
+  PluginRegistry,
+  PluginRuntimeLifecycleRegistryRegistration,
+} from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 import { normalizeSessionEntrySlotKey } from "./session-entry-slot-keys.js";
 
@@ -29,8 +32,49 @@ export type PluginHostCleanupResult = {
 
 type ResolveCleanupSessionStorePaths = () => readonly string[];
 
+type RuntimeLifecycleCleanup = NonNullable<
+  PluginRuntimeLifecycleRegistryRegistration["lifecycle"]["cleanup"]
+>;
+
+type RuntimeLifecycleCleanupRecord =
+  | {
+      ok: true;
+      pluginId: string;
+      hookId: string;
+      cleanup?: RuntimeLifecycleCleanup;
+    }
+  | {
+      ok: false;
+      pluginId: string;
+      hookId: string;
+      error: unknown;
+    };
+
 function shouldCleanPlugin(pluginId: string, filterPluginId?: string): boolean {
   return !filterPluginId || pluginId === filterPluginId;
+}
+
+function readRuntimeLifecycleCleanupRecord(
+  registration: PluginRuntimeLifecycleRegistryRegistration,
+): RuntimeLifecycleCleanupRecord {
+  let pluginId = "plugin-host";
+  try {
+    pluginId = registration.pluginId;
+    const lifecycle = registration.lifecycle;
+    return {
+      ok: true,
+      pluginId,
+      hookId: `runtime:${lifecycle.id}`,
+      cleanup: lifecycle.cleanup,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      pluginId,
+      hookId: "runtime:<unreadable>",
+      error,
+    };
+  }
 }
 
 function collectStoredSessionEntrySlotKeys(entry: SessionEntry, pluginId?: string): Set<string> {
@@ -428,16 +472,24 @@ export async function runPluginHostCleanup(params: {
       if (!shouldCleanup()) {
         return { cleanupCount, failures };
       }
-      if (!shouldCleanPlugin(registration.pluginId, params.pluginId)) {
+      const record = readRuntimeLifecycleCleanupRecord(registration);
+      if (!shouldCleanPlugin(record.pluginId, params.pluginId)) {
         continue;
       }
-      const cleanup = registration.lifecycle.cleanup;
+      if (!record.ok) {
+        failures.push({
+          pluginId: record.pluginId,
+          hookId: record.hookId,
+          error: record.error,
+        });
+        continue;
+      }
+      const cleanup = record.cleanup;
       if (!cleanup) {
         continue;
       }
-      const hookId = `runtime:${registration.lifecycle.id}`;
       try {
-        await withPluginHostCleanupTimeout(hookId, () =>
+        await withPluginHostCleanupTimeout(record.hookId, () =>
           cleanup({
             reason: params.reason,
             sessionKey: params.sessionKey,
@@ -447,8 +499,8 @@ export async function runPluginHostCleanup(params: {
         cleanupCount += 1;
       } catch (error) {
         failures.push({
-          pluginId: registration.pluginId,
-          hookId,
+          pluginId: record.pluginId,
+          hookId: record.hookId,
           error,
         });
       }


### PR DESCRIPTION
## Summary

- Guard plugin runtime lifecycle cleanup metadata reads so a stale/unreadable registration is reported as a cleanup failure instead of crashing cleanup.
- Preserve targeted cleanup filtering so unrelated stale lifecycle rows are ignored when cleaning a specific plugin.
- Add regressions for both targeted unreadable metadata and unrelated unreadable metadata during targeted cleanup.

## Verification

- Red repro: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next103-red node_modules/.bin/vitest run src/plugins/host-hook-cleanup.config.test.ts -t "records unreadable runtime lifecycle metadata while continuing cleanup" --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=verbose` failed pre-patch with `plugin runtime lifecycle metadata getter exploded`.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next103-rebase-full node_modules/.bin/vitest run src/plugins/host-hook-cleanup.config.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=dot` passed: 1 file, 3 tests.
- `node_modules/.bin/oxfmt --check src/plugins/host-hook-cleanup.ts src/plugins/host-hook-cleanup.config.test.ts` passed.
- `node_modules/.bin/oxlint src/plugins/host-hook-cleanup.ts src/plugins/host-hook-cleanup.config.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings, overall `patch is correct (0.86)`.
- `blacksmith testbox list --all` blocked: not authenticated.
- `nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` blocked before lease creation with coordinator `401 unauthorized`.
- `.agents/skills/agent-transcript/scripts/agent-transcript find` returned `[]`.

## Real behavior proof

Behavior addressed: stale or malformed plugin runtime lifecycle cleanup metadata no longer crashes `runPluginHostCleanup` before later healthy cleanup hooks run.

Real environment tested: local Codex worktree on Node/Vitest with the plugin cleanup test file selected by the touched surface; Testbox and Crabbox broad gates were attempted but blocked by auth.

Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next103-rebase-full node_modules/.bin/vitest run src/plugins/host-hook-cleanup.config.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1 --reporter=dot`.

Evidence after fix: the post-rebase touched test command passed 1 file and 3 tests; the focused red repro failed before the implementation with `plugin runtime lifecycle metadata getter exploded`.

Observed result after fix: targeted unreadable lifecycle metadata is recorded as a cleanup failure, healthy cleanup hooks still execute, and unreadable lifecycle metadata for unrelated plugins is ignored during targeted cleanup.

What was not tested: `pnpm check:changed` did not run because Blacksmith Testbox was unauthenticated and the AWS Crabbox coordinator returned `401 unauthorized` before lease creation.
