### PR TITLE
fix(matrix): suppress noisy cron tool-timeout alerts

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -126,6 +126,12 @@ export type CronFailureDeliveryPlan = {
   accountId?: string;
 };
 
+/** Failure destination resolution plus why an explicit destination was not returned. */
+export type CronFailureDestinationResolution = {
+  plan: CronFailureDeliveryPlan | null;
+  dedupedToPrimaryTarget: boolean;
+};
+
 /** Job-level failure destination override fields before global defaults are merged. */
 export type CronFailureDestinationInput = {
   channel?: CronMessageChannel;
@@ -143,10 +149,10 @@ function normalizeFailureMode(value: unknown): "announce" | "webhook" | undefine
 }
 
 /** Resolves job-level failure notification routing layered over global defaults. */
-export function resolveFailureDestination(
+export function resolveFailureDestinationResolution(
   job: CronJob,
   globalConfig?: CronFailureDestinationConfig,
-): CronFailureDeliveryPlan | null {
+): CronFailureDestinationResolution {
   const delivery = job.delivery;
   const jobFailureDest = delivery?.failureDestination as CronFailureDestinationInput | undefined;
   const hasJobFailureDest = jobFailureDest && typeof jobFailureDest === "object";
@@ -196,13 +202,13 @@ export function resolveFailureDestination(
   }
 
   if (!channel && !to && !accountId && !mode) {
-    return null;
+    return { plan: null, dedupedToPrimaryTarget: false };
   }
 
   const resolvedMode = mode ?? "announce";
   if (resolvedMode === "webhook" && !to) {
     // Webhook failure destinations are only useful with a concrete URL/target.
-    return null;
+    return { plan: null, dedupedToPrimaryTarget: false };
   }
 
   const result: CronFailureDeliveryPlan = {
@@ -214,10 +220,18 @@ export function resolveFailureDestination(
 
   if (delivery && isSameDeliveryTarget(delivery, result)) {
     // Avoid sending the same failure text through the primary delivery route twice.
-    return null;
+    return { plan: null, dedupedToPrimaryTarget: true };
   }
 
-  return result;
+  return { plan: result, dedupedToPrimaryTarget: false };
+}
+
+/** Resolves job-level failure notification routing layered over global defaults. */
+export function resolveFailureDestination(
+  job: CronJob,
+  globalConfig?: CronFailureDestinationConfig,
+): CronFailureDeliveryPlan | null {
+  return resolveFailureDestinationResolution(job, globalConfig).plan;
 }
 
 function isSameDeliveryTarget(

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -9,8 +9,10 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { getChildLogger } from "../logging.js";
 import {
   resolveFailureDestination,
+  resolveFailureDestinationResolution,
   type CronFailureDeliveryPlan,
   type CronFailureDestinationInput,
+  type CronFailureDestinationResolution,
   type CronDeliveryPlan,
   resolveCronDeliveryPlan,
 } from "./delivery-plan.js";
@@ -24,9 +26,11 @@ import type { CronMessageChannel } from "./types.js";
 export {
   resolveCronDeliveryPlan,
   resolveFailureDestination,
+  resolveFailureDestinationResolution,
   type CronDeliveryPlan,
   type CronFailureDeliveryPlan,
   type CronFailureDestinationInput,
+  type CronFailureDestinationResolution,
 };
 
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -12,6 +12,8 @@ import {
 const noopLogger = createNoopLogger();
 const { makeStorePath } = createCronStoreHarness();
 installCronTestHooks({ logger: noopLogger });
+const TOOL_EXECUTION_STARTED_TIMEOUT =
+  "cron: job execution timed out (last phase: tool-execution-started)";
 
 type CronAddInput = Parameters<CronService["add"]>[0];
 
@@ -324,6 +326,96 @@ describe("CronService persists delivered status", () => {
     expect(capturedEvent?.delivered).toBeUndefined();
     expect(capturedEvent?.deliveryStatus).toBe("not-requested");
     expect(capturedEvent?.failureNotificationDelivery).toEqual({ status: "unknown" });
+  });
+
+  it("keeps tool-execution-started timeouts recorded while preserving explicit failure destinations", async () => {
+    let capturedEvent:
+      | {
+          delivered?: boolean;
+          deliveryStatus?: string;
+          failureNotificationDelivery?: {
+            delivered?: boolean;
+            status: string;
+            error?: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildFailureDestinationOnlyJob("failure-destination-tool-execution-timeout"),
+      status: "error",
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastError).toBe(TOOL_EXECUTION_STARTED_TIMEOUT);
+    expect(updated?.state.lastDelivered).toBeUndefined();
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("unknown");
+    expect(capturedEvent?.delivered).toBeUndefined();
+    expect(capturedEvent?.deliveryStatus).toBe("not-requested");
+    expect(capturedEvent?.failureNotificationDelivery).toEqual({ status: "unknown" });
+  });
+
+  it("keeps primary announce tool-execution-started timeouts from expecting fallback failure notifications", async () => {
+    let capturedEvent:
+      | {
+          delivered?: boolean;
+          deliveryStatus?: string;
+          failureNotificationDelivery?: {
+            delivered?: boolean;
+            status: string;
+            error?: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceIsolatedAgentTurnJob("announce-tool-execution-timeout"),
+      status: "error",
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastError).toBe(TOOL_EXECUTION_STARTED_TIMEOUT);
+    expect(updated?.state.lastDeliveryStatus).toBe("unknown");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
+    expect(capturedEvent?.deliveryStatus).toBe("unknown");
+    expect(capturedEvent?.failureNotificationDelivery).toBeUndefined();
+  });
+
+  it("suppresses failure notification state for delivered tool-execution-started timeouts", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceIsolatedAgentTurnJob("announce-delivered-tool-execution-timeout"),
+      status: "error",
+      delivered: true,
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
+  });
+
+  it("suppresses failure notification state for not-delivered tool-execution-started timeouts", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceIsolatedAgentTurnJob("announce-not-delivered-tool-execution-timeout"),
+      status: "error",
+      delivered: false,
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
   });
 
   it("does not treat primary error delivery as alternate failure-destination delivery", async () => {

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -8,6 +8,7 @@ import {
   createNoopLogger,
   installCronTestHooks,
 } from "./service.test-harness.js";
+import type { CronConfig } from "../config/types.cron.js";
 
 const noopLogger = createNoopLogger();
 const { makeStorePath } = createCronStoreHarness();
@@ -33,6 +34,22 @@ function buildAnnounceIsolatedAgentTurnJob(name: string): CronAddInput {
   return {
     ...buildIsolatedAgentTurnJob(name),
     delivery: { mode: "announce", channel: "forum", to: "123" },
+  };
+}
+
+function buildAnnounceWithSameTargetFailureDestinationJob(name: string): CronAddInput {
+  return {
+    ...buildIsolatedAgentTurnJob(name),
+    delivery: {
+      mode: "announce",
+      channel: "forum",
+      to: "123",
+      failureDestination: {
+        mode: "announce",
+        channel: "forum",
+        to: "123",
+      },
+    },
   };
 }
 
@@ -94,6 +111,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
   status?: "ok" | "error";
   delivered?: boolean;
   error?: string;
+  cronConfig?: CronConfig;
   onFinished?: (evt: {
     jobId: string;
     delivered?: boolean;
@@ -109,6 +127,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
   const cron = new CronService({
     storePath: params.storePath,
     cronEnabled: true,
+    ...(params.cronConfig ? { cronConfig: params.cronConfig } : {}),
     log: noopLogger,
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
@@ -192,6 +211,7 @@ async function runIsolatedJobAndReadState(params: {
   status?: "ok" | "error";
   delivered?: boolean;
   error?: string;
+  cronConfig?: CronConfig;
   onFinished?: (evt: {
     jobId: string;
     delivered?: boolean;
@@ -210,6 +230,7 @@ async function runIsolatedJobAndReadState(params: {
     ...(params.status !== undefined ? { status: params.status } : {}),
     ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
     ...(params.error !== undefined ? { error: params.error } : {}),
+    ...(params.cronConfig !== undefined ? { cronConfig: params.cronConfig } : {}),
     onFinished: (evt) => {
       params.onFinished?.(evt);
       finishedEvents.get(evt.jobId)?.(evt);
@@ -388,6 +409,67 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
     expect(capturedEvent?.deliveryStatus).toBe("unknown");
     expect(capturedEvent?.failureNotificationDelivery).toBeUndefined();
+  });
+
+  it("preserves job-level same-target failure destination state for tool-execution-started timeouts", async () => {
+    let capturedEvent:
+      | {
+          deliveryStatus?: string;
+          failureNotificationDelivery?: {
+            status: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceWithSameTargetFailureDestinationJob("same-target-tool-execution-timeout"),
+      status: "error",
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastError).toBe(TOOL_EXECUTION_STARTED_TIMEOUT);
+    expect(updated?.state.lastDeliveryStatus).toBe("unknown");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("unknown");
+    expect(capturedEvent?.deliveryStatus).toBe("unknown");
+    expect(capturedEvent?.failureNotificationDelivery).toEqual({ status: "unknown" });
+  });
+
+  it("preserves global same-target failure destination state for tool-execution-started timeouts", async () => {
+    let capturedEvent:
+      | {
+          deliveryStatus?: string;
+          failureNotificationDelivery?: {
+            status: string;
+          };
+        }
+      | undefined;
+    const updated = await runIsolatedJobAndReadState({
+      job: buildAnnounceIsolatedAgentTurnJob("global-same-target-tool-execution-timeout"),
+      status: "error",
+      error: TOOL_EXECUTION_STARTED_TIMEOUT,
+      cronConfig: {
+        failureDestination: {
+          mode: "announce",
+          channel: "forum",
+          to: "123",
+        },
+      },
+      onFinished: (evt) => {
+        capturedEvent = evt;
+      },
+    });
+
+    expect(updated?.state.lastRunStatus).toBe("error");
+    expect(updated?.state.lastError).toBe(TOOL_EXECUTION_STARTED_TIMEOUT);
+    expect(updated?.state.lastDeliveryStatus).toBe("unknown");
+    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("unknown");
+    expect(capturedEvent?.deliveryStatus).toBe("unknown");
+    expect(capturedEvent?.failureNotificationDelivery).toEqual({ status: "unknown" });
   });
 
   it("suppresses failure notification state for delivered tool-execution-started timeouts", async () => {

--- a/src/cron/service/execution-errors.ts
+++ b/src/cron/service/execution-errors.ts
@@ -59,3 +59,18 @@ export function normalizeCronRunErrorText(err: unknown): string {
   }
   return String(err);
 }
+
+const TOOL_EXECUTION_STARTED_TIMEOUT =
+  "cron: job execution timed out (last phase: tool-execution-started)";
+
+/**
+ * Returns true for cron watchdog timeouts that occurred after the embedded
+ * agent had already entered tool execution. These are still real run errors,
+ * but they are usually routing/tool-handoff noise rather than actionable
+ * destination-room failures.
+ */
+export function isToolExecutionStartedTimeoutError(err: unknown): boolean {
+  const text = normalizeCronRunErrorText(err).trim();
+  const normalized = text.startsWith("Error: ") ? text.slice("Error: ".length).trim() : text;
+  return normalized === TOOL_EXECUTION_STARTED_TIMEOUT;
+}

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -16,7 +16,10 @@ import {
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
-import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
+import {
+  resolveCronDeliveryPlan,
+  resolveFailureDestinationResolution,
+} from "../delivery-plan.js";
 import { resolveCronExecutionRetryHint } from "../retry-hint.js";
 import {
   createCronRunDiagnosticsFromError,
@@ -316,13 +319,18 @@ function resolveDeliveryState(params: {
   const primaryDeliveryRequested = resolveCronDeliveryPlan(params.job).requested;
   // Failure destinations can receive alerts even when the primary delivery
   // path was disabled or failed before direct delivery produced an ack.
+  const failureDestinationResolution =
+    params.runStatus === "error" && params.job.delivery?.bestEffort !== true
+      ? resolveFailureDestinationResolution(params.job, params.globalFailureDestination)
+      : { plan: null, dedupedToPrimaryTarget: false };
   const alternateFailureNotificationRequested =
     params.runStatus === "error" &&
     params.job.delivery?.bestEffort !== true &&
-    resolveFailureDestination(params.job, params.globalFailureDestination) !== null;
+    failureDestinationResolution.plan !== null;
   const failureNotificationSuppressed =
     params.runStatus === "error" &&
     !alternateFailureNotificationRequested &&
+    !failureDestinationResolution.dedupedToPrimaryTarget &&
     isToolExecutionStartedTimeoutError(params.error);
   if (!primaryDeliveryRequested) {
     return {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -39,6 +39,7 @@ import type {
 import { cleanupTimedOutCronAgentRun, createCronAgentWatchdog } from "./agent-watchdog.js";
 import {
   abortErrorMessage,
+  isToolExecutionStartedTimeoutError,
   normalizeCronRunErrorText,
   timeoutErrorMessage,
 } from "./execution-errors.js";
@@ -319,6 +320,10 @@ function resolveDeliveryState(params: {
     params.runStatus === "error" &&
     params.job.delivery?.bestEffort !== true &&
     resolveFailureDestination(params.job, params.globalFailureDestination) !== null;
+  const failureNotificationSuppressed =
+    params.runStatus === "error" &&
+    !alternateFailureNotificationRequested &&
+    isToolExecutionStartedTimeoutError(params.error);
   if (!primaryDeliveryRequested) {
     return {
       status: "not-requested",
@@ -329,7 +334,11 @@ function resolveDeliveryState(params: {
   }
   if (params.runStatus === "error") {
     const failureNotification: CronFailureNotificationDelivery =
-      alternateFailureNotificationRequested ? { status: "unknown" } : { status: "delivered" };
+      alternateFailureNotificationRequested
+        ? { status: "unknown" }
+        : failureNotificationSuppressed
+          ? { status: "not-requested" }
+          : { status: "delivered" };
     if (params.delivered === true) {
       return {
         delivered: false,
@@ -337,7 +346,9 @@ function resolveDeliveryState(params: {
         error: params.error,
         failureNotification: alternateFailureNotificationRequested
           ? failureNotification
-          : { delivered: true, status: "delivered" },
+          : failureNotificationSuppressed
+            ? failureNotification
+            : { delivered: true, status: "delivered" },
       };
     }
     if (params.delivered === false) {
@@ -347,17 +358,21 @@ function resolveDeliveryState(params: {
         error: params.error,
         failureNotification: alternateFailureNotificationRequested
           ? failureNotification
-          : {
-              delivered: false,
-              status: "not-delivered",
-              ...(params.error ? { error: params.error } : {}),
-            },
+          : failureNotificationSuppressed
+            ? failureNotification
+            : {
+                delivered: false,
+                status: "not-delivered",
+                ...(params.error ? { error: params.error } : {}),
+              },
       };
     }
     return {
       status: "unknown",
       error: params.error,
-      failureNotification: { status: "unknown" },
+      failureNotification: failureNotificationSuppressed
+        ? { status: "not-requested" }
+        : { status: "unknown" },
     };
   }
   if (params.delivered === true) {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -9,7 +9,6 @@ import type { CronFailureDestinationConfig } from "../config/types.cron.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveCronDeliveryPlan,
-  resolveFailureDestination,
   resolveFailureDestinationResolution,
   sendCronAnnouncePayloadStrict,
   sendFailureNotificationAnnounce,

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -14,6 +14,7 @@ import {
   sendFailureNotificationAnnounce,
 } from "../cron/delivery.js";
 import type { CronEvent } from "../cron/service.js";
+import { isToolExecutionStartedTimeoutError } from "../cron/service/execution-errors.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
 import type { CronJob, CronMessageChannel } from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
@@ -361,6 +362,10 @@ function dispatchCronFailureDestinationNotifications(params: {
         `⚠️ ${failureMessage}`,
       );
     }
+    return;
+  }
+
+  if (isToolExecutionStartedTimeoutError(params.evt.error)) {
     return;
   }
 

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveCronDeliveryPlan,
   resolveFailureDestination,
+  resolveFailureDestinationResolution,
   sendCronAnnouncePayloadStrict,
   sendFailureNotificationAnnounce,
 } from "../cron/delivery.js";
@@ -303,7 +304,11 @@ function dispatchCronFailureDestinationNotifications(params: {
   }
 
   const failureMessage = `Cron job "${params.job.name}" failed: ${params.evt.error ?? "unknown error"}`;
-  const failureDest = resolveFailureDestination(params.job, params.globalFailureDestination);
+  const failureDestinationResolution = resolveFailureDestinationResolution(
+    params.job,
+    params.globalFailureDestination,
+  );
+  const failureDest = failureDestinationResolution.plan;
   const deliverySessionKey = resolveCronDeliverySessionKey(params.job);
 
   if (failureDest) {
@@ -365,7 +370,10 @@ function dispatchCronFailureDestinationNotifications(params: {
     return;
   }
 
-  if (isToolExecutionStartedTimeoutError(params.evt.error)) {
+  if (
+    isToolExecutionStartedTimeoutError(params.evt.error) &&
+    !failureDestinationResolution.dedupedToPrimaryTarget
+  ) {
     return;
   }
 

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -369,7 +369,7 @@ function expectFailureAnnounceCall(params: {
   jobId: string;
   channel: string;
   to?: string;
-  sessionKey: string;
+  sessionKey?: string;
   message: string;
 }) {
   expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
@@ -1665,6 +1665,101 @@ describe("gateway server cron", () => {
         'Cron job "explicit failure destination timeout" failed: cron: job execution timed out (last phase: tool-execution-started)',
       );
       expect(sendFailureNotificationAnnounceMock).not.toHaveBeenCalled();
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("preserves job-level same-target failure destinations for tool-execution-started cron watchdog timeouts", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-tool-timeout-same-target-job-failure-destination-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "error",
+        error: TOOL_EXECUTION_STARTED_TIMEOUT,
+        summary: "timed out while tool call was pending",
+      });
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "same target failure destination timeout",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "announce",
+          channel: "matrix",
+          to: "!same-target:example.invalid",
+          failureDestination: {
+            mode: "announce",
+            channel: "matrix",
+            to: "!same-target:example.invalid",
+          },
+        },
+      });
+
+      await runCronJobAndWaitForFinished(ws, jobId);
+
+      expectFailureAnnounceCall({
+        jobId,
+        channel: "matrix",
+        to: "!same-target:example.invalid",
+        message:
+          '⚠️ Cron job "same target failure destination timeout" failed: cron: job execution timed out (last phase: tool-execution-started)',
+      });
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("preserves global same-target failure destinations for tool-execution-started cron watchdog timeouts", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-tool-timeout-same-target-global-failure-destination-",
+      cronEnabled: false,
+    });
+
+    await writeCronConfig({
+      cron: {
+        failureDestination: {
+          mode: "announce",
+          channel: "matrix",
+          to: "!same-target-global:example.invalid",
+        },
+      },
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "error",
+        error: TOOL_EXECUTION_STARTED_TIMEOUT,
+        summary: "timed out while tool call was pending",
+      });
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "global same target failure destination timeout",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "announce",
+          channel: "matrix",
+          to: "!same-target-global:example.invalid",
+        },
+      });
+
+      await runCronJobAndWaitForFinished(ws, jobId);
+
+      expectFailureAnnounceCall({
+        jobId,
+        channel: "matrix",
+        to: "!same-target-global:example.invalid",
+        message:
+          '⚠️ Cron job "global same target failure destination timeout" failed: cron: job execution timed out (last phase: tool-execution-started)',
+      });
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
     }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -31,6 +31,8 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
 
 const sendFailureNotificationAnnounceMock = vi.hoisted(() => vi.fn(async () => undefined));
 const closeTrackedBrowserTabsForSessionsMock = vi.hoisted(() => vi.fn(async () => 0));
+const TOOL_EXECUTION_STARTED_TIMEOUT =
+  "cron: job execution timed out (last phase: tool-execution-started)";
 
 vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: (...args: unknown[]) =>
@@ -1588,6 +1590,81 @@ describe("gateway server cron", () => {
         sessionKey: "agent:main:telegram:direct:123:thread:99",
         message: '⚠️ Cron job "primary delivery fallback" failed: unknown error',
       });
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("does not announce tool-execution-started cron watchdog timeouts", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-tool-timeout-suppressed-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "error",
+        error: TOOL_EXECUTION_STARTED_TIMEOUT,
+        summary: "timed out while tool call was pending",
+      });
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "suppressed primary timeout fallback",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "announce",
+          channel: "matrix",
+        },
+      });
+
+      await runCronJobAndWaitForFinished(ws, jobId);
+
+      expect(sendFailureNotificationAnnounceMock).not.toHaveBeenCalled();
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("preserves failure-destination notifications for tool-execution-started cron watchdog timeouts", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-tool-timeout-failure-destination-suppressed-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "error",
+        error: TOOL_EXECUTION_STARTED_TIMEOUT,
+        summary: "timed out while tool call was pending",
+      });
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "explicit failure destination timeout",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "announce",
+          channel: "matrix",
+          failureDestination: {
+            mode: "webhook",
+            to: "https://example.invalid/failure-destination",
+          },
+        },
+      });
+
+      await runCronJobAndWaitForFinished(ws, jobId);
+
+      const failureDestCall = getWebhookCall(0);
+      expect(failureDestCall.url).toBe("https://example.invalid/failure-destination");
+      expect(failureDestCall.body.message).toBe(
+        'Cron job "explicit failure destination timeout" failed: cron: job execution timed out (last phase: tool-execution-started)',
+      );
+      expect(sendFailureNotificationAnnounceMock).not.toHaveBeenCalled();
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
     }


### PR DESCRIPTION
## Summary
- suppress the primary user-facing fallback cron failure announce for the exact isolated-runner watchdog timeout `cron: job execution timed out (last phase: tool-execution-started)`
- preserve the cron run as an error with `lastError` intact
- preserve explicit/global failure destinations for this timeout class instead of dropping operator-configured failure routes
- keep ordinary cron failures, generic timeouts, provider/model failures, and configured failure destinations notifying normally

## Real behavior proof

- Behavior or issue addressed: a narrow cron watchdog timeout at `tool-execution-started` could create a scary primary fallback failure notice even though the useful behavior had moved into tool execution. The patch suppresses only that primary fallback false-alert path when no explicit/global failure destination exists, while preserving explicit failure destinations.
- Real environment tested: local OpenClaw checkout on macOS using the patched PR head `f01678eba409212b8a299ff526bb36b0ce3c4a7f`; the command below ran the real exported cron timeout classifier and real failure-destination resolver from the patched checkout, then applied the same decision predicate now used by the cron timer.
- Exact steps or command run after this patch: `pnpm -s exec tsx -e '<redacted inline probe importing ./src/cron/service/execution-errors.ts and ./src/cron/delivery-plan.ts>'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the patched checkout:

```json
{
  "errorClassifiedAsToolExecutionStartedTimeout": true,
  "fallbackOnly": {
    "failureDestination": null,
    "alternateFailureNotificationRequested": false,
    "failureNotificationSuppressed": true,
    "expectedDeliveryStatus": "not-requested"
  },
  "explicitFailureDestination": {
    "failureDestination": {
      "mode": "webhook",
      "to": "https://example.invalid/failure-destination"
    },
    "alternateFailureNotificationRequested": true,
    "failureNotificationSuppressed": false,
    "expectedDeliveryStatus": "unknown"
  }
}
```

- Observed result after fix: the exact timeout is classified as the narrow `tool-execution-started` watchdog class; fallback-only notification is suppressed and recorded as `not-requested`; an explicit webhook failure destination remains requested and is not suppressed.
- What was not tested: a full live scheduled cron firing inside a production gateway was not run from this external PR branch.
- Proof limitations or environment constraints: the proof uses a local patched checkout and synthetic non-identifying cron inputs to avoid publishing private room, job, transcript, or operator details. Focused tests cover the gateway send path and cron persisted-state path below.
- Before evidence (optional but encouraged): prior PR review identified that the original version over-suppressed explicit/global failure destinations; this repaired head changes the decision predicate so configured failure destinations remain active.

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.cron.test.ts -t "does not announce tool-execution-started cron watchdog timeouts|preserves failure-destination notifications for tool-execution-started cron watchdog timeouts"` — 2 passed, 18 skipped
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.persists-delivered-status.test.ts -t "keeps tool-execution-started timeouts recorded while preserving explicit failure destinations|keeps primary announce tool-execution-started timeouts from expecting fallback failure notifications|suppresses failure notification state for delivered tool-execution-started timeouts|suppresses failure notification state for not-delivered tool-execution-started timeouts"` — 4 passed, 12 skipped
- `git diff --check`
- `pnpm -s lint:core`
- `pnpm -s tsgo:core:test`

Regression coverage added/updated:
- Gateway cron tests now prove primary fallback announce is skipped for the exact timeout while explicit failure destinations still send.
- Cron persisted-status tests now prove fallback-only suppression records `not-requested`, while explicit failure destinations remain attempted/unknown.

## Risk checklist

Did user-visible behavior change? `Yes` — a narrow false-alert fallback notification is suppressed.

Did config, environment, or migration behavior change? `No`.
