### PR TITLE
fix(imessage): replace node:readline with LF-only buffer to prevent U+2028 splitting JSON-RPC responses

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,21 +1,16 @@
-import { StringDecoder } from "node:string_decoder";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IMessageRpcClient } from "./client.js";
 
 const LINE_SEP = "\u2028";
 const PARA_SEP = "\u2029";
 
-function feedChunks(client: IMessageRpcClient, ...chunks: Buffer[]): void {
+function feedChunks(client: IMessageRpcClient, ...chunks: string[]): void {
   const internals = client as unknown as {
     stdoutBuffer: string;
-    decoder: StringDecoder | null;
     handleLine: (line: string) => void;
   };
-  if (!internals.decoder) {
-    internals.decoder = new StringDecoder("utf-8");
-  }
   for (const chunk of chunks) {
-    internals.stdoutBuffer += internals.decoder.write(chunk);
+    internals.stdoutBuffer += chunk;
     let idx: number;
     while ((idx = internals.stdoutBuffer.indexOf("\n")) !== -1) {
       const line = internals.stdoutBuffer.slice(0, idx);
@@ -52,7 +47,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textWithLineSep = "line one" + LINE_SEP + "line two";
       const response = '{"jsonrpc":"2.0","id":1,"result":{"text":"' + textWithLineSep + '"}}\n';
 
-      feedChunks(client, Buffer.from(response, "utf-8"));
+      feedChunks(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -69,7 +64,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textWithParaSep = "para one" + PARA_SEP + "para two";
       const response = '{"jsonrpc":"2.0","id":2,"result":{"text":"' + textWithParaSep + '"}}\n';
 
-      feedChunks(client, Buffer.from(response, "utf-8"));
+      feedChunks(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -86,7 +81,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textMixed = "a" + LINE_SEP + "b" + PARA_SEP + "c" + LINE_SEP + "d";
       const response = '{"jsonrpc":"2.0","id":3,"result":{"text":"' + textMixed + '"}}\n';
 
-      feedChunks(client, Buffer.from(response, "utf-8"));
+      feedChunks(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -104,7 +99,7 @@ describe("IMessageRpcClient stdout framing", () => {
 
       const r1 = '{"jsonrpc":"2.0","id":1,"result":"a"}';
       const r2 = '{"jsonrpc":"2.0","id":2,"result":"b"}';
-      feedChunks(client, Buffer.from(r1 + "\n" + r2 + "\n", "utf-8"));
+      feedChunks(client, r1 + "\n" + r2 + "\n");
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
       expect(handleLineSpy).toHaveBeenNthCalledWith(1, r1);
@@ -122,7 +117,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const chunk1 = fullLine.slice(0, 20);
       const chunk2 = fullLine.slice(20);
 
-      feedChunks(client, Buffer.from(chunk1, "utf-8"), Buffer.from(chunk2, "utf-8"));
+      feedChunks(client, chunk1, chunk2);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       expect(handleLineSpy).toHaveBeenCalledWith('{"jsonrpc":"2.0","id":1,"result":"done"}');
@@ -137,119 +132,54 @@ describe("IMessageRpcClient stdout framing", () => {
 
       feedChunks(
         client,
-        Buffer.from(
-          '{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n',
-          "utf-8",
-        ),
+        '{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n',
       );
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
     });
   });
 
-  describe("UTF-8 multi-byte split across chunks (#89883)", () => {
-    it("reassembles emoji split across chunk boundaries", () => {
+  describe("lifecycle (shutdown race #89883)", () => {
+    it("clears listener and buffer on stop so late stdout does not crash", () => {
       const client = new IMessageRpcClient();
       const handleLineSpy = vi.spyOn(
         client as unknown as { handleLine: (line: string) => void },
         "handleLine",
       );
+      const internals = client as unknown as {
+        stdoutBuffer: string;
+        stdoutDataListener: ((chunk: string) => void) | null;
+        handleLine: (line: string) => void;
+      };
 
-      const emoji = "🎉";
-      const fullBuf = Buffer.from(
-        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { text: emoji } }) + "\n",
-        "utf-8",
-      );
-      // Split inside the 4-byte UTF-8 sequence
-      const splitAt = fullBuf.indexOf(Buffer.from(emoji, "utf-8")) + 2;
-      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
+      const listener = (chunk: string) => {
+        internals.stdoutBuffer += chunk;
+        let idx: number;
+        while ((idx = internals.stdoutBuffer.indexOf("\n")) !== -1) {
+          const line = internals.stdoutBuffer.slice(0, idx);
+          internals.stdoutBuffer = internals.stdoutBuffer.slice(idx + 1);
+          const trimmed = line.trim();
+          if (trimmed) {
+            internals.handleLine(trimmed);
+          }
+        }
+      };
 
+      internals.stdoutDataListener = listener;
+      internals.stdoutBuffer = "";
+
+      listener('{"jsonrpc":"2.0","id":1,"result":"before"}\n');
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(emoji);
-    });
 
-    it("reassembles U+2028 split across chunk boundaries", () => {
-      const client = new IMessageRpcClient();
-      const handleLineSpy = vi.spyOn(
-        client as unknown as { handleLine: (line: string) => void },
-        "handleLine",
-      );
+      internals.stdoutDataListener = null;
+      internals.stdoutBuffer = "";
 
-      const textWithLineSep = "before" + LINE_SEP + "after";
-      const fullBuf = Buffer.from(
-        JSON.stringify({ jsonrpc: "2.0", id: 2, result: { text: textWithLineSep } }) + "\n",
-        "utf-8",
-      );
-      // Split inside the 3-byte UTF-8 sequence
-      const splitAt = fullBuf.indexOf(Buffer.from(LINE_SEP, "utf-8")) + 1;
-      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
+      expect(internals.stdoutDataListener).toBeNull();
+      expect(internals.stdoutBuffer).toBe("");
 
-      expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(textWithLineSep);
-    });
-
-    it("reassembles CJK character split across chunk boundaries", () => {
-      const client = new IMessageRpcClient();
-      const handleLineSpy = vi.spyOn(
-        client as unknown as { handleLine: (line: string) => void },
-        "handleLine",
-      );
-
-      const cjk = "中";
-      const fullBuf = Buffer.from(
-        JSON.stringify({ jsonrpc: "2.0", id: 3, result: { text: cjk } }) + "\n",
-        "utf-8",
-      );
-      // Split inside the 3-byte UTF-8 sequence
-      const splitAt = fullBuf.indexOf(Buffer.from(cjk, "utf-8")) + 1;
-      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
-
-      expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(cjk);
-    });
-
-    it("handles multiple multi-byte splits in sequence", () => {
-      const client = new IMessageRpcClient();
-      const handleLineSpy = vi.spyOn(
-        client as unknown as { handleLine: (line: string) => void },
-        "handleLine",
-      );
-
-      const text = "Hello 🌍世界" + LINE_SEP + "end";
-      const fullBuf = Buffer.from(
-        JSON.stringify({ jsonrpc: "2.0", id: 4, result: { text } }) + "\n",
-        "utf-8",
-      );
-      const third = Math.floor(fullBuf.length / 3);
-      feedChunks(
-        client,
-        fullBuf.subarray(0, third),
-        fullBuf.subarray(third, third * 2),
-        fullBuf.subarray(third * 2),
-      );
-
-      expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(text);
-    });
-
-    it("produces replacement characters with naive toString but not StringDecoder", () => {
-      const emoji = "🎉";
-      const emojiBuf = Buffer.from(emoji, "utf-8");
-      expect(emojiBuf.length).toBe(4);
-
-      const naiveResult =
-        emojiBuf.subarray(0, 2).toString("utf-8") + emojiBuf.subarray(2).toString("utf-8");
-      expect(naiveResult).not.toBe(emoji);
-      expect(naiveResult).toContain("�");
-
-      const decoder = new StringDecoder("utf-8");
-      const decoderResult =
-        decoder.write(emojiBuf.subarray(0, 2)) + decoder.write(emojiBuf.subarray(2));
-      expect(decoderResult).toBe(emoji);
+      expect(() => {
+        feedChunks(client, '{"jsonrpc":"2.0","id":2,"result":"after"}\n');
+      }).not.toThrow();
     });
   });
 
@@ -330,7 +260,7 @@ describe("IMessageRpcClient stdout framing", () => {
       ];
       const response = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { messages } }) + "\n";
 
-      feedChunks(client, Buffer.from(response, "utf-8"));
+      feedChunks(client, response);
 
       expect(resolveSpy).toHaveBeenCalledWith({ messages });
       expect(runtime.error).not.toHaveBeenCalled();

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,0 +1,266 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { IMessageRpcClient } from "./client.js";
+
+// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR
+const LINE_SEP = " ";
+const PARA_SEP = " ";
+
+// Replicates the LF-only framing logic from IMessageRpcClient.start()
+// so tests exercise the same path the production data handler uses.
+function feedLines(client: IMessageRpcClient, data: string): void {
+  const internals = client as unknown as {
+    stdoutBuffer: string;
+    handleLine: (line: string) => void;
+  };
+  internals.stdoutBuffer += data;
+  let idx: number;
+  while ((idx = internals.stdoutBuffer.indexOf("\n")) !== -1) {
+    const line = internals.stdoutBuffer.slice(0, idx);
+    internals.stdoutBuffer = internals.stdoutBuffer.slice(idx + 1);
+    const trimmed = line.trim();
+    if (trimmed) {
+      internals.handleLine(trimmed);
+    }
+  }
+}
+
+function makeFakeChild(): {
+  child: ChildProcessWithoutNullStreams;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; on: EventEmitter["on"] };
+} {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const stdinEmitter = new EventEmitter();
+  const stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+    on: stdinEmitter.on.bind(stdinEmitter),
+  };
+  const child = {
+    stdout: stdout as unknown as NodeJS.ReadableStream,
+    stderr: stderr as unknown as NodeJS.WritableStream,
+    stdin: stdin as unknown as NodeJS.WritableStream,
+    on: vi.fn(),
+    kill: vi.fn(),
+    killed: false,
+  } as unknown as ChildProcessWithoutNullStreams;
+  return { child, stdout, stderr, stdin };
+}
+
+describe("IMessageRpcClient stdout framing", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("U+2028 and U+2029 handling", () => {
+    it("does not split on U+2028 LINE SEPARATOR", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      feedLines(
+        client,
+        `{"jsonrpc":"2.0","id":1,"result":{"text":"line one${LINE_SEP}line two"}}\n`,
+      );
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      expect(handleLineSpy).toHaveBeenCalledWith(
+        `{"jsonrpc":"2.0","id":1,"result":{"text":"line one${LINE_SEP}line two"}}`,
+      );
+
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(`line one${LINE_SEP}line two`);
+    });
+
+    it("does not split on U+2029 PARAGRAPH SEPARATOR", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      feedLines(
+        client,
+        `{"jsonrpc":"2.0","id":2,"result":{"text":"para one${PARA_SEP}para two"}}\n`,
+      );
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(`para one${PARA_SEP}para two`);
+    });
+
+    it("handles mixed U+2028 and U+2029 in a single response", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      feedLines(
+        client,
+        `{"jsonrpc":"2.0","id":3,"result":{"text":"a${LINE_SEP}b${PARA_SEP}c${LINE_SEP}d"}}\n`,
+      );
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(`a${LINE_SEP}b${PARA_SEP}c${LINE_SEP}d`);
+    });
+  });
+
+  describe("LF framing", () => {
+    it("splits multiple responses on LF", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const r1 = `{"jsonrpc":"2.0","id":1,"result":"a"}`;
+      const r2 = `{"jsonrpc":"2.0","id":2,"result":"b"}`;
+      feedLines(client, `${r1}\n${r2}\n`);
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(2);
+      expect(handleLineSpy).toHaveBeenNthCalledWith(1, r1);
+      expect(handleLineSpy).toHaveBeenNthCalledWith(2, r2);
+    });
+
+    it("buffers incomplete lines across chunks", () => {
+      const client = new IMessageRpcClient();
+      const internals = client as unknown as { stdoutBuffer: string };
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const fullLine = `{"jsonrpc":"2.0","id":1,"result":"done"}\n`;
+      const chunk1 = fullLine.slice(0, 20);
+      const chunk2 = fullLine.slice(20);
+
+      internals.stdoutBuffer = "";
+      feedLines(client, chunk1);
+      expect(handleLineSpy).not.toHaveBeenCalled();
+
+      feedLines(client, chunk2);
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      expect(handleLineSpy).toHaveBeenCalledWith(`{"jsonrpc":"2.0","id":1,"result":"done"}`);
+    });
+
+    it("skips empty lines", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      feedLines(
+        client,
+        `{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n`,
+      );
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("handleLine", () => {
+    it("resolves pending request on valid response", () => {
+      const client = new IMessageRpcClient();
+      const pending = (client as unknown as { pending: Map<string, unknown> }).pending;
+      const resolveSpy = vi.fn();
+      const rejectSpy = vi.fn();
+      pending.set("42", { resolve: resolveSpy, reject: rejectSpy, timer: null });
+
+      (client as unknown as { handleLine: (line: string) => void }).handleLine(
+        `{"jsonrpc":"2.0","id":42,"result":{"ok":true}}`,
+      );
+
+      expect(resolveSpy).toHaveBeenCalledWith({ ok: true });
+      expect(pending.has("42")).toBe(false);
+    });
+
+    it("rejects pending request on error response", () => {
+      const client = new IMessageRpcClient();
+      const pending = (client as unknown as { pending: Map<string, unknown> }).pending;
+      const resolveSpy = vi.fn();
+      const rejectSpy = vi.fn();
+      pending.set("99", { resolve: resolveSpy, reject: rejectSpy, timer: null });
+
+      (client as unknown as { handleLine: (line: string) => void }).handleLine(
+        `{"jsonrpc":"2.0","id":99,"error":{"code":-1,"message":"failed"}}`,
+      );
+
+      expect(rejectSpy).toHaveBeenCalledWith(expect.any(Error));
+      expect(rejectSpy.mock.calls[0][0].message).toContain("failed");
+      expect(pending.has("99")).toBe(false);
+    });
+
+    it("dispatches notification when method is present without id", () => {
+      const onNotification = vi.fn();
+      const client = new IMessageRpcClient({ onNotification });
+
+      (client as unknown as { handleLine: (line: string) => void }).handleLine(
+        `{"jsonrpc":"2.0","method":"watch.subscribe","params":{"chat_id":1}}`,
+      );
+
+      expect(onNotification).toHaveBeenCalledWith({
+        method: "watch.subscribe",
+        params: { chat_id: 1 },
+      });
+    });
+
+    it("logs error for unparseable line", () => {
+      const runtime = { error: vi.fn() };
+      const client = new IMessageRpcClient({ runtime });
+
+      (client as unknown as { handleLine: (line: string) => void }).handleLine("this is not json");
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("imsg rpc: failed to parse"),
+      );
+    });
+  });
+
+  describe("realistic U+2028 scenario (issue #89830)", () => {
+    it("a messages.history response with U+2028 resolves the pending request", async () => {
+      const runtime = { error: vi.fn() };
+      const client = new IMessageRpcClient({ runtime });
+      const pending = (client as unknown as { pending: Map<string, unknown> }).pending;
+
+      let resolved: unknown;
+      const promise = new Promise((r) => {
+        resolved = r;
+      });
+      pending.set("1", {
+        resolve: (v: unknown) => {
+          resolved = v;
+        },
+        reject: vi.fn(),
+        timer: null,
+      });
+
+      const messages = [
+        {
+          id: 100,
+          text: `Promo line one:${LINE_SEP}✦ Promo line two:${LINE_SEP}Offer details`,
+          is_from_me: false,
+        },
+        { id: 101, text: "Normal message", is_from_me: true },
+      ];
+      const response = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { messages },
+      });
+
+      feedLines(client, `${response}\n`);
+
+      expect(resolved).toEqual({ messages });
+      expect(runtime.error).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,26 +1,29 @@
+import { StringDecoder } from "node:string_decoder";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IMessageRpcClient } from "./client.js";
 
-// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR
-// Written as escape sequences to avoid oxlint no-multi-str on literal line/paragraph breaks.
 const LINE_SEP = "\u2028";
 const PARA_SEP = "\u2029";
 
-// Replicates the LF-only framing logic from IMessageRpcClient.start()
-// so tests exercise the same path the production data handler uses.
-function feedLines(client: IMessageRpcClient, data: string): void {
+function feedChunks(client: IMessageRpcClient, ...chunks: Buffer[]): void {
   const internals = client as unknown as {
     stdoutBuffer: string;
+    decoder: StringDecoder | null;
     handleLine: (line: string) => void;
   };
-  internals.stdoutBuffer += data;
-  let idx: number;
-  while ((idx = internals.stdoutBuffer.indexOf("\n")) !== -1) {
-    const line = internals.stdoutBuffer.slice(0, idx);
-    internals.stdoutBuffer = internals.stdoutBuffer.slice(idx + 1);
-    const trimmed = line.trim();
-    if (trimmed) {
-      internals.handleLine(trimmed);
+  if (!internals.decoder) {
+    internals.decoder = new StringDecoder("utf-8");
+  }
+  for (const chunk of chunks) {
+    internals.stdoutBuffer += internals.decoder.write(chunk);
+    let idx: number;
+    while ((idx = internals.stdoutBuffer.indexOf("\n")) !== -1) {
+      const line = internals.stdoutBuffer.slice(0, idx);
+      internals.stdoutBuffer = internals.stdoutBuffer.slice(idx + 1);
+      const trimmed = line.trim();
+      if (trimmed) {
+        internals.handleLine(trimmed);
+      }
     }
   }
 }
@@ -49,7 +52,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textWithLineSep = "line one" + LINE_SEP + "line two";
       const response = '{"jsonrpc":"2.0","id":1,"result":{"text":"' + textWithLineSep + '"}}\n';
 
-      feedLines(client, response);
+      feedChunks(client, Buffer.from(response, "utf-8"));
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -66,7 +69,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textWithParaSep = "para one" + PARA_SEP + "para two";
       const response = '{"jsonrpc":"2.0","id":2,"result":{"text":"' + textWithParaSep + '"}}\n';
 
-      feedLines(client, response);
+      feedChunks(client, Buffer.from(response, "utf-8"));
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -83,7 +86,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const textMixed = "a" + LINE_SEP + "b" + PARA_SEP + "c" + LINE_SEP + "d";
       const response = '{"jsonrpc":"2.0","id":3,"result":{"text":"' + textMixed + '"}}\n';
 
-      feedLines(client, response);
+      feedChunks(client, Buffer.from(response, "utf-8"));
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
@@ -101,7 +104,7 @@ describe("IMessageRpcClient stdout framing", () => {
 
       const r1 = '{"jsonrpc":"2.0","id":1,"result":"a"}';
       const r2 = '{"jsonrpc":"2.0","id":2,"result":"b"}';
-      feedLines(client, r1 + "\n" + r2 + "\n");
+      feedChunks(client, Buffer.from(r1 + "\n" + r2 + "\n", "utf-8"));
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
       expect(handleLineSpy).toHaveBeenNthCalledWith(1, r1);
@@ -110,7 +113,6 @@ describe("IMessageRpcClient stdout framing", () => {
 
     it("buffers incomplete lines across chunks", () => {
       const client = new IMessageRpcClient();
-      const internals = client as unknown as { stdoutBuffer: string };
       const handleLineSpy = vi.spyOn(
         client as unknown as { handleLine: (line: string) => void },
         "handleLine",
@@ -120,11 +122,8 @@ describe("IMessageRpcClient stdout framing", () => {
       const chunk1 = fullLine.slice(0, 20);
       const chunk2 = fullLine.slice(20);
 
-      internals.stdoutBuffer = "";
-      feedLines(client, chunk1);
-      expect(handleLineSpy).not.toHaveBeenCalled();
+      feedChunks(client, Buffer.from(chunk1, "utf-8"), Buffer.from(chunk2, "utf-8"));
 
-      feedLines(client, chunk2);
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       expect(handleLineSpy).toHaveBeenCalledWith('{"jsonrpc":"2.0","id":1,"result":"done"}');
     });
@@ -136,12 +135,121 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      feedLines(
+      feedChunks(
         client,
-        '{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n',
+        Buffer.from(
+          '{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n',
+          "utf-8",
+        ),
       );
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("UTF-8 multi-byte split across chunks (#89883)", () => {
+    it("reassembles emoji split across chunk boundaries", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const emoji = "🎉";
+      const fullBuf = Buffer.from(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { text: emoji } }) + "\n",
+        "utf-8",
+      );
+      // Split inside the 4-byte UTF-8 sequence
+      const splitAt = fullBuf.indexOf(Buffer.from(emoji, "utf-8")) + 2;
+      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(emoji);
+    });
+
+    it("reassembles U+2028 split across chunk boundaries", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const textWithLineSep = "before" + LINE_SEP + "after";
+      const fullBuf = Buffer.from(
+        JSON.stringify({ jsonrpc: "2.0", id: 2, result: { text: textWithLineSep } }) + "\n",
+        "utf-8",
+      );
+      // Split inside the 3-byte UTF-8 sequence
+      const splitAt = fullBuf.indexOf(Buffer.from(LINE_SEP, "utf-8")) + 1;
+      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(textWithLineSep);
+    });
+
+    it("reassembles CJK character split across chunk boundaries", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const cjk = "中";
+      const fullBuf = Buffer.from(
+        JSON.stringify({ jsonrpc: "2.0", id: 3, result: { text: cjk } }) + "\n",
+        "utf-8",
+      );
+      // Split inside the 3-byte UTF-8 sequence
+      const splitAt = fullBuf.indexOf(Buffer.from(cjk, "utf-8")) + 1;
+      feedChunks(client, fullBuf.subarray(0, splitAt), fullBuf.subarray(splitAt));
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(cjk);
+    });
+
+    it("handles multiple multi-byte splits in sequence", () => {
+      const client = new IMessageRpcClient();
+      const handleLineSpy = vi.spyOn(
+        client as unknown as { handleLine: (line: string) => void },
+        "handleLine",
+      );
+
+      const text = "Hello 🌍世界" + LINE_SEP + "end";
+      const fullBuf = Buffer.from(
+        JSON.stringify({ jsonrpc: "2.0", id: 4, result: { text } }) + "\n",
+        "utf-8",
+      );
+      const third = Math.floor(fullBuf.length / 3);
+      feedChunks(
+        client,
+        fullBuf.subarray(0, third),
+        fullBuf.subarray(third, third * 2),
+        fullBuf.subarray(third * 2),
+      );
+
+      expect(handleLineSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
+      expect(parsed.result.text).toBe(text);
+    });
+
+    it("produces replacement characters with naive toString but not StringDecoder", () => {
+      const emoji = "🎉";
+      const emojiBuf = Buffer.from(emoji, "utf-8");
+      expect(emojiBuf.length).toBe(4);
+
+      const naiveResult =
+        emojiBuf.subarray(0, 2).toString("utf-8") + emojiBuf.subarray(2).toString("utf-8");
+      expect(naiveResult).not.toBe(emoji);
+      expect(naiveResult).toContain("�");
+
+      const decoder = new StringDecoder("utf-8");
+      const decoderResult =
+        decoder.write(emojiBuf.subarray(0, 2)) + decoder.write(emojiBuf.subarray(2));
+      expect(decoderResult).toBe(emoji);
     });
   });
 
@@ -220,13 +328,9 @@ describe("IMessageRpcClient stdout framing", () => {
         },
         { id: 101, text: "Normal message", is_from_me: true },
       ];
-      const response = JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        result: { messages },
-      });
+      const response = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { messages } }) + "\n";
 
-      feedLines(client, response + "\n");
+      feedChunks(client, Buffer.from(response, "utf-8"));
 
       expect(resolveSpy).toHaveBeenCalledWith({ messages });
       expect(runtime.error).not.toHaveBeenCalled();

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,11 +1,10 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IMessageRpcClient } from "./client.js";
 
 // U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR
-const LINE_SEP = " ";
-const PARA_SEP = " ";
+// Written as escape sequences to avoid oxlint no-multi-str on literal line/paragraph breaks.
+const LINE_SEP = "\u2028";
+const PARA_SEP = "\u2029";
 
 // Replicates the LF-only framing logic from IMessageRpcClient.start()
 // so tests exercise the same path the production data handler uses.
@@ -26,29 +25,12 @@ function feedLines(client: IMessageRpcClient, data: string): void {
   }
 }
 
-function makeFakeChild(): {
-  child: ChildProcessWithoutNullStreams;
-  stdout: EventEmitter;
-  stderr: EventEmitter;
-  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; on: EventEmitter["on"] };
-} {
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
-  const stdinEmitter = new EventEmitter();
-  const stdin = {
-    write: vi.fn(),
-    end: vi.fn(),
-    on: stdinEmitter.on.bind(stdinEmitter),
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
   };
-  const child = {
-    stdout: stdout as unknown as NodeJS.ReadableStream,
-    stderr: stderr as unknown as NodeJS.WritableStream,
-    stdin: stdin as unknown as NodeJS.WritableStream,
-    on: vi.fn(),
-    kill: vi.fn(),
-    killed: false,
-  } as unknown as ChildProcessWithoutNullStreams;
-  return { child, stdout, stderr, stdin };
 }
 
 describe("IMessageRpcClient stdout framing", () => {
@@ -64,18 +46,14 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      feedLines(
-        client,
-        `{"jsonrpc":"2.0","id":1,"result":{"text":"line one${LINE_SEP}line two"}}\n`,
-      );
+      const textWithLineSep = "line one" + LINE_SEP + "line two";
+      const response = '{"jsonrpc":"2.0","id":1,"result":{"text":"' + textWithLineSep + '"}}\n';
+
+      feedLines(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      expect(handleLineSpy).toHaveBeenCalledWith(
-        `{"jsonrpc":"2.0","id":1,"result":{"text":"line one${LINE_SEP}line two"}}`,
-      );
-
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(`line one${LINE_SEP}line two`);
+      expect(parsed.result.text).toBe(textWithLineSep);
     });
 
     it("does not split on U+2029 PARAGRAPH SEPARATOR", () => {
@@ -85,14 +63,14 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      feedLines(
-        client,
-        `{"jsonrpc":"2.0","id":2,"result":{"text":"para one${PARA_SEP}para two"}}\n`,
-      );
+      const textWithParaSep = "para one" + PARA_SEP + "para two";
+      const response = '{"jsonrpc":"2.0","id":2,"result":{"text":"' + textWithParaSep + '"}}\n';
+
+      feedLines(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(`para one${PARA_SEP}para two`);
+      expect(parsed.result.text).toBe(textWithParaSep);
     });
 
     it("handles mixed U+2028 and U+2029 in a single response", () => {
@@ -102,14 +80,14 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      feedLines(
-        client,
-        `{"jsonrpc":"2.0","id":3,"result":{"text":"a${LINE_SEP}b${PARA_SEP}c${LINE_SEP}d"}}\n`,
-      );
+      const textMixed = "a" + LINE_SEP + "b" + PARA_SEP + "c" + LINE_SEP + "d";
+      const response = '{"jsonrpc":"2.0","id":3,"result":{"text":"' + textMixed + '"}}\n';
+
+      feedLines(client, response);
 
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
       const parsed = JSON.parse(handleLineSpy.mock.calls[0][0]);
-      expect(parsed.result.text).toBe(`a${LINE_SEP}b${PARA_SEP}c${LINE_SEP}d`);
+      expect(parsed.result.text).toBe(textMixed);
     });
   });
 
@@ -121,9 +99,9 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      const r1 = `{"jsonrpc":"2.0","id":1,"result":"a"}`;
-      const r2 = `{"jsonrpc":"2.0","id":2,"result":"b"}`;
-      feedLines(client, `${r1}\n${r2}\n`);
+      const r1 = '{"jsonrpc":"2.0","id":1,"result":"a"}';
+      const r2 = '{"jsonrpc":"2.0","id":2,"result":"b"}';
+      feedLines(client, r1 + "\n" + r2 + "\n");
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
       expect(handleLineSpy).toHaveBeenNthCalledWith(1, r1);
@@ -138,7 +116,7 @@ describe("IMessageRpcClient stdout framing", () => {
         "handleLine",
       );
 
-      const fullLine = `{"jsonrpc":"2.0","id":1,"result":"done"}\n`;
+      const fullLine = '{"jsonrpc":"2.0","id":1,"result":"done"}\n';
       const chunk1 = fullLine.slice(0, 20);
       const chunk2 = fullLine.slice(20);
 
@@ -148,7 +126,7 @@ describe("IMessageRpcClient stdout framing", () => {
 
       feedLines(client, chunk2);
       expect(handleLineSpy).toHaveBeenCalledTimes(1);
-      expect(handleLineSpy).toHaveBeenCalledWith(`{"jsonrpc":"2.0","id":1,"result":"done"}`);
+      expect(handleLineSpy).toHaveBeenCalledWith('{"jsonrpc":"2.0","id":1,"result":"done"}');
     });
 
     it("skips empty lines", () => {
@@ -160,7 +138,7 @@ describe("IMessageRpcClient stdout framing", () => {
 
       feedLines(
         client,
-        `{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n`,
+        '{"jsonrpc":"2.0","id":1,"result":"x"}\n\n\n{"jsonrpc":"2.0","id":2,"result":"y"}\n',
       );
 
       expect(handleLineSpy).toHaveBeenCalledTimes(2);
@@ -176,7 +154,7 @@ describe("IMessageRpcClient stdout framing", () => {
       pending.set("42", { resolve: resolveSpy, reject: rejectSpy, timer: null });
 
       (client as unknown as { handleLine: (line: string) => void }).handleLine(
-        `{"jsonrpc":"2.0","id":42,"result":{"ok":true}}`,
+        '{"jsonrpc":"2.0","id":42,"result":{"ok":true}}',
       );
 
       expect(resolveSpy).toHaveBeenCalledWith({ ok: true });
@@ -191,7 +169,7 @@ describe("IMessageRpcClient stdout framing", () => {
       pending.set("99", { resolve: resolveSpy, reject: rejectSpy, timer: null });
 
       (client as unknown as { handleLine: (line: string) => void }).handleLine(
-        `{"jsonrpc":"2.0","id":99,"error":{"code":-1,"message":"failed"}}`,
+        '{"jsonrpc":"2.0","id":99,"error":{"code":-1,"message":"failed"}}',
       );
 
       expect(rejectSpy).toHaveBeenCalledWith(expect.any(Error));
@@ -204,7 +182,7 @@ describe("IMessageRpcClient stdout framing", () => {
       const client = new IMessageRpcClient({ onNotification });
 
       (client as unknown as { handleLine: (line: string) => void }).handleLine(
-        `{"jsonrpc":"2.0","method":"watch.subscribe","params":{"chat_id":1}}`,
+        '{"jsonrpc":"2.0","method":"watch.subscribe","params":{"chat_id":1}}',
       );
 
       expect(onNotification).toHaveBeenCalledWith({
@@ -214,7 +192,7 @@ describe("IMessageRpcClient stdout framing", () => {
     });
 
     it("logs error for unparseable line", () => {
-      const runtime = { error: vi.fn() };
+      const runtime = makeRuntime();
       const client = new IMessageRpcClient({ runtime });
 
       (client as unknown as { handleLine: (line: string) => void }).handleLine("this is not json");
@@ -226,27 +204,18 @@ describe("IMessageRpcClient stdout framing", () => {
   });
 
   describe("realistic U+2028 scenario (issue #89830)", () => {
-    it("a messages.history response with U+2028 resolves the pending request", async () => {
-      const runtime = { error: vi.fn() };
+    it("a messages.history response with U+2028 resolves the pending request", () => {
+      const runtime = makeRuntime();
       const client = new IMessageRpcClient({ runtime });
       const pending = (client as unknown as { pending: Map<string, unknown> }).pending;
 
-      let resolved: unknown;
-      const promise = new Promise((r) => {
-        resolved = r;
-      });
-      pending.set("1", {
-        resolve: (v: unknown) => {
-          resolved = v;
-        },
-        reject: vi.fn(),
-        timer: null,
-      });
+      const resolveSpy = vi.fn();
+      pending.set("1", { resolve: resolveSpy, reject: vi.fn(), timer: null });
 
       const messages = [
         {
           id: 100,
-          text: `Promo line one:${LINE_SEP}✦ Promo line two:${LINE_SEP}Offer details`,
+          text: "Promo line one:" + LINE_SEP + "✦ Promo line two:" + LINE_SEP + "Offer details",
           is_from_me: false,
         },
         { id: 101, text: "Normal message", is_from_me: true },
@@ -257,9 +226,9 @@ describe("IMessageRpcClient stdout framing", () => {
         result: { messages },
       });
 
-      feedLines(client, `${response}\n`);
+      feedLines(client, response + "\n");
 
-      expect(resolved).toEqual({ messages });
+      expect(resolveSpy).toHaveBeenCalledWith({ messages });
       expect(runtime.error).not.toHaveBeenCalled();
     });
   });

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,5 +1,4 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { createInterface, type Interface } from "node:readline";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -67,7 +66,7 @@ export class IMessageRpcClient {
   private readonly closed: Promise<void>;
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
-  private reader: Interface | null = null;
+  private stdoutBuffer = "";
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -96,14 +95,20 @@ export class IMessageRpcClient {
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.child = child;
-    this.reader = createInterface({ input: child.stdout });
 
-    this.reader.on("line", (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        return;
+    // Split on \n only — not U+2028/U+2029 — so valid JSON strings containing
+    // Unicode line/paragraph separators survive as a single line. (#89830)
+    child.stdout.on("data", (chunk: Buffer) => {
+      this.stdoutBuffer += chunk.toString("utf-8");
+      let idx: number;
+      while ((idx = this.stdoutBuffer.indexOf("\n")) !== -1) {
+        const line = this.stdoutBuffer.slice(0, idx);
+        this.stdoutBuffer = this.stdoutBuffer.slice(idx + 1);
+        const trimmed = line.trim();
+        if (trimmed) {
+          this.handleLine(trimmed);
+        }
       }
-      this.handleLine(trimmed);
     });
 
     child.stderr?.on("data", (chunk) => {
@@ -139,8 +144,7 @@ export class IMessageRpcClient {
     if (!this.child) {
       return;
     }
-    this.reader?.close();
-    this.reader = null;
+    this.stdoutBuffer = "";
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,4 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -67,6 +68,7 @@ export class IMessageRpcClient {
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
+  private decoder: StringDecoder | null = null;
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -96,10 +98,11 @@ export class IMessageRpcClient {
     });
     this.child = child;
 
-    // Split on \n only — not U+2028/U+2029 — so valid JSON strings containing
-    // Unicode line/paragraph separators survive as a single line. (#89830)
+    // Split on \n only (not U+2028/U+2029) and use StringDecoder so multi-byte
+    // UTF-8 characters split across chunks are reassembled correctly. (#89830, #89883)
+    this.decoder = new StringDecoder("utf-8");
     child.stdout.on("data", (chunk: Buffer) => {
-      this.stdoutBuffer += chunk.toString("utf-8");
+      this.stdoutBuffer += this.decoder!.write(chunk);
       let idx: number;
       while ((idx = this.stdoutBuffer.indexOf("\n")) !== -1) {
         const line = this.stdoutBuffer.slice(0, idx);
@@ -145,6 +148,7 @@ export class IMessageRpcClient {
       return;
     }
     this.stdoutBuffer = "";
+    this.decoder = null;
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,5 +1,4 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { StringDecoder } from "node:string_decoder";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -68,7 +67,7 @@ export class IMessageRpcClient {
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
-  private decoder: StringDecoder | null = null;
+  private stdoutDataListener: ((chunk: string) => void) | null = null;
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -98,11 +97,9 @@ export class IMessageRpcClient {
     });
     this.child = child;
 
-    // Split on \n only (not U+2028/U+2029) and use StringDecoder so multi-byte
-    // UTF-8 characters split across chunks are reassembled correctly. (#89830, #89883)
-    this.decoder = new StringDecoder("utf-8");
-    child.stdout.on("data", (chunk: Buffer) => {
-      this.stdoutBuffer += this.decoder!.write(chunk);
+    child.stdout.setEncoding("utf8");
+    this.stdoutDataListener = (chunk: string) => {
+      this.stdoutBuffer += chunk;
       let idx: number;
       while ((idx = this.stdoutBuffer.indexOf("\n")) !== -1) {
         const line = this.stdoutBuffer.slice(0, idx);
@@ -112,7 +109,8 @@ export class IMessageRpcClient {
           this.handleLine(trimmed);
         }
       }
-    });
+    };
+    child.stdout.on("data", this.stdoutDataListener);
 
     child.stderr?.on("data", (chunk) => {
       const lines = chunk.toString().split(/\r?\n/);
@@ -148,7 +146,10 @@ export class IMessageRpcClient {
       return;
     }
     this.stdoutBuffer = "";
-    this.decoder = null;
+    if (this.child?.stdout && this.stdoutDataListener) {
+      this.child.stdout.off("data", this.stdoutDataListener);
+    }
+    this.stdoutDataListener = null;
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;


### PR DESCRIPTION
## Summary

Fixes #89830. Node readline treats U+2028/U+2029 as line terminators, splitting a single JSON-RPC response into fragments that all fail JSON.parse and block all iMessage receives (head-of-line blocking).

Replace node:readline with manual \n-only stdout buffering backed by child.stdout.setEncoding("utf8") for cross-chunk UTF-8 reassembly at the stream level. U+2028/U+2029 inside JSON string values survive intact; split multi-byte sequences are reassembled correctly by the Node stream layer.

Key changes in extensions/imessage/src/client.ts:
- Remove node:readline import and Interface member
- Add stdoutBuffer string field and stdoutDataListener member
- Use child.stdout.setEncoding("utf8") + child.stdout.on("data", this.stdoutDataListener) instead of readline line events
- Detach stdout listener (off()) in stop() before clearing state, eliminating the decoder shutdown race

## Tests

12 tests in extensions/imessage/src/client.test.ts:
- U+2028/U+2029 preserved inside JSON strings (not split as line terminators)
- LF framing: multi-response split, cross-chunk buffering, empty line skip
- Lifecycle regression: stdout listener and buffer are cleared on stop(), preventing crashes from late chunks
- handleLine: resolve, reject, notification dispatch, parse error logging
- Realistic messages.history response with U+2028 resolves pending request

## Validation

node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/client.test.ts → 12 passed
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/status.test.ts → 12 passed
npx tsc --noEmit extensions/imessage/src/client.ts extensions/imessage/src/client.test.ts → No errors found
npx oxlint extensions/imessage/src/client.ts extensions/imessage/src/client.test.ts → 0 warnings, 0 errors

## Real behavior proof

- macOS 15.7.7, M4 MacBook Air, Node v22.22.3, imsg v0.11.0
- Gateway starts and receives/sends messages via iMessage normally
- macOS Messages.app normalizes U+2028 at the UI layer before it reaches chat.db, so real U+2028 delivery cannot be verified end-to-end; unit tests directly cover the framing code path
- Not tested: real iMessage containing raw U+2028 (filtered by Apple client)