### PR TITLE
fix(plugins): guard synthetic auth metadata

### DIFF
--- a/src/plugins/synthetic-auth.runtime.test.ts
+++ b/src/plugins/synthetic-auth.runtime.test.ts
@@ -30,6 +30,22 @@ const pluginRegistryMocks = vi.hoisted(() => ({
   ),
 }));
 
+function poisonedSyntheticAuthPlugin(): { syntheticAuthRefs?: string[] } {
+  return Object.defineProperty({}, "syntheticAuthRefs", {
+    get() {
+      throw new Error("synthetic auth metadata exploded");
+    },
+  }) as { syntheticAuthRefs?: string[] };
+}
+
+function poisonedExternalAuthPlugin(): { contracts?: { externalAuthProviders?: string[] } } {
+  return Object.defineProperty({}, "contracts", {
+    get() {
+      throw new Error("external auth metadata exploded");
+    },
+  }) as { contracts?: { externalAuthProviders?: string[] } };
+}
+
 vi.mock("./runtime-state.js", () => ({
   getPluginRegistryState,
 }));
@@ -85,6 +101,25 @@ describe("synthetic auth runtime refs", () => {
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({});
   });
 
+  it("skips unreadable persisted synthetic auth plugin metadata", () => {
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: {
+        plugins: [
+          { syntheticAuthRefs: ["local-provider"] },
+          poisonedSyntheticAuthPlugin(),
+          { syntheticAuthRefs: ["remote-provider"] },
+        ],
+      },
+      diagnostics: [],
+    });
+
+    expect(resolveRuntimeSyntheticAuthProviderRefs()).toEqual([
+      "local-provider",
+      "remote-provider",
+    ]);
+  });
+
   it("loads manifest synthetic auth refs with the current runtime scope", () => {
     const config = { plugins: { allow: ["external-local"] } };
     const env = { OPENCLAW_HOME: "/tmp/openclaw-home" };
@@ -135,6 +170,24 @@ describe("synthetic auth runtime refs", () => {
     expect(pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledWith({
       index: snapshot,
     });
+  });
+
+  it("skips unreadable persisted external auth plugin metadata", () => {
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: { plugins: [] },
+      diagnostics: [],
+    });
+    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [
+        { contracts: { externalAuthProviders: ["runtime-provider"] } },
+        poisonedExternalAuthPlugin(),
+        { contracts: { externalAuthProviders: ["external-cli"] } },
+      ],
+      diagnostics: [],
+    });
+
+    expect(resolveRuntimeExternalAuthProviderRefs()).toEqual(["runtime-provider", "external-cli"]);
   });
 
   it("does not derive the registry just to resolve synthetic auth refs", () => {
@@ -247,6 +300,41 @@ describe("synthetic auth runtime refs", () => {
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
   });
 
+  it("skips unreadable active runtime synthetic auth plugin metadata", () => {
+    getPluginRegistryState.mockReturnValue({
+      activeRegistry: {
+        providers: [
+          {
+            provider: {
+              id: "runtime-provider",
+              resolveSyntheticAuth: () => undefined,
+            },
+          },
+        ],
+        cliBackends: [
+          {
+            backend: {
+              id: "runtime-cli",
+              resolveSyntheticAuth: () => undefined,
+            },
+          },
+        ],
+        plugins: [
+          { syntheticAuthRefs: ["manifest-provider"] },
+          poisonedSyntheticAuthPlugin(),
+          { syntheticAuthRefs: ["manifest-cli"] },
+        ],
+      },
+    });
+
+    expect(resolveRuntimeSyntheticAuthProviderRefs()).toEqual([
+      "manifest-provider",
+      "manifest-cli",
+      "runtime-provider",
+      "runtime-cli",
+    ]);
+  });
+
   it("prefers active runtime registry external auth refs when plugins are already loaded", () => {
     getPluginRegistryState.mockReturnValue({
       activeRegistry: {
@@ -282,5 +370,48 @@ describe("synthetic auth runtime refs", () => {
       "runtime-cli",
     ]);
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
+  });
+
+  it("skips unreadable active runtime external auth plugin metadata", () => {
+    getPluginRegistryState.mockReturnValue({
+      activeRegistry: {
+        plugins: [
+          {
+            contracts: {
+              externalAuthProviders: ["manifest-provider"],
+            },
+          },
+          poisonedExternalAuthPlugin(),
+          {
+            contracts: {
+              externalAuthProviders: ["manifest-cli"],
+            },
+          },
+        ],
+        providers: [
+          {
+            provider: {
+              id: "runtime-provider",
+              resolveExternalAuthProfiles: () => [],
+            },
+          },
+        ],
+        cliBackends: [
+          {
+            backend: {
+              id: "runtime-cli",
+              resolveExternalAuthProfiles: () => [],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(resolveRuntimeExternalAuthProviderRefs()).toEqual([
+      "manifest-provider",
+      "manifest-cli",
+      "runtime-provider",
+      "runtime-cli",
+    ]);
   });
 });

--- a/src/plugins/synthetic-auth.runtime.ts
+++ b/src/plugins/synthetic-auth.runtime.ts
@@ -19,6 +19,26 @@ function uniqueProviderRefs(values: readonly string[]): string[] {
   return next;
 }
 
+function readSyntheticAuthRefs(plugin: {
+  syntheticAuthRefs?: readonly string[];
+}): readonly string[] {
+  try {
+    return plugin.syntheticAuthRefs ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function readExternalAuthProviderRefs(plugin: {
+  contracts?: { externalAuthProviders?: readonly string[] };
+}): readonly string[] {
+  try {
+    return plugin.contracts?.externalAuthProviders ?? [];
+  } catch {
+    return [];
+  }
+}
+
 function resolveManifestSyntheticAuthProviderRefState(
   params: SyntheticAuthProviderRefParams = {},
 ): { refs: string[]; complete: boolean } {
@@ -30,9 +50,7 @@ function resolveManifestSyntheticAuthProviderRefState(
     return { refs: [], complete: false };
   }
   return {
-    refs: uniqueProviderRefs(
-      result.snapshot.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
-    ),
+    refs: uniqueProviderRefs(result.snapshot.plugins.flatMap(readSyntheticAuthRefs)),
     complete: true,
   };
 }
@@ -55,9 +73,7 @@ function resolveManifestExternalAuthProviderRefs(
   const manifestRegistry = loadPluginManifestRegistryForInstalledIndex({
     index: result.snapshot,
   });
-  return uniqueProviderRefs(
-    manifestRegistry.plugins.flatMap((plugin) => plugin.contracts?.externalAuthProviders ?? []),
-  );
+  return uniqueProviderRefs(manifestRegistry.plugins.flatMap(readExternalAuthProviderRefs));
 }
 
 export function resolveRuntimeSyntheticAuthProviderRefs(
@@ -73,7 +89,7 @@ export function resolveRuntimeSyntheticAuthProviderRefState(
   if (registry) {
     return {
       refs: uniqueProviderRefs([
-        ...registry.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
+        ...registry.plugins.flatMap(readSyntheticAuthRefs),
         ...(registry.providers ?? [])
           .filter(
             (entry) =>
@@ -101,7 +117,7 @@ export function resolveRuntimeExternalAuthProviderRefs(
   const registry = getPluginRegistryState()?.activeRegistry;
   if (registry) {
     return uniqueProviderRefs([
-      ...registry.plugins.flatMap((plugin) => plugin.contracts?.externalAuthProviders ?? []),
+      ...registry.plugins.flatMap(readExternalAuthProviderRefs),
       ...(registry.providers ?? [])
         .filter(
           (entry) =>


### PR DESCRIPTION
## Summary

- Skip unreadable plugin metadata rows when resolving synthetic auth provider refs.
- Apply the same guard to `contracts.externalAuthProviders` resolution for persisted manifest metadata and the active runtime registry.
- Add regression coverage for persisted and active runtime paths so one poisoned plugin row cannot hide healthy auth providers.

## Verification

- `node scripts/run-vitest.mjs src/plugins/synthetic-auth.runtime.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/synthetic-auth.runtime.ts src/plugins/synthetic-auth.runtime.test.ts`
- `./node_modules/.bin/oxlint src/plugins/synthetic-auth.runtime.ts src/plugins/synthetic-auth.runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, overall patch is correct (0.84)
- `.agents/skills/autoreview/scripts/autoreview --mode branch` — clean, overall patch is correct (0.86)

## Real behavior proof

Behavior addressed: resolving synthetic/external auth provider refs no longer aborts when one plugin metadata row throws while reading `syntheticAuthRefs` or `contracts.externalAuthProviders`.

Real environment tested: focused local plugin Vitest lane in the sparse OpenClaw worktree; local formatter/linter/diff checks.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/synthetic-auth.runtime.test.ts` plus the formatter, linter, diff check, and autoreview commands listed above.

Evidence after fix: the focused Vitest file passes 13 tests, including four regression cases for poisoned persisted and active runtime metadata.

Observed result after fix: healthy synthetic/external auth provider refs are still returned while the unreadable plugin metadata row is skipped.

What was not tested: broad `pnpm check:changed` did not run because the Crabbox coordinator returned HTTP 401 before lease creation; Blacksmith Testbox is also unauthenticated in this environment.
