### PR TITLE
fix(channels): guard package-state failure logging

### DIFF
--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -169,6 +169,38 @@ describe("channel package-state probes", () => {
     ).toBe(true);
   });
 
+  it("treats unreadable package-state load failure metadata as nonblocking", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-load-failure-"));
+    tempDirs.push(root);
+    const sourceRoot = path.join(root, "extensions", "broken");
+    fs.mkdirSync(sourceRoot, { recursive: true });
+
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        get pluginId() {
+          throw new Error("package-state plugin id getter exploded");
+        },
+        origin: "bundled",
+        rootDir: sourceRoot,
+        channel: {
+          id: "broken",
+          persistedAuthState: {
+            specifier: "./missing-auth-presence",
+            exportName: "hasAnyBrokenAuth",
+          },
+        },
+      } satisfies PluginChannelCatalogEntry,
+    ]);
+
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "persistedAuthState",
+        channelId: "broken",
+        cfg: {},
+      }),
+    ).toBe(false);
+  });
+
   it("preserves source overlay precedence over packaged package-state probes", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-overlay-"));
     tempDirs.push(root);

--- a/src/channels/plugins/package-state-probes.ts
+++ b/src/channels/plugins/package-state-probes.ts
@@ -218,10 +218,19 @@ function resolveChannelPackageStateChecker(params: {
   if (loadError) {
     const detail = formatErrorMessage(loadError);
     log.warn(
-      `[channels] failed to load ${params.metadataKey} checker for ${params.entry.pluginId}: ${detail}`,
+      `[channels] failed to load ${params.metadataKey} checker for ${channelPackageStatePluginIdForLog(params.entry)}: ${detail}`,
     );
   }
   return null;
+}
+
+function channelPackageStatePluginIdForLog(entry: PluginChannelCatalogEntry): string {
+  try {
+    const pluginId = entry.pluginId;
+    return typeof pluginId === "string" && pluginId.trim() ? pluginId : "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 function resolvePackageStateChannelId(entry: PluginChannelCatalogEntry): string | undefined {


### PR DESCRIPTION
## Summary

- Guard channel package-state probe load-failure logging so an unreadable
  catalog `pluginId` accessor falls back to `unknown`.
- Add a regression for a stale package-state catalog entry whose checker cannot
  load and whose `pluginId` getter throws.

## Verification

- `node --import tsx -e "await import('./src/channels/plugins/package-state-probes.ts'); console.log('import ok')"`: passed.
- `node_modules/.bin/oxfmt --check src/channels/plugins/package-state-probes.ts src/channels/plugins/package-state-probes.test.ts`: passed.
- `node_modules/.bin/oxlint src/channels/plugins/package-state-probes.ts src/channels/plugins/package-state-probes.test.ts`: passed.
- `git diff --check origin/main..HEAD`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings, `overall: patch is correct (0.9)`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings, `overall: patch is correct (0.88)`.

## Real behavior proof

Behavior addressed: package-state probe load failures remain nonblocking even
when stale catalog metadata cannot provide a readable plugin id for the warning.

Real environment tested: local linked OpenClaw worktree on macOS with Node via
`node --import tsx`. Testbox and Crabbox broad gates were unavailable due auth.

Exact steps or command run after this patch:

```bash
node --import tsx -e "await import('./src/channels/plugins/package-state-probes.ts'); console.log('import ok')"
node_modules/.bin/oxfmt --check src/channels/plugins/package-state-probes.ts src/channels/plugins/package-state-probes.test.ts
node_modules/.bin/oxlint src/channels/plugins/package-state-probes.ts src/channels/plugins/package-state-probes.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode local
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
blacksmith testbox list --all
nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"
.agents/skills/agent-transcript/scripts/agent-transcript find
```

Evidence after fix:

```text
import ok
```

Observed result after fix: the touched package-state probe module imports
cleanly, static hygiene passes, and autoreview found no actionable issue in the
guarded failure-log path or regression coverage.

What was not tested: `pnpm check:changed` did not run because Blacksmith Testbox
reported unauthenticated and the AWS Crabbox coordinator returned `401
unauthorized` before lease creation. Local focused Vitest for
`src/channels/plugins/package-state-probes.test.ts` remained transform-bound in
this linked worktree and was stopped before test execution; the regression is
checked in for CI.
