### PR TITLE
fix(plugins): guard plugin service registration metadata

### DIFF
--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -228,6 +228,109 @@ describe("startPluginServices", () => {
     expect(stopThrows).toHaveBeenCalledOnce();
   });
 
+  it("keeps healthy plugin services after unreadable service registration metadata", async () => {
+    const registry = createEmptyPluginRegistry();
+    const starts: string[] = [];
+    const stops: string[] = [];
+    const contexts: OpenClawPluginServiceContext[] = [];
+
+    const unreadableServiceRegistration = {
+      get pluginId() {
+        return "plugin:broken-service";
+      },
+      get service() {
+        throw new Error("plugin service getter exploded");
+      },
+      source: "test",
+      origin: "workspace",
+      rootDir: "/plugins/broken-service",
+    } as never;
+    const unreadableOwnerRegistration = {
+      get pluginId() {
+        throw new Error("plugin service plugin id getter exploded");
+      },
+      service: createTrackingService("service-broken-owner", { starts }),
+      source: "test",
+      origin: "workspace",
+      rootDir: "/plugins/broken-owner-service",
+    } as never;
+    const healthyService = createTrackingService("service-ok", {
+      starts,
+      stops,
+      contexts,
+    });
+    registry.services = [
+      unreadableServiceRegistration,
+      unreadableOwnerRegistration,
+      {
+        pluginId: "plugin:healthy",
+        service: healthyService,
+        source: "test",
+        origin: "workspace",
+        rootDir: "/plugins/healthy-service",
+      },
+    ] as typeof registry.services;
+
+    const config = createServiceConfig();
+    const handle = await startPluginServices({
+      registry,
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+    await handle.stop();
+
+    expect(starts).toEqual(["k"]);
+    expect(stops).toEqual(["k"]);
+    expectServiceContexts(contexts, config);
+    expect(requireLoggerErrorMessage()).toContain("plugin service registration unreadable");
+    expect(requireLoggerErrorMessage(1)).toContain("plugin service registration unreadable");
+  });
+
+  it("preserves the plugin service receiver while using snapshotted metadata", async () => {
+    const starts: string[] = [];
+    const stops: string[] = [];
+    const service: OpenClawPluginService & { marker: string } = {
+      id: "receiver-service",
+      marker: "receiver-ok",
+      start() {
+        starts.push(this.marker);
+      },
+      stop() {
+        stops.push(this.marker);
+      },
+    };
+
+    const handle = await startPluginServices({
+      registry: createRegistry([service]),
+      config: createServiceConfig(),
+    });
+    await handle.stop();
+
+    expect(starts).toEqual(["receiver-ok"]);
+    expect(stops).toEqual(["receiver-ok"]);
+  });
+
+  it("uses stop handlers installed during service startup", async () => {
+    const stops: string[] = [];
+    const service: OpenClawPluginService & { marker: string } = {
+      id: "dynamic-stop-service",
+      marker: "dynamic-stop-ok",
+      start() {
+        this.stop = () => {
+          stops.push(this.marker);
+        };
+      },
+    };
+
+    const handle = await startPluginServices({
+      registry: createRegistry([service]),
+      config: createServiceConfig(),
+    });
+    await handle.stop();
+
+    expect(stops).toEqual(["dynamic-stop-ok"]);
+  });
+
   it("emits per-service startup trace spans and summary", async () => {
     const measured: string[] = [];
     const details: Array<{

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -9,7 +9,7 @@ import { withPluginHttpRouteRegistry } from "./http-registry.js";
 import type { PluginServiceRegistration } from "./registry-types.js";
 import type { PluginRegistry } from "./registry.js";
 import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
-import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
+import type { OpenClawPluginService, OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
 function createPluginLogger(): PluginLogger {
@@ -25,15 +25,15 @@ function createServiceContext(params: {
   config: OpenClawConfig;
   startupTrace?: PluginServiceStartupTrace;
   workspaceDir?: string;
-  service: PluginServiceRegistration;
+  service: ReadablePluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   const isDiagnosticsExporter =
-    params.service?.pluginId === params.service?.service.id &&
-    (params.service?.service.id === "diagnostics-otel" ||
-      params.service?.service.id === "diagnostics-prometheus");
+    params.service.pluginId === params.service.serviceId &&
+    (params.service.serviceId === "diagnostics-otel" ||
+      params.service.serviceId === "diagnostics-prometheus");
   const grantsInternalDiagnostics =
     isDiagnosticsExporter &&
-    (params.service?.origin === "bundled" || params.service?.trustedOfficialInstall === true);
+    (params.service.origin === "bundled" || params.service.trustedOfficialInstall === true);
 
   return {
     config: params.config,
@@ -59,8 +59,47 @@ function createServiceContext(params: {
   };
 }
 
-function createPluginServiceTraceName(entry: PluginServiceRegistration): string {
-  return `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.service.id)}`;
+type ReadablePluginServiceRegistration = {
+  readonly pluginId: string;
+  readonly serviceId: string;
+  readonly pluginService: OpenClawPluginService;
+  readonly start: OpenClawPluginService["start"];
+  readonly origin: PluginServiceRegistration["origin"];
+  readonly trustedOfficialInstall?: boolean;
+  readonly rootDir?: string;
+};
+
+type PluginServiceRegistrationReadResult =
+  | { readonly ok: true; readonly entry: ReadablePluginServiceRegistration }
+  | { readonly ok: false; readonly error: unknown };
+
+function createPluginServiceTraceName(entry: ReadablePluginServiceRegistration): string {
+  return `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.serviceId)}`;
+}
+
+function readPluginServiceRegistration(
+  entry: PluginServiceRegistration,
+): PluginServiceRegistrationReadResult {
+  try {
+    const pluginId = entry.pluginId;
+    const service = entry.service;
+    return {
+      ok: true,
+      entry: {
+        pluginId,
+        serviceId: service.id,
+        pluginService: service,
+        start: service.start,
+        origin: entry.origin,
+        ...(entry.trustedOfficialInstall === undefined
+          ? {}
+          : { trustedOfficialInstall: entry.trustedOfficialInstall }),
+        ...(entry.rootDir === undefined ? {} : { rootDir: entry.rootDir }),
+      },
+    };
+  } catch (error) {
+    return { ok: false, error };
+  }
 }
 
 function createScopedPluginServiceStartupTrace(
@@ -103,31 +142,42 @@ export async function startPluginServices(params: {
   }> = [];
   let failedCount = 0;
   for (const entry of params.registry.services) {
-    const service = entry.service;
-    const traceName = createPluginServiceTraceName(entry);
+    const readable = readPluginServiceRegistration(entry);
+    if (!readable.ok) {
+      failedCount += 1;
+      log.error(`plugin service registration unreadable: ${String(readable.error)}`);
+      continue;
+    }
+    const service = readable.entry;
+    const traceName = createPluginServiceTraceName(service);
     const serviceContext = createServiceContext({
       config: params.config,
       startupTrace: params.startupTrace,
       workspaceDir: params.workspaceDir,
-      service: entry,
+      service,
     });
     try {
       const startService = () =>
-        withPluginHttpRouteRegistry(params.registry, () => service.start(serviceContext));
+        withPluginHttpRouteRegistry(params.registry, () =>
+          service.start.call(service.pluginService, serviceContext),
+        );
       if (params.startupTrace) {
         await params.startupTrace.measure(traceName, startService);
       } else {
         await startService();
       }
+      const stopService = service.pluginService.stop;
       running.push({
-        id: service.id,
-        stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
+        id: service.serviceId,
+        stop: stopService
+          ? () => stopService.call(service.pluginService, serviceContext)
+          : undefined,
       });
     } catch (err) {
       failedCount += 1;
       const error = err as Error;
       log.error(
-        `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
+        `plugin service failed (${service.serviceId}, plugin=${service.pluginId}, root=${service.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- Guard plugin service registration reads before startup so malformed service rows cannot abort later healthy services.
- Preserve existing lifecycle behavior by calling `start`/`stop` with the original service receiver and reading `stop` after startup.
- Add regressions for unreadable service/owner metadata, receiver binding, and dynamic stop handlers installed during startup.

## Verification

- `node scripts/run-vitest.mjs src/plugins/services.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/services.ts src/plugins/services.test.ts`
- `node_modules/.bin/oxlint src/plugins/services.ts src/plugins/services.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: A malformed plugin service registration with unreadable metadata can no longer stop healthy plugin services from starting.

Real environment tested: Local Codex worktree on Node/Vitest through `scripts/run-vitest.mjs`; AWS Crabbox coordinator attempted for changed-gate proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/services.test.ts`; oxfmt/oxlint on the touched files; `git diff --check origin/main...HEAD`; local and branch autoreview.

Evidence after fix: `src/plugins/services.test.ts` passes 10 tests, including unreadable service metadata, unreadable owner metadata, receiver binding, and stop handlers installed during startup.

Observed result after fix: Healthy services still start and stop after malformed service registration rows are skipped and logged.

What was not tested: `pnpm check:changed` could not run in Testbox/Crabbox from this machine. Blacksmith Testbox is unauthenticated, and AWS Crabbox failed before lease creation with coordinator `401 unauthorized`.
