### PR TITLE
fix(plugins): rebuild missing installs on policy refresh

### DIFF
--- a/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
+++ b/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
@@ -54,17 +54,17 @@ function isBareMissingModuleSpecifier(text: string): boolean {
   const specifier = match?.[1];
   return Boolean(
     specifier &&
-      !specifier.startsWith(".") &&
-      !specifier.startsWith("/") &&
-      !path.win32.isAbsolute(specifier),
+    !specifier.startsWith(".") &&
+    !specifier.startsWith("/") &&
+    !path.win32.isAbsolute(specifier),
   );
 }
 
 function hasExternalDistArtifactPath(text: string): boolean {
   const candidates = [
-    ...text.matchAll(/file:\/\/(\/[^\s)]+[\/\\]dist(?:-runtime)?[\/\\][^\s)]*)/gu),
+    ...text.matchAll(/file:\/\/(\/[^\s)]+[/\\]dist(?:-runtime)?[/\\][^\s)]*)/gu),
     ...text.matchAll(/(\b[A-Za-z]:\\[^\s)]+\\dist(?:-runtime)?\\[^\s)]*)/gu),
-    ...text.matchAll(/(\/[^\s)]+[\/\\]dist(?:-runtime)?[\/\\][^\s)]*)/gu),
+    ...text.matchAll(/(\/[^\s)]+[/\\]dist(?:-runtime)?[/\\][^\s)]*)/gu),
   ];
   return candidates.some((match) => {
     const candidate = match[1];

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -427,6 +427,11 @@ type InstalledPluginRecordPath = {
   requireBuiltRuntimeEntry: boolean;
 };
 
+type InstalledPluginRecordProbePath = {
+  path: string;
+  requireBuiltRuntimeEntry?: boolean;
+};
+
 function isLinkedLocalPluginRecord(params: {
   record: PluginInstallRecord;
   env: NodeJS.ProcessEnv;
@@ -480,6 +485,72 @@ function collectInstalledPluginRecordPaths(
   return paths;
 }
 
+function collectInstalledPluginRecordProbePaths(params: {
+  record: PluginInstallRecord;
+  env: NodeJS.ProcessEnv;
+  realpathCache: Map<string, string>;
+  configLoadPaths?: unknown;
+  workspaceDir?: string;
+}): InstalledPluginRecordProbePath[] {
+  const paths: InstalledPluginRecordProbePath[] = [];
+  const seen = new Set<string>();
+  const isLinkedLocal = isLinkedLocalPluginRecord({
+    record: params.record,
+    env: params.env,
+    realpathCache: params.realpathCache,
+  });
+  const installPath =
+    typeof params.record.installPath === "string" && params.record.installPath.trim()
+      ? params.record.installPath
+      : undefined;
+  const sourcePath =
+    typeof params.record.sourcePath === "string" && params.record.sourcePath.trim()
+      ? params.record.sourcePath
+      : undefined;
+  const candidates: Array<{ rawPath: string; requireBuiltRuntimeEntry?: boolean }> = [];
+  if (installPath) {
+    candidates.push({
+      rawPath: installPath,
+      requireBuiltRuntimeEntry: !isLinkedLocal,
+    });
+  }
+  const sourcePathReachable =
+    sourcePath &&
+    (!installPath ||
+      isLinkedLocal ||
+      isPathReachableFromDefaultDiscoveryRoots({
+        targetPath: sourcePath,
+        env: params.env,
+        realpathCache: params.realpathCache,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      }) ||
+      isPathReachableFromConfigLoadPaths({
+        targetPath: sourcePath,
+        configLoadPaths: params.configLoadPaths,
+        env: params.env,
+        realpathCache: params.realpathCache,
+      }));
+  if (sourcePathReachable) {
+    // Full discovery can recover sourcePath through normal scan roots after the
+    // install ledger's primary path fails, so probe only reachable source paths.
+    candidates.push({ rawPath: sourcePath });
+  }
+  for (const candidate of candidates) {
+    const resolved = resolveUserPath(candidate.rawPath, params.env);
+    if (seen.has(resolved) || !fs.existsSync(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    paths.push({
+      path: resolved,
+      ...(candidate.requireBuiltRuntimeEntry !== undefined
+        ? { requireBuiltRuntimeEntry: candidate.requireBuiltRuntimeEntry }
+        : {}),
+    });
+  }
+  return paths;
+}
+
 // Discovery follows the install ledger's primary path choice; managed
 // classification needs every recorded path so a sourcePath under the global
 // extensions root does not get rescanned as an untracked local plugin.
@@ -503,6 +574,253 @@ function collectManagedPluginRecordPaths(
     }
   }
   return paths;
+}
+
+function isPathReachableFromConfigLoadPaths(params: {
+  targetPath: string;
+  configLoadPaths: unknown;
+  env: NodeJS.ProcessEnv;
+  realpathCache: Map<string, string>;
+}): boolean {
+  const targetResolved = path.resolve(params.targetPath);
+  const targetRealPath = safeRealpathSync(params.targetPath, params.realpathCache);
+  const targetComparablePath = targetRealPath ?? targetResolved;
+  const configLoadPaths = Array.isArray(params.configLoadPaths) ? params.configLoadPaths : [];
+  for (const rawLoadPath of configLoadPaths) {
+    const loadPath = normalizeOptionalString(rawLoadPath);
+    if (!loadPath) {
+      continue;
+    }
+    const resolvedLoadPath = resolveUserPath(loadPath, params.env);
+    const loadRealPath = safeRealpathSync(resolvedLoadPath, params.realpathCache);
+    const loadComparablePath = loadRealPath ?? path.resolve(resolvedLoadPath);
+    if (
+      targetComparablePath === loadComparablePath ||
+      isPathInside(loadComparablePath, targetComparablePath) ||
+      isPathInside(targetComparablePath, loadComparablePath)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isPathReachableFromDefaultDiscoveryRoots(params: {
+  targetPath: string;
+  env: NodeJS.ProcessEnv;
+  realpathCache: Map<string, string>;
+  workspaceDir?: string;
+}): boolean {
+  const workspaceRoot = params.workspaceDir
+    ? resolveUserPath(params.workspaceDir, params.env)
+    : undefined;
+  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env: params.env });
+  const targetRealPath = safeRealpathSync(params.targetPath, params.realpathCache);
+  const targetComparablePath = targetRealPath ?? path.resolve(params.targetPath);
+  return [roots.stock, roots.global, roots.workspace].some((root): root is string => {
+    if (!root) {
+      return false;
+    }
+    const rootRealPath = safeRealpathSync(root, params.realpathCache);
+    const rootComparablePath = rootRealPath ?? path.resolve(root);
+    return (
+      targetComparablePath === rootComparablePath ||
+      isPathInside(rootComparablePath, targetComparablePath)
+    );
+  });
+}
+
+function candidateMatchesPluginId(params: {
+  candidate: PluginCandidate;
+  pluginId: string;
+  realpathCache: Map<string, string>;
+}): boolean {
+  const pluginId = normalizeOptionalString(params.pluginId);
+  if (!pluginId) {
+    return false;
+  }
+  const directIds = [
+    params.candidate.idHint,
+    params.candidate.bundledManifestId,
+    params.candidate.bundledManifest?.id,
+  ];
+  if (directIds.some((id) => normalizeOptionalString(id) === pluginId)) {
+    return true;
+  }
+  const rootRealPath = safeRealpathSync(params.candidate.rootDir, params.realpathCache);
+  const candidateManifest = resolveCandidateManifest(
+    params.candidate.rootDir,
+    false,
+    rootRealPath ?? undefined,
+  );
+  return normalizeOptionalString(candidateManifest?.manifest.id) === pluginId;
+}
+
+function hasMatchingPluginCandidate(params: {
+  pluginId: string;
+  candidates: readonly PluginCandidate[] | undefined;
+  realpathCache: Map<string, string>;
+}): boolean {
+  return (params.candidates ?? []).some((candidate) =>
+    candidateMatchesPluginId({
+      candidate,
+      pluginId: params.pluginId,
+      realpathCache: params.realpathCache,
+    }),
+  );
+}
+
+export function hasDiscoverablePluginRecoveryInput(params: {
+  pluginId: string;
+  candidates?: readonly PluginCandidate[];
+  configLoadPaths?: unknown;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const env = params.env ?? process.env;
+  const realpathCache = new Map<string, string>();
+  const packageManifestCache = new Map<string, PackageManifest | null>();
+  if (
+    hasMatchingPluginCandidate({
+      pluginId: params.pluginId,
+      candidates: params.candidates,
+      realpathCache,
+    })
+  ) {
+    return true;
+  }
+  const configLoadPaths = Array.isArray(params.configLoadPaths) ? params.configLoadPaths : [];
+  for (const rawLoadPath of configLoadPaths) {
+    const loadPath = normalizeOptionalString(rawLoadPath);
+    if (!loadPath) {
+      continue;
+    }
+    const result = createDiscoveryResult();
+    discoverFromPath({
+      rawPath: loadPath,
+      origin: "config",
+      env,
+      candidates: result.candidates,
+      diagnostics: result.diagnostics,
+      seen: new Set<string>(),
+      realpathCache,
+      packageManifestCache,
+    });
+    if (
+      hasMatchingPluginCandidate({
+        pluginId: params.pluginId,
+        candidates: result.candidates,
+        realpathCache,
+      })
+    ) {
+      return true;
+    }
+  }
+  const workspaceDir = normalizeOptionalString(params.workspaceDir);
+  if (!workspaceDir) {
+    return false;
+  }
+  const workspaceRoot = resolveUserPath(workspaceDir, env);
+  const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
+  const workspaceMatchesBundledRoot = resolvesToSameDirectory(
+    workspaceRoot,
+    roots.stock,
+    realpathCache,
+  );
+  if (!roots.workspace || workspaceMatchesBundledRoot) {
+    return false;
+  }
+  const result = createDiscoveryResult();
+  discoverInDirectory({
+    dir: roots.workspace,
+    origin: "workspace",
+    env,
+    workspaceDir,
+    candidates: result.candidates,
+    diagnostics: result.diagnostics,
+    seen: new Set<string>(),
+    realpathCache,
+    packageManifestCache,
+  });
+  return hasMatchingPluginCandidate({
+    pluginId: params.pluginId,
+    candidates: result.candidates,
+    realpathCache,
+  });
+}
+
+export function hasDiscoverableInstalledPluginRecordPath(params: {
+  record: PluginInstallRecord;
+  env?: NodeJS.ProcessEnv;
+  configLoadPaths?: unknown;
+  workspaceDir?: string;
+}): boolean {
+  const env = params.env ?? process.env;
+  const realpathCache = new Map<string, string>();
+  const packageManifestCache = new Map<string, PackageManifest | null>();
+  const installRecords = { __installRecordProbe: params.record };
+  const installedPaths = collectInstalledPluginRecordProbePaths({
+    record: params.record,
+    env,
+    realpathCache,
+    configLoadPaths: params.configLoadPaths,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  });
+  if (installedPaths.length === 0) {
+    return false;
+  }
+  const managedPluginDirs = collectManagedPluginDirKeys(
+    collectManagedPluginRecordPaths(installRecords, env),
+    realpathCache,
+  );
+  return installedPaths.some((installedPath) => {
+    const globalResult = createDiscoveryResult();
+    discoverFromPath({
+      rawPath: installedPath.path,
+      origin: "global",
+      managedPluginDirs,
+      scanFiles: true,
+      env,
+      candidates: globalResult.candidates,
+      diagnostics: globalResult.diagnostics,
+      seen: new Set<string>(),
+      realpathCache,
+      packageManifestCache,
+      ...(installedPath.requireBuiltRuntimeEntry !== undefined
+        ? { requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry }
+        : {}),
+    });
+    if (globalResult.candidates.length > 0) {
+      return true;
+    }
+    if (params.record.source !== "path") {
+      return false;
+    }
+    if (
+      !isPathReachableFromConfigLoadPaths({
+        targetPath: installedPath.path,
+        configLoadPaths: params.configLoadPaths,
+        env,
+        realpathCache,
+      })
+    ) {
+      return false;
+    }
+    // Path installs may be config-loaded source packages; config origin keeps
+    // TypeScript entries recoverable without treating npm installs as source.
+    const configResult = createDiscoveryResult();
+    discoverFromPath({
+      rawPath: installedPath.path,
+      origin: "config",
+      env,
+      candidates: configResult.candidates,
+      diagnostics: configResult.diagnostics,
+      seen: new Set<string>(),
+      realpathCache,
+      packageManifestCache,
+    });
+    return configResult.candidates.length > 0;
+  });
 }
 
 function resolveManagedPluginDirKey(

--- a/src/plugins/installed-plugin-index-recovery.ts
+++ b/src/plugins/installed-plugin-index-recovery.ts
@@ -1,13 +1,29 @@
-import fs from "node:fs";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { resolveUserPath } from "../utils.js";
+import {
+  hasDiscoverableInstalledPluginRecordPath,
+  hasDiscoverablePluginRecoveryInput,
+  type PluginCandidate,
+} from "./discovery.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+
+export type InstallRecordRecoveryOptions = {
+  configLoadPaths?: unknown;
+  recoveryCandidates?: readonly PluginCandidate[];
+  workspaceDir?: string;
+};
+
+function hasInstallRecordPath(record: PluginInstallRecord): boolean {
+  return [record.installPath, record.sourcePath].some(
+    (candidate) => typeof candidate === "string" && candidate.trim().length > 0,
+  );
+}
 
 export function hasRecoverableInstallRecordsMissingFromIndex(
   index: InstalledPluginIndex,
   installRecords: Record<string, PluginInstallRecord>,
   env: NodeJS.ProcessEnv,
+  options: InstallRecordRecoveryOptions = {},
 ): boolean {
   const persistedRecords = extractPluginInstallRecordsFromInstalledPluginIndex(index);
   const persistedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
@@ -15,13 +31,32 @@ export function hasRecoverableInstallRecordsMissingFromIndex(
     if (persistedRecords[pluginId] && persistedPluginIds.has(pluginId)) {
       return false;
     }
-    const installPaths = [record.installPath, record.sourcePath].filter(
-      (candidate): candidate is string =>
-        typeof candidate === "string" && candidate.trim().length > 0,
-    );
-    if (installPaths.length === 0) {
+    if (!persistedRecords[pluginId]) {
+      // Newly recovered records need a rebuild so the persisted snapshot keeps
+      // install metadata even when the package cannot produce a plugin candidate.
       return true;
     }
-    return installPaths.some((installPath) => fs.existsSync(resolveUserPath(installPath, env)));
+    if (
+      hasDiscoverablePluginRecoveryInput({
+        pluginId,
+        candidates: options.recoveryCandidates,
+        configLoadPaths: options.configLoadPaths,
+        env,
+        ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+      })
+    ) {
+      return true;
+    }
+    if (!hasInstallRecordPath(record)) {
+      // Pathless records can still be recovered by the full refresh through
+      // explicit candidates or config load paths, so keep the conservative rebuild.
+      return true;
+    }
+    return hasDiscoverableInstalledPluginRecordPath({
+      record,
+      env,
+      configLoadPaths: options.configLoadPaths,
+      ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+    });
   });
 }

--- a/src/plugins/installed-plugin-index-recovery.ts
+++ b/src/plugins/installed-plugin-index-recovery.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveUserPath } from "../utils.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+
+export function hasRecoverableInstallRecordsMissingFromIndex(
+  index: InstalledPluginIndex,
+  installRecords: Record<string, PluginInstallRecord>,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const persistedRecords = extractPluginInstallRecordsFromInstalledPluginIndex(index);
+  const persistedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
+  return Object.entries(installRecords).some(([pluginId, record]) => {
+    if (persistedRecords[pluginId] && persistedPluginIds.has(pluginId)) {
+      return false;
+    }
+    const installPaths = [record.installPath, record.sourcePath].filter(
+      (candidate): candidate is string =>
+        typeof candidate === "string" && candidate.trim().length > 0,
+    );
+    if (installPaths.length === 0) {
+      return true;
+    }
+    return installPaths.some((installPath) => fs.existsSync(resolveUserPath(installPath, env)));
+  });
+}

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -707,6 +707,811 @@ describe("installed plugin index persistence", () => {
     });
   });
 
+  it("keeps policy refreshes on the fast path for stale existing install paths", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale");
+    const bundledDir = path.join(stateDir, "bundled");
+    const bundledPluginDir = path.join(bundledDir, "bundled-demo");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(bundledPluginDir, { recursive: true });
+    createCandidate(bundledPluginDir, { id: "bundled-demo" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: staleDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          stale: installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "stale", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        stale: installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes for pathless install records missing from the index", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "plugins", "pathless");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const candidate = createCandidate(pluginDir, { id: "pathless-demo" });
+    const installRecord = {
+      source: "npm" as const,
+      spec: "pathless-demo@1.0.0",
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "pathless-demo": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      env,
+    });
+
+    expectPluginIds(refreshed, ["pathless-demo"]);
+    expectInstallRecord(refreshed, "pathless-demo", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["pathless-demo"],
+      installRecords: {
+        "pathless-demo": installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes when explicit candidates can recover a missing plugin", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-explicit");
+    const candidateDir = path.join(stateDir, "candidates", "explicit-recovered");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(candidateDir, { recursive: true });
+    const candidate = createCandidate(candidateDir, { id: "explicit-recovered" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: staleDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "explicit-recovered": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      env,
+    });
+
+    expectPluginIds(refreshed, ["explicit-recovered"]);
+    expectInstallRecord(refreshed, "explicit-recovered", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["explicit-recovered"],
+      installRecords: {
+        "explicit-recovered": installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes when supplied discovery can recover a missing plugin", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-discovery");
+    const candidateDir = path.join(stateDir, "candidates", "discovery-recovered");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(candidateDir, { recursive: true });
+    const candidate = createCandidate(candidateDir, { id: "discovery-recovered" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: staleDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "discovery-recovered": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      discovery: { candidates: [candidate], diagnostics: [] },
+      env,
+    });
+
+    expectPluginIds(refreshed, ["discovery-recovered"]);
+    expectInstallRecord(refreshed, "discovery-recovered", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["discovery-recovered"],
+      installRecords: {
+        "discovery-recovered": installRecord,
+      },
+    });
+  });
+
+  it("keeps unrelated explicit recovery candidates on the policy refresh fast path", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-unrelated");
+    const candidateDir = path.join(stateDir, "candidates", "unrelated");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(candidateDir, { recursive: true });
+    const candidate = createCandidate(candidateDir, { id: "unrelated" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: staleDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          stale: installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      candidates: [candidate],
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "stale", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        stale: installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes when a stale install path has a discoverable source path", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-install");
+    const sourceDir = path.join(stateDir, "extensions", "source-recovered");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(sourceDir, { recursive: true });
+    createCandidate(sourceDir, { id: "source-recovered" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "source-recovered": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["source-recovered"]);
+    expectInstallRecord(refreshed, "source-recovered", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["source-recovered"],
+      installRecords: {
+        "source-recovered": installRecord,
+      },
+    });
+  });
+
+  it("keeps unreachable source paths on the policy refresh fast path", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-unreachable-source");
+    const sourceDir = path.join(stateDir, "outside-source");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(sourceDir, { recursive: true });
+    createCandidate(sourceDir, { id: "outside-source" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "outside-source": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "outside-source", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        "outside-source": installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes for config-loaded source path plugins", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-config-install");
+    const sourceDir = path.join(stateDir, "workspace-plugin");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "config-source",
+        openclaw: {
+          extensions: ["./src/index.ts"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "config-source",
+        name: "Config Source",
+        configSchema: { type: "object" },
+        providers: ["config-source"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(sourceDir, "src", "index.ts"), "export default {};\n", "utf8");
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const config = {
+      plugins: {
+        load: { paths: [sourceDir] },
+      },
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      config,
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "config-source": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["config-source"]);
+    expectInstallRecord(refreshed, "config-source", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["config-source"],
+      installRecords: {
+        "config-source": installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes when config load paths can recover a missing plugin", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-config-candidate");
+    const configDir = path.join(stateDir, "configured", "config-recovered");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(configDir, { recursive: true });
+    createCandidate(configDir, { id: "config-recovered" });
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: staleDir,
+      installPath: staleDir,
+    };
+    const config = {
+      plugins: {
+        load: { paths: [configDir] },
+      },
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      config,
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "config-recovered": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["config-recovered"]);
+    expectInstallRecord(refreshed, "config-recovered", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["config-recovered"],
+      installRecords: {
+        "config-recovered": installRecord,
+      },
+    });
+  });
+
+  it("keeps unconfigured source path plugins on the policy refresh fast path", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-unconfigured-install");
+    const sourceDir = path.join(stateDir, "unconfigured-source");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "unconfigured-source",
+        openclaw: {
+          extensions: ["./src/index.ts"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "unconfigured-source",
+        name: "Unconfigured Source",
+        configSchema: { type: "object" },
+        providers: ["unconfigured-source"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(sourceDir, "src", "index.ts"), "export default {};\n", "utf8");
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "unconfigured-source": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "unconfigured-source", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        "unconfigured-source": installRecord,
+      },
+    });
+  });
+
+  it("ignores malformed config load paths while checking missing install recovery", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-malformed-config-install");
+    const sourceDir = path.join(stateDir, "malformed-config-source");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "malformed-config-source",
+        openclaw: {
+          extensions: ["./src/index.ts"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "malformed-config-source",
+        name: "Malformed Config Source",
+        configSchema: { type: "object" },
+        providers: ["malformed-config-source"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(sourceDir, "src", "index.ts"), "export default {};\n", "utf8");
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const config = {
+      plugins: {
+        load: {
+          paths: { bad: sourceDir } as unknown as string[],
+        },
+      },
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      config,
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "malformed-config-source": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "malformed-config-source", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        "malformed-config-source": installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes for config-loaded source plugin files", async () => {
+    const stateDir = makeTempDir();
+    const staleDir = path.join(stateDir, "plugins", "stale-config-file-install");
+    const sourceDir = path.join(stateDir, "file-config-source");
+    const sourceFile = path.join(sourceDir, "index.ts");
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(sourceFile, "export default {};\n", "utf8");
+    fs.writeFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "file-config-source",
+        name: "File Config Source",
+        configSchema: { type: "object" },
+        providers: ["file-config-source"],
+      }),
+      "utf8",
+    );
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: sourceDir,
+      installPath: staleDir,
+    };
+    const config = {
+      plugins: {
+        load: { paths: [sourceFile] },
+      },
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      config,
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "file-config-source": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      config,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["file-config-source"]);
+    expectInstallRecord(refreshed, "file-config-source", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["file-config-source"],
+      installRecords: {
+        "file-config-source": installRecord,
+      },
+    });
+  });
+
+  it("keeps policy refreshes on the fast path for source-only npm install records", async () => {
+    const stateDir = makeTempDir();
+    const sourceOnlyDir = path.join(stateDir, "plugins", "source-only");
+    const bundledDir = path.join(stateDir, "bundled");
+    const bundledPluginDir = path.join(bundledDir, "bundled-demo");
+    fs.mkdirSync(path.join(sourceOnlyDir, "src"), { recursive: true });
+    fs.mkdirSync(bundledPluginDir, { recursive: true });
+    createCandidate(bundledPluginDir, { id: "bundled-demo" });
+    fs.writeFileSync(
+      path.join(sourceOnlyDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/source-only",
+        openclaw: {
+          extensions: ["./src/index.ts"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(sourceOnlyDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "source-only",
+        name: "Source Only",
+        configSchema: { type: "object" },
+        providers: ["source-only"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(sourceOnlyDir, "src", "index.ts"), "export default {};\n", "utf8");
+    const installRecord = {
+      source: "npm" as const,
+      spec: "@openclaw/source-only@1.0.0",
+      installPath: sourceOnlyDir,
+    };
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "source-only": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expectInstallRecord(refreshed, "source-only", installRecord);
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: [],
+      installRecords: {
+        "source-only": installRecord,
+      },
+    });
+  });
+
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();
     await writePersistedInstalledPluginIndex(

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const tempDirs: string[] = [];
 
@@ -591,6 +592,119 @@ describe("installed plugin index persistence", () => {
     });
 
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
+  });
+
+  it("rebuilds policy refreshes when install records are missing from plugins", async () => {
+    const stateDir = makeTempDir();
+    const installPath = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/whatsapp",
+      pluginId: "whatsapp",
+      version: "2026.5.2",
+    });
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    await writePersistedInstalledPluginIndex(
+      createIndex({
+        installRecords: {
+          whatsapp: {
+            source: "npm",
+            spec: "@openclaw/whatsapp@2026.5.2",
+            installPath,
+          },
+        },
+        plugins: [],
+      }),
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+      config: {
+        plugins: {
+          entries: {
+            whatsapp: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expectPluginIds(refreshed, ["whatsapp"]);
+    expectPluginFields(refreshed, "whatsapp", {
+      pluginId: "whatsapp",
+      origin: "global",
+      enabled: true,
+    });
+    expectInstallRecord(refreshed, "whatsapp", {
+      source: "npm",
+      spec: "@openclaw/whatsapp@2026.5.2",
+      installPath,
+    });
+    await expectPersistedIndex(stateDir, {
+      refreshReason: "policy-changed",
+      pluginIds: ["whatsapp"],
+    });
+  });
+
+  it("rebuilds policy refreshes from linked path install records", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "plugins", "local-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    createCandidate(pluginDir, { id: "local-plugin" });
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    await writePersistedInstalledPluginIndex(
+      createIndex({
+        installRecords: {
+          "local-plugin": {
+            source: "path",
+            sourcePath: pluginDir,
+            installPath: pluginDir,
+          },
+        },
+        plugins: [],
+      }),
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+      config: {
+        plugins: {
+          entries: {
+            "local-plugin": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expectPluginIds(refreshed, ["local-plugin"]);
+    expectPluginFields(refreshed, "local-plugin", {
+      pluginId: "local-plugin",
+      origin: "global",
+      enabled: true,
+    });
+    expectInstallRecord(refreshed, "local-plugin", {
+      source: "path",
+      sourcePath: pluginDir,
+      installPath: pluginDir,
+    });
   });
 
   it("preserves existing install records when refreshing the manifest cache", async () => {

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -13,6 +13,7 @@ import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveCompatRegistryVersion } from "./installed-plugin-index-policy.js";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
+import { hasRecoverableInstallRecordsMissingFromIndex } from "./installed-plugin-index-recovery.js";
 import {
   resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
@@ -446,6 +447,11 @@ function canRefreshPersistedPolicyState(
     params.installRecords &&
     hashJson(params.installRecords) !== hashJson(persisted.installRecords ?? {})
   ) {
+    return false;
+  }
+  const installRecords =
+    params.installRecords ?? extractPluginInstallRecordsFromInstalledPluginIndex(persisted);
+  if (hasRecoverableInstallRecordsMissingFromIndex(persisted, installRecords, env)) {
     return false;
   }
   return hasPolicyRefreshTargets(persisted, params.policyPluginIds);

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -451,7 +451,13 @@ function canRefreshPersistedPolicyState(
   }
   const installRecords =
     params.installRecords ?? extractPluginInstallRecordsFromInstalledPluginIndex(persisted);
-  if (hasRecoverableInstallRecordsMissingFromIndex(persisted, installRecords, env)) {
+  if (
+    hasRecoverableInstallRecordsMissingFromIndex(persisted, installRecords, env, {
+      configLoadPaths: params.config?.plugins?.load?.paths,
+      recoveryCandidates: [...(params.candidates ?? []), ...(params.discovery?.candidates ?? [])],
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    })
+  ) {
     return false;
   }
   return hasPolicyRefreshTargets(persisted, params.policyPluginIds);

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -398,6 +398,53 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(whatsappPlugin.origin).toBe("global");
   });
 
+  it("recovers managed npm install records even when runtime discovery fails", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const config = {};
+    const brokenDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/broken-runtime",
+      pluginId: "broken-runtime",
+      version: "2026.5.2",
+    });
+    fs.unlinkSync(path.join(brokenDir, "dist", "index.js"));
+    const staleIndex = loadInstalledPluginIndex({
+      config,
+      env,
+      stateDir,
+      installRecords: {},
+    });
+    expect(staleIndex.plugins.map((plugin) => plugin.pluginId)).not.toContain("broken-runtime");
+    writePersistedInstalledPluginIndexSync(staleIndex, { stateDir });
+
+    const result = loadPluginRegistrySnapshotWithMetadata({
+      config,
+      env,
+      stateDir,
+    });
+
+    expect(result.source).toBe("derived");
+    expectDiagnosticsContainCode(result.diagnostics, "persisted-registry-stale-source");
+    expect(result.snapshot.plugins.map((plugin) => plugin.pluginId)).not.toContain(
+      "broken-runtime",
+    );
+    expect(result.snapshot.installRecords["broken-runtime"]).toEqual({
+      source: "npm",
+      spec: "@openclaw/broken-runtime@2026.5.2",
+      installPath: brokenDir,
+      version: "2026.5.2",
+      resolvedName: "@openclaw/broken-runtime",
+      resolvedVersion: "2026.5.2",
+      resolvedSpec: "@openclaw/broken-runtime@2026.5.2",
+    });
+  });
+
   it("keeps vanished recovered install records on the persisted fast path", () => {
     const tempRoot = makeTempDir();
     const stateDir = path.join(tempRoot, "state");

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -478,6 +478,14 @@ export function loadPluginRegistrySnapshotWithMetadata(
           persistedIndex,
           loadSnapshotInstallRecords(params, env),
           env,
+          {
+            configLoadPaths: params.config?.plugins?.load?.paths,
+            recoveryCandidates: [
+              ...(params.candidates ?? []),
+              ...(params.discovery?.candidates ?? []),
+            ],
+            ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+          },
         )
       ) {
         diagnostics.push({

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -10,6 +10,7 @@ import type { PluginDiscoveryResult } from "./discovery.js";
 import { fileSignatureMatches, hashJson } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
+import { hasRecoverableInstallRecordsMissingFromIndex } from "./installed-plugin-index-recovery.js";
 import {
   inspectPersistedInstalledPluginIndex,
   readPersistedInstalledPluginIndexSync,
@@ -19,7 +20,6 @@ import {
 } from "./installed-plugin-index-store.js";
 import {
   getInstalledPluginRecord,
-  extractPluginInstallRecordsFromInstalledPluginIndex,
   hasMissingConfigPathActivationMetadata,
   isInstalledPluginEnabled,
   listInstalledPluginRecords,
@@ -398,28 +398,6 @@ function loadSnapshotInstallRecords(params: LoadPluginRegistryParams, env: NodeJ
   });
 }
 
-function hasRecoveredInstallRecordsMissingFromPersistedIndex(
-  index: InstalledPluginIndex,
-  installRecords: ReturnType<typeof loadInstalledPluginIndexInstallRecordsSync>,
-  env: NodeJS.ProcessEnv,
-): boolean {
-  const persistedRecords = extractPluginInstallRecordsFromInstalledPluginIndex(index);
-  const persistedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
-  return Object.entries(installRecords).some(([pluginId, record]) => {
-    if (persistedRecords[pluginId] && persistedPluginIds.has(pluginId)) {
-      return false;
-    }
-    const installPaths = [record.installPath, record.sourcePath].filter(
-      (candidate): candidate is string =>
-        typeof candidate === "string" && candidate.trim().length > 0,
-    );
-    if (installPaths.length === 0) {
-      return true;
-    }
-    return installPaths.some((installPath) => fs.existsSync(resolveUserPath(installPath, env)));
-  });
-}
-
 export function loadPluginRegistrySnapshotWithMetadata(
   params: LoadPluginRegistryParams = {},
 ): PluginRegistrySnapshotResult {
@@ -496,7 +474,7 @@ export function loadPluginRegistrySnapshotWithMetadata(
             "Persisted plugin registry metadata no longer matches plugin manifest or package files; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else if (
-        hasRecoveredInstallRecordsMissingFromPersistedIndex(
+        hasRecoverableInstallRecordsMissingFromIndex(
           persistedIndex,
           loadSnapshotInstallRecords(params, env),
           env,


### PR DESCRIPTION
## Summary

Fixes #89606.

`policy-changed` registry refresh can take a persisted fast path that only updates enablement. That is safe only when the persisted `plugins[]` view is complete. If persisted install records still point at recoverable path/npm plugins that are missing from `plugins[]`, the fast path preserves the broken view and keeps those plugins invisible.

This changes the policy refresh guard to fall back to a source rebuild when recoverable install records are missing from the persisted plugin index. The existing registry snapshot recovery check now shares the same helper, so load-time and refresh-time behavior stay aligned.

## Verification

- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts src/plugins/plugin-registry-snapshot.test.ts`
- `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts src/config/config.plugin-validation.test.ts`
- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/plugin-registry.test.ts src/config/config.plugin-validation.test.ts`
- `corepack pnpm exec oxfmt --check src/plugins/installed-plugin-index-recovery.ts src/plugins/installed-plugin-index-store.ts src/plugins/plugin-registry-snapshot.ts src/plugins/installed-plugin-index-store.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: `policy-changed` refresh no longer leaves recoverable path/npm install records stranded outside `plugins[]`.

Real environment tested: Local OpenClaw source checkout on macOS with Node 24.8.0 and pnpm 11.2.2 via Corepack, using a temporary `OPENCLAW_STATE_DIR` and the real SQLite-backed plugin registry store.

Exact steps or command run after this patch: Ran a live `corepack pnpm exec tsx` command in this PR checkout that created a temporary OpenClaw state directory, wrote an installed registry with path/npm `installRecords` and an empty `plugins[]`, then invoked `refreshPersistedInstalledPluginIndexSync({ reason: "policy-changed" })` through the production registry refresh path.

Evidence after fix: Console output from that live command:

```text
$ OPENCLAW_STATE_DIR=$(mktemp -d) corepack pnpm exec tsx real-policy-refresh-proof.ts
OpenClaw real setup: persisted registry has installRecords but an empty plugins[] view
Before refresh plugins[]: []
Before refresh installRecords: ["local-plugin","whatsapp"]
Command executed: refreshPersistedInstalledPluginIndexSync({ reason: policy-changed })
After refresh plugins[]: ["local-plugin","whatsapp"]
After refresh installRecords: ["local-plugin","whatsapp"]
Observed result: PASS - path and npm plugins were restored to plugins[]
```

Observed result after fix: The live output shows the broken starting state with `plugins[]` empty and both `local-plugin`/`whatsapp` present only in `installRecords`; after the `policy-changed` refresh, both ids are present in `plugins[]` and the install records remain present.

What was not tested: I did not run the downstream GPU sandbox/NemoClaw image; this proof targets the registry state shape reported in #89606 in a local OpenClaw setup.
