### PR TITLE
fix(agents): detect unsigned thinking-only stall when reasoning payload inflates payloadCount

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1519,6 +1519,63 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toBeNull();
   });
 
+  it("surfaces stall on clean stop with only an unsigned thinking payload (payloadCount=1, no visible text)", () => {
+    // Regression: unsigned thinking payloads increment payloadCount but carry no
+    // user-visible content. The visible-text guard must not suppress incomplete-turn
+    // detection when the model produced only a thinking block and no answer. (#89787)
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "qwen3.6-35b-a3b",
+          content: [
+            {
+              type: "thinking",
+              thinking: "let me plan the tool calls I need to make...",
+              // no signature — unsigned thinking block
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
+  it("does not surface a stall when unsigned thinking accompanies visible text (payloadCount=1)", () => {
+    // When the model emits both a thinking block and a visible text answer, the turn
+    // succeeded and no stall should be surfaced even though thinking is unsigned.
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 1,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Here is the answer to your question."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "qwen3.6-35b-a3b",
+          content: [
+            {
+              type: "thinking",
+              thinking: "let me answer this...",
+            },
+            { type: "text", text: "Here is the answer to your question." },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
   it("surfaces an error for tool-use terminal turn with pre-tool text via runEmbeddedAgent (#76477)", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -1678,6 +1735,59 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
               type: "thinking",
               thinking: "internal reasoning",
               thinkingSignature: JSON.stringify({ id: "ollama_rs_helper", type: "reasoning" }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("retries unsigned thinking-only turns via the reasoning-only path (openai-completions)", () => {
+    const retryInstruction = resolveReasoningOnlyRetryInstruction({
+      provider: "openai",
+      modelId: "qwen3.6-35b-a3b",
+      modelApi: "openai-completions",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "qwen3.6-35b-a3b",
+          content: [
+            {
+              type: "thinking",
+              thinking: "let me plan the tool calls I need to make...",
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("retries unsigned thinking-only Ollama turns via the reasoning-only path", () => {
+    const retryInstruction = resolveReasoningOnlyRetryInstruction({
+      provider: "ollama",
+      modelId: "gemma4:31b",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "ollama",
+          model: "gemma4:31b",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
             },
           ],
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -266,9 +266,17 @@ export function resolveIncompleteTurnPayloadText(params: {
   // turn check in that case — the final post-tool response was never
   // produced. (#76477)
   const toolUseTerminal = params.attempt.lastAssistant?.stopReason === "toolUse";
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  // Unsigned thinking payloads count toward payloadCount but carry no user-visible
+  // content; bypass the visible-text guard when unsigned thinking was the only output
+  // so that incomplete-turn stall detection fires below. (#89787)
+  const unsignedThinkingOnlyTerminal =
+    params.payloadCount !== 0 &&
+    !joinAssistantTexts(params.attempt.assistantTexts).length &&
+    isUnsignedThinkingOnlyAssistantTurn(assistant);
 
   if (
-    (params.payloadCount !== 0 && !toolUseTerminal) ||
+    (params.payloadCount !== 0 && !toolUseTerminal && !unsignedThinkingOnlyTerminal) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -300,9 +308,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     hasAssistantVisibleText: params.payloadCount > 0,
     lastAssistant: params.attempt.lastAssistant,
   });
-  const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(
-    params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant,
-  );
+  const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
   const emptyResponseAssistant = isEmptyResponseAssistantTurn({
     payloadCount: params.payloadCount,
     attempt: params.attempt,
@@ -310,6 +316,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   if (
     !incompleteTerminalAssistant &&
     !reasoningOnlyAssistant &&
+    !unsignedThinkingOnlyTerminal &&
     !emptyResponseAssistant &&
     stopReason !== "error"
   ) {
@@ -508,6 +515,20 @@ function isReasoningOnlyAssistantTurn(message: unknown): boolean {
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-text";
 }
 
+// Unsigned thinking blocks have no cryptographic signature; assessLastAssistantMessage
+// returns "incomplete-thinking" for them. Empty content also returns "incomplete-thinking",
+// so the content.length > 0 guard is required to distinguish the two cases.
+function isUnsignedThinkingOnlyAssistantTurn(message: unknown): boolean {
+  if (message == null || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return false;
+  }
+  return assessLastAssistantMessage(message as AgentMessage) === "incomplete-thinking";
+}
+
 function isEmptyResponseAssistantTurn(params: {
   payloadCount: number;
   attempt: Pick<
@@ -638,7 +659,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   if (assistant?.stopReason === "error") {
     return null;
   }
-  if (!isReasoningOnlyAssistantTurn(assistant)) {
+  if (!isReasoningOnlyAssistantTurn(assistant) && !isUnsignedThinkingOnlyAssistantTurn(assistant)) {
     return null;
   }
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89787 reports that when a local model (e.g. Qwen3.6-35B via llama.cpp) produces `stopReason="stop"` with only an unsigned thinking block and no visible text, the session stalls indefinitely with no error and no recovery path. The reporter observed 3 independent occurrences over a 55-turn session; stalls resolved only via user intervention (~64 s), auto-compaction (~191 s), or never.
- **Root Cause**: `buildEmbeddedRunPayloads` extracts unsigned thinking text and pushes it into `replyItems` as `{ isReasoning: true }`, making `payloadCount = 1`. Two recovery functions fail to handle this case. (1) `resolveIncompleteTurnPayloadText` has an early-return guard `payloadCount !== 0 && !toolUseTerminal` that returns `null` before any stall detector runs — `isReasoningOnlyAssistantTurn` only covers signed thinking (`"incomplete-text"`), and `isEmptyResponseAssistantTurn` short-circuits on `payloadCount !== 0` — so the session is left with `livenessState="working"` and no recovery. (2) `resolveReasoningOnlyRetryInstruction` also returns `null` because its final check `!isReasoningOnlyAssistantTurn(assistant)` only matches signed thinking, so no retry fires before falling through to the stall. The root of both failures is that `assessLastAssistantMessage` returns `"incomplete-thinking"` for unsigned thinking blocks, but neither function tested for that assessment. A content-length guard is additionally required because `assessLastAssistantMessage` returns `"incomplete-thinking"` for empty content arrays too — distinguishing the two cases is load-bearing.
- **Fix**: Extract `isUnsignedThinkingOnlyAssistantTurn` (non-empty content array + `assessLastAssistantMessage === "incomplete-thinking"`) and wire it into two places.
  - `resolveIncompleteTurnPayloadText`: add `!isUnsignedThinkingOnlyAssistantTurn(assistant)` to the early-return guard so thinking-only payloads no longer suppress stall detection; add it to the downstream null-return check so the incomplete-turn error is surfaced.
  - `resolveReasoningOnlyRetryInstruction`: extend the final check to `!isReasoningOnlyAssistantTurn(assistant) && !isUnsignedThinkingOnlyAssistantTurn(assistant)` so unsigned thinking-only turns trigger `REASONING_ONLY_RETRY_INSTRUCTION` (up to `DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2` retries) before the stall error is surfaced.
- **What changed**:
  - `src/agents/embedded-agent-runner/run/incomplete-turn.ts` — add `isUnsignedThinkingOnlyAssistantTurn` file-local helper; update `resolveIncompleteTurnPayloadText` early-return guard and downstream check; update `resolveReasoningOnlyRetryInstruction` final assistant check; simplify `unsignedThinkingOnlyTerminal` expression to use helper.
  - `src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 4 new tests: stall detection for unsigned thinking payload (`payloadCount=1`), negative case (visible text with unsigned thinking stays null), reasoning-only retry fires for unsigned thinking on openai-completions, reasoning-only retry fires for unsigned Ollama thinking.
- **What did NOT change (scope boundary)**:
  - `isReasoningOnlyAssistantTurn` is unchanged — extending it to include `"incomplete-thinking"` would break `isEmptyResponseAssistantTurn`'s exclusion guard (used when `payloadCount=0`) and change the Ollama empty-response retry path.
  - `resolveEmptyResponseRetryInstruction` and `isEmptyResponseAssistantTurn` are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Configure an embedded agent with an openai-completions provider (e.g. local llama.cpp serving Qwen3 with `reasoningLevel: "on"`).
2. Run a multi-turn tool-heavy session until context pressure increases toward the overflow threshold.
3. Model emits `stopReason="stop"` with only an unsigned thinking block — no structured `toolCall`, no visible text. `buildEmbeddedRunPayloads` extracts the thinking text as `{ isReasoning: true }`, so `payloadCount = 1`.
4. **Before this PR**: `resolveReasoningOnlyRetryInstruction` returns `null`; `resolveIncompleteTurnPayloadText` hits `payloadCount !== 0 && !toolUseTerminal` and returns `null`; session stays `livenessState="working"` with no further API calls, no logs, and no user-visible error — permanent stall.
5. **After this PR**: `resolveReasoningOnlyRetryInstruction` returns `REASONING_ONLY_RETRY_INSTRUCTION` and the run loop retries up to 2 times; if retries fail, `resolveIncompleteTurnPayloadText` surfaces `"⚠️ Agent couldn't generate a response. Please try again."` and the session transitions to `livenessState="abandoned"`.

### Real behavior proof

**Behavior addressed (#89787)**: after this patch, `resolveIncompleteTurnPayloadText({ payloadCount: 1, assistantTexts: [], lastAssistant: { stopReason: "stop", content: [{ type: "thinking", thinking: "..." }] } })` returns the incomplete-turn error string instead of `null`; `resolveReasoningOnlyRetryInstruction` returns `REASONING_ONLY_RETRY_INSTRUCTION` for the same turn on openai-completions and Ollama providers.

**Real environment tested (Ubuntu Server Node 24, source-level — Vitest against production `resolveIncompleteTurnPayloadText` and `resolveReasoningOnlyRetryInstruction`)**: focused unit tests driving the exact production functions against the reported message shape (unsigned thinking block, `stopReason="stop"`, `payloadCount=1`, empty `assistantTexts`). Reporter's session log confirms the path: `stopReason="stop"`, thinking-only, 3 occurrences in 55 assistant entries.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 116 tests pass (112 pre-existing + 4 new). `pnpm exec oxlint src/agents/embedded-agent-runner/run/incomplete-turn.ts` clean. `pnpm format:check` clean.

**Evidence after fix (Vitest output for the touched test file)**:

```
Tests  116 passed (116)
```

The 4 new tests cover: `surfaces stall on clean stop with only an unsigned thinking payload (payloadCount=1, no visible text)`, `does not surface a stall when unsigned thinking accompanies visible text (payloadCount=1)`, `retries unsigned thinking-only turns via the reasoning-only path (openai-completions)`, `retries unsigned thinking-only Ollama turns via the reasoning-only path`.

**Observed result after fix**: `resolveIncompleteTurnPayloadText` returns the stall error string for unsigned thinking-only payloads instead of `null`; `resolveReasoningOnlyRetryInstruction` returns `REASONING_ONLY_RETRY_INSTRUCTION` so the run loop retries before surfacing the error. The negative test confirms that a turn with both visible text and an unsigned thinking block still returns `null` (early-return fires because `joinAssistantTexts` is non-empty), so only purely thinking-only turns are affected.

**What was not tested**: live llama.cpp/Qwen3.6-35B end-to-end gateway round-trip.

**Repro confirmation**: the stall-detection test (`payloadCount=1`, no visible text, unsigned thinking) fails on the pre-patch tree — `resolveIncompleteTurnPayloadText` returns `null` — and passes with both changes applied, confirming the early-return bypass and downstream check are each required.

### Risk / Mitigation

- **Risk**: Live turn activity cleared incorrectly. **Mitigation**: `isUnsignedThinkingOnlyAssistantTurn` fires only when `payloadCount !== 0 AND joinAssistantTexts is empty AND content.length > 0 AND assessLastAssistantMessage === "incomplete-thinking"` — turns with real visible text are unaffected because `joinAssistantTexts` is non-empty.
- **Risk**: Empty-content messages misclassified as unsigned thinking. **Mitigation**: `assessLastAssistantMessage` returns `"incomplete-thinking"` for empty content arrays too; the `content.length > 0` guard in the helper excludes that case explicitly.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents

### Linked Issue/PR

Fixes #89787