### PR TITLE
refactor: add transcript update identity contract

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -360,6 +360,15 @@ export async function mirrorCodexAppServerTranscript(params: {
       sessionFile: params.sessionFile,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.sessionId && params.sessionKey && params.agentId
+        ? {
+            target: {
+              agentId: params.agentId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            },
+          }
+        : {}),
       message: update.message,
       messageId: update.messageId,
       messageSeq: update.messageSeq,

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -959,6 +959,7 @@ export async function runCopilotAttempt(
     await dualWriteCopilotTranscriptBestEffort({
       sessionFile: sessionFileForMirror,
       sessionKey: readString((input as { sessionKey?: unknown }).sessionKey),
+      sessionId: readString(input.sessionId),
       agentId: readString(input.agentId),
       messages: taggedMessages,
       idempotencyScope: sessionIdForScope ? `copilot:${sessionIdForScope}` : undefined,

--- a/extensions/copilot/src/dual-write-transcripts.ts
+++ b/extensions/copilot/src/dual-write-transcripts.ts
@@ -96,6 +96,7 @@ function buildMirrorDedupeIdentity(message: MirroredAgentMessage): string {
 export interface MirrorCopilotTranscriptParams {
   sessionFile: string;
   sessionKey?: string;
+  sessionId?: string;
   agentId?: string;
   messages: AgentMessage[];
   /**
@@ -168,7 +169,20 @@ export async function mirrorCopilotTranscript(
   }
 
   if (params.sessionKey) {
-    emitSessionTranscriptUpdate({ sessionFile: params.sessionFile, sessionKey: params.sessionKey });
+    emitSessionTranscriptUpdate({
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.sessionId && params.agentId
+        ? {
+            target: {
+              agentId: params.agentId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            },
+          }
+        : {}),
+    });
   } else {
     emitSessionTranscriptUpdate(params.sessionFile);
   }

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -15,7 +15,6 @@ import type {
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { emitInternalSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -34,6 +33,25 @@ type SyncParams = {
   sessionFiles?: string[];
   progress?: (update: MemorySyncProgressUpdate) => void;
 };
+
+type MemorySessionTranscriptUpdate = {
+  agentId?: string;
+  sessionFile?: string;
+  sessionKey?: string;
+  target?: {
+    agentId: string;
+    sessionId: string;
+    sessionKey: string;
+  };
+};
+
+type MemoryTranscriptUpdateSubscriber = (
+  listener: (update: MemorySessionTranscriptUpdate) => void,
+) => () => void;
+
+const MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY = Symbol.for(
+  "openclaw.memoryCore.sessionTranscriptUpdateSubscriber",
+);
 
 type SourceStateRow = { path: string; hash: string; mtime: number; size: number };
 
@@ -377,20 +395,45 @@ describe("session startup catch-up", () => {
   it("queues transcript update identity without requiring a session file", async () => {
     vi.useFakeTimers();
     const harness = new SessionStartupCatchupHarness([]);
+    const originalSubscriber = (globalThis as Record<symbol, unknown>)[
+      MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY
+    ];
+    let transcriptListener: ((update: MemorySessionTranscriptUpdate) => void) | undefined;
+    (globalThis as Record<symbol, unknown>)[MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY] = ((
+      listener,
+    ) => {
+      transcriptListener = listener;
+      return () => {
+        if (transcriptListener === listener) {
+          transcriptListener = undefined;
+        }
+      };
+    }) satisfies MemoryTranscriptUpdateSubscriber;
     harness.startTranscriptListener();
 
-    emitInternalSessionTranscriptUpdate({
-      target: {
-        agentId: "main",
-        sessionId: "thread",
-        sessionKey: "agent:main:thread",
-      },
-    });
+    try {
+      transcriptListener?.({
+        target: {
+          agentId: "main",
+          sessionId: "thread",
+          sessionKey: "agent:main:thread",
+        },
+      });
 
-    expect(harness.getPendingSessionTargets()).toEqual([
-      { agentId: "main", sessionId: "thread", sessionKey: "agent:main:thread" },
-    ]);
-    harness.stopTranscriptListener();
+      expect(harness.getPendingSessionTargets()).toEqual([
+        { agentId: "main", sessionId: "thread", sessionKey: "agent:main:thread" },
+      ]);
+    } finally {
+      harness.stopTranscriptListener();
+      if (originalSubscriber === undefined) {
+        delete (globalThis as Record<symbol, unknown>)[
+          MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY
+        ];
+      } else {
+        (globalThis as Record<symbol, unknown>)[MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY] =
+          originalSubscriber;
+      }
+    }
   });
 
   it("keeps canonical path transcript update compatibility", async () => {

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { emitSessionTranscriptUpdate } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   resolveSessionTranscriptsDirForAgent,
   type OpenClawConfig,
@@ -14,6 +15,7 @@ import type {
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitInternalSessionTranscriptUpdate } from "../../../../src/sessions/transcript-events.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -111,8 +113,21 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return Array.from(this.sessionsDirtyFiles);
   }
 
+  getPendingSessionTargets(): MemorySyncParams["sessions"] {
+    return Array.from(this.sessionPendingTargets.values());
+  }
+
   isSessionsDirty(): boolean {
     return this.sessionsDirty;
+  }
+
+  startTranscriptListener(): void {
+    this.ensureSessionListener();
+  }
+
+  stopTranscriptListener(): void {
+    this.sessionUnsubscribe?.();
+    this.sessionUnsubscribe = null;
   }
 
   protected computeProviderKey(): string {
@@ -162,6 +177,8 @@ describe("session startup catch-up", () => {
   });
 
   afterEach(async () => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
@@ -355,5 +372,62 @@ describe("session startup catch-up", () => {
     });
 
     expect(harness.indexedPaths).toEqual([]);
+  });
+
+  it("queues transcript update identity without requiring a session file", async () => {
+    vi.useFakeTimers();
+    const harness = new SessionStartupCatchupHarness([]);
+    harness.startTranscriptListener();
+
+    emitInternalSessionTranscriptUpdate({
+      target: {
+        agentId: "main",
+        sessionId: "thread",
+        sessionKey: "agent:main:thread",
+      },
+    });
+
+    expect(harness.getPendingSessionTargets()).toEqual([
+      { agentId: "main", sessionId: "thread", sessionKey: "agent:main:thread" },
+    ]);
+    harness.stopTranscriptListener();
+  });
+
+  it("keeps canonical path transcript update compatibility", async () => {
+    vi.useFakeTimers();
+    const session = await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+    harness.startTranscriptListener();
+
+    emitSessionTranscriptUpdate({
+      sessionFile: session.filePath,
+      sessionKey: "agent:main:thread",
+    });
+
+    expect(harness.getPendingSessionTargets()).toEqual([
+      { agentId: "main", sessionId: "thread", sessionKey: "agent:main:thread" },
+    ]);
+    harness.stopTranscriptListener();
+  });
+
+  it("prefers transcript update identity before path compatibility", async () => {
+    vi.useFakeTimers();
+    const session = await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+    harness.startTranscriptListener();
+
+    emitSessionTranscriptUpdate({
+      sessionFile: session.filePath,
+      target: {
+        agentId: "main",
+        sessionId: "identity-target",
+        sessionKey: "agent:main:identity-target",
+      },
+    });
+
+    expect(harness.getPendingSessionTargets()).toEqual([
+      { agentId: "main", sessionId: "identity-target", sessionKey: "agent:main:identity-target" },
+    ]);
+    harness.stopTranscriptListener();
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -135,6 +135,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return Array.from(this.sessionPendingTargets.values());
   }
 
+  getPendingSessionFiles(): string[] {
+    return Array.from(this.sessionPendingFiles);
+  }
+
   isSessionsDirty(): boolean {
     return this.sessionsDirty;
   }
@@ -447,13 +451,12 @@ describe("session startup catch-up", () => {
       sessionKey: "agent:main:thread",
     });
 
-    expect(harness.getPendingSessionTargets()).toEqual([
-      { agentId: "main", sessionId: "thread", sessionKey: "agent:main:thread" },
-    ]);
+    expect(harness.getPendingSessionFiles()).toEqual([session.filePath]);
+    expect(harness.getPendingSessionTargets()).toEqual([]);
     harness.stopTranscriptListener();
   });
 
-  it("prefers transcript update identity before path compatibility", async () => {
+  it("prefers transcript update path compatibility before identity", async () => {
     vi.useFakeTimers();
     const session = await writeSessionFile("thread.jsonl");
     const harness = new SessionStartupCatchupHarness([]);
@@ -468,9 +471,8 @@ describe("session startup catch-up", () => {
       },
     });
 
-    expect(harness.getPendingSessionTargets()).toEqual([
-      { agentId: "main", sessionId: "identity-target", sessionKey: "agent:main:identity-target" },
-    ]);
+    expect(harness.getPendingSessionFiles()).toEqual([session.filePath]);
+    expect(harness.getPendingSessionTargets()).toEqual([]);
     harness.stopTranscriptListener();
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -170,8 +170,26 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
 ]);
 
 const log = createSubsystemLogger("memory");
+const MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY = Symbol.for(
+  "openclaw.memoryCore.sessionTranscriptUpdateSubscriber",
+);
 const TEST_MEMORY_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
 const TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+
+type MemorySessionTranscriptUpdate = {
+  agentId?: string;
+  sessionFile?: string;
+  sessionKey?: string;
+  target?: {
+    agentId: string;
+    sessionId: string;
+    sessionKey: string;
+  };
+};
+
+type MemoryTranscriptUpdateSubscriber = (
+  listener: (update: MemorySessionTranscriptUpdate) => void,
+) => () => void;
 
 function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
   return Boolean(
@@ -190,6 +208,18 @@ type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
   ino: number;
 };
+
+function subscribeMemorySessionTranscriptUpdates(
+  listener: (update: MemorySessionTranscriptUpdate) => void,
+): () => void {
+  const injected = (globalThis as Record<symbol, unknown>)[
+    MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY
+  ];
+  if (typeof injected === "function") {
+    return (injected as MemoryTranscriptUpdateSubscriber)(listener);
+  }
+  return onSessionTranscriptUpdate(listener);
+}
 
 function resolveMemoryWatchFactory(): typeof chokidar.watch {
   if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
@@ -1422,17 +1452,17 @@ export abstract class MemoryManagerSyncOps {
     if (!this.sources.has("sessions") || this.sessionUnsubscribe) {
       return;
     }
-    this.sessionUnsubscribe = onSessionTranscriptUpdate((update) => {
+    this.sessionUnsubscribe = subscribeMemorySessionTranscriptUpdates((update) => {
       if (this.closed) {
-        return;
-      }
-      const sessionFile = update.sessionFile;
-      if (!this.isSessionFileForAgent(sessionFile)) {
         return;
       }
       const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
       if (target) {
         this.scheduleSessionDirty(target);
+        return;
+      }
+      const sessionFile = update.sessionFile;
+      if (!sessionFile || !this.isSessionFileForAgent(sessionFile)) {
         return;
       }
       this.scheduleSessionDirty(sessionFile);
@@ -1703,13 +1733,30 @@ export abstract class MemoryManagerSyncOps {
     return resolvedFile.startsWith(`${resolvedDir}${path.sep}`);
   }
 
-  private resolveSessionTranscriptUpdateSyncTarget(update: {
-    agentId?: string;
-    sessionFile: string;
-    sessionKey?: string;
-  }): MemorySessionSyncTarget | null {
+  private resolveSessionTranscriptUpdateSyncTarget(
+    update: MemorySessionTranscriptUpdate,
+  ): MemorySessionSyncTarget | null {
+    if (update.sessionFile && isSessionArchiveArtifactName(path.basename(update.sessionFile))) {
+      return null;
+    }
+    if (update.target) {
+      const agentId = update.target.agentId.trim();
+      const sessionId = update.target.sessionId.trim();
+      const sessionKey = update.target.sessionKey.trim();
+      if (!agentId || !sessionId || normalizeAgentId(agentId) !== normalizeAgentId(this.agentId)) {
+        return null;
+      }
+      return {
+        agentId,
+        sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+      };
+    }
+    if (!update.sessionFile) {
+      return null;
+    }
     const parsed = parseCanonicalSessionSyncTargetFromPath(update.sessionFile);
-    if (!parsed || isSessionArchiveArtifactName(path.basename(update.sessionFile))) {
+    if (!parsed) {
       return null;
     }
     const agentId = update.agentId?.trim() || parsed.agentId;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1456,16 +1456,18 @@ export abstract class MemoryManagerSyncOps {
       if (this.closed) {
         return;
       }
+      const sessionFile = update.sessionFile;
+      if (sessionFile && isSessionArchiveArtifactName(path.basename(sessionFile))) {
+        return;
+      }
+      if (sessionFile && this.isSessionFileForAgent(sessionFile)) {
+        this.scheduleSessionDirty(sessionFile);
+        return;
+      }
       const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
       if (target) {
         this.scheduleSessionDirty(target);
-        return;
       }
-      const sessionFile = update.sessionFile;
-      if (!sessionFile || !this.isSessionFileForAgent(sessionFile)) {
-        return;
-      }
-      this.scheduleSessionDirty(sessionFile);
     });
   }
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -393,6 +393,11 @@ async function mirrorTelegramAssistantReplyToTranscript(params: {
     sessionFile,
     sessionKey: params.sessionKey,
     agentId: params.route.agentId,
+    target: {
+      agentId: params.route.agentId,
+      sessionId: sessionEntry.sessionId,
+      sessionKey: params.sessionKey,
+    },
     message: appendedMessage,
     messageId,
   });

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -926,6 +926,15 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
       sessionFile: params.sessionFile,
       sessionKey: params.sessionKey,
       ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.sessionId && params.sessionKey && params.agentId
+        ? {
+            target: {
+              agentId: params.agentId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            },
+          }
+        : {}),
     });
   }
 
@@ -997,6 +1006,15 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
       sessionFile: params.sessionFile,
       sessionKey: params.sessionKey,
       ...(params.agentId ? { agentId: params.agentId } : {}),
+      ...(params.sessionId && params.sessionKey && params.agentId
+        ? {
+            target: {
+              agentId: params.agentId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            },
+          }
+        : {}),
     });
   }
 
@@ -1063,6 +1081,7 @@ export async function truncateOversizedToolResultsInSession(params: {
       sessionFile,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
+      agentId: params.agentId,
     });
   } catch (err) {
     const errMsg = formatErrorMessage(err);

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -155,10 +155,8 @@ function requireString(value: string | undefined, label: string): string {
 beforeAll(async () => {
   ({ onSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js"));
   ({ installSessionToolResultGuard } = await import("../session-tool-result-guard.js"));
-  ({
-    rewriteTranscriptEntriesInRuntimeTranscript,
-    rewriteTranscriptEntriesInSessionManager,
-  } = await import("./transcript-rewrite.js"));
+  ({ rewriteTranscriptEntriesInRuntimeTranscript, rewriteTranscriptEntriesInSessionManager } =
+    await import("./transcript-rewrite.js"));
 });
 
 beforeEach(() => {
@@ -394,7 +392,13 @@ describe("rewriteTranscriptEntriesInRuntimeTranscript", () => {
       expect(listener).toHaveBeenCalledWith({
         agentId: "main",
         sessionFile: resolvedSessionFile,
+        sessionId,
         sessionKey: "agent:main:test",
+        target: {
+          agentId: "main",
+          sessionId,
+          sessionKey: "agent:main:test",
+        },
       });
 
       const rewrittenSession = SessionManager.open(sessionFile);
@@ -411,5 +415,4 @@ describe("rewriteTranscriptEntriesInRuntimeTranscript", () => {
       cleanup();
     }
   });
-
 });

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -18,6 +18,7 @@ import {
 import { SessionManager } from "../sessions/index.js";
 import { log } from "./logger.js";
 import {
+  persistTranscriptStateMutation,
   readTranscriptFileState,
   type TranscriptFileState,
   type TranscriptPersistedEntry,
@@ -463,12 +464,85 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
         sessionFile: target.sessionFile,
         sessionKey: target.sessionKey,
         agentId: target.agentId,
+        target: {
+          agentId: target.agentId,
+          sessionId: target.sessionId,
+          sessionKey: target.sessionKey,
+        },
       });
       log.info(
         `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
           `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
           `bytesFreed=${result.bytesFreed} ` +
           `sessionKey=${target.sessionKey}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const reason = formatErrorMessage(err);
+    log.warn(`[transcript-rewrite] failed: ${reason}`);
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason,
+    };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Rewrites a named transcript file artifact. Runtime callers should prefer
+ * rewriteTranscriptEntriesInRuntimeTranscript with agent/session scope.
+ */
+export async function rewriteTranscriptEntriesInSessionFile(params: {
+  sessionFile: string;
+  sessionId?: string;
+  sessionKey?: string;
+  agentId?: string;
+  request: TranscriptRewriteRequest;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<TranscriptRewriteResult> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+  try {
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: params.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(params.sessionFile);
+    const result = rewriteTranscriptEntriesInState({
+      state,
+      replacements: params.request.replacements,
+      ...(params.request.allowedRewriteSuffixEntryIds
+        ? { allowedRewriteSuffixEntryIds: params.request.allowedRewriteSuffixEntryIds }
+        : {}),
+    });
+    if (result.changed) {
+      await persistTranscriptStateMutation({
+        sessionFile: params.sessionFile,
+        state,
+        appendedEntries: result.appendedEntries,
+      });
+      emitSessionTranscriptUpdate({
+        sessionFile: params.sessionFile,
+        sessionKey: params.sessionKey,
+        ...(params.agentId ? { agentId: params.agentId } : {}),
+        ...(params.sessionId && params.sessionKey && params.agentId
+          ? {
+              target: {
+                agentId: params.agentId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+              },
+            }
+          : {}),
+      });
+      log.info(
+        `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
+          `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
+          `bytesFreed=${result.bytesFreed} ` +
+          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
       );
     }
     return result;

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1399,8 +1399,14 @@ describe("session accessor file-backed seam", () => {
         agentId: "main",
         message: appended.message,
         messageId: appended.messageId,
+        sessionId: scope.sessionId,
         sessionFile: transcriptPath,
         sessionKey: scope.sessionKey,
+        target: {
+          agentId: "main",
+          sessionId: scope.sessionId,
+          sessionKey: scope.sessionKey,
+        },
       },
     ]);
   });

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -10,7 +10,10 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type {
+  SessionTranscriptUpdate,
+  SessionTranscriptUpdateTarget,
+} from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
@@ -910,6 +913,7 @@ export async function publishTranscriptUpdate(
   emitSessionTranscriptUpdate({
     ...update,
     sessionFile: transcript.sessionFile,
+    ...(transcript.target ? { target: transcript.target } : {}),
   });
 }
 
@@ -1760,11 +1764,47 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
+type ResolvedTranscriptAccess = {
   sessionFile: string;
-}> {
+  target?: SessionTranscriptUpdateTarget;
+};
+
+function projectTranscriptUpdateTarget(
+  target: Pick<Partial<SessionTranscriptRuntimeTarget>, "agentId" | "sessionId" | "sessionKey">,
+): SessionTranscriptUpdateTarget | undefined {
+  if (!target.agentId || !target.sessionId || !target.sessionKey) {
+    return undefined;
+  }
+  return {
+    agentId: target.agentId,
+    sessionId: target.sessionId,
+    sessionKey: target.sessionKey,
+  };
+}
+
+async function resolveTranscriptAccess(
+  scope: SessionTranscriptWriteScope,
+): Promise<ResolvedTranscriptAccess> {
   if (scope.sessionFile?.trim()) {
-    return { sessionFile: scope.sessionFile };
+    const scopeSessionKey = scope.sessionKey?.trim();
+    const agentId = scopeSessionKey
+      ? (scope.agentId ?? resolveAgentIdFromSessionKey(scopeSessionKey))
+      : undefined;
+    return {
+      sessionFile: scope.sessionFile,
+      ...(agentId && scope.sessionId && scopeSessionKey
+        ? {
+            target: projectTranscriptUpdateTarget({
+              agentId,
+              sessionId: scope.sessionId,
+              sessionKey: scopeSessionKey,
+            }),
+          }
+        : {}),
+    };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   // Past this point resolution goes through the session entry, so the owning
   // key is mandatory; explicit-artifact writes returned above never need it.
@@ -1774,14 +1814,16 @@ async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Prom
       "Cannot resolve a transcript write scope without a session key or explicit session file",
     );
   }
-  if (!scope.sessionId) {
-    throw new Error(`Cannot resolve transcript scope without a session id: ${scopeSessionKey}`);
-  }
-  return await resolveSessionTranscriptRuntimeTarget({
+  const target = await resolveSessionTranscriptRuntimeTarget({
     ...scope,
     sessionId: scope.sessionId,
     sessionKey: scopeSessionKey,
   });
+  const updateTarget = projectTranscriptUpdateTarget(target);
+  return {
+    sessionFile: target.sessionFile,
+    ...(updateTarget ? { target: updateTarget } : {}),
+  };
 }
 
 async function resolveTranscriptTurnTarget(

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -2,7 +2,7 @@
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
-import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
 import type {
   ChatRunState,
@@ -226,7 +226,7 @@ export function startGatewayEventSubscriptions(params: {
     params.broadcast("heartbeat", evt, { dropIfSlow: true });
   });
 
-  const transcriptUnsub = onSessionTranscriptUpdate((evt) => {
+  const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
     void getTranscriptUpdateHandler().then((handler) => handler(evt));
   });
 

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -6,7 +6,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
-import type { SessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
@@ -92,7 +92,7 @@ export function createTranscriptUpdateBroadcastHandler(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
 }) {
   let broadcastQueue = Promise.resolve();
-  return (update: SessionTranscriptUpdate): void => {
+  return (update: InternalSessionTranscriptUpdate): void => {
     // Preserve transcript update order even when counting messages requires an
     // async read from the session file.
     broadcastQueue = broadcastQueue
@@ -108,19 +108,22 @@ async function handleTranscriptUpdateBroadcast(
     sessionMessageSubscribers: SessionMessageSubscribers;
     chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   },
-  update: SessionTranscriptUpdate,
+  update: InternalSessionTranscriptUpdate,
 ): Promise<void> {
-  const sessionKey = update.sessionKey ?? resolveSessionKeyForTranscriptFile(update.sessionFile);
+  const sessionKey =
+    update.target?.sessionKey ??
+    update.sessionKey ??
+    (update.sessionFile ? resolveSessionKeyForTranscriptFile(update.sessionFile) : undefined);
   if (!sessionKey || update.message === undefined) {
     return;
   }
-  const effectiveAgentId = update.agentId;
+  const effectiveAgentId = update.target?.agentId ?? update.agentId;
   const defaultGlobalAgentId =
     sessionKey === "global"
       ? normalizeAgentId(resolveDefaultAgentId(getRuntimeConfig()))
       : undefined;
   const visibleAgentId =
-    update.agentId ??
+    effectiveAgentId ??
     (effectiveAgentId && effectiveAgentId !== defaultGlobalAgentId ? effectiveAgentId : undefined);
   const connIds = new Set<string>();
   for (const connId of params.sessionEventSubscribers.getAll()) {

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -8,7 +8,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vite
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
-import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import {
+  emitInternalSessionTranscriptUpdate,
+  emitSessionTranscriptUpdate,
+} from "../sessions/transcript-events.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectOk,
@@ -515,6 +518,44 @@ describe("session.message websocket events", () => {
       expectRecordFields(messageEvent.payload, {
         sessionKey: "agent:main:main",
         messageId: "msg-single-frame",
+        messageSeq: 1,
+      });
+    });
+  });
+
+  test("broadcasts identity-only transcript updates to live session listeners", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const messageEventPromise = waitForSessionMessageEvent(ws, "agent:main:main");
+      emitInternalSessionTranscriptUpdate({
+        target: {
+          agentId: "main",
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+        },
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "identity frame" }],
+          timestamp: Date.now(),
+        },
+        messageId: "msg-identity-frame",
+        messageSeq: 1,
+      });
+
+      const messageEvent = await messageEventPromise;
+      expectRecordFields(messageEvent.payload, {
+        sessionKey: "agent:main:main",
+        messageId: "msg-identity-frame",
         messageSeq: 1,
       });
     });

--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -29,7 +29,7 @@ vi.mock("../config/sessions.js", () => ({
 }));
 
 vi.mock("../sessions/transcript-events.js", () => ({
-  onSessionTranscriptUpdate: (cb: typeof transcriptUpdateHandler) => {
+  onInternalSessionTranscriptUpdate: (cb: typeof transcriptUpdateHandler) => {
     transcriptUpdateHandler = cb;
     return () => {
       if (transcriptUpdateHandler === cb) {

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -10,7 +10,10 @@ import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
 } from "../config/sessions/transcript.js";
-import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import {
+  emitInternalSessionTranscriptUpdate,
+  emitSessionTranscriptUpdate,
+} from "../sessions/transcript-events.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   connectReq,
@@ -733,6 +736,34 @@ describe("session history HTTP endpoints", () => {
         seq: 2,
         id: appendedId,
       });
+    });
+  });
+
+  test("streams identity-only transcript updates over SSE", async () => {
+    await seedSession({ text: "first message" });
+
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message"]);
+
+      emitInternalSessionTranscriptUpdate({
+        target: {
+          agentId: "main",
+          sessionId: "sess-main",
+          sessionKey: "agent:main:main",
+        },
+        message: makeTranscriptAssistantMessage({ text: "identity second message" }),
+        messageId: "msg-identity-second",
+        messageSeq: 2,
+      });
+
+      await expectMessageEventMatch(stream, {
+        text: "identity second message",
+        seq: 2,
+        id: "msg-identity-second",
+      });
+
+      await stream.reader.cancel();
     });
   });
 

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -8,7 +8,8 @@ import {
 import { getRuntimeConfig } from "../config/io.js";
 import { loadSessionStore } from "../config/sessions.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS } from "./chat-display-projection.js";
@@ -308,17 +309,20 @@ export async function handleSessionHistoryHttpRequest(
     });
   }, 15_000);
 
-  const unsubscribe: (() => void) | undefined = onSessionTranscriptUpdate((update) => {
+  const unsubscribe: (() => void) | undefined = onInternalSessionTranscriptUpdate((update) => {
     // Filter to candidate sessions synchronously before enqueueing any async
-    // work. `onSessionTranscriptUpdate` is a global fan-out listener, so every
+    // work. Transcript updates use a global fan-out listener, so every
     // transcript write in the gateway would otherwise append a Promise-chain
     // entry capturing `update.message` to every open SSE stream's queue —
     // O(streams × updates) for busy deployments.
     if (!entry?.sessionId) {
       return;
     }
+    const updateMatchesIdentity =
+      update.target?.sessionId === entry.sessionId &&
+      normalizeAgentId(update.target.agentId) === normalizeAgentId(target.agentId);
     const updatePath = resolveTranscriptPathForComparison(update.sessionFile);
-    if (!updatePath || !transcriptCandidates.has(updatePath)) {
+    if (!updateMatchesIdentity && (!updatePath || !transcriptCandidates.has(updatePath))) {
       return;
     }
     queueStreamWork(async () => {

--- a/src/plugin-sdk/memory-core-host-engine-foundation.ts
+++ b/src/plugin-sdk/memory-core-host-engine-foundation.ts
@@ -1,6 +1,8 @@
 /**
  * Public SDK foundation surface for memory host engine config, paths, and shared helpers.
  */
+import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+
 export * from "../../packages/memory-host-sdk/src/engine-foundation.js";
 export {
   resolveAgentContextLimits,
@@ -42,6 +44,16 @@ export { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 export { resolveGlobalSingleton } from "../shared/global-singleton.js";
 export { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 export { splitShellArgs } from "../utils/shell-argv.js";
+
+const MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY = Symbol.for(
+  "openclaw.memoryCore.sessionTranscriptUpdateSubscriber",
+);
+
+// Memory-core needs target-only internal updates before the SQLite flip, while
+// the public SDK listener stays file-backed during the compatibility window.
+(globalThis as Record<symbol, unknown>)[MEMORY_CORE_TRANSCRIPT_UPDATE_SUBSCRIBER_KEY] ??=
+  onInternalSessionTranscriptUpdate;
+
 export {
   resolveUserPath,
   shortenHomeInString,

--- a/src/plugin-sdk/session-transcript-runtime.test.ts
+++ b/src/plugin-sdk/session-transcript-runtime.test.ts
@@ -181,6 +181,11 @@ describe("session transcript runtime SDK", () => {
       messageId: "message-from-direct-publish",
       sessionFile: scope.sessionFile,
       sessionKey: "agent:main:main",
+      target: {
+        agentId: "main",
+        sessionId: "publish-session",
+        sessionKey: "agent:main:main",
+      },
     });
   });
 

--- a/src/sessions/transcript-events.test.ts
+++ b/src/sessions/transcript-events.test.ts
@@ -1,6 +1,12 @@
 // Transcript event tests cover transcript event parsing and compaction.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { emitSessionTranscriptUpdate, onSessionTranscriptUpdate } from "./transcript-events.js";
+import {
+  emitInternalSessionTranscriptUpdate,
+  emitSessionTranscriptUpdate,
+  onInternalSessionTranscriptUpdate,
+  onSessionTranscriptUpdate,
+  type SessionTranscriptUpdate,
+} from "./transcript-events.js";
 
 const cleanup: Array<() => void> = [];
 
@@ -41,6 +47,86 @@ describe("transcript events", () => {
       message: { role: "assistant", content: "hi" },
       messageId: "msg-1",
       messageSeq: 2,
+    });
+  });
+
+  it("does not expose identity-only updates to public listeners", () => {
+    const listener = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(listener));
+
+    emitSessionTranscriptUpdate({
+      target: {
+        agentId: " main ",
+        sessionId: " sess-1 ",
+        sessionKey: " agent:main:main ",
+      },
+      messageId: " msg-1 ",
+    } as unknown as SessionTranscriptUpdate);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emits storage-neutral identity updates to internal listeners", () => {
+    const listener = vi.fn();
+    cleanup.push(onInternalSessionTranscriptUpdate(listener));
+
+    emitInternalSessionTranscriptUpdate({
+      target: {
+        agentId: " main ",
+        sessionId: " sess-1 ",
+        sessionKey: " agent:main:main ",
+      },
+      messageId: " msg-1 ",
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      target: {
+        agentId: "main",
+        sessionId: "sess-1",
+        sessionKey: "agent:main:main",
+      },
+      agentId: "main",
+      sessionId: "sess-1",
+      sessionKey: "agent:main:main",
+      messageId: "msg-1",
+    });
+  });
+
+  it("derives target identity from public file updates", () => {
+    const listener = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(listener));
+
+    emitSessionTranscriptUpdate({
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      sessionFile: "/tmp/session.jsonl",
+      target: {
+        agentId: "main",
+        sessionId: "sess-1",
+        sessionKey: "agent:main:main",
+      },
+      agentId: "main",
+      sessionId: "sess-1",
+      sessionKey: "agent:main:main",
+    });
+  });
+
+  it("keeps public global file updates on the compatibility shape", () => {
+    const listener = vi.fn();
+    cleanup.push(onSessionTranscriptUpdate(listener));
+
+    emitSessionTranscriptUpdate({
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "global",
+    });
+
+    expect(listener).toHaveBeenCalledWith({
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "global",
     });
   });
 

--- a/src/sessions/transcript-events.ts
+++ b/src/sessions/transcript-events.ts
@@ -1,20 +1,41 @@
 // Transcript event helpers serialize and trim session transcript events.
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 
-/** Normalized transcript update emitted after a session transcript changes. */
-export type SessionTranscriptUpdate = {
-  sessionFile: string;
+/** Storage-neutral identity for the session transcript that changed. */
+export type SessionTranscriptUpdateTarget = {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+};
+
+type SessionTranscriptUpdateFields = {
+  sessionFile?: string;
+  target?: SessionTranscriptUpdateTarget;
   sessionKey?: string;
   agentId?: string;
+  /** @deprecated Pre-SQLite compatibility mirror. Prefer `target.sessionId`. */
+  sessionId?: string;
   message?: unknown;
   messageId?: string;
   messageSeq?: number;
 };
 
+/** Normalized transcript update emitted after a session transcript changes. */
+export type SessionTranscriptUpdate = SessionTranscriptUpdateFields & {
+  /** @deprecated File-backed compatibility hint. Prefer `target` for identity. */
+  sessionFile: string;
+};
+
+/** Internal transcript update that may identify a transcript without a file path. */
+export type InternalSessionTranscriptUpdate = SessionTranscriptUpdateFields;
+
 type SessionTranscriptListener = (update: SessionTranscriptUpdate) => void;
+type InternalSessionTranscriptListener = (update: InternalSessionTranscriptUpdate) => void;
 
 const SESSION_TRANSCRIPT_LISTENERS = new Set<SessionTranscriptListener>();
+const INTERNAL_SESSION_TRANSCRIPT_LISTENERS = new Set<InternalSessionTranscriptListener>();
 
 /** Registers a listener for normalized session transcript updates. */
 export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): () => void {
@@ -24,38 +45,78 @@ export function onSessionTranscriptUpdate(listener: SessionTranscriptListener): 
   };
 }
 
+/** Registers an internal listener for identity-only or file-backed transcript updates. */
+export function onInternalSessionTranscriptUpdate(
+  listener: InternalSessionTranscriptListener,
+): () => void {
+  INTERNAL_SESSION_TRANSCRIPT_LISTENERS.add(listener);
+  return () => {
+    INTERNAL_SESSION_TRANSCRIPT_LISTENERS.delete(listener);
+  };
+}
+
 /** Emits a normalized transcript update to all registered listeners. */
 export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUpdate): void {
+  const nextUpdate = normalizeSessionTranscriptUpdate(update, { allowIdentityOnly: false });
+  if (!nextUpdate?.sessionFile) {
+    return;
+  }
+  emitPublicSessionTranscriptUpdate(nextUpdate as SessionTranscriptUpdate);
+  emitInternalTranscriptUpdate(nextUpdate);
+}
+
+/** Emits an internal transcript update, including identity-only updates. */
+export function emitInternalSessionTranscriptUpdate(update: InternalSessionTranscriptUpdate): void {
+  const nextUpdate = normalizeSessionTranscriptUpdate(update, { allowIdentityOnly: true });
+  if (!nextUpdate) {
+    return;
+  }
+  emitInternalTranscriptUpdate(nextUpdate);
+}
+
+function normalizeSessionTranscriptUpdate(
+  update: string | InternalSessionTranscriptUpdate,
+  options: { allowIdentityOnly: boolean },
+): InternalSessionTranscriptUpdate | undefined {
+  // Public callers still need a file-backed update, while internal callers can
+  // carry identity-only updates during the pre-SQLite transition.
   const normalized =
     typeof update === "string"
       ? { sessionFile: update }
       : {
           sessionFile: update.sessionFile,
+          target: update.target,
           sessionKey: update.sessionKey,
           agentId: update.agentId,
+          sessionId: update.sessionId,
           message: update.message,
           messageId: update.messageId,
           messageSeq: update.messageSeq,
         };
   const trimmed = normalizeOptionalString(normalized.sessionFile);
-  if (!trimmed) {
-    return;
+  const target = normalizeUpdateTarget(normalized);
+  if (!trimmed && (!options.allowIdentityOnly || !target)) {
+    return undefined;
   }
   const messageSeq = asPositiveSafeInteger(normalized.messageSeq);
-  const nextUpdate: SessionTranscriptUpdate = {
-    sessionFile: trimmed,
-    ...(normalizeOptionalString(normalized.sessionKey)
-      ? { sessionKey: normalizeOptionalString(normalized.sessionKey) }
-      : {}),
-    ...(normalizeOptionalString(normalized.agentId)
-      ? { agentId: normalizeOptionalString(normalized.agentId) }
-      : {}),
+  const sessionKey = normalizeOptionalString(normalized.sessionKey) ?? target?.sessionKey;
+  const agentId = normalizeOptionalString(normalized.agentId) ?? target?.agentId;
+  const sessionId = normalizeOptionalString(normalized.sessionId) ?? target?.sessionId;
+  return {
+    ...(trimmed ? { sessionFile: trimmed } : {}),
+    ...(target ? { target } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(agentId ? { agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
     ...(normalized.message !== undefined ? { message: normalized.message } : {}),
     ...(normalizeOptionalString(normalized.messageId)
       ? { messageId: normalizeOptionalString(normalized.messageId) }
       : {}),
     ...(messageSeq !== undefined ? { messageSeq } : {}),
   };
+}
+
+function emitPublicSessionTranscriptUpdate(nextUpdate: SessionTranscriptUpdate): void {
   for (const listener of SESSION_TRANSCRIPT_LISTENERS) {
     try {
       listener(nextUpdate);
@@ -63,4 +124,39 @@ export function emitSessionTranscriptUpdate(update: string | SessionTranscriptUp
       /* ignore */
     }
   }
+}
+
+function emitInternalTranscriptUpdate(nextUpdate: InternalSessionTranscriptUpdate): void {
+  for (const listener of INTERNAL_SESSION_TRANSCRIPT_LISTENERS) {
+    try {
+      listener(nextUpdate);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function normalizeUpdateTarget(update: {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  target?: SessionTranscriptUpdate["target"];
+}): SessionTranscriptUpdateTarget | undefined {
+  const sessionKey =
+    normalizeOptionalString(update.target?.sessionKey) ??
+    normalizeOptionalString(update.sessionKey);
+  const agentId =
+    normalizeOptionalString(update.target?.agentId) ??
+    normalizeOptionalString(update.agentId) ??
+    (sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined);
+  const sessionId =
+    normalizeOptionalString(update.target?.sessionId) ?? normalizeOptionalString(update.sessionId);
+  if (!agentId || !sessionId || !sessionKey) {
+    return undefined;
+  }
+  return {
+    agentId,
+    sessionId,
+    sessionKey,
+  };
 }


### PR DESCRIPTION
## What

Adds storage-neutral transcript update identity to `SessionTranscriptUpdate` delivery while keeping `sessionFile` compatibility for existing file-backed emitters and subscribers.

## Why

Path 3 SQLite writer validation needs transcript update subscribers to match changed sessions without inventing file paths. This keeps the pre-SQLite `sessionFile` contract intact while giving internal gateway/history/memory consumers an identity-first update path.

Refs #88838.

## Changes

- Add update target identity
- Keep `sessionFile` compatibility
- Add internal identity-only fan-out
- Prefer identity in gateway/history/memory
- Thread identity through known emitters

| File | Change |
|------|--------|
| `src/sessions/transcript-events.ts` | Adds storage-neutral update target identity and internal identity-only events |
| `src/config/sessions/session-accessor.ts` | Publishes explicit identity for scoped transcript updates |
| `src/gateway/server-session-events.ts` | Resolves session.message updates by identity before path fallback |
| `src/gateway/sessions-history-http.ts` | Filters history updates by identity before transcript path fallback |
| `extensions/memory-core/src/memory/manager-sync-ops.ts` | Schedules dirty work by update identity before file path compatibility |
| `extensions/{codex,copilot,telegram}/src/**` | Threads known session identity into transcript update emitters |
| `src/agents/embedded-agent-runner/**` | Carries identity for transcript rewrite/truncation update publication |

## Testing

- `node scripts/run-vitest.mjs src/sessions/transcript-events.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts src/config/sessions/session-accessor.test.ts src/gateway/session-message-events.test.ts src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts src/gateway/server-session-events.test.ts`
- `node_modules/.bin/oxfmt --check $(git diff --name-only upstream/main | sort -u)`
- `node scripts/run-oxlint.mjs $(git diff --name-only upstream/main | sort -u)`
- `git diff --check`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` clean after addressing one public-event compatibility finding.

## Real behavior proof

Behavior addressed: Transcript update identity delivery still produces live session.message updates, chat.history results, sessions.get results, and persisted transcript bytes on the live Gateway while this PR keeps sessionFile compatibility for the pre-SQLite window.

Real environment tested: Local live Gateway from PR head 203d961d28e960a8096638d8bf722a597249e65a; OpenClaw 2026.6.9 (203d961); Node v24.15.0; pnpm 11.2.2; Gateway ready on 127.0.0.1:18789. The restart also ran local legacy state migrations/warnings for update-check, plugin install index, and config-health state; no repo files changed from those migrations.

Exact steps or command run after this patch:

- `pnpm build`
- `pnpm openclaw gateway restart`
- `pnpm openclaw --version` -> `OpenClaw 2026.6.9 (203d961)`
- `pnpm openclaw gateway status` -> Gateway probe ok/admin-capable, listening on loopback
- `curl -fsS http://127.0.0.1:18789/readyz` -> `{"ready":true,...}`
- `curl -fsS http://127.0.0.1:18789/healthz` -> `{"ok":true,"status":"live"}`
- `node --import tsx --input-type=module` proof script using GatewayClient RPCs: sessions.create, sessions.messages.subscribe, chat.inject, chat.history, sessions.get, transcript file read
- `pnpm openclaw gateway call chat.history --params '{"sessionKey":"agent:main:path3-proof-1782140583672-031acd","agentId":"main","maxChars":20000}' --json`
- `pnpm openclaw gateway call sessions.delete --params '{"key":"agent:main:path3-proof-1782140583672-031acd","agentId":"main","deleteTranscript":true}' --json`

Evidence after fix: Created proof session `agent:main:path3-proof-1782140583672-031acd` with sessionId `e1a25070-e538-4d81-bdd3-c57cf86df515`; injected messageId `259da569-21b6-4340-8382-fb23f31e1798`; observed subscribed `session.message` event with the marker; `chat.history` returned 1 message containing the marker and sessionId `e1a25070-e538-4d81-bdd3-c57cf86df515`; `sessions.get` contained the same marker; the backing transcript file contained the marker (669 bytes before cleanup). The exact CLI `gateway call chat.history` response also contained the marker for the same sessionId. Cleanup deleted both generated proof sessions; Gateway archived the generated proof transcripts with `.deleted.<timestamp>` suffixes as part of its delete lifecycle.

Observed result after fix: The live Gateway delivered the identity-aware transcript update to active subscribers, history readers, direct session readers, and the file-backed transcript compatibility path for the same session identity.

What was not tested: Future SQLite transcript writer storage, doctor migrations, remote Crabbox/Testbox lanes, and external plugin SDK consumers. The proof intentionally stayed on the PR's pre-SQLite sessionFile-compatible live path while testing the additive identity behavior.
