### PR TITLE
fix(plugins): guard model catalog registration metadata

### DIFF
--- a/src/plugins/model-catalog-registration.ts
+++ b/src/plugins/model-catalog-registration.ts
@@ -7,13 +7,13 @@ import {
   type MediaGenerationCatalogKind,
   type MediaGenerationCatalogProvider,
 } from "../../packages/media-generation-core/src/catalog.js";
+import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import { uniqueValues } from "../../packages/normalization-core/src/string-normalization.js";
 import {
   synthesizeVoiceModelCatalogEntries,
   type VoiceModelCapabilities,
   type VoiceModelProvider,
 } from "../../packages/speech-core/voice-models.js";
-import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
-import { uniqueValues } from "../../packages/normalization-core/src/string-normalization.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { projectProviderCatalogResultToUnifiedTextRows } from "./provider-catalog-unified-text.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
@@ -62,11 +62,33 @@ export function createModelCatalogRegistrationHandlers(params: {
   registry: PluginRegistry;
   pushDiagnostic: (diagnostic: PluginDiagnostic) => void;
 }) {
-  const registerModelCatalogProvider = (
+  const normalizeModelCatalogProvider = (
     record: PluginRecord,
     provider: UnifiedModelCatalogProviderPlugin,
-  ) => {
-    const providerId = normalizeOptionalString(provider.provider) ?? "";
+  ): UnifiedModelCatalogProviderPlugin | null => {
+    let providerId: string;
+    let normalizedKinds: UnifiedModelCatalogProviderPlugin["kinds"];
+    let staticCatalog: UnifiedModelCatalogProviderPlugin["staticCatalog"];
+    let liveCatalog: UnifiedModelCatalogProviderPlugin["liveCatalog"];
+    try {
+      providerId = normalizeOptionalString(provider.provider) ?? "";
+      const kinds = provider.kinds;
+      if (!Array.isArray(kinds) || kinds.length === 0) {
+        normalizedKinds = [];
+      } else {
+        normalizedKinds = uniqueValues(kinds);
+      }
+      staticCatalog = provider.staticCatalog;
+      liveCatalog = provider.liveCatalog;
+    } catch {
+      params.pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "model catalog provider registration metadata unreadable",
+      });
+      return null;
+    }
     if (!providerId) {
       params.pushDiagnostic({
         level: "error",
@@ -74,17 +96,34 @@ export function createModelCatalogRegistrationHandlers(params: {
         source: record.source,
         message: "model catalog provider registration missing provider",
       });
-      return;
+      return null;
     }
-    if (!provider.kinds || provider.kinds.length === 0) {
+    if (normalizedKinds.length === 0) {
       params.pushDiagnostic({
         level: "error",
         pluginId: record.id,
         source: record.source,
         message: `model catalog provider "${providerId}" registration missing kinds`,
       });
+      return null;
+    }
+    return {
+      provider: providerId,
+      kinds: normalizedKinds,
+      ...(staticCatalog ? { staticCatalog } : {}),
+      ...(liveCatalog ? { liveCatalog } : {}),
+    };
+  };
+
+  const registerModelCatalogProvider = (
+    record: PluginRecord,
+    provider: UnifiedModelCatalogProviderPlugin,
+  ) => {
+    const normalizedProvider = normalizeModelCatalogProvider(record, provider);
+    if (!normalizedProvider) {
       return;
     }
+    const providerId = normalizedProvider.provider;
     const existing = params.registry.modelCatalogProviders.find(
       (entry) => entry.provider.provider === providerId && entry.pluginId !== record.id,
     );
@@ -97,7 +136,7 @@ export function createModelCatalogRegistrationHandlers(params: {
       });
       return;
     }
-    const normalizedKinds = uniqueValues(provider.kinds);
+    const normalizedKinds = normalizedProvider.kinds;
     const samePluginOverlapping = params.registry.modelCatalogProviders.find(
       (entry) =>
         entry.provider.provider === providerId &&
@@ -107,18 +146,18 @@ export function createModelCatalogRegistrationHandlers(params: {
     if (samePluginOverlapping) {
       samePluginOverlapping.provider = {
         ...samePluginOverlapping.provider,
-        ...provider,
+        ...normalizedProvider,
         provider: providerId,
         kinds: uniqueValues([...samePluginOverlapping.provider.kinds, ...normalizedKinds]),
         staticCatalog: mergeModelCatalogHooks(
           "static",
           samePluginOverlapping.provider.staticCatalog,
-          provider.staticCatalog,
+          normalizedProvider.staticCatalog,
         ),
         liveCatalog: mergeModelCatalogHooks(
           "live",
           samePluginOverlapping.provider.liveCatalog,
-          provider.liveCatalog,
+          normalizedProvider.liveCatalog,
         ),
       };
       return;
@@ -127,7 +166,7 @@ export function createModelCatalogRegistrationHandlers(params: {
       pluginId: record.id,
       pluginName: record.name,
       provider: {
-        ...provider,
+        ...normalizedProvider,
         provider: providerId,
         kinds: normalizedKinds,
       },
@@ -140,28 +179,31 @@ export function createModelCatalogRegistrationHandlers(params: {
     record: PluginRecord;
     provider: ProviderPlugin;
   }) => {
-    if (!registration.provider.catalog && !registration.provider.staticCatalog) {
+    const providerId = registration.provider.id;
+    const staticCatalog = registration.provider.staticCatalog;
+    const liveCatalog = registration.provider.catalog;
+    if (!liveCatalog && !staticCatalog) {
       return;
     }
     registerModelCatalogProvider(registration.record, {
-      provider: registration.provider.id,
+      provider: providerId,
       kinds: ["text"],
-      ...(registration.provider.staticCatalog
+      ...(staticCatalog
         ? {
             staticCatalog: async (ctx: UnifiedModelCatalogProviderContext) =>
               projectProviderCatalogResultToUnifiedTextRows({
-                providerId: registration.provider.id,
-                result: await registration.provider.staticCatalog!.run(ctx),
+                providerId,
+                result: await staticCatalog.run(ctx),
                 source: "static",
               }),
           }
         : {}),
-      ...(registration.provider.catalog
+      ...(liveCatalog
         ? {
             liveCatalog: async (ctx: UnifiedModelCatalogProviderContext) =>
               projectProviderCatalogResultToUnifiedTextRows({
-                providerId: registration.provider.id,
-                result: await registration.provider.catalog!.run(ctx),
+                providerId,
+                result: await liveCatalog.run(ctx),
                 source: "live",
               }),
           }

--- a/src/plugins/registry.provider-like.test.ts
+++ b/src/plugins/registry.provider-like.test.ts
@@ -60,6 +60,104 @@ describe("plugin registry provider-like registrations", () => {
     expect(catalogRegistration?.provider.kinds).toEqual(["text", "video_generation"]);
   });
 
+  it("snapshots model catalog provider descriptors during registration", async () => {
+    const pluginRegistry = createTestRegistry();
+    const record = createPluginRecord({
+      id: "catalog-owner",
+      name: "Catalog Owner",
+      source: "/tmp/catalog-owner/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    let providerReads = 0;
+    let kindsReads = 0;
+    let staticCatalogReads = 0;
+
+    pluginRegistry.registerModelCatalogProvider(record, {
+      get provider() {
+        providerReads += 1;
+        if (providerReads > 1) {
+          throw new Error("provider id getter exploded");
+        }
+        return "catalog-provider";
+      },
+      get kinds() {
+        kindsReads += 1;
+        if (kindsReads > 1) {
+          throw new Error("provider kinds getter exploded");
+        }
+        return ["text"];
+      },
+      get staticCatalog() {
+        staticCatalogReads += 1;
+        if (staticCatalogReads > 1) {
+          throw new Error("static catalog getter exploded");
+        }
+        return () => [
+          {
+            kind: "text",
+            provider: "catalog-provider",
+            model: "catalog-model",
+            source: "static",
+          },
+        ];
+      },
+    });
+
+    expect(pluginRegistry.registry.modelCatalogProviders).toHaveLength(1);
+    const catalogProvider = pluginRegistry.registry.modelCatalogProviders[0]?.provider;
+    expect(catalogProvider?.provider).toBe("catalog-provider");
+    expect(catalogProvider?.kinds).toEqual(["text"]);
+    expect(catalogProvider?.staticCatalog?.({} as never)).toEqual([
+      {
+        kind: "text",
+        provider: "catalog-provider",
+        model: "catalog-model",
+        source: "static",
+      },
+    ]);
+    expect(providerReads).toBe(1);
+    expect(kindsReads).toBe(1);
+    expect(staticCatalogReads).toBe(1);
+  });
+
+  it("keeps healthy model catalog providers after unreadable registration metadata", () => {
+    const pluginRegistry = createTestRegistry();
+    const record = createPluginRecord({
+      id: "catalog-owner",
+      name: "Catalog Owner",
+      source: "/tmp/catalog-owner/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+
+    pluginRegistry.registerModelCatalogProvider(record, {
+      get provider() {
+        throw new Error("provider id getter exploded");
+      },
+      kinds: ["text"],
+    });
+    pluginRegistry.registerModelCatalogProvider(record, {
+      provider: "catalog-provider",
+      kinds: ["text"],
+    });
+
+    expect(pluginRegistry.registry.modelCatalogProviders).toHaveLength(1);
+    expect(pluginRegistry.registry.modelCatalogProviders[0]?.provider.provider).toBe(
+      "catalog-provider",
+    );
+    expect(pluginRegistry.registry.diagnostics).toEqual([
+      {
+        level: "error",
+        pluginId: "catalog-owner",
+        source: "/tmp/catalog-owner/index.js",
+        message: "model catalog provider registration metadata unreadable",
+      },
+    ]);
+  });
+
   it("combines same-plugin overlapping model catalog hooks", async () => {
     const pluginRegistry = createTestRegistry();
     const record = createPluginRecord({


### PR DESCRIPTION
## Summary
- snapshot model catalog provider registration descriptors once before registry insertion/merging
- turn unreadable model catalog provider registration metadata into a plugin diagnostic instead of a registry crash
- snapshot synthesized text catalog provider hooks so later catalog calls do not re-read provider descriptors

## Verification
- `node scripts/run-vitest.mjs src/plugins/registry.provider-like.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/model-catalog-registration.ts src/plugins/registry.provider-like.test.ts && node_modules/.bin/oxlint src/plugins/model-catalog-registration.ts src/plugins/registry.provider-like.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` blocked: coordinator 401 before lease

## Real behavior proof
Behavior addressed: A plugin-owned model catalog provider descriptor with unreadable or one-shot `provider`, `kinds`, or catalog hook metadata no longer crashes registration or gets re-read later; healthy catalog providers still register.
Real environment tested: Local sparse Codex worktree on Node/Vitest using repo test wrappers.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/registry.provider-like.test.ts`
Evidence after fix: Focused test file passed: 1 file, 9 tests.
Observed result after fix: One-shot descriptors are read once, unreadable descriptors produce a diagnostic, and the following healthy registration remains available.
What was not tested: `pnpm check:changed` broad gate; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
