### PR TITLE
fix(ui): guard abort UI with local live send/stream state

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -3388,3 +3388,43 @@ describe("chat session controls", () => {
     expect(thinkingSelect.title).toContain("Adaptive");
   });
 });
+
+describe("abort UI live guard (regression #87387)", () => {
+  it("hides Stop button when canAbort is true but isBusy is false", () => {
+    // Simulates the bug: stale session-list state keeps canAbort true after
+    // response completes (stream is null, sending is false).
+    const container = renderChatView({
+      canAbort: true,
+      sending: false,
+      stream: null,
+      runStatus: null,
+    });
+
+    // Stop button should NOT be visible when there's no active send/stream
+    expect(container.querySelector(".chat-send-btn--stop")).toBeNull();
+  });
+
+  it("shows Stop button when canAbort is true and isBusy is true", () => {
+    const container = renderChatView({
+      canAbort: true,
+      sending: false,
+      stream: "data",
+      runStatus: null,
+    });
+
+    // Stop button SHOULD be visible when there's an active stream
+    expect(container.querySelector(".chat-send-btn--stop")).not.toBeNull();
+  });
+
+  it("shows Stop button when sending is true", () => {
+    const container = renderChatView({
+      canAbort: true,
+      sending: true,
+      stream: null,
+      runStatus: null,
+    });
+
+    // Stop button SHOULD be visible when sending is in progress
+    expect(container.querySelector(".chat-send-btn--stop")).not.toBeNull();
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1529,7 +1529,11 @@ export function renderChat(props: ChatProps) {
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const showAbortableUi = canAbort && !hasTerminalRunStatus(props.runStatus);
-  const composerRunStatus = showAbortableUi ? { phase: "in-progress" as const } : props.runStatus;
+  // Only show "In progress" badge and Stop button while a local send/stream is
+  // actively in progress.  Without the isBusy guard, stale session-list state
+  // can keep the UI in abortable mode after the response has already completed.
+  const showActiveAbortUi = showAbortableUi && isBusy;
+  const composerRunStatus = showActiveAbortUi ? { phase: "in-progress" as const } : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
@@ -2191,7 +2195,7 @@ export function renderChat(props: ChatProps) {
             ? html`<div class="agent-chat__composer-controls">${composerControls}</div>`
             : nothing}
           ${renderChatRunControls({
-            canAbort: showAbortableUi,
+            canAbort: showActiveAbortUi,
             connected: props.connected,
             draft: visibleDraft,
             hasMessages: props.messages.length > 0,


### PR DESCRIPTION
fix(ui): guard abort UI with local live send/stream state

## Summary
**Problem:** The "In progress" badge and Stop button were driven by `showAbortableUi`, which can stay `true` from stale session-list state (`hasAbortableSessionRun`) even after the response has completed. Users see a false busy/abortable state until a hard refresh.

**Fix:** Add `isBusy` guard (`sending || stream !== null`) so the abort UI only shows while a local send or stream is actively in progress. The new `showActiveAbortUi` variable gates the "In progress" badge and Stop button, while `showAbortableUi` continues to drive queue steer buttons and compact disable logic.

**Out of scope:** No changes to `hasAbortableSessionRun`, `isSessionRunActive`, or session-list state management.

## Linked context
Closes #87387

## Real behavior proof

- Behavior or issue addressed: Control UI webchat shows false "In progress" / "Stop" state after response completes because `canAbort` stays true from stale session-list state
- Real environment tested: Windows 10, Node.js v22.11.0, OpenClaw latest main (commit 70a989a, 2026-06-03)
- Exact steps or command run after this patch: Added regression tests verifying Stop button visibility requires local active send/stream state
- Evidence after fix: Terminal output showing the tests passing:
```
$ node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts -t "abort UI live guard"

 ✓  ui  ui/src/ui/views/chat.test.ts
   ✓ abort UI live guard (regression #87387)
     ✓ hides Stop button when canAbort is true but isBusy is false
     ✓ shows Stop button when canAbort is true and isBusy is true
     ✓ shows Stop button when sending is true

 Test Files  1 passed (1)
      Tests  3 passed (3)
```
- Observed result after fix: Stop button is hidden when `canAbort` is true but there's no active send/stream (stale state). Stop button is shown when there's an active stream or sending is in progress.
- What was not tested: Live Control UI browser screenshot (requires running gateway + browser)

## Tests and validation
- `ui/src/ui/views/chat.test.ts`: 3 new regression tests for abort UI live guard
- No CHANGELOG.md edits

## Risk checklist
- userVisible: Yes (Stop button and badge no longer show after response completes)
- configEnvMigration: No
- securityAuthNetwork: No
- Mitigation: Only adds isBusy guard; queue steer and compact logic unchanged

## Current review state
- Addressed ClawSweeper P1: Added focused regression tests for stale session-list-only abortability and active send/stream abortability
- [x] AI-assisted (built with Claude Code)
