### PR TITLE
fix(channels): guard startup maintenance metadata

### DIFF
--- a/src/channels/plugins/lifecycle-startup.test.ts
+++ b/src/channels/plugins/lifecycle-startup.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listChannelPlugins: vi.fn(),
+}));
+
+vi.mock("./registry.js", () => ({
+  listChannelPlugins: mocks.listChannelPlugins,
+}));
+
+import { runChannelPluginStartupMaintenance } from "./lifecycle-startup.js";
+
+describe("runChannelPluginStartupMaintenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("continues startup maintenance after unreadable channel plugin lifecycle metadata", async () => {
+    const warn = vi.fn();
+    const healthyMaintenance = vi.fn();
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "broken-channel",
+        get lifecycle() {
+          throw new Error("channel lifecycle getter exploded");
+        },
+      },
+      {
+        id: "healthy-channel",
+        lifecycle: {
+          runStartupMaintenance: healthyMaintenance,
+        },
+      },
+    ]);
+
+    await runChannelPluginStartupMaintenance({
+      cfg: {},
+      log: { warn },
+    });
+
+    expect(healthyMaintenance).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "gateway: broken-channel startup maintenance failed; continuing: Error: channel lifecycle getter exploded",
+    );
+  });
+
+  it("keeps startup maintenance failure logging best-effort when plugin id is unreadable", async () => {
+    const warn = vi.fn();
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        get id() {
+          throw new Error("channel id getter exploded");
+        },
+        lifecycle: {
+          runStartupMaintenance: () => {
+            throw new Error("startup maintenance exploded");
+          },
+        },
+      },
+    ]);
+
+    await runChannelPluginStartupMaintenance({
+      cfg: {},
+      log: { warn },
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "gateway: unknown startup maintenance failed; continuing: Error: startup maintenance exploded",
+    );
+  });
+});

--- a/src/channels/plugins/lifecycle-startup.ts
+++ b/src/channels/plugins/lifecycle-startup.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listChannelPlugins } from "./registry.js";
+import type { ChannelPlugin } from "./types.plugin.js";
 
 type ChannelStartupLogger = {
   info?: (message: string) => void;
@@ -14,16 +15,45 @@ export async function runChannelPluginStartupMaintenance(params: {
   logPrefix?: string;
 }): Promise<void> {
   for (const plugin of listChannelPlugins()) {
-    const runStartupMaintenance = plugin.lifecycle?.runStartupMaintenance;
+    const pluginId = channelStartupPluginIdForLog(plugin);
+    let runStartupMaintenance:
+      | NonNullable<ChannelPlugin["lifecycle"]>["runStartupMaintenance"]
+      | undefined;
+    try {
+      runStartupMaintenance = plugin.lifecycle?.runStartupMaintenance;
+    } catch (err) {
+      warnChannelStartupMaintenanceFailure(params, pluginId, err);
+      continue;
+    }
     if (!runStartupMaintenance) {
       continue;
     }
     try {
       await runStartupMaintenance(params);
     } catch (err) {
-      params.log.warn?.(
-        `${params.logPrefix?.trim() || "gateway"}: ${plugin.id} startup maintenance failed; continuing: ${String(err)}`,
-      );
+      warnChannelStartupMaintenanceFailure(params, pluginId, err);
     }
+  }
+}
+
+function warnChannelStartupMaintenanceFailure(
+  params: {
+    log: ChannelStartupLogger;
+    logPrefix?: string;
+  },
+  pluginId: string,
+  err: unknown,
+): void {
+  params.log.warn?.(
+    `${params.logPrefix?.trim() || "gateway"}: ${pluginId} startup maintenance failed; continuing: ${String(err)}`,
+  );
+}
+
+function channelStartupPluginIdForLog(plugin: ChannelPlugin): string {
+  try {
+    const pluginId = plugin.id;
+    return typeof pluginId === "string" && pluginId.trim() ? pluginId : "unknown";
+  } catch {
+    return "unknown";
   }
 }


### PR DESCRIPTION
## Summary

- guard channel plugin startup maintenance against unreadable `lifecycle` metadata so one malformed channel cannot stop later startup maintenance hooks
- keep startup maintenance warning logs best-effort when a plugin `id` getter is unreadable
- add regression coverage for both malformed metadata paths

## Verification

- direct red repro before the patch: a channel plugin with a throwing `lifecycle` getter aborted `runChannelPluginStartupMaintenance` before a later healthy plugin could run
- `node --import tsx -e "await import('./src/channels/plugins/lifecycle-startup.ts'); console.log('import ok')"`
- direct green runtime repro with `pinActivePluginChannelRegistry`: malformed first channel warned, healthy second channel ran, output `pass`
- `node_modules/.bin/oxfmt --check src/channels/plugins/lifecycle-startup.ts src/channels/plugins/lifecycle-startup.test.ts`
- `node_modules/.bin/oxlint src/channels/plugins/lifecycle-startup.ts src/channels/plugins/lifecycle-startup.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings
- `.agents/skills/agent-transcript/scripts/agent-transcript find` returned `[]`

## Real behavior proof

Behavior addressed: malformed channel plugin startup metadata no longer aborts startup maintenance for later healthy channel plugins.

Real environment tested: local linked Codex worktree with repo symlinked dependencies; direct runtime repro exercised the real channel registry pinning path and `runChannelPluginStartupMaintenance`.

Exact steps or command run after this patch: import smoke, direct green runtime repro, `oxfmt --check`, `oxlint`, `git diff --check origin/main..HEAD`, local autoreview, branch autoreview, transcript scan.

Evidence after fix: direct runtime repro printed `pass`; formatter, linter, diff check, and both autoreview runs exited cleanly.

Observed result after fix: a throwing `lifecycle` getter logs `gateway: broken-channel startup maintenance failed; continuing: Error: channel lifecycle getter exploded`, then the healthy channel startup maintenance hook still runs.

What was not tested: focused Vitest remained transform-bound in this linked worktree and was stopped before execution; the regression file is checked in for CI. Broad remote `pnpm check:changed` was blocked because Blacksmith Testbox is unauthenticated locally and AWS Crabbox coordinator returned HTTP 401 before lease creation.
