### PR TITLE
fix(media): guard hosted resolver failure logging

### DIFF
--- a/src/media/web-media.hosted-resolvers.test.ts
+++ b/src/media/web-media.hosted-resolvers.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { setVerbose } from "../globals.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { loadWebMedia } from "./web-media.js";
+
+describe("hosted media resolvers", () => {
+  afterEach(() => {
+    setVerbose(false);
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("keeps trying hosted media resolvers when verbose failure logging cannot read plugin id", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hosted-media-"));
+    try {
+      const pngFile = path.join(fixtureRoot, "tiny.png");
+      await fs.writeFile(pngFile, createSolidPngBuffer(1, 1, { r: 255, g: 255, b: 255 }));
+      const registry = createEmptyPluginRegistry();
+      registry.hostedMediaResolvers = [
+        {
+          get pluginId() {
+            throw new Error("plugin id unavailable");
+          },
+          resolver: () => {
+            throw new Error("resolver failed");
+          },
+          source: "test",
+        },
+        {
+          pluginId: "fallback",
+          resolver: (mediaUrl) => (mediaUrl === "/__openclaw__/fallback/tiny.png" ? pngFile : null),
+          source: "test",
+        },
+      ];
+      setActivePluginRegistry(registry);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      setVerbose(true);
+
+      try {
+        const result = await loadWebMedia("/__openclaw__/fallback/tiny.png", {
+          maxBytes: 1024 * 1024,
+          localRoots: [fixtureRoot],
+        });
+
+        expect(result.kind).toBe("image");
+        expect(result.buffer.length).toBeGreaterThan(0);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -105,12 +105,24 @@ async function resolveHostedPluginMediaUrl(mediaUrl: string): Promise<string | n
     } catch (err) {
       if (shouldLogVerbose()) {
         logVerbose(
-          `Hosted media resolver failed (${entry.pluginId ?? "unknown"}): ${formatErrorMessage(err)}`,
+          `Hosted media resolver failed (${hostedMediaResolverPluginIdForLog(entry)}): ${formatErrorMessage(err)}`,
         );
       }
     }
   }
   return null;
+}
+
+function hostedMediaResolverPluginIdForLog(entry: unknown): string {
+  if (!entry || typeof entry !== "object") {
+    return "unknown";
+  }
+  try {
+    const pluginId = (entry as { pluginId?: unknown }).pluginId;
+    return typeof pluginId === "string" && pluginId.trim() ? pluginId : "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 function resolveWebMediaOptions(params: {


### PR DESCRIPTION
## Summary

- Guard hosted plugin media resolver failure logging so an unreadable `pluginId`
  accessor falls back to `unknown` instead of escaping the resolver catch path.
- Add regression coverage for poisoned failed-resolver metadata followed by a
  healthy fallback resolver.

## Verification

- `node --import tsx -e '<hosted media resolver runtime repro>'`: pre-patch
  failed with `Error: plugin id unavailable`; post-fix passed with
  `Hosted media resolver failed (unknown): resolver failed` and `pass`.
- `node_modules/.bin/oxfmt --check src/media/web-media.ts src/media/web-media.hosted-resolvers.test.ts`: passed.
- `node_modules/.bin/oxlint src/media/web-media.ts src/media/web-media.hosted-resolvers.test.ts`: passed.
- `git diff --check`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings, `overall: patch is correct (0.9)`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings, `overall: patch is correct (0.9)`.

## Real behavior proof

Behavior addressed: hosted media resolution no longer crashes when verbose
failure logging cannot read a failed resolver's `pluginId`; later healthy hosted
media resolvers still run.

Real environment tested: local linked OpenClaw worktree on macOS with Node via
`node --import tsx`. Testbox and Crabbox broad gates were unavailable due auth.

Exact steps or command run after this patch:

```bash
node --import tsx -e '<runtime repro that installs a poisoned hosted media resolver, then a healthy fallback resolver, and calls loadWebMedia("/__openclaw__/fallback/tiny.png") with explicit localRoots>'
node_modules/.bin/oxfmt --check src/media/web-media.ts src/media/web-media.hosted-resolvers.test.ts
node_modules/.bin/oxlint src/media/web-media.ts src/media/web-media.hosted-resolvers.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
blacksmith testbox list --all
nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"
.agents/skills/agent-transcript/scripts/agent-transcript find
```

Evidence after fix:

```text
Hosted media resolver failed (unknown): resolver failed
pass
```

Observed result after fix: the failed resolver is contained, verbose logging uses
`unknown`, and the fallback resolver loads an image result.

What was not tested: `pnpm check:changed` did not run because Blacksmith Testbox
reported unauthenticated and the AWS Crabbox coordinator returned `401
unauthorized` before lease creation. Direct Vitest for
`src/media/web-media.hosted-resolvers.test.ts` remained transform-bound in this
linked worktree and was stopped after it never reached test execution.
