### PR TITLE
fix: redact media urls in plugin logs

### DIFF
--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -115,6 +115,7 @@ describe("canvas host", () => {
     log: (..._args: Parameters<typeof console.log>) => {},
   };
   let createCanvasHostHandler: typeof import("./server.js").createCanvasHostHandler;
+  let escapeCanvasHostHtmlText: typeof import("./server.js").escapeCanvasHostHtmlText;
   let startCanvasHost: typeof import("./server.js").startCanvasHost;
   let WebSocketServerClass: typeof import("ws").WebSocketServer;
   let watcherState: ReturnType<typeof createMockWatcherState>;
@@ -158,7 +159,8 @@ describe("canvas host", () => {
       };
     });
     vi.resetModules();
-    ({ createCanvasHostHandler, startCanvasHost } = await import("./server.js"));
+    ({ createCanvasHostHandler, escapeCanvasHostHtmlText, startCanvasHost } =
+      await import("./server.js"));
     const wsModule = await vi.importActual<typeof import("ws")>("ws");
     WebSocketServerClass = wsModule.WebSocketServer;
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-fixtures-"));
@@ -194,6 +196,22 @@ describe("canvas host", () => {
       expect(response.body).toContain(CANVAS_WS_PATH);
       expect(response.body).toContain('document.createElement("span")');
       expect(response.body).not.toContain("statusEl.innerHTML");
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("escapes the canvas root in missing directory HTML", async () => {
+    expect(escapeCanvasHostHtmlText('<root>&"')).toBe("&lt;root&gt;&amp;&quot;");
+    const dir = path.join(fixtureRoot, `case-${fixtureCount++}&unsafe`);
+    await fs.mkdir(path.join(dir, "missing"), { recursive: true });
+    const handler = await createTestCanvasHostHandler(dir);
+
+    try {
+      const response = await captureHandlerResponse(handler, `${CANVAS_HOST_PATH}/missing/`);
+      expect(response.status).toBe(404);
+      expect(response.body).toContain(`${escapeCanvasHostHtmlText(dir)}/index.html`);
+      expect(response.body).not.toContain(`${dir}/index.html`);
     } finally {
       await handler.close();
     }
@@ -388,6 +406,7 @@ describe("canvas host", () => {
     const linkName = `test-link-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
     const linkPath = path.join(a2uiRoot, linkName);
     let createdBundle = false;
+    let createdSymlink = false;
 
     try {
       await fs.stat(bundlePath);
@@ -396,7 +415,14 @@ describe("canvas host", () => {
       createdBundle = true;
     }
 
-    await fs.symlink(path.join(process.cwd(), "package.json"), linkPath);
+    try {
+      await fs.symlink(path.join(process.cwd(), "package.json"), linkPath);
+      createdSymlink = true;
+    } catch (error) {
+      if (process.platform !== "win32") {
+        throw error;
+      }
+    }
 
     try {
       const res = await captureA2uiResponse(`${A2UI_PATH}/`);
@@ -415,9 +441,11 @@ describe("canvas host", () => {
       const malformedRes = await captureA2uiResponse(`${A2UI_PATH}/%E0%A4%A`);
       expect(malformedRes.status).toBe(404);
       expect(malformedRes.body).toBe("not found");
-      const symlinkRes = await captureA2uiResponse(`${A2UI_PATH}/${linkName}`);
-      expect(symlinkRes.status).toBe(404);
-      expect(symlinkRes.body).toBe("not found");
+      if (createdSymlink) {
+        const symlinkRes = await captureA2uiResponse(`${A2UI_PATH}/${linkName}`);
+        expect(symlinkRes.status).toBe(404);
+        expect(symlinkRes.body).toBe("not found");
+      }
     } finally {
       await fs.rm(linkPath, { force: true });
       if (createdBundle) {

--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -69,6 +69,14 @@ export type CanvasHostHandler = {
   close: () => Promise<void>;
 };
 
+export function escapeCanvasHostHtmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
 function defaultIndexHTML() {
   return `<!doctype html>
 <meta charset="utf-8" />
@@ -380,7 +388,7 @@ export async function createCanvasHostHandler(
           res.statusCode = 404;
           res.setHeader("Content-Type", "text/html; charset=utf-8");
           res.end(
-            `<!doctype html><meta charset="utf-8" /><title>OpenClaw Canvas</title><pre>Missing file.\nCreate ${rootDir}/index.html</pre>`,
+            `<!doctype html><meta charset="utf-8" /><title>OpenClaw Canvas</title><pre>Missing file.\nCreate ${escapeCanvasHostHtmlText(rootDir)}/index.html</pre>`,
           );
           return true;
         }

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -391,24 +391,35 @@ describe("feishu_doc image fetch hardening", () => {
 
   it("skips image upload when markdown image URL is blocked", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    readRemoteMediaBufferMock.mockRejectedValueOnce(
-      new Error("Blocked: resolves to private/internal IP address"),
-    );
+    try {
+      readRemoteMediaBufferMock.mockRejectedValueOnce(
+        new Error(
+          "Blocked https://user:pass@x.test/image.png?token=download-token&safe=value#frag: resolves to private/internal IP address",
+        ),
+      );
 
-    const feishuDocTool = resolveFeishuDocTool();
+      const feishuDocTool = resolveFeishuDocTool();
 
-    const result = await executeFeishuDocTool(feishuDocTool, {
-      action: "write",
-      doc_token: "doc_1",
-      content: "![x](https://x.test/image.png)",
-    });
+      const result = await executeFeishuDocTool(feishuDocTool, {
+        action: "write",
+        doc_token: "doc_1",
+        content: "![x](https://user:pass@x.test/image.png?token=download-token&safe=value#frag)",
+      });
 
-    expect(readRemoteMediaBufferMock).toHaveBeenCalled();
-    expect(driveUploadAllMock).not.toHaveBeenCalled();
-    expect(blockPatchMock).not.toHaveBeenCalled();
-    expect(result.details.images_processed).toBe(0);
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
+      expect(readRemoteMediaBufferMock).toHaveBeenCalled();
+      expect(driveUploadAllMock).not.toHaveBeenCalled();
+      expect(blockPatchMock).not.toHaveBeenCalled();
+      expect(result.details.images_processed).toBe(0);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://x.test/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("create grants permission only to trusted Feishu requester", async () => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -27,6 +27,7 @@ import {
   resolveAnyEnabledFeishuToolsConfig,
   resolveFeishuToolAccount,
 } from "./tool-account.js";
+import { redactTextForLog, redactUrlForLog } from "./url-redaction.js";
 
 // ============ Helpers ============
 
@@ -695,7 +696,9 @@ async function processImages(
 
       processed++;
     } catch (err) {
-      console.error(`Failed to process image ${url}:`, err);
+      console.error(
+        `Failed to process image ${redactUrlForLog(url)}: ${redactTextForLog(formatErrorMessage(err))}`,
+      );
     }
   }
 

--- a/extensions/feishu/src/url-redaction.ts
+++ b/extensions/feishu/src/url-redaction.ts
@@ -1,0 +1,35 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return value;
+  }
+}

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
@@ -72,6 +72,33 @@ describe("engine/gateway/inbound-attachments", () => {
     expect(result.attachmentLocalPaths).toEqual([null]);
   });
 
+  it("redacts failed attachment URLs in logs", async () => {
+    downloadFileMock.mockResolvedValue(null);
+    const log = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    await processAttachments(
+      [
+        {
+          content_type: "image/png",
+          url: "https://user:pass@cdn.example.test/a.png?token=download-token&safe=value#frag",
+          filename: "a.png",
+        },
+      ],
+      { accountId: "qq", cfg: {}, audioConvert, log },
+    );
+
+    expect(log.error).toHaveBeenCalledWith("Failed to download: https://cdn.example.test/a.png");
+    const logged = log.error.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+  });
+
   it("prefers voice_wav_url for voice downloads and transcribes with configured STT", async () => {
     downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/voice.wav");
     resolveSTTConfigMock.mockReturnValue({

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
@@ -3,6 +3,7 @@ import { downloadFile } from "../utils/file-utils.js";
 import { getQQBotMediaDir } from "../utils/platform.js";
 import { normalizeOptionalString } from "../utils/string-normalize.js";
 import { transcribeAudio, resolveSTTConfig } from "../utils/stt.js";
+import { redactUrlForLog } from "../utils/url-redaction.js";
 
 // Re-export the port type for convenience.
 export type { AudioConvertPort } from "../adapter/audio.port.js";
@@ -147,7 +148,7 @@ export async function processAttachments(
         log?.debug?.(`Downloaded attachment to: ${localPath}`);
         return { localPath, type: "other" as const, filename: att.filename, meta };
       }
-      log?.error(`Failed to download: ${attUrl}`);
+      log?.error(`Failed to download: ${redactUrlForLog(attUrl)}`);
       if (att.content_type?.startsWith("image/")) {
         return {
           localPath: null,

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -28,6 +28,7 @@ import {
   resolveQQBotPayloadLocalFilePath,
 } from "../utils/platform.js";
 import { normalizeLowercaseStringOrEmpty, sanitizeFileName } from "../utils/string-normalize.js";
+import { redactUrlForLog } from "../utils/url-redaction.js";
 import { audioFileToSilkBase64, shouldTranscodeVoice, waitForFile } from "./outbound-audio-port.js";
 import {
   buildDailyLimitExceededResult,
@@ -191,7 +192,10 @@ export async function sendPhoto(
     if (localFile) {
       return await sendPhotoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download image: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download image: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   if (isLocal) {
@@ -345,7 +349,10 @@ export async function sendVoice(
     if (localFile) {
       return await sendVoiceFromLocal(ctx, localFile, directUploadFormats, transcodeEnabled);
     }
-    return { channel: "qqbot", error: `Failed to download audio: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download audio: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   return await sendVoiceFromLocal(ctx, mediaPath, directUploadFormats, transcodeEnabled);
@@ -444,7 +451,10 @@ export async function sendVideoMsg(
     if (localFile) {
       return await sendVideoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download video: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download video: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   try {
@@ -551,7 +561,10 @@ export async function sendDocument(
     if (localFile) {
       return await sendDocumentFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download file: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download file: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   try {
@@ -646,7 +659,7 @@ async function downloadToFallbackDir(httpUrl: string, caller: string): Promise<s
     const downloadDir = getQQBotMediaDir("downloads", "url-fallback");
     const localFile = await downloadFile(httpUrl, downloadDir);
     if (!localFile) {
-      debugError(`${caller} fallback: download also failed for ${httpUrl.slice(0, 80)}`);
+      debugError(`${caller} fallback: download also failed for ${redactUrlForLog(httpUrl, 80)}`);
       return null;
     }
     debugLog(`${caller} fallback: downloaded → ${localFile}`);

--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -96,6 +96,33 @@ describe("qqbot file-utils downloadFile", () => {
     expect(adapterMocks.fetchMedia).not.toHaveBeenCalled();
   });
 
+  it("redacts URL credentials and query params before logging download failures", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      adapterMocks.fetchMedia.mockRejectedValueOnce(
+        new Error(
+          "fetch failed for https://user:pass@media.qq.com/assets/photo.png?token=download-token#frag",
+        ),
+      );
+
+      const savedPath = await downloadFile(
+        "https://user:pass@media.qq.com/assets/photo.png?token=download-token&safe=value#frag",
+        tempDir,
+        "photo.png",
+      );
+
+      expect(savedPath).toBeNull();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://media.qq.com/assets/photo.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it.skipIf(process.platform === "win32")("rejects symlinked local media helpers", async () => {
     const targetPath = path.join(tempDir, "target.png");
     const linkPath = path.join(tempDir, "link.png");

--- a/extensions/qqbot/src/engine/utils/file-utils.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.ts
@@ -12,6 +12,7 @@ import type { SsrfPolicyConfig } from "../adapter/types.js";
 import { MediaFileType } from "../types.js";
 import { formatErrorMessage } from "./format.js";
 import { normalizeOptionalString } from "./string-normalize.js";
+import { redactTextForLog, redactUrlForLog } from "./url-redaction.js";
 
 /** Maximum file size accepted by the QQ Bot one-shot upload API (base64 direct). */
 export const MAX_UPLOAD_SIZE = 20 * 1024 * 1024;
@@ -202,13 +203,17 @@ export async function downloadFile(
     return destPath;
   } catch (err) {
     console.error(
-      `[qqbot:downloadFile] FAILED url=${url.slice(0, 120)} error=${err instanceof Error ? err.message : String(err)}`,
+      `[qqbot:downloadFile] FAILED url=${redactUrlForLog(url, 120)} error=${redactTextForLog(formatErrorMessage(err))}`,
     );
     if (err instanceof Error && err.stack) {
-      console.error(`[qqbot:downloadFile] stack=${err.stack.split("\n").slice(0, 3).join(" | ")}`);
+      console.error(
+        `[qqbot:downloadFile] stack=${redactTextForLog(err.stack.split("\n").slice(0, 3).join(" | "))}`,
+      );
     }
     if (err instanceof Error && err.cause) {
-      console.error(`[qqbot:downloadFile] cause=${formatErrorMessage(err.cause)}`);
+      console.error(
+        `[qqbot:downloadFile] cause=${redactTextForLog(formatErrorMessage(err.cause))}`,
+      );
     }
     return null;
   }

--- a/extensions/qqbot/src/engine/utils/url-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/url-redaction.ts
@@ -1,0 +1,39 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string, maxLength?: number): string {
+  const redacted = redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+  if (maxLength === undefined || redacted.length <= maxLength) {
+    return redacted;
+  }
+  return `${redacted.slice(0, maxLength)}...`;
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return value;
+  }
+}

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -77,4 +77,41 @@ describe("tlon monitor media", () => {
     expect(result).toBeNull();
     expect(readRemoteMediaBufferMock).not.toHaveBeenCalled();
   });
+
+  it("redacts media URL secrets in rejection and download error logs", async () => {
+    await expect(
+      downloadMedia("ftp://user:pass@example.com/photo.png?token=download-token&safe=value#frag"),
+    ).resolves.toBeNull();
+
+    let logged = vi
+      .mocked(console.warn)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("ftp://example.com/photo.png");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+
+    vi.mocked(console.warn).mockClear();
+    saveRemoteMediaMock.mockRejectedValueOnce(
+      new Error(
+        "fetch failed for https://user:pass@example.com/photo.png?token=download-token&safe=value#frag",
+      ),
+    );
+
+    await expect(
+      downloadMedia("https://user:pass@example.com/photo.png?token=download-token&safe=value#frag"),
+    ).resolves.toBeNull();
+
+    logged = vi
+      .mocked(console.error)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("https://example.com/photo.png");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+  });
 });

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getDefaultSsrFPolicy } from "../urbit/context.js";
+import { redactTextForLog, redactUrlForLog } from "../url-redaction.js";
 
 const MAX_IMAGES_PER_MESSAGE = 8;
 const TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
@@ -63,7 +64,7 @@ export async function downloadMedia(
     // Validate URL is http/https before fetching
     const parsedUrl = new URL(url);
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-      console.warn(`[tlon-media] Rejected non-http(s) URL: ${url}`);
+      console.warn(`[tlon-media] Rejected non-http(s) URL: ${redactUrlForLog(url)}`);
       return null;
     }
 
@@ -100,7 +101,9 @@ export async function downloadMedia(
       originalUrl: url,
     };
   } catch (error: unknown) {
-    console.error(`[tlon-media] Error downloading ${url}: ${formatErrorMessage(error)}`);
+    console.error(
+      `[tlon-media] Error downloading ${redactUrlForLog(url)}: ${redactTextForLog(formatErrorMessage(error))}`,
+    );
     return null;
   }
 }

--- a/extensions/tlon/src/urbit/upload.test.ts
+++ b/extensions/tlon/src/urbit/upload.test.ts
@@ -99,6 +99,44 @@ describe("uploadImageFromUrl", () => {
     expect(result).toBe("https://example.com/image.png");
   });
 
+  it("redacts source URL secrets before logging rejected or failed fetches", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const rejected = await uploadImageFromUrl(
+        "ftp://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+      expect(rejected).toBe(
+        "ftp://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+
+      mockFetch.mockResolvedValueOnce({
+        response: {
+          ok: false,
+          status: 404,
+        } as unknown as Response,
+        finalUrl: "https://example.com/image.png",
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const failed = await uploadImageFromUrl(
+        "https://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+      expect(failed).toBe(
+        "https://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+
+      const logged = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("ftp://example.com/image.png");
+      expect(logged).toContain("https://example.com/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("returns original URL if upload fails", async () => {
     await setupSuccessfulUpload();
     mockUploadFile.mockRejectedValue(new Error("Upload failed"));

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -3,6 +3,7 @@
  */
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { uploadFile } from "../tlon-api.js";
+import { redactTextForLog, redactUrlForLog } from "../url-redaction.js";
 import { getDefaultSsrFPolicy } from "./context.js";
 
 /**
@@ -16,7 +17,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
     // Validate URL is http/https before fetching
     const url = new URL(imageUrl);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
-      console.warn(`[tlon] Rejected non-http(s) URL: ${imageUrl}`);
+      console.warn(`[tlon] Rejected non-http(s) URL: ${redactUrlForLog(imageUrl)}`);
       return imageUrl;
     }
 
@@ -31,7 +32,9 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
 
     try {
       if (!response.ok) {
-        console.warn(`[tlon] Failed to fetch image from ${imageUrl}: ${response.status}`);
+        console.warn(
+          `[tlon] Failed to fetch image from ${redactUrlForLog(imageUrl)}: ${response.status}`,
+        );
         return imageUrl;
       }
 
@@ -54,7 +57,9 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
       await release();
     }
   } catch (err) {
-    console.warn(`[tlon] Failed to upload image, using original URL: ${String(err)}`);
+    console.warn(
+      `[tlon] Failed to upload image, using original URL: ${redactTextForLog(String(err))}`,
+    );
     return imageUrl;
   }
 }

--- a/extensions/tlon/src/url-redaction.ts
+++ b/extensions/tlon/src/url-redaction.ts
@@ -1,0 +1,35 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary

  What problem does this PR solve?

  - Prevents credential-bearing and signed media URLs from being written raw in QQBot, Tlon, and Feishu media failure
  logs.
  - Prevents QQBot URL download fallback errors from surfacing raw signed URLs in user-visible error strings.
  - Escapes the Canvas host missing-file root path before rendering it into HTML.

  Why does this matter now?

  - Media URLs often carry short-lived tokens, signatures, or embedded credentials. Logging them raw can leak access
  material into local logs or diagnostics.

  What is the intended outcome?

  - Logs and fallback error text keep useful host/path context while stripping URL userinfo, query strings, and
  fragments.
  - Canvas missing-file HTML treats the root path as text, not markup.

  What is intentionally out of scope?

  - No config changes, migrations, or runtime behavior changes to media fetching/uploading.
  - No full live channel integration proof.

  What does success look like?

  - A failed media download can be diagnosed without exposing `user:pass`, token query values, or URL fragments.
  - The Canvas missing-file page cannot inject markup from the configured root path.

  What should reviewers focus on?

  - Whether the redaction boundary is applied at every touched log/user-visible error site.
  - Whether plugin-local helpers are appropriate for this scoped fix without expanding public SDK surface.
  - Whether the Canvas escaping is sufficient for text inside the 404 HTML response.

  ## Linked context

  Which issue does this close?

  None.

  Which issues, PRs, or discussions are related?

  None.

  Was this requested by a maintainer or owner?

  No. This came from a local code audit.

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: signed media URLs and credential-bearing URLs are no longer written raw in affected
  plugin logs or QQBot fallback error strings; Canvas no longer injects an unescaped root path into missing-file HTML.
  - Real environment tested: local Windows checkout, Node 24.15.0.
 Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs extensions/qqbot/src/engine/utils/file-utils.test.ts extensions/qqbot/src/engine/gateway/
  inbound-attachments.test.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.test.ts
  extensions/feishu/src/docx.test.ts extensions/canvas/src/host/server.test.ts

  - Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact,
  or copied live output): targeted Vitest output reported `passed 3 Vitest shards`; tests assert `user:pass`, `download-
  token`, query values, and fragments are absent from QQBot, Tlon, and Feishu failure logs. Canvas test asserts escaped
  root text in the HTML response.
  - Observed result after fix: all focused tests passed; targeted oxlint passed; `git diff --check` passed; structured
  autoreview reported no accepted/actionable findings.
  - What was not tested: full repository CI and live channel integrations.
  - Proof limitations or environment constraints: proof is local and focused on log/error redaction behavior; no real
  QQBot, Tlon, Feishu, or Canvas browser session was run.
  - Before evidence (optional but encouraged): the touched call sites previously interpolated raw URL strings such as
  `attUrl`, `url`, `imageUrl`, or `mediaPath.slice(...)` directly into logs or fallback errors.

  ## Tests and validation

  ```markdown
  Which commands did you run?

  ```bash
  node scripts/run-vitest.mjs extensions/qqbot/src/engine/utils/file-utils.test.ts extensions/qqbot/src/engine/gateway/
  inbound-attachments.test.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.test.ts
  extensions/feishu/src/docx.test.ts extensions/canvas/src/host/server.test.ts
  node_modules\.bin\oxlint.CMD <touched files>
  git diff --check
  python .agents\skills\autoreview\scripts\autoreview --mode local

  What regression coverage was added or updated?

  - QQBot tests now assert failed attachment/download logs redact URL userinfo, query values, and fragments.
  - Tlon monitor/upload tests now assert rejected and failed media URL logs are redacted.
  - Feishu docx image hardening test now asserts blocked image URL logs are redacted.
  - Canvas host test now asserts root-path HTML escaping.

  What failed before this fix, if known?

  - The audited call sites logged or returned raw URL strings directly.

  If no test was added, why not?

  - Tests were added for the touched behavior.

  ## Risk checklist

  Did user-visible behavior change? (`Yes/No`)

  Yes. QQBot fallback error strings now show redacted URL context instead of raw signed URLs.

  Did config, environment, or migration behavior change? (`Yes/No`)

  No.

  Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

  Yes. This changes secret-bearing URL handling in logs and fallback errors.

  What is the highest-risk area?

  - Over-redacting diagnostic URL details or missing a touched error path that still logs raw URL text.

  How is that risk mitigated?

  - Redaction preserves scheme/host/path for diagnostics while stripping userinfo, query, and fragments.
  - Focused tests cover each touched plugin path and Canvas HTML escaping.
  - Structured autoreview found no accepted/actionable findings.

  ## Current review state

  What is the next action?

  - Maintainer review and CI.

  What is still waiting on author, maintainer, CI, or external proof?

  - CI and any maintainer-requested live/channel proof.

  Which bot or reviewer comments were addressed?

  - None yet.