### PR TITLE
feat(slack/monitor):        
  optional env-gated HTTP pre-router hook

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -83,6 +83,7 @@ import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { resolveStorePath, updateLastRoute } from "../config.runtime.js";
 import { recordInboundSession } from "../conversation.runtime.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
+import { runPreRouterHook } from "../pre-router.js";
 import {
   createSlackReplyDeliveryPlan,
   deliverReplies,
@@ -91,6 +92,7 @@ import {
   resolveSlackThreadTs,
 } from "../replies.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../reply.runtime.js";
+import { sendMessageSlack } from "../send.runtime.js";
 import { finalizeSlackPreviewEdit } from "./preview-finalize.js";
 import { resolveSlackTimestampMs } from "./timestamp.js";
 import type { PreparedSlackMessage } from "./types.js";
@@ -454,6 +456,53 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const { ctx, account, message, route } = prepared;
   const cfg = ctx.cfg;
   const runtime = ctx.runtime;
+
+  // Optional env-gated HTTP pre-router hook. When OPENCLAW_PRE_ROUTER_URL
+  // is set, consult an external pattern-matcher service before paying
+  // for an LLM round-trip. On a hit, post the response directly to the
+  // resolved Slack thread and skip dispatch entirely. On miss, timeout,
+  // HTTP error, or malformed response, fall through to the LLM path
+  // exactly as before — the hook is fails-safe (see pre-router.ts).
+  const preRouterHit = await runPreRouterHook(
+    {
+      prompt: prepared.ctxPayload.BodyForAgent ?? message.text ?? "",
+      channel: message.channel,
+      user: message.user ?? message.bot_id ?? "",
+      ts: message.ts ?? message.event_ts ?? "",
+    },
+    {
+      log: (msg) => logVerbose(msg),
+      error: (msg) => runtime.error?.(danger(msg)),
+    },
+  );
+  if (preRouterHit !== null) {
+    const preRouterThreadTs = resolveSlackThreadTs({
+      replyToMode: prepared.replyToMode,
+      incomingThreadTs: message.thread_ts,
+      messageTs: message.ts ?? message.event_ts,
+      hasReplied: false,
+      isThreadReply: Boolean(message.thread_ts),
+    });
+    try {
+      await sendMessageSlack(prepared.replyTarget, preRouterHit, {
+        cfg,
+        token: ctx.botToken,
+        accountId: account.accountId,
+        threadTs: preRouterThreadTs,
+      });
+      logVerbose(
+        `slack pre-router hook: posted response to ${prepared.replyTarget} thread=${preRouterThreadTs ?? "-"}`,
+      );
+      return;
+    } catch (err) {
+      // Post-back failed (Slack API rejected the message, network
+      // glitch, etc.). Treat this exactly like a hook miss — fall
+      // through to LLM dispatch so the user still gets a reply.
+      runtime.error?.(
+        danger(`slack pre-router hook: post failed (${String(err)}); falling through to LLM`),
+      );
+    }
+  }
 
   // Resolve agent identity for Slack chat:write.customize overrides.
   const outboundIdentity = resolveAgentOutboundIdentity(cfg, route.agentId);

--- a/extensions/slack/src/monitor/pre-router.dispatch.test.ts
+++ b/extensions/slack/src/monitor/pre-router.dispatch.test.ts
@@ -1,0 +1,120 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { runPreRouterHook } from "./pre-router.js";
+
+/**
+ * Integration-style fixture: spin up a real local HTTP server that
+ * behaves like the orbit-mcp `/skill-matcher/dispatch` endpoint, then
+ * exercise `runPreRouterHook` against it. This proves the wire
+ * contract works against an actual TCP/JSON round-trip — not just
+ * mocked `fetch`.
+ *
+ * Lives alongside the unit tests so CI exercises both paths.
+ * Does not depend on Python — just confirms the HTTP shape.
+ */
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+let server: http.Server | undefined;
+let handler: Handler | undefined;
+let baseUrl = "";
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (!handler) {
+      res.statusCode = 500;
+      res.end("no handler");
+      return;
+    }
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => {
+    server!.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}/skill-matcher/dispatch`;
+});
+
+afterAll(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => {
+      server!.close(() => resolve());
+    });
+  }
+});
+
+afterEach(() => {
+  handler = undefined;
+});
+
+const payload = {
+  prompt: "help",
+  channel: "C0123",
+  user: "U0123",
+  ts: "1717423420.000100",
+};
+
+describe("runPreRouterHook against a real local HTTP server", () => {
+  it("returns the response body on a real 200 OK hit", async () => {
+    let receivedBody: unknown;
+    handler = (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        res.setHeader("content-type", "application/json");
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            matched: true,
+            response: "real http hit",
+            pattern_id: "help",
+            latency_ms: 7.5,
+          }),
+        );
+      });
+    };
+
+    const result = await runPreRouterHook(payload, { readUrl: () => baseUrl });
+    expect(result).toBe("real http hit");
+    expect(receivedBody).toEqual(payload);
+  });
+
+  it("falls through to null on real HTTP 503", async () => {
+    handler = (_req, res) => {
+      res.statusCode = 503;
+      res.end("Service Unavailable");
+    };
+    const result = await runPreRouterHook(payload, { readUrl: () => baseUrl });
+    expect(result).toBeNull();
+  });
+
+  it("falls through to null when the server hangs longer than the timeout", async () => {
+    // Server intentionally never responds. Hook should abort after
+    // its configured timeout (50ms here) and return null without
+    // hanging the test.
+    handler = (_req, _res) => {
+      // hold open indefinitely
+    };
+    const start = Date.now();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => baseUrl,
+      readTimeoutMs: () => 50,
+    });
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    // Sanity: timeout fired within a reasonable budget. Generous
+    // upper bound to avoid flakiness on loaded CI.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("falls through to null on truly malformed (non-JSON) body", async () => {
+    handler = (_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.statusCode = 200;
+      res.end("definitely not json");
+    };
+    const result = await runPreRouterHook(payload, { readUrl: () => baseUrl });
+    expect(result).toBeNull();
+  });
+});

--- a/extensions/slack/src/monitor/pre-router.test.ts
+++ b/extensions/slack/src/monitor/pre-router.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { runPreRouterHook } from "./pre-router.js";
+
+const payload = {
+  prompt: "show me last week's brief",
+  channel: "C0123",
+  user: "U0123",
+  ts: "1717423420.000100",
+};
+
+function makeFetchResponse(body: unknown, init: { status?: number; ok?: boolean } = {}): Response {
+  const status = init.status ?? 200;
+  const ok = init.ok ?? status < 400;
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "ERR",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("runPreRouterHook", () => {
+  it("returns null when OPENCLAW_PRE_ROUTER_URL is unset", async () => {
+    // The hook MUST be a no-op when the env var is unset — that's the
+    // default state, and we must not change behavior for the 99% of
+    // OpenClaw installs that don't run a pre-router service.
+    const fetchFn = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => undefined,
+      fetchFn,
+    });
+    expect(result).toBeNull();
+    // The most important assertion: we don't even attempt the network
+    // call when the hook is off.
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("returns response string on 200 OK with matched=true", async () => {
+    const fetchFn = vi.fn(async () =>
+      makeFetchResponse({ matched: true, response: "hello from pattern" }),
+    );
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      readTimeoutMs: () => 2000,
+      fetchFn,
+    });
+    expect(result).toBe("hello from pattern");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("http://example.test/dispatch");
+    const init2 = init as RequestInit;
+    expect(init2.method).toBe("POST");
+    expect(JSON.parse(init2.body as string)).toEqual(payload);
+  });
+
+  it("returns null on 200 OK with matched=false", async () => {
+    const fetchFn = vi.fn(async () => makeFetchResponse({ matched: false }));
+    const log = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      log,
+    });
+    expect(result).toBeNull();
+    // We log misses at INFO so operators can observe hook activity.
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("miss"));
+  });
+
+  it("returns null on HTTP 500", async () => {
+    const fetchFn = vi.fn(async () => makeFetchResponse({ error: "boom" }, { status: 500 }));
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    // Errors must surface in logs so operators can debug a dead pre-router.
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("HTTP 500"));
+  });
+
+  it("returns null on fetch timeout (AbortError)", async () => {
+    // Real fetch with AbortController: we simulate by making fetch
+    // throw an AbortError after signal.abort() fires.
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      // 50ms timeout so the test completes quickly.
+      readTimeoutMs: () => 50,
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("fetch failed"));
+  });
+
+  it("returns null on malformed JSON body", async () => {
+    const fetchFn = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => {
+            throw new SyntaxError("Unexpected token");
+          },
+          text: async () => "not json",
+        }) as unknown as Response,
+    );
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("non-JSON"));
+  });
+
+  it("returns null when matched field is missing", async () => {
+    // Schema regression guard: if a future pre-router service forgets
+    // to include `matched`, we must not treat the body as a hit. Falls
+    // through to LLM.
+    const fetchFn = vi.fn(async () => makeFetchResponse({ response: "would-be reply" }));
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("malformed"));
+  });
+
+  it("returns null when matched=true but response is missing", async () => {
+    // matched=true without a response string is contract violation —
+    // we can't post an empty message to Slack, so we fall through.
+    const fetchFn = vi.fn(async () => makeFetchResponse({ matched: true }));
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("malformed"));
+  });
+
+  it("returns null on network error (DNS, refused, etc.)", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const error = vi.fn();
+    const result = await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      error,
+    });
+    expect(result).toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("ECONNREFUSED"));
+  });
+
+  it("logs pattern_id and latency_ms on hit for observability", async () => {
+    const fetchFn = vi.fn(async () =>
+      makeFetchResponse({
+        matched: true,
+        response: "ok",
+        pattern_id: "help",
+        latency_ms: 12.3,
+      }),
+    );
+    const log = vi.fn();
+    await runPreRouterHook(payload, {
+      readUrl: () => "http://example.test/dispatch",
+      fetchFn,
+      log,
+    });
+    // The hit log line includes pattern_id + latency so ops can audit
+    // matcher behavior without re-running the request.
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("hit pattern=help"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("latency_ms=12.3"));
+  });
+});

--- a/extensions/slack/src/monitor/pre-router.ts
+++ b/extensions/slack/src/monitor/pre-router.ts
@@ -1,0 +1,225 @@
+/**
+ * Optional env-gated HTTP pre-router hook for the Slack monitor.
+ *
+ * Some workspaces front the Slack monitor with an external
+ * pattern-matcher service (a Python skill_matcher, a static FAQ
+ * responder, anything that wants to answer common prompts without
+ * an LLM round-trip). This hook lets that external service inspect
+ * a prompt BEFORE the agent turn is created.
+ *
+ * Behavior
+ * --------
+ *
+ *   OPENCLAW_PRE_ROUTER_URL unset       → no-op, returns null
+ *                                        (LLM dispatch unchanged)
+ *   set + HTTP 200 matched=true         → returns the response text
+ *                                        (caller posts it + skips LLM)
+ *   set + HTTP 200 matched=false        → returns null
+ *   set + HTTP 500 / timeout / parse-fail → returns null
+ *
+ * The hook is "fails-safe": ANY error returns null so the bot
+ * always falls through to LLM dispatch. A broken pre-router service
+ * cannot break the Slack bot.
+ *
+ * Security
+ * --------
+ *
+ * ``OPENCLAW_PRE_ROUTER_URL`` must point to a trusted service. The
+ * operator chooses what URL to set; we don't validate it beyond
+ * "looks like a URL". Treat it like any other trusted internal
+ * service URL — do not point it at an untrusted host that could
+ * inject arbitrary text into your Slack workspace.
+ *
+ * The hook sends the raw user prompt to the configured URL. Operators
+ * who don't want user messages leaving their boundary should leave
+ * the env var unset.
+ */
+
+const DEFAULT_PRE_ROUTER_TIMEOUT_MS = 2000;
+
+/**
+ * Request payload posted to the pre-router URL.
+ *
+ * ``prompt`` is the raw user text from the Slack message.
+ * ``channel``, ``user``, ``ts`` are Slack identifiers — opaque to the
+ * pre-router service, included so it can correlate with Slack thread
+ * URLs in its own logs.
+ */
+export interface PreRouterRequest {
+  prompt: string;
+  channel: string;
+  user: string;
+  ts: string;
+}
+
+/**
+ * Response shape expected from the pre-router URL.
+ *
+ * On ``matched: true``, ``response`` MUST be a non-empty string —
+ * this is what gets posted to Slack. On ``matched: false``, the
+ * other fields are ignored and the hook returns null.
+ *
+ * Any other shape (missing ``matched`` field, wrong types, etc.) is
+ * treated as malformed and falls through to LLM dispatch.
+ */
+export interface PreRouterResponse {
+  matched: boolean;
+  response?: string;
+  error?: string;
+  pattern_id?: string;
+  latency_ms?: number;
+}
+
+/** Per-call dependencies, dependency-injected for unit testing. */
+export interface PreRouterDeps {
+  /** Reads the URL env var. Pass () => undefined to disable. */
+  readUrl?: () => string | undefined;
+  /** Reads the timeout env var. */
+  readTimeoutMs?: () => number;
+  /** HTTP client. Override in tests to assert call shape / inject failures. */
+  fetchFn?: typeof fetch;
+  /** Logger surface — accepts info + error severity for hook telemetry. */
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+function defaultReadUrl(): string | undefined {
+  const value = process.env.OPENCLAW_PRE_ROUTER_URL;
+  return value && value.trim() ? value.trim() : undefined;
+}
+
+function defaultReadTimeoutMs(): number {
+  const raw = process.env.OPENCLAW_PRE_ROUTER_TIMEOUT_MS;
+  if (!raw) {
+    return DEFAULT_PRE_ROUTER_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_PRE_ROUTER_TIMEOUT_MS;
+  }
+  // Cap at 10s to avoid pathological misconfiguration starving the
+  // LLM path. The default is 2s; we accept overrides but bound them.
+  return Math.min(parsed, 10_000);
+}
+
+function isPreRouterResponseShape(value: unknown): value is PreRouterResponse {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.matched !== "boolean") {
+    return false;
+  }
+  if (obj.matched && typeof obj.response !== "string") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Consult the pre-router service.
+ *
+ * Returns:
+ *   - the matched response string on a clean hit (caller posts it
+ *     to Slack + skips LLM dispatch);
+ *   - ``null`` on any other outcome (env unset, miss, error, timeout,
+ *     malformed response) — caller proceeds with normal LLM dispatch.
+ *
+ * Never throws. ANY exception inside the hook is caught and turned
+ * into a null result so the bot stays alive.
+ *
+ * @example
+ *   const hit = await runPreRouterHook({
+ *     prompt: "show me last week's brief",
+ *     channel: "C012345",
+ *     user: "U012345",
+ *     ts: "1717423420.000100",
+ *   });
+ *   if (hit !== null) {
+ *     await sendMessageSlack(target, hit, sendOpts);
+ *     return; // skip LLM
+ *   }
+ */
+export async function runPreRouterHook(
+  payload: PreRouterRequest,
+  deps: PreRouterDeps = {},
+): Promise<string | null> {
+  const readUrl = deps.readUrl ?? defaultReadUrl;
+  const readTimeoutMs = deps.readTimeoutMs ?? defaultReadTimeoutMs;
+  const fetchFn = deps.fetchFn ?? fetch;
+
+  const url = readUrl();
+  if (!url) {
+    // Hook is off — default behavior. No log; runs on every message.
+    return null;
+  }
+
+  const timeoutMs = readTimeoutMs();
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // AbortError on timeout, network errors, DNS, etc. All treated as
+    // "no hit", fall through to LLM. Log so operators can see if the
+    // pre-router service is dead.
+    const reason = err instanceof Error ? err.message : String(err);
+    deps.error?.(`slack pre-router hook fetch failed (${reason}); falling through to LLM`);
+    return null;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  if (!response.ok) {
+    deps.error?.(`slack pre-router hook returned HTTP ${response.status}; falling through to LLM`);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    deps.error?.(
+      `slack pre-router hook returned non-JSON body (${reason}); falling through to LLM`,
+    );
+    return null;
+  }
+
+  if (!isPreRouterResponseShape(parsed)) {
+    deps.error?.("slack pre-router hook returned malformed body; falling through to LLM");
+    return null;
+  }
+
+  if (!parsed.matched) {
+    deps.log?.("slack pre-router hook: miss; falling through to LLM");
+    return null;
+  }
+
+  // We confirmed matched=true + response is a string in isPreRouterResponseShape.
+  const text = parsed.response ?? "";
+  if (!text) {
+    deps.error?.(
+      "slack pre-router hook returned matched=true but empty response; falling through to LLM",
+    );
+    return null;
+  }
+
+  deps.log?.(
+    `slack pre-router hook: hit pattern=${parsed.pattern_id ?? "-"} latency_ms=${parsed.latency_ms ?? "-"}`,
+  );
+  return text;
+}
+
+/**
+ * Public for tests and integration fixtures — lets callers inspect
+ * the default timeout without re-implementing the parse.
+ */
+export const PRE_ROUTER_DEFAULT_TIMEOUT_MS = DEFAULT_PRE_ROUTER_TIMEOUT_MS;


### PR DESCRIPTION
Adds a single opt-in hook to the Slack message dispatch path. When the
operator sets ``OPENCLAW_PRE_ROUTER_URL``, the monitor consults that
URL with the prompt before paying for an LLM round-trip. On a hit, the
response is posted directly to the Slack thread and the LLM dispatch
is skipped. On any other outcome — env unset, miss, HTTP error,
timeout, malformed response, post-back failure — the bot falls
through to the LLM path exactly as it does today.

Use case: external pattern-matcher services that handle frequent
prompts (help text, last-N-days reports, etc.) without an LLM trip.
The hook is a single HTTP POST, fails-safe, and adds < 5ms when
the env var is unset (just one ``process.env`` read).

Defaults
========

* ``OPENCLAW_PRE_ROUTER_URL`` unset → hook is a no-op, no behavior
  change vs main. This is the default for every existing install.
* ``OPENCLAW_PRE_ROUTER_TIMEOUT_MS`` default 2000, capped at 10000.

API contract
============

The pre-router service receives::

    POST <OPENCLAW_PRE_ROUTER_URL>
    Content-Type: application/json
    {prompt, channel, user, ts}

And must respond 200 OK with::

    {"matched": true,  "response": "..."}  // hit
    {"matched": false}                     // miss → LLM
    {"matched": false, "error": "..."}     // matcher crashed → LLM

The hook validates the shape; any other body falls through to LLM.

Security
========

The configured URL must be trusted. We send the raw user prompt to it.
Operators who don't want user messages leaving their boundary should
leave the env var unset (the default).

Tests
=====

  * extensions/slack/src/monitor/pre-router.test.ts (10 unit tests):
    flag-off, HTTP 200 hit, HTTP 200 miss, HTTP 500, AbortError,
    malformed JSON, missing ``matched``, ``matched=true`` no response,
    network error, observability log lines.
  * extensions/slack/src/monitor/pre-router.dispatch.test.ts
    (4 integration tests): real Node HTTP server fixture, exercises
    the wire contract end-to-end without mocking ``fetch``.

All 14 new tests + 1253 existing Slack extension tests pass.

Companion
=========

Pairs with a Python orbit-mcp endpoint that implements the contract on
the matcher side. The hook works against any service that honors the
contract above; the orbit-mcp implementation is one example.

Refs
====

Conceptually adjacent to openclaw#18160 (cron-schema validation),
but this is a different code path — Slack monitor, not cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

