### PR TITLE
fix(plugins): guard setup backend metadata

### DIFF
--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -155,6 +155,81 @@ describe("setup-registry runtime fallback", () => {
     });
   });
 
+  it("skips unreadable bundled setup backend metadata in runtime fallback lookups", async () => {
+    const poisonedPlugin = Object.defineProperty({}, "origin", {
+      get() {
+        throw new Error("setup backend origin exploded");
+      },
+    });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      index: {
+        diagnostics: [],
+        plugins: [
+          {
+            pluginId: "openai",
+            origin: "bundled",
+            enabled: true,
+          },
+        ],
+      },
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "openai",
+          origin: "bundled",
+          cliBackends: ["Codex-CLI"],
+        },
+      ],
+    });
+
+    const { testing, resolvePluginSetupCliBackendRuntime } =
+      await import("./setup-registry.runtime.js");
+    testing.resetRuntimeState();
+    testing.setRuntimeModuleForTest(null);
+
+    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli" })).toEqual({
+      pluginId: "openai",
+      backend: { id: "Codex-CLI" },
+    });
+  });
+
+  it("skips unreadable setup backend metadata in descriptor lookups", async () => {
+    const poisonedPlugin = Object.defineProperty({}, "id", {
+      get() {
+        throw new Error("setup backend id exploded");
+      },
+    });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      index: {
+        diagnostics: [],
+        plugins: [
+          {
+            pluginId: "openai",
+            origin: "bundled",
+            enabled: true,
+          },
+        ],
+      },
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "openai",
+          origin: "bundled",
+          cliBackends: ["Codex-CLI"],
+        },
+      ],
+    });
+
+    const { testing, resolvePluginSetupCliBackendDescriptor } =
+      await import("./setup-registry.runtime.js");
+    testing.resetRuntimeState();
+
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli" })).toEqual({
+      pluginId: "openai",
+      backend: { id: "Codex-CLI" },
+    });
+  });
+
   it("refreshes bundled registry cliBackends when the current metadata snapshot changes", async () => {
     const { testing, resolvePluginSetupCliBackendRuntime } =
       await import("./setup-registry.runtime.js");

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import {
   resolvePluginMetadataSnapshot,
   type PluginMetadataSnapshot,
@@ -87,16 +88,7 @@ function resolveBundledSetupCliBackends(
     return cachedBundledSetupCliBackends.entries;
   }
   const entries = snapshot.plugins.flatMap((plugin) => {
-    if (plugin.origin !== "bundled" || !isInstalledPluginEnabled(snapshot.index, plugin.id)) {
-      return [];
-    }
-    return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].map(
-      (backendId) =>
-        ({
-          pluginId: plugin.id,
-          backend: { id: backendId },
-        }) satisfies SetupCliBackendRuntimeEntry,
-    );
+    return readSetupCliBackendRuntimeEntries({ plugin, snapshot, bundledOnly: true });
   });
   if (cacheable && configFingerprint) {
     cachedBundledSetupCliBackends = { configFingerprint, entries };
@@ -117,21 +109,37 @@ function resolveSetupCliBackendDescriptors(
     return cachedSetupCliBackendDescriptors.entries;
   }
   const entries = snapshot.plugins.flatMap((plugin) => {
-    if (!isInstalledPluginEnabled(snapshot.index, plugin.id)) {
-      return [];
-    }
-    return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].map(
-      (backendId) =>
-        ({
-          pluginId: plugin.id,
-          backend: { id: backendId },
-        }) satisfies SetupCliBackendRuntimeEntry,
-    );
+    return readSetupCliBackendRuntimeEntries({ plugin, snapshot });
   });
   if (cacheable && configFingerprint) {
     cachedSetupCliBackendDescriptors = { configFingerprint, entries };
   }
   return entries;
+}
+
+function readSetupCliBackendRuntimeEntries(params: {
+  plugin: PluginManifestRecord;
+  snapshot: PluginMetadataSnapshot;
+  bundledOnly?: boolean;
+}): SetupCliBackendRuntimeEntry[] {
+  try {
+    if (params.bundledOnly && params.plugin.origin !== "bundled") {
+      return [];
+    }
+    const pluginId = params.plugin.id;
+    if (!isInstalledPluginEnabled(params.snapshot.index, pluginId)) {
+      return [];
+    }
+    return [...params.plugin.cliBackends, ...(params.plugin.setup?.cliBackends ?? [])].map(
+      (backendId) =>
+        ({
+          pluginId,
+          backend: { id: backendId },
+        }) satisfies SetupCliBackendRuntimeEntry,
+    );
+  } catch {
+    return [];
+  }
 }
 
 function loadSetupRegistryRuntime(): SetupRegistryRuntimeModule | null {


### PR DESCRIPTION
## Summary
- isolate unreadable setup CLI backend manifest metadata to the affected plugin row
- preserve enabled-plugin and bundled-only filtering for setup backend descriptor/runtime fallback lookup
- add regression coverage for both descriptor lookup and runtime fallback lookup after poisoned metadata rows

## Verification
- red: `node scripts/run-vitest.mjs src/plugins/setup-registry.runtime.test.ts` failed on `setup backend origin exploded` and `setup backend id exploded` before the guard
- green: `node scripts/run-vitest.mjs src/plugins/setup-registry.runtime.test.ts`
- green: `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/setup-registry.runtime.ts src/plugins/setup-registry.runtime.test.ts`
- green: `./node_modules/.bin/oxlint src/plugins/setup-registry.runtime.ts src/plugins/setup-registry.runtime.test.ts`
- green: `git diff --check origin/main...HEAD`
- green: `.agents/skills/autoreview/scripts/autoreview --mode local`
- green: `.agents/skills/autoreview/scripts/autoreview --mode branch`
- blocked: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` failed before lease with coordinator HTTP 401

## Real behavior proof
Behavior addressed: setup CLI backend lookup no longer aborts all healthy backend discovery when one plugin metadata row has unreadable setup backend fields.
Real environment tested: local linked OpenClaw worktree on Node/Vitest via `node scripts/run-vitest.mjs`; Crabbox AWS changed gate attempted but coordinator auth failed.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/setup-registry.runtime.test.ts`; `./node_modules/.bin/oxlint src/plugins/setup-registry.runtime.ts src/plugins/setup-registry.runtime.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.
Evidence after fix: the focused Vitest file passed 7 tests, including poisoned metadata coverage for runtime fallback and descriptor lookup; local and branch autoreview both reported no accepted/actionable findings.
Observed result after fix: poisoned setup backend metadata rows are skipped and the healthy `openai` setup backend still resolves to `Codex-CLI`.
What was not tested: full `pnpm check:changed`; Crabbox could not create run history or a lease because the coordinator returned HTTP 401 unauthorized.
