### PR TITLE
fix(plugins): guard web search credential metadata

### DIFF
--- a/src/plugins/web-search-credential-presence.test.ts
+++ b/src/plugins/web-search-credential-presence.test.ts
@@ -1,10 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+const manifestMetadataMocks = vi.hoisted(() => ({
+  loadManifestMetadataSnapshot: vi.fn((): { plugins: unknown[] } => ({ plugins: [] })),
+}));
+
+vi.mock("./manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: manifestMetadataMocks.loadManifestMetadataSnapshot,
+}));
 
 let hasConfiguredWebSearchCredential: typeof import("./web-search-credential-presence.js").hasConfiguredWebSearchCredential;
 
@@ -13,6 +21,11 @@ beforeAll(async () => {
 });
 
 describe("hasConfiguredWebSearchCredential", () => {
+  beforeEach(() => {
+    manifestMetadataMocks.loadManifestMetadataSnapshot.mockReset();
+    manifestMetadataMocks.loadManifestMetadataSnapshot.mockReturnValue({ plugins: [] });
+  });
+
   it("does not statically import web-search runtime providers", () => {
     const source = fs.readFileSync(
       path.join(repoRoot, "src/plugins/web-search-credential-presence.ts"),
@@ -40,6 +53,45 @@ describe("hasConfiguredWebSearchCredential", () => {
           tools: { web: { search: { apiKey: "brave-key" } } },
         } as OpenClawConfig,
         env: {},
+        origin: "bundled",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps healthy manifest env credential candidates after unreadable plugin metadata", () => {
+    const unreadablePlugin = {
+      get origin() {
+        throw new Error("web search credential plugin origin getter exploded");
+      },
+      contracts: {
+        webSearchProviders: ["broken"],
+      },
+    } as never;
+    manifestMetadataMocks.loadManifestMetadataSnapshot.mockReturnValue({
+      plugins: [
+        unreadablePlugin,
+        {
+          origin: "bundled",
+          contracts: {
+            webSearchProviders: ["healthy-search"],
+          },
+          setup: {
+            providers: [
+              {
+                envVars: ["HEALTHY_SEARCH_API_KEY"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(
+      hasConfiguredWebSearchCredential({
+        config: {} as OpenClawConfig,
+        env: {
+          HEALTHY_SEARCH_API_KEY: "configured",
+        },
         origin: "bundled",
       }),
     ).toBe(true);

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -2,6 +2,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 
+type WebSearchCredentialPluginMetadata = Pick<
+  PluginManifestRecord,
+  "origin" | "contracts" | "setup" | "providerAuthEnvVars"
+>;
+
 function hasConfiguredCredentialValue(value: unknown): boolean {
   if (typeof value === "string") {
     return value.trim().length > 0;
@@ -33,6 +38,21 @@ function hasConfiguredPluginWebSearchCandidate(config: OpenClawConfig): boolean 
   });
 }
 
+function readWebSearchCredentialPluginMetadata(
+  plugin: PluginManifestRecord,
+): WebSearchCredentialPluginMetadata | undefined {
+  try {
+    return {
+      origin: plugin.origin,
+      contracts: plugin.contracts,
+      setup: plugin.setup,
+      providerAuthEnvVars: plugin.providerAuthEnvVars,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 function hasManifestWebSearchEnvCredentialCandidate(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -42,22 +62,30 @@ function hasManifestWebSearchEnvCredentialCandidate(params: {
   if (!env) {
     return false;
   }
-  return loadManifestMetadataSnapshot({
+  const snapshot = loadManifestMetadataSnapshot({
     config: params.config,
     env,
-  }).plugins.some((plugin) => {
+  });
+  for (const snapshotPlugin of snapshot.plugins) {
+    const plugin = readWebSearchCredentialPluginMetadata(snapshotPlugin);
+    if (!plugin) {
+      continue;
+    }
     if (params.origin && plugin.origin !== params.origin) {
-      return false;
+      continue;
     }
     if ((plugin.contracts?.webSearchProviders?.length ?? 0) === 0) {
-      return false;
+      continue;
     }
     const envVars = [
       ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
       ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
     ];
-    return envVars.some((envVar) => hasConfiguredCredentialValue(env[envVar]));
-  });
+    if (envVars.some((envVar) => hasConfiguredCredentialValue(env[envVar]))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function hasConfiguredWebSearchCredential(params: {


### PR DESCRIPTION
## Summary

- Guard web-search credential detection against unreadable plugin manifest metadata rows.
- Keep healthy manifest env credential candidates available when a neighboring plugin row throws during metadata reads.
- Add a regression for unreadable metadata before a healthy bundled web-search provider credential.

## Verification

- `node scripts/run-vitest.mjs src/plugins/web-search-credential-presence.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`
- `node_modules/.bin/oxlint src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (blocked: coordinator returned HTTP 401 before lease)

## Real behavior proof

Behavior addressed: web-search credential detection now skips unreadable plugin metadata rows instead of throwing before healthy manifest env credential candidates are considered.

Real environment tested: local linked OpenClaw worktree on Node/Vitest via `scripts/run-vitest.mjs`; Crabbox AWS changed-gate attempt reached coordinator auth and failed before lease.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/web-search-credential-presence.test.ts`; `node_modules/.bin/oxfmt --check src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`; `node_modules/.bin/oxlint src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview; Crabbox changed-gate attempt.

Evidence after fix: `src/plugins/web-search-credential-presence.test.ts` passed 4 tests, including the unreadable plugin metadata regression; touched-file format/lint and diff whitespace checks passed; autoreview reported no accepted/actionable findings after the test mock type fix.

Observed result after fix: healthy web-search manifest env credential candidates remain detectable when an earlier plugin metadata row throws during property access.

What was not tested: full `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing an AWS box; Blacksmith Testbox is also unavailable in this environment.
