### PR TITLE
fix(plugins): guard model suppression metadata

### DIFF
--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -23,6 +23,38 @@ function createMetadataSnapshot(plugins: Record<string, unknown>[]) {
   };
 }
 
+function createRawMetadataSnapshot(plugins: Record<string, unknown>[]) {
+  return {
+    index: { plugins: [] },
+    diagnostics: [],
+    plugins,
+  };
+}
+
+function poisonedAvailabilityPlugin(): Record<string, unknown> {
+  return Object.defineProperty({ id: "poisoned-availability" }, "origin", {
+    get() {
+      throw new Error("model suppression availability exploded");
+    },
+  });
+}
+
+function poisonedModelCatalogPlugin(): Record<string, unknown> {
+  return Object.defineProperty(
+    {
+      id: "poisoned-model-catalog",
+      origin: "bundled",
+      providers: ["poisoned-model-catalog"],
+    },
+    "modelCatalog",
+    {
+      get() {
+        throw new Error("model suppression catalog exploded");
+      },
+    },
+  );
+}
+
 describe("manifest model suppression", () => {
   beforeEach(() => {
     mocks.loadPluginMetadataSnapshot.mockReset();
@@ -104,6 +136,63 @@ describe("manifest model suppression", () => {
         env: process.env,
       }),
     ).toBeUndefined();
+  });
+
+  it("skips unreadable manifest model suppression plugin metadata", () => {
+    mocks.loadPluginMetadataSnapshot.mockReturnValue(
+      createRawMetadataSnapshot([
+        {
+          id: "openai",
+          origin: "bundled",
+          providers: ["openai"],
+          modelCatalog: {
+            aliases: {
+              "azure-openai-responses": {
+                provider: "openai",
+              },
+            },
+            suppressions: [
+              {
+                provider: "azure-openai-responses",
+                model: "gpt-5.3-codex-spark",
+                reason: "Use openai/gpt-5.5.",
+              },
+            ],
+          },
+        },
+        poisonedAvailabilityPlugin(),
+        poisonedModelCatalogPlugin(),
+        {
+          id: "qwen",
+          origin: "bundled",
+          providers: ["qwen"],
+          modelCatalog: {
+            suppressions: [
+              {
+                provider: "qwen",
+                model: "qwen3.6-plus",
+                reason: "Use qwen/qwen3.5-plus.",
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "azure-openai-responses",
+        id: "gpt-5.3-codex-spark",
+        env: process.env,
+      })?.suppress,
+    ).toBe(true);
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "qwen",
+        id: "qwen3.6-plus",
+        env: process.env,
+      })?.suppress,
+    ).toBe(true);
   });
 
   it("reads planned manifest suppressions fresh per lookup", () => {

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -10,6 +10,36 @@ import {
   loadManifestMetadataSnapshot,
 } from "./manifest-contract-eligibility.js";
 
+type ManifestModelCatalogSuppressionPlugin = Parameters<
+  typeof planManifestModelCatalogSuppressions
+>[0]["registry"]["plugins"][number];
+type ManifestMetadataSnapshot = ReturnType<typeof loadManifestMetadataSnapshot>;
+
+function readAvailableManifestModelCatalogSuppressionPlugin(params: {
+  snapshot: ManifestMetadataSnapshot;
+  plugin: ManifestMetadataSnapshot["plugins"][number];
+  config?: OpenClawConfig;
+}): ManifestModelCatalogSuppressionPlugin | undefined {
+  try {
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot: params.snapshot,
+        plugin: params.plugin,
+        config: params.config,
+      })
+    ) {
+      return undefined;
+    }
+    return {
+      id: params.plugin.id,
+      providers: params.plugin.providers,
+      modelCatalog: params.plugin.modelCatalog,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 function listManifestModelCatalogSuppressions(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -20,15 +50,17 @@ function listManifestModelCatalogSuppressions(params: {
     workspaceDir: params.workspaceDir,
     env: params.env,
   });
+  const plugins = snapshot.plugins.flatMap((plugin) => {
+    const readable = readAvailableManifestModelCatalogSuppressionPlugin({
+      snapshot,
+      plugin,
+      config: params.config,
+    });
+    return readable ? [readable] : [];
+  });
   const registry = {
     diagnostics: snapshot.diagnostics,
-    plugins: snapshot.plugins.filter((plugin) =>
-      isManifestPluginAvailableForControlPlane({
-        snapshot,
-        plugin,
-        config: params.config,
-      }),
-    ),
+    plugins,
   };
   const planned = planManifestModelCatalogSuppressions({ registry });
   return planned.suppressions;


### PR DESCRIPTION
## Summary

- Skip unreadable manifest plugin rows while planning manifest-driven built-in model suppressions.
- Build a narrow readable planner view after control-plane availability filtering, so one bad metadata row cannot prevent later valid suppressions from applying.
- Add regression coverage for poisoned availability metadata and poisoned `modelCatalog` metadata while preserving healthy suppressions before and after the poisoned rows.

## Verification

- `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`
- `./node_modules/.bin/oxlint src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, overall patch is correct (0.86)
- `.agents/skills/autoreview/scripts/autoreview --mode branch` — clean, overall patch is correct (0.82)

## Real behavior proof

Behavior addressed: manifest-driven model suppression no longer aborts when one plugin metadata row throws while reading availability metadata or `modelCatalog`.

Real environment tested: focused local plugin Vitest lane in the sparse OpenClaw worktree; local formatter/linter/diff checks.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts` plus the formatter, linter, diff check, and autoreview commands listed above.

Evidence after fix: the focused Vitest file passes 9 tests, including a regression with poisoned availability metadata and poisoned model catalog metadata between healthy suppression providers.

Observed result after fix: healthy suppressions before and after unreadable plugin rows still apply; unreadable rows are skipped.

What was not tested: broad `pnpm check:changed` did not run because the Crabbox coordinator returned HTTP 401 before lease creation; Blacksmith Testbox is also unauthenticated in this environment. Focused Vitest runs waited behind the repo local heavy-check lock instead of bypassing it.
