### PR TITLE
fix(ui): show stale context indicator instead of hiding it

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -132,6 +132,11 @@
   border-color: color-mix(in srgb, var(--border) 70%, transparent);
 }
 
+.context-notice--stale {
+  opacity: 0.6;
+  font-style: italic;
+}
+
 .context-notice__icon {
   width: 16px;
   height: 16px;

--- a/ui/src/ui/chat/context-notice.ts
+++ b/ui/src/ui/chat/context-notice.ts
@@ -62,10 +62,9 @@ export function getContextNoticeViewModel(
   bg: string;
   warning: boolean;
   compactRecommended: boolean;
+  stale: boolean;
 } | null {
-  if (session?.totalTokensFresh === false) {
-    return null;
-  }
+  const stale = session?.totalTokensFresh === false;
   const used = session?.totalTokens;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (typeof used !== "number" || !Number.isFinite(used) || used < 0 || !limit) {
@@ -74,14 +73,16 @@ export function getContextNoticeViewModel(
   const ratio = used / limit;
   const pct = Math.min(Math.round(ratio * 100), 100);
   const warning = ratio >= CONTEXT_NOTICE_RATIO;
+  const prefix = stale ? "~" : "";
   if (!warning) {
     return {
       pct,
-      detail: `${formatTokensCompact(used)} / ${formatTokensCompact(limit)}`,
+      detail: `${prefix}${formatTokensCompact(used)} / ${formatTokensCompact(limit)}`,
       color: "var(--muted)",
       bg: "color-mix(in srgb, var(--muted) 8%, transparent)",
       warning,
       compactRecommended: false,
+      stale,
     };
   }
   // Read theme semantic tokens so color tracks the active theme (Dash, dark, light ...).
@@ -97,11 +98,12 @@ export function getContextNoticeViewModel(
   const bg = `rgba(${r}, ${g}, ${b}, ${bgOpacity})`;
   return {
     pct,
-    detail: `${formatTokensCompact(used)} / ${formatTokensCompact(limit)}`,
+    detail: `${prefix}${formatTokensCompact(used)} / ${formatTokensCompact(limit)}`,
     color,
     bg,
     warning,
     compactRecommended: ratio >= CONTEXT_COMPACT_RATIO,
+    stale,
   };
 }
 
@@ -116,12 +118,13 @@ export function renderContextNotice(
   }
   const canRenderCompact = model.compactRecommended && options.onCompact;
   const compactDisabled = options.compactDisabled === true || options.compactBusy === true;
+  const staleClass = model.stale ? " context-notice--stale" : "";
   return html`
     <div
-      class="context-notice ${model.warning ? "context-notice--warning" : "context-notice--usage"}"
+      class="context-notice ${model.warning ? "context-notice--warning" : "context-notice--usage"}${staleClass}"
       role="status"
       style="--ctx-color:${model.color};--ctx-bg:${model.bg}"
-      title=${`Session context usage: ${model.detail} (${model.pct}%)`}
+      title=${`Session context usage: ${model.detail} (${model.pct}%)${model.stale ? " (stale)" : ""}`}
     >
       ${model.warning
         ? html`

--- a/ui/src/ui/chat/run-controls.test.ts
+++ b/ui/src/ui/chat/run-controls.test.ts
@@ -408,7 +408,12 @@ describe("context notice", () => {
         },
         200_000,
       ),
-    ).toBeNull();
+    ).toEqual(
+      expect.objectContaining({
+        stale: true,
+        detail: "~190k / 200k",
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
fix(ui): show stale context indicator instead of hiding it

## Summary
**Problem:** When `totalTokensFresh` is `false` (during/after a run without fresh usage data), the context usage indicator was completely hidden. This created a jarring UX where the indicator disappeared after sending a message and didn't reappear until the next run completed with valid usage data.

**Fix:** Instead of returning `null` when `totalTokensFresh === false`, show the last known token count with a `~` prefix (matching `/status` behavior) and muted/italic styling. Users always see context usage information.

**Out of scope:** No changes to backend `totalTokensFresh` logic, `/status` command, or per-message context percentage. The `/status` count mismatch (1.8k vs 3.9k) is a separate issue not addressed here.

## Linked context
Closes #89662

## Real behavior proof

- Behavior or issue addressed: Context usage indicator disappears after sending a message and doesn't reappear until page refresh
- Real environment tested: Windows 10, Node.js v22.11.0, OpenClaw latest main (commit 70a989a, 2026-06-03)
- Exact steps or command run after this patch: Ran OpenClaw's production `getContextNoticeViewModel` via `node --import tsx` with real session data
- Evidence after fix: Terminal output from running OpenClaw's production helper:
```
$ node --import tsx -e "
import { getContextNoticeViewModel } from './ui/src/ui/chat/context-notice.ts';

const staleSession = { totalTokens: 1800, totalTokensFresh: false, contextTokens: 180000 };
const staleResult = getContextNoticeViewModel(staleSession, null);
console.log('=== Stale session (totalTokensFresh=false) ===');
console.log('Result:', JSON.stringify(staleResult, null, 2));
console.log('Has stale flag:', staleResult?.stale);
console.log('Detail has ~ prefix:', staleResult?.detail.startsWith('~'));

const freshSession = { totalTokens: 1800, totalTokensFresh: true, contextTokens: 180000 };
const freshResult = getContextNoticeViewModel(freshSession, null);
console.log('');
console.log('=== Fresh session (totalTokensFresh=true) ===');
console.log('Result:', JSON.stringify(freshResult, null, 2));
console.log('Has stale flag:', freshResult?.stale);
console.log('Detail has ~ prefix:', freshResult?.detail.startsWith('~'));
"

=== Stale session (totalTokensFresh=false) ===
Result: {
  "pct": 1,
  "detail": "~1.8k / 180k",
  "color": "var(--muted)",
  "bg": "color-mix(in srgb, var(--muted) 8%, transparent)",
  "warning": false,
  "compactRecommended": false,
  "stale": true
}
Has stale flag: true
Detail has ~ prefix: true

=== Fresh session (totalTokensFresh=true) ===
Result: {
  "pct": 1,
  "detail": "1.8k / 180k",
  "color": "var(--muted)",
  "bg": "color-mix(in srgb, var(--muted) 8%, transparent)",
  "warning": false,
  "compactRecommended": false,
  "stale": false
}
Has stale flag: false
Detail has ~ prefix: false
```
- Observed result after fix: When `totalTokensFresh` is `false`, the indicator now shows `~1.8k / 180k` with `stale: true` instead of returning `null`. The `~` prefix matches `/status` behavior for stale data. When `totalTokensFresh` is `true`, the indicator shows `1.8k / 180k` without prefix (normal behavior).
- What was not tested: Live Control UI browser screenshot (requires running gateway + browser)

## Tests and validation
- Existing tests in `ui/src/ui/chat/context-notice.test.ts` cover the normal path
- No CHANGELOG.md edits

## Risk checklist
- userVisible: Yes (context indicator now shows during runs instead of disappearing)
- configEnvMigration: No
- securityAuthNetwork: No
- Mitigation: Only changes UI display; stale data is clearly marked with ~ prefix and muted styling

## Current review state
- Addressed ClawSweeper: Added real behavior proof running OpenClaw's production `getContextNoticeViewModel` helper
- [x] AI-assisted (built with Claude Code)
