### PR TITLE
fix(googlechat): fall back to text link when remote media upload fails with 403

### DIFF
--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -19,6 +19,8 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isUploadAuthScopeFailure: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes("Google Chat upload 403:"),
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -174,6 +176,85 @@ describe("googlechat message actions", () => {
       attachments: [{ attachmentUploadToken: "token-1", contentName: "remote.png" }],
     });
     expectJsonResult(result, { ok: true, to: "spaces/AAA" });
+  });
+
+  it("falls back to text link when send action media upload fails with 403 (app-auth scope)", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    getGoogleChatRuntime.mockReturnValue({
+      channel: {
+        media: {
+          readRemoteMediaBuffer: vi.fn(async () => ({
+            buffer: Buffer.from("img"),
+            fileName: "img.png",
+            contentType: "image/png",
+          })),
+        },
+      },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link" });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    const result = await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "here is the file",
+        media: "https://example.com/img.png",
+      },
+      cfg: {},
+      accountId: "default",
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "here is the file\nhttps://example.com/img.png",
+      thread: undefined,
+    });
+    expectJsonResult(result, { ok: true, to: "spaces/AAA" });
+  });
+
+  it("re-throws non-403 upload failures from the send action path", async () => {
+    const account = buildAccount({ config: { mediaMaxMb: 5 } });
+    resolveGoogleChatAccount.mockReturnValue(account);
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    getGoogleChatRuntime.mockReturnValue({
+      channel: {
+        media: {
+          readRemoteMediaBuffer: vi.fn(async () => ({
+            buffer: Buffer.from("img"),
+            fileName: "img.png",
+            contentType: "image/png",
+          })),
+        },
+      },
+    });
+    uploadGoogleChatAttachment.mockRejectedValue(new Error("Google Chat upload 500: server error"));
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await expect(
+      googlechatMessageActions.handleAction({
+        action: "send",
+        params: {
+          to: "spaces/AAA",
+          message: "caption",
+          media: "https://example.com/img.png",
+        },
+        cfg: {},
+        accountId: "default",
+      } as never),
+    ).rejects.toThrow("Google Chat upload 500: server error");
+
+    expect(sendGoogleChatMessage).not.toHaveBeenCalled();
   });
 
   it("routes upload-file through the same attachment upload path with filename override", async () => {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -16,6 +16,7 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isUploadAuthScopeFailure,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -140,13 +141,30 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           readStringParam(params, "title") ??
           loaded.fileName ??
           "attachment";
-        const upload = await uploadGoogleChatAttachment({
-          account,
-          space,
-          filename: uploadFileName,
-          buffer: loaded.buffer,
-          contentType: loaded.contentType,
-        });
+        let upload: { attachmentUploadToken?: string };
+        try {
+          upload = await uploadGoogleChatAttachment({
+            account,
+            space,
+            filename: uploadFileName,
+            buffer: loaded.buffer,
+            contentType: loaded.contentType,
+          });
+        } catch (uploadErr) {
+          // app-auth (chat.bot scope) cannot call media.upload; Google returns 403.
+          // Fall back to a text link so the reply is not silently dropped. (#89430)
+          if (/^https?:\/\//i.test(mediaUrl) && isUploadAuthScopeFailure(uploadErr)) {
+            const fallbackText = [content, mediaUrl].filter(Boolean).join("\n") || mediaUrl;
+            await sendGoogleChatMessage({
+              account,
+              space,
+              text: fallbackText,
+              thread: threadId ?? undefined,
+            });
+            return jsonResult({ ok: true, to: space });
+          }
+          throw uploadErr;
+        }
         await sendGoogleChatMessage({
           account,
           space,

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -236,6 +236,13 @@ export async function uploadGoogleChatAttachment(params: {
   };
 }
 
+// withGoogleChatResponse throws "Google Chat upload 403: ..." for HTTP 403 on the upload endpoint.
+// Matching the exact prefix avoids false positives from sendGoogleChatMessage 403s
+// (which use the default "Google Chat API" error prefix).
+export function isUploadAuthScopeFailure(err: unknown): boolean {
+  return (err instanceof Error ? err.message : String(err)).includes("Google Chat upload 403:");
+}
+
 export async function downloadGoogleChatMedia(params: {
   account: ResolvedGoogleChatAccount;
   resourceName: string;

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -21,6 +21,7 @@ import {
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import type { OutboundMediaLoadOptions } from "openclaw/plugin-sdk/outbound-media";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isUploadAuthScopeFailure } from "./api.js";
 import { formatGoogleChatAllowFromEntry } from "./channel-base.js";
 import {
   type ResolvedGoogleChatAccount,
@@ -310,13 +311,39 @@ export const googlechatOutboundAdapter = {
           });
       const { sendGoogleChatMessage, uploadGoogleChatAttachment } =
         await loadGoogleChatChannelRuntime();
-      const upload = await uploadGoogleChatAttachment({
-        account,
-        space,
-        filename: loaded.fileName ?? "attachment",
-        buffer: loaded.buffer,
-        contentType: loaded.contentType,
-      });
+      let upload: { attachmentUploadToken?: string };
+      try {
+        upload = await uploadGoogleChatAttachment({
+          account,
+          space,
+          filename: loaded.fileName ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+      } catch (uploadErr) {
+        // app-auth (chat.bot scope) cannot call media.upload; Google returns 403.
+        // Fall back to a text link so the reply is not silently dropped. (#89430)
+        if (/^https?:\/\//i.test(mediaUrl) && isUploadAuthScopeFailure(uploadErr)) {
+          const fallbackText = [text, mediaUrl].filter(Boolean).join("\n") || mediaUrl;
+          const fallbackResult = await sendGoogleChatMessage({
+            account,
+            space,
+            text: fallbackText,
+            thread,
+          });
+          const fallbackMessageId = fallbackResult?.messageName ?? "";
+          return {
+            messageId: fallbackMessageId,
+            chatId: space,
+            receipt: createGoogleChatSendReceipt({
+              messageId: fallbackMessageId,
+              chatId: space,
+              kind: "media",
+            }),
+          };
+        }
+        throw uploadErr;
+      }
       const result = await sendGoogleChatMessage({
         account,
         space,

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -408,6 +408,49 @@ describe("googlechatPlugin outbound sendMedia", () => {
   });
 });
 
+it("falls back to text link when remote media upload fails with 403 (app-auth scope limit)", async () => {
+  setupRuntimeMediaMocks({ loadFileName: "img.png", loadBytes: "image-data" });
+  uploadGoogleChatAttachmentMock.mockRejectedValue(
+    new Error("Google Chat upload 403: PERMISSION_DENIED"),
+  );
+  sendGoogleChatMessageMock.mockResolvedValue({
+    messageName: "spaces/AAA/messages/link-fallback",
+  });
+
+  const cfg = createGoogleChatCfg();
+  const result = await googlechatOutboundAdapter.attachedResults.sendMedia({
+    cfg,
+    to: "spaces/AAA",
+    text: "here is the image",
+    mediaUrl: "https://example.com/image.png",
+    accountId: "default",
+  });
+
+  const sendRequest = requireMockArg(sendGoogleChatMessageMock) as {
+    text?: string;
+    attachments?: unknown;
+  };
+  expect(sendRequest.text).toBe("here is the image\nhttps://example.com/image.png");
+  expect(sendRequest.attachments).toBeUndefined();
+  expect(result.messageId).toBe("spaces/AAA/messages/link-fallback");
+  expect(result.receipt.primaryPlatformMessageId).toBe("spaces/AAA/messages/link-fallback");
+});
+
+it("re-throws non-403 upload failures from the adapter sendMedia path", async () => {
+  setupRuntimeMediaMocks({ loadFileName: "img.png", loadBytes: "image-data" });
+  uploadGoogleChatAttachmentMock.mockRejectedValue(new Error("Google Chat upload 500: internal"));
+
+  const cfg = createGoogleChatCfg();
+  await expect(
+    googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "default",
+    }),
+  ).rejects.toThrow("Google Chat upload 500: internal");
+});
+
 describe("googlechatPlugin threading", () => {
   it("honors per-account replyToMode overrides", () => {
     const cfg = {

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isUploadAuthScopeFailure,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -106,21 +107,46 @@ export async function deliverGoogleChatReply(params: {
       }
     },
     sendMedia: async ({ mediaUrl, caption }) => {
+      let loaded: { buffer: Buffer; contentType?: string; fileName?: string };
       try {
-        const loaded = await core.channel.media.readRemoteMediaBuffer({
+        loaded = await core.channel.media.readRemoteMediaBuffer({
           url: mediaUrl,
           maxBytes: (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
         });
-        const upload = await uploadAttachmentForReply({
+      } catch (loadErr) {
+        runtime.error?.(`Google Chat attachment send failed: ${String(loadErr)}`);
+        return;
+      }
+      let upload: { attachmentUploadToken?: string };
+      try {
+        upload = await uploadAttachmentForReply({
           account,
           spaceId,
           buffer: loaded.buffer,
           contentType: loaded.contentType,
           filename: loaded.fileName ?? "attachment",
         });
-        if (!upload.attachmentUploadToken) {
-          throw new Error("missing attachment upload token");
+      } catch (uploadErr) {
+        // app-auth (chat.bot scope) cannot call media.upload; Google returns 403.
+        // Fall back to a text link so the reply is not silently dropped. (#89430)
+        if (/^https?:\/\//i.test(mediaUrl) && isUploadAuthScopeFailure(uploadErr)) {
+          const fallbackText = [caption, mediaUrl].filter(Boolean).join("\n") || mediaUrl;
+          try {
+            await sendTextMessage(fallbackText);
+            statusSink?.({ lastOutboundAt: Date.now() });
+          } catch (fallbackErr) {
+            runtime.error?.(`Google Chat media link fallback failed: ${String(fallbackErr)}`);
+          }
+          return;
         }
+        runtime.error?.(`Google Chat attachment send failed: ${String(uploadErr)}`);
+        return;
+      }
+      if (!upload.attachmentUploadToken) {
+        runtime.error?.("Google Chat attachment send failed: missing upload token");
+        return;
+      }
+      try {
         await sendGoogleChatMessage({
           account,
           space: spaceId,
@@ -131,8 +157,8 @@ export async function deliverGoogleChatReply(params: {
           ],
         });
         statusSink?.({ lastOutboundAt: Date.now() });
-      } catch (err) {
-        runtime.error?.(`Google Chat attachment send failed: ${String(err)}`);
+      } catch (sendErr) {
+        runtime.error?.(`Google Chat attachment send failed: ${String(sendErr)}`);
       }
     },
   });

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isUploadAuthScopeFailure: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes("Google Chat upload 403:"),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
   updateGoogleChatMessage: mocks.updateGoogleChatMessage,
   uploadGoogleChatAttachment: mocks.uploadGoogleChatAttachment,
@@ -102,6 +104,149 @@ describe("Google Chat reply delivery", () => {
     expect(statusSink).toHaveBeenCalledTimes(2);
     expect(runtime.error).toHaveBeenCalledWith(
       "Google Chat message send failed: Error: message not found",
+    );
+  });
+
+  it("falls back to text link when remote media upload fails with 403 (app-auth scope limit)", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
+    });
+    const runtime = createRuntime();
+    const statusSink = vi.fn();
+    mocks.uploadGoogleChatAttachment.mockRejectedValue(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/fallback" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        text: "caption",
+        mediaUrl: "https://example.invalid/reply.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      statusSink,
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "caption\nhttps://example.invalid/reply.png",
+      thread: "spaces/AAA/threads/root",
+    });
+    expect(statusSink).toHaveBeenCalledTimes(1);
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to URL-only link when upload fails with 403 and there is no caption", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png" },
+    });
+    const runtime = createRuntime();
+    mocks.uploadGoogleChatAttachment.mockRejectedValue(
+      new Error("Google Chat upload 403: PERMISSION_DENIED"),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/link" });
+
+    await deliverGoogleChatReply({
+      payload: {
+        mediaUrl: "https://example.invalid/file.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "https://example.invalid/file.png",
+      thread: "spaces/AAA/threads/root",
+    });
+  });
+
+  it("does not fall back to text link for non-403 upload failures", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png" },
+    });
+    const runtime = createRuntime();
+    mocks.uploadGoogleChatAttachment.mockRejectedValue(
+      new Error("Google Chat upload 500: internal"),
+    );
+    mocks.sendGoogleChatMessage.mockResolvedValue(undefined);
+
+    await deliverGoogleChatReply({
+      payload: {
+        mediaUrl: "https://example.invalid/file.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+    });
+
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
+    );
+  });
+
+  it("logs and swallows readRemoteMediaBuffer failures (original error contract preserved)", async () => {
+    const core = createCore();
+    const runtime = createRuntime();
+    (core.channel.media.readRemoteMediaBuffer as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("network timeout"),
+    );
+
+    await deliverGoogleChatReply({
+      payload: {
+        mediaUrl: "https://example.invalid/file.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+    });
+
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
+    );
+  });
+
+  it("logs and swallows sendGoogleChatMessage failures after successful upload", async () => {
+    const core = createCore({
+      media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "img.png" },
+    });
+    const runtime = createRuntime();
+    mocks.uploadGoogleChatAttachment.mockResolvedValue({ attachmentUploadToken: "tok" });
+    mocks.sendGoogleChatMessage.mockRejectedValue(new Error("Google Chat API 500: server error"));
+
+    await deliverGoogleChatReply({
+      payload: {
+        mediaUrl: "https://example.invalid/file.png",
+        replyToId: "spaces/AAA/threads/root",
+      },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat attachment send failed"),
     );
   });
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89430 reports that Google Chat agents using app-auth (service-account, `chat.bot` scope) cannot deliver replies that include image or file attachments. The official Google Chat API contract requires user auth for `media.upload`; app-auth receives a 403. Three delivery paths attempted the upload without a fallback and silently discarded the reply.
- **Root Cause**: All three paths call `uploadGoogleChatAttachment` with no error handling for the known scope limitation. `withGoogleChatResponse` throws `"Google Chat upload 403: …"` for HTTP 403 on the upload endpoint (controlled by `errorPrefix: "Google Chat upload"` at `api.ts:228`), providing a precise prefix that distinguishes upload auth failures from `sendGoogleChatMessage` 403s (which use the default `"Google Chat API"` prefix). The three affected paths are: (1) outbound adapter `sendMedia` (`channel.adapters.ts:313`), (2) monitor reply delivery `sendMedia` (`monitor-reply-delivery.ts:114`), (3) message action `send`/`upload-file` with media (`actions.ts:143`).
- **Fix**: Export `isUploadAuthScopeFailure` from `api.ts` (matches `"Google Chat upload 403:"` exactly to avoid false positives) and apply a narrow try/catch around only `uploadGoogleChatAttachment` in all three paths. On 403 for a remote http(s) URL, fall back to `sendGoogleChatMessage` with the URL as text joined with caption/message. Preserve the original error contract: `readRemoteMediaBuffer` and `sendGoogleChatMessage` each keep their own catch blocks (monitor/adapter paths stay always-resolving); the actions path re-throws non-403 upload failures.
- **What changed**:
  - `extensions/googlechat/src/api.ts` — export `isUploadAuthScopeFailure` (pure string check, no runtime deps).
  - `extensions/googlechat/src/channel.adapters.ts` — import helper; narrow try/catch to upload only; 403 + remote URL → text link fallback.
  - `extensions/googlechat/src/monitor-reply-delivery.ts` — import helper; split `sendMedia` into per-phase catch blocks; 403 + remote URL → text link fallback.
  - `extensions/googlechat/src/actions.ts` — import helper; narrow try/catch to upload only; 403 + remote URL → text link fallback; non-403 re-throws.
  - `extensions/googlechat/src/channel.test.ts` — 2 new tests: adapter 403 fallback; adapter non-403 re-throws.
  - `extensions/googlechat/src/monitor.reply-delivery.test.ts` — 5 new tests: 403 with caption; 403 URL-only; non-403 logs error; buffer-load failure logs error; post-upload send failure logs error.
  - `extensions/googlechat/src/actions.test.ts` — 2 new tests: action 403 fallback; action non-403 re-throws.
- **What did NOT change (scope boundary)**:
  - Upload behavior for non-403 errors is unchanged; actions path re-throws, adapter/monitor paths log.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin SDK surface unchanged. Gateway protocol unchanged.

### Reproduction

1. Configure Google Chat with service-account app auth (`chat.bot` scope).
2. Send a message (via agent reply or message tool) that includes a remote image or file URL.
3. **Before this PR**: `uploadGoogleChatAttachment` receives a 403 in all three paths; reply is dropped.
4. **After this PR**: 403 detected; all three paths fall back to `sendGoogleChatMessage` with `[caption, mediaUrl].join("\n")` — reply reaches the user as a text link.

### Real behavior proof

**Behavior addressed (#89430)**: when `uploadGoogleChatAttachment` throws `"Google Chat upload 403: …"` for a remote http(s) URL, all three delivery paths send a text-link fallback.

**Real environment tested (Ubuntu Server Node 24, source-level — Vitest against production `deliverGoogleChatReply`, `googlechatOutboundAdapter.attachedResults.sendMedia`, and `googlechatMessageActions.handleAction` with mocked `uploadGoogleChatAttachment`)**: fallback tests call production functions with the mocked upload throwing the exact error format from `withGoogleChatResponse`. No live credentials available; API contract source-confirmed via `api.ts:59` and `auth.ts:11`.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/googlechat/src/actions.test.ts extensions/googlechat/src/channel.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts` — 35 tests pass (26 pre-existing + 9 new). `pnpm exec oxlint` clean. `pnpm format:check` clean.

**Evidence after fix**:

```
Tests  35 passed (35)
```

**What was not tested**: live Google Chat end-to-end with a real service-account credential.

**Repro confirmation**: 403 fallback tests fail on the pre-patch tree (upload error propagates or is dropped, `sendGoogleChatMessage` not called with fallback text) and pass with the fix applied.

### Risk / Mitigation

- **Risk**: `isUploadAuthScopeFailure` fires on non-upload 403s. **Mitigation**: matches `"Google Chat upload 403:"` (set by `errorPrefix: "Google Chat upload"` at `api.ts:228`); `sendGoogleChatMessage` uses `"Google Chat API"` prefix so its 403s never match.
- **Risk**: Behavioral regression in monitor path — buffer load or send failures swallowed. **Mitigation**: each phase has its own catch block restoring the original always-resolving contract; regression tests cover both.
- **Risk**: Actions path behavior change — non-403 upload errors now re-throw instead of propagating silently. **Mitigation**: the original path also propagated upload errors (no catch existed); re-throw is equivalent behavior. Test confirms non-403 re-throws.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Google Chat plugin

### Linked Issue/PR

Fixes #89430