### PR TITLE
fix: keep stream-to-parent spawns registered

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -570,7 +570,14 @@ describe("sessions_spawn tool", () => {
     const spawnContext = mockCallArg(hoisted.spawnAcpDirectMock, 0, 1, "spawnAcpDirect");
     expect(spawnContext.agentSessionKey).toBe("agent:main:main");
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
+    const registration = mockCallArg(hoisted.registerSubagentRunMock, 0, 0, "registerSubagentRun");
+    expect(registration.runId).toBe("run-acp");
+    expect(registration.childSessionKey).toBe("agent:codex:acp:1");
+    expect(registration.requesterSessionKey).toBe("agent:main:main");
+    expect(registration.task).toBe("investigate the failing CI run");
+    expect(registration.cleanup).toBe("keep");
+    expect(registration.spawnMode).toBe("session");
+    expect(registration.expectsCompletionMessage).toBe(true);
   });
 
   it("passes inherited tool denies to ACP spawns", async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -410,10 +410,7 @@ export function createSessionsSpawnTool(
         const childSessionKey = result.childSessionKey?.trim();
         const childRunId = isSpawnAcpAcceptedResult(result) ? result.runId?.trim() : undefined;
         const shouldTrackViaRegistry =
-          result.status === "accepted" &&
-          Boolean(childSessionKey) &&
-          Boolean(childRunId) &&
-          streamTo !== "parent";
+          result.status === "accepted" && Boolean(childSessionKey) && Boolean(childRunId);
         if (shouldTrackViaRegistry && childSessionKey && childRunId) {
           const cfg = getRuntimeConfig();
           const trackedSpawnMode = resolveTrackedSpawnMode({


### PR DESCRIPTION
## Summary

This PR fixes ACP child completion delivery when a `sessions_spawn` call explicitly requests `streamTo="parent"`.

- Keeps accepted ACP `sessions_spawn` runs registered in `subagent-registry` even when `streamTo="parent"` is set.
- Preserves parent streaming as a realtime UX enhancement, but no longer lets it replace the registry-backed completion announce contract.
- Updates the ACP `sessions_spawn` unit coverage so `streamTo="parent"` still forwards to ACP and also registers the child run for lifecycle completion handling.

Why this matters now:

Recent subagent completion work made the registry-backed path the owner for completion handoffs. That exposed an older `streamTo !== "parent"` registry short-circuit: ACP child runs that requested parent streaming were invisible to the registry, so completion handoff/announce logic never saw them.

Intended outcome:

A child ACP run can stream progress to its parent and still receive the normal completion announce/handoff when it ends. In practice, weixin direct sessions now receive the child completion message instead of dropping it when the model chooses `streamTo="parent"`.

Intentionally out of scope:

- Changing `acp-spawn-parent-stream` system-event relay behavior.
- Reworking steer vs direct announce dispatch.
- Adding prompt/tool-description guidance to discourage `streamTo="parent"`; this fix makes the runtime contract reliable instead.

Success looks like:

- `streamTo="parent"` ACP runs enter `subagent-registry`.
- `announce:v1:<childRunId>:...` is emitted for completed child runs.
- weixin receives the final child completion message.
- Existing webchat/feishu paths continue using the same registry-backed announce path without duplicate final messages.

Reviewers should focus on:

- Whether registry tracking should be the common owner for accepted ACP runs, including streamed-to-parent runs.
- Whether `inlineDelivery` remains the right suppression point for completion messages.
- Whether the test now captures the intended `streamTo="parent"` contract.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #40885
Related #88260
Related #88416
Related #88613

Was this requested by a maintainer or owner?

Maintainer-debugged regression from live weixin, webchat, and feishu channel experiments.

Root-cause timeline:

- 2026-03-29, `443295448c9` / #40885 added ACP `sessions_spawn` registry tracking, but excluded `streamTo="parent"` runs with `streamTo !== "parent"`. At that time this was mostly lifecycle telemetry, so the exclusion stayed hidden.
- 2026-05-30, `5374c7a8a20` / #88260 persisted the subagent registry in SQLite, making it durable state rather than only in-memory bookkeeping.
- 2026-05-30, `3fc0df953cf` / #88416 moved channel-bound subagent thread binding into core, making non-`main:main` direct-session parents a normal spawn shape.
- 2026-05-31, `1e54e908e2e` / #88613 queued subagent completion handoffs from the registry into the parent agent's next turn. This made P-Reg the completion handoff source of truth.
- After that sequence, `streamTo="parent"` ACP runs could still stream via P-Stream, but they never entered P-Reg. The new completion handoff queue could not lease them, and direct-session channels such as weixin had no reliable user-visible completion fallback.

The regression was therefore not a weixin-specific outbound failure. The deciding variable across live tests was whether `streamTo="parent"` caused `shouldTrackViaRegistry=false`. Feishu proved that a channel-bound direct session can receive a registry-backed `announce:v1` inter-session completion when the run is registered.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ACP child completion messages were dropped for weixin direct sessions when the model called `sessions_spawn` with `streamTo="parent"`.
- Real environment tested: Maintainer live OpenClaw setup with weixin direct session, plus comparison runs on webchat and feishu direct sessions.
- Exact steps or command run after this patch: Triggered the same ACP child-spawn workflow from weixin after removing the registry short-circuit for `streamTo="parent"`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):             
                                                    
https://github.com/user-attachments/assets/e6a0a099-b216-4550-afd2-f218a13dc4f6

- Observed result after fix: weixin received the child completion message; maintainer confirmed the fix succeeded.
- What was not tested: Broad channel matrix, full CI, and a dedicated `acp-spawn-parent-stream` relay redesign.
- Proof limitations or environment constraints: Live proof was run in a maintainer environment; this PR contains targeted unit coverage for the registry contract but does not include committed recordings or logs.
- Before evidence (optional but encouraged): 

https://github.com/user-attachments/assets/73046cd7-db4a-43e8-a35d-a1e257a87911

## Tests and validation

Which commands did you run?

```bash
node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

What regression coverage was added or updated?

Updated `src/agents/tools/sessions-spawn-tool.test.ts` so the ACP `runtime="acp"` / `streamTo="parent"` case now expects `registerSubagentRun` to be called. The assertion verifies the registered run id, child session key, requester session key, task, cleanup mode, spawn mode, and `expectsCompletionMessage: true`.

What failed before this fix, if known?

Before this fix, the same test asserted `registerSubagentRun` was not called for `streamTo="parent"`, matching the buggy runtime behavior. Live weixin proof showed no `announce:v1` run and no user-visible child completion message.

If no test was added, why not?

A targeted regression assertion was added by updating the existing ACP `sessions_spawn` test.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. ACP child completions for `streamTo="parent"` are now delivered through the registry-backed completion path instead of relying only on parent-stream system events.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Duplicate completion visibility if a future channel surfaces both P-Stream done events and P-Reg completion announces to the same user.

How is that risk mitigated?

The change only registers accepted ACP runs; it does not change P-Stream rendering. The registry announce path already uses stable `announce:v1` idempotency for completion handoffs. Existing `inlineDelivery` suppression remains intact, and live webchat/feishu comparison showed the registry-backed direct announce path is the expected completion route for channel-bound sessions.