### PR TITLE
fix(models): guard manifest model id metadata

### DIFF
--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -6,6 +6,24 @@ import {
   stripSelfProviderModelPrefix,
 } from "./provider-model-id-normalization.js";
 
+function poisonedModelIdNormalizationRecord() {
+  return Object.defineProperty({}, "modelIdNormalization", {
+    get() {
+      throw new Error("model id normalization metadata exploded");
+    },
+  });
+}
+
+function poisonedModelIdNormalizationProvidersRecord() {
+  return {
+    modelIdNormalization: Object.defineProperty({}, "providers", {
+      get() {
+        throw new Error("model id normalization providers exploded");
+      },
+    }),
+  };
+}
+
 describe("provider model id policy normalization", () => {
   it("applies manifest policies before built-in provider normalization", () => {
     const policies = collectManifestModelIdNormalizationPolicies([
@@ -22,6 +40,40 @@ describe("provider model id policy normalization", () => {
       },
     ]);
 
+    expect(normalizeStaticProviderModelIdWithPolicies("google-vertex", "pro", policies)).toBe(
+      "gemini-3.1-pro-preview",
+    );
+  });
+
+  it("skips unreadable manifest model id normalization records", () => {
+    const policies = collectManifestModelIdNormalizationPolicies([
+      {
+        modelIdNormalization: {
+          providers: {
+            custom: {
+              prefixWhenBare: "vendor",
+            },
+          },
+        },
+      },
+      poisonedModelIdNormalizationRecord(),
+      poisonedModelIdNormalizationProvidersRecord(),
+      {
+        modelIdNormalization: {
+          providers: {
+            "Google-Vertex": {
+              aliases: {
+                pro: "gemini-3-pro",
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(normalizeStaticProviderModelIdWithPolicies("custom", "latest", policies)).toBe(
+      "vendor/latest",
+    );
     expect(normalizeStaticProviderModelIdWithPolicies("google-vertex", "pro", policies)).toBe(
       "gemini-3.1-pro-preview",
     );

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -29,7 +29,13 @@ export function collectManifestModelIdNormalizationPolicies(
 ): Map<string, ManifestModelIdNormalizationProvider> {
   const policies = new Map<string, ManifestModelIdNormalizationProvider>();
   for (const plugin of plugins) {
-    for (const [provider, policy] of Object.entries(plugin.modelIdNormalization?.providers ?? {})) {
+    let providers: Record<string, ManifestModelIdNormalizationProvider> | undefined;
+    try {
+      providers = plugin.modelIdNormalization?.providers;
+    } catch {
+      continue;
+    }
+    for (const [provider, policy] of Object.entries(providers ?? {})) {
       policies.set(normalizeLowercaseStringOrEmpty(provider), policy);
     }
   }


### PR DESCRIPTION
## Summary

- Skip unreadable plugin records while collecting manifest model-id normalization policies.
- Preserve policy collection from healthy records before and after a poisoned metadata row.
- Add regression coverage for both throwing `modelIdNormalization` and throwing nested `providers` metadata reads.

## Verification

- `node scripts/run-vitest.mjs packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/plugins/manifest-model-id-normalization.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 packages/model-catalog-core/src/provider-model-id-normalization.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts`
- `./node_modules/.bin/oxlint packages/model-catalog-core/src/provider-model-id-normalization.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, overall patch is correct (0.84)
- `.agents/skills/autoreview/scripts/autoreview --mode branch` — clean, overall patch is correct (0.88)

## Real behavior proof

Behavior addressed: manifest model-id normalization policy collection no longer aborts when one plugin metadata row throws while reading `modelIdNormalization` or its nested `providers` table.

Real environment tested: focused local package and plugin Vitest lanes in the sparse OpenClaw worktree; local formatter/linter/diff checks.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/plugins/manifest-model-id-normalization.test.ts` plus the formatter, linter, diff check, and autoreview commands listed above.

Evidence after fix: the focused model-catalog-core test file passes 6 tests and the plugin wrapper test file passes 7 tests; the new regression includes poisoned top-level and nested model-id normalization metadata access.

Observed result after fix: healthy manifest model-id normalization policies are still collected while unreadable plugin metadata rows are skipped.

What was not tested: broad `pnpm check:changed` did not run because the Crabbox coordinator returned HTTP 401 before lease creation; Blacksmith Testbox is also unauthenticated in this environment.
