### PR TITLE
fix(agents): guard provider auth alias metadata

### DIFF
--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -45,8 +45,8 @@ import {
   clearCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "../plugins/current-plugin-metadata-snapshot.js";
-import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
@@ -168,6 +168,32 @@ describe("provider auth aliases", () => {
     expect(resolveProviderIdForAuth("codex-cli", { metadataSnapshot })).toBe("openai");
     expect(resolveProviderIdForAuth("openai-chatgpt-import", { metadataSnapshot })).toBe("openai");
     expect(resolveProviderIdForAuth("openai", { metadataSnapshot })).toBe("openai");
+  });
+
+  it("keeps healthy auth aliases after unreadable plugin metadata", () => {
+    const unreadablePlugin = {
+      id: "broken",
+      get origin() {
+        throw new Error("provider auth alias plugin origin getter exploded");
+      },
+      providerAuthAliases: {
+        broken: "broken-target",
+      },
+    } as never;
+    const metadataSnapshot = {
+      plugins: [
+        unreadablePlugin,
+        createPluginManifestRecord({
+          id: "healthy",
+          origin: "bundled",
+          providerAuthAliases: {
+            healthy: "healthy-provider",
+          },
+        }),
+      ],
+    } as never;
+
+    expect(resolveProviderIdForAuth("healthy", { metadataSnapshot })).toBe("healthy-provider");
   });
 
   it("does not reuse aliases across env-resolved plugin roots", () => {

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -24,6 +24,10 @@ type ProviderAuthAliasCandidate = {
   origin?: PluginOrigin;
   target: string;
 };
+type ProviderAuthAliasPluginMetadata = Pick<
+  PluginManifestRecord,
+  "id" | "origin" | "providerAuthAliases" | "providerAuthChoices"
+>;
 
 const PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {
   config: 0,
@@ -63,7 +67,7 @@ function resolveProviderAuthAliasOriginPriority(origin: PluginOrigin | undefined
 }
 
 function isWorkspacePluginTrustedForAuthAliases(
-  plugin: PluginManifestRecord,
+  plugin: ProviderAuthAliasPluginMetadata,
   config: OpenClawConfig | undefined,
 ): boolean {
   return isWorkspacePluginAllowedByConfig({
@@ -75,13 +79,28 @@ function isWorkspacePluginTrustedForAuthAliases(
 }
 
 function shouldUsePluginAuthAliases(
-  plugin: PluginManifestRecord,
+  plugin: ProviderAuthAliasPluginMetadata,
   params: ProviderAuthAliasLookupParams | undefined,
 ): boolean {
   if (plugin.origin !== "workspace" || params?.includeUntrustedWorkspacePlugins === true) {
     return true;
   }
   return isWorkspacePluginTrustedForAuthAliases(plugin, params?.config);
+}
+
+function readProviderAuthAliasPluginMetadata(
+  plugin: PluginManifestRecord,
+): ProviderAuthAliasPluginMetadata | undefined {
+  try {
+    return {
+      id: plugin.id,
+      origin: plugin.origin,
+      providerAuthAliases: plugin.providerAuthAliases,
+      providerAuthChoices: plugin.providerAuthChoices,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function setPreferredAlias(params: {
@@ -161,7 +180,11 @@ export function resolveProviderAuthAliasMap(
     });
   const preferredAliases = new Map<string, ProviderAuthAliasCandidate>();
   const aliases: Record<string, string> = Object.create(null) as Record<string, string>;
-  for (const plugin of snapshot.plugins) {
+  for (const snapshotPlugin of snapshot.plugins) {
+    const plugin = readProviderAuthAliasPluginMetadata(snapshotPlugin);
+    if (!plugin) {
+      continue;
+    }
     if (!shouldUsePluginAuthAliases(plugin, params)) {
       continue;
     }

--- a/src/plugins/plugin-config-trust.ts
+++ b/src/plugins/plugin-config-trust.ts
@@ -33,7 +33,7 @@ function findPluginConfigEntry(
 export function isWorkspacePluginAllowedByConfig(params: {
   config: OpenClawConfig | undefined;
   isImplicitlyAllowed?: (pluginId: string) => boolean;
-  plugin: PluginManifestRecord;
+  plugin: Pick<PluginManifestRecord, "id">;
 }): boolean {
   const pluginsConfig = params.config?.plugins;
   if (pluginsConfig?.enabled === false) {


### PR DESCRIPTION
## Summary

- Guard provider auth alias resolution against unreadable plugin manifest metadata rows.
- Keep healthy auth aliases resolvable when a neighboring plugin row throws during alias metadata reads.
- Narrow the workspace trust helper type to the `id` field it actually reads.

## Verification

- `node scripts/run-vitest.mjs src/agents/provider-auth-aliases.test.ts`
- `node_modules/.bin/oxfmt --check src/agents/provider-auth-aliases.ts src/agents/provider-auth-aliases.test.ts src/plugins/plugin-config-trust.ts`
- `node_modules/.bin/oxlint src/agents/provider-auth-aliases.ts src/agents/provider-auth-aliases.test.ts src/plugins/plugin-config-trust.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (blocked: coordinator returned HTTP 401 before lease)

## Real behavior proof

Behavior addressed: provider auth alias resolution now skips unreadable plugin metadata rows instead of throwing before healthy provider auth aliases are considered.

Real environment tested: local linked OpenClaw worktree on Node/Vitest via `scripts/run-vitest.mjs`; Crabbox AWS changed-gate attempt reached coordinator auth and failed before lease.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/provider-auth-aliases.test.ts`; `node_modules/.bin/oxfmt --check src/agents/provider-auth-aliases.ts src/agents/provider-auth-aliases.test.ts src/plugins/plugin-config-trust.ts`; `node_modules/.bin/oxlint src/agents/provider-auth-aliases.ts src/agents/provider-auth-aliases.test.ts src/plugins/plugin-config-trust.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview; Crabbox changed-gate attempt.

Evidence after fix: `src/agents/provider-auth-aliases.test.ts` passed 5 tests, including the unreadable plugin metadata regression; touched-file format/lint and diff whitespace checks passed; autoreview reported no accepted/actionable findings.

Observed result after fix: healthy provider auth aliases remain resolvable when an earlier plugin metadata row throws during property access.

What was not tested: full `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing an AWS box; Blacksmith Testbox is also unavailable in this environment.
