### PR TITLE
fix(plugins): guard manifest contract metadata

### DIFF
--- a/src/plugins/manifest-contract-runtime.test.ts
+++ b/src/plugins/manifest-contract-runtime.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 
 const loadPluginMetadataSnapshot = vi.hoisted(() => vi.fn());
 
@@ -63,6 +64,87 @@ describe("resolveManifestContractRuntimePluginResolution", () => {
       config: {},
       env: process.env,
       preferPersisted: false,
+    });
+  });
+
+  it("skips unreadable contract plugin metadata while resolving healthy plugins", () => {
+    const poisonedContracts = Object.defineProperty({}, "contracts", {
+      get() {
+        throw new Error("contract metadata exploded");
+      },
+    }) as PluginManifestRecord;
+    const poisonedOrigin = Object.defineProperties(
+      {},
+      {
+        contracts: {
+          value: { webSearchProviders: ["search"] },
+        },
+        origin: {
+          get() {
+            throw new Error("contract origin exploded");
+          },
+        },
+      },
+    ) as PluginManifestRecord;
+    const poisonedId = Object.defineProperties(
+      {},
+      {
+        contracts: {
+          value: { webSearchProviders: ["search"] },
+        },
+        origin: {
+          value: "global",
+        },
+        id: {
+          get() {
+            throw new Error("contract id exploded");
+          },
+        },
+      },
+    ) as PluginManifestRecord;
+    loadPluginMetadataSnapshot.mockReturnValue({
+      index: {
+        plugins: [
+          {
+            pluginId: "bundled-search",
+            origin: "bundled",
+            enabled: true,
+            enabledByDefault: true,
+          },
+          {
+            pluginId: "external-search",
+            origin: "global",
+            enabled: true,
+            enabledByDefault: true,
+          },
+        ],
+      },
+      plugins: [
+        poisonedContracts,
+        poisonedOrigin,
+        poisonedId,
+        {
+          id: "bundled-search",
+          origin: "bundled",
+          contracts: { webSearchProviders: ["search"] },
+        },
+        {
+          id: "external-search",
+          origin: "global",
+          contracts: { webSearchProviders: ["search"] },
+        },
+      ],
+    });
+
+    expect(
+      resolveManifestContractRuntimePluginResolution({
+        cfg: {},
+        contract: "webSearchProviders",
+        value: "search",
+      }),
+    ).toEqual({
+      pluginIds: ["bundled-search", "external-search"],
+      bundledCompatPluginIds: ["bundled-search"],
     });
   });
 });

--- a/src/plugins/manifest-contract-runtime.ts
+++ b/src/plugins/manifest-contract-runtime.ts
@@ -2,9 +2,9 @@ import { sortUniqueStrings } from "@openclaw/normalization-core/string-normaliza
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   hasManifestContractValue,
-  listAvailableManifestContractPlugins,
+  isManifestPluginAvailableForControlPlane,
 } from "./manifest-contract-eligibility.js";
