### PR TITLE
fix(plugins): recover installed records on policy refresh

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -505,6 +505,46 @@ function collectManagedPluginRecordPaths(
   return paths;
 }
 
+export function hasDiscoverableInstalledPluginRecordPath(params: {
+  record: PluginInstallRecord;
+  env?: NodeJS.ProcessEnv;
+  ownershipUid?: number | null;
+}): boolean {
+  const env = params.env ?? process.env;
+  const realpathCache = new Map<string, string>();
+  const packageManifestCache = new Map<string, PackageManifest | null>();
+  const installRecords = { __installRecordProbe: params.record };
+  const installedPaths = collectInstalledPluginRecordPaths(installRecords, env, realpathCache);
+  if (installedPaths.length === 0) {
+    return false;
+  }
+  const managedPluginDirs = collectManagedPluginDirKeys(
+    collectManagedPluginRecordPaths(installRecords, env),
+    realpathCache,
+  );
+  for (const installedPath of installedPaths) {
+    const result = createDiscoveryResult();
+    discoverFromPath({
+      rawPath: installedPath.path,
+      origin: "global",
+      ownershipUid: params.ownershipUid,
+      requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry,
+      managedPluginDirs,
+      scanFiles: true,
+      env,
+      candidates: result.candidates,
+      diagnostics: result.diagnostics,
+      seen: new Set<string>(),
+      realpathCache,
+      packageManifestCache,
+    });
+    if (result.candidates.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function resolveManagedPluginDirKey(
   installedPath: string,
   realpathCache: Map<string, string>,

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -593,6 +593,238 @@ describe("installed plugin index persistence", () => {
     expect(refreshed.plugins.map((plugin) => plugin.pluginId)).toContain("next-demo");
   });
 
+  it("rebuilds policy refreshes when install records are missing from plugins", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "demo");
+    const bundledDir = path.join(stateDir, "empty-bundled");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.mkdirSync(bundledDir, { recursive: true });
+    createCandidate(pluginDir);
+    const installRecord = {
+      source: "path" as const,
+      sourcePath: pluginDir,
+      installPath: pluginDir,
+    };
+    const env = {
+      HOME: stateDir,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      installRecords: {
+        demo: installRecord,
+      },
+      env,
+    });
+    expectPluginIds(baseline, ["demo"]);
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["demo"]);
+    expectInstallRecord(refreshed, "demo", installRecord);
+    await expectPersistedIndex(stateDir, {
+      pluginIds: ["demo"],
+      installRecords: {
+        demo: installRecord,
+      },
+    });
+  });
+
+  it("rebuilds policy refreshes when npm install records are missing from plugins", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "npm-demo");
+    const bundledDir = path.join(stateDir, "empty-bundled");
+    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+    fs.mkdirSync(bundledDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/npm-demo",
+        openclaw: {
+          extensions: ["./dist/index.js"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "npm-demo",
+        name: "NPM Demo",
+        configSchema: { type: "object" },
+        providers: ["npm-demo"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export default {};\n", "utf8");
+    const installRecord = {
+      source: "npm" as const,
+      spec: "@openclaw/npm-demo@1.0.0",
+      installPath: pluginDir,
+    };
+    const env = {
+      HOME: stateDir,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      installRecords: {
+        "npm-demo": installRecord,
+      },
+      env,
+    });
+    expectPluginIds(baseline, ["npm-demo"]);
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, ["npm-demo"]);
+    expectInstallRecord(refreshed, "npm-demo", installRecord);
+  });
+
+  it("keeps policy refreshes on the fast path for missing records without plugin entries", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "stale");
+    const bundledDir = path.join(stateDir, "bundled");
+    const bundledPluginDir = path.join(bundledDir, "bundled-demo");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.mkdirSync(bundledPluginDir, { recursive: true });
+    createCandidate(bundledPluginDir, { id: "bundled-demo" });
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          stale: {
+            source: "path",
+            sourcePath: pluginDir,
+            installPath: pluginDir,
+          },
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expect(refreshed.refreshReason).toBe("policy-changed");
+    expectInstallRecord(refreshed, "stale", {
+      source: "path",
+      sourcePath: pluginDir,
+      installPath: pluginDir,
+    });
+  });
+
+  it("keeps policy refreshes on the fast path for missing package records without built runtime", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "source-only");
+    const bundledDir = path.join(stateDir, "bundled");
+    const bundledPluginDir = path.join(bundledDir, "bundled-demo");
+    fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+    fs.mkdirSync(bundledPluginDir, { recursive: true });
+    createCandidate(bundledPluginDir, { id: "bundled-demo" });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/source-only",
+        openclaw: {
+          extensions: ["./src/index.ts"],
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "source-only",
+        name: "Source Only",
+        configSchema: { type: "object" },
+        providers: ["source-only"],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "src", "index.ts"), "export default {};\n", "utf8");
+    const env = {
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const installRecord = {
+      source: "npm" as const,
+      spec: "@openclaw/source-only@1.0.0",
+      installPath: pluginDir,
+    };
+    const baseline = await refreshPersistedInstalledPluginIndex({
+      reason: "manual",
+      stateDir,
+      candidates: [],
+      env,
+    });
+    await writePersistedInstalledPluginIndex(
+      {
+        ...baseline,
+        installRecords: {
+          "source-only": installRecord,
+        },
+        plugins: [],
+      },
+      { stateDir },
+    );
+
+    const refreshed = await refreshPersistedInstalledPluginIndex({
+      reason: "policy-changed",
+      stateDir,
+      env,
+    });
+
+    expectPluginIds(refreshed, []);
+    expect(refreshed.refreshReason).toBe("policy-changed");
+    expectInstallRecord(refreshed, "source-only", installRecord);
+  });
+
   it("preserves existing install records when refreshing the manifest cache", async () => {
     const stateDir = makeTempDir();
     await writePersistedInstalledPluginIndex(

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -10,6 +10,7 @@ import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
+import { hasDiscoverableInstalledPluginRecordPath } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveCompatRegistryVersion } from "./installed-plugin-index-policy.js";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
@@ -425,6 +426,22 @@ function hasPolicyRefreshTargets(
   return policyPluginIds.every((pluginId) => pluginIds.has(pluginId));
 }
 
+function hasMissingDiscoverableInstallRecordPlugin(
+  persisted: InstalledPluginIndex,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  for (const [pluginId, record] of Object.entries(persisted.installRecords ?? {})) {
+    if (pluginIds.has(pluginId)) {
+      continue;
+    }
+    if (hasDiscoverableInstalledPluginRecordPath({ record, env })) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function canRefreshPersistedPolicyState(
   persisted: InstalledPluginIndex | null,
   params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
@@ -446,6 +463,9 @@ function canRefreshPersistedPolicyState(
     params.installRecords &&
     hashJson(params.installRecords) !== hashJson(persisted.installRecords ?? {})
   ) {
+    return false;
+  }
+  if (hasMissingDiscoverableInstallRecordPlugin(persisted, env)) {
     return false;
   }
   return hasPolicyRefreshTargets(persisted, params.policyPluginIds);


### PR DESCRIPTION
## Summary

- Make `policy-changed` installed plugin index refresh fall back to a source rebuild when persisted `installRecords` point at plugin candidates that normal discovery can recover but `plugins[]` no longer lists.
- Add a single-record discovery probe so the fast-path guard uses the same path/npm package rules as the main plugin scanner instead of a broad path-exists heuristic.
- Add regression coverage for path installs, npm installs, and stale install records that should stay on the policy fast path.

Fixes #89606.

Related: #89882 also targets this issue; this variant keeps the recoverability check tied to discovery candidate resolution so stale existing paths without plugin entries do not force repeat rebuilds.

## Real behavior proof

Behavior addressed: A policy-changed plugin registry refresh restores path and npm plugins that are still present in installRecords after plugins[] loses those entries.

Real environment tested: Local OpenClaw installed-plugin-index runtime in this branch using a temporary state directory and the production SQLite-backed refresh path.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` in this PR checkout. The script created a temporary state directory, wrote one path plugin and one npm-style package plugin, persisted an installed plugin index, removed both ids from plugins[], called `refreshPersistedInstalledPluginIndex({ reason: "policy-changed" })`, and asserted both ids returned through the production refresh path.

Evidence after fix:

```json
{"recoveredPathPlugin":true,"recoveredNpmPlugin":true,"recoveredCount":2,"installRecordSources":{"demo":"path","npmDemo":"npm"}}
```

Observed result after fix: The policy refresh recovered both install-record-backed plugin ids into plugins[] and preserved their install record sources as `path` and `npm`.

What was not tested: A GPU sandbox/NemoClaw image was not exercised; the local proof targets the installed-index refresh state shape reported in #89606.

## Validation

- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts --reporter=dot` -> 1 file, 18 tests passed.
- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-store.test.ts src/plugins/installed-plugin-index.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/discovery.test.ts --reporter=dot` -> 4 files, 141 tests passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` -> exit 0.
- `node scripts/run-oxlint.mjs src/plugins/discovery.ts src/plugins/installed-plugin-index-store.ts src/plugins/installed-plugin-index-store.test.ts` -> exit 0.
- `npx oxfmt --check src/plugins/discovery.ts src/plugins/installed-plugin-index-store.ts src/plugins/installed-plugin-index-store.test.ts` -> all matched files use the correct format.
- `git diff --check` -> exit 0.
