### PR TITLE
fix(channels): guard loaded plugin metadata

### DIFF
--- a/src/channels/plugins/registry-loaded-read.ts
+++ b/src/channels/plugins/registry-loaded-read.ts
@@ -1,21 +1,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { ActiveChannelPluginRuntimeShape } from "../../plugins/channel-registry-state.types.js";
 import { getActivePluginChannelRegistryFromState } from "../../plugins/runtime-channel-state.js";
+import { coerceLoadedChannelPlugin } from "./registry-loaded.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
-
-function coerceLoadedChannelPlugin(
-  plugin: ActiveChannelPluginRuntimeShape | null | undefined,
-): ChannelPlugin | undefined {
-  const id = normalizeOptionalString(plugin?.id) ?? "";
-  if (!plugin || !id) {
-    return undefined;
-  }
-  if (!plugin.meta || typeof plugin.meta !== "object") {
-    plugin.meta = {};
-  }
-  return plugin as ChannelPlugin;
-}
 
 export function getLoadedChannelPluginForRead(id: ChannelId): ChannelPlugin | undefined {
   const resolvedId = normalizeOptionalString(id) ?? "";

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -21,17 +21,106 @@ type ChannelPluginView = {
   entriesById: Map<string, LoadedChannelPluginEntry>;
 };
 
-function coerceLoadedChannelPlugin(
+const stableLoadedChannelPlugins = new WeakMap<
+  ActiveChannelPluginRuntimeShape,
+  LoadedChannelPlugin
+>();
+
+function hasAccessorDescriptor(descriptor: PropertyDescriptor | undefined): boolean {
+  return Boolean(descriptor && ("get" in descriptor || "set" in descriptor));
+}
+
+function readLoadedChannelPluginId(plugin: ActiveChannelPluginRuntimeShape): string {
+  try {
+    return normalizeOptionalString(plugin.id) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function readLoadedChannelPluginMeta(plugin: ActiveChannelPluginRuntimeShape): {
+  meta: LoadedChannelPlugin["meta"];
+  valid: boolean;
+} {
+  try {
+    const meta = plugin.meta;
+    if (meta && typeof meta === "object") {
+      return { meta: meta as LoadedChannelPlugin["meta"], valid: true };
+    }
+  } catch {
+    // Fall through to empty metadata.
+  }
+  return { meta: {}, valid: false };
+}
+
+function stableLoadedChannelPlugin(params: {
+  plugin: ActiveChannelPluginRuntimeShape;
+  id: string;
+  meta: LoadedChannelPlugin["meta"];
+}): LoadedChannelPlugin {
+  const plugin = Object.create(Object.getPrototypeOf(params.plugin)) as LoadedChannelPlugin;
+  const descriptors = Object.getOwnPropertyDescriptors(params.plugin);
+  delete descriptors.id;
+  delete descriptors.meta;
+  Object.defineProperties(plugin, descriptors);
+  Object.defineProperties(plugin, {
+    id: {
+      value: params.id,
+      enumerable: true,
+      configurable: true,
+    },
+    meta: {
+      value: params.meta,
+      enumerable: true,
+      configurable: true,
+    },
+  });
+  return plugin;
+}
+
+export function coerceLoadedChannelPlugin(
   plugin: ActiveChannelPluginRuntimeShape | null | undefined,
 ): LoadedChannelPlugin | null {
-  const id = normalizeOptionalString(plugin?.id) ?? "";
-  if (!plugin || !id) {
+  if (!plugin || typeof plugin !== "object") {
     return null;
   }
-  if (!plugin.meta || typeof plugin.meta !== "object") {
-    plugin.meta = {};
+  const idDescriptor = Object.getOwnPropertyDescriptor(plugin, "id");
+  const metaDescriptor = Object.getOwnPropertyDescriptor(plugin, "meta");
+  const needsStableWrapper =
+    hasAccessorDescriptor(idDescriptor) || hasAccessorDescriptor(metaDescriptor);
+  if (needsStableWrapper) {
+    const cached = stableLoadedChannelPlugins.get(plugin);
+    if (cached) {
+      return cached;
+    }
   }
-  return plugin as LoadedChannelPlugin;
+  const id = readLoadedChannelPluginId(plugin);
+  if (!id) {
+    return null;
+  }
+  const meta = readLoadedChannelPluginMeta(plugin);
+  if (!needsStableWrapper && meta.valid) {
+    return plugin as LoadedChannelPlugin;
+  }
+  if (!needsStableWrapper) {
+    try {
+      plugin.meta = meta.meta;
+      return plugin as LoadedChannelPlugin;
+    } catch {
+      // Fall through to a stable wrapper when malformed metadata is read-only.
+    }
+  }
+  const cached = stableLoadedChannelPlugins.get(plugin);
+  if (cached) {
+    return cached;
+  }
+  const stable = stableLoadedChannelPlugin({
+    plugin,
+    id,
+    meta: meta.meta,
+  });
+  stableLoadedChannelPlugins.set(plugin, stable);
+  return stable;
 }
 
 function dedupeChannels(channels: LoadedChannelPlugin[]): LoadedChannelPlugin[] {

--- a/src/channels/plugins/registry.test.ts
+++ b/src/channels/plugins/registry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { getLoadedChannelPluginForRead } from "./registry-loaded-read.js";
 import { getChannelPlugin, listChannelPlugins } from "./registry.js";
 
 vi.mock("./bundled.js", () => ({
@@ -36,6 +37,77 @@ describe("listChannelPlugins", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
 
     expect(getChannelPlugin("fallback")?.meta.label).toBe("fallback");
+  });
+
+  it("skips unreadable channel plugin ids and snapshots readable metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    let betaIdReads = 0;
+    let betaMetaReads = 0;
+    registry.channels = [
+      {
+        pluginId: "broken",
+        plugin: {
+          get id() {
+            throw new Error("channel id getter exploded");
+          },
+          meta: { label: "broken" },
+        } as never,
+        source: "test",
+      },
+      {
+        pluginId: "beta",
+        plugin: {
+          get id() {
+            betaIdReads += 1;
+            if (betaIdReads > 1) {
+              throw new Error("beta channel id reread");
+            }
+            return "beta";
+          },
+          get meta() {
+            betaMetaReads += 1;
+            if (betaMetaReads > 1) {
+              throw new Error("beta channel meta reread");
+            }
+            return { label: "beta" };
+          },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    const plugins = listChannelPlugins();
+
+    expect(plugins.map((plugin) => plugin.id)).toEqual(["beta"]);
+    expect(plugins[0]?.meta.label).toBe("beta");
+    expect(betaIdReads).toBe(1);
+    expect(betaMetaReads).toBe(1);
+    expect(getChannelPlugin("beta")?.id).toBe("beta");
+    expect(getLoadedChannelPluginForRead("beta")?.id).toBe("beta");
+    expect(betaIdReads).toBe(1);
+    expect(betaMetaReads).toBe(1);
+    expect(getChannelPlugin("broken")).toBeUndefined();
+    expect(getLoadedChannelPluginForRead("broken")).toBeUndefined();
+  });
+
+  it("keeps frozen channel plugin descriptors readable", () => {
+    const registry = createEmptyPluginRegistry();
+    const frozenPlugin = Object.freeze({
+      id: "frozen",
+      meta: { label: "frozen" },
+    });
+    registry.channels = [
+      {
+        pluginId: "frozen",
+        plugin: frozenPlugin as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["frozen"]);
+    expect(getChannelPlugin("frozen")).toBe(frozenPlugin);
   });
 
   it("rebuilds channel lookups when the active registry object changes without a version bump", () => {


### PR DESCRIPTION
## Summary

- guard loaded channel plugin registry coercion against unreadable `id` and `meta` descriptors
- preserve normal/frozen plugin object identity while using cached stable wrappers only for accessor or read-only malformed metadata cases
- route read-path channel lookup through the same guarded coercion helper

## Verification

- direct runtime repro with a pinned channel registry: broken channel `id` getter threw, healthy `beta` channel remained listable/readable, repeated `getChannelPlugin` and `getLoadedChannelPluginForRead` lookups did not reread poisoned metadata, output `pass`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next107-final3 node scripts/run-vitest.mjs src/channels/plugins/registry.test.ts --reporter=dot`
- `node_modules/.bin/oxfmt --check src/channels/plugins/registry-loaded.ts src/channels/plugins/registry-loaded-read.ts src/channels/plugins/registry.test.ts`
- `node_modules/.bin/oxlint src/channels/plugins/registry-loaded.ts src/channels/plugins/registry-loaded-read.ts src/channels/plugins/registry.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` found descriptor/cache issues in intermediate patches; both were fixed with regressions
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings after the read-path fix
- `.agents/skills/agent-transcript/scripts/agent-transcript find` returned `[]`

## Real behavior proof

Behavior addressed: malformed loaded channel plugin metadata no longer crashes channel plugin listing or read-path lookup before healthy channel plugins can be used.

Real environment tested: local linked Codex worktree with repo symlinked dependencies; direct runtime repro used the real pinned plugin channel registry plus `listChannelPlugins`, `getChannelPlugin`, and `getLoadedChannelPluginForRead`.

Exact steps or command run after this patch: direct runtime repro, focused `registry.test.ts` Vitest shard, `oxfmt --check`, `oxlint`, `git diff --check origin/main..HEAD`, local autoreview, final branch autoreview, transcript scan.

Evidence after fix: direct runtime repro printed `pass`; focused Vitest passed 1 file / 5 tests; formatter, linter, diff check, and final branch autoreview exited cleanly.

Observed result after fix: the poisoned channel is skipped, healthy channel metadata is snapshotted once, normal/frozen plugin identity is preserved, and read-path lookup shares the guarded behavior.

What was not tested: broad remote `pnpm check:changed` was blocked because Blacksmith Testbox is unauthenticated locally and AWS Crabbox coordinator returned HTTP 401 before lease creation.
