### PR TITLE
fix(plugins): guard manifest command alias metadata

### DIFF
--- a/src/plugins/manifest-command-aliases.test.ts
+++ b/src/plugins/manifest-command-aliases.test.ts
@@ -56,6 +56,72 @@ describe("manifest command aliases", () => {
     });
   });
 
+  it("keeps healthy command aliases after unreadable plugin metadata", () => {
+    const registry = {
+      plugins: [
+        {
+          get id() {
+            throw new Error("command alias plugin id getter exploded");
+          },
+          commandAliases: [{ name: "broken" }],
+        },
+        {
+          id: "healthy",
+          commandAliases: [{ name: "healthy-command" }],
+        },
+      ],
+    } as never;
+
+    expect(
+      resolveManifestCommandAliasOwnerInRegistry({ command: "healthy-command", registry }),
+    ).toEqual({
+      name: "healthy-command",
+      pluginId: "healthy",
+    });
+  });
+
+  it("does not drop command aliases when unrelated tool metadata is unreadable", () => {
+    const registry = {
+      plugins: [
+        {
+          id: "healthy",
+          commandAliases: [{ name: "healthy-command" }],
+          get contracts() {
+            throw new Error("unrelated command alias contracts getter exploded");
+          },
+        },
+      ],
+    } as never;
+
+    expect(
+      resolveManifestCommandAliasOwnerInRegistry({ command: "healthy-command", registry }),
+    ).toEqual({
+      name: "healthy-command",
+      pluginId: "healthy",
+    });
+  });
+
+  it("does not let aliases shadow readable plugin ids with unreadable alias metadata", () => {
+    const registry = {
+      plugins: [
+        {
+          id: "memory",
+          get commandAliases() {
+            throw new Error("same id plugin command aliases getter exploded");
+          },
+        },
+        {
+          id: "memory-core",
+          commandAliases: [{ name: "memory" }],
+        },
+      ],
+    } as never;
+
+    expect(resolveManifestCommandAliasOwnerInRegistry({ command: "memory", registry })).toBe(
+      undefined,
+    );
+  });
+
   it("resolves agent tool owners from contracts.tools", () => {
     const registry = {
       plugins: [
@@ -82,5 +148,46 @@ describe("manifest command aliases", () => {
       resolveManifestToolOwnerInRegistry({ toolName: "missing_tool", registry }),
     ).toBeUndefined();
     expect(resolveManifestToolOwnerInRegistry({ toolName: "", registry })).toBeUndefined();
+  });
+
+  it("keeps healthy tool owners after unreadable plugin metadata", () => {
+    const registry = {
+      plugins: [
+        {
+          id: "broken",
+          get contracts() {
+            throw new Error("tool owner plugin contracts getter exploded");
+          },
+        },
+        {
+          id: "healthy",
+          contracts: { tools: ["healthy_tool"] },
+        },
+      ],
+    } as never;
+
+    expect(resolveManifestToolOwnerInRegistry({ toolName: "healthy_tool", registry })).toEqual({
+      toolName: "healthy_tool",
+      pluginId: "healthy",
+    });
+  });
+
+  it("does not drop tool owners when unrelated command alias metadata is unreadable", () => {
+    const registry = {
+      plugins: [
+        {
+          id: "healthy",
+          contracts: { tools: ["healthy_tool"] },
+          get commandAliases() {
+            throw new Error("unrelated tool owner command aliases getter exploded");
+          },
+        },
+      ],
+    } as never;
+
+    expect(resolveManifestToolOwnerInRegistry({ toolName: "healthy_tool", registry })).toEqual({
+      toolName: "healthy_tool",
+      pluginId: "healthy",
+    });
   });
 });

--- a/src/plugins/manifest-command-aliases.ts
+++ b/src/plugins/manifest-command-aliases.ts
@@ -45,6 +45,24 @@ export type PluginManifestCommandAliasRegistry = {
     contracts?: { tools?: readonly string[] };
   }[];
 };
