### PR TITLE
fix(context-engine): forward abortSignal through delegation bridge to runtime compaction

### DIFF
--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -603,6 +603,32 @@ describe("Engine contract tests", () => {
     });
   });
 
+  it("delegateCompactionToRuntime forwards the caller abortSignal to the runtime (#89868)", async () => {
+    installCompactRuntimeSpy();
+    const controller = new AbortController();
+    await delegateCompactionToRuntime({
+      sessionId: "s-abort",
+      sessionFile: "/tmp/session-abort.json",
+      tokenBudget: 4096,
+      abortSignal: controller.signal,
+    });
+
+    const compactRuntimeParams = requireCompactRuntimeParams(0);
+    expect(compactRuntimeParams.abortSignal).toBe(controller.signal);
+  });
+
+  it("delegateCompactionToRuntime passes undefined abortSignal when none supplied", async () => {
+    installCompactRuntimeSpy();
+    await delegateCompactionToRuntime({
+      sessionId: "s-no-abort",
+      sessionFile: "/tmp/session-no-abort.json",
+      tokenBudget: 4096,
+    });
+
+    const compactRuntimeParams = requireCompactRuntimeParams(0);
+    expect(compactRuntimeParams.abortSignal).toBeUndefined();
+  });
+
   it("builds a normalized memory system prompt addition from the active memory prompt path", () => {
     registerMemoryPromptSection(({ citationsMode }) => [
       "## Memory Recall",

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -60,6 +60,7 @@ export async function delegateCompactionToRuntime(
     ...(currentTokenCount !== undefined ? { currentTokenCount } : {}),
     force: params.force,
     customInstructions: params.customInstructions,
+    abortSignal: params.abortSignal,
     workspaceDir:
       typeof runtimeContext.workspaceDir === "string" ? runtimeContext.workspaceDir : process.cwd(),
   });


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89868 reports that pressing stop during auto-compaction cancels the wait but allows the compaction LLM call to finish and write its result to the session. The next message sees a compacted session the user did not consent to (e.g. 239→4 messages), causing model confusion about ongoing work and instructions.
- **Root Cause**: `delegateCompactionToRuntime` in `src/context-engine/delegate.ts` builds the `CompactEmbeddedAgentSessionDirect` params object without forwarding `params.abortSignal`. The `ContextEngine.compact()` public API (`types.ts:356`) and `CompactEmbeddedAgentSessionParams` (`compact.types.ts:91`) both carry `abortSignal?: AbortSignal`, and the runtime consumer (`compact.ts`) passes it to `compactWithSafetyTimeout` which honors it via a truthiness guard. The delegate bridge was introduced by PR #49061 and never wired this field, so every abort signal passed by the host to the public `compact()` contract was silently dropped at the bridge.
- **Fix**: Add `abortSignal: params.abortSignal` to the `compactEmbeddedAgentSessionDirect` call in `delegateCompactionToRuntime`. The field is already part of `CompactEmbeddedAgentSessionParams` and the downstream runtime already handles `undefined` identically to omission, so no other change is needed.
- **What changed**:
  - `src/context-engine/delegate.ts` — one-line addition forwarding `params.abortSignal` to the runtime params object, placed after the `...runtimeContext` spread so a real caller signal always overrides any spread value.
  - `src/context-engine/context-engine.test.ts` — two new tests: signal-forwarding verified with `toBe` reference identity; undefined-signal case confirmed to remain `undefined`.
- **What did NOT change (scope boundary)**:
  - The `delegateCompactionToRuntime` function signature is unchanged.
  - `compactWithSafetyTimeout`, `compactEmbeddedAgentSessionDirect`, and all existing compaction paths are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Start a session with enough context to trigger auto-compaction (~200K+ tokens).
2. Wait for auto-compaction to begin (logs: `context overflow detected; attempting auto-compaction`).
3. Press the stop button while the compaction LLM call is in-flight.
4. **Before this PR**: abort signal cancels the wait but is dropped at the delegate bridge; the compaction LLM call runs to completion and writes its summary to the session file; the next turn sees a compacted session (e.g. 239→4 messages) and the model loses track of ongoing work and instructions.
5. **After this PR**: abort signal is forwarded to `compactEmbeddedAgentSessionDirect`; when the signal fires, the runtime's `compactWithSafetyTimeout` honors it and the in-flight compaction is cancelled before it can write its result; the session remains in its pre-compaction state.

### Real behavior proof

**Behavior addressed (#89868)**: `delegateCompactionToRuntime` now forwards `params.abortSignal` to the runtime; when the caller's abort controller fires, the in-flight runtime compaction is cancelled instead of completing silently.

**Real environment tested (Ubuntu Server Node 24, source-level — Vitest against the production `delegateCompactionToRuntime` function and the mocked `compactEmbeddedAgentSessionDirect` spy)**: the signal-forwarding test calls `delegateCompactionToRuntime` with a live `AbortController` signal and asserts `toBe` reference identity on the spy's received params. The spy intercept is the same one used by the existing delegate test at line 417, run under the same `beforeEach` mock-reset guard.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts` — 43 tests pass (41 pre-existing + 2 new). `pnpm exec oxlint src/context-engine/delegate.ts` clean. `pnpm format:check` clean.

**Evidence after fix (Vitest output for the touched test file)**:

```
Tests  43 passed (43)
```

The two new tests cover: `delegateCompactionToRuntime forwards the caller abortSignal to the runtime (#89868)` and `delegateCompactionToRuntime passes undefined abortSignal when none supplied`.

**Observed result after fix**: `requireCompactRuntimeParams(0).abortSignal` equals the caller's `controller.signal` by reference; without the fix the field is `undefined`.

**What was not tested**: live stop-button + 200K-token compaction end-to-end gateway round-trip. The abort propagation from the delegate to the runtime's `compactWithSafetyTimeout` is exercised by existing safety-timeout tests; this PR closes the gap at the bridge entry point.

**Repro confirmation**: the signal-forwarding test fails on the pre-patch tree — `compactRuntimeParams.abortSignal` is `undefined` — and passes with the single-line fix applied, confirming the bridge omission is the sole cause.

### Risk / Mitigation

- **Risk**: Signal forwarded when caller did not intend cancellation. **Mitigation**: `params.abortSignal` is `undefined` when the caller omits it; `compactWithSafetyTimeout` guards with `if (abortSignal) { ... }` so `undefined` is treated identically to the previous behavior where the field was absent.
- **Risk**: `...runtimeContext` spread could carry a stale signal that overrides the caller's. **Mitigation**: `abortSignal: params.abortSignal` is placed after the spread, so the explicit caller value always wins.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents
- [x] Context engine

### Linked Issue/PR

Fixes #89868