### PR TITLE
[codex] Skip Skill Research auto-capture for Active Memory helpers

### DIFF
--- a/src/agents/harness/agent-end-side-effects.test.ts
+++ b/src/agents/harness/agent-end-side-effects.test.ts
@@ -113,4 +113,22 @@ describe("agent end side effects", () => {
     });
     expect(mockAwaitAgentEndHook).toHaveBeenCalledTimes(1);
   });
+
+  it("skips Skill Research auto-capture for Active Memory helper sessions", async () => {
+    runAgentEndSideEffects({
+      event: {
+        messages: [],
+        success: true,
+      },
+      ctx: {
+        runId: "run-1",
+        workspaceDir: "/workspace",
+        sessionId: "active-memory-abcdef123456",
+        sessionKey: "agent:main:telegram:direct:12345:active-memory:abcdef123456",
+      },
+    });
+
+    expect(mockAutoCapture).not.toHaveBeenCalled();
+    expect(mockRunAgentEndHook).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/harness/agent-end-side-effects.ts
+++ b/src/agents/harness/agent-end-side-effects.ts
@@ -1,4 +1,5 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { shouldSkipSkillResearchAutoCaptureSession } from "../../skills/research/autocapture-session.js";
 import { runSkillResearchAutoCapture } from "../../skills/research/autocapture.js";
 import {
   awaitAgentHarnessAgentEndHook,
@@ -10,6 +11,10 @@ const log = createSubsystemLogger("agents/harness");
 type AgentEndSideEffectsParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
 
 async function runCoreAgentEndSideEffects(params: AgentEndSideEffectsParams): Promise<void> {
+  if (shouldSkipSkillResearchAutoCaptureSession(params.ctx)) {
+    return;
+  }
+
   try {
     await runSkillResearchAutoCapture({
       event: params.event,

--- a/src/skills/research/autocapture-session.ts
+++ b/src/skills/research/autocapture-session.ts
@@ -1,0 +1,18 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+
+export type SkillResearchAutoCaptureSessionContext = {
+  sessionId?: string;
+  sessionKey?: string;
+};
+
+export function shouldSkipSkillResearchAutoCaptureSession(
+  ctx: SkillResearchAutoCaptureSessionContext,
+): boolean {
+  const sessionId = normalizeOptionalString(ctx.sessionId);
+  if (sessionId?.startsWith("active-memory-")) {
+    return true;
+  }
+
+  const sessionKey = normalizeOptionalString(ctx.sessionKey);
+  return sessionKey?.includes(":active-memory:") === true;
+}

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -95,6 +95,56 @@ describe("skill research auto-capture", () => {
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
   });
 
+  it("skips Active Memory helper sessions", async () => {
+    const cases = [
+      {
+        label: "session id prefix",
+        ctx: {
+          sessionId: "active-memory-abcdef123456",
+        },
+      },
+      {
+        label: "session key segment",
+        ctx: {
+          sessionKey: "agent:main:telegram:direct:12345:active-memory:abcdef123456",
+        },
+      },
+    ];
+
+    for (const { ctx, label } of cases) {
+      const workspaceDir = await makeWorkspace();
+
+      await runSkillResearchAutoCapture({
+        event: {
+          success: true,
+          messages: [
+            {
+              role: "user",
+              content:
+                "From now on, when working on GitHub PRs, always check CI before final response.",
+            },
+          ],
+        },
+        ctx: {
+          workspaceDir,
+          agentId: "main",
+          ...ctx,
+        },
+        config: {
+          skills: {
+            workshop: {
+              autonomous: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      });
+
+      expect((await listSkillProposals({ workspaceDir })).proposals, label).toHaveLength(0);
+    }
+  });
+
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -3,6 +3,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
 import { listSkillProposals, proposeCreateSkill, proposeUpdateSkill } from "../workshop/service.js";
 import { readWorkspaceSkillFile, resolveSkillProposalTarget } from "../workshop/store.js";
+import {
+  shouldSkipSkillResearchAutoCaptureSession,
+  type SkillResearchAutoCaptureSessionContext,
+} from "./autocapture-session.js";
 import { extractDurableInstructionProposal } from "./signals.js";
 
 type SkillResearchAgentEndEvent = {
@@ -10,7 +14,7 @@ type SkillResearchAgentEndEvent = {
   success?: boolean;
 };
 
-type SkillResearchAgentContext = {
+type SkillResearchAgentContext = SkillResearchAutoCaptureSessionContext & {
   agentId?: string;
   workspaceDir?: string;
 };
@@ -33,6 +37,9 @@ export async function runSkillResearchAutoCapture(params: {
     return;
   }
   if (params.event.success === false) {
+    return;
+  }
+  if (shouldSkipSkillResearchAutoCaptureSession(params.ctx)) {
     return;
   }
   const workspaceDir = params.ctx.workspaceDir;


### PR DESCRIPTION
## Summary
- Skip Skill Research auto-capture for Active Memory helper sessions by recognizing `active-memory-` session ids and `:active-memory:` session-key segments.
- Share the guard between the direct auto-capture service and the agent-end side-effect wrapper so internal helper sessions cannot enqueue Skill Workshop proposals.
- Add regression coverage for both direct auto-capture and the agent-end side-effect path.

Fixes #87352

## Root Cause
Current main no longer has the old Skill Workshop LLM reviewer path, but Skill Research auto-capture still ran on every successful agent-end side effect. Active Memory recall runs use helper session ids/keys, so helper-session content could trigger Skill Workshop capture work for an internal session instead of only for the user-facing turn.

## Real Behavior Proof
- **Behavior addressed:** Active Memory helper sessions are skipped by Skill Research auto-capture before a Skill Workshop proposal is queued, while ordinary sessions with the same durable instruction can still create a proposal.
- **Real environment tested:** Local OpenClaw source checkout on macOS in `/Users/cornna/.config/superpowers/worktrees/openclaw/issue-87352`, using Node with `tsx` against real `runSkillResearchAutoCapture` and `listSkillProposals` with a real temporary state/workspace directory.
- **Exact steps or command run after this patch:** Ran `node --import tsx --input-type=module -e '<script>'`, where the script invoked `runSkillResearchAutoCapture` once with `sessionKey: "agent:main:telegram:direct:12345:active-memory:abcdef123456"` and once with `sessionKey: "agent:main:main"`, then read proposal counts through `listSkillProposals`.
- **Evidence after fix:** Terminal output:

```text
[skills/research] skill research auto-capture queued workshop proposal github-pr-workflow
{"activeMemoryProposalCount":0,"normalProposalCount":1}
```

- **Observed result after fix:** The Active Memory helper session produced 0 proposals; the ordinary session produced 1 proposal, proving the skip is scoped to helper sessions and does not disable normal auto-capture.
- **What was not tested:** I did not run a real Active Memory gateway recall session end-to-end; the proof exercises the production auto-capture service directly with real temporary state.

## Validation
- `node scripts/run-vitest.mjs src/skills/research/autocapture.test.ts src/agents/harness/agent-end-side-effects.test.ts src/agents/harness/lifecycle-hook-helpers.test.ts src/plugins/hooks.correlation.test.ts --reporter=dot` passed: 3 shards, 4 files, 26 tests.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` passed.
- `node scripts/run-oxlint.mjs src/skills/research/autocapture.ts src/skills/research/autocapture-session.ts src/skills/research/autocapture.test.ts src/agents/harness/agent-end-side-effects.ts src/agents/harness/agent-end-side-effects.test.ts` passed.
- `npx oxfmt --check src/skills/research/autocapture.ts src/skills/research/autocapture-session.ts src/skills/research/autocapture.test.ts src/agents/harness/agent-end-side-effects.ts src/agents/harness/agent-end-side-effects.test.ts` passed.
- `git diff --check` passed.
