### PR TITLE
fix(vertex): route eu/us multi-region to .rep.googleapis.com host

### DIFF
--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -567,6 +567,16 @@
     },
     {
       "endpointClass": "google-vertex",
+      "hosts": ["aiplatform.eu.rep.googleapis.com"],
+      "googleVertexRegion": "eu"
+    },
+    {
+      "endpointClass": "google-vertex",
+      "hosts": ["aiplatform.us.rep.googleapis.com"],
+      "googleVertexRegion": "us"
+    },
+    {
+      "endpointClass": "google-vertex",
       "hostSuffixes": ["-aiplatform.googleapis.com"],
       "googleVertexRegionHostSuffix": "-aiplatform.googleapis.com"
     }

--- a/extensions/google/provider-policy.ts
+++ b/extensions/google/provider-policy.ts
@@ -41,10 +41,18 @@ function stripUrlUserInfo(url: URL): void {
 
 const GOOGLE_VERTEX_HOST = "aiplatform.googleapis.com";
 const GOOGLE_VERTEX_REGION_HOST_SUFFIX = "-aiplatform.googleapis.com";
+const GOOGLE_VERTEX_MULTI_REGION_HOSTS = new Set([
+  "aiplatform.eu.rep.googleapis.com",
+  "aiplatform.us.rep.googleapis.com",
+]);
 
 export function isGoogleVertexHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized === GOOGLE_VERTEX_HOST || normalized.endsWith(GOOGLE_VERTEX_REGION_HOST_SUFFIX);
+  return (
+    normalized === GOOGLE_VERTEX_HOST ||
+    normalized.endsWith(GOOGLE_VERTEX_REGION_HOST_SUFFIX) ||
+    GOOGLE_VERTEX_MULTI_REGION_HOSTS.has(normalized)
+  );
 }
 
 export function isGoogleVertexBaseUrl(baseUrl?: string | null): boolean {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -356,7 +356,7 @@ function resolveGoogleVertexLocation(options: GoogleTransportOptions | undefined
   return location;
 }
 
-function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
+export function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
   const configured = normalizeOptionalString(model.baseUrl);
   if (configured && !configured.includes("{location}")) {
     try {
@@ -371,6 +371,12 @@ function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: st
   }
   if (location === "global") {
     return "https://aiplatform.googleapis.com";
+  }
+  // Multi-region locations (eu, us) use the dedicated .rep.googleapis.com host
+  // with the location embedded in the host, matching @google/genai SDK behavior.
+  // A regional prefix (eu-aiplatform.googleapis.com) returns an HTML 404.
+  if (location === "eu" || location === "us") {
+    return `https://aiplatform.${location}.rep.googleapis.com`;
   }
   return `https://${location}-aiplatform.googleapis.com`;
 }

--- a/extensions/google/vertex-multi-region-host.test.ts
+++ b/extensions/google/vertex-multi-region-host.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { resolveGoogleVertexBaseOrigin } from "./transport-stream";
+import { isGoogleVertexHostname } from "./provider-policy";
+
+// Minimal Vertex model whose baseUrl carries the {location} template, so the
+// base-origin resolver falls through to location-based host construction
+// (the configured-baseUrl early return only fires for a literal host).
+function buildModel(overrides: Partial<Model<"google-vertex">> = {}): Model<"google-vertex"> {
+  return {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    api: "google-vertex",
+    provider: "google-vertex",
+    baseUrl: "https://{location}-aiplatform.googleapis.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+    ...overrides,
+  };
+}
+
+describe("Google Vertex multi-region host construction", () => {
+  const model = buildModel();
+
+  it("routes the eu multi-region to the dedicated .rep.googleapis.com host", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "eu")).toBe(
+      "https://aiplatform.eu.rep.googleapis.com",
+    );
+  });
+
+  it("routes the us multi-region to the dedicated .rep.googleapis.com host", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "us")).toBe(
+      "https://aiplatform.us.rep.googleapis.com",
+    );
+  });
+
+  it("keeps the unprefixed host for the global location", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "global")).toBe(
+      "https://aiplatform.googleapis.com",
+    );
+  });
+
+  it("keeps the regional prefix for normal regions", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "europe-west1")).toBe(
+      "https://europe-west1-aiplatform.googleapis.com",
+    );
+  });
+});
+
+describe("Google Vertex hostname recognition", () => {
+  it("recognizes the multi-region rep host as a Vertex host", () => {
+    expect(isGoogleVertexHostname("aiplatform.eu.rep.googleapis.com")).toBe(true);
+    expect(isGoogleVertexHostname("aiplatform.us.rep.googleapis.com")).toBe(true);
+  });
+
+  it("still recognizes the unprefixed and regional Vertex hosts", () => {
+    expect(isGoogleVertexHostname("aiplatform.googleapis.com")).toBe(true);
+    expect(isGoogleVertexHostname("europe-west1-aiplatform.googleapis.com")).toBe(true);
+  });
+});

