### PR TITLE
fix(plugins): guard config contract metadata

### DIFF
--- a/src/plugins/config-contracts.test.ts
+++ b/src/plugins/config-contracts.test.ts
@@ -265,6 +265,97 @@ describe("resolvePluginConfigContractsById", () => {
     );
   });
 
+  it("keeps healthy config contract records after unreadable registry plugin metadata", () => {
+    const unreadableRecord = {
+      get id() {
+        throw new Error("config contract plugin id getter exploded");
+      },
+      origin: "config",
+      configContracts: {
+        compatibilityMigrationPaths: ["plugins.entries.broken.config"],
+      },
+    } as never;
+    mocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue(
+      createRegistry([
+        unreadableRecord,
+        createPluginRecord({
+          id: "healthy",
+          origin: "config",
+          configContracts: {
+            compatibilityMigrationPaths: ["plugins.entries.healthy.config"],
+          },
+        }),
+      ]),
+    );
+
+    expect(
+      resolvePluginConfigContractsById({
+        pluginIds: ["healthy"],
+        fallbackToBundledMetadata: false,
+      }),
+    ).toEqual(
+      new Map([
+        [
+          "healthy",
+          {
+            origin: "config",
+            configContracts: {
+              compatibilityMigrationPaths: ["plugins.entries.healthy.config"],
+            },
+          },
+        ],
+      ]),
+    );
+  });
+
+  it("keeps bundled config contract fallback after unreadable bundled plugin metadata", () => {
+    const unreadableRecord = {
+      get id() {
+        throw new Error("bundled config contract plugin id getter exploded");
+      },
+      origin: "bundled",
+      configContracts: {
+        secretInputs: {
+          paths: [{ path: "broken.secret", expected: "string" }],
+        },
+      },
+    } as never;
+    mocks.loadBundledManifestRegistry.mockReturnValue(
+      createRegistry([
+        unreadableRecord,
+        createPluginRecord({
+          id: "healthy-bundled",
+          origin: "bundled",
+          configContracts: {
+            secretInputs: {
+              paths: [{ path: "healthy.secret", expected: "string" }],
+            },
+          },
+        }),
+      ]),
+    );
+
+    expect(
+      resolvePluginConfigContractsById({
+        pluginIds: ["healthy-bundled"],
+      }),
+    ).toEqual(
+      new Map([
+        [
+          "healthy-bundled",
+          {
+            origin: "bundled",
+            configContracts: {
+              secretInputs: {
+                paths: [{ path: "healthy.secret", expected: "string" }],
+              },
+            },
+          },
+        ],
+      ]),
+    );
+  });
+
   it("can skip bundled metadata fallback for registry-scoped callers", () => {
     expect(
       resolvePluginConfigContractsById({

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -1,7 +1,7 @@
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestConfigContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
@@ -14,6 +14,30 @@ export type PluginConfigContractMetadata = {
   origin: PluginOrigin;
   configContracts: PluginManifestConfigContracts;
 };
+
+type PluginConfigContractRecordRead =
+  | {
+      ok: true;
+      id: string;
+      origin: PluginOrigin;
+      configContracts?: PluginManifestConfigContracts;
+    }
+  | { ok: false };
+
+function readPluginConfigContractRecord(
+  plugin: PluginManifestRegistry["plugins"][number],
+): PluginConfigContractRecordRead {
+  try {
+    return {
+      ok: true,
+      id: plugin.id,
+      origin: plugin.origin,
+      configContracts: plugin.configContracts,
+    };
+  } catch {
+    return { ok: false };
+  }
+}
 
 export function resolvePluginConfigContractsById(params: {
   config?: OpenClawConfig;
@@ -54,7 +78,11 @@ export function resolvePluginConfigContractsById(params: {
       diagnostics: discovery.diagnostics,
     });
     for (const plugin of registry.plugins) {
-      bundledContractFallbacks.set(plugin.id, plugin.configContracts);
+      const record = readPluginConfigContractRecord(plugin);
+      if (!record.ok) {
+        continue;
+      }
+      bundledContractFallbacks.set(record.id, record.configContracts);
     }
     if (!bundledContractFallbacks.has(pluginId)) {
       bundledContractFallbacks.set(pluginId, undefined);
@@ -70,16 +98,17 @@ export function resolvePluginConfigContractsById(params: {
     includeDisabled: true,
   });
   for (const plugin of registry.plugins) {
-    if (!pluginIds.includes(plugin.id)) {
+    const record = readPluginConfigContractRecord(plugin);
+    if (!record.ok || !pluginIds.includes(record.id)) {
       continue;
     }
-    resolvedPluginOrigins.set(plugin.id, plugin.origin);
-    if (!plugin.configContracts) {
+    resolvedPluginOrigins.set(record.id, record.origin);
+    if (!record.configContracts) {
       continue;
     }
-    matches.set(plugin.id, {
-      origin: plugin.origin,
-      configContracts: plugin.configContracts,
+    matches.set(record.id, {
+      origin: record.origin,
+      configContracts: record.configContracts,
     });
   }
 


### PR DESCRIPTION
## Summary

- Guard config contract registry and bundled fallback reads so one malformed plugin metadata row cannot abort config-contract resolution.
- Preserve healthy plugin config contracts and bundled fallback contracts after unreadable registry rows.
- Add regressions for unreadable normal registry metadata and unreadable bundled fallback metadata.

## Verification

- `node scripts/run-vitest.mjs src/plugins/config-contracts.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/config-contracts.ts src/plugins/config-contracts.test.ts`
- `node_modules/.bin/oxlint src/plugins/config-contracts.ts src/plugins/config-contracts.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (blocked: coordinator returned HTTP 401 before lease)

## Real behavior proof

Behavior addressed: config contract resolution now skips unreadable registry metadata rows instead of throwing before healthy plugin contract records are considered.

Real environment tested: local linked OpenClaw worktree on Node/Vitest via `scripts/run-vitest.mjs`; Crabbox AWS changed-gate attempt reached coordinator auth and failed before lease.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/config-contracts.test.ts`; `node_modules/.bin/oxfmt --check src/plugins/config-contracts.ts src/plugins/config-contracts.test.ts`; `node_modules/.bin/oxlint src/plugins/config-contracts.ts src/plugins/config-contracts.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview; Crabbox changed-gate attempt.

Evidence after fix: `src/plugins/config-contracts.test.ts` passed 9 tests, including unreadable installed-registry and bundled-fallback metadata regressions; touched-file format/lint and diff whitespace checks passed; autoreview reported no accepted/actionable findings.

Observed result after fix: healthy config contract records remain resolvable when a neighboring plugin registry row throws during metadata property access.

What was not tested: full `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing an AWS box; Blacksmith Testbox is also unavailable in this environment.
