### PR TITLE
fix(plugins): guard provider auth choice metadata

### DIFF
--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -58,6 +58,33 @@ function createProviderAuthChoice(overrides: Record<string, unknown>) {
   return overrides;
 }
 
+function createPoisonedManifestPlugin(
+  id: string,
+  field: "id" | "providerAuthChoices" | "setup",
+): Record<string, unknown> {
+  const plugin: Record<string, unknown> = {
+    id,
+    origin: "config",
+    providerAuthChoices: [
+      createProviderAuthChoice({
+        provider: "broken",
+        method: "api-key",
+        choiceId: "broken-api-key",
+        choiceLabel: "Broken API key",
+      }),
+    ],
+    setup: {
+      providers: [{ id: "broken", authMethods: ["api-key"] }],
+    },
+  };
+  Object.defineProperty(plugin, field, {
+    get() {
+      throw new Error(`provider auth choice ${field} metadata exploded`);
+    },
+  });
+  return plugin;
+}
+
 function setManifestPlugins(plugins: Array<Record<string, unknown>>) {
   pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
     plugins,
@@ -158,22 +185,10 @@ describe("provider auth choice manifest helpers", () => {
   });
 
   it("keeps healthy provider auth choices after unreadable plugin metadata", () => {
-    const unreadablePlugin = {
-      get id() {
-        throw new Error("provider auth choice plugin id getter exploded");
-      },
-      origin: "config",
-      providerAuthChoices: [
-        createProviderAuthChoice({
-          provider: "broken",
-          method: "api-key",
-          choiceId: "broken-api-key",
-          choiceLabel: "Broken API key",
-        }),
-      ],
-    } as never;
     setManifestPlugins([
-      unreadablePlugin,
+      createPoisonedManifestPlugin("bad-id", "id"),
+      createPoisonedManifestPlugin("bad-provider-auth-choices", "providerAuthChoices"),
+      createPoisonedManifestPlugin("bad-setup-auth-choices", "setup"),
       {
         id: "healthy",
         origin: "bundled",

--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -157,6 +157,63 @@ describe("provider auth choice manifest helpers", () => {
     });
   });
 
+  it("keeps healthy provider auth choices after unreadable plugin metadata", () => {
+    const unreadablePlugin = {
+      get id() {
+        throw new Error("provider auth choice plugin id getter exploded");
+      },
+      origin: "config",
+      providerAuthChoices: [
+        createProviderAuthChoice({
+          provider: "broken",
+          method: "api-key",
+          choiceId: "broken-api-key",
+          choiceLabel: "Broken API key",
+        }),
+      ],
+    } as never;
+    setManifestPlugins([
+      unreadablePlugin,
+      {
+        id: "healthy",
+        origin: "bundled",
+        providerAuthChoices: [
+          createProviderAuthChoice({
+            provider: "healthy",
+            method: "api-key",
+            choiceId: "healthy-api-key",
+            choiceLabel: "Healthy API key",
+            optionKey: "healthyApiKey",
+            cliFlag: "--healthy-api-key",
+            cliOption: "--healthy-api-key <key>",
+          }),
+        ],
+      },
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([
+      {
+        pluginId: "healthy",
+        providerId: "healthy",
+        methodId: "api-key",
+        choiceId: "healthy-api-key",
+        choiceLabel: "Healthy API key",
+        optionKey: "healthyApiKey",
+        cliFlag: "--healthy-api-key",
+        cliOption: "--healthy-api-key <key>",
+      },
+    ]);
+    expect(resolveManifestProviderOnboardAuthFlags()).toEqual([
+      {
+        optionKey: "healthyApiKey",
+        authChoice: "healthy-api-key",
+        cliFlag: "--healthy-api-key",
+        cliOption: "--healthy-api-key <key>",
+        description: "Healthy API key",
+      },
+    ]);
+  });
+
   it.each([
     {
       name: "deduplicates flag metadata by option key + flag",

--- a/src/plugins/provider-auth-choices.ts
+++ b/src/plugins/provider-auth-choices.ts
@@ -49,6 +49,10 @@ type ManifestProviderAuthChoiceParams = {
   env?: NodeJS.ProcessEnv;
   includeUntrustedWorkspacePlugins?: boolean;
 };
+type ProviderAuthChoicePluginMetadata = Pick<
+  PluginManifestRecord,
+  "id" | "origin" | "providerAuthChoices" | "setup" | "setupSource"
+>;
 
 const PROVIDER_AUTH_CHOICE_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {
   config: 0,
@@ -124,8 +128,24 @@ function normalizeManifestAuthDescriptorId(value: string): string {
   return sanitizeForLog(value).trim();
 }
 
+function readProviderAuthChoicePluginMetadata(
+  plugin: PluginManifestRecord,
+): ProviderAuthChoicePluginMetadata | undefined {
+  try {
+    return {
+      id: plugin.id,
+      origin: plugin.origin,
+      providerAuthChoices: plugin.providerAuthChoices,
+      setup: plugin.setup,
+      setupSource: plugin.setupSource,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 function toSetupProviderAuthChoiceCandidate(params: {
-  plugin: PluginManifestRecord;
+  plugin: ProviderAuthChoicePluginMetadata;
   providerId: string;
   methodId: string;
 }): ProviderAuthChoiceCandidate {
@@ -145,7 +165,7 @@ function toSetupProviderAuthChoiceCandidate(params: {
   };
 }
 
-function listSetupProviderAuthChoiceCandidates(plugin: PluginManifestRecord) {
+function listSetupProviderAuthChoiceCandidates(plugin: ProviderAuthChoicePluginMetadata) {
   if (plugin.setup?.requiresRuntime !== false && plugin.setupSource) {
     return [];
   }
@@ -189,7 +209,11 @@ function resolveManifestProviderAuthChoiceCandidates(params?: {
   });
   const registry = metadataSnapshot.manifestRegistry;
   const normalizedConfig = normalizePluginsConfig(params?.config?.plugins);
-  return registry.plugins.flatMap((plugin) => {
+  return registry.plugins.flatMap((registryPlugin) => {
+    const plugin = readProviderAuthChoicePluginMetadata(registryPlugin);
+    if (!plugin) {
+      return [];
+    }
     if (
       plugin.origin === "workspace" &&
       params?.includeUntrustedWorkspacePlugins === false &&


### PR DESCRIPTION
## Summary

- Guard provider auth choice discovery against unreadable plugin manifest metadata rows.
- Keep healthy auth choices and onboarding flags available when a neighboring plugin row throws during metadata reads.
- Add a regression covering unreadable plugin metadata before a healthy bundled provider auth choice.

## Verification

- `node scripts/run-vitest.mjs src/plugins/provider-auth-choices.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`
- `node_modules/.bin/oxlint src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (blocked: coordinator returned HTTP 401 before lease)

## Real behavior proof

Behavior addressed: provider auth choice discovery now skips unreadable plugin metadata rows instead of throwing before healthy provider auth choices and onboarding flags are considered.

Real environment tested: local linked OpenClaw worktree on Node/Vitest via `scripts/run-vitest.mjs`; Crabbox AWS changed-gate attempt reached coordinator auth and failed before lease.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/provider-auth-choices.test.ts`; `node_modules/.bin/oxfmt --check src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`; `node_modules/.bin/oxlint src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview; Crabbox changed-gate attempt.

Evidence after fix: `src/plugins/provider-auth-choices.test.ts` passed 13 tests, including the unreadable plugin metadata regression; touched-file format/lint and diff whitespace checks passed; autoreview reported no accepted/actionable findings.

Observed result after fix: healthy provider auth choices and CLI onboarding auth flags remain resolvable when an earlier plugin metadata row throws during property access.

What was not tested: full `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing an AWS box; Blacksmith Testbox is also unavailable in this environment.