--- a/extensions/google/vertex-multi-region-host.test.ts
+++ b/extensions/google/vertex-multi-region-host.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
 import type { Model } from "openclaw/plugin-sdk/llm";
-import { resolveGoogleVertexBaseOrigin } from "./transport-stream.js";
+import { describe, expect, it } from "vitest";
 import { isGoogleVertexHostname } from "./provider-policy.js";
+import { resolveGoogleVertexBaseOrigin } from "./transport-stream.js";
 
 // Minimal Vertex model whose baseUrl carries the {location} template, so the
 // base-origin resolver falls through to location-based host construction
@@ -54,6 +54,11 @@ describe("Google Vertex hostname recognition", () => {
   it("recognizes the multi-region rep host as a Vertex host", () => {
     expect(isGoogleVertexHostname("aiplatform.eu.rep.googleapis.com")).toBe(true);
     expect(isGoogleVertexHostname("aiplatform.us.rep.googleapis.com")).toBe(true);
+  });
+
+  it("does not classify unrelated rep hosts as Vertex hosts", () => {
+    expect(isGoogleVertexHostname("discoveryengine.eu.rep.googleapis.com")).toBe(false);
+    expect(isGoogleVertexHostname("not-aiplatform.eu.rep.googleapis.com")).toBe(false);
   });
 
   it("still recognizes the unprefixed and regional Vertex hosts", () => {

--- a/extensions/google/vertex-multi-region-host.test.ts
+++ b/extensions/google/vertex-multi-region-host.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Model } from "openclaw/plugin-sdk/llm";
-import { resolveGoogleVertexBaseOrigin } from "./transport-stream";
-import { isGoogleVertexHostname } from "./provider-policy";
+import { resolveGoogleVertexBaseOrigin } from "./transport-stream.js";
+import { isGoogleVertexHostname } from "./provider-policy.js";
 
 // Minimal Vertex model whose baseUrl carries the {location} template, so the
 // base-origin resolver falls through to location-based host construction

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -38,6 +38,16 @@ const providerEndpointPlugins = vi.hoisted(() => [
       },
       {
         endpointClass: "google-vertex",
+        hosts: ["aiplatform.eu.rep.googleapis.com"],
+        googleVertexRegion: "eu",
+      },
+      {
+        endpointClass: "google-vertex",
+        hosts: ["aiplatform.us.rep.googleapis.com"],
+        googleVertexRegion: "us",
+      },
+      {
+        endpointClass: "google-vertex",
         hostSuffixes: ["-aiplatform.googleapis.com"],
         googleVertexRegionHostSuffix: "-aiplatform.googleapis.com",
       },

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -731,6 +731,23 @@ describe("provider attribution", () => {
       googleVertexRegion: "global",
     });
 
+    expectRecordFields(resolveProviderEndpoint("https://aiplatform.eu.rep.googleapis.com"), {
+      endpointClass: "google-vertex",
+      hostname: "aiplatform.eu.rep.googleapis.com",
+      googleVertexRegion: "eu",
+    });
+
+    expectRecordFields(resolveProviderEndpoint("https://aiplatform.us.rep.googleapis.com"), {
+      endpointClass: "google-vertex",
+      hostname: "aiplatform.us.rep.googleapis.com",
+      googleVertexRegion: "us",
+    });
+
+    expectRecordFields(resolveProviderEndpoint("https://discoveryengine.eu.rep.googleapis.com"), {
+      endpointClass: "custom",
+      hostname: "discoveryengine.eu.rep.googleapis.com",
+    });
+
     expectRecordFields(resolveProviderEndpoint("https://proxy.example.com/google"), {
       endpointClass: "custom",
       hostname: "proxy.example.com",


### PR DESCRIPTION
## Summary

Fixes #89891.

Vertex AI multi-region locations (`eu`, `us`) are unreachable. `resolveGoogleVertexBaseOrigin` only special-cases `global`, so `eu`/`us` fall through to the regional-prefix form `https://${location}-aiplatform.googleapis.com` (e.g. `eu-aiplatform.googleapis.com`), which Google answers with an HTML 404. Setting `GOOGLE_CLOUD_LOCATION=eu` (required for models released to the EU multi-region first, such as `gemini-3.5-flash`) breaks every model invocation.

## Changes

Following the endpoint contract in the authoritative `@google/genai` SDK (`MULTI_REGIONAL_LOCATIONS = new Set(['us', 'eu'])`, routed to `aiplatform.${location}.rep.googleapis.com`):

1. `resolveGoogleVertexBaseOrigin` (`extensions/google/transport-stream.ts`): adds a multi-region branch so `eu`/`us` resolve to `https://aiplatform.${location}.rep.googleapis.com`, keeping `global` on the unprefixed host and all regional locations on the existing prefixed form. The request path keeps `locations/${location}` unchanged, matching the working curl in the report.
2. `isGoogleVertexHostname` (`extensions/google/provider-policy.ts`): recognizes the `.rep.googleapis.com` multi-region host as a Vertex host. Without this, the new host is not classified as Vertex and provider/payload policy is bypassed for multi-region requests.

The fix uses the dedicated `.rep.googleapis.com` hosts rather than the unprefixed global host for `eu`/`us`, matching `@google/genai` and Google's current endpoint documentation. The unprefixed host would also make `eu`/`us` indistinguishable from `global` on the reverse baseUrl-to-region path.

## Real behavior proof
Behavior addressed: Vertex AI `eu` / `us` multi-region invocations fail before the provider call reaches Vertex because OpenClaw builds `eu-aiplatform.googleapis.com` / `us-aiplatform.googleapis.com`, which Google returns as an HTML 404. #89891.

Real environment tested: Local OpenClaw checkout with real GCP service-account credentials loaded from 1Password Molty. Secret values were not printed. The service account can mint a Google OAuth token, but it does not have permission to invoke the tested Vertex model.

Exact steps or command run after this patch:

```shell
node scripts/run-vitest.mjs extensions/google/vertex-multi-region-host.test.ts src/agents/provider-attribution.test.ts extensions/google/api.test.ts
```

Live redacted probe steps:

1. Minted a Google OAuth access token via service-account JWT exchange.
2. Sent `generateContent` to the broken OpenClaw host shape for `locations/eu`.
3. Sent the same request to the fixed REP host for `locations/eu`.

Evidence after fix:

```text
vertex_auth: status=200 tokenPrefix=ya29 tokenLen=1024
wrong_eu: host=https://eu-aiplatform.googleapis.com status=404 contentType=text/html html=true
rep_eu: host=https://aiplatform.eu.rep.googleapis.com status=403 contentType=application/json html=false error=PERMISSION_DENIED
global_host_eu_location: host=https://aiplatform.googleapis.com status=403 contentType=application/json html=false error=PERMISSION_DENIED
```

Focused test output after the rebased patch:

```text
node scripts/run-vitest.mjs extensions/google/vertex-multi-region-host.test.ts src/agents/provider-attribution.test.ts extensions/google/api.test.ts
Test Files  1 passed (1)
Tests  31 passed (31)
Test Files  2 passed (2)
Tests  21 passed (21)
[test] passed 2 Vitest shards in 8.41s
```

Observed result after fix: The malformed `eu-aiplatform.googleapis.com` host reproduces the reported HTML 404. The fixed `aiplatform.eu.rep.googleapis.com` host reaches the Vertex API JSON error path with the same token and request shape, which proves the host construction bug is fixed even though this service account lacks model invocation permission. Unit coverage also verifies `eu` / `us` route to exact REP hosts, `global` and regional locations remain unchanged, unrelated REP hosts are rejected, and endpoint attribution reports `googleVertexRegion` `eu` / `us` for the new hosts.

What was not tested: A successful 200 model response was not possible with the available service account because Vertex returned `PERMISSION_DENIED` on valid Vertex hosts. Azure/Microsoft Foundry and Bedrock were not tested because no matching credentials were available in 1Password Molty.
## Out-of-scope follow-ups

- `anthropic-vertex` multi-region host construction follows the same pattern in a separate provider path; it is left for a focused follow-up to keep this change scoped to the reported `google-vertex` issue.

## Verification

`pnpm tsgo:core` and `pnpm tsgo:extensions` clean; oxlint clean on the touched files.

## Note on #89901

This overlaps with #89901. The key difference is the `eu`/`us` host: the authoritative `@google/genai` SDK routes multi-region `eu`/`us` to `aiplatform.${location}.rep.googleapis.com`, not the unprefixed `aiplatform.googleapis.com`. This PR follows that contract, adds the `isGoogleVertexHostname` recognition the new host requires, and includes regression tests for `global`/`eu`/`us`/regional. Happy to consolidate if the maintainers prefer a single PR.

