### PR TITLE
fix(matrix): replace recovered command progress lines

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -142,6 +142,7 @@ type DispatchInboundParams = {
     }) => Promise<void> | void;
     onItemEvent?: (payload: {
       itemId?: string;
+      toolCallId?: string;
       kind?: string;
       progressText?: string;
       summary?: string;
@@ -156,6 +157,8 @@ type DispatchInboundParams = {
     }) => Promise<void> | void;
     onApprovalEvent?: (payload: { phase?: string; command?: string }) => Promise<void> | void;
     onCommandOutput?: (payload: {
+      itemId?: string;
+      toolCallId?: string;
       phase?: string;
       name?: string;
       title?: string;
@@ -2952,6 +2955,45 @@ describe("processDiscordMessage draft streaming", () => {
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n🛠️ Exec\n• exec done");
     expect(deliverDiscordReply).not.toHaveBeenCalled();
     expectPreviewEditContent("done");
+  });
+
+  it("replaces Discord command progress items with matching command output", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onItemEvent?.({
+        itemId: "tool:call-1",
+        toolCallId: "call-1",
+        kind: "command",
+        name: "exec",
+        progressText: "install dependencies",
+      });
+      await params?.replyOptions?.onCommandOutput?.({
+        itemId: "tool:call-1-output",
+        toolCallId: "call-1",
+        phase: "end",
+        name: "exec",
+        exitCode: 0,
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Shelling",
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const lastUpdate = draftStream.update.mock.calls.at(-1)?.[0];
+    expect(lastUpdate).toContain("completed");
+    expect(lastUpdate).not.toContain("install dependencies");
   });
 
   it("drops later tool warning finals after progress preview final replies", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1027,6 +1027,8 @@ async function processDiscordMessageInner(
               discordConfig,
               {
                 event: "tool",
+                itemId: payload.itemId,
+                toolCallId: payload.toolCallId,
                 name: payload.name,
                 phase: payload.phase,
                 args: payload.args,
@@ -1052,6 +1054,7 @@ async function processDiscordMessageInner(
             buildChannelProgressDraftLineForEntry(discordConfig, {
               event: "item",
               itemId: payload.itemId,
+              toolCallId: payload.toolCallId,
               itemKind: payload.kind,
               title: payload.title,
               name: payload.name,
@@ -1099,6 +1102,8 @@ async function processDiscordMessageInner(
           await draftPreview.pushToolProgress(
             buildChannelProgressDraftLine({
               event: "command-output",
+              itemId: payload.itemId,
+              toolCallId: payload.toolCallId,
               phase: payload.phase,
               title: payload.title,
               name: payload.name,
@@ -1114,6 +1119,8 @@ async function processDiscordMessageInner(
           await draftPreview.pushToolProgress(
             buildChannelProgressDraftLine({
               event: "patch",
+              itemId: payload.itemId,
+              toolCallId: payload.toolCallId,
               phase: payload.phase,
               title: payload.title,
               name: payload.name,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2952,10 +2952,15 @@ describe("matrix monitor handler draft streaming", () => {
     suppressDefaultToolProgressMessages?: boolean;
     onToolStart?: (payload: { name?: string }) => Promise<void>;
     onItemEvent?: (payload: {
+      itemId?: string;
+      toolCallId?: string;
       progressText?: string;
       summary?: string;
       title?: string;
       name?: string;
+      kind?: string;
+      phase?: string;
+      status?: string;
     }) => Promise<void>;
     onPlanUpdate?: (payload: {
       phase: string;
@@ -2964,9 +2969,12 @@ describe("matrix monitor handler draft streaming", () => {
     }) => Promise<void>;
     onApprovalEvent?: (payload: { phase: string; command?: string }) => Promise<void>;
     onCommandOutput?: (payload: {
+      itemId?: string;
+      toolCallId?: string;
       phase: string;
       name?: string;
       exitCode?: number;
+      status?: string;
       title?: string;
     }) => Promise<void>;
     onPatchSummary?: (payload: {
@@ -3136,6 +3144,64 @@ describe("matrix monitor handler draft streaming", () => {
     });
     expect(singleTextMessageBody()).toBe("- `second`");
     await finish();
+  });
+
+  it("replaces recovered Matrix command progress instead of leaving stale failed text", async () => {
+    const { dispatch } = createStreamingHarness({
+      streaming: "progress",
+      previewToolProgressEnabled: true,
+      accountConfig: {
+        streaming: { mode: "progress", progress: { label: "Working" } },
+      } as never,
+    });
+    const { opts, finish } = await dispatch();
+
+    await opts.onItemEvent?.({
+      itemId: "command-1",
+      toolCallId: "call-1",
+      kind: "command",
+      name: "exec",
+      phase: "end",
+      status: "failed",
+      progressText: "run openclaw cron -> run jq (agent) failed",
+    });
+    await opts.onItemEvent?.({
+      itemId: "command-1",
+      toolCallId: "call-1",
+      kind: "command",
+      name: "exec",
+      phase: "end",
+      status: "failed",
+      progressText: "run openclaw cron -> run jq (agent) failed",
+    });
+
+    await vi.waitFor(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    expect(singleTextMessageBody()).toContain("failed");
+
+    await opts.onCommandOutput?.({
+      itemId: "command-1",
+      toolCallId: "call-1",
+      phase: "end",
+      name: "exec",
+      status: "completed",
+      exitCode: 0,
+    });
+
+    await finish();
+    expect(editMessageMatrixMock).toHaveBeenCalledWith(
+      "!room:example.org",
+      "$draft1",
+      expect.stringContaining("completed"),
+      expect.any(Object),
+    );
+    const recoveredEdit = mockCalls(editMessageMatrixMock, "editMessageMatrix").find(
+      ([, eventId, body]) =>
+        eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
+    );
+    expect(recoveredEdit?.[2]).not.toContain("failed");
+    expect(recoveredEdit?.[2]).not.toContain("run openclaw cron -> run jq");
   });
 
   it("keeps Matrix tool progress mentions inside code formatting", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2950,7 +2950,14 @@ describe("matrix monitor handler draft streaming", () => {
     ) => Promise<void> | void;
     onAssistantMessageStart?: () => void;
     suppressDefaultToolProgressMessages?: boolean;
-    onToolStart?: (payload: { name?: string }) => Promise<void>;
+    onToolStart?: (payload: {
+      itemId?: string;
+      toolCallId?: string;
+      name?: string;
+      phase?: string;
+      args?: Record<string, unknown>;
+      detailMode?: "explain" | "raw";
+    }) => Promise<void>;
     onItemEvent?: (payload: {
       itemId?: string;
       toolCallId?: string;
@@ -3158,7 +3165,6 @@ describe("matrix monitor handler draft streaming", () => {
 
     await opts.onItemEvent?.({
       itemId: "command-1",
-      toolCallId: "call-1",
       kind: "command",
       name: "exec",
       phase: "end",
@@ -3167,7 +3173,6 @@ describe("matrix monitor handler draft streaming", () => {
     });
     await opts.onItemEvent?.({
       itemId: "command-1",
-      toolCallId: "call-1",
       kind: "command",
       name: "exec",
       phase: "end",
@@ -3202,6 +3207,62 @@ describe("matrix monitor handler draft streaming", () => {
     );
     expect(recoveredEdit?.[2]).not.toContain("failed");
     expect(recoveredEdit?.[2]).not.toContain("run openclaw cron -> run jq");
+  });
+
+  it("replaces Matrix tool-start progress when command output completes", async () => {
+    const { dispatch } = createStreamingHarness({
+      streaming: "progress",
+      previewToolProgressEnabled: true,
+      accountConfig: {
+        streaming: { mode: "progress", progress: { label: "Working" } },
+      } as never,
+    });
+    const { opts, finish } = await dispatch();
+
+    await opts.onToolStart?.({
+      itemId: "fc-call-2",
+      toolCallId: "call-2",
+      name: "exec",
+      phase: "start",
+      args: { command: "npm install" },
+    });
+    await opts.onToolStart?.({
+      itemId: "fc-call-2",
+      toolCallId: "call-2",
+      name: "exec",
+      phase: "update",
+      args: { command: "npm install" },
+    });
+
+    await vi.waitFor(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    expect(singleTextMessageBody()).toContain("install dependencies");
+
+    await opts.onItemEvent?.({
+      itemId: "fc-call-2",
+      toolCallId: "call-2",
+      kind: "command",
+      name: "exec",
+      phase: "update",
+      progressText: "install dependencies",
+    });
+
+    await opts.onCommandOutput?.({
+      itemId: "fc-call-2-output",
+      toolCallId: "call-2",
+      phase: "end",
+      name: "exec",
+      status: "completed",
+      exitCode: 0,
+    });
+
+    await finish();
+    const completedEdit = mockCalls(editMessageMatrixMock, "editMessageMatrix").find(
+      ([, eventId, body]) =>
+        eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
+    );
+    expect(completedEdit?.[2]).not.toContain("install dependencies");
   });
 
   it("keeps Matrix tool progress mentions inside code formatting", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2985,9 +2985,15 @@ describe("matrix monitor handler draft streaming", () => {
       title?: string;
     }) => Promise<void>;
     onPatchSummary?: (payload: {
+      itemId?: string;
+      toolCallId?: string;
       phase: string;
+      name?: string;
       summary?: string;
       title?: string;
+      added?: string[];
+      modified?: string[];
+      deleted?: string[];
     }) => Promise<void>;
     disableBlockStreaming?: boolean;
   };
@@ -3263,6 +3269,55 @@ describe("matrix monitor handler draft streaming", () => {
         eventId === "$draft1" && typeof body === "string" && body.includes("completed"),
     );
     expect(completedEdit?.[2]).not.toContain("install dependencies");
+  });
+
+  it("replaces Matrix patch progress when the patch summary completes", async () => {
+    const { dispatch } = createStreamingHarness({
+      streaming: "progress",
+      previewToolProgressEnabled: true,
+      accountConfig: {
+        streaming: { mode: "progress", progress: { label: "Working" } },
+      } as never,
+    });
+    const { opts, finish } = await dispatch();
+
+    await opts.onItemEvent?.({
+      itemId: "patch:call-3",
+      toolCallId: "call-3",
+      kind: "patch",
+      name: "apply_patch",
+      phase: "update",
+      progressText: "updating Matrix progress handling",
+    });
+    await opts.onItemEvent?.({
+      itemId: "patch:call-3",
+      toolCallId: "call-3",
+      kind: "patch",
+      name: "apply_patch",
+      phase: "update",
+      progressText: "updating Matrix progress handling",
+    });
+
+    await vi.waitFor(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    expect(singleTextMessageBody()).toContain("updating Matrix progress handling");
+
+    await opts.onPatchSummary?.({
+      itemId: "patch:call-3",
+      toolCallId: "call-3",
+      phase: "end",
+      name: "apply_patch",
+      modified: ["extensions/matrix/src/matrix/monitor/handler.ts"],
+      summary: "1 file modified",
+    });
+
+    await finish();
+    const patchEdit = mockCalls(editMessageMatrixMock, "editMessageMatrix").find(
+      ([, eventId, body]) =>
+        eventId === "$draft1" && typeof body === "string" && body.includes("1 file modified"),
+    );
+    expect(patchEdit?.[2]).not.toContain("updating Matrix progress handling");
   });
 
   it("keeps Matrix tool progress mentions inside code formatting", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2015,8 +2015,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               return;
             }
             await pushPreviewToolProgress(
-              formatChannelProgressDraftLine({
+              buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "patch",
+                itemId: payload.itemId,
+                toolCallId: payload.toolCallId,
                 phase: payload.phase,
                 title: payload.title,
                 name: payload.name,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1996,8 +1996,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               return;
             }
             await pushPreviewToolProgress(
-              formatChannelProgressDraftLine({
+              buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "command-output",
+                itemId: payload.itemId,
+                toolCallId: payload.toolCallId,
                 phase: payload.phase,
                 title: payload.title,
                 name: payload.name,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -16,7 +16,6 @@ import {
   createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
   formatChannelProgressDraftLine,
-  formatChannelProgressDraftLineForEntry,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
   mergeChannelProgressDraftLine,
@@ -128,6 +127,7 @@ import { isMatrixVerificationRoomMessage } from "./verification-utils.js";
 const ALLOW_FROM_STORE_CACHE_TTL_MS = 30_000;
 const PAIRING_REPLY_COOLDOWN_MS = 5 * 60_000;
 const MATRIX_TOOL_PROGRESS_MAX_CHARS = 300;
+const COMMAND_PROGRESS_TOOL_NAMES = new Set(["exec", "bash", "shell"]);
 let matrixSendModulePromise: Promise<typeof import("../send.js")> | undefined;
 let acpBindingRuntimePromise:
   | Promise<typeof import("openclaw/plugin-sdk/acp-binding-runtime")>
@@ -137,6 +137,29 @@ let sessionBindingRuntimePromise:
   | undefined;
 let matrixReactionEventsPromise: Promise<typeof import("./reaction-events.js")> | undefined;
 let matrixDraftStreamPromise: Promise<typeof import("../draft-stream.js")> | undefined;
+
+function isMatrixCommandProgressToolName(name: string | undefined): boolean {
+  const normalized = name?.trim().toLowerCase();
+  return Boolean(normalized && COMMAND_PROGRESS_TOOL_NAMES.has(normalized));
+}
+
+function resolveMatrixCommandProgressItemId(payload: {
+  itemId?: string;
+  toolCallId?: string;
+  name?: string;
+}): string | undefined {
+  const itemId = payload.itemId?.trim();
+  if (itemId && /^command(?::|-)/i.test(itemId)) {
+    return itemId;
+  }
+  if (payload.toolCallId && isMatrixCommandProgressToolName(payload.name)) {
+    return `command:${payload.toolCallId}`;
+  }
+  if (itemId) {
+    return itemId;
+  }
+  return undefined;
+}
 
 function loadMatrixSendModule(): Promise<typeof import("../send.js")> {
   matrixSendModulePromise ??= import("../send.js");
@@ -1933,10 +1956,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           onToolStart: async (payload) => {
             const toolName = payload.name?.trim();
             await pushPreviewToolProgress(
-              formatChannelProgressDraftLineForEntry(
+              buildChannelProgressDraftLineForEntry(
                 progressConfigEntry,
                 {
                   event: "tool",
+                  itemId: resolveMatrixCommandProgressItemId(payload),
+                  toolCallId: payload.toolCallId,
                   name: toolName,
                   phase: payload.phase,
                   args: payload.args,
@@ -1947,10 +1972,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             );
           },
           onItemEvent: async (payload) => {
+            const toolName =
+              payload.name ??
+              (payload.kind?.trim().toLowerCase() === "command" ? "exec" : undefined);
             await pushPreviewToolProgress(
               buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "item",
-                itemId: payload.itemId,
+                itemId: resolveMatrixCommandProgressItemId({
+                  itemId: payload.itemId,
+                  toolCallId: payload.toolCallId,
+                  name: toolName,
+                }),
                 itemKind: payload.kind,
                 title: payload.title,
                 name: payload.name,
@@ -1998,7 +2030,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             await pushPreviewToolProgress(
               buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "command-output",
-                itemId: payload.itemId,
+                itemId: resolveMatrixCommandProgressItemId(payload),
                 toolCallId: payload.toolCallId,
                 phase: payload.phase,
                 title: payload.title,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -127,7 +127,6 @@ import { isMatrixVerificationRoomMessage } from "./verification-utils.js";
 const ALLOW_FROM_STORE_CACHE_TTL_MS = 30_000;
 const PAIRING_REPLY_COOLDOWN_MS = 5 * 60_000;
 const MATRIX_TOOL_PROGRESS_MAX_CHARS = 300;
-const COMMAND_PROGRESS_TOOL_NAMES = new Set(["exec", "bash", "shell"]);
 let matrixSendModulePromise: Promise<typeof import("../send.js")> | undefined;
 let acpBindingRuntimePromise:
   | Promise<typeof import("openclaw/plugin-sdk/acp-binding-runtime")>
@@ -137,29 +136,6 @@ let sessionBindingRuntimePromise:
   | undefined;
 let matrixReactionEventsPromise: Promise<typeof import("./reaction-events.js")> | undefined;
 let matrixDraftStreamPromise: Promise<typeof import("../draft-stream.js")> | undefined;
-
-function isMatrixCommandProgressToolName(name: string | undefined): boolean {
-  const normalized = name?.trim().toLowerCase();
-  return Boolean(normalized && COMMAND_PROGRESS_TOOL_NAMES.has(normalized));
-}
-
-function resolveMatrixCommandProgressItemId(payload: {
-  itemId?: string;
-  toolCallId?: string;
-  name?: string;
-}): string | undefined {
-  const itemId = payload.itemId?.trim();
-  if (itemId && /^command(?::|-)/i.test(itemId)) {
-    return itemId;
-  }
-  if (payload.toolCallId && isMatrixCommandProgressToolName(payload.name)) {
-    return `command:${payload.toolCallId}`;
-  }
-  if (itemId) {
-    return itemId;
-  }
-  return undefined;
-}
 
 function loadMatrixSendModule(): Promise<typeof import("../send.js")> {
   matrixSendModulePromise ??= import("../send.js");
@@ -1960,7 +1936,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                 progressConfigEntry,
                 {
                   event: "tool",
-                  itemId: resolveMatrixCommandProgressItemId(payload),
+                  itemId: payload.itemId,
                   toolCallId: payload.toolCallId,
                   name: toolName,
                   phase: payload.phase,
@@ -1972,17 +1948,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             );
           },
           onItemEvent: async (payload) => {
-            const toolName =
-              payload.name ??
-              (payload.kind?.trim().toLowerCase() === "command" ? "exec" : undefined);
             await pushPreviewToolProgress(
               buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "item",
-                itemId: resolveMatrixCommandProgressItemId({
-                  itemId: payload.itemId,
-                  toolCallId: payload.toolCallId,
-                  name: toolName,
-                }),
+                itemId: payload.itemId,
+                toolCallId: payload.toolCallId,
                 itemKind: payload.kind,
                 title: payload.title,
                 name: payload.name,
@@ -2030,7 +2000,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             await pushPreviewToolProgress(
               buildChannelProgressDraftLineForEntry(progressConfigEntry, {
                 event: "command-output",
-                itemId: resolveMatrixCommandProgressItemId(payload),
+                itemId: payload.itemId,
                 toolCallId: payload.toolCallId,
                 phase: payload.phase,
                 title: payload.title,

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -428,6 +428,36 @@ describe("createMSTeamsReplyDispatcher", () => {
     expect(getStreamMock().update).toHaveBeenCalled();
   });
 
+  it("replaces command progress items with matching command output", async () => {
+    const dispatcher = createDispatcher("personal", {
+      streaming: {
+        mode: "progress",
+        progress: {
+          label: "Working",
+        },
+      },
+    });
+
+    await dispatcher.replyOptions.onItemEvent?.({
+      itemId: "tool:call-1",
+      toolCallId: "call-1",
+      kind: "command",
+      name: "exec",
+      progressText: "install dependencies",
+    });
+    await dispatcher.replyOptions.onCommandOutput?.({
+      itemId: "tool:call-1-output",
+      toolCallId: "call-1",
+      phase: "end",
+      name: "exec",
+      exitCode: 0,
+    });
+
+    const lastUpdate = getStreamMock().update.mock.calls.at(-1)?.[0];
+    expect(lastUpdate).toContain("completed");
+    expect(lastUpdate).not.toContain("install dependencies");
+  });
+
   it("replaces reasoning progress snapshots in progress mode", async () => {
     const dispatcher = createDispatcher("personal", {
       streaming: {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -421,6 +421,10 @@ export function createMSTeamsReplyDispatcher(params: {
               msteamsCfg,
               {
                 event: "tool",
+                ...(typeof payload?.itemId === "string" ? { itemId: payload.itemId } : {}),
+                ...(typeof payload?.toolCallId === "string"
+                  ? { toolCallId: payload.toolCallId }
+                  : {}),
                 ...(name ? { name } : {}),
                 ...(typeof payload?.phase === "string" ? { phase: payload.phase } : {}),
                 ...(payload?.args && typeof payload.args === "object"
@@ -436,6 +440,10 @@ export function createMSTeamsReplyDispatcher(params: {
           await streamController.pushProgressLine(
             buildChannelProgressDraftLineForEntry(msteamsCfg, {
               event: "item",
+              ...(typeof payload?.itemId === "string" ? { itemId: payload.itemId } : {}),
+              ...(typeof payload?.toolCallId === "string"
+                ? { toolCallId: payload.toolCallId }
+                : {}),
               ...(typeof payload?.kind === "string" ? { itemKind: payload.kind } : {}),
               ...(typeof payload?.title === "string" ? { title: payload.title } : {}),
               ...(typeof payload?.name === "string" ? { name: payload.name } : {}),
@@ -490,6 +498,10 @@ export function createMSTeamsReplyDispatcher(params: {
           await streamController.pushProgressLine(
             buildChannelProgressDraftLine({
               event: "command-output",
+              ...(typeof payload?.itemId === "string" ? { itemId: payload.itemId } : {}),
+              ...(typeof payload?.toolCallId === "string"
+                ? { toolCallId: payload.toolCallId }
+                : {}),
               phase: payload.phase as string,
               ...(typeof payload?.title === "string" ? { title: payload.title } : {}),
               ...(typeof payload?.name === "string" ? { name: payload.name } : {}),
@@ -505,6 +517,10 @@ export function createMSTeamsReplyDispatcher(params: {
           await streamController.pushProgressLine(
             buildChannelProgressDraftLine({
               event: "patch",
+              ...(typeof payload?.itemId === "string" ? { itemId: payload.itemId } : {}),
+              ...(typeof payload?.toolCallId === "string"
+                ? { toolCallId: payload.toolCallId }
+                : {}),
               phase: payload.phase as string,
               ...(typeof payload?.title === "string" ? { title: payload.title } : {}),
               ...(typeof payload?.name === "string" ? { name: payload.name } : {}),

--- a/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
@@ -25,6 +25,7 @@ type MatrixQaScenarioId =
   | "matrix-room-partial-streaming-preview"
   | "matrix-room-quiet-streaming-preview"
   | "matrix-room-tool-progress-preview"
+  | "matrix-room-tool-progress-command-preview"
   | "matrix-room-tool-progress-preview-opt-out"
   | "matrix-room-tool-progress-error"
   | "matrix-room-tool-progress-mention-safety"
@@ -416,6 +417,15 @@ export const MATRIX_QA_SCENARIOS: MatrixQaScenarioDefinition[] = [
     id: "matrix-room-tool-progress-preview",
     timeoutMs: 60_000,
     title: "Matrix streaming folds tool progress into the preview message",
+    configOverrides: {
+      streaming: "quiet",
+      toolProfile: "coding",
+    },
+  },
+  {
+    id: "matrix-room-tool-progress-command-preview",
+    timeoutMs: 60_000,
+    title: "Matrix streaming replaces command progress lines inside the preview message",
     configOverrides: {
       streaming: "quiet",
       toolProfile: "coding",

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -21,6 +21,7 @@ import {
   buildMatrixPartialStreamingPrompt,
   buildMatrixQuietStreamingPrompt,
   buildMatrixQaToken,
+  buildMatrixToolProgressCommandPrompt,
   buildMatrixToolProgressTaskContent,
   buildMatrixToolProgressErrorPrompt,
   buildMatrixToolProgressMentionSafetyPrompt,
@@ -876,6 +877,8 @@ async function runMatrixToolProgressScenario(
     allowGenericProgressLine?: boolean;
     mentionSafety?: boolean;
     progressPattern: RegExp;
+    rejectProgressBodyPattern?: RegExp;
+    rejectProgressBodyMessage?: string;
     triggerBodyBuilder: (sutUserId: string, finalText: string) => string;
   },
 ) {
@@ -1120,6 +1123,14 @@ async function runMatrixToolProgressScenario(
   if (params.mentionSafety) {
     assertMatrixQaToolProgressMentionsInert(progress.event);
   }
+  if (
+    params.rejectProgressBodyPattern &&
+    params.rejectProgressBodyPattern.test(progress.event.body ?? "")
+  ) {
+    throw new Error(
+      `${params.rejectProgressBodyMessage ?? "Matrix tool progress preview body matched a rejected pattern"}: ${progress.event.body ?? "<none>"}`,
+    );
+  }
 
   const finalized =
     topLevelFinalBeforeProgress ??
@@ -1218,6 +1229,19 @@ export async function runToolProgressPreviewScenario(context: MatrixQaScenarioCo
     allowGenericProgressLine: true,
     progressPattern: /\b(?:tool:\s*)?read\s*:\s*from\b|\btool:\s*read\b/i,
     triggerBodyBuilder: buildMatrixToolProgressPrompt,
+  });
+}
+
+export async function runToolProgressCommandPreviewScenario(context: MatrixQaScenarioContext) {
+  return runMatrixToolProgressScenario(context, {
+    expectedPreviewKind: "notice",
+    finalText: buildMatrixQaToken("MATRIX_QA_TOOL_PROGRESS_COMMAND"),
+    label: "tool progress command preview",
+    progressPattern: /\bcompleted\b|\bexit\s+0\b/i,
+    rejectProgressBodyPattern:
+      /`(?![^`]*\bcompleted\b)[^`]*(?:matrix-command-progress-start|print text\s*→\s*run sleep 2)[^`]*`/i,
+    rejectProgressBodyMessage: "Matrix command progress kept stale command text after completion",
+    triggerBodyBuilder: buildMatrixToolProgressCommandPrompt,
   });
 }
 

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -96,6 +96,7 @@ export function buildMatrixPartialStreamingPrompt(sutUserId: string, text: strin
 export const MATRIX_QA_TOOL_PROGRESS_TASK_FILENAME = "QA_KICKOFF_TASK.md";
 export const MATRIX_QA_TOOL_PROGRESS_MENTION_FILENAME =
   "matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt";
+export const MATRIX_QA_TOOL_PROGRESS_COMMAND = "printf 'matrix-command-progress-start\\n'; sleep 2";
 
 export function buildMatrixToolProgressTaskContent(text: string) {
   return [
@@ -112,6 +113,14 @@ export function buildMatrixToolProgressPrompt(sutUserId: string) {
     `Do not guess or send any marker before the tool result returns.`,
     `Do not read \`HEARTBEAT.md\` for this check.`,
     `After that read completes, reply with only the exact marker from the file and no other text.`,
+  ].join(" ");
+}
+
+export function buildMatrixToolProgressCommandPrompt(sutUserId: string, text: string) {
+  return [
+    `${sutUserId} Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`${MATRIX_QA_TOOL_PROGRESS_COMMAND}\`.`,
+    `The QA harness must observe that exec command preview and its completion as edits to one Matrix draft.`,
+    `After that exec command completes or fails, reply exactly \`${text}\`.`,
   ].join(" ");
 }
 

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime.ts
@@ -109,6 +109,7 @@ import {
   runThreadNestedReplyShapeScenario,
   runThreadRootPreservationScenario,
   runToolProgressErrorScenario,
+  runToolProgressCommandPreviewScenario,
   runToolProgressMentionSafetyScenario,
   runToolProgressPreviewOptOutScenario,
   runToolProgressPreviewScenario,
@@ -235,6 +236,8 @@ export async function runMatrixQaScenario(
       return await runQuietStreamingPreviewScenario(context);
     case "matrix-room-tool-progress-preview":
       return await runToolProgressPreviewScenario(context);
+    case "matrix-room-tool-progress-command-preview":
+      return await runToolProgressCommandPreviewScenario(context);
     case "matrix-room-tool-progress-preview-opt-out":
       return await runToolProgressPreviewOptOutScenario(context);
     case "matrix-room-tool-progress-error":

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -381,6 +381,7 @@ describe("matrix live qa scenarios", () => {
       "matrix-room-partial-streaming-preview",
       "matrix-room-quiet-streaming-preview",
       "matrix-room-tool-progress-preview",
+      "matrix-room-tool-progress-command-preview",
       "matrix-room-tool-progress-preview-opt-out",
       "matrix-room-tool-progress-error",
       "matrix-room-tool-progress-mention-safety",
@@ -3283,6 +3284,99 @@ describe("matrix live qa scenarios", () => {
     expect(artifacts.previewBodyPreview).toBe("- `tool: exec_command`");
     expect(artifacts.previewEventId).toBe("$tool-progress-generic-preview");
     expect(artifacts.reply?.eventId).toBe("$tool-progress-generic-final");
+  });
+
+  it("rejects stale Matrix command text after command progress completes", async () => {
+    const previewEventId = "$tool-progress-command-preview";
+    mockMatrixQaRoomClient({
+      driverEventId: "$tool-progress-command-trigger",
+      events: [
+        {
+          event: matrixQaMessageEvent({
+            kind: "notice",
+            eventId: previewEventId,
+            body: "Working\n`🔧 Exec: matrix-command-progress-start`",
+          }),
+          since: "driver-sync-preview",
+        },
+        {
+          event: matrixQaMessageEvent({
+            kind: "notice",
+            eventId: "$tool-progress-command-update",
+            body: "Working\n`🔧 Exec: matrix-command-progress-start`\n`🔧 Exec: completed`",
+            relatesTo: {
+              relType: "m.replace",
+              eventId: previewEventId,
+            },
+          }),
+          since: "driver-sync-progress",
+        },
+      ],
+    });
+
+    const scenario = requireMatrixQaScenario("matrix-room-tool-progress-command-preview");
+
+    await expect(runMatrixQaScenario(scenario, matrixQaScenarioContext())).rejects.toThrow(
+      "Matrix command progress kept stale command text after completion",
+    );
+  });
+
+  it("accepts completed Matrix command progress when the stale command line is gone", async () => {
+    const previewEventId = "$tool-progress-command-clean-preview";
+    mockMatrixQaRoomClient({
+      driverEventId: "$tool-progress-command-clean-trigger",
+      events: [
+        {
+          event: matrixQaMessageEvent({
+            kind: "notice",
+            eventId: previewEventId,
+            body: "Working\n`🔧 Exec: matrix-command-progress-start`",
+          }),
+          since: "driver-sync-preview",
+        },
+        {
+          event: matrixQaMessageEvent({
+            kind: "notice",
+            eventId: "$tool-progress-command-clean-update",
+            body: "Working\n`🔧 Exec: completed`",
+            relatesTo: {
+              relType: "m.replace",
+              eventId: previewEventId,
+            },
+          }),
+          since: "driver-sync-progress",
+        },
+        {
+          event: ({ sendTextMessage }) =>
+            matrixQaMessageEvent({
+              kind: "notice",
+              eventId: "$tool-progress-command-clean-final",
+              body: readMatrixQaReplyDirective(
+                mockMessageBody(sendTextMessage, "sendTextMessage"),
+                "MATRIX_QA_TOOL_PROGRESS_COMMAND",
+              ),
+              relatesTo: {
+                relType: "m.replace",
+                eventId: previewEventId,
+              },
+            }),
+          since: "driver-sync-final",
+        },
+      ],
+    });
+
+    const scenario = requireMatrixQaScenario("matrix-room-tool-progress-command-preview");
+
+    const result = await runMatrixQaScenario(scenario, matrixQaScenarioContext());
+    const artifacts = result.artifacts as {
+      previewBodyPreview?: unknown;
+      previewEventId?: unknown;
+      reply?: { eventId?: unknown; tokenMatched?: unknown };
+    };
+    expect(artifacts.previewBodyPreview).toBe("Working\n`🔧 Exec: completed`");
+    expect(artifacts.previewEventId).toBe(previewEventId);
+    expect(artifacts.reply?.eventId).toBe("$tool-progress-command-clean-final");
+    expect(artifacts.reply?.tokenMatched).toBe(true);
   });
 
   it("reports Matrix tool progress preview candidates when the progress wait times out", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -54,6 +54,7 @@ let capturedReplyOptions:
       onItemEvent?: (payload: {
         kind?: string;
         itemId?: string;
+        toolCallId?: string;
         progressText?: string;
         summary?: string;
         title?: string;
@@ -61,6 +62,15 @@ let capturedReplyOptions:
         phase?: string;
         status?: string;
         meta?: string;
+      }) => Promise<void> | void;
+      onCommandOutput?: (payload: {
+        itemId?: string;
+        toolCallId?: string;
+        phase?: string;
+        title?: string;
+        name?: string;
+        status?: string;
+        exitCode?: number | null;
       }) => Promise<void> | void;
       onToolStart?: (payload: {
         itemId?: string;
@@ -130,6 +140,7 @@ let mockedReplyOptionEvents: Array<
   | {
       kind: "item";
       itemId?: string;
+      toolCallId?: string;
       itemKind?: string;
       progressText?: string;
       summary?: string;
@@ -159,6 +170,16 @@ let mockedReplyOptionEvents: Array<
       modified?: string[];
       deleted?: string[];
       summary?: string;
+    }
+  | {
+      kind: "command_output";
+      itemId?: string;
+      toolCallId?: string;
+      phase?: string;
+      title?: string;
+      name?: string;
+      status?: string;
+      exitCode?: number | null;
     }
   | { kind: "concurrent_items"; progressTexts: string[] }
   | { kind: "partial"; text: string }
@@ -235,6 +256,29 @@ function planUpdate(title: string) {
 
 function taskUpdate(id: unknown, title: string, status: "in_progress" | "complete" | "error") {
   return { type: "task_update", id, title, status };
+}
+
+function collectNativeTaskUpdates() {
+  const chunks: unknown[] = [];
+  const collectChunks = (call: unknown[]) => {
+    const arg = requireRecord(call[0], "native progress call");
+    if (Array.isArray(arg.chunks)) {
+      chunks.push(...arg.chunks);
+    }
+  };
+  for (const call of startSlackStreamMock.mock.calls) {
+    collectChunks(call);
+  }
+  for (const call of appendSlackStreamMock.mock.calls) {
+    collectChunks(call);
+  }
+  for (const call of stopSlackStreamMock.mock.calls) {
+    collectChunks(call);
+  }
+  return chunks.flatMap((chunk) => {
+    const record = requireRecord(chunk, "native progress chunk");
+    return record.type === "task_update" ? [record] : [];
+  });
 }
 
 function expectDeliverReplyCall(index: number, text: string, fields?: Record<string, unknown>) {
@@ -470,11 +514,10 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
             : params.exitCode != null
               ? `exit ${params.exitCode}`
               : params.status;
+        const id = params.toolCallId ? `command:${params.toolCallId}` : params.itemId;
         return {
           kind: "command-output",
-          ...((params.itemId ?? params.toolCallId)
-            ? { id: params.itemId ?? params.toolCallId }
-            : {}),
+          ...(id ? { id } : {}),
           text: status ?? params.title ?? params.name ?? "exec",
           label: params.name ?? "exec",
           ...(status ? { status } : {}),
@@ -542,16 +585,25 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
           "status" &&
         (params.itemKind === "command" || params.name === "exec")
       ) {
+        const id = params.toolCallId ? `command:${params.toolCallId}` : params.itemId;
         return {
           kind: "item",
+          ...(id ? { id } : {}),
           text: "🛠️ Exec",
           label: "Exec",
         };
       }
       const text = params.progressText ?? params.summary ?? params.title ?? params.name;
+      const id =
+        params.itemKind === "command" || params.name === "exec"
+          ? params.toolCallId
+            ? `command:${params.toolCallId}`
+            : params.itemId
+          : undefined;
       return text
         ? {
             kind: "item",
+            ...(id ? { id } : {}),
             text,
             label: params.title ?? params.name ?? "Update",
           }
@@ -895,6 +947,7 @@ vi.mock("../reply.runtime.js", () => ({
       onItemEvent?: (payload: {
         kind?: string;
         itemId?: string;
+        toolCallId?: string;
         progressText?: string;
         summary?: string;
         title?: string;
@@ -902,6 +955,15 @@ vi.mock("../reply.runtime.js", () => ({
         phase?: string;
         status?: string;
         meta?: string;
+      }) => Promise<void> | void;
+      onCommandOutput?: (payload: {
+        itemId?: string;
+        toolCallId?: string;
+        phase?: string;
+        title?: string;
+        name?: string;
+        status?: string;
+        exitCode?: number | null;
       }) => Promise<void> | void;
       onToolStart?: (payload: {
         itemId?: string;
@@ -938,6 +1000,7 @@ vi.mock("../reply.runtime.js", () => ({
           await params.replyOptions?.onItemEvent?.({
             kind: entry.itemKind,
             itemId: entry.itemId,
+            toolCallId: entry.toolCallId,
             progressText: entry.progressText,
             summary: entry.summary,
             title: entry.title,
@@ -945,6 +1008,16 @@ vi.mock("../reply.runtime.js", () => ({
             phase: entry.phase,
             status: entry.status,
             meta: entry.meta,
+          });
+        } else if (entry.kind === "command_output") {
+          await params.replyOptions?.onCommandOutput?.({
+            itemId: entry.itemId,
+            toolCallId: entry.toolCallId,
+            phase: entry.phase,
+            title: entry.title,
+            name: entry.name,
+            status: entry.status,
+            exitCode: entry.exitCode,
           });
         } else if (entry.kind === "tool_start") {
           await params.replyOptions?.onToolStart?.({
@@ -2489,6 +2562,43 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectNativeProgressAppend(0, [planUpdate("bash"), taskUpdate(taskId, "bash", "complete")]);
     expect(startSlackStreamMock.mock.invocationCallOrder[0]).toBeLessThan(
       appendSlackStreamMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("reuses native Slack progress task identity across command item and output events", async () => {
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events: [
+        {
+          kind: "item",
+          itemId: "tool:call-1",
+          toolCallId: "call-1",
+          itemKind: "command",
+          name: "bash",
+          phase: "update",
+          status: "running",
+          progressText: "install dependencies",
+        },
+        {
+          kind: "command_output",
+          itemId: "tool:call-1-output",
+          toolCallId: "call-1",
+          name: "bash",
+          phase: "end",
+          exitCode: 0,
+        },
+      ],
+    });
+
+    const taskUpdates = collectNativeTaskUpdates();
+    expect([...new Set(taskUpdates.map((task) => task.id))]).toEqual([
+      expect.stringMatching(/^command_call_1_[a-f0-9]{8}$/),
+    ]);
+    expect(taskUpdates.at(0)?.id).toEqual(expect.stringMatching(/^command_call_1_[a-f0-9]{8}$/));
+    expect(taskUpdates).toContainEqual(
+      taskUpdate(taskUpdates.at(0)?.id, "bash — completed", "complete"),
     );
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1908,6 +1908,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             buildChannelProgressDraftLineForEntry(account.config, {
               event: "item",
               itemId: payload.itemId,
+              toolCallId: payload.toolCallId,
               itemKind: payload.kind,
               title: payload.title,
               name: payload.name,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2464,9 +2464,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    const lastUpdate = answerDraftStream.update.mock.calls.at(-1)?.[0];
-    expect(lastUpdate).toContain("completed");
-    expect(lastUpdate).not.toContain("install dependencies");
+    const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(lastUpdate?.text).toContain("completed");
+    expect(lastUpdate?.text).not.toContain("install dependencies");
+    expect(lastUpdate?.richMessage.html).toContain("<code>completed</code>");
+    expect(lastUpdate?.richMessage.html).not.toContain("install dependencies");
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2467,8 +2467,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("completed");
     expect(lastUpdate?.text).not.toContain("install dependencies");
-    expect(lastUpdate?.richMessage.html).toContain("<code>completed</code>");
-    expect(lastUpdate?.richMessage.html).not.toContain("install dependencies");
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2438,6 +2438,37 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("replaces Telegram command progress items with matching command output", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onItemEvent?.({
+        itemId: "tool:call-1",
+        toolCallId: "call-1",
+        kind: "command",
+        name: "exec",
+        progressText: "install dependencies",
+      });
+      await replyOptions?.onCommandOutput?.({
+        itemId: "tool:call-1-output",
+        toolCallId: "call-1",
+        phase: "end",
+        name: "exec",
+        exitCode: 0,
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    const lastUpdate = answerDraftStream.update.mock.calls.at(-1)?.[0];
+    expect(lastUpdate).toContain("completed");
+    expect(lastUpdate).not.toContain("install dependencies");
+  });
+
   it("sends trailing verbose status after a progress-mode final answer", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -30,6 +30,7 @@ import {
   type ChannelProgressDraftLine,
   type ChannelProgressDraftCompositorLine,
   createChannelProgressDraftCompositor,
+  formatChannelProgressDraftLine,
   resolveChannelStreamingBlockEnabled,
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -2355,6 +2356,8 @@ export const dispatchTelegramMessage = async ({
                         telegramCfg,
                         {
                           event: "tool",
+                          itemId: payload.itemId,
+                          toolCallId: payload.toolCallId,
                           name: toolName,
                           phase: payload.phase,
                           args: payload.args,
@@ -2382,6 +2385,7 @@ export const dispatchTelegramMessage = async ({
                       buildChannelProgressDraftLineForEntry(telegramCfg, {
                         event: "item",
                         itemId: payload.itemId,
+                        toolCallId: payload.toolCallId,
                         itemKind: payload.kind,
                         title: payload.title,
                         name: payload.name,
@@ -2429,6 +2433,8 @@ export const dispatchTelegramMessage = async ({
                     await pushStreamToolProgress(
                       buildChannelProgressDraftLine({
                         event: "command-output",
+                        itemId: payload.itemId,
+                        toolCallId: payload.toolCallId,
                         phase: payload.phase,
                         title: payload.title,
                         name: payload.name,
@@ -2444,6 +2450,8 @@ export const dispatchTelegramMessage = async ({
                     await pushStreamToolProgress(
                       buildChannelProgressDraftLine({
                         event: "patch",
+                        itemId: payload.itemId,
+                        toolCallId: payload.toolCallId,
                         phase: payload.phase,
                         title: payload.title,
                         name: payload.name,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -30,7 +30,6 @@ import {
   type ChannelProgressDraftLine,
   type ChannelProgressDraftCompositorLine,
   createChannelProgressDraftCompositor,
-  formatChannelProgressDraftLine,
   resolveChannelStreamingBlockEnabled,
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-outbound";

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -134,6 +134,7 @@ export type GetReplyOptions = {
   /** Called when a concrete work item starts, updates, or completes. */
   onItemEvent?: (payload: {
     itemId?: string;
+    toolCallId?: string;
     kind?: string;
     title?: string;
     name?: string;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -317,6 +317,7 @@ type EmbeddedAgentParams = {
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onItemEvent?: (payload: {
     itemId?: string;
+    toolCallId?: string;
     kind?: string;
     title?: string;
     name?: string;
@@ -3771,6 +3772,7 @@ describe("runAgentTurnWithFallback", () => {
         stream: "item",
         data: {
           itemId: "tool:read-1",
+          toolCallId: "read-1",
           kind: "tool",
           title: "read",
           name: "read",
@@ -3814,6 +3816,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
     expect(onItemEvent).toHaveBeenCalledWith({
       itemId: "tool:read-1",
+      toolCallId: "read-1",
       kind: "tool",
       title: "read",
       name: "read",
@@ -3830,6 +3833,7 @@ describe("runAgentTurnWithFallback", () => {
         stream: "item",
         data: {
           itemId: "cmd-1",
+          toolCallId: "cmd-1",
           kind: "command",
           title: "Command",
           name: "bash",
@@ -3880,6 +3884,7 @@ describe("runAgentTurnWithFallback", () => {
         stream: "item",
         data: {
           itemId: "cmd-1",
+          toolCallId: "cmd-1",
           kind: "command",
           title: "Command",
           name: "bash",
@@ -3913,6 +3918,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
     expect(onItemEvent).toHaveBeenCalledWith({
       itemId: "cmd-1",
+      toolCallId: "cmd-1",
       kind: "command",
       title: "Command",
       name: "bash",

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4468,6 +4468,179 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("forwards Codex command tool results as command output completion", async () => {
+    const onCommandOutput = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase: "result",
+          itemId: "command:exec-1",
+          toolCallId: "exec-1",
+          name: "exec",
+          status: "completed",
+          result: {
+            exitCode: 0,
+            durationMs: 42,
+          },
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onCommandOutput } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      itemId: "command:exec-1",
+      phase: "end",
+      title: undefined,
+      toolCallId: "exec-1",
+      name: "exec",
+      output: undefined,
+      status: "completed",
+      exitCode: 0,
+      durationMs: 42,
+      cwd: undefined,
+    });
+  });
+
+  it("marks Codex command tool result errors as failed command output", async () => {
+    const onCommandOutput = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase: "result",
+          itemId: "command:exec-1",
+          toolCallId: "exec-1",
+          name: "exec",
+          isError: true,
+          result: {
+            content: [{ type: "text", text: "command failed" }],
+          },
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onCommandOutput } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(onCommandOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: "command:exec-1",
+        phase: "end",
+        toolCallId: "exec-1",
+        name: "exec",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("does not synthesize command output from bare exec tool results", async () => {
+    const onCommandOutput = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "exec",
+          toolCallId: "exec-1",
+          isError: false,
+        },
+      });
+      await params.onAgentEvent?.({
+        stream: "command_output",
+        data: {
+          itemId: "command:exec-1",
+          phase: "end",
+          title: "command ls",
+          toolCallId: "exec-1",
+          name: "exec",
+          status: "completed",
+          exitCode: 0,
+        },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onCommandOutput } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+    expect(onCommandOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: "command:exec-1",
+        phase: "end",
+        status: "completed",
+      }),
+    );
+  });
+
   it("suppresses progress callbacks after message-tool-only delivery completes", async () => {
     let releaseItemEvent: (() => void) | undefined;
     const itemEventGate = new Promise<void>((resolve) => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2544,6 +2544,7 @@ export async function runAgentTurnWithFallback(params: {
                       ) {
                         await params.opts?.onItemEvent?.({
                           itemId: readStringValue(evt.data.itemId),
+                          toolCallId: readStringValue(evt.data.toolCallId),
                           kind: readStringValue(evt.data.kind),
                           title: readStringValue(evt.data.title),
                           name: itemName,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -294,6 +294,83 @@ function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined 
   return value === "turn" || value === "session" ? value : undefined;
 }
 
+function readRecordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readFiniteNumberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readNullableNumberValue(value: unknown): number | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  return readFiniteNumberValue(value);
+}
+
+function isCommandToolName(name: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(name);
+  return normalized === "exec" || normalized === "bash" || normalized === "shell";
+}
+
+export function buildCommandOutputFromToolResultEvent(evt: {
+  stream: string;
+  data: Record<string, unknown>;
+}): Parameters<NonNullable<GetReplyOptions["onCommandOutput"]>>[0] | undefined {
+  if (evt.stream !== "tool" || readStringValue(evt.data.phase) !== "result") {
+    return undefined;
+  }
+  const name = readStringValue(evt.data.name);
+  if (!isCommandToolName(name)) {
+    return undefined;
+  }
+  const result = readRecordValue(evt.data.result);
+  const details = readRecordValue(result?.details);
+  const output =
+    readStringValue(evt.data.output) ??
+    readStringValue(result?.output) ??
+    readStringValue(details?.output);
+  const explicitStatus =
+    readStringValue(evt.data.status) ??
+    readStringValue(result?.status) ??
+    readStringValue(details?.status);
+  const exitCode = readNullableNumberValue(
+    result?.exitCode ?? details?.exitCode ?? evt.data.exitCode,
+  );
+  const durationMs = readFiniteNumberValue(
+    result?.durationMs ?? details?.durationMs ?? evt.data.durationMs,
+  );
+  const cwd = readStringValue(evt.data.cwd);
+  const hasConcreteCommandResult =
+    output !== undefined ||
+    explicitStatus !== undefined ||
+    exitCode !== undefined ||
+    durationMs !== undefined ||
+    cwd !== undefined ||
+    (result !== undefined && Object.keys(result).length > 0);
+  if (!hasConcreteCommandResult) {
+    return undefined;
+  }
+  const errorStatus =
+    evt.data.isError === true ? "failed" : evt.data.isError === false ? "completed" : undefined;
+  const status = explicitStatus ?? errorStatus;
+  return {
+    itemId: readStringValue(evt.data.itemId),
+    phase: "end",
+    title: readStringValue(evt.data.title),
+    toolCallId: readStringValue(evt.data.toolCallId),
+    name,
+    output,
+    status,
+    exitCode,
+    durationMs,
+    cwd,
+  };
+}
+
 /** One attempted runtime fallback candidate and its failure reason. */
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -2512,6 +2589,10 @@ export async function runAgentTurnWithFallback(params: {
                             params.typingSignals.signalToolStart(),
                             toolStartProgressPromise,
                           ]);
+                        }
+                        const commandOutput = buildCommandOutputFromToolResultEvent(evt);
+                        if (commandOutput) {
+                          await params.opts?.onCommandOutput?.(commandOutput);
                         }
                       }
                       const suppressItemChannelProgress =

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2291,6 +2291,179 @@ describe("createFollowupRunner progress forwarding", () => {
     );
   });
 
+  it("forwards queued Codex command tool results as command output completion", async () => {
+    const onCommandOutput = vi.fn(async () => {});
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        messageProvider: "discord",
+        verboseLevel: "on",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        await args.onAgentEvent?.({
+          stream: "tool",
+          data: {
+            phase: "result",
+            itemId: "command:queued-exec",
+            toolCallId: "queued-exec",
+            name: "exec",
+            status: "completed",
+            result: {
+              exitCode: 0,
+              durationMs: 24,
+            },
+          },
+        });
+        return { payloads: [{ text: "final reply" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      itemId: "command:queued-exec",
+      phase: "end",
+      title: undefined,
+      toolCallId: "queued-exec",
+      name: "exec",
+      output: undefined,
+      status: "completed",
+      exitCode: 0,
+      durationMs: 24,
+      cwd: undefined,
+    });
+  });
+
+  it("marks queued Codex command tool result errors as failed command output", async () => {
+    const onCommandOutput = vi.fn(async () => {});
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        messageProvider: "discord",
+        verboseLevel: "on",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        await args.onAgentEvent?.({
+          stream: "tool",
+          data: {
+            phase: "result",
+            itemId: "command:queued-exec",
+            toolCallId: "queued-exec",
+            name: "exec",
+            isError: true,
+            result: {
+              content: [{ type: "text", text: "command failed" }],
+            },
+          },
+        });
+        return { payloads: [{ text: "final reply" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(onCommandOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: "command:queued-exec",
+        phase: "end",
+        toolCallId: "queued-exec",
+        name: "exec",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("does not synthesize queued command output from bare exec tool results", async () => {
+    const onCommandOutput = vi.fn(async () => {});
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        messageProvider: "discord",
+        verboseLevel: "on",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        await args.onAgentEvent?.({
+          stream: "tool",
+          data: {
+            phase: "result",
+            name: "exec",
+            toolCallId: "queued-exec",
+            isError: false,
+          },
+        });
+        await args.onAgentEvent?.({
+          stream: "command_output",
+          data: {
+            itemId: "command:queued-exec",
+            phase: "end",
+            title: "command ls",
+            toolCallId: "queued-exec",
+            name: "exec",
+            status: "completed",
+            exitCode: 0,
+          },
+        });
+        return { payloads: [{ text: "final reply" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+    expect(onCommandOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: "command:queued-exec",
+        phase: "end",
+        status: "completed",
+      }),
+    );
+  });
+
   it("suppresses queued follow-up progress when verbose progress is disabled", async () => {
     const storePath = path.join(
       await fs.mkdtemp(path.join(tmpdir(), "openclaw-followup-progress-off-")),

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2090,6 +2090,8 @@ describe("createFollowupRunner progress forwarding", () => {
         await args.onAgentEvent?.({
           stream: "tool",
           data: {
+            itemId: "tool:queued-progress",
+            toolCallId: "queued-progress",
             phase: "start",
             name: "exec",
             args: { command: "echo queued-progress" },
@@ -2111,6 +2113,8 @@ describe("createFollowupRunner progress forwarding", () => {
     await runner(queued);
 
     expect(onToolStart).toHaveBeenCalledWith({
+      itemId: "tool:queued-progress",
+      toolCallId: "queued-progress",
       name: "exec",
       phase: "start",
       args: { command: "echo queued-progress" },
@@ -2189,6 +2193,7 @@ describe("createFollowupRunner progress forwarding", () => {
 
   it("preserves queued verbose progress when default tool progress is suppressed", async () => {
     const onToolStart = vi.fn(async () => {});
+    const onItemEvent = vi.fn(async () => {});
     const onCommandOutput = vi.fn(async () => {});
     const queued = createQueuedRun({
       originatingChannel: "discord",
@@ -2220,6 +2225,18 @@ describe("createFollowupRunner progress forwarding", () => {
           },
         });
         await args.onAgentEvent?.({
+          stream: "item",
+          data: {
+            itemId: "command:queued-suppressed-preview",
+            toolCallId: "queued-suppressed-preview",
+            kind: "command",
+            name: "exec",
+            phase: "update",
+            status: "running",
+            progressText: "queued output",
+          },
+        });
+        await args.onAgentEvent?.({
           stream: "command_output",
           data: { phase: "chunk", output: "queued output" },
         });
@@ -2229,7 +2246,12 @@ describe("createFollowupRunner progress forwarding", () => {
     );
 
     const runner = createFollowupRunner({
-      opts: { suppressDefaultToolProgressMessages: true, onToolStart, onCommandOutput },
+      opts: {
+        suppressDefaultToolProgressMessages: true,
+        onToolStart,
+        onItemEvent,
+        onCommandOutput,
+      },
       typing: createMockTypingController(),
       typingMode: "instant",
       defaultModel: "claude",
@@ -2244,6 +2266,15 @@ describe("createFollowupRunner progress forwarding", () => {
       args: { command: "echo queued-suppressed-preview" },
       detailMode: "raw",
     });
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: "command:queued-suppressed-preview",
+        toolCallId: "queued-suppressed-preview",
+        kind: "command",
+        name: "exec",
+        phase: "update",
+      }),
+    );
     expect(onCommandOutput).toHaveBeenCalledWith(
       expect.objectContaining({ phase: "chunk", output: "queued output" }),
     );

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -151,6 +151,8 @@ async function forwardFollowupProgressEvent(params: {
     const name = readStringValue(evt.data.name);
     if (phase === "start" || phase === "update") {
       await opts?.onToolStart?.({
+        itemId: readStringValue(evt.data.itemId),
+        toolCallId: readStringValue(evt.data.toolCallId),
         name,
         phase,
         args:

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -51,6 +51,7 @@ import {
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
 import {
+  buildCommandOutputFromToolResultEvent,
   buildPreflightCompactionFailureText,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
   resolveSessionRuntimeOverrideForProvider,
@@ -101,6 +102,14 @@ function filterStringArray(value: unknown): string[] | undefined {
 }
 
 function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
+  const commandOutput = buildCommandOutputFromToolResultEvent(evt);
+  if (commandOutput) {
+    return (
+      commandOutput.status === "failed" ||
+      commandOutput.status === "error" ||
+      (typeof commandOutput.exitCode === "number" && commandOutput.exitCode !== 0)
+    );
+  }
   if (evt.stream !== "item" && evt.stream !== "command_output") {
     return false;
   }
@@ -118,7 +127,7 @@ function canForwardFailedFollowupProgressEvent(
   evt: FollowupAgentEvent,
   opts?: GetReplyOptions,
 ): boolean {
-  if (evt.stream === "command_output") {
+  if (evt.stream === "command_output" || buildCommandOutputFromToolResultEvent(evt)) {
     return typeof opts?.onCommandOutput === "function";
   }
   if (evt.stream !== "item") {
@@ -161,6 +170,10 @@ async function forwardFollowupProgressEvent(params: {
             : undefined,
         detailMode: params.detailMode,
       });
+    }
+    const commandOutput = buildCommandOutputFromToolResultEvent(evt);
+    if (commandOutput) {
+      await opts?.onCommandOutput?.(commandOutput);
     }
   }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -169,6 +169,7 @@ async function forwardFollowupProgressEvent(params: {
   if (evt.stream === "item" && !suppressItemChannelProgress) {
     await opts?.onItemEvent?.({
       itemId: readStringValue(evt.data.itemId),
+      toolCallId: readStringValue(evt.data.toolCallId),
       kind: readStringValue(evt.data.kind),
       title: readStringValue(evt.data.title),
       name: readStringValue(evt.data.name),

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -223,6 +223,7 @@ export type ChannelProgressDraftLineInput =
   | {
       event: "item";
       itemId?: string;
+      toolCallId?: string;
       itemKind?: string;
       title?: string;
       name?: string;
@@ -293,6 +294,8 @@ export type ChannelProgressDraftLine = {
   prefix?: boolean;
 };
 
+const progressDraftLineCorrelationKeys = new WeakMap<ChannelProgressDraftLine, string>();
+
 function compactStrings(values: readonly (string | undefined | null)[]): string[] {
   return values.map((value) => value?.replace(/\s+/g, " ").trim()).filter(Boolean) as string[];
 }
@@ -314,6 +317,7 @@ function buildNamedProgressLine(
   metas: readonly (string | undefined | null)[] | undefined,
   options?: ChannelProgressLineOptions,
   fields?: {
+    correlationKey?: string;
     id?: string;
     status?: string;
   },
@@ -332,7 +336,7 @@ function buildNamedProgressLine(
   const detail = text.startsWith(`${prefix}: `)
     ? text.slice(prefix.length + 2).trim()
     : compactCommandPrefix;
-  return {
+  const line = {
     ...(fields?.id ? { id: fields.id } : {}),
     kind,
     text,
@@ -342,6 +346,18 @@ function buildNamedProgressLine(
     ...(fields?.status ? { status: fields.status } : {}),
     toolName: display.name,
   };
+  setProgressDraftLineCorrelationKey(line, fields?.correlationKey);
+  return line;
+}
+
+function setProgressDraftLineCorrelationKey(
+  line: ChannelProgressDraftLine,
+  correlationKey: string | undefined,
+): void {
+  const normalized = correlationKey?.trim();
+  if (normalized) {
+    progressDraftLineCorrelationKeys.set(line, normalized);
+  }
 }
 
 function itemKindToToolName(kind: string | undefined): string | undefined {
@@ -367,6 +383,28 @@ function isCommandToolName(name: string | undefined): boolean {
 function isCommandProgressItem(input: Extract<ChannelProgressDraftLineInput, { event: "item" }>) {
   const itemKind = normalizeOptionalLowercaseString(input.itemKind);
   return itemKind === "command" || isCommandToolName(input.name);
+}
+
+function resolveProgressDraftLineId(
+  input: {
+    itemId?: string;
+    toolCallId?: string;
+  },
+  params?: {
+    useToolCallIdFallback?: boolean;
+  },
+): string | undefined {
+  const itemId = input.itemId?.trim();
+  const toolCallId = input.toolCallId?.trim();
+  if (itemId) {
+    return itemId;
+  }
+  return params?.useToolCallIdFallback === true ? toolCallId : undefined;
+}
+
+function resolveCommandProgressCorrelationKey(input: { toolCallId?: string }): string | undefined {
+  const toolCallId = input.toolCallId?.trim();
+  return toolCallId ? `command:${toolCallId}` : undefined;
 }
 
 function isEmptyReasoningProgressItem(
@@ -454,7 +492,12 @@ export function buildChannelProgressDraftLine(
           input.phase && !input.name ? input.phase : undefined,
         ],
         options,
-        { id: itemId },
+        {
+          correlationKey: isCommandToolName(input.name)
+            ? resolveCommandProgressCorrelationKey(input)
+            : undefined,
+          id: itemId,
+        },
       );
     }
     case "item": {
@@ -470,20 +513,30 @@ export function buildChannelProgressDraftLine(
       }
       if (name) {
         return buildNamedProgressLine(input.event, name, [meta], options, {
-          id: input.itemId,
+          correlationKey: isCommandProgressItem(input)
+            ? resolveCommandProgressCorrelationKey(input)
+            : undefined,
+          id: resolveProgressDraftLineId(input),
           status: input.status,
         });
       }
       const text = compactStrings([meta, input.title]).at(0);
-      return text
-        ? {
-            ...(input.itemId ? { id: input.itemId } : {}),
-            kind: input.event,
-            text,
-            label: input.title?.trim() || input.itemKind?.trim() || "Update",
-            ...(input.status ? { status: input.status } : {}),
-          }
+      const id = resolveProgressDraftLineId(input);
+      const correlationKey = isCommandProgressItem(input)
+        ? resolveCommandProgressCorrelationKey(input)
         : undefined;
+      if (!text) {
+        return undefined;
+      }
+      const line = {
+        ...(id ? { id } : {}),
+        kind: input.event,
+        text,
+        label: input.title?.trim() || input.itemKind?.trim() || "Update",
+        ...(input.status ? { status: input.status } : {}),
+      };
+      setProgressDraftLineCorrelationKey(line, correlationKey);
+      return line;
     }
     case "plan": {
       if (input.phase !== undefined && input.phase !== "update") {
@@ -523,7 +576,11 @@ export function buildChannelProgressDraftLine(
         input.name ?? "exec",
         [status, input.title],
         options,
-        { id: input.itemId ?? input.toolCallId, status },
+        {
+          correlationKey: resolveCommandProgressCorrelationKey(input),
+          id: resolveProgressDraftLineId(input, { useToolCallIdFallback: true }),
+          status,
+        },
       );
     }
     case "patch": {
@@ -1013,10 +1070,10 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
     return lines;
   }
   const maxLines = Math.max(1, params.maxLines);
-  const lineId = typeof line === "object" ? line.id?.trim() : undefined;
-  if (lineId) {
-    const existingIndex = lines.findIndex(
-      (entry) => typeof entry === "object" && entry.id?.trim() === lineId,
+  const lineKeys = resolveProgressDraftLineMergeKeys(line);
+  if (lineKeys.length > 0) {
+    const existingIndex = lines.findIndex((entry) =>
+      resolveProgressDraftLineMergeKeys(entry).some((entryKey) => lineKeys.includes(entryKey)),
     );
     if (existingIndex >= 0) {
       if (normalizeChannelProgressDraftLineIdentity(lines[existingIndex]) === normalized) {
@@ -1032,6 +1089,16 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
     return lines;
   }
   return [...lines, line].slice(-maxLines);
+}
+
+function resolveProgressDraftLineMergeKeys(line: string | ChannelProgressDraftLine): string[] {
+  if (typeof line !== "object") {
+    return [];
+  }
+  const keys = [progressDraftLineCorrelationKeys.get(line), line.id]
+    .map((key) => key?.trim())
+    .filter((key): key is string => Boolean(key));
+  return [...new Set(keys)];
 }
 
 export function formatChannelProgressDraftText(params: {

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -554,26 +554,36 @@ describe("channel-streaming", () => {
     ).toBe("🛠️ Exec\n• Checking the app-server stream");
   });
 
-  it("preserves stable ids on named tool and command-output progress lines", () => {
+  it("normalizes command progress ids across tool and output lines", () => {
     const toolLine = buildChannelProgressDraftLine({
       event: "tool",
-      itemId: "tool:item-1",
+      itemId: "tool:call-1",
       toolCallId: "call-1",
       name: "bash",
       phase: "start",
     });
     const commandLine = buildChannelProgressDraftLine({
       event: "command-output",
-      itemId: "command:item-1",
+      itemId: "tool:call-1-output",
       toolCallId: "call-1",
       name: "bash",
       phase: "end",
       exitCode: 0,
     });
+    const itemLine = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "tool:call-1",
+      toolCallId: "call-1",
+      itemKind: "command",
+      name: "bash",
+      phase: "update",
+      progressText: "install dependencies",
+    });
 
-    expect(toolLine).toMatchObject({ id: "tool:item-1", kind: "tool", toolName: "bash" });
+    expect(toolLine).toMatchObject({ id: "command:call-1", kind: "tool", toolName: "bash" });
+    expect(itemLine).toMatchObject({ id: "command:call-1", kind: "item", toolName: "bash" });
     expect(commandLine).toMatchObject({
-      id: "command:item-1",
+      id: "command:call-1",
       kind: "command-output",
       status: "completed",
       toolName: "bash",

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -554,7 +554,7 @@ describe("channel-streaming", () => {
     ).toBe("🛠️ Exec\n• Checking the app-server stream");
   });
 
-  it("normalizes command progress ids across tool and output lines", () => {
+  it("keeps public command progress ids while replacing by command correlation", () => {
     const toolLine = buildChannelProgressDraftLine({
       event: "tool",
       itemId: "tool:call-1",
@@ -580,14 +580,61 @@ describe("channel-streaming", () => {
       progressText: "install dependencies",
     });
 
-    expect(toolLine).toMatchObject({ id: "command:call-1", kind: "tool", toolName: "bash" });
-    expect(itemLine).toMatchObject({ id: "command:call-1", kind: "item", toolName: "bash" });
+    expect(toolLine).toMatchObject({ id: "tool:call-1", kind: "tool", toolName: "bash" });
+    expect(itemLine).toMatchObject({ id: "tool:call-1", kind: "item", toolName: "bash" });
     expect(commandLine).toMatchObject({
-      id: "command:call-1",
+      id: "tool:call-1-output",
       kind: "command-output",
       status: "completed",
       toolName: "bash",
     });
+
+    if (!toolLine || !itemLine || !commandLine) {
+      throw new Error("expected command progress lines");
+    }
+    const updated = [itemLine, commandLine].reduce(
+      (lines, line) => mergeChannelProgressDraftLine(lines, line, { maxLines: 4 }),
+      mergeChannelProgressDraftLine([], toolLine, { maxLines: 4 }),
+    );
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toMatchObject({
+      id: "tool:call-1-output",
+      kind: "command-output",
+      status: "completed",
+    });
+
+    const recoveredItemLine = buildChannelProgressDraftLine({
+      event: "item",
+      itemId: "command-2",
+      itemKind: "command",
+      name: "bash",
+      phase: "end",
+      status: "failed",
+      progressText: "install dependencies failed",
+    });
+    const recoveredCommandLine = buildChannelProgressDraftLine({
+      event: "command-output",
+      itemId: "command-2",
+      toolCallId: "call-2",
+      name: "bash",
+      phase: "end",
+      exitCode: 0,
+    });
+    if (!recoveredItemLine || !recoveredCommandLine) {
+      throw new Error("expected recovered command progress lines");
+    }
+    expect(
+      mergeChannelProgressDraftLine([recoveredItemLine], recoveredCommandLine, {
+        maxLines: 4,
+      }),
+    ).toMatchObject([
+      {
+        id: "command-2",
+        kind: "command-output",
+        status: "completed",
+      },
+    ]);
   });
 
   it("starts progress drafts after five seconds or a second work event", async () => {


### PR DESCRIPTION
## Summary
- preserve Matrix command-output progress identity with item/tool call IDs so recovered command output updates the existing draft line
- prevent stale nested tool failures like `run openclaw cron -> run jq (agent) failed` from remaining visible after the command recovers
- add a Matrix monitor regression covering failed nested progress followed by completed command output

## Proof

### Redacted live behavior that motivated this fix

In a private Matrix room, a tool-progress notice presented a nested tool-chain failure as a live/current failure:

`run openclaw cron -> run jq (agent) failed`

The private room, sender, Matrix event IDs, cron job ID, exact room label, and surrounding transcript are intentionally omitted. The important user-visible behavior was that Matrix progress rendering made the stale nested failure remain visible even after the underlying work had recovered.

A follow-up check of the underlying cron/run state showed the later run was green, so the remaining bad user experience was Matrix progress state reconciliation: the old failed progress line was not being replaced by later recovered command output.

Here is a screenshot of the same behavior (see the failed message posted after the substantive work which did *not* actually fail):
<img width="1423" height="857" alt="Screenshot 2026-06-08 at 4 41 10 PM" src="https://github.com/user-attachments/assets/e511da4b-4038-4359-b058-0d4a488110de" />


### Redacted after-fix live Matrix transport proof

First, here is a screenshot of after-fix behavior from the same agent (no more false "failed" message):
<img width="975" height="479" alt="Screenshot 2026-06-08 at 4 38 09 PM" src="https://github.com/user-attachments/assets/274a234d-ea7c-4055-a978-a4d362a0637b" />


Further, I verified the after-fix behavior on 2026-06-07 against a real Matrix homeserver through the Matrix Client-Server API, using the [redacted] bot account in a temporary private proof room with no invites and no user transcript content.

Setup:
- PR commit: `41512ac1636d28e4e98d25391d4245b825a5c372`
- Matrix setup: real Matrix homeserver, private temporary room, [redacted] bot account
- Redactions: room ID, original draft event ID, edit event ID, account identifiers, and all server-local identifiers

Readback proof:
```json
{
  "roomId": "[redacted-room-id]",
  "originalDraftEventId": "[redacted-original-event-id]",
  "editEventId": "[redacted-edit-event-id]",
  "beforeDraftBody": "Working\n- `🛠️ redacted command failed`",
  "editOuterBody": "* Working\n- `🛠️ completed`",
  "editNewContentBody": "Working\n- `🛠️ completed`",
  "editRelation": {
    "rel_type": "m.replace",
    "event_id": "[redacted-original-event-id]"
  },
  "assertions": {
    "sameDraftEdited": true,
    "beforeContainsFailed": true,
    "afterContainsCompleted": true,
    "afterOmitsFailed": true,
    "originalRoomHasNoInvites": true
  }
}
```

This proves the visible Matrix transport operation is an edit of the existing draft event via `m.replace`, and the edited `m.new_content.body` contains `completed` while no longer containing `failed`.

### Matrix handler regression proof

The regression in `extensions/matrix/src/matrix/monitor/handler.test.ts` uses synthetic Matrix identifiers and the public-safe failure string above.

Reproduction sequence:
1. Emit a failed command item with stable synthetic IDs:
   - `itemId: command-1`
   - `toolCallId: call-1`
   - `progressText: run openclaw cron -> run jq (agent) failed`
2. Verify the Matrix draft initially contains `failed`.
3. Emit recovered command output for the same synthetic IDs:
   - `status: completed`
   - `exitCode: 0`
4. Verify the edited Matrix draft contains `completed`.
5. Verify the edited Matrix draft no longer contains:
   - `failed`
   - `run openclaw cron -> run jq`

That proves the recovered command progress replaces the stale failed line instead of leaving a fake live failure in Matrix.

Commands run:
- `pnpm -s exec vitest run --config test/vitest/vitest.extension-matrix.config.ts extensions/matrix/src/matrix/monitor/handler.test.ts -t "replaces recovered Matrix command progress"` — 1 passed, 113 skipped
- `pnpm -s exec vitest run --config test/vitest/vitest.extension-matrix.config.ts extensions/matrix/src/matrix/monitor/handler.test.ts` — 114 passed
- `git diff --check` — passed

### Redaction note

No live Matrix room IDs, user IDs, message IDs, cron IDs, room labels, private transcript text, or private job contents are included. The proof uses synthetic identifiers and the minimum public-safe failure string needed to demonstrate the behavior.


## Real behavior proof

Behavior addressed: Matrix command-progress drafts used the public `itemId` for both the command start line and the later command-output line. When those IDs differed for the same command call, the draft kept the stale command-start line instead of replacing it with the completed command-output line.

Real environment tested: OpenClaw Matrix QA on rebased head `e220ad3f905`, with a real OpenClaw gateway process, Matrix room topology, `ghcr.io/matrix-construct/tuwunel:v1.5.1`, and mock OpenAI provider. The QA harness captured Matrix room events and verified the preview edit relation.

Exact steps or command run after this patch:
```text
QA_ROOT="$(mktemp -d /tmp/openclaw-matrix-pr-rebased.XXXXXX)"
mkdir -p "$QA_ROOT/home/.openclaw" "$QA_ROOT/state"
printf '{}\n' > "$QA_ROOT/home/.openclaw/openclaw.json"
OPENCLAW_HOME="$QA_ROOT/home" \
OPENCLAW_CONFIG_PATH="$QA_ROOT/home/.openclaw/openclaw.json" \
OPENCLAW_STATE_DIR="$QA_ROOT/state" \
OPENCLAW_QA_MATRIX_CAPTURE_CONTENT=1 \
pnpm openclaw qa matrix \
  --provider-mode mock-openai \
  --profile all \
  --scenario matrix-room-tool-progress-command-preview \
  --output-dir .artifacts/qa-e2e/manual-command-progress-pr-rebased-latest \
  --fail-fast
```

Evidence after fix:
```text
[matrix-qa] scenario pass matrix-room-tool-progress-command-preview 3.9s
[matrix-qa] suite pass 4/4 total=23.8s
preview body: Clawing

`🛠️ completed; command print text → run sleep 2`
final reply relation: m.replace
final reply target: $iJqknkCMdBm47S0T6Bt6WocytEd8ibv6GVzqbqgNQw8
final reply token matched: yes
```

Observed result after fix: the Matrix preview contains the completed command line only, and the final Matrix reply replaces the same preview event with `m.replace`. The stale `matrix-command-progress-start` command line is gone.

Additional before/after check on the same merge helper:
```text
origin/main d012d29e6f29:
lineCount 2
🛠️ `matrix-command-progress-start`
🛠️ `completed`
RESULT=STALE

PR head e220ad3f905:
lineCount 1
🛠️ `completed`
RESULT=CLEAN
```

What was not tested: an external production Matrix homeserver was not rerun after the rebase. The PR already includes earlier redacted live Matrix transport evidence, and this rebase rerun used the Matrix QA homeserver plus the real OpenClaw Matrix gateway path.
