### PR TITLE
fix(plugins): guard effective channel owner metadata

### DIFF
--- a/src/plugins/effective-plugin-ids.test.ts
+++ b/src/plugins/effective-plugin-ids.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 const mocks = vi.hoisted(() => ({
@@ -113,6 +114,33 @@ describe("resolveEffectivePluginIds", () => {
         },
       }),
     ).toStrictEqual([]);
+  });
+
+  it("skips unreadable bundled channel-owner metadata while resolving healthy owners", () => {
+    const poisonedPlugin = Object.defineProperty({}, "origin", {
+      get() {
+        throw new Error("poisoned origin");
+      },
+    }) as PluginManifestRecord;
+    const healthyPlugin = {
+      id: "demo-channel-plugin",
+      channels: ["demo-channel"],
+      cliBackends: [],
+      hooks: [],
+      manifestPath: "/plugins/demo/package.json",
+      origin: "bundled",
+      providers: [],
+      rootDir: "/plugins/demo",
+      skills: [],
+      source: "manifest",
+    } satisfies PluginManifestRecord;
+
+    mocks.listPotentialConfiguredChannelIds.mockReturnValue(["demo-channel"]);
+    mocks.loadManifestMetadataSnapshot.mockReturnValue({
+      plugins: [poisonedPlugin, healthyPlugin],
+    } as unknown as PluginMetadataSnapshot);
+
+    expect(resolve({})).toStrictEqual(["demo-channel-plugin"]);
   });
 
   it.each([

--- a/src/plugins/effective-plugin-ids.ts
+++ b/src/plugins/effective-plugin-ids.ts
@@ -14,7 +14,13 @@ import {
 import { normalizePluginsConfig } from "./config-state.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import { passesManifestOwnerBasePolicy } from "./manifest-owner-policy.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { defaultSlotIdForKey } from "./slots.js";
+
+type BundledChannelOwnerMetadata = {
+  pluginId: string;
+  channelIds: readonly string[];
+};
 
 function collectConfiguredChannelIds(
   config: OpenClawConfig,
@@ -72,28 +78,41 @@ function collectBundledChannelOwnerPluginIds(params: {
   });
   const pluginIds = new Set<string>();
   for (const plugin of snapshot.plugins) {
-    if (plugin.origin !== "bundled") {
+    const owner = readBundledChannelOwnerMetadata(plugin);
+    if (!owner?.channelIds.some((channelId) => channelIds.has(channelId))) {
       continue;
     }
     if (
-      plugin.channels.some((channelId) =>
-        channelIds.has(normalizeOptionalLowercaseString(channelId) ?? ""),
-      )
+      passesManifestOwnerBasePolicy({
+        plugin: { id: owner.pluginId },
+        normalizedConfig: plugins,
+        allowRestrictiveAllowlistBypass: true,
+      })
     ) {
-      const pluginId = normalizeOptionalLowercaseString(plugin.id);
-      if (
-        pluginId &&
-        passesManifestOwnerBasePolicy({
-          plugin: { id: pluginId },
-          normalizedConfig: plugins,
-          allowRestrictiveAllowlistBypass: true,
-        })
-      ) {
-        pluginIds.add(pluginId);
-      }
+      pluginIds.add(owner.pluginId);
     }
   }
   return sortUniqueStrings(pluginIds);
+}
+
+function readBundledChannelOwnerMetadata(
+  plugin: PluginManifestRecord,
+): BundledChannelOwnerMetadata | undefined {
+  try {
+    if (plugin.origin !== "bundled") {
+      return undefined;
+    }
+    const pluginId = normalizeOptionalLowercaseString(plugin.id);
+    const channelIds = plugin.channels
+      .map((channelId) => normalizeOptionalLowercaseString(channelId))
+      .filter((channelId): channelId is string => Boolean(channelId));
+    if (!pluginId || channelIds.length === 0) {
+      return undefined;
+    }
+    return { pluginId, channelIds };
+  } catch {
+    return undefined;
+  }
 }
 
 function collectExplicitEffectivePluginIds(config: OpenClawConfig): string[] {


### PR DESCRIPTION
## Summary
- isolate unreadable bundled channel-owner manifest metadata to the affected plugin row during effective plugin id resolution
- keep healthy bundled channel owners eligible when a different manifest row throws while exposing `origin`, `channels`, or `id`
- add a regression test with a poisoned manifest metadata row before a healthy bundled owner

## Verification
- red: `node scripts/run-vitest.mjs src/plugins/effective-plugin-ids.test.ts` failed on `poisoned origin` before the guard
- green: `node scripts/run-vitest.mjs src/plugins/effective-plugin-ids.test.ts`
- green: `./node_modules/.bin/oxfmt --write --threads=1 src/plugins/effective-plugin-ids.ts src/plugins/effective-plugin-ids.test.ts`
- green: `git diff --check origin/main...HEAD`
- green: `.agents/skills/autoreview/scripts/autoreview --mode local`
- green: `.agents/skills/autoreview/scripts/autoreview --mode branch`
- blocked: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` failed before lease with coordinator HTTP 401

## Real behavior proof
Behavior addressed: effective plugin id resolution no longer aborts all bundled channel-owner discovery when one plugin metadata row is unreadable.
Real environment tested: local linked OpenClaw worktree on Node/Vitest via `node scripts/run-vitest.mjs`; Crabbox AWS changed gate attempted but coordinator auth failed.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/effective-plugin-ids.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.
Evidence after fix: the focused Vitest file passed 6 tests, including the poisoned metadata regression; local and branch autoreview both reported no accepted/actionable findings.
Observed result after fix: a poisoned bundled metadata row is skipped and the healthy bundled channel owner still resolves to `demo-channel-plugin`.
What was not tested: full `pnpm check:changed`; Crabbox could not create run history or a lease because the coordinator returned HTTP 401 unauthorized.
