### PR TITLE
fix(plugins): isolate extractor artifact failures

### DIFF
--- a/src/plugins/document-extractor-public-artifacts.ts
+++ b/src/plugins/document-extractor-public-artifacts.ts
@@ -10,16 +10,32 @@ const DOCUMENT_EXTRACTOR_ARTIFACT_CANDIDATES = [
   "document-extractor-api.js",
 ] as const;
 
-function isDocumentExtractorPlugin(value: unknown): value is DocumentExtractorPlugin {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.label === "string" &&
-    Array.isArray(value.mimeTypes) &&
-    value.mimeTypes.every((mimeType) => typeof mimeType === "string" && mimeType.trim()) &&
-    (value.autoDetectOrder === undefined || typeof value.autoDetectOrder === "number") &&
-    typeof value.extract === "function"
-  );
+function normalizeDocumentExtractorPlugin(value: unknown): DocumentExtractorPlugin | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const id = value.id;
+  const label = value.label;
+  const mimeTypes = value.mimeTypes;
+  const autoDetectOrder = value.autoDetectOrder;
+  const extract = value.extract;
+  if (
+    typeof id !== "string" ||
+    typeof label !== "string" ||
+    !Array.isArray(mimeTypes) ||
+    !mimeTypes.every((mimeType) => typeof mimeType === "string" && mimeType.trim()) ||
+    (autoDetectOrder !== undefined && typeof autoDetectOrder !== "number") ||
+    typeof extract !== "function"
+  ) {
+    return null;
+  }
+  return {
+    id,
+    label,
+    mimeTypes,
+    ...(autoDetectOrder === undefined ? {} : { autoDetectOrder }),
+    extract,
+  };
 }
 
 function tryLoadBundledPublicArtifactModule(params: {
@@ -61,15 +77,15 @@ function collectExtractorFactories(mod: Record<string, unknown>): {
     ) {
       continue;
     }
-    let candidate: unknown;
     try {
-      candidate = exported();
+      const candidate = exported();
+      const extractor = normalizeDocumentExtractorPlugin(candidate);
+      if (extractor) {
+        extractors.push(extractor);
+      }
     } catch (error) {
       errors.push(error);
       continue;
-    }
-    if (isDocumentExtractorPlugin(candidate)) {
-      extractors.push(candidate);
     }
   }
   return { extractors, errors };

--- a/src/plugins/web-content-extractor-public-artifacts.test.ts
+++ b/src/plugins/web-content-extractor-public-artifacts.test.ts
@@ -7,13 +7,13 @@ const { publicArtifactModule } = vi.hoisted(() => ({
 vi.mock("./public-surface-loader.js", () => ({
   loadBundledPluginPublicArtifactModuleSync: vi.fn(() => publicArtifactModule),
   resolveBundledPluginPublicArtifactPath: vi.fn(
-    () => "/repo/extensions/demo/document-extractor.ts",
+    () => "/repo/extensions/demo/web-content-extractor.ts",
   ),
 }));
 
-import { loadBundledDocumentExtractorEntriesFromDir } from "./document-extractor-public-artifacts.js";
+import { loadBundledWebContentExtractorEntriesFromDir } from "./web-content-extractor-public-artifacts.js";
 
-describe("loadBundledDocumentExtractorEntriesFromDir", () => {
+describe("loadBundledWebContentExtractorEntriesFromDir", () => {
   beforeEach(() => {
     for (const key of Object.keys(publicArtifactModule)) {
       delete publicArtifactModule[key];
@@ -22,26 +22,24 @@ describe("loadBundledDocumentExtractorEntriesFromDir", () => {
 
   it("isolates a throwing factory when another extractor factory succeeds", () => {
     const extract = vi.fn();
-    publicArtifactModule.createBrokenDocumentExtractor = () => {
+    publicArtifactModule.createBrokenWebContentExtractor = () => {
       throw new Error("native probe failed");
     };
-    publicArtifactModule.createPdfDocumentExtractor = () => ({
-      id: "pdf",
-      label: "PDF",
-      mimeTypes: ["application/pdf"],
+    publicArtifactModule.createReadabilityWebContentExtractor = () => ({
+      id: "readability",
+      label: "Readability",
       extract,
     });
 
     expect(
-      loadBundledDocumentExtractorEntriesFromDir({
+      loadBundledWebContentExtractorEntriesFromDir({
         dirName: "demo",
         pluginId: "demo",
       }),
     ).toStrictEqual([
       {
-        id: "pdf",
-        label: "PDF",
-        mimeTypes: ["application/pdf"],
+        id: "readability",
+        label: "Readability",
         extract,
         pluginId: "demo",
       },
@@ -50,42 +48,40 @@ describe("loadBundledDocumentExtractorEntriesFromDir", () => {
 
   it("surfaces initialization failure when every matching factory throws", () => {
     const cause = new Error("native probe failed");
-    publicArtifactModule.createPdfDocumentExtractor = () => {
+    publicArtifactModule.createReadabilityWebContentExtractor = () => {
       throw cause;
     };
 
     expect(() =>
-      loadBundledDocumentExtractorEntriesFromDir({
+      loadBundledWebContentExtractorEntriesFromDir({
         dirName: "demo",
         pluginId: "demo",
       }),
-    ).toThrow("Unable to initialize document extractors for plugin demo");
+    ).toThrow("Unable to initialize web content extractors for plugin demo");
   });
 
   it("isolates a malformed descriptor when another extractor factory succeeds", () => {
     const extract = vi.fn();
-    publicArtifactModule.createBrokenDocumentExtractor = () => ({
+    publicArtifactModule.createBrokenWebContentExtractor = () => ({
       get id() {
         throw new Error("descriptor read failed");
       },
     });
-    publicArtifactModule.createPdfDocumentExtractor = () => ({
-      id: "pdf",
-      label: "PDF",
-      mimeTypes: ["application/pdf"],
+    publicArtifactModule.createReadabilityWebContentExtractor = () => ({
+      id: "readability",
+      label: "Readability",
       extract,
     });
 
     expect(
-      loadBundledDocumentExtractorEntriesFromDir({
+      loadBundledWebContentExtractorEntriesFromDir({
         dirName: "demo",
         pluginId: "demo",
       }),
     ).toStrictEqual([
       {
-        id: "pdf",
-        label: "PDF",
-        mimeTypes: ["application/pdf"],
+        id: "readability",
+        label: "Readability",
         extract,
         pluginId: "demo",
       },

--- a/src/plugins/web-content-extractor-public-artifacts.ts
+++ b/src/plugins/web-content-extractor-public-artifacts.ts
@@ -10,14 +10,28 @@ const WEB_CONTENT_EXTRACTOR_ARTIFACT_CANDIDATES = [
   "web-content-extractor-api.js",
 ] as const;
 
-function isWebContentExtractorPlugin(value: unknown): value is WebContentExtractorPlugin {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.label === "string" &&
-    (value.autoDetectOrder === undefined || typeof value.autoDetectOrder === "number") &&
-    typeof value.extract === "function"
-  );
+function normalizeWebContentExtractorPlugin(value: unknown): WebContentExtractorPlugin | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const id = value.id;
+  const label = value.label;
+  const autoDetectOrder = value.autoDetectOrder;
+  const extract = value.extract;
+  if (
+    typeof id !== "string" ||
+    typeof label !== "string" ||
+    (autoDetectOrder !== undefined && typeof autoDetectOrder !== "number") ||
+    typeof extract !== "function"
+  ) {
+    return null;
+  }
+  return {
+    id,
+    label,
+    ...(autoDetectOrder === undefined ? {} : { autoDetectOrder }),
+    extract,
+  };
 }
 
 function tryLoadBundledPublicArtifactModule(params: {
@@ -42,8 +56,12 @@ function tryLoadBundledPublicArtifactModule(params: {
   return null;
 }
 
-function collectExtractorFactories(mod: Record<string, unknown>): WebContentExtractorPlugin[] {
+function collectExtractorFactories(mod: Record<string, unknown>): {
+  extractors: WebContentExtractorPlugin[];
+  errors: unknown[];
+} {
   const extractors: WebContentExtractorPlugin[] = [];
+  const errors: unknown[] = [];
   for (const [name, exported] of Object.entries(mod).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -55,12 +73,17 @@ function collectExtractorFactories(mod: Record<string, unknown>): WebContentExtr
     ) {
       continue;
     }
-    const candidate = exported();
-    if (isWebContentExtractorPlugin(candidate)) {
-      extractors.push(candidate);
+    try {
+      const candidate = exported();
+      const extractor = normalizeWebContentExtractorPlugin(candidate);
+      if (extractor) {
+        extractors.push(extractor);
+      }
+    } catch (error) {
+      errors.push(error);
     }
   }
-  return extractors;
+  return { extractors, errors };
 }
 
 export function loadBundledWebContentExtractorEntriesFromDir(params: {
@@ -71,8 +94,13 @@ export function loadBundledWebContentExtractorEntriesFromDir(params: {
   if (!mod) {
     return null;
   }
-  const extractors = collectExtractorFactories(mod);
+  const { extractors, errors } = collectExtractorFactories(mod);
   if (extractors.length === 0) {
+    if (errors.length > 0) {
+      throw new Error(`Unable to initialize web content extractors for plugin ${params.pluginId}`, {
+        cause: errors.length === 1 ? errors[0] : new AggregateError(errors),
+      });
+    }
     return null;
   }
   return extractors.map((extractor) => Object.assign({}, extractor, { pluginId: params.pluginId }));

--- a/src/plugins/web-content-extractors.runtime.test.ts
+++ b/src/plugins/web-content-extractors.runtime.test.ts
@@ -1,4 +1,60 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const { loadBundledWebContentExtractorEntriesFromDir } = vi.hoisted(() => ({
+  loadBundledWebContentExtractorEntriesFromDir: vi.fn(
+    ({ dirName }: { dirName: string; pluginId: string }) => {
+      if (dirName === "broken-readability") {
+        throw new Error("native probe failed");
+      }
+      if (dirName === "web-readability") {
+        return [
+          {
+            id: "readability",
+            label: "Readability",
+            pluginId: "web-readability",
+            extract: vi.fn(),
+          },
+        ];
+      }
+      return null;
+    },
+  ),
+}));
+
+vi.mock("./manifest-contract-eligibility.js", () => ({
+  loadManifestContractSnapshot: vi.fn(() => ({
+    index: { plugins: [], providers: {} },
+    plugins: [
+      {
+        id: "broken-readability",
+        origin: "bundled",
+        enabledByDefault: true,
+        enabledByDefaultOnPlatforms: [],
+        channels: [],
+        cliBackends: [],
+        providers: [],
+        legacyPluginIds: [],
+        contracts: { webContentExtractors: ["broken"] },
+      },
+      {
+        id: "web-readability",
+        origin: "bundled",
+        enabledByDefault: true,
+        enabledByDefaultOnPlatforms: [],
+        channels: [],
+        cliBackends: [],
+        providers: [],
+        legacyPluginIds: [],
+        contracts: { webContentExtractors: ["readability"] },
+      },
+    ],
+  })),
+}));
+
+vi.mock("./web-content-extractor-public-artifacts.js", () => ({
+  loadBundledWebContentExtractorEntriesFromDir,
+}));
+
 import { resolvePluginWebContentExtractors } from "./web-content-extractors.runtime.js";
 
 describe("resolvePluginWebContentExtractors", () => {
@@ -12,5 +68,19 @@ describe("resolvePluginWebContentExtractors", () => {
         },
       }),
     ).toStrictEqual([]);
+  });
+
+  it("isolates one plugin load failure when another extractor plugin succeeds", () => {
+    expect(resolvePluginWebContentExtractors().map((extractor) => extractor.id)).toEqual([
+      "readability",
+    ]);
+  });
+
+  it("surfaces plugin load failure when every extractor plugin fails", () => {
+    expect(() =>
+      resolvePluginWebContentExtractors({
+        onlyPluginIds: ["broken-readability"],
+      }),
+    ).toThrow("Unable to load web content extractor plugins");
   });
 });

--- a/src/plugins/web-content-extractors.runtime.ts
+++ b/src/plugins/web-content-extractors.runtime.ts
@@ -22,6 +22,7 @@ export function resolvePluginWebContentExtractors(params?: {
   onlyPluginIds?: readonly string[];
 }): PluginWebContentExtractorEntry[] {
   const extractors: PluginWebContentExtractorEntry[] = [];
+  const loadErrors: unknown[] = [];
   for (const plugin of resolveEnabledBundledManifestContractPlugins({
     config: params?.config,
     workspaceDir: params?.workspaceDir,
@@ -33,13 +34,24 @@ export function resolvePluginWebContentExtractors(params?: {
       vitest: true,
     },
   })) {
-    const loaded = loadBundledWebContentExtractorEntriesFromDir({
-      dirName: plugin.id,
-      pluginId: plugin.id,
-    });
+    let loaded: PluginWebContentExtractorEntry[] | null;
+    try {
+      loaded = loadBundledWebContentExtractorEntriesFromDir({
+        dirName: plugin.id,
+        pluginId: plugin.id,
+      });
+    } catch (error) {
+      loadErrors.push(error);
+      continue;
+    }
     if (loaded) {
       extractors.push(...loaded);
     }
+  }
+  if (extractors.length === 0 && loadErrors.length > 0) {
+    throw new Error("Unable to load web content extractor plugins", {
+      cause: loadErrors.length === 1 ? loadErrors[0] : new AggregateError(loadErrors),
+    });
   }
   return extractors.toSorted(compareExtractors);
 }


### PR DESCRIPTION
## Summary
- isolate throwing or malformed document/web content extractor factory descriptors so a healthy extractor from the same plugin can still load
- make web content extractor runtime skip a failed extractor plugin when another enabled extractor plugin succeeds, while still surfacing failure when no valid extractor can load
- add regression coverage for throwing factories, malformed descriptors, and mixed web extractor plugin load failure

## Verification
- `node scripts/run-vitest.mjs src/plugins/web-content-extractor-public-artifacts.test.ts src/plugins/document-extractor-public-artifacts.test.ts src/plugins/web-content-extractors.runtime.test.ts src/plugins/document-extractors.runtime.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/web-content-extractor-public-artifacts.ts src/plugins/document-extractor-public-artifacts.ts src/plugins/web-content-extractors.runtime.ts src/plugins/web-content-extractor-public-artifacts.test.ts src/plugins/document-extractor-public-artifacts.test.ts src/plugins/web-content-extractors.runtime.test.ts && node_modules/.bin/oxlint src/plugins/web-content-extractor-public-artifacts.ts src/plugins/document-extractor-public-artifacts.ts src/plugins/web-content-extractors.runtime.ts src/plugins/web-content-extractor-public-artifacts.test.ts src/plugins/document-extractor-public-artifacts.test.ts src/plugins/web-content-extractors.runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` blocked: coordinator 401 before lease

## Real behavior proof
Behavior addressed: Broken extractor factory output no longer disables healthy document/web content extractor factories; broken web extractor plugins no longer disable healthy enabled web extractor plugins.
Real environment tested: Local sparse Codex worktree on Node/Vitest using repo test wrappers.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/web-content-extractor-public-artifacts.test.ts src/plugins/document-extractor-public-artifacts.test.ts src/plugins/web-content-extractors.runtime.test.ts src/plugins/document-extractors.runtime.test.ts`
Evidence after fix: Focused tests passed: 4 files, 12 tests.
Observed result after fix: Healthy extractor entries are returned after sibling factory/descriptor/plugin-load failures; all-failed web plugin loading still throws.
What was not tested: `pnpm check:changed` broad gate; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
