### PR TITLE
docs: document Skill Workshop tool visibility rules

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -20,12 +20,12 @@ sidebarTitle: "Tools and custom providers"
 Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
 </Note>
 
-| Profile     | Includes                                                                                                                        |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `minimal`   | `session_status` only                                                                                                           |
-| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `image`, `image_generate`, `video_generate` |
-| `messaging` | `group:messaging`, `sessions_list`, `sessions_history`, `sessions_send`, `session_status`                                       |
-| `full`      | No restriction (same as unset)                                                                                                  |
+| Profile     | Includes                                                                                                                                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `minimal`   | `session_status` only                                                                                                                                                                                                                      |
+| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `skill_workshop`, `cron`, `image`, `image_generate`, `music_generate`, `video_generate`, `bundle-mcp` |
+| `messaging` | `group:messaging`, `sessions_list`, `sessions_history`, `sessions_send`, `session_status`, `bundle-mcp`                                                                                                                                    |
+| `full`      | No restriction (same as unset)                                                                                                                                                                                                             |
 
 ### Tool groups
 
@@ -40,7 +40,7 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | `group:automation` | `heartbeat_respond`, `cron`, `gateway`                                                                                  |
 | `group:messaging`  | `message`                                                                                                               |
 | `group:nodes`      | `nodes`                                                                                                                 |
-| `group:agents`     | `agents_list`, `update_plan`                                                                                            |
+| `group:agents`     | `agents_list`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `skill_workshop`                                |
 | `group:media`      | `image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                                    |
 | `group:openclaw`   | All built-in tools (excludes provider plugins)                                                                          |
 | `group:plugins`    | Tools owned by loaded plugins, including configured MCP servers exposed through `bundle-mcp`                            |

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -98,7 +98,7 @@ Available groups:
 - `group:automation`: `heartbeat_respond`, `cron`, `gateway`
 - `group:messaging`: `message`
 - `group:nodes`: `nodes`
-- `group:agents`: `agents_list`, `update_plan`
+- `group:agents`: `agents_list`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `skill_workshop`
 - `group:media`: `image`, `image_generate`, `music_generate`, `video_generate`, `tts`
 - `group:openclaw`: all built-in OpenClaw tools (excludes provider plugins)
 - `group:plugins`: all loaded plugin-owned tools, including configured MCP servers exposed through `bundle-mcp`

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -53,6 +53,51 @@ Only `pending` proposals can be revised, applied, rejected, or quarantined.
 Ask the agent for the skill you want. The agent calls `skill_workshop` and
 returns a proposal id.
 
+Tool-profile note: `tools.profile: "coding"` already includes
+`skill_workshop`. If you use `minimal`, `messaging`, or another agent/provider
+profile that does not expose it, add `skill_workshop` at the profile stage:
+
+```json5
+{
+  tools: {
+    profile: "minimal",
+    alsoAllow: ["skill_workshop"],
+  },
+}
+```
+
+Use `alsoAllow: ["skill_workshop"]` to add only Skill Workshop to the selected
+restrictive profile. If a provider-specific profile filters tools, add the same
+entry in that provider scope:
+
+```json5
+{
+  tools: {
+    byProvider: {
+      openai: {
+        profile: "minimal",
+        alsoAllow: ["skill_workshop"],
+      },
+    },
+  },
+}
+```
+
+Sandboxed agent runs do not expose `skill_workshop`. If sandbox mode applies to
+the run, use a non-sandboxed run for chat-managed proposals, or use the CLI and
+Gateway methods below. Sandbox tool policy cannot re-add `skill_workshop`
+because the tool is not constructed for sandboxed runs.
+
+If you need an exact single-tool allowlist, remove the restrictive profile or
+set `profile: "full"`, then use `allow: ["skill_workshop"]`. `allow` cannot add
+a tool that an earlier profile already filtered out. If the same scope already
+uses `allow`, include `skill_workshop` in `allow` instead of setting
+`alsoAllow`, and make sure the profile in that scope is unset or includes
+`skill_workshop`. Then check later policy gates such as `tools.deny`,
+agent-specific tool policy, sandbox tool policy, and subagent tool policy. See
+[Tools and custom providers](/gateway/config-tools#tool-profiles) for the full
+profile and group list.
+
 Create:
 
 ```text
@@ -248,6 +293,15 @@ Default state directory: `~/.openclaw`.
   (default 50).
 
 ## Troubleshooting
+
+If `skill_workshop` is missing from agent tools, remember that
+`tools.profile: "coding"` should include it. Check restrictive
+`tools.allow`/`tools.deny`, provider, agent, sender, sandbox, and subagent
+policy. For `minimal`, `messaging`, or another restrictive profile, add
+`alsoAllow: ["skill_workshop"]` in the same scope that sets that profile, then
+start a fresh run. If that scope uses exact `allow`, remove or relax the
+restrictive profile because `allow` cannot widen it. If the run is sandboxed,
+use a non-sandboxed run, CLI, or Gateway method instead.
 
 | Problem                                        | Resolution                                                                                   |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Clarify that `skill_workshop` is already included in `tools.profile: "coding"`.
- Document the correct fixes for restrictive profiles, provider-scoped profiles, exact allowlists, and sandboxed runs.
- Update the tool profile/group reference so `coding`, `messaging`, and `group:agents` match the current tool catalog.

Fixes #87570.

## Real behavior proof

- Behavior addressed: Documents Skill Workshop tool visibility accurately for the current OpenClaw tool profile/policy pipeline, including coding profile availability, restrictive profiles, provider-scoped allowlists, and sandboxed runs.
- Real environment tested: Local OpenClaw source checkout on branch `codex/issue-87570` using the actual runtime modules from this patch.
- Exact steps or command run after this patch: Ran a Node console probe with `node --import tsx` importing `src/agents/tool-catalog.ts` and `src/agents/openclaw-tools.ts` to inspect the live tool profile and constructed tool lists.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Console output from the runtime probe:

```text
coding profile includes skill_workshop: true
minimal + alsoAllow includes skill_workshop: true
minimal + alsoAllow also keeps session_status: true
sandboxed coding includes skill_workshop: false
```

- Observed result after fix: The copied live output matches the docs: coding includes `skill_workshop`, `alsoAllow` adds it to a restrictive profile while preserving the profile's existing tools, and sandboxed runs do not expose `skill_workshop`.
- What was not tested: No docs preview server was started; docs checks and markdown lint were run as supplemental verification only.

## Verification

- `pnpm docs:list`
- `git diff --check`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `pnpm docs:check-i18n-glossary`
- `pnpm lint:docs`
- `node --import tsx` runtime probe against `src/agents/tool-catalog.ts` and `src/agents/openclaw-tools.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local ...` clean

## Known gaps

- `pnpm docs:check-links:anchors` is currently blocked by Mintlify `@mintlify/link-rot` failing to import `react` under this local environment. The added `/gateway/config-tools#tool-profiles` anchor was checked directly in `docs/gateway/config-tools.md`.