-import type { PluginManifestContractListKey } from "./manifest-registry.js";
+import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
 export type ManifestContractRuntimePluginResolution = {
@@ -16,6 +16,11 @@ const DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS = {
   preferPersisted: false,
 } as const;
 
+type ReadableManifestContractPlugin = Pick<
+  PluginManifestRecord,
+  "contracts" | "enabledByDefault" | "enabledByDefaultOnPlatforms" | "id" | "origin"
+>;
+
 export function resolveManifestContractRuntimePluginResolution(params: {
   cfg?: OpenClawConfig;
   contract: PluginManifestContractListKey;
@@ -26,24 +31,56 @@ export function resolveManifestContractRuntimePluginResolution(params: {
     env: process.env,
     ...DEMAND_ONLY_CONTRACT_LOOKUP_OPTIONS,
   });
-  const allContractPlugins = snapshot.plugins.filter((plugin) =>
-    hasManifestContractValue({
+  const allContractPlugins = snapshot.plugins.flatMap((plugin) => {
+    const readable = readManifestContractRuntimePlugin({
       plugin,
       contract: params.contract,
       value: params.value,
-    }),
-  );
+    });
+    return readable ? [readable] : [];
+  });
   const bundledCompatPluginIds = allContractPlugins
     .filter((plugin) => plugin.origin === "bundled")
     .map((plugin) => plugin.id);
-  const pluginIds = listAvailableManifestContractPlugins({
-    snapshot: { index: snapshot.index, plugins: allContractPlugins },
-    contract: params.contract,
-    value: params.value,
-    config: params.cfg,
-  }).map((plugin) => plugin.id);
+  const pluginIds = allContractPlugins
+    .filter((plugin) =>
+      isManifestPluginAvailableForControlPlane({
+        snapshot: { index: snapshot.index },
+        plugin,
+        config: params.cfg,
+      }),
+    )
+    .map((plugin) => plugin.id);
   return {
     pluginIds: sortUniqueStrings(pluginIds),
     bundledCompatPluginIds: sortUniqueStrings(bundledCompatPluginIds),
   };
+}
+
+function readManifestContractRuntimePlugin(params: {
+  plugin: PluginManifestRecord;
+  contract: PluginManifestContractListKey;
+  value?: string;
+}): ReadableManifestContractPlugin | undefined {
+  try {
+    const plugin = {
+      contracts: params.plugin.contracts,
+      enabledByDefault: params.plugin.enabledByDefault,
+      enabledByDefaultOnPlatforms: params.plugin.enabledByDefaultOnPlatforms,
+      id: params.plugin.id,
+      origin: params.plugin.origin,
+    };
+    if (
+      !hasManifestContractValue({
+        plugin,
+        contract: params.contract,
+        value: params.value,
+      })
+    ) {
+      return undefined;
+    }
+    return plugin;
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary
- isolate unreadable manifest contract metadata to the affected plugin row during runtime contract plugin resolution
- preserve existing contract matching, bundled compatibility ids, enabled-plugin filtering, and stable sorting
- add regression coverage with poisoned `contracts`, `origin`, and `id` metadata rows before healthy bundled/external providers

## Verification
- red: `node scripts/run-vitest.mjs src/plugins/manifest-contract-runtime.test.ts` failed on `contract metadata exploded` before the guard
- green: `node scripts/run-vitest.mjs src/plugins/manifest-contract-runtime.test.ts`
- green: `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/manifest-contract-runtime.ts src/plugins/manifest-contract-runtime.test.ts`
- green: `./node_modules/.bin/oxlint src/plugins/manifest-contract-runtime.ts src/plugins/manifest-contract-runtime.test.ts`
- green: `git diff --check origin/main...HEAD`
- green: `.agents/skills/autoreview/scripts/autoreview --mode local`
- green: `.agents/skills/autoreview/scripts/autoreview --mode branch`
- blocked: `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"` failed before lease with coordinator HTTP 401

## Real behavior proof
Behavior addressed: manifest contract runtime resolution no longer aborts all healthy contract plugin discovery when one plugin metadata row has unreadable contract/runtime fields.
Real environment tested: local linked OpenClaw worktree on Node/Vitest via `node scripts/run-vitest.mjs`; Crabbox AWS changed gate attempted but coordinator auth failed.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/manifest-contract-runtime.test.ts`; `./node_modules/.bin/oxlint src/plugins/manifest-contract-runtime.ts src/plugins/manifest-contract-runtime.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch`; `node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"`.
Evidence after fix: the focused Vitest file passed 2 tests, including poisoned metadata coverage for `contracts`, `origin`, and `id`; local and branch autoreview both reported no accepted/actionable findings.
Observed result after fix: poisoned contract metadata rows are skipped and healthy bundled/external contract providers still resolve, including bundled compatibility ids.
What was not tested: full `pnpm check:changed`; Crabbox could not create run history or a lease because the coordinator returned HTTP 401 unauthorized.
