### PR TITLE
fix(gateway): guard discovery service metadata

### DIFF
--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -186,6 +186,93 @@ describe("startGatewayDiscovery", () => {
     expect(stopped).toEqual(["peer", "bonjour"]);
   });
 
+  it("keeps healthy local discovery services after unreadable service registration metadata", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.VITEST;
+
+    const stopped: string[] = [];
+    const unreadableServiceRegistration = {
+      get pluginId() {
+        return "broken-discovery";
+      },
+      get service() {
+        throw new Error("gateway discovery service getter exploded");
+      },
+      source: "test",
+    } as never;
+    const unreadableOwnerRegistration = {
+      get pluginId() {
+        throw new Error("gateway discovery plugin id getter exploded");
+      },
+      source: "test",
+      service: {
+        id: "broken-owner-discovery",
+        advertise: vi.fn(async () => ({ stop: () => stopped.push("broken-owner") })),
+      },
+    } as never;
+    const healthy = makeDiscoveryService({
+      id: "healthy-discovery",
+      pluginId: "healthy",
+      stop: () => {
+        stopped.push("healthy");
+      },
+    });
+    const logs = makeLogs();
+
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "serve",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [
+        unreadableServiceRegistration,
+        unreadableOwnerRegistration,
+        healthy,
+      ],
+      logDiscovery: logs,
+    });
+
+    expect(healthy.service.advertise).toHaveBeenCalledTimes(1);
+    expect(logs.warn.mock.calls.slice(0, 2)).toEqual([
+      [
+        "gateway discovery service registration unreadable: Error: gateway discovery service getter exploded",
+      ],
+      [
+        "gateway discovery service registration unreadable: Error: gateway discovery plugin id getter exploded",
+      ],
+    ]);
+
+    await result.bonjourStop?.();
+    expect(stopped).toEqual(["healthy"]);
+  });
+
+  it("preserves the gateway discovery service receiver while using snapshotted metadata", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.VITEST;
+
+    const advertised: string[] = [];
+    const service = makeDiscoveryService({ id: "receiver-discovery" });
+    Object.assign(service.service, {
+      marker: "receiver-ok",
+      advertise(this: { marker: string }) {
+        advertised.push(this.marker);
+      },
+    });
+
+    await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "off",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [service],
+      logDiscovery: makeLogs(),
+    });
+
+    expect(advertised).toEqual(["receiver-ok"]);
+  });
+
   it("omits invalid SSH discovery ports", async () => {
     await expectSshPortOmitted("2222abc");
   });

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -273,6 +273,30 @@ describe("startGatewayDiscovery", () => {
     expect(advertised).toEqual(["receiver-ok"]);
   });
 
+  it("allows unknown-discovery-service as an explicit discovery service id", async () => {
+    useDevelopmentDiscoveryEnv();
+
+    const service = makeDiscoveryService({
+      id: "unknown-discovery-service",
+      pluginId: "custom-discovery-plugin",
+    });
+    const logs = makeLogs();
+
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "serve",
+      mdnsMode: "full",
+      gatewayDiscoveryServices: [service],
+      logDiscovery: logs,
+    });
+
+    expect(service.service.advertise).toHaveBeenCalledTimes(1);
+    expect(logs.warn).not.toHaveBeenCalled();
+    await result.bonjourStop?.();
+  });
+
   it("omits invalid SSH discovery ports", async () => {
     await expectSshPortOmitted("2222abc");
   });

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -4,6 +4,7 @@ import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet
 import { parseTcpPort } from "../infra/tcp-port.js";
 import { resolveWideAreaDiscoveryDomain, writeWideAreaGatewayZone } from "../infra/widearea-dns.js";
 import type { PluginGatewayDiscoveryServiceRegistration } from "../plugins/registry-types.js";
