### PR TITLE
fix: redact media urls in plugin logs

### DIFF
--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -115,6 +115,7 @@ describe("canvas host", () => {
     log: (..._args: Parameters<typeof console.log>) => {},
   };
   let createCanvasHostHandler: typeof import("./server.js").createCanvasHostHandler;
+  let escapeCanvasHostHtmlText: typeof import("./server.js").escapeCanvasHostHtmlText;
   let startCanvasHost: typeof import("./server.js").startCanvasHost;
   let WebSocketServerClass: typeof import("ws").WebSocketServer;
   let watcherState: ReturnType<typeof createMockWatcherState>;
@@ -158,7 +159,8 @@ describe("canvas host", () => {
       };
     });
     vi.resetModules();
-    ({ createCanvasHostHandler, startCanvasHost } = await import("./server.js"));
+    ({ createCanvasHostHandler, escapeCanvasHostHtmlText, startCanvasHost } =
+      await import("./server.js"));
     const wsModule = await vi.importActual<typeof import("ws")>("ws");
     WebSocketServerClass = wsModule.WebSocketServer;
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-fixtures-"));
@@ -194,6 +196,22 @@ describe("canvas host", () => {
       expect(response.body).toContain(CANVAS_WS_PATH);
       expect(response.body).toContain('document.createElement("span")');
       expect(response.body).not.toContain("statusEl.innerHTML");
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("escapes the canvas root in missing directory HTML", async () => {
+    expect(escapeCanvasHostHtmlText('<root>&"')).toBe("&lt;root&gt;&amp;&quot;");
+    const dir = path.join(fixtureRoot, `case-${fixtureCount++}&unsafe`);
+    await fs.mkdir(path.join(dir, "missing"), { recursive: true });
+    const handler = await createTestCanvasHostHandler(dir);
+
+    try {
+      const response = await captureHandlerResponse(handler, `${CANVAS_HOST_PATH}/missing/`);
+      expect(response.status).toBe(404);
+      expect(response.body).toContain(`${escapeCanvasHostHtmlText(dir)}/index.html`);
+      expect(response.body).not.toContain(`${dir}/index.html`);
     } finally {
       await handler.close();
     }
@@ -388,6 +406,7 @@ describe("canvas host", () => {
     const linkName = `test-link-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
     const linkPath = path.join(a2uiRoot, linkName);
     let createdBundle = false;
+    let createdSymlink = false;
 
     try {
       await fs.stat(bundlePath);
@@ -396,7 +415,14 @@ describe("canvas host", () => {
       createdBundle = true;
     }
 
-    await fs.symlink(path.join(process.cwd(), "package.json"), linkPath);
+    try {
+      await fs.symlink(path.join(process.cwd(), "package.json"), linkPath);
+      createdSymlink = true;
+    } catch (error) {
+      if (process.platform !== "win32") {
+        throw error;
+      }
+    }
 
     try {
       const res = await captureA2uiResponse(`${A2UI_PATH}/`);
@@ -415,9 +441,11 @@ describe("canvas host", () => {
       const malformedRes = await captureA2uiResponse(`${A2UI_PATH}/%E0%A4%A`);
       expect(malformedRes.status).toBe(404);
       expect(malformedRes.body).toBe("not found");
-      const symlinkRes = await captureA2uiResponse(`${A2UI_PATH}/${linkName}`);
-      expect(symlinkRes.status).toBe(404);
-      expect(symlinkRes.body).toBe("not found");
+      if (createdSymlink) {
+        const symlinkRes = await captureA2uiResponse(`${A2UI_PATH}/${linkName}`);
+        expect(symlinkRes.status).toBe(404);
+        expect(symlinkRes.body).toBe("not found");
+      }
     } finally {
       await fs.rm(linkPath, { force: true });
       if (createdBundle) {

--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -69,6 +69,14 @@ export type CanvasHostHandler = {
   close: () => Promise<void>;
 };
 
+export function escapeCanvasHostHtmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
 function defaultIndexHTML() {
   return `<!doctype html>
 <meta charset="utf-8" />
@@ -380,7 +388,7 @@ export async function createCanvasHostHandler(
           res.statusCode = 404;
           res.setHeader("Content-Type", "text/html; charset=utf-8");
           res.end(
-            `<!doctype html><meta charset="utf-8" /><title>OpenClaw Canvas</title><pre>Missing file.\nCreate ${rootDir}/index.html</pre>`,
+            `<!doctype html><meta charset="utf-8" /><title>OpenClaw Canvas</title><pre>Missing file.\nCreate ${escapeCanvasHostHtmlText(rootDir)}/index.html</pre>`,
           );
           return true;
         }

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -391,24 +391,68 @@ describe("feishu_doc image fetch hardening", () => {
 
   it("skips image upload when markdown image URL is blocked", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    readRemoteMediaBufferMock.mockRejectedValueOnce(
-      new Error("Blocked: resolves to private/internal IP address"),
-    );
+    try {
+      readRemoteMediaBufferMock.mockRejectedValueOnce(
+        new Error(
+          "Blocked https://user:pass@x.test/image.png?token=download-token&safe=value#frag: resolves to private/internal IP address",
+        ),
+      );
 
-    const feishuDocTool = resolveFeishuDocTool();
+      const feishuDocTool = resolveFeishuDocTool();
 
-    const result = await executeFeishuDocTool(feishuDocTool, {
-      action: "write",
-      doc_token: "doc_1",
-      content: "![x](https://x.test/image.png)",
-    });
+      const result = await executeFeishuDocTool(feishuDocTool, {
+        action: "write",
+        doc_token: "doc_1",
+        content: "![x](https://user:pass@x.test/image.png?token=download-token&safe=value#frag)",
+      });
 
-    expect(readRemoteMediaBufferMock).toHaveBeenCalled();
-    expect(driveUploadAllMock).not.toHaveBeenCalled();
-    expect(blockPatchMock).not.toHaveBeenCalled();
-    expect(result.details.images_processed).toBe(0);
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
+      expect(readRemoteMediaBufferMock).toHaveBeenCalled();
+      expect(driveUploadAllMock).not.toHaveBeenCalled();
+      expect(blockPatchMock).not.toHaveBeenCalled();
+      expect(result.details.images_processed).toBe(0);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://x.test/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("redacts malformed URL-like secrets when markdown image upload fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      readRemoteMediaBufferMock.mockRejectedValueOnce(
+        new Error(
+          "Blocked https://user:pass@%zz/image.png?token=download-token&safe=value#frag: invalid URL",
+        ),
+      );
+
+      const feishuDocTool = resolveFeishuDocTool();
+
+      const result = await executeFeishuDocTool(feishuDocTool, {
+        action: "write",
+        doc_token: "doc_1",
+        content: "![x](https://example.com/image.png)",
+      });
+
+      expect(readRemoteMediaBufferMock).toHaveBeenCalled();
+      expect(driveUploadAllMock).not.toHaveBeenCalled();
+      expect(blockPatchMock).not.toHaveBeenCalled();
+      expect(result.details.images_processed).toBe(0);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://%zz/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("create grants permission only to trusted Feishu requester", async () => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -27,6 +27,7 @@ import {
   resolveAnyEnabledFeishuToolsConfig,
   resolveFeishuToolAccount,
 } from "./tool-account.js";
+import { redactTextForLog, redactUrlForLog } from "./url-redaction.js";
 
 // ============ Helpers ============
 
@@ -695,7 +696,9 @@ async function processImages(
 
       processed++;
     } catch (err) {
-      console.error(`Failed to process image ${url}:`, err);
+      console.error(
+        `Failed to process image ${redactUrlForLog(url)}: ${redactTextForLog(formatErrorMessage(err))}`,
+      );
     }
   }
 

--- a/extensions/feishu/src/url-redaction.ts
+++ b/extensions/feishu/src/url-redaction.ts
@@ -1,0 +1,42 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return stripMalformedUrlSecrets(value);
+  }
+}
+
+function stripMalformedUrlSecrets(value: string): string {
+  return value
+    .replace(/#.*$/su, "")
+    .replace(/\?.*$/su, "")
+    .replace(/^((?:[a-z][a-z\d+.-]*:)?\/\/)[^/@\s"'<>]*@/iu, "$1");
+}

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
@@ -72,6 +72,33 @@ describe("engine/gateway/inbound-attachments", () => {
     expect(result.attachmentLocalPaths).toEqual([null]);
   });
 
+  it("redacts failed attachment URLs in logs", async () => {
+    downloadFileMock.mockResolvedValue(null);
+    const log = {
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    await processAttachments(
+      [
+        {
+          content_type: "image/png",
+          url: "https://user:pass@cdn.example.test/a.png?token=download-token&safe=value#frag",
+          filename: "a.png",
+        },
+      ],
+      { accountId: "qq", cfg: {}, audioConvert, log },
+    );
+
+    expect(log.error).toHaveBeenCalledWith("Failed to download: https://cdn.example.test/a.png");
+    const logged = log.error.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+  });
+
   it("prefers voice_wav_url for voice downloads and transcribes with configured STT", async () => {
     downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/voice.wav");
     resolveSTTConfigMock.mockReturnValue({

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
@@ -3,6 +3,7 @@ import { downloadFile } from "../utils/file-utils.js";
 import { getQQBotMediaDir } from "../utils/platform.js";
 import { normalizeOptionalString } from "../utils/string-normalize.js";
 import { transcribeAudio, resolveSTTConfig } from "../utils/stt.js";
+import { redactUrlForLog } from "../utils/url-redaction.js";
 
 // Re-export the port type for convenience.
 export type { AudioConvertPort } from "../adapter/audio.port.js";
@@ -147,7 +148,7 @@ export async function processAttachments(
         log?.debug?.(`Downloaded attachment to: ${localPath}`);
         return { localPath, type: "other" as const, filename: att.filename, meta };
       }
-      log?.error(`Failed to download: ${attUrl}`);
+      log?.error(`Failed to download: ${redactUrlForLog(attUrl)}`);
       if (att.content_type?.startsWith("image/")) {
         return {
           localPath: null,

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MediaTargetContext } from "./outbound-types.js";
+
+const fileUtilsMocks = vi.hoisted(() => ({
+  downloadFile: vi.fn(),
+}));
+
+const logMocks = vi.hoisted(() => ({
+  debugError: vi.fn(),
+  debugLog: vi.fn(),
+  debugWarn: vi.fn(),
+}));
+
+const senderMocks = vi.hoisted(() => ({
+  sendMedia: vi.fn(),
+  sendText: vi.fn(),
+}));
+
+vi.mock("../utils/file-utils.js", () => ({
+  checkFileSize: () => ({ ok: true, size: 1 }),
+  downloadFile: fileUtilsMocks.downloadFile,
+  fileExistsAsync: vi.fn(async () => true),
+  formatFileSize: (size: number) => `${size} bytes`,
+  getImageMimeType: () => "image/png",
+  getMaxUploadSize: () => Number.MAX_SAFE_INTEGER,
+  readFileAsync: vi.fn(async () => Buffer.from("media")),
+}));
+
+vi.mock("../utils/log.js", () => ({
+  debugError: logMocks.debugError,
+  debugLog: logMocks.debugLog,
+  debugWarn: logMocks.debugWarn,
+}));
+
+vi.mock("../utils/platform.js", () => ({
+  getQQBotDataDir: (...parts: string[]) => ["qqbot-data", ...parts].join("/"),
+  getQQBotMediaDir: (...parts: string[]) => ["qqbot-media", ...parts].join("/"),
+  isLocalPath: (value: string) =>
+    !value.startsWith("http://") && !value.startsWith("https://") && !value.startsWith("data:"),
+  normalizePath: (value: string) => value,
+  resolveQQBotPayloadLocalFilePath: (value: string) => value,
+}));
+
+vi.mock("./sender.js", () => ({
+  accountToCreds: (account: { appId: string; clientSecret: string }) => ({
+    appId: account.appId,
+    clientSecret: account.clientSecret,
+  }),
+  sendMedia: senderMocks.sendMedia,
+  sendText: senderMocks.sendText,
+  UploadDailyLimitExceededError: class UploadDailyLimitExceededError extends Error {},
+}));
+
+import { sendDocument, sendPhoto, sendVideoMsg, sendVoice } from "./outbound-media-send.js";
+
+const signedUrl =
+  "https://user:pass@example.com/media/photo.png?token=download-token&safe=value#frag";
+const malformedSignedUrl =
+  "https://user:pass@%zz/media/photo.png?token=download-token&safe=value#frag";
+
+const ctx: MediaTargetContext = {
+  targetType: "group",
+  targetId: "group-1",
+  account: {
+    accountId: "qq",
+    appId: "app",
+    clientSecret: "secret",
+    config: {},
+    markdownSupport: false,
+  },
+};
+
+function captureOutput(resultError: string | undefined): string {
+  return [
+    resultError ?? "",
+    ...logMocks.debugWarn.mock.calls.flat().map(String),
+    ...logMocks.debugError.mock.calls.flat().map(String),
+  ].join("\n");
+}
+
+function expectRedactedOutput(output: string): void {
+  expect(output).toContain("https://example.com/media/photo.png");
+  expect(output).not.toContain("user:pass");
+  expect(output).not.toContain("download-token");
+  expect(output).not.toContain("safe=value");
+  expect(output).not.toContain("#frag");
+}
+
+describe("engine/messaging/outbound-media-send direct URL uploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileUtilsMocks.downloadFile.mockResolvedValue(null);
+    senderMocks.sendMedia.mockRejectedValue(new Error(`upload failed for ${signedUrl}`));
+    senderMocks.sendText.mockResolvedValue({ id: "msg-1", timestamp: 1 });
+  });
+
+  it.each([
+    ["image", () => sendPhoto(ctx, signedUrl)],
+    ["voice", () => sendVoice(ctx, signedUrl)],
+    ["video", () => sendVideoMsg(ctx, signedUrl)],
+    ["document", () => sendDocument(ctx, signedUrl)],
+  ] as const)("redacts failed %s direct-upload errors", async (_name, send) => {
+    const result = await send();
+
+    expect(result.channel).toBe("qqbot");
+    expect(senderMocks.sendMedia).toHaveBeenCalled();
+    expectRedactedOutput(captureOutput(result.error));
+  });
+
+  it("redacts malformed URL-like secrets in direct-upload errors", async () => {
+    senderMocks.sendMedia.mockRejectedValue(new Error(`upload failed for ${malformedSignedUrl}`));
+
+    const result = await sendPhoto(ctx, signedUrl);
+    const output = captureOutput(result.error);
+
+    expect(output).toContain("https://%zz/media/photo.png");
+    expect(output).not.toContain("user:pass");
+    expect(output).not.toContain("download-token");
+    expect(output).not.toContain("safe=value");
+    expect(output).not.toContain("#frag");
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -28,6 +28,7 @@ import {
   resolveQQBotPayloadLocalFilePath,
 } from "../utils/platform.js";
 import { normalizeLowercaseStringOrEmpty, sanitizeFileName } from "../utils/string-normalize.js";
+import { redactTextForLog, redactUrlForLog } from "../utils/url-redaction.js";
 import { audioFileToSilkBase64, shouldTranscodeVoice, waitForFile } from "./outbound-audio-port.js";
 import {
   buildDailyLimitExceededResult,
@@ -191,7 +192,10 @@ export async function sendPhoto(
     if (localFile) {
       return await sendPhotoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download image: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download image: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   if (isLocal) {
@@ -228,7 +232,7 @@ export async function sendPhoto(
     debugLog(`sendPhoto: channel does not support local/Base64 images`);
     return { channel: "qqbot", error: "Channel does not support local/Base64 images" };
   } catch (err) {
-    const msg = formatErrorMessage(err);
+    const msg = redactTextForLog(formatErrorMessage(err));
 
     // Fall back to plugin-managed download + local upload when QQ fails to
     // fetch the URL directly. One-shot, non-recursive.
@@ -332,7 +336,7 @@ export async function sendVoice(
         debugLog(`sendVoice: voice not supported in channel`);
         return { channel: "qqbot", error: "Voice not supported in channel" };
       } catch (err) {
-        const msg = formatErrorMessage(err);
+        const msg = redactTextForLog(formatErrorMessage(err));
         debugWarn(
           `sendVoice: URL direct upload failed (${msg}), downloading locally and retrying...`,
         );
@@ -345,7 +349,10 @@ export async function sendVoice(
     if (localFile) {
       return await sendVoiceFromLocal(ctx, localFile, directUploadFormats, transcodeEnabled);
     }
-    return { channel: "qqbot", error: `Failed to download audio: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download audio: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   return await sendVoiceFromLocal(ctx, mediaPath, directUploadFormats, transcodeEnabled);
@@ -444,7 +451,10 @@ export async function sendVideoMsg(
     if (localFile) {
       return await sendVideoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download video: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download video: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   try {
@@ -467,7 +477,7 @@ export async function sendVideoMsg(
 
     return await sendVideoFromLocal(ctx, mediaPath);
   } catch (err) {
-    const msg = formatErrorMessage(err);
+    const msg = redactTextForLog(formatErrorMessage(err));
 
     // If direct URL upload fails, retry through a local download path.
     if (isHttp) {
@@ -551,7 +561,10 @@ export async function sendDocument(
     if (localFile) {
       return await sendDocumentFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download file: ${mediaPath.slice(0, 80)}` };
+    return {
+      channel: "qqbot",
+      error: `Failed to download file: ${redactUrlForLog(mediaPath, 80)}`,
+    };
   }
 
   try {
@@ -575,7 +588,7 @@ export async function sendDocument(
 
     return await sendDocumentFromLocal(ctx, mediaPath);
   } catch (err) {
-    const msg = formatErrorMessage(err);
+    const msg = redactTextForLog(formatErrorMessage(err));
 
     // If direct URL upload fails, retry through a local download path.
     if (isHttp) {
@@ -646,7 +659,7 @@ async function downloadToFallbackDir(httpUrl: string, caller: string): Promise<s
     const downloadDir = getQQBotMediaDir("downloads", "url-fallback");
     const localFile = await downloadFile(httpUrl, downloadDir);
     if (!localFile) {
-      debugError(`${caller} fallback: download also failed for ${httpUrl.slice(0, 80)}`);
+      debugError(`${caller} fallback: download also failed for ${redactUrlForLog(httpUrl, 80)}`);
       return null;
     }
     debugLog(`${caller} fallback: downloaded → ${localFile}`);

--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -96,6 +96,56 @@ describe("qqbot file-utils downloadFile", () => {
     expect(adapterMocks.fetchMedia).not.toHaveBeenCalled();
   });
 
+  it("redacts URL credentials and query params before logging download failures", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      adapterMocks.fetchMedia.mockRejectedValueOnce(
+        new Error(
+          "fetch failed for https://user:pass@media.qq.com/assets/photo.png?token=download-token#frag",
+        ),
+      );
+
+      const savedPath = await downloadFile(
+        "https://user:pass@media.qq.com/assets/photo.png?token=download-token&safe=value#frag",
+        tempDir,
+        "photo.png",
+      );
+
+      expect(savedPath).toBeNull();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://media.qq.com/assets/photo.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("redacts malformed URL-like secrets before logging download failures", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      adapterMocks.fetchMedia.mockRejectedValueOnce(
+        new Error(
+          "fetch failed for https://user:pass@%zz/assets/photo.png?token=download-token&safe=value#frag",
+        ),
+      );
+
+      const savedPath = await downloadFile("https://media.qq.com/assets/photo.png", tempDir);
+
+      expect(savedPath).toBeNull();
+      const logged = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://%zz/assets/photo.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it.skipIf(process.platform === "win32")("rejects symlinked local media helpers", async () => {
     const targetPath = path.join(tempDir, "target.png");
     const linkPath = path.join(tempDir, "link.png");

--- a/extensions/qqbot/src/engine/utils/file-utils.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.ts
@@ -12,6 +12,7 @@ import type { SsrfPolicyConfig } from "../adapter/types.js";
 import { MediaFileType } from "../types.js";
 import { formatErrorMessage } from "./format.js";
 import { normalizeOptionalString } from "./string-normalize.js";
+import { redactTextForLog, redactUrlForLog } from "./url-redaction.js";
 
 /** Maximum file size accepted by the QQ Bot one-shot upload API (base64 direct). */
 export const MAX_UPLOAD_SIZE = 20 * 1024 * 1024;
@@ -202,13 +203,17 @@ export async function downloadFile(
     return destPath;
   } catch (err) {
     console.error(
-      `[qqbot:downloadFile] FAILED url=${url.slice(0, 120)} error=${err instanceof Error ? err.message : String(err)}`,
+      `[qqbot:downloadFile] FAILED url=${redactUrlForLog(url, 120)} error=${redactTextForLog(formatErrorMessage(err))}`,
     );
     if (err instanceof Error && err.stack) {
-      console.error(`[qqbot:downloadFile] stack=${err.stack.split("\n").slice(0, 3).join(" | ")}`);
+      console.error(
+        `[qqbot:downloadFile] stack=${redactTextForLog(err.stack.split("\n").slice(0, 3).join(" | "))}`,
+      );
     }
     if (err instanceof Error && err.cause) {
-      console.error(`[qqbot:downloadFile] cause=${formatErrorMessage(err.cause)}`);
+      console.error(
+        `[qqbot:downloadFile] cause=${redactTextForLog(formatErrorMessage(err.cause))}`,
+      );
     }
     return null;
   }

--- a/extensions/qqbot/src/engine/utils/url-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/url-redaction.ts
@@ -1,0 +1,46 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string, maxLength?: number): string {
+  const redacted = redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+  if (maxLength === undefined || redacted.length <= maxLength) {
+    return redacted;
+  }
+  return `${redacted.slice(0, maxLength)}...`;
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return stripMalformedUrlSecrets(value);
+  }
+}
+
+function stripMalformedUrlSecrets(value: string): string {
+  return value
+    .replace(/#.*$/su, "")
+    .replace(/\?.*$/su, "")
+    .replace(/^((?:[a-z][a-z\d+.-]*:)?\/\/)[^/@\s"'<>]*@/iu, "$1");
+}

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -77,4 +77,60 @@ describe("tlon monitor media", () => {
     expect(result).toBeNull();
     expect(readRemoteMediaBufferMock).not.toHaveBeenCalled();
   });
+
+  it("redacts media URL secrets in rejection and download error logs", async () => {
+    await expect(
+      downloadMedia("ftp://user:pass@example.com/photo.png?token=download-token&safe=value#frag"),
+    ).resolves.toBeNull();
+
+    let logged = vi
+      .mocked(console.warn)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("ftp://example.com/photo.png");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+
+    vi.mocked(console.warn).mockClear();
+    saveRemoteMediaMock.mockRejectedValueOnce(
+      new Error(
+        "fetch failed for https://user:pass@example.com/photo.png?token=download-token&safe=value#frag",
+      ),
+    );
+
+    await expect(
+      downloadMedia("https://user:pass@example.com/photo.png?token=download-token&safe=value#frag"),
+    ).resolves.toBeNull();
+
+    logged = vi
+      .mocked(console.error)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("https://example.com/photo.png");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+
+    vi.mocked(console.error).mockClear();
+    saveRemoteMediaMock.mockRejectedValueOnce(
+      new Error(
+        "fetch failed for https://user:pass@%zz/photo.png?token=download-token&safe=value#frag",
+      ),
+    );
+
+    await expect(downloadMedia("https://example.com/photo.png")).resolves.toBeNull();
+
+    logged = vi
+      .mocked(console.error)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(logged).toContain("https://%zz/photo.png");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("download-token");
+    expect(logged).not.toContain("safe=value");
+    expect(logged).not.toContain("#frag");
+  });
 });

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getDefaultSsrFPolicy } from "../urbit/context.js";
+import { redactTextForLog, redactUrlForLog } from "../url-redaction.js";
 
 const MAX_IMAGES_PER_MESSAGE = 8;
 const TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
@@ -63,7 +64,7 @@ export async function downloadMedia(
     // Validate URL is http/https before fetching
     const parsedUrl = new URL(url);
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-      console.warn(`[tlon-media] Rejected non-http(s) URL: ${url}`);
+      console.warn(`[tlon-media] Rejected non-http(s) URL: ${redactUrlForLog(url)}`);
       return null;
     }
 
@@ -100,7 +101,9 @@ export async function downloadMedia(
       originalUrl: url,
     };
   } catch (error: unknown) {
-    console.error(`[tlon-media] Error downloading ${url}: ${formatErrorMessage(error)}`);
+    console.error(
+      `[tlon-media] Error downloading ${redactUrlForLog(url)}: ${redactTextForLog(formatErrorMessage(error))}`,
+    );
     return null;
   }
 }

--- a/extensions/tlon/src/urbit/upload.test.ts
+++ b/extensions/tlon/src/urbit/upload.test.ts
@@ -99,6 +99,61 @@ describe("uploadImageFromUrl", () => {
     expect(result).toBe("https://example.com/image.png");
   });
 
+  it("redacts source URL secrets before logging rejected or failed fetches", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const rejected = await uploadImageFromUrl(
+        "ftp://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+      expect(rejected).toBe(
+        "ftp://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+
+      mockFetch.mockResolvedValueOnce({
+        response: {
+          ok: false,
+          status: 404,
+        } as unknown as Response,
+        finalUrl: "https://example.com/image.png",
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const failed = await uploadImageFromUrl(
+        "https://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+      expect(failed).toBe(
+        "https://user:pass@example.com/image.png?token=download-token&safe=value#frag",
+      );
+
+      let logged = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("ftp://example.com/image.png");
+      expect(logged).toContain("https://example.com/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+
+      warnSpy.mockClear();
+      mockFetch.mockRejectedValueOnce(
+        new Error(
+          "fetch failed for https://user:pass@%zz/image.png?token=download-token&safe=value#frag",
+        ),
+      );
+
+      const malformedFailed = await uploadImageFromUrl("https://example.com/image.png");
+      expect(malformedFailed).toBe("https://example.com/image.png");
+
+      logged = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(logged).toContain("https://%zz/image.png");
+      expect(logged).not.toContain("user:pass");
+      expect(logged).not.toContain("download-token");
+      expect(logged).not.toContain("safe=value");
+      expect(logged).not.toContain("#frag");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("returns original URL if upload fails", async () => {
     await setupSuccessfulUpload();
     mockUploadFile.mockRejectedValue(new Error("Upload failed"));

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -3,6 +3,7 @@
  */
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { uploadFile } from "../tlon-api.js";
+import { redactTextForLog, redactUrlForLog } from "../url-redaction.js";
 import { getDefaultSsrFPolicy } from "./context.js";
 
 /**
@@ -16,7 +17,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
     // Validate URL is http/https before fetching
     const url = new URL(imageUrl);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
-      console.warn(`[tlon] Rejected non-http(s) URL: ${imageUrl}`);
+      console.warn(`[tlon] Rejected non-http(s) URL: ${redactUrlForLog(imageUrl)}`);
       return imageUrl;
     }
 
@@ -31,7 +32,9 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
 
     try {
       if (!response.ok) {
-        console.warn(`[tlon] Failed to fetch image from ${imageUrl}: ${response.status}`);
+        console.warn(
+          `[tlon] Failed to fetch image from ${redactUrlForLog(imageUrl)}: ${response.status}`,
+        );
         return imageUrl;
       }
 
@@ -54,7 +57,9 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
       await release();
     }
   } catch (err) {
-    console.warn(`[tlon] Failed to upload image, using original URL: ${String(err)}`);
+    console.warn(
+      `[tlon] Failed to upload image, using original URL: ${redactTextForLog(String(err))}`,
+    );
     return imageUrl;
   }
 }

--- a/extensions/tlon/src/url-redaction.ts
+++ b/extensions/tlon/src/url-redaction.ts
@@ -1,0 +1,42 @@
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
+
+const REDACT_OPTIONS = { mode: "tools" as const };
+
+export function redactUrlForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecrets(value), REDACT_OPTIONS);
+}
+
+export function redactTextForLog(value: string): string {
+  return redactSensitiveText(stripUrlSecretsInText(value), REDACT_OPTIONS);
+}
+
+function stripUrlSecretsInText(value: string): string {
+  return value.replace(/(?:https?:\/\/|\/\/)[^\s"'<>]+/gu, (match) => stripUrlSecrets(match));
+}
+
+function stripUrlSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  try {
+    const protocolRelative = trimmed.startsWith("//");
+    const parsed = new URL(protocolRelative ? `https:${trimmed}` : trimmed);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    const clean = parsed.toString();
+    return protocolRelative ? clean.replace(/^https:/u, "") : clean;
+  } catch {
+    return stripMalformedUrlSecrets(value);
+  }
+}
+
+function stripMalformedUrlSecrets(value: string): string {
+  return value
+    .replace(/#.*$/su, "")
+    .replace(/\?.*$/su, "")
+    .replace(/^((?:[a-z][a-z\d+.-]*:)?\/\/)[^/@\s"'<>]*@/iu, "$1");
+}


### PR DESCRIPTION
﻿## Summary

What problem does this PR solve?

- Prevents credential-bearing and signed media URLs from being written raw in QQBot, Tlon, and Feishu media failure logs.
- Prevents QQBot URL download fallback errors from surfacing raw signed URLs in user-visible error strings.
- Escapes the Canvas host missing-file root path before rendering it into HTML.

Why does this matter now?

- Media URLs often carry short-lived tokens, signatures, or embedded credentials. Logging them raw can leak access material into local logs or diagnostics.

What is the intended outcome?

- Logs and fallback error text keep useful host/path context while stripping URL userinfo, query strings, and fragments.
- Canvas missing-file HTML treats the root path as text, not markup.

What is intentionally out of scope?

- No config changes, migrations, or runtime behavior changes to media fetching/uploading.
- No full live channel integration proof.

What does success look like?

- A failed media download can be diagnosed without exposing `user:pass`, token query values, or URL fragments.
- The Canvas missing-file page cannot inject markup from the configured root path.

What should reviewers focus on?

- Whether the redaction boundary is applied at every touched log/user-visible error site.
- Whether plugin-local helpers are appropriate for this scoped fix without expanding public SDK surface.
- Whether the Canvas escaping is sufficient for text inside the 404 HTML response.

## Linked context

Which issue does this close?

None.

Which issues, PRs, or discussions are related?

None.

Was this requested by a maintainer or owner?

No. This came from a local code audit.

## Real behavior proof (required for external PRs)

- Behavior addressed: Signed media URLs and credential-bearing URLs are no longer written raw in affected QQBot, Tlon, and Feishu logs or QQBot fallback error strings; Canvas no longer injects an unescaped root path into missing-file HTML.
- Real environment tested: Local Windows checkout, Node 24.15.0, current PR branch `fix/redact-media-url-logs`, latest head `90b4ebbf187f85d6099cec19191c2d7137e301fb`.
- Exact steps or command run after this patch:

```bash
node --import tsx tmp-real-proof.ts
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts --reporter=verbose
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/tmp-outbound-direct-proof.test.ts --reporter=verbose
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts extensions/qqbot/src/engine/utils/file-utils.test.ts extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.test.ts extensions/feishu/src/docx.test.ts extensions/canvas/src/host/server.test.ts
```

- Evidence after fix:

```text
OpenClaw media URL redaction proof
source URL contained: userinfo=user:pass query=token=download-token&safe=value fragment=#frag
captured redacted output:
[qqbot:downloadFile] FAILED url=https://example.com/media/photo.png error=fetch failed for https://example.com/media/photo.png
[qqbot:downloadFile] stack=Error: fetch failed for https://example.com/media/photo.png |     at Object.fetchMedia ([repo]\tmp-real-proof.ts:24:37) |     at downloadFile ([repo]\extensions\qqbot\src\engine\utils\file-utils.ts:182:48)
[tlon-media] Rejected non-http(s) URL: ftp://example.com/media/photo.png
[tlon] Rejected non-http(s) URL: ftp://example.com/media/photo.png
feishu-docx simulated failure: https://example.com/media/photo.png: Blocked https://example.com/media/photo.png
tlon returned original URL unchanged: yes
canvas escaped sample root: &lt;root&gt;&amp;&quot;
leaked sensitive URL parts: none
```

Fresh QQBot outbound direct-upload proof used a credential-bearing URL containing `user:pass`, `token=download-token`, `safe=value`, and `#frag`, forced direct-upload failures for image, voice, video, and document sends, and captured the returned error plus debug warn/error output:

```text
OpenClaw QQBot outbound direct-upload redaction proof
source URL contained: userinfo=user:pass query=token=download-token&safe=value fragment=#frag

image captured redacted output:
result=upload failed for https://example.com/media/photo.png
warn=sendPhoto: URL direct upload failed (upload failed for https://example.com/media/photo.png), downloading locally and retrying as Base64...
error=sendPhoto fallback: download also failed for https://example.com/media/photo.png
error=sendPhoto failed: upload failed for https://example.com/media/photo.png

voice captured redacted output:
result=Failed to download audio: https://example.com/media/photo.png
warn=sendVoice: URL direct upload failed (upload failed for https://example.com/media/photo.png), downloading locally and retrying...
error=sendVoice fallback: download also failed for https://example.com/media/photo.png

video captured redacted output:
result=upload failed for https://example.com/media/photo.png
warn=sendVideoMsg: URL direct upload failed (upload failed for https://example.com/media/photo.png), downloading locally and retrying as Base64...
error=sendVideoMsg fallback: download also failed for https://example.com/media/photo.png
error=sendVideoMsg failed: upload failed for https://example.com/media/photo.png

document captured redacted output:
result=upload failed for https://example.com/media/photo.png
warn=sendDocument: URL direct upload failed (upload failed for https://example.com/media/photo.png), downloading locally and retrying as Base64...
error=sendDocument fallback: download also failed for https://example.com/media/photo.png
error=sendDocument failed: upload failed for https://example.com/media/photo.png
leaked sensitive URL parts: none
```

The latest head also covers malformed URL-like inputs that `new URL()` cannot parse, such as `https://user:pass@%zz/image.png?token=download-token&safe=value#frag`. Focused tests assert the redaction fallback still removes `user:pass`, `download-token`, `safe=value`, and `#frag` while preserving diagnostic context such as `https://%zz/image.png`.

Fresh committed QQBot outbound regression test run after the latest head:

```text
RUN  v4.1.7 D:/Users/zhukeyu/Downloads/openclaw-main/openclaw-main/openclaw

??|extension-messaging| extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts > engine/messaging/outbound-media-send direct URL uploads > redacts failed image direct-upload errors 248ms
??|extension-messaging| extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts > engine/messaging/outbound-media-send direct URL uploads > redacts failed voice direct-upload errors 2ms
??|extension-messaging| extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts > engine/messaging/outbound-media-send direct URL uploads > redacts failed video direct-upload errors 1ms
??|extension-messaging| extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts > engine/messaging/outbound-media-send direct URL uploads > redacts failed document direct-upload errors 1ms

Test Files  1 passed (1)
Tests  4 passed (4)
[test] passed 1 Vitest shard in 13.18s
```

- Observed result after fix: The captured output preserves diagnostic scheme/host/path context and reports `leaked sensitive URL parts: none`; the original URL userinfo, query values, and fragment are absent. The latest QQBot outbound direct-upload regression test passed for image, voice, video, and document failure paths. Malformed URL-like regression coverage also passed for QQBot, Tlon, and Feishu affected media paths. Focused Vitest passed all targeted shards.
- What was not tested: Full repository CI and live QQBot, Tlon, Feishu, or browser-based Canvas integrations.
- Proof limitations or environment constraints: This is local after-fix terminal proof against the patched plugin code paths, not live channel-provider integration proof.
- Before evidence: The touched call sites previously interpolated raw URL strings such as `attUrl`, `url`, `imageUrl`, or `mediaPath.slice(...)` directly into logs or fallback errors.

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts --reporter=verbose
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts extensions/qqbot/src/engine/utils/file-utils.test.ts extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.test.ts extensions/feishu/src/docx.test.ts extensions/canvas/src/host/server.test.ts
node_modules\.bin\oxlint.CMD extensions/canvas/src/host/server.ts extensions/canvas/src/host/server.test.ts extensions/feishu/src/docx.ts extensions/feishu/src/docx.test.ts extensions/feishu/src/url-redaction.ts extensions/qqbot/src/engine/gateway/inbound-attachments.ts extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.ts extensions/qqbot/src/engine/utils/file-utils.ts extensions/qqbot/src/engine/utils/file-utils.test.ts extensions/qqbot/src/engine/utils/url-redaction.ts extensions/tlon/src/monitor/media.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.ts extensions/tlon/src/urbit/upload.test.ts extensions/tlon/src/url-redaction.ts
git diff --check
python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD
```

What regression coverage was added or updated?

- QQBot tests now assert failed attachment/download logs redact URL userinfo, query values, and fragments.
- QQBot outbound media tests now assert failed image, voice, video, and document direct-upload logs and returned errors redact URL userinfo, query values, and fragments.
- Tlon monitor/upload tests now assert rejected and failed media URL logs are redacted.
- Feishu docx image hardening test now asserts blocked image URL logs are redacted.
- QQBot, Tlon, and Feishu tests now cover malformed URL-like media strings that fail URL parsing but still contain userinfo, query values, and fragments.
- Canvas host test now asserts root-path HTML escaping.

What failed before this fix, if known?

- The audited call sites logged or returned raw URL strings directly.

If no test was added, why not?

- Tests were added for the touched behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. QQBot fallback error strings now show redacted URL context instead of raw signed URLs.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This changes secret-bearing URL handling in logs and fallback errors.

What is the highest-risk area?

- Over-redacting diagnostic URL details or missing a touched error path that still logs raw URL text.

How is that risk mitigated?

- Redaction preserves scheme/host/path for diagnostics while stripping userinfo, query, and fragments.
- Focused tests cover each touched plugin path and Canvas HTML escaping.
- Structured autoreview found no accepted/actionable findings.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- CI and any maintainer-requested live/channel proof.

Which bot or reviewer comments were addressed?

- Real behavior proof gate feedback was addressed by adding copied after-fix terminal output with the required field labels.
- Codex review feedback for QQBot outbound direct-upload proof was addressed with fresh captured output and a fresh `outbound-media-send.test.ts` run after latest head `bca58314ad93c531d3d448ba20285de1078eac70`.
- Codex review feedback for malformed URL-like input was addressed by making helper parse failures fail closed and adding malformed credential-bearing URL coverage for the affected QQBot, Tlon, and Feishu media paths.

