### PR TITLE
fix(plugins): guard active runtime registry metadata

### DIFF
--- a/src/plugins/active-runtime-registry.test.ts
+++ b/src/plugins/active-runtime-registry.test.ts
@@ -97,6 +97,104 @@ describe("getLoadedRuntimePluginRegistry", () => {
     ).toBeUndefined();
   });
 
+  it("keeps healthy runtime plugins after unreadable plugin record metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      get id() {
+        throw new Error("plugin id getter exploded");
+      },
+      status: "loaded",
+    } as never);
+    registry.plugins.push({
+      id: "healthy",
+      status: "loaded",
+    } as never);
+    setActivePluginRegistry(registry, "healthy", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: ["healthy"],
+      }),
+    ).toBe(registry);
+  });
+
+  it("does not treat unreadable runtime metadata as an empty plugin scope", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      get id() {
+        throw new Error("plugin id getter exploded");
+      },
+      status: "loaded",
+    } as never);
+    setActivePluginRegistry(registry, "broken", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat unreadable plugin status as loaded through registrations", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      id: "broken",
+      get status() {
+        throw new Error("plugin status getter exploded");
+      },
+    } as never);
+    registry.tools.push({
+      pluginId: "broken",
+    } as never);
+    setActivePluginRegistry(registry, "broken", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: ["broken"],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps healthy runtime plugins after unreadable registration owner metadata", () => {
+    const registry = createRegistryWithPlugin("healthy");
+    registry.tools.push({
+      get pluginId() {
+        throw new Error("plugin registration owner getter exploded");
+      },
+    } as never);
+    registry.tools.push({
+      pluginId: "healthy",
+    } as never);
+    setActivePluginRegistry(registry, "healthy", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: ["healthy"],
+      }),
+    ).toBe(registry);
+  });
+
+  it("does not treat unreadable registration owner metadata as an empty plugin scope", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.tools.push({
+      get pluginId() {
+        throw new Error("plugin registration owner getter exploded");
+      },
+    } as never);
+    setActivePluginRegistry(registry, "broken", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: [],
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not reuse workspace-agnostic registries for workspace-specific requests", () => {
     setActivePluginRegistry(createRegistryWithPlugin("demo"), "demo");
 

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -10,6 +10,8 @@ import {
 
 export type ActiveRuntimePluginRegistrySurface = "active" | "channel" | "http-route";
 
+const UNREADABLE_RUNTIME_PLUGIN_STATUS = "__openclaw_unreadable__";
+
 export function getActiveRuntimePluginRegistry(): PluginRegistry | null {
   return getActivePluginRegistry();
 }
@@ -31,11 +33,28 @@ export function registryContainsRuntimePluginIds(
   const present = new Set<string>();
   const loaded = new Set<string>();
   const pluginStatusById = new Map<string, string | undefined>();
+  let hasUnreadableRuntimeEntry = false;
   for (const plugin of registry.plugins ?? []) {
-    present.add(plugin.id);
-    pluginStatusById.set(plugin.id, plugin.status);
-    if (plugin.status === undefined || plugin.status === "loaded") {
-      loaded.add(plugin.id);
+    let pluginId: unknown;
+    try {
+      pluginId = plugin.id;
+    } catch {
+      hasUnreadableRuntimeEntry = true;
+      continue;
+    }
+    if (typeof pluginId === "string" && pluginId.length > 0) {
+      present.add(pluginId);
+      let status: string | undefined;
+      try {
+        status = plugin.status;
+      } catch {
+        pluginStatusById.set(pluginId, UNREADABLE_RUNTIME_PLUGIN_STATUS);
+        continue;
+      }
+      pluginStatusById.set(pluginId, status);
+      if (status === undefined || status === "loaded") {
+        loaded.add(pluginId);
+      }
     }
   }
   for (const [key, value] of Object.entries(registry)) {
@@ -46,20 +65,26 @@ export function registryContainsRuntimePluginIds(
       continue;
     }
     for (const entry of value) {
-      if (entry && typeof entry === "object" && "pluginId" in entry) {
-        const pluginId = entry.pluginId;
-        if (typeof pluginId === "string" && pluginId.length > 0) {
-          present.add(pluginId);
-          const status = pluginStatusById.get(pluginId);
-          if (status === undefined || status === "loaded") {
-            loaded.add(pluginId);
-          }
+      let pluginId: unknown;
+      try {
+        if (entry && typeof entry === "object" && "pluginId" in entry) {
+          pluginId = entry.pluginId;
+        }
+      } catch {
+        hasUnreadableRuntimeEntry = true;
+        continue;
+      }
+      if (typeof pluginId === "string" && pluginId.length > 0) {
+        present.add(pluginId);
+        const status = pluginStatusById.get(pluginId);
+        if (status === undefined || status === "loaded") {
+          loaded.add(pluginId);
         }
       }
     }
   }
   if (pluginIds.length === 0) {
-    return present.size === 0;
+    return present.size === 0 && !hasUnreadableRuntimeEntry;
   }
   return pluginIds.every((pluginId) => loaded.has(pluginId));
 }


### PR DESCRIPTION
## Summary
- guard active runtime registry compatibility checks against unreadable plugin record metadata
- guard unreadable runtime registration `pluginId` metadata without treating it as an empty registry
- keep fail-closed behavior for explicit empty scopes and unreadable plugin statuses while allowing healthy required plugins to reuse the active registry

## Verification
- `node scripts/run-vitest.mjs src/plugins/active-runtime-registry.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/active-runtime-registry.ts src/plugins/active-runtime-registry.test.ts && node_modules/.bin/oxlint src/plugins/active-runtime-registry.ts src/plugins/active-runtime-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` blocked: coordinator 401 before lease

## Real behavior proof
Behavior addressed: Malformed active runtime registry plugin records or registration owner metadata no longer crash compatibility checks or make unreadable entries look like an empty/loaded registry.
Real environment tested: Local sparse Codex worktree on Node/Vitest using repo test wrappers.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/active-runtime-registry.test.ts`
Evidence after fix: Focused test file passed: 1 file, 11 tests.
Observed result after fix: Healthy required plugin ids still reuse the active registry after unreadable sibling metadata; explicit empty scopes and unreadable statuses remain fail-closed.
What was not tested: `pnpm check:changed` broad gate; Testbox auth is missing and AWS Crabbox coordinator returned 401 before lease.