+import type { OpenClawGatewayDiscoveryService } from "../plugins/types.js";
 import {
   formatBonjourInstanceName,
   resolveBonjourCliPath,
@@ -22,6 +23,37 @@ function resolveDiscoveryAdvertiseTimeoutMs(env: NodeJS.ProcessEnv): number {
     return DEFAULT_DISCOVERY_ADVERTISE_TIMEOUT_MS;
   }
   return parsed;
+}
+
+type ReadableGatewayDiscoveryServiceRegistration = {
+  readonly pluginId: string;
+  readonly serviceId: string;
+  readonly pluginService: OpenClawGatewayDiscoveryService;
+  readonly advertise: OpenClawGatewayDiscoveryService["advertise"];
+};
+
+type GatewayDiscoveryServiceRegistrationReadResult =
+  | { readonly ok: true; readonly entry: ReadableGatewayDiscoveryServiceRegistration }
+  | { readonly ok: false; readonly error: unknown };
+
+function readGatewayDiscoveryServiceRegistration(
+  entry: PluginGatewayDiscoveryServiceRegistration,
+): GatewayDiscoveryServiceRegistrationReadResult {
+  try {
+    const pluginId = entry.pluginId;
+    const service = entry.service;
+    return {
+      ok: true,
+      entry: {
+        pluginId,
+        serviceId: service.id,
+        pluginService: service,
+        advertise: service.advertise,
+      },
+    };
+  } catch (error) {
+    return { ok: false, error };
+  }
 }
 
 export async function startGatewayDiscovery(params: {
@@ -62,8 +94,16 @@ export async function startGatewayDiscovery(params: {
     const stops: Array<() => void | Promise<void>> = [];
     let attemptedLocalDiscovery = false;
     let stoppedLocalDiscovery = false;
-    for (const entry of params.gatewayDiscoveryServices ?? []) {
+    for (const registration of params.gatewayDiscoveryServices ?? []) {
       attemptedLocalDiscovery = true;
+      const readable = readGatewayDiscoveryServiceRegistration(registration);
+      if (!readable.ok) {
+        params.logDiscovery.warn(
+          `gateway discovery service registration unreadable: ${String(readable.error)}`,
+        );
+        continue;
+      }
+      const entry = readable.entry;
       try {
         let timer: ReturnType<typeof setTimeout> | undefined;
         let timedOut = false;
@@ -80,7 +120,7 @@ export async function startGatewayDiscovery(params: {
           minimal: mdnsMinimal,
         };
         const advertisePromise = Promise.resolve()
-          .then(() => entry.service.advertise(context))
+          .then(() => entry.advertise.call(entry.pluginService, context))
           .then(
             async (started) => {
               if (timedOut) {
@@ -96,14 +136,14 @@ export async function startGatewayDiscovery(params: {
                   }
                 }
                 params.logDiscovery.warn(
-                  `gateway discovery service completed after startup timeout (${entry.service.id}, plugin=${entry.pluginId})`,
+                  `gateway discovery service completed after startup timeout (${entry.serviceId}, plugin=${entry.pluginId})`,
                 );
               }
               return started;
             },
             (err: unknown) => {
               params.logDiscovery.warn(
-                `gateway discovery service failed${timedOut ? " after startup timeout" : ""} (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
+                `gateway discovery service failed${timedOut ? " after startup timeout" : ""} (${entry.serviceId}, plugin=${entry.pluginId}): ${String(err)}`,
               );
               return undefined;
             },
@@ -112,7 +152,7 @@ export async function startGatewayDiscovery(params: {
           timer = setTimeout(() => {
             timedOut = true;
             params.logDiscovery.warn(
-              `gateway discovery service timed out after ${advertiseTimeoutMs}ms (${entry.service.id}, plugin=${entry.pluginId}); continuing startup`,
+              `gateway discovery service timed out after ${advertiseTimeoutMs}ms (${entry.serviceId}, plugin=${entry.pluginId}); continuing startup`,
             );
             resolve(undefined);
           }, advertiseTimeoutMs);
@@ -127,7 +167,7 @@ export async function startGatewayDiscovery(params: {
         }
       } catch (err) {
         params.logDiscovery.warn(
-          `gateway discovery service failed (${entry.service.id}, plugin=${entry.pluginId}): ${String(err)}`,
+          `gateway discovery service failed (${entry.serviceId}, plugin=${entry.pluginId}): ${String(err)}`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- Guard gateway discovery service registration reads so malformed rows cannot abort healthy local discovery advertisers.
- Snapshot plugin/service identifiers before async timeout/failure logging and invoke `advertise` with the original service receiver.
- Add regressions for unreadable discovery service metadata and method-style advertiser receivers.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-discovery-runtime.test.ts`
- `node_modules/.bin/oxfmt --check src/gateway/server-discovery-runtime.ts src/gateway/server-discovery-runtime.test.ts`
- `node_modules/.bin/oxlint src/gateway/server-discovery-runtime.ts src/gateway/server-discovery-runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: A malformed gateway discovery service registration with unreadable plugin-owned metadata can no longer stop healthy discovery advertisers from starting.

Real environment tested: Local Codex worktree on Node/Vitest through `scripts/run-vitest.mjs`; AWS Crabbox coordinator attempted for changed-gate proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-discovery-runtime.test.ts`; oxfmt/oxlint on the touched files; `git diff --check origin/main...HEAD`; local and branch autoreview.

Evidence after fix: `src/gateway/server-discovery-runtime.test.ts` passes 24 tests across the gateway Vitest projects, including unreadable service metadata, unreadable owner metadata, and service receiver preservation.

Observed result after fix: Healthy gateway discovery services still advertise and stop after malformed discovery registration rows are skipped and warned.

What was not tested: `pnpm check:changed` could not run in Testbox/Crabbox from this machine. Blacksmith Testbox is unauthenticated, and AWS Crabbox failed before lease creation with coordinator `401 unauthorized`.