+type PluginManifestCommandAliasRegistryPlugin =
+  PluginManifestCommandAliasRegistry["plugins"][number];
+type PluginManifestToolOwnerRegistryRecord =
+  | {
+      ok: true;
+      id: string;
+      contracts?: { tools?: readonly string[] };
+    }
+  | { ok: false };
+type PluginManifestCommandAliasRegistryRecord =
+  | {
+      ok: true;
+      id: string;
+      enabledByDefault?: boolean;
+      commandAliases?: readonly PluginManifestCommandAlias[];
+    }
+  | { ok: false };
+type PluginManifestCommandAliasRegistryIdRead = { ok: true; id: string } | { ok: false };
 
 export function normalizeManifestCommandAliases(
   value: unknown,
@@ -80,6 +98,48 @@ export function normalizeManifestCommandAliases(
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function readToolOwnerRegistryPlugin(
+  plugin: PluginManifestCommandAliasRegistryPlugin,
+): PluginManifestToolOwnerRegistryRecord {
+  try {
+    return {
+      ok: true,
+      id: plugin.id,
+      contracts: plugin.contracts,
+    };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readCommandAliasRegistryPlugin(
+  plugin: PluginManifestCommandAliasRegistryPlugin,
+): PluginManifestCommandAliasRegistryRecord {
+  try {
+    return {
+      ok: true,
+      id: plugin.id,
+      enabledByDefault: plugin.enabledByDefault,
+      commandAliases: plugin.commandAliases,
+    };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readCommandAliasRegistryPluginId(
+  plugin: PluginManifestCommandAliasRegistryPlugin,
+): PluginManifestCommandAliasRegistryIdRead {
+  try {
+    return {
+      ok: true,
+      id: plugin.id,
+    };
+  } catch {
+    return { ok: false };
+  }
+}
+
 export function resolveManifestToolOwnerInRegistry(params: {
   toolName: string | undefined;
   registry: PluginManifestCommandAliasRegistry;
@@ -88,7 +148,11 @@ export function resolveManifestToolOwnerInRegistry(params: {
   if (!normalizedToolName) {
     return undefined;
   }
-  for (const plugin of params.registry.plugins) {
+  for (const registryPlugin of params.registry.plugins) {
+    const plugin = readToolOwnerRegistryPlugin(registryPlugin);
+    if (!plugin.ok) {
+      continue;
+    }
     const tools = plugin.contracts?.tools;
     if (!tools || tools.length === 0) {
       continue;
@@ -112,11 +176,23 @@ export function resolveManifestCommandAliasOwnerInRegistry(params: {
     return undefined;
   }
 
-  const commandIsPluginId = params.registry.plugins.some(
-    (plugin) => normalizeOptionalLowercaseString(plugin.id) === normalizedCommand,
-  );
+  let commandIsPluginId = false;
+  for (const registryPlugin of params.registry.plugins) {
+    const idRead = readCommandAliasRegistryPluginId(registryPlugin);
+    if (!idRead.ok) {
+      continue;
+    }
+    if (normalizeOptionalLowercaseString(idRead.id) === normalizedCommand) {
+      commandIsPluginId = true;
+      break;
+    }
+  }
 
-  for (const plugin of params.registry.plugins) {
+  for (const registryPlugin of params.registry.plugins) {
+    const plugin = readCommandAliasRegistryPlugin(registryPlugin);
+    if (!plugin.ok) {
+      continue;
+    }
     const alias = plugin.commandAliases?.find(
       (entry) => normalizeOptionalLowercaseString(entry.name) === normalizedCommand,
     );


### PR DESCRIPTION
## Summary

- Guard manifest command alias and tool-owner registry walks against unreadable plugin metadata rows.
- Preserve healthy command aliases and tool owners after bad rows while keeping real plugin IDs from being shadowed by aliases.
- Add regressions for unreadable alias metadata, tool metadata, unrelated-field failures, and same-id alias shadowing.

## Verification

- `node scripts/run-vitest.mjs src/plugins/manifest-command-aliases.test.ts`
- `node_modules/.bin/oxfmt --check src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts`
- `node_modules/.bin/oxlint src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` (blocked: coordinator returned HTTP 401 before lease)

## Real behavior proof

Behavior addressed: manifest command alias and tool-owner resolution now skip unreadable plugin metadata rows instead of throwing before healthy registry owners are considered.

Real environment tested: local linked OpenClaw worktree on Node/Vitest via `scripts/run-vitest.mjs`; Crabbox AWS changed-gate attempt reached coordinator auth and failed before lease.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/manifest-command-aliases.test.ts`; `node_modules/.bin/oxfmt --check src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts`; `node_modules/.bin/oxlint src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview; Crabbox changed-gate attempt.

Evidence after fix: `src/plugins/manifest-command-aliases.test.ts` passed 8 tests, including unreadable command alias metadata, unreadable tool metadata, unrelated-field failures, and same-id alias shadowing regressions; touched-file format/lint and diff whitespace checks passed; autoreview reported no accepted/actionable findings after two review-driven fixes.

Observed result after fix: healthy manifest command aliases and tool owners remain resolvable when earlier plugin registry rows throw during property access, and aliases still cannot shadow a readable real plugin ID.

What was not tested: full `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing an AWS box; Blacksmith Testbox is also unavailable in this environment.
