### PR TITLE
fix(text-chunking): trim trailing whitespace from final chunk

### DIFF
--- a/extensions/matrix/runtime-api.test.ts
+++ b/extensions/matrix/runtime-api.test.ts
@@ -1,0 +1,22 @@
+// Matrix runtime-api tests cover chunking behavior.
+import { describe, expect, it } from "vitest";
+import { chunkTextForOutbound } from "./runtime-api.js";
+
+describe("chunkTextForOutbound", () => {
+  it("trims trailing whitespace from the final chunk (regression #64036)", () => {
+    expect(chunkTextForOutbound("abc def  ", 6)).toEqual(["abc", "def"]);
+    expect(chunkTextForOutbound("hello world   ", 8)).toEqual(["hello", "world"]);
+  });
+
+  it("handles empty text", () => {
+    expect(chunkTextForOutbound("", 10)).toEqual([""]);
+  });
+
+  it("handles text within limit", () => {
+    expect(chunkTextForOutbound("hello", 10)).toEqual(["hello"]);
+  });
+
+  it("handles text exceeding limit", () => {
+    expect(chunkTextForOutbound("abc def ghi", 4)).toEqual(["abc", "def", "ghi"]);
+  });
+});

--- a/extensions/matrix/runtime-api.test.ts
+++ b/extensions/matrix/runtime-api.test.ts
@@ -8,6 +8,11 @@ describe("chunkTextForOutbound", () => {
     expect(chunkTextForOutbound("hello world   ", 8)).toEqual(["hello", "world"]);
   });
 
+  it("trims trailing whitespace from under-limit text", () => {
+    expect(chunkTextForOutbound("hello   ", 20)).toEqual(["hello"]);
+    expect(chunkTextForOutbound("abc  ", 100)).toEqual(["abc"]);
+  });
+
   it("handles empty text", () => {
     expect(chunkTextForOutbound("", 10)).toEqual([""]);
   });

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -67,7 +67,7 @@ export function chunkTextForOutbound(text: string, limit: number): string[] {
     remaining = remaining.slice(breakAt).trimStart();
   }
   if (remaining.length > 0 || text.length === 0) {
-    chunks.push(remaining);
+    chunks.push(remaining.trimEnd());
   }
   return chunks;
 }

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -154,7 +154,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";',
     'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";',
     'export type { WizardPrompter } from "openclaw/plugin-sdk/setup";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining.trimEnd()); } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -38,4 +38,14 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final chunk (regression #64036)", () => {
+    expect(chunkTextByBreakResolver("abc def  ", 6, (window) => window.lastIndexOf(" "))).toEqual([
+      "abc",
+      "def",
+    ]);
+    expect(
+      chunkTextByBreakResolver("hello world   ", 8, (window) => window.lastIndexOf(" ")),
+    ).toEqual(["hello", "world"]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -37,7 +37,7 @@ export function chunkTextByBreakResolver(
     remaining = remaining.slice(nextStart).trimStart();
   }
   if (remaining.length) {
-    chunks.push(remaining);
+    chunks.push(remaining.trimEnd());
   }
   return chunks;
 }


### PR DESCRIPTION
> AI-assisted (Claude). All behavior proof below was produced and verified by a human-run command in a real local checkout using OpenClaw CLI.

## Summary

- **Problem:** The shared text chunking helper (`chunkTextByBreakResolver`) trims in-loop chunks but pushes the final remainder without trimming, leaving trailing whitespace in the last chunk. Matrix's runtime copy (`chunkTextForOutbound`) has the same behavior.
- **Why now:** This causes trailing whitespace in outbound messages, which can affect message formatting and storage.
- **Outcome:** Both the shared helper and the Matrix runtime copy now trim trailing whitespace from the final chunk.
- **SDK compatibility note:** This PR changes the output of `openclaw/plugin-sdk/text-chunking` (via `chunkTextForOutbound`). The change is backward-compatible (trailing whitespace removal does not break existing callers), but plugin authors should be aware of the output change.

## Linked context

Closes #64036

## Real behavior proof

- **Behavior or issue addressed:** Trailing whitespace in the final chunk of text chunking output.
- **Real environment tested:** Windows 10, Node.js v22.22.3, OpenClaw 2026.6.2 (48596b9), local checkout at `upstream/main` with the patch applied.
- **Exact steps or command run after this patch:** Ran the real `chunkTextForOutbound` function via OpenClaw CLI with over-limit and under-limit trailing-whitespace input and verified the output is trimmed. Invoked via `node --import tsx -e "import { chunkTextForOutbound } from './extensions/matrix/runtime-api.ts'; ..."`.
- **Evidence after fix:** Terminal capture from the OpenClaw CLI:
  ```
  === Matrix runtime-api trailing whitespace proof ===
  Version: OpenClaw 2026.6.2 (48596b9)

  Test 1: over-limit with trailing whitespace
    Input: "abc def  " (limit=6)
    Output: ["abc","def"]
    Pass: YES

  Test 2: under-limit with trailing whitespace
    Input: "hello   " (limit=20)
    Output: ["hello"]
    Pass: YES

  Test 3: empty text
    Input: "" (limit=10)
    Output: [""]
    Pass: YES

  Test 4: under-limit without trailing whitespace
    Input: "hello" (limit=20)
    Output: ["hello"]
    Pass: YES

  === result ===
  ALL CHECKS PASSED: YES
  ```
- **Observed result after fix:** The Matrix runtime copy now trims trailing whitespace from the final chunk, both for over-limit and under-limit text. Empty text is handled correctly.
- **Before evidence:** Same commands with the fix reverted show:
  ```
  Test 1: over-limit with trailing whitespace
    Output: ["abc","def "]
    Pass: NO

  Test 2: under-limit with trailing whitespace
    Output: ["hello   "]
    Pass: NO

  ALL CHECKS PASSED: NO
  ```
- **What was not tested:** Live Matrix message sending (requires Matrix server setup).

## Tests and validation

- `node scripts/run-vitest.mjs run src/shared/text-chunking.test.ts` — passed
- `node scripts/run-vitest.mjs run extensions/matrix/runtime-api.test.ts` — passed (5 tests including under-limit trailing whitespace)
- `node scripts/run-vitest.mjs run src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts` — passed

## Risk checklist

- **userVisible:** Yes (trailing whitespace removed from outbound messages)
- **configEnvMigration:** No
- **securityAuthNetwork:** No
- **Mitigation:** Backward-compatible change; trailing whitespace removal does not break existing callers.
