### PR TITLE
fix(slack): emit message_sent hook on outbound delivery (mirror Telegram)

### DIFF
--- a/extensions/slack/src/message-sent-hook.ts
+++ b/extensions/slack/src/message-sent-hook.ts
@@ -1,0 +1,111 @@
+/**
+ * Slack-side emission of the `message_sent` plugin hook.
+ *
+ * Mirrors the Telegram pattern in `extensions/telegram/src/bot/delivery.replies.ts`
+ * (`buildTelegramSentHookContext`, `emitMessageSentHooks`, `emitTelegramMessageSentHooks`).
+ *
+ * Without this, plugins observing `message_sent` see Telegram outbound but not
+ * Slack outbound — even though `docs/plugins/hooks.md` documents the hook as
+ * firing for all successful outbound deliveries.
+ */
+import {
+  buildCanonicalSentMessageHookContext,
+  createInternalHookEvent,
+  fireAndForgetHook,
+  toInternalMessageSentContext,
+  toPluginMessageContext,
+  toPluginMessageSentEvent,
+  triggerInternalHook,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
+
+export type EmitSlackMessageSentHookParams = {
+  /** Optional canonical session key. When set, the internal `message:sent` hook fires too. */
+  sessionKeyForInternalHooks?: string;
+  /** Slack target (channel ID `C…`, DM channel ID `D…`, group `G…`, or user ID `U…`). */
+  to: string;
+  accountId?: string | null;
+  /** The outbound content that was sent. Mirrors `MessageSentEvent.content`. */
+  content: string;
+  success: boolean;
+  error?: string;
+  /** Slack message `ts` returned by `chat.postMessage` on success. */
+  messageId?: string;
+  isGroup?: boolean;
+  groupId?: string;
+};
+
+function buildSlackSentHookContext(params: EmitSlackMessageSentHookParams) {
+  return buildCanonicalSentMessageHookContext({
+    to: params.to,
+    content: params.content,
+    success: params.success,
+    error: params.error,
+    channelId: "slack",
+    accountId: params.accountId ?? undefined,
+    conversationId: params.to,
+    messageId: params.messageId,
+    isGroup: params.isGroup,
+    groupId: params.groupId,
+  });
+}
+
+function emitInternalSlackMessageSentHook(params: EmitSlackMessageSentHookParams): void {
+  if (!params.sessionKeyForInternalHooks) {
+    return;
+  }
+  const canonical = buildSlackSentHookContext(params);
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent(
+        "message",
+        "sent",
+        params.sessionKeyForInternalHooks,
+        toInternalMessageSentContext(canonical),
+      ),
+    ),
+    "slack: message:sent internal hook failed",
+  );
+}
+
+function emitMessageSentHooks(
+  params: EmitSlackMessageSentHookParams & {
+    hookRunner: ReturnType<typeof getGlobalHookRunner>;
+    enabled: boolean;
+  },
+): void {
+  if (!params.enabled && !params.sessionKeyForInternalHooks) {
+    return;
+  }
+  const canonical = buildSlackSentHookContext(params);
+  if (params.enabled) {
+    fireAndForgetHook(
+      Promise.resolve(
+        params.hookRunner!.runMessageSent(
+          toPluginMessageSentEvent(canonical),
+          toPluginMessageContext(canonical),
+        ),
+      ),
+      "slack: message_sent plugin hook failed",
+    );
+  }
+  emitInternalSlackMessageSentHook(params);
+}
+
+/**
+ * Fire both the plugin `message_sent` hook and (if a session key is supplied)
+ * the internal `message:sent` hook for a successful or failed Slack outbound
+ * delivery.
+ *
+ * Safe to call after every `chat.postMessage` — the function self-gates on
+ * `hookRunner.hasHooks("message_sent")` so plugins not observing the hook
+ * incur no cost.
+ */
+export function emitSlackMessageSentHooks(params: EmitSlackMessageSentHookParams): void {
+  const hookRunner = getGlobalHookRunner();
+  emitMessageSentHooks({
+    ...params,
+    hookRunner,
+    enabled: hookRunner?.hasHooks("message_sent") ?? false,
+  });
+}

--- a/extensions/slack/src/message-sent-hook.ts
+++ b/extensions/slack/src/message-sent-hook.ts
@@ -44,6 +44,12 @@ function buildSlackSentHookContext(params: EmitSlackMessageSentHookParams) {
     channelId: "slack",
     accountId: params.accountId ?? undefined,
     conversationId: params.to,
+    // Mirror the canonical session key into the `message_sent` hook context so
+    // plugins observing both `message_sending` and `message_sent` see the same
+    // `sessionKey` (and it matches the value the internal `message:sent` hook
+    // fires with). This matches the shared outbound emitter in
+    // `src/infra/outbound/deliver.ts`.
+    sessionKey: params.sessionKeyForInternalHooks,
     messageId: params.messageId,
     isGroup: params.isGroup,
     groupId: params.groupId,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -834,7 +834,8 @@ vi.mock("../config.runtime.js", () => ({
 
 vi.mock("../replies.js", () => ({
   createSlackReplyDeliveryPlan: () => ({
-    peekThreadTs: () => mockedReplyThreadTsSequence?.[0] ?? mockedReplyThreadTs,
+    peekThreadTs: () =>
+      mockedReplyThreadTsSequence ? mockedReplyThreadTsSequence[0] : mockedReplyThreadTs,
     nextThreadTs: () =>
       mockedReplyThreadTsSequence ? mockedReplyThreadTsSequence.shift() : mockedReplyThreadTs,
     markSent: () => {},
@@ -3094,16 +3095,22 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     ]);
   });
 
-  it("suppresses duplicate TTS supplement finals after preview finalization", async () => {
+  it("defers hooks and suppresses duplicate TTS finals when flush creates the preview id", async () => {
+    let flushed = false;
     const draftStream = {
       ...createDraftStreamStub(),
-      flush: vi.fn(noopAsync),
+      flush: vi.fn(async () => {
+        flushed = true;
+      }),
       clear: vi.fn(noopAsync),
       discardPending: vi.fn(noopAsync),
       seal: vi.fn(noopAsync),
+      messageId: () => (flushed ? "171234.567" : undefined),
     };
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+    mockedSlackIsThreadReply = false;
+    mockedReplyThreadTsSequence = [undefined, undefined];
     const payload = {
       text: "Spoken answer",
       mediaUrl: "https://example.com/tts.mp3",
@@ -3116,7 +3123,12 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       { kind: "final", payload },
     ];
 
-    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        message: { thread_ts: undefined },
+        replyToMode: "first",
+      }),
+    );
 
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
@@ -3124,6 +3136,48 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
       "deliver replies params",
     );
+    expectRecordFields(delivered, { replyThreadTs: THREAD_TS });
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses duplicate TTS supplement finals after preview finalization", async () => {
+    const draftStream = {
+      ...createDraftStreamStub(),
+      flush: vi.fn(noopAsync),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+      seal: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+    mockedSlackIsThreadReply = false;
+    mockedReplyThreadTsSequence = [undefined];
+    const payload = {
+      text: "Spoken answer",
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: { spokenText: "Spoken answer" },
+    };
+    mockedDispatchSequence = [
+      { kind: "final", payload },
+      { kind: "final", payload },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        message: { thread_ts: undefined },
+        replyToMode: "first",
+      }),
+    );
+
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    const delivered = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expectRecordFields(delivered, { replyThreadTs: THREAD_TS });
     expect(delivered.replies).toEqual([
       {
         mediaUrl: "https://example.com/tts.mp3",

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -297,6 +297,13 @@ function createPreparedSlackMessage(params?: {
   const mainSessionKey = params?.route?.mainSessionKey ?? "main";
   const lastRoutePolicy =
     params?.route?.lastRoutePolicy ?? (routeSessionKey === mainSessionKey ? "main" : "session");
+  const message = {
+    channel: "C123",
+    ts: "171234.111",
+    thread_ts: THREAD_TS,
+    user: "U123",
+    ...params?.message,
+  };
 
   return {
     ctx: {
@@ -319,13 +326,7 @@ function createPreparedSlackMessage(params?: {
       accountId: "default",
       config: params?.accountConfig ?? {},
     },
-    message: {
-      channel: "C123",
-      ts: "171234.111",
-      thread_ts: THREAD_TS,
-      user: "U123",
-      ...params?.message,
-    },
+    message,
     route: {
       agentId: "agent-1",
       accountId: "default",
@@ -335,7 +336,7 @@ function createPreparedSlackMessage(params?: {
       ...params?.route,
     },
     channelConfig: params?.channelConfig ?? null,
-    replyTarget: "channel:C123",
+    replyTarget: `channel:${message.channel}`,
     ctxPayload: {
       MessageThreadId: THREAD_TS,
       ...params?.ctxPayload,
@@ -2019,7 +2020,18 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
     stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.567" });
 
-    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        isDirectMessage: true,
+        message: { channel: "D123" },
+        route: { sessionKey: "agent:agent-1:slack:direct:u123" },
+        ctxPayload: {
+          SessionKey: "agent:agent-1:slack:direct:u123:thread:thread-1",
+          To: "user:U123",
+          OriginatingTo: "user:U123",
+        },
+      }),
+    );
 
     // The final was flushed through the stream, not deliverReplies.
     expect(deliverRepliesMock).not.toHaveBeenCalled();
@@ -2032,7 +2044,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       content: FINAL_REPLY_TEXT,
       success: true,
       messageId: "171234.567",
-      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+      to: "user:U123",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:direct:u123:thread:thread-1",
     });
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -800,9 +800,8 @@ vi.mock("../../streaming.js", () => ({
     pendingText: string;
     stopped: boolean;
   }) => {
-    session.delivered = true;
     session.pendingText = "";
-    session.stopped = true;
+    session.stopped = !session.delivered;
   },
   SlackStreamNotDeliveredError: TestSlackStreamNotDeliveredError,
   startSlackStream: startSlackStreamMock,
@@ -2188,6 +2187,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, "still buffered");
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(2);
   });
 
   it("finalizes buffered finals natively before attempting fallback delivery", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1515,6 +1515,13 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       messageId: "171234.567",
       text: "✅",
     });
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "preview message_sent", {
+      content: "✅",
+      success: true,
+      messageId: "171234.567",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+    });
     expect(deliverRepliesMock).not.toHaveBeenCalled();
     expect(draftStream.clear).not.toHaveBeenCalled();
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -20,7 +20,8 @@ const startSlackStreamMock = vi.fn(async () => ({
   delivered: true,
   pendingText: "",
 }));
-const stopSlackStreamMock = vi.fn(async () => {});
+const stopSlackStreamMock = vi.fn(async () => ({}) as { messageId?: string });
+const emitSlackMessageSentHooksMock = vi.fn(() => {});
 const reactSlackMessageMock = vi.fn(async () => {});
 const removeSlackReactionMock = vi.fn(async () => {});
 class TestSlackStreamNotDeliveredError extends Error {
@@ -807,6 +808,10 @@ vi.mock("../../streaming.js", () => ({
   stopSlackStream: stopSlackStreamMock,
 }));
 
+vi.mock("../../message-sent-hook.js", () => ({
+  emitSlackMessageSentHooks: emitSlackMessageSentHooksMock,
+}));
+
 vi.mock("../../threading.js", () => ({
   resolveSlackThreadTargets: () => ({
     statusThreadTs: THREAD_TS,
@@ -1173,7 +1178,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       pendingText: "",
     });
     appendSlackStreamMock.mockResolvedValue(undefined);
-    stopSlackStreamMock.mockResolvedValue(undefined);
+    stopSlackStreamMock.mockResolvedValue({});
+    emitSlackMessageSentHooksMock.mockClear();
   });
 
   it("falls back to normal delivery when preview finalize fails", async () => {
@@ -1958,6 +1964,114 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("emits message_sent only once for native progress final replies (no double emit)", async () => {
+    // In native-progress mode the final answer is delivered through
+    // deliverNormally -> deliverReplies, which owns the message_sent emit. The
+    // dispatch-level stream finalizer must NOT also emit for the same final
+    // answer (regression for the streamedFinalContent double-emit bug).
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events: [{ kind: "item", progressText: "slow tool" }],
+    });
+
+    // Final routed through deliverReplies (the owner of the emit here)...
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    // ...and the stream WAS finalized, so the old code would have double-emitted.
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    // The dispatch-level finalizer must not emit (deliverReplies already does).
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("emits message_sent exactly once via the finalizer for a plain text-stream final reply", async () => {
+    // Plain text-stream mode (no native progress card): the final answer is
+    // flushed through the text stream and never goes through deliverReplies, so
+    // the dispatch finalizer owns the single message_sent emit. This is the
+    // positive counterpart to the native-progress no-double-emit regression.
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
+    startSlackStreamMock.mockResolvedValueOnce({
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    });
+    stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.567" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    // The final was flushed through the stream, not deliverReplies.
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    // The finalizer emits exactly once, with success and the delivered Slack ts,
+    // and threads the canonical session key (mirrors the P2 fix in replies.ts:
+    // the dispatch finalizer emit must also carry session correlation).
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "finalizer message_sent", {
+      content: FINAL_REPLY_TEXT,
+      success: true,
+      messageId: "171234.567",
+      sessionKeyForInternalHooks: "agent:agent-1:slack:C123",
+    });
+  });
+
+  it("emits message_sent exactly once when stopSlackStream throws and the pending stream falls back", async () => {
+    // On a SlackStreamNotDeliveredError the dispatch finalizer must NOT emit;
+    // the pending-stream fallback re-enters deliverReplies, which owns the emit.
+    // Guards against the finalizer double-emitting alongside the fallback.
+    mockedNativeStreaming = true;
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: FINAL_REPLY_TEXT,
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, "user_not_found"),
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    // Fallback delivered the final exactly once (deliverReplies owns the emit).
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    // The finalizer itself must not emit on the fallback branch (no double).
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("emits message_sent exactly once when an append flush fails and the buffered stream falls back", async () => {
+    // appendSlackStream throwing SlackStreamNotDeliveredError mid-stream routes
+    // all buffered text through deliverReplies; the finalizer must not also emit.
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "first buffered" } },
+      { kind: "final", payload: { text: "second flushes" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "first buffered",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText += "\nsecond flushes";
+      throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "first buffered\nsecond flushes");
+    expect(stopSlackStreamMock).not.toHaveBeenCalled();
+    // The finalizer must not emit on the buffered-fallback branch (no double).
+    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
   });
 
   it("does not start a text stream for native progress mode when no progress card exists", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -2108,9 +2108,14 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
     expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "fallback message_sent", {
       content: FINAL_REPLY_TEXT,
-      messageId: "171234.901",
       success: true,
     });
+    expect(
+      requireRecord(
+        requireMockCall(emitSlackMessageSentHooksMock, 0, "fallback message_sent")[0],
+        "fallback message_sent",
+      ),
+    ).not.toHaveProperty("messageId");
   });
 
   it("emits message_sent for a tool-only stream fallback", async () => {
@@ -2139,9 +2144,14 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
     expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "tool fallback message_sent", {
       content: "tool output",
-      messageId: "171234.902",
       success: true,
     });
+    expect(
+      requireRecord(
+        requireMockCall(emitSlackMessageSentHooksMock, 0, "tool fallback message_sent")[0],
+        "tool fallback message_sent",
+      ),
+    ).not.toHaveProperty("messageId");
   });
 
   it("emits acknowledged finals before a pending stream suffix falls back", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -6,7 +6,9 @@ const THREAD_TS = "thread-1";
 const SAME_TEXT = "same reply";
 
 const createSlackDraftStreamMock = vi.fn();
-const deliverRepliesMock = vi.fn(async () => {});
+const deliverRepliesMock = vi.fn(
+  async () => undefined as { messageId?: string; channelId?: string } | undefined,
+);
 const finalizeSlackPreviewEditMock = vi.fn(async () => {});
 const postMessageMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
 const chatUpdateMock = vi.fn(async () => ({ ok: true, ts: "171234.999" }));
@@ -20,7 +22,7 @@ const startSlackStreamMock = vi.fn(async () => ({
   delivered: true,
   pendingText: "",
 }));
-const stopSlackStreamMock = vi.fn(async () => ({}) as { messageId?: string });
+const stopSlackStreamMock = vi.fn(async (_params?: unknown) => ({}) as { messageId?: string });
 const emitSlackMessageSentHooksMock = vi.fn(() => {});
 const reactSlackMessageMock = vi.fn(async () => {});
 const removeSlackReactionMock = vi.fn(async () => {});
@@ -121,6 +123,7 @@ let mockedDispatchSequence: Array<{
   payload: TestReplyPayload;
 }> = [];
 let mockedQueuedDispatchCounts: TestDispatchCounts = { tool: 0, block: 0, final: 0 };
+let mockedDispatcherCapturesDeliveryErrors = false;
 
 let mockedProgressEvents: string[] = [];
 let mockedReplyOptionEvents: Array<
@@ -796,16 +799,16 @@ vi.mock("../../streaming.js", () => ({
     pendingText: string;
     stopped: boolean;
   }) => {
-    const hadNativeDelivery = session.delivered;
     session.delivered = true;
     session.pendingText = "";
-    if (!hadNativeDelivery) {
-      session.stopped = true;
-    }
+    session.stopped = true;
   },
   SlackStreamNotDeliveredError: TestSlackStreamNotDeliveredError,
   startSlackStream: startSlackStreamMock,
-  stopSlackStream: stopSlackStreamMock,
+  stopSlackStream: async (params: { session: { stopped: boolean } }) => {
+    params.session.stopped = true;
+    return await stopSlackStreamMock(params);
+  },
 }));
 
 vi.mock("../../message-sent-hook.js", () => ({
@@ -1001,7 +1004,14 @@ vi.mock("../reply.runtime.js", () => ({
         continue;
       }
       mockedQueuedDispatchCounts[entry.kind] += 1;
-      await params.dispatcherOptions.deliver(deliverPayload, { kind: entry.kind });
+      try {
+        await params.dispatcherOptions.deliver(deliverPayload, { kind: entry.kind });
+      } catch (error) {
+        if (!mockedDispatcherCapturesDeliveryErrors) {
+          throw error;
+        }
+        mockedQueuedDispatchCounts[entry.kind] -= 1;
+      }
     }
     return {
       queuedFinal: false,
@@ -1165,6 +1175,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedSlackIsThreadReply = true;
     mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
     mockedQueuedDispatchCounts = { tool: 0, block: 0, final: 0 };
+    mockedDispatcherCapturesDeliveryErrors = false;
     mockedProgressEvents = [];
     mockedReplyOptionEvents = [];
 
@@ -2025,10 +2036,40 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
   });
 
+  it("emits message_sent for every final payload appended to one text stream", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "answer" } },
+      { kind: "final", payload: { text: "late warning", isError: true } },
+    ];
+    startSlackStreamMock.mockResolvedValueOnce({
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    });
+    stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.890" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(2);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "first final message_sent", {
+      content: "answer",
+      success: true,
+      messageId: "171234.890",
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "second final message_sent", {
+      content: "late warning",
+      success: true,
+      messageId: "171234.890",
+    });
+  });
+
   it("emits message_sent exactly once when stopSlackStream throws and the pending stream falls back", async () => {
-    // On a SlackStreamNotDeliveredError the dispatch finalizer must NOT emit;
-    // the pending-stream fallback re-enters deliverReplies, which owns the emit.
-    // Guards against the finalizer double-emitting alongside the fallback.
+    // The combined fallback send defers hooks so dispatch can preserve the
+    // original final-payload boundary.
     mockedNativeStreaming = true;
     const session = {
       channel: "C123",
@@ -2041,17 +2082,316 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     stopSlackStreamMock.mockRejectedValueOnce(
       new TestSlackStreamNotDeliveredError(FINAL_REPLY_TEXT, "user_not_found"),
     );
+    deliverRepliesMock.mockResolvedValueOnce({
+      messageId: "171234.901",
+      channelId: "C123",
+    });
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
-    // Fallback delivered the final exactly once (deliverReplies owns the emit).
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
-    // The finalizer itself must not emit on the fallback branch (no double).
-    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "fallback message_sent", {
+      content: FINAL_REPLY_TEXT,
+      messageId: "171234.901",
+      success: true,
+    });
   });
 
-  it("emits message_sent exactly once when an append flush fails and the buffered stream falls back", async () => {
+  it("emits message_sent for a tool-only stream fallback", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [{ kind: "tool", payload: { text: "tool output" } }];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "tool output",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("tool output", "user_not_found"),
+    );
+    deliverRepliesMock.mockResolvedValueOnce({
+      messageId: "171234.902",
+      channelId: "C123",
+    });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "tool output");
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "tool fallback message_sent", {
+      content: "tool output",
+      messageId: "171234.902",
+      success: true,
+    });
+  });
+
+  it("emits acknowledged finals before a pending stream suffix falls back", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "already visible" } },
+      { kind: "final", payload: { text: "still buffered" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText = "\nstill buffered";
+    });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("still buffered", "user_not_found"),
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(2);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "acknowledged message_sent", {
+      content: "already visible",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "fallback message_sent", {
+      content: "still buffered",
+      success: true,
+    });
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "still buffered");
+  });
+
+  it("finalizes buffered finals natively before attempting fallback delivery", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "already visible" } },
+      { kind: "final", payload: { text: "buffered second" } },
+      { kind: "final", payload: { text: "failing third" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock
+      .mockImplementationOnce(async () => {
+        session.pendingText = "\nbuffered second";
+      })
+      .mockImplementationOnce(async () => {
+        session.pendingText += "\nfailing third";
+        throw new TestSlackStreamNotDeliveredError(
+          "buffered second\nfailing third",
+          "user_not_found",
+        );
+      });
+    stopSlackStreamMock.mockResolvedValueOnce({ messageId: "171234.999" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(3);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "first final message_sent", {
+      content: "already visible",
+      messageId: "171234.999",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "second final message_sent", {
+      content: "buffered second",
+      messageId: "171234.999",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 2, "third final message_sent", {
+      content: "failing third",
+      messageId: "171234.999",
+      success: true,
+    });
+  });
+
+  it("emits one terminal failure per buffered final when native stop and fallback fail", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "already visible" } },
+      { kind: "final", payload: { text: "buffered second" } },
+      { kind: "final", payload: { text: "failing third" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: true,
+      pendingText: "",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock
+      .mockImplementationOnce(async () => {
+        session.pendingText = "\nbuffered second";
+      })
+      .mockImplementationOnce(async () => {
+        session.pendingText += "\nfailing third";
+        throw new TestSlackStreamNotDeliveredError(
+          "buffered second\nfailing third",
+          "user_not_found",
+        );
+      });
+    deliverRepliesMock.mockRejectedValueOnce(new Error("fallback send failed"));
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("buffered second\nfailing third", "user_not_found"),
+    );
+
+    await expect(dispatchPreparedSlackMessage(createPreparedSlackMessage())).rejects.toThrowError(
+      "slack-stream not delivered: user_not_found",
+    );
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "buffered second\nfailing third");
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(3);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "acknowledged message_sent", {
+      content: "already visible",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "buffered message_sent", {
+      content: "buffered second",
+      error: "fallback send failed",
+      success: false,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 2, "failed-append message_sent", {
+      content: "failing third",
+      error: "fallback send failed",
+      success: false,
+    });
+  });
+
+  it("removes all failed buffered finals from production-style delivery counts", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatcherCapturesDeliveryErrors = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "first buffered" } },
+      { kind: "final", payload: { text: "second buffered" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "first buffered",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText += "\nsecond buffered";
+      throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
+    });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("first buffered\nsecond buffered", "user_not_found"),
+    );
+    deliverRepliesMock.mockRejectedValueOnce(new Error("fallback send failed"));
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { statusReactions: { enabled: true } } },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(2);
+    expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes all failed buffered tools from production-style delivery counts", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatcherCapturesDeliveryErrors = true;
+    mockedDispatchSequence = [
+      { kind: "tool", payload: { text: "first tool" } },
+      { kind: "tool", payload: { text: "second tool" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "first tool",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock.mockImplementationOnce(async () => {
+      session.pendingText += "\nsecond tool";
+      throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
+    });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("first tool\nsecond tool", "user_not_found"),
+    );
+    deliverRepliesMock.mockRejectedValueOnce(new Error("fallback send failed"));
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { statusReactions: { enabled: true } } },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(2);
+    expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a buffered final acknowledged when a later block flushes the stream", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "buffered final" } },
+      { kind: "block", payload: { text: "flushes both" } },
+      { kind: "final", payload: { text: "pending tail" } },
+    ];
+    const session = {
+      channel: "C123",
+      threadTs: THREAD_TS,
+      stopped: false,
+      delivered: false,
+      pendingText: "buffered final",
+    };
+    startSlackStreamMock.mockResolvedValueOnce(session);
+    appendSlackStreamMock
+      .mockImplementationOnce(async () => {
+        session.delivered = true;
+        session.pendingText = "";
+      })
+      .mockImplementationOnce(async () => {
+        session.pendingText = "\npending tail";
+      });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("pending tail", "user_not_found"),
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(3);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "flushed final message_sent", {
+      content: "buffered final",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "flushed block message_sent", {
+      content: "flushes both",
+      success: true,
+    });
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, "pending tail");
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 2, "fallback final message_sent", {
+      content: "pending tail",
+      success: true,
+    });
+  });
+
+  it("emits message_sent for each payload when an append flush falls back", async () => {
     // appendSlackStream throwing SlackStreamNotDeliveredError mid-stream routes
     // all buffered text through deliverReplies; the finalizer must not also emit.
     mockedNativeStreaming = true;
@@ -2071,14 +2411,24 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       session.pendingText += "\nsecond flushes";
       throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
     });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("first buffered\nsecond flushes", "user_not_found"),
+    );
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, "first buffered\nsecond flushes");
-    expect(stopSlackStreamMock).not.toHaveBeenCalled();
-    // The finalizer must not emit on the buffered-fallback branch (no double).
-    expect(emitSlackMessageSentHooksMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(emitSlackMessageSentHooksMock).toHaveBeenCalledTimes(2);
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 0, "fallback block message_sent", {
+      content: "first buffered",
+      success: true,
+    });
+    expectMockCallArgFields(emitSlackMessageSentHooksMock, 1, "fallback final message_sent", {
+      content: "second flushes",
+      success: true,
+    });
   });
 
   it("does not start a text stream for native progress mode when no progress card exists", async () => {
@@ -2958,13 +3308,16 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       session.pendingText += "\nsecond flushes";
       throw new TestSlackStreamNotDeliveredError(session.pendingText, "user_not_found");
     });
+    stopSlackStreamMock.mockRejectedValueOnce(
+      new TestSlackStreamNotDeliveredError("first buffered\nsecond flushes", "user_not_found"),
+    );
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
     expect(postMessageMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, "first buffered\nsecond flushes");
-    expect(stopSlackStreamMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
   });
 
   it("forwards oversized pending stream text to the chunked sender intact (chunking is the sender's responsibility)", async () => {
@@ -3013,6 +3366,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       session.pendingText += "\nsecond payload";
       throw new Error("network socket closed");
     });
+    stopSlackStreamMock.mockRejectedValueOnce(new Error("stop failed"));
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
@@ -3020,11 +3374,11 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     // payload (so the earlier buffered chunk is not dropped).
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, "first buffered\nsecond payload");
-    // Session was marked fallback-delivered by deliverPendingStreamFallback,
-    // so finalize skips stopSlackStream.
+    // Session was retired after fallback, so finalization cannot resend the
+    // Slack SDK's retained private buffer.
     expect(session.pendingText).toBe("");
     expect(session.stopped).toBe(true);
-    expect(stopSlackStreamMock).not.toHaveBeenCalled();
+    expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
     // No raw postMessage path was invoked.
     expect(postMessageMock).not.toHaveBeenCalled();
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -805,6 +805,19 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   };
   const deliveryTracker = createSlackEventDeliveryTracker();
+  const markPreviewPayloadDelivered = (params: {
+    kind: ReplyDispatchKind;
+    payload: ReplyPayload;
+    threadTs: string | undefined;
+  }) => {
+    deliveryTracker.markDelivered(params);
+    // Single-use reply modes move later same-turn payloads off the preview
+    // thread, so protect both delivery keys from duplicates.
+    const nextThreadTs = replyPlan.peekThreadTs();
+    if (nextThreadTs !== params.threadTs) {
+      deliveryTracker.markDelivered({ ...params, threadTs: nextThreadTs });
+    }
+  };
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
@@ -908,7 +921,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     payload: ReplyPayload;
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
-  }): Promise<void> => {
+  }): Promise<string | undefined> => {
     if (params.payload.isReasoning === true) {
       return;
     }
@@ -925,7 +938,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       })
     ) {
       logVerbose("slack: suppressed duplicate normal delivery within the same turn");
-      return;
+      return deliveryReplyThreadTs;
     }
     await deliverReplies({
       cfg: ctx.cfg,
@@ -958,6 +971,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       payload: params.payload,
       threadTs: deliveryReplyThreadTs,
     });
+    return deliveryReplyThreadTs;
   };
 
   const deliverBufferedStreamFallback = async (params: {
@@ -1311,7 +1325,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           kind: info.kind,
           forcedThreadTs: finalThreadTs,
         });
-        deliveryTracker.markDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
+        markPreviewPayloadDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
         return;
       }
     }
@@ -1363,14 +1377,16 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ...(edit.blocks?.length ? { blocks: edit.blocks } : {}),
             threadTs: edit.threadTs,
           });
-          emitSlackMessageSentHooks({
-            ...messageSentHookContext,
-            to: messageSentHookTarget,
-            accountId: account.accountId,
-            content: trimmedFinalText,
-            success: true,
-            messageId: preview.messageId,
-          });
+          if (!ttsSupplement) {
+            emitSlackMessageSentHooks({
+              ...messageSentHookContext,
+              to: messageSentHookTarget,
+              accountId: account.accountId,
+              content: trimmedFinalText,
+              success: true,
+              messageId: preview.messageId,
+            });
+          }
           draftPreviewCommitted = true;
           observedFinalReplyDelivery = true;
         },
@@ -1382,14 +1398,25 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           const finalThreadTs = usedReplyThreadTs ?? statusThreadTs;
           observedReplyDelivery = true;
           replyPlan.markSent();
-          deliveryTracker.markDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
+          // Supplemental TTS media is the terminal delivery for the logical
+          // payload. Marking the preview first would suppress that media send.
+          if (!ttsSupplement) {
+            markPreviewPayloadDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
+          }
         },
         buildSupplementalPayload: () =>
           ttsSupplement ? buildTtsSupplementMediaPayload(payload) : undefined,
         deliverSupplemental: async (supplementalPayload) => {
-          await deliverNormally({
+          const previewThreadTs = usedReplyThreadTs ?? statusThreadTs;
+          const supplementalThreadTs = await deliverNormally({
             payload: supplementalPayload,
             kind: info.kind,
+            forcedThreadTs: previewThreadTs,
+          });
+          markPreviewPayloadDelivered({
+            kind: info.kind,
+            payload,
+            threadTs: supplementalThreadTs,
           });
         },
         logPreviewEditFailure: (err) => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -523,10 +523,16 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   // Shared context for the `message_sent` plugin hook emitted on each delivered
   // reply (both the `deliverReplies` paths and the native-streaming finalizer).
+  const messageSentHookTarget =
+    prepared.ctxPayload.OriginatingTo ?? prepared.ctxPayload.To ?? prepared.replyTarget;
   const messageSentHookContext = {
-    sessionKeyForInternalHooks: route.sessionKey,
+    sessionKeyForInternalHooks: prepared.ctxPayload.SessionKey ?? route.sessionKey,
     isGroup: prepared.isRoomish,
     groupId: prepared.isRoomish ? message.channel : undefined,
+  };
+  const messageSentDeliveryHookContext = {
+    ...messageSentHookContext,
+    messageSentHookTarget,
   };
 
   const reactionMessageTs = prepared.ackReactionMessageTs;
@@ -757,7 +763,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
       emitSlackMessageSentHooks({
         ...messageSentHookContext,
-        to: prepared.replyTarget,
+        to: messageSentHookTarget,
         accountId: account.accountId,
         content: delivery.content,
         success: true,
@@ -773,7 +779,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
       emitSlackMessageSentHooks({
         ...messageSentHookContext,
-        to: prepared.replyTarget,
+        to: messageSentHookTarget,
         accountId: account.accountId,
         content: delivery.content,
         success: false,
@@ -789,7 +795,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
       emitSlackMessageSentHooks({
         ...messageSentHookContext,
-        to: prepared.replyTarget,
+        to: messageSentHookTarget,
         accountId: account.accountId,
         content: delivery.content,
         success: true,
@@ -876,7 +882,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         replyToMode: replyDeliveryMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
-        ...messageSentHookContext,
+        ...messageSentDeliveryHookContext,
         deferMessageSentHooks: true,
       });
       markSlackStreamFallbackDelivered(session);
@@ -933,7 +939,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
       ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
-      ...messageSentHookContext,
+      ...messageSentDeliveryHookContext,
     });
     observedReplyDelivery = true;
     if (params.kind === "final") {
@@ -1359,7 +1365,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           });
           emitSlackMessageSentHooks({
             ...messageSentHookContext,
-            to: prepared.replyTarget,
+            to: messageSentHookTarget,
             accountId: account.accountId,
             content: trimmedFinalText,
             success: true,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -899,6 +899,20 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         deferMessageSentHooks: true,
       });
       markSlackStreamFallbackDelivered(session);
+      if (!session.stopped) {
+        try {
+          await stopSlackStream({
+            session,
+            ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+          });
+        } catch (finalizeErr) {
+          runtime.error?.(
+            danger(
+              `slack-stream: failed to finalize native stream after fallback delivery: ${formatSlackError(finalizeErr)}`,
+            ),
+          );
+        }
+      }
       // The combined fallback can span multiple logical payloads and Slack
       // chunks, so no single message `ts` correctly identifies every event.
       emitSuccessfulPendingStreamedDeliveries();

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1241,6 +1241,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ...(edit.blocks?.length ? { blocks: edit.blocks } : {}),
             threadTs: edit.threadTs,
           });
+          emitSlackMessageSentHooks({
+            ...messageSentHookContext,
+            to: prepared.replyTarget,
+            accountId: account.accountId,
+            content: trimmedFinalText,
+            success: true,
+            messageId: preview.messageId,
+          });
           draftPreviewCommitted = true;
           observedFinalReplyDelivery = true;
         },

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -891,13 +891,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
 
     const text = reply.trimmedText;
-    // Remember the final reply text streamed to Slack so the `message_sent`
-    // hook can fire after the stream is finalized. The SDK may buffer this
-    // locally until stopSlackStream flushes it, so we capture regardless of the
-    // current `streamSession.delivered` state.
-    if (params.kind === "final" && text) {
-      streamedFinalContent = text;
-    }
     let plannedThreadTs: string | undefined;
     try {
       if (!streamSession && nativeProgressStreamStartPromise) {
@@ -965,6 +958,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             observedFinalReplyDelivery = true;
           }
         }
+        // Remember the final reply text delivered through the text stream so
+        // the `message_sent` hook can fire after stopSlackStream flushes it.
+        // Only the text-stream path captures this; every deliverNormally branch
+        // already emits via deliverReplies, so capturing there would
+        // double-emit for the same final answer.
+        if (params.kind === "final" && text) {
+          streamedFinalContent = text;
+        }
         rememberDeliveredThreadTs(params.kind, streamThreadTs);
         replyPlan.markSent();
         deliveryTracker.markDelivered({
@@ -1031,6 +1032,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         if (params.kind === "final") {
           observedFinalReplyDelivery = true;
         }
+      }
+      // Remember the final reply text appended to the text stream so the
+      // `message_sent` hook can fire after stopSlackStream flushes it (see the
+      // matching capture on the stream-start path above).
+      if (params.kind === "final" && text) {
+        streamedFinalContent = text;
       }
       deliveryTracker.markDelivered({
         kind: params.kind,
@@ -1856,7 +1863,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           accountId: account.accountId,
           content: streamedFinalContent,
           success: true,
-          ...(stopResult.messageId ? { messageId: stopResult.messageId } : {}),
+          ...(stopResult?.messageId ? { messageId: stopResult.messageId } : {}),
         });
       }
     } catch (err) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -62,6 +62,7 @@ import {
   isSlackInteractiveRepliesEnabled,
 } from "../../interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "../../limits.js";
+import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
 import {
   buildSlackProgressDraftBlocks,
   buildSlackProgressStreamCompletionChunks,
@@ -520,6 +521,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
 
+  // Shared context for the `message_sent` plugin hook emitted on each delivered
+  // reply (both the `deliverReplies` paths and the native-streaming finalizer).
+  const messageSentHookContext = {
+    sessionKeyForInternalHooks: route.sessionKey,
+    isGroup: prepared.isRoomish,
+    groupId: prepared.isRoomish ? message.channel : undefined,
+  };
+
   const reactionMessageTs = prepared.ackReactionMessageTs;
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
@@ -703,6 +712,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
   let observedFinalReplyDelivery = false;
+  // Text of the final reply delivered through the native stream. Captured so
+  // the `message_sent` plugin hook can be emitted once the stream is finalized
+  // (stopSlackStream flushes any locally-buffered text to Slack). Mirrors the
+  // streaming-path emit in Telegram (extensions/telegram/src/bot-native-commands.ts).
+  let streamedFinalContent: string | undefined;
   const deliveryTracker = createSlackEventDeliveryTracker();
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
@@ -754,6 +768,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         replyToMode: replyDeliveryMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+        ...messageSentHookContext,
       });
       markSlackStreamFallbackDelivered(session);
       observedReplyDelivery = true;
@@ -807,6 +822,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
       ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+      ...messageSentHookContext,
     });
     observedReplyDelivery = true;
     if (params.kind === "final") {
@@ -875,6 +891,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
 
     const text = reply.trimmedText;
+    // Remember the final reply text streamed to Slack so the `message_sent`
+    // hook can fire after the stream is finalized. The SDK may buffer this
+    // locally until stopSlackStream flushes it, so we capture regardless of the
+    // current `streamSession.delivered` state.
+    if (params.kind === "final" && text) {
+      streamedFinalContent = text;
+    }
     let plannedThreadTs: string | undefined;
     try {
       if (!streamSession && nativeProgressStreamStartPromise) {
@@ -1816,15 +1839,40 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       if (completionChunks?.length) {
         nativeProgressCompletionSent = true;
       }
-      await stopSlackStream({
+      const stopResult = await stopSlackStream({
         session: finalStream,
         ...(completionChunks?.length ? { chunks: completionChunks } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
       });
+      // The stream finalized successfully, flushing any buffered final text to
+      // Slack. Emit the `message_sent` plugin hook for the streamed final reply
+      // here (the streaming happy-path never goes through deliverReplies, which
+      // emits for the non-streaming/fallback paths). emitSlackMessageSentHooks
+      // self-gates on registered listeners, so this is a no-op when unused.
+      if (streamedFinalContent) {
+        emitSlackMessageSentHooks({
+          ...messageSentHookContext,
+          to: prepared.replyTarget,
+          accountId: account.accountId,
+          content: streamedFinalContent,
+          success: true,
+          ...(stopResult.messageId ? { messageId: stopResult.messageId } : {}),
+        });
+      }
     } catch (err) {
       if (err instanceof SlackStreamNotDeliveredError) {
         streamFallbackDelivered = await deliverPendingStreamFallback(finalStream, err);
       } else {
+        if (streamedFinalContent) {
+          emitSlackMessageSentHooks({
+            ...messageSentHookContext,
+            to: prepared.replyTarget,
+            accountId: account.accountId,
+            content: streamedFinalContent,
+            success: false,
+            error: formatSlackError(err),
+          });
+        }
         runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatSlackError(err)}`));
       }
     }

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -883,7 +883,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return false;
     }
     try {
-      const fallbackResult = await deliverReplies({
+      await deliverReplies({
         cfg: ctx.cfg,
         replies: [{ text: fallbackText } as ReplyPayload],
         target: prepared.replyTarget,
@@ -899,7 +899,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         deferMessageSentHooks: true,
       });
       markSlackStreamFallbackDelivered(session);
-      emitSuccessfulPendingStreamedDeliveries(fallbackResult?.messageId);
+      // The combined fallback can span multiple logical payloads and Slack
+      // chunks, so no single message `ts` correctly identifies every event.
+      emitSuccessfulPendingStreamedDeliveries();
       observedReplyDelivery = true;
       usedReplyThreadTs ??= session.threadTs;
       logVerbose(
@@ -923,7 +925,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     forcedThreadTs?: string;
   }): Promise<string | undefined> => {
     if (params.payload.isReasoning === true) {
-      return;
+      return undefined;
     }
     const replyThreadTs = resolveDeliveryThreadTs(params);
     const deliveryReplyThreadTs =

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -712,11 +712,92 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
   let observedFinalReplyDelivery = false;
-  // Text of the final reply delivered through the native stream. Captured so
-  // the `message_sent` plugin hook can be emitted once the stream is finalized
-  // (stopSlackStream flushes any locally-buffered text to Slack). Mirrors the
-  // streaming-path emit in Telegram (extensions/telegram/src/bot-native-commands.ts).
-  let streamedFinalContent: string | undefined;
+  // Reply payloads routed through the native text stream. Track Slack
+  // acknowledgement separately because a later buffered suffix can fall back
+  // after earlier payloads are already visible.
+  const streamedDeliveries: Array<{
+    kind: ReplyDispatchKind;
+    content: string;
+    acknowledged: boolean;
+    outcome?: "success" | "failure";
+  }> = [];
+  const streamedFailuresOwnedByDispatcher: Record<ReplyDispatchKind, number> = {
+    tool: 0,
+    block: 0,
+    final: 0,
+  };
+  const refreshStreamedAcknowledgements = (session: SlackStreamSession) => {
+    if (session.pendingText.length === 0) {
+      for (const delivery of streamedDeliveries) {
+        delivery.acknowledged = true;
+      }
+    }
+  };
+  const recordStreamedDelivery = (kind: ReplyDispatchKind, content: string) => {
+    const delivery: (typeof streamedDeliveries)[number] = {
+      kind,
+      content,
+      acknowledged: false,
+    };
+    streamedDeliveries.push(delivery);
+    return delivery;
+  };
+  const rememberStreamedDelivery = (
+    kind: ReplyDispatchKind,
+    content: string,
+    session: SlackStreamSession,
+  ) => {
+    recordStreamedDelivery(kind, content);
+    refreshStreamedAcknowledgements(session);
+  };
+  const emitAcknowledgedStreamedDeliveries = (messageId?: string) => {
+    for (const delivery of streamedDeliveries) {
+      if (!delivery.acknowledged || delivery.outcome) {
+        continue;
+      }
+      emitSlackMessageSentHooks({
+        ...messageSentHookContext,
+        to: prepared.replyTarget,
+        accountId: account.accountId,
+        content: delivery.content,
+        success: true,
+        ...(messageId ? { messageId } : {}),
+      });
+      delivery.outcome = "success";
+    }
+  };
+  const emitFailedPendingStreamedDeliveries = (error: string) => {
+    for (const delivery of streamedDeliveries) {
+      if (delivery.acknowledged || delivery.outcome) {
+        continue;
+      }
+      emitSlackMessageSentHooks({
+        ...messageSentHookContext,
+        to: prepared.replyTarget,
+        accountId: account.accountId,
+        content: delivery.content,
+        success: false,
+        error,
+      });
+      delivery.outcome = "failure";
+    }
+  };
+  const emitSuccessfulPendingStreamedDeliveries = (messageId?: string) => {
+    for (const delivery of streamedDeliveries) {
+      if (delivery.acknowledged || delivery.outcome) {
+        continue;
+      }
+      emitSlackMessageSentHooks({
+        ...messageSentHookContext,
+        to: prepared.replyTarget,
+        accountId: account.accountId,
+        content: delivery.content,
+        success: true,
+        ...(messageId ? { messageId } : {}),
+      });
+      delivery.outcome = "success";
+    }
+  };
   const deliveryTracker = createSlackEventDeliveryTracker();
   const resolveDeliveryThreadTs = (params: {
     kind: ReplyDispatchKind;
@@ -745,18 +826,45 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     session: SlackStreamSession,
     err: SlackStreamNotDeliveredError,
   ): Promise<boolean> => {
+    let fallbackError = err;
+    if (!session.stopped) {
+      try {
+        const stopResult = await stopSlackStream({
+          session,
+          ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+        });
+        for (const delivery of streamedDeliveries) {
+          delivery.acknowledged = true;
+        }
+        emitAcknowledgedStreamedDeliveries(stopResult.messageId);
+        observedReplyDelivery = true;
+        usedReplyThreadTs ??= session.threadTs;
+        return true;
+      } catch (stopErr) {
+        if (stopErr instanceof SlackStreamNotDeliveredError) {
+          fallbackError = stopErr;
+        } else {
+          runtime.error?.(
+            danger(
+              `slack-stream: failed to finalize buffered text before fallback: ${formatSlackError(stopErr)}`,
+            ),
+          );
+        }
+      }
+    }
+    emitAcknowledgedStreamedDeliveries();
     // The Slack SDK still owns this text in-memory; no streaming API call has
     // acknowledged it. Route through deliverReplies so pendingText that
     // exceeds Slack's per-message text limit still lands (a single
     // chat.postMessage would have failed with msg_too_long), and so the
     // fallback respects the configured replyToMode/identity the same way
     // normal replies do.
-    const fallbackText = err.pendingText.trim();
+    const fallbackText = fallbackError.pendingText.trim();
     if (!fallbackText) {
       return false;
     }
     try {
-      await deliverReplies({
+      const fallbackResult = await deliverReplies({
         cfg: ctx.cfg,
         replies: [{ text: fallbackText } as ReplyPayload],
         target: prepared.replyTarget,
@@ -769,18 +877,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         ...(slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
         ...messageSentHookContext,
+        deferMessageSentHooks: true,
       });
       markSlackStreamFallbackDelivered(session);
+      emitSuccessfulPendingStreamedDeliveries(fallbackResult?.messageId);
       observedReplyDelivery = true;
       usedReplyThreadTs ??= session.threadTs;
       logVerbose(
-        `slack-stream: streamed delivery failed (${err.slackCode}); delivered ${fallbackText.length} chars via deliverReplies fallback`,
+        `slack-stream: streamed delivery failed (${fallbackError.slackCode}); delivered ${fallbackText.length} chars via deliverReplies fallback`,
       );
       return true;
     } catch (postErr) {
+      emitFailedPendingStreamedDeliveries(formatErrorMessage(postErr));
       runtime.error?.(
         danger(
-          `slack-stream: fallback deliverReplies failed after ${err.slackCode}: ${formatErrorMessage(postErr)}`,
+          `slack-stream: fallback deliverReplies failed after ${fallbackError.slackCode}: ${formatErrorMessage(postErr)}`,
         ),
       );
       return false;
@@ -852,6 +963,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }): Promise<boolean> => {
     const delivered = await deliverPendingStreamFallback(params.session, params.err);
     if (!delivered) {
+      // The reply dispatcher will charge the currently executing payload as
+      // failed; earlier buffered payloads need separate reconciliation below.
+      streamedFailuresOwnedByDispatcher[params.kind] += 1;
       return false;
     }
     replyPlan.markSent();
@@ -950,6 +1064,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           }),
           userId: message.user,
         });
+        refreshStreamedAcknowledgements(streamSession);
         // startSlackStream may only buffer locally. Count delivery only after
         // the SDK reports a real Slack response.
         if (streamSession.delivered) {
@@ -958,13 +1073,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             observedFinalReplyDelivery = true;
           }
         }
-        // Remember the final reply text delivered through the text stream so
-        // the `message_sent` hook can fire after stopSlackStream flushes it.
+        // Remember the reply text delivered through the text stream so the
+        // `message_sent` hook can fire after stopSlackStream flushes it.
         // Only the text-stream path captures this; every deliverNormally branch
         // already emits via deliverReplies, so capturing there would
-        // double-emit for the same final answer.
-        if (params.kind === "final" && text) {
-          streamedFinalContent = text;
+        // double-emit for the same payload.
+        if (text) {
+          rememberStreamedDelivery(params.kind, text, streamSession);
         }
         rememberDeliveredThreadTs(params.kind, streamThreadTs);
         replyPlan.markSent();
@@ -1017,11 +1132,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         });
         return;
       }
+      if (text) {
+        // appendSlackStream buffers text before attempting the Slack flush.
+        // Record first so a later successful stop can acknowledge a thrown append.
+        recordStreamedDelivery(params.kind, text);
+      }
       await appendSlackStream({
         session: streamSession,
         text: "\n" + text,
         chunks: completionChunks,
       });
+      refreshStreamedAcknowledgements(streamSession);
       if (completionChunks?.length) {
         nativeProgressCompletionSent = true;
       }
@@ -1032,12 +1153,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         if (params.kind === "final") {
           observedFinalReplyDelivery = true;
         }
-      }
-      // Remember the final reply text appended to the text stream so the
-      // `message_sent` hook can fire after stopSlackStream flushes it (see the
-      // matching capture on the stream-start path above).
-      if (params.kind === "final" && text) {
-        streamedFinalContent = text;
       }
       deliveryTracker.markDelivered({
         kind: params.kind,
@@ -1093,6 +1208,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         if (delivered) {
           return;
         }
+        throw err;
       }
       await deliverNormally({
         payload: params.payload,
@@ -1669,7 +1785,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   let dispatchError: unknown;
   let queuedFinal = false;
-  let counts: { final?: number; block?: number } = {};
+  let counts: Partial<Record<ReplyDispatchKind, number>> = {};
   try {
     const turnResult = await dispatchChannelInboundReply({
       cfg,
@@ -1859,39 +1975,43 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         ...(completionChunks?.length ? { chunks: completionChunks } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
       });
-      // The stream finalized successfully, flushing any buffered final text to
-      // Slack. Emit the `message_sent` plugin hook for the streamed final reply
+      for (const delivery of streamedDeliveries) {
+        delivery.acknowledged = true;
+      }
+      // The stream finalized successfully, flushing any buffered text to Slack.
+      // Emit the `message_sent` plugin hook for every streamed reply payload
       // here (the streaming happy-path never goes through deliverReplies, which
       // emits for the non-streaming/fallback paths). emitSlackMessageSentHooks
       // self-gates on registered listeners, so this is a no-op when unused.
-      if (streamedFinalContent) {
-        emitSlackMessageSentHooks({
-          ...messageSentHookContext,
-          to: prepared.replyTarget,
-          accountId: account.accountId,
-          content: streamedFinalContent,
-          success: true,
-          ...(stopResult?.messageId ? { messageId: stopResult.messageId } : {}),
-        });
-      }
+      emitAcknowledgedStreamedDeliveries(stopResult?.messageId);
     } catch (err) {
       if (err instanceof SlackStreamNotDeliveredError) {
         streamFallbackDelivered = await deliverPendingStreamFallback(finalStream, err);
       } else {
-        if (streamedFinalContent) {
-          emitSlackMessageSentHooks({
-            ...messageSentHookContext,
-            to: prepared.replyTarget,
-            accountId: account.accountId,
-            content: streamedFinalContent,
-            success: false,
-            error: formatSlackError(err),
-          });
-        }
-        runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatSlackError(err)}`));
+        const error = formatSlackError(err);
+        emitAcknowledgedStreamedDeliveries();
+        emitFailedPendingStreamedDeliveries(error);
+        runtime.error?.(danger(`slack-stream: failed to stop stream: ${error}`));
       }
     }
   }
+
+  for (const kind of ["tool", "block", "final"] as const) {
+    const failedStreamedCount = streamedDeliveries.filter(
+      (delivery) => delivery.kind === kind && delivery.outcome === "failure",
+    ).length;
+    const additionalFailedStreamed = Math.max(
+      0,
+      failedStreamedCount - streamedFailuresOwnedByDispatcher[kind],
+    );
+    if (additionalFailedStreamed > 0) {
+      counts = {
+        ...counts,
+        [kind]: Math.max(0, (counts[kind] ?? 0) - additionalFailedStreamed),
+      };
+    }
+  }
+  queuedFinal = queuedFinal && (counts.final ?? 0) > 0;
 
   const anyReplyDelivered = hasVisibleInboundReplyDispatch(
     { queuedFinal, counts },

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -474,6 +474,25 @@ describe("deliverReplies message_sent hook", () => {
     expect(context).toMatchObject({ sessionKey: "slack:C123:U1" });
   });
 
+  it("uses the logical hook target while delivering to a physical DM channel", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "ts", channelId: "D123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "direct reply" }],
+        target: "channel:D123",
+        messageSentHookTarget: "user:U123",
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledWith("channel:D123", "direct reply", expect.anything());
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    const context = messageHookRunner.runMessageSent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(event).toMatchObject({ to: "user:U123" });
+    expect(context).toMatchObject({ conversationId: "user:U123" });
+  });
+
   it("emits message_sent with success=false when delivery throws", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
     sendMock.mockRejectedValue(new Error("channel_not_found"));

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -308,6 +308,13 @@ describe("createSlackReplyDeliveryPlan", () => {
 });
 
 describe("deliverSlackSlashReplies chunking", () => {
+  beforeEach(() => {
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSent.mockReset();
+    triggerInternalHook.mockReset();
+  });
+
   it("keeps a 4205-character reply in a single slash response by default", async () => {
     const respond = vi.fn(async () => undefined);
     const text = "a".repeat(4205);
@@ -367,6 +374,115 @@ describe("deliverSlackSlashReplies chunking", () => {
     expect(respond).toHaveBeenCalledWith({
       text: "final answer",
       response_type: "in_channel",
+    });
+  });
+
+  it("emits terminal hooks for successful slash responses", async () => {
+    const respond = vi.fn(async () => undefined);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    await deliverSlackSlashReplies({
+      replies: [{ text: "final answer" }],
+      respond,
+      ephemeral: false,
+      textLimit: 8000,
+      messageSentHookTarget: "user:U1",
+      accountId: "default",
+      sessionKeyForInternalHooks: "agent:main:slack:slash:u1",
+    });
+
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    const context = messageHookRunner.runMessageSent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      to: "user:U1",
+      content: "final answer",
+      success: true,
+      sessionKey: "agent:main:slack:slash:u1",
+    });
+    expect(context).toMatchObject({
+      conversationId: "user:U1",
+      sessionKey: "agent:main:slack:slash:u1",
+    });
+    expect(triggerInternalHook).toHaveBeenCalledOnce();
+  });
+
+  it("emits one terminal hook for a multi-part slash reply", async () => {
+    const respond = vi.fn(async () => undefined);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    await deliverSlackSlashReplies({
+      replies: [{ text: "first\nsecond" }],
+      respond,
+      ephemeral: true,
+      textLimit: 8,
+      chunkMode: "newline",
+      messageSentHookTarget: "user:U1",
+    });
+
+    expect(respond).toHaveBeenCalledTimes(2);
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      to: "user:U1",
+      content: "first\nsecond",
+      success: true,
+    });
+  });
+
+  it("emits only failure when a later slash response chunk throws", async () => {
+    const respond = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("response_url_expired"));
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    await expect(
+      deliverSlackSlashReplies({
+        replies: [{ text: "first\nsecond" }],
+        respond,
+        ephemeral: true,
+        textLimit: 8,
+        chunkMode: "newline",
+        messageSentHookTarget: "user:U1",
+      }),
+    ).rejects.toThrow(/response_url_expired/);
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      to: "user:U1",
+      content: "first\nsecond",
+      success: false,
+    });
+    expect(String(event.error)).toMatch(/response_url_expired/);
+  });
+
+  it("reports spoken text for media-only TTS slash replies", async () => {
+    const respond = vi.fn(async () => undefined);
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    await deliverSlackSlashReplies({
+      replies: [
+        {
+          mediaUrl: "https://example.com/tts.mp3",
+          audioAsVoice: true,
+          spokenText: "Spoken slash answer",
+        },
+      ],
+      respond,
+      ephemeral: true,
+      textLimit: 8000,
+      messageSentHookTarget: "user:U1",
+    });
+
+    expect(respond).toHaveBeenCalledWith({
+      text: "https://example.com/tts.mp3",
+      response_type: "ephemeral",
+    });
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "Spoken slash answer",
+      success: true,
     });
   });
 });
@@ -583,6 +699,55 @@ describe("deliverReplies message_sent hook", () => {
       content: "Spoken answer",
       success: true,
       messageId: "tts-1",
+    });
+  });
+
+  it("reports spoken text for explicit media-only TTS replies", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "tts-2", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            mediaUrl: "https://example.com/tts.mp3",
+            audioAsVoice: true,
+            spokenText: "  Explicit spoken answer  ",
+          },
+        ],
+      }),
+    );
+
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "Explicit spoken answer",
+      success: true,
+      messageId: "tts-2",
+    });
+  });
+
+  it("keeps visible media captions ahead of hidden spoken text", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "tts-3", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "Visible caption",
+            mediaUrl: "https://example.com/tts.mp3",
+            audioAsVoice: true,
+            spokenText: "Hidden spoken answer",
+          },
+        ],
+      }),
+    );
+
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "Visible caption",
+      success: true,
+      messageId: "tts-3",
     });
   });
 

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -427,9 +427,10 @@ describe("deliverReplies message_sent hook", () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
     sendMock.mockResolvedValue({ messageId: "1700000000.000100", channelId: "C123" });
 
-    await deliverReplies(baseParams({ replies: [{ text: "shipped" }] }));
+    const result = await deliverReplies(baseParams({ replies: [{ text: "shipped" }] }));
 
     expect(sendMock).toHaveBeenCalledOnce();
+    expect(result).toEqual({ messageId: "1700000000.000100", channelId: "C123" });
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(event).toMatchObject({
@@ -440,6 +441,17 @@ describe("deliverReplies message_sent hook", () => {
     });
     const context = messageHookRunner.runMessageSent.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(context).toMatchObject({ channelId: "slack" });
+  });
+
+  it("reports the trimmed content sent for text-only replies", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "ts", channelId: "C123" });
+
+    await deliverReplies(baseParams({ replies: [{ text: "  shipped  " }] }));
+
+    expect(sendMock).toHaveBeenCalledWith("C123", "shipped", expect.anything());
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({ content: "shipped", success: true });
   });
 
   it("threads the session key into the message_sent plugin context for correlation", async () => {
@@ -474,6 +486,112 @@ describe("deliverReplies message_sent hook", () => {
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(event).toMatchObject({ success: false, content: "boom" });
     expect(String(event.error)).toMatch(/channel_not_found/);
+  });
+
+  it("defers both success and failure hooks for caller-owned terminal delivery", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValueOnce({ messageId: "ts", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "deferred success" }],
+        sessionKeyForInternalHooks: "slack:C123:U1",
+        deferMessageSentHooks: true,
+      }),
+    );
+
+    sendMock.mockRejectedValueOnce(new Error("deferred failure"));
+    await expect(
+      deliverReplies(
+        baseParams({
+          replies: [{ text: "deferred failure" }],
+          sessionKeyForInternalHooks: "slack:C123:U1",
+          deferMessageSentHooks: true,
+        }),
+      ),
+    ).rejects.toThrow(/deferred failure/);
+
+    expect(messageHookRunner.runMessageSent).not.toHaveBeenCalled();
+    expect(triggerInternalHook).not.toHaveBeenCalled();
+  });
+
+  it("emits one message_sent event after a multi-media reply succeeds", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock
+      .mockResolvedValueOnce({ messageId: "media-1", channelId: "C123" })
+      .mockResolvedValueOnce({ messageId: "media-2", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "two attachments",
+            mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledTimes(1);
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "two attachments",
+      success: true,
+      messageId: "media-2",
+    });
+  });
+
+  it("reports spoken text for media-only TTS supplements", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "tts-1", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            mediaUrl: "https://example.com/tts.mp3",
+            spokenText: "Spoken answer",
+            ttsSupplement: { spokenText: "Spoken answer" },
+          },
+        ],
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "Spoken answer",
+      success: true,
+      messageId: "tts-1",
+    });
+  });
+
+  it("emits only failure when a later attachment in the payload fails", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock
+      .mockResolvedValueOnce({ messageId: "media-1", channelId: "C123" })
+      .mockRejectedValueOnce(new Error("second_upload_failed"));
+
+    await expect(
+      deliverReplies(
+        baseParams({
+          replies: [
+            {
+              text: "two attachments",
+              mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+            },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(/second_upload_failed/);
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledTimes(1);
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      content: "two attachments",
+      success: false,
+    });
   });
 
   it("does not emit the plugin hook when no listener observes message_sent", async () => {

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -442,6 +442,26 @@ describe("deliverReplies message_sent hook", () => {
     expect(context).toMatchObject({ channelId: "slack" });
   });
 
+  it("threads the session key into the message_sent plugin context for correlation", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000200", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "correlated" }],
+        sessionKeyForInternalHooks: "slack:C123:U1",
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    const context = messageHookRunner.runMessageSent.mock.calls[0]?.[1] as Record<string, unknown>;
+    // Plugins observing both `message_sending` and `message_sent` must see the
+    // same `sessionKey` (mirrors the shared outbound emitter contract).
+    expect(event).toMatchObject({ sessionKey: "slack:C123:U1" });
+    expect(context).toMatchObject({ sessionKey: "slack:C123:U1" });
+  });
+
   it("emits message_sent with success=false when delivery throws", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
     sendMock.mockRejectedValue(new Error("channel_not_found"));

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -6,6 +6,28 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
+const triggerInternalHook = vi.hoisted(() => vi.fn(async () => {}));
+const messageHookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSent: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/hook-runtime")>();
+  return {
+    ...actual,
+    triggerInternalHook,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => messageHookRunner,
+  };
+});
+
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveDeliveredSlackReplyThreadTs: typeof import("./replies.js").resolveDeliveredSlackReplyThreadTs;
@@ -385,5 +407,96 @@ describe("deliverReplies reasoning suppression", () => {
     );
 
     expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("deliverReplies message_sent hook", () => {
+  beforeAll(async () => {
+    ({ deliverReplies } = await import("./replies.js"));
+  });
+
+  beforeEach(() => {
+    sendMock.mockReset();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSent.mockReset();
+    triggerInternalHook.mockReset();
+  });
+
+  it("emits message_sent with success=true after a text reply is delivered", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockResolvedValue({ messageId: "1700000000.000100", channelId: "C123" });
+
+    await deliverReplies(baseParams({ replies: [{ text: "shipped" }] }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({
+      to: "C123",
+      content: "shipped",
+      success: true,
+      messageId: "1700000000.000100",
+    });
+    const context = messageHookRunner.runMessageSent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(context).toMatchObject({ channelId: "slack" });
+  });
+
+  it("emits message_sent with success=false when delivery throws", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    sendMock.mockRejectedValue(new Error("channel_not_found"));
+
+    await expect(deliverReplies(baseParams({ replies: [{ text: "boom" }] }))).rejects.toThrow(
+      /channel_not_found/,
+    );
+
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
+    const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(event).toMatchObject({ success: false, content: "boom" });
+    expect(String(event.error)).toMatch(/channel_not_found/);
+  });
+
+  it("does not emit the plugin hook when no listener observes message_sent", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    sendMock.mockResolvedValue({ messageId: "ts", channelId: "C123" });
+
+    await deliverReplies(baseParams({ replies: [{ text: "quiet" }] }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(messageHookRunner.runMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("fires the internal message:sent hook when a session key is supplied", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    sendMock.mockResolvedValue({ messageId: "ts", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "internal" }],
+        sessionKeyForInternalHooks: "slack:C123:U1",
+      }),
+    );
+
+    expect(triggerInternalHook).toHaveBeenCalledOnce();
+  });
+
+  it("threads group context into the internal message:sent hook when isGroup is set", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    sendMock.mockResolvedValue({ messageId: "ts", channelId: "C123" });
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "in a channel" }],
+        sessionKeyForInternalHooks: "slack:C123:U1",
+        isGroup: true,
+        groupId: "C123",
+      }),
+    );
+
+    expect(triggerInternalHook).toHaveBeenCalledOnce();
+    const internalCalls = triggerInternalHook.mock.calls as unknown as Array<
+      [{ context?: Record<string, unknown> }]
+    >;
+    expect(internalCalls[0]?.[0]?.context).toMatchObject({ isGroup: true, groupId: "C123" });
   });
 });

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -673,8 +673,8 @@ describe("deliverReplies message_sent hook", () => {
     expect(event).toMatchObject({
       content: "two attachments",
       success: true,
-      messageId: "media-2",
     });
+    expect(event).not.toHaveProperty("messageId");
   });
 
   it("reports spoken text for media-only TTS supplements", async () => {
@@ -698,8 +698,8 @@ describe("deliverReplies message_sent hook", () => {
     expect(event).toMatchObject({
       content: "Spoken answer",
       success: true,
-      messageId: "tts-1",
     });
+    expect(event).not.toHaveProperty("messageId");
   });
 
   it("reports spoken text for explicit media-only TTS replies", async () => {
@@ -722,8 +722,8 @@ describe("deliverReplies message_sent hook", () => {
     expect(event).toMatchObject({
       content: "Explicit spoken answer",
       success: true,
-      messageId: "tts-2",
     });
+    expect(event).not.toHaveProperty("messageId");
   });
 
   it("keeps visible media captions ahead of hidden spoken text", async () => {
@@ -747,8 +747,8 @@ describe("deliverReplies message_sent hook", () => {
     expect(event).toMatchObject({
       content: "Visible caption",
       success: true,
-      messageId: "tts-3",
     });
+    expect(event).not.toHaveProperty("messageId");
   });
 
   it("emits only failure when a later attachment in the payload fails", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -49,6 +49,8 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
   metadata?: MessageMetadata;
+  /** Logical conversation target used by lifecycle hooks when delivery uses a physical Slack id. */
+  messageSentHookTarget?: string;
   /**
    * Canonical session key for the internal `message:sent` hook. When set, the
    * internal hook fires alongside the plugin `message_sent` hook. The plugin
@@ -91,7 +93,7 @@ export async function deliverReplies(params: {
       }
       emitSlackMessageSentHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
-        to: params.target,
+        to: params.messageSentHookTarget ?? params.target,
         accountId: params.accountId,
         content,
         success: true,
@@ -106,7 +108,7 @@ export async function deliverReplies(params: {
       }
       emitSlackMessageSentHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
-        to: params.target,
+        to: params.messageSentHookTarget ?? params.target,
         accountId: params.accountId,
         content,
         success: false,

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements replies behavior.
 import type { MessageMetadata } from "@slack/types";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   chunkMarkdownTextWithMode,
   isSilentReplyText,
@@ -16,8 +17,9 @@ import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
+import { emitSlackMessageSentHooks } from "../message-sent-hook.js";
 import { resolveSlackReplyBlocks } from "../reply-blocks.js";
-import { sendMessageSlack, type SlackSendIdentity } from "./send.runtime.js";
+import { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "./send.runtime.js";
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
@@ -46,6 +48,16 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
   metadata?: MessageMetadata;
+  /**
+   * Canonical session key for the internal `message:sent` hook. When set, the
+   * internal hook fires alongside the plugin `message_sent` hook. The plugin
+   * hook fires regardless (self-gated on registered listeners).
+   */
+  sessionKeyForInternalHooks?: string;
+  /** Whether the reply target is a group/channel (vs a DM). */
+  isGroup?: boolean;
+  /** Group/channel id for the `message_sent` event when `isGroup` is true. */
+  groupId?: string;
 }) {
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
@@ -62,6 +74,35 @@ export async function deliverReplies(params: {
       continue;
     }
 
+    // Fire the `message_sent` hook(s) after delivery, mirroring Telegram's
+    // `emitMessageSentHooks` in `extensions/telegram/src/bot/delivery.replies.ts`.
+    // `emitSlackMessageSentHooks` self-gates on registered listeners, so this is
+    // a no-op when no plugin observes `message_sent`.
+    const emitSent = (content: string, result?: SlackSendResult) => {
+      emitSlackMessageSentHooks({
+        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+        to: params.target,
+        accountId: params.accountId,
+        content,
+        success: true,
+        messageId: result?.messageId,
+        isGroup: params.isGroup,
+        groupId: params.groupId,
+      });
+    };
+    const emitFailed = (content: string, error: unknown) => {
+      emitSlackMessageSentHooks({
+        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+        to: params.target,
+        accountId: params.accountId,
+        content,
+        success: false,
+        error: formatErrorMessage(error),
+        isGroup: params.isGroup,
+        groupId: params.groupId,
+      });
+    };
+
     if (!reply.hasMedia && slackBlocks?.length) {
       const trimmed = reply.trimmedText;
       if (!trimmed && !slackBlocks?.length) {
@@ -70,15 +111,22 @@ export async function deliverReplies(params: {
       if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
-        cfg: params.cfg,
-        token: params.token,
-        threadTs,
-        accountId: params.accountId,
-        ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
-        ...(params.identity ? { identity: params.identity } : {}),
-        ...(params.metadata ? { metadata: params.metadata } : {}),
-      });
+      let result: SlackSendResult;
+      try {
+        result = await sendMessageSlack(params.target, trimmed, {
+          cfg: params.cfg,
+          token: params.token,
+          threadTs,
+          accountId: params.accountId,
+          ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
+          ...(params.identity ? { identity: params.identity } : {}),
+          ...(params.metadata ? { metadata: params.metadata } : {}),
+        });
+      } catch (error) {
+        emitFailed(trimmed, error);
+        throw error;
+      }
+      emitSent(trimmed, result);
       params.runtime.log?.(`delivered reply to ${params.target}`);
       continue;
     }
@@ -96,25 +144,40 @@ export async function deliverReplies(params: {
           }
         : undefined,
       sendText: async (trimmed) => {
-        await sendMessageSlack(params.target, trimmed, {
-          cfg: params.cfg,
-          token: params.token,
-          threadTs,
-          accountId: params.accountId,
-          ...(params.identity ? { identity: params.identity } : {}),
-          ...(params.metadata ? { metadata: params.metadata } : {}),
-        });
+        let result: SlackSendResult;
+        try {
+          result = await sendMessageSlack(params.target, trimmed, {
+            cfg: params.cfg,
+            token: params.token,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+            ...(params.metadata ? { metadata: params.metadata } : {}),
+          });
+        } catch (error) {
+          emitFailed(trimmed, error);
+          throw error;
+        }
+        emitSent(trimmed, result);
       },
       sendMedia: async ({ mediaUrl, caption }) => {
-        await sendMessageSlack(params.target, caption ?? "", {
-          cfg: params.cfg,
-          token: params.token,
-          mediaUrl,
-          threadTs,
-          accountId: params.accountId,
-          ...(params.identity ? { identity: params.identity } : {}),
-          ...(params.metadata ? { metadata: params.metadata } : {}),
-        });
+        const content = caption ?? "";
+        let result: SlackSendResult;
+        try {
+          result = await sendMessageSlack(params.target, content, {
+            cfg: params.cfg,
+            token: params.token,
+            mediaUrl,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+            ...(params.metadata ? { metadata: params.metadata } : {}),
+          });
+        } catch (error) {
+          emitFailed(content, error);
+          throw error;
+        }
+        emitSent(content, result);
       },
     });
     if (delivered !== "empty") {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/reply-chunking";
 import {
   deliverTextOrMediaReply,
+  getReplyPayloadTtsSupplement,
   resolveSendableOutboundReplyParts,
   type ReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
@@ -58,7 +59,13 @@ export async function deliverReplies(params: {
   isGroup?: boolean;
   /** Group/channel id for the `message_sent` event when `isGroup` is true. */
   groupId?: string;
+  /**
+   * Defer hook emission to a caller that must resolve another delivery path
+   * before reporting the terminal outcome.
+   */
+  deferMessageSentHooks?: true;
 }) {
+  let latestResult: SlackSendResult | undefined;
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
       continue;
@@ -79,6 +86,9 @@ export async function deliverReplies(params: {
     // `emitSlackMessageSentHooks` self-gates on registered listeners, so this is
     // a no-op when no plugin observes `message_sent`.
     const emitSent = (content: string, result?: SlackSendResult) => {
+      if (params.deferMessageSentHooks) {
+        return;
+      }
       emitSlackMessageSentHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
         to: params.target,
@@ -91,6 +101,9 @@ export async function deliverReplies(params: {
       });
     };
     const emitFailed = (content: string, error: unknown) => {
+      if (params.deferMessageSentHooks) {
+        return;
+      }
       emitSlackMessageSentHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
         to: params.target,
@@ -127,26 +140,31 @@ export async function deliverReplies(params: {
         throw error;
       }
       emitSent(trimmed, result);
+      latestResult = result;
       params.runtime.log?.(`delivered reply to ${params.target}`);
       continue;
     }
 
-    const delivered = await deliverTextOrMediaReply({
-      payload,
-      text: reply.text,
-      chunkText: !reply.hasMedia
-        ? (value) => {
-            const trimmed = value.trim();
-            if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-              return [];
+    const hookContent = reply.hasMedia
+      ? (getReplyPayloadTtsSupplement(payload)?.spokenText ?? reply.text)
+      : reply.trimmedText;
+    let lastResult: SlackSendResult | undefined;
+    let delivered: Awaited<ReturnType<typeof deliverTextOrMediaReply>>;
+    try {
+      delivered = await deliverTextOrMediaReply({
+        payload,
+        text: reply.text,
+        chunkText: !reply.hasMedia
+          ? (value) => {
+              const trimmed = value.trim();
+              if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+                return [];
+              }
+              return [trimmed];
             }
-            return [trimmed];
-          }
-        : undefined,
-      sendText: async (trimmed) => {
-        let result: SlackSendResult;
-        try {
-          result = await sendMessageSlack(params.target, trimmed, {
+          : undefined,
+        sendText: async (trimmed) => {
+          lastResult = await sendMessageSlack(params.target, trimmed, {
             cfg: params.cfg,
             token: params.token,
             threadTs,
@@ -154,17 +172,9 @@ export async function deliverReplies(params: {
             ...(params.identity ? { identity: params.identity } : {}),
             ...(params.metadata ? { metadata: params.metadata } : {}),
           });
-        } catch (error) {
-          emitFailed(trimmed, error);
-          throw error;
-        }
-        emitSent(trimmed, result);
-      },
-      sendMedia: async ({ mediaUrl, caption }) => {
-        const content = caption ?? "";
-        let result: SlackSendResult;
-        try {
-          result = await sendMessageSlack(params.target, content, {
+        },
+        sendMedia: async ({ mediaUrl, caption }) => {
+          lastResult = await sendMessageSlack(params.target, caption ?? "", {
             cfg: params.cfg,
             token: params.token,
             mediaUrl,
@@ -173,17 +183,19 @@ export async function deliverReplies(params: {
             ...(params.identity ? { identity: params.identity } : {}),
             ...(params.metadata ? { metadata: params.metadata } : {}),
           });
-        } catch (error) {
-          emitFailed(content, error);
-          throw error;
-        }
-        emitSent(content, result);
-      },
-    });
+        },
+      });
+    } catch (error) {
+      emitFailed(hookContent, error);
+      throw error;
+    }
     if (delivered !== "empty") {
+      emitSent(hookContent, lastResult);
+      latestResult = lastResult;
       params.runtime.log?.(`delivered reply to ${params.target}`);
     }
   }
+  return latestResult;
 }
 
 export type SlackRespondFn = (payload: {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -197,7 +197,9 @@ export async function deliverReplies(params: {
       throw error;
     }
     if (delivered !== "empty") {
-      emitSent(hookContent, lastResult);
+      // Slack file uploads return file IDs, not the posted message `ts` expected
+      // by message_sent consumers.
+      emitSent(hookContent, reply.hasMedia ? undefined : lastResult);
       latestResult = lastResult;
       params.runtime.log?.(`delivered reply to ${params.target}`);
     }

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -26,6 +26,11 @@ export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
 }
 
+function resolveSlackMediaHookSpokenText(payload: ReplyPayload): string | undefined {
+  const spokenText = getReplyPayloadTtsSupplement(payload)?.spokenText ?? payload.spokenText;
+  return spokenText?.trim() || undefined;
+}
+
 export function resolveDeliveredSlackReplyThreadTs(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   payloadReplyToId?: string;
@@ -147,9 +152,9 @@ export async function deliverReplies(params: {
       continue;
     }
 
-    const hookContent = reply.hasMedia
-      ? (getReplyPayloadTtsSupplement(payload)?.spokenText ?? reply.text)
-      : reply.trimmedText;
+    const spokenText = resolveSlackMediaHookSpokenText(payload);
+    const mediaHookContent = reply.hasText ? reply.text : spokenText || reply.text;
+    const hookContent = reply.hasMedia ? mediaHookContent : reply.trimmedText;
     let lastResult: SlackSendResult | undefined;
     let delivered: Awaited<ReturnType<typeof deliverTextOrMediaReply>>;
     try {
@@ -288,8 +293,16 @@ export async function deliverSlackSlashReplies(params: {
   textLimit: number;
   tableMode?: MarkdownTableMode;
   chunkMode?: ChunkMode;
+  messageSentHookTarget?: string;
+  accountId?: string;
+  sessionKeyForInternalHooks?: string;
+  isGroup?: boolean;
+  groupId?: string;
 }) {
-  const messages: Array<{ text: string; blocks?: ReturnType<typeof readSlackReplyBlocks> }> = [];
+  const deliveries: Array<{
+    hookContent: string;
+    messages: Array<{ text: string; blocks?: ReturnType<typeof readSlackReplyBlocks> }>;
+  }> = [];
   const chunkLimit = Math.min(params.textLimit, SLACK_TEXT_LIMIT);
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
@@ -302,7 +315,10 @@ export async function deliverSlackSlashReplies(params: {
         ? reply.trimmedText
         : undefined;
     if (slackBlocks?.length && !reply.hasMedia) {
-      messages.push({ text: text ?? "", blocks: slackBlocks });
+      deliveries.push({
+        hookContent: text ?? "",
+        messages: [{ text: text ?? "", blocks: slackBlocks }],
+      });
       continue;
     }
     const combined = [text ?? "", ...reply.mediaUrls].filter(Boolean).join("\n");
@@ -320,18 +336,48 @@ export async function deliverSlackSlashReplies(params: {
     if (!chunks.length && combined) {
       chunks.push(combined);
     }
-    for (const chunk of chunks) {
-      messages.push({ text: chunk });
-    }
+    deliveries.push({
+      hookContent: text ?? resolveSlackMediaHookSpokenText(payload) ?? combined,
+      messages: chunks.map((chunk) => ({ text: chunk })),
+    });
   }
 
-  if (messages.length === 0) {
+  if (deliveries.length === 0) {
     return;
   }
 
   // Slack slash command responses can be multi-part by sending follow-ups via response_url.
   const responseType = params.ephemeral ? "ephemeral" : "in_channel";
-  for (const message of messages) {
-    await params.respond({ ...message, response_type: responseType });
+  for (const delivery of deliveries) {
+    try {
+      for (const message of delivery.messages) {
+        await params.respond({ ...message, response_type: responseType });
+      }
+    } catch (error) {
+      if (params.messageSentHookTarget) {
+        emitSlackMessageSentHooks({
+          sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+          to: params.messageSentHookTarget,
+          accountId: params.accountId,
+          content: delivery.hookContent,
+          success: false,
+          error: formatErrorMessage(error),
+          isGroup: params.isGroup,
+          groupId: params.groupId,
+        });
+      }
+      throw error;
+    }
+    if (params.messageSentHookTarget) {
+      emitSlackMessageSentHooks({
+        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+        to: params.messageSentHookTarget,
+        accountId: params.accountId,
+        content: delivery.hookContent,
+        success: true,
+        isGroup: params.isGroup,
+        groupId: params.groupId,
+      });
+    }
   }
 }

--- a/extensions/slack/src/monitor/send.runtime.ts
+++ b/extensions/slack/src/monitor/send.runtime.ts
@@ -1,2 +1,6 @@
 // Slack plugin module implements send behavior.
-export { sendMessageSlack, type SlackSendIdentity } from "../send.js";
+export {
+  sendMessageSlack,
+  type SlackSendIdentity,
+  type SlackSendResult,
+} from "../send.js";

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -12,11 +12,12 @@ const mocks = vi.hoisted(() => ({
   resolveConversationLabelMock: vi.fn(),
   recordSessionMetaFromInboundMock: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   resolveStorePathMock: vi.fn(),
+  deliverSlackSlashRepliesMock: vi.fn<(params: unknown) => Promise<unknown>>(async () => {}),
 }));
 
 vi.mock("./slash-dispatch.runtime.js", () => {
   return {
-    deliverSlackSlashReplies: vi.fn(async () => {}),
+    deliverSlackSlashReplies: (params: unknown) => mocks.deliverSlackSlashRepliesMock(params),
     dispatchReplyWithDispatcher: (...args: unknown[]) => mocks.dispatchMock(...args),
     finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),
     resolveAgentRoute: (...args: unknown[]) => mocks.resolveAgentRouteMock(...args),
@@ -37,6 +38,7 @@ type SlashHarnessMocks = {
   resolveConversationLabelMock: ReturnType<typeof vi.fn>;
   recordSessionMetaFromInboundMock: AsyncMock;
   resolveStorePathMock: ReturnType<typeof vi.fn>;
+  deliverSlackSlashRepliesMock: AsyncMock;
 };
 
 export function getSlackSlashMocks(): SlashHarnessMocks {
@@ -56,4 +58,5 @@ export function resetSlackSlashMocks() {
   mocks.resolveConversationLabelMock.mockReset().mockReturnValue(undefined);
   mocks.recordSessionMetaFromInboundMock.mockReset().mockResolvedValue(undefined);
   mocks.resolveStorePathMock.mockReset().mockReturnValue("/tmp/openclaw-sessions.json");
+  mocks.deliverSlackSlashRepliesMock.mockReset().mockResolvedValue(undefined);
 }

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -977,6 +977,7 @@ function createPolicyHarness(overrides?: {
   channelName?: string;
   allowFrom?: string[];
   useAccessGroups?: boolean;
+  slashEphemeral?: boolean;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
   resolveChannelName?: () => Promise<{ name?: string; type?: string }>;
 }) {
@@ -1010,7 +1011,7 @@ function createPolicyHarness(overrides?: {
     slashCommand: {
       enabled: true,
       name: "openclaw",
-      ephemeral: true,
+      ephemeral: overrides?.slashEphemeral ?? true,
       sessionPrefix: "slack:slash",
     },
     textLimit: 4000,
@@ -1251,7 +1252,7 @@ describe("slack slash commands access groups", () => {
 });
 
 describe("slack slash command session metadata", () => {
-  const { recordSessionMetaFromInboundMock } = getSlackSlashMocks();
+  const { deliverSlackSlashRepliesMock, recordSessionMetaFromInboundMock } = getSlackSlashMocks();
 
   it("calls recordSessionMetaFromInbound after dispatching a slash command", async () => {
     const harness = createPolicyHarness({ groupPolicy: "open" });
@@ -1271,6 +1272,50 @@ describe("slack slash command session metadata", () => {
     expect(call.ctx?.GroupSpace).toBe("T1");
     expect(call.sessionKey).toBeTypeOf("string");
     expect(call.sessionKey).not.toBe("");
+  });
+
+  it("passes canonical hook correlation to slash reply delivery", async () => {
+    const harness = createPolicyHarness({ groupPolicy: "open" });
+    await registerAndRunPolicySlash({ harness });
+    const dispatchArg = firstDispatchArg() as {
+      ctx?: { OriginatingTo?: string; SessionKey?: string };
+      dispatcherOptions?: { deliver?: (payload: { text: string }) => Promise<void> };
+    };
+
+    await dispatchArg.dispatcherOptions?.deliver?.({ text: "final answer" });
+
+    expect(deliverSlackSlashRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "final answer" }],
+        messageSentHookTarget: dispatchArg.ctx?.OriginatingTo,
+        sessionKeyForInternalHooks: dispatchArg.ctx?.SessionKey,
+        accountId: "acct",
+        isGroup: true,
+        groupId: harness.channelId,
+      }),
+    );
+  });
+
+  it("targets the channel for public slash reply hooks", async () => {
+    const harness = createPolicyHarness({
+      groupPolicy: "open",
+      slashEphemeral: false,
+    });
+    await registerAndRunPolicySlash({ harness });
+    const dispatchArg = firstDispatchArg() as {
+      dispatcherOptions?: { deliver?: (payload: { text: string }) => Promise<void> };
+    };
+
+    await dispatchArg.dispatcherOptions?.deliver?.({ text: "public answer" });
+
+    expect(firstDispatchArg().ctx?.OriginatingTo).toBe(`channel:${harness.channelId}`);
+    expect(deliverSlackSlashRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageSentHookTarget: `channel:${harness.channelId}`,
+        isGroup: true,
+        groupId: harness.channelId,
+      }),
+    );
   });
 
   it("awaits session metadata persistence before dispatch", async () => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -661,6 +661,10 @@ export async function registerSlackMonitorSlashCommands(params: {
         targetSessionKey: route.sessionKey,
         lowercaseSessionKey: true,
       });
+      const slashReplyTarget =
+        !slashCommand.ephemeral && isRoomish
+          ? `channel:${command.channel_id}`
+          : `user:${command.user_id}`;
       const ctxPayload = finalizeInboundContext({
         Body: prompt,
         BodyForAgent: prompt,
@@ -702,7 +706,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         CommandSource: "native" as const,
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "slack" as const,
-        OriginatingTo: `user:${command.user_id}`,
+        OriginatingTo: slashReplyTarget,
       });
 
       await recordInboundSessionMetaSafe({
@@ -731,12 +735,18 @@ export async function registerSlackMonitorSlashCommands(params: {
         },
       });
 
+      const messageSentHookTarget = ctxPayload.OriginatingTo ?? ctxPayload.To ?? slashReplyTarget;
       const deliverSlashPayloads = async (replies: ReplyPayload[]) => {
         await deliverSlackSlashReplies({
           replies,
           respond,
           ephemeral: slashCommand.ephemeral,
           textLimit: ctx.textLimit,
+          messageSentHookTarget,
+          accountId: route.accountId,
+          sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
+          isGroup: isRoomish,
+          groupId: isRoomish ? command.channel_id : undefined,
           chunkMode: resolveChunkMode(cfg, "slack", route.accountId),
           tableMode: resolveMarkdownTableMode({
             cfg,

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover streaming plugin behavior.
-import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
+import { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { describe, expect, it, vi } from "vitest";
 import {
   appendSlackStream,
@@ -312,7 +312,7 @@ describe("stopSlackStream finalize error handling", () => {
   it("retires fallback-delivered sessions so buffered text cannot be resent", () => {
     const neverDelivered = makeSession({});
     markSlackStreamFallbackDelivered(neverDelivered);
-    expect(neverDelivered.delivered).toBe(true);
+    expect(neverDelivered.delivered).toBe(false);
     expect(neverDelivered.pendingText).toBe("");
     expect(neverDelivered.stopped).toBe(true);
 
@@ -321,7 +321,52 @@ describe("stopSlackStream finalize error handling", () => {
     markSlackStreamFallbackDelivered(alreadyDelivered);
     expect(alreadyDelivered.delivered).toBe(true);
     expect(alreadyDelivered.pendingText).toBe("");
-    expect(alreadyDelivered.stopped).toBe(true);
+    expect(alreadyDelivered.stopped).toBe(false);
+  });
+
+  it("clears the SDK buffer before finalizing an already-visible fallback stream", async () => {
+    const startStream = vi.fn(async () => ({ ok: true, ts: "1700000000.500300" }));
+    const stopStream = vi.fn(async () => ({ ok: true, ts: "1700000000.500300" }));
+    const client = {
+      chat: {
+        startStream,
+        appendStream: vi.fn(async () => ({ ok: true })),
+        stopStream,
+      },
+    };
+    const streamer = new ChatStreamer(
+      client as never,
+      { debug: vi.fn() } as never,
+      {
+        channel: "C123",
+        thread_ts: "1700000000.000100",
+      },
+      { buffer_size: 10 },
+    );
+    const session: SlackStreamSession = {
+      streamer,
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      stopped: false,
+      delivered: false,
+      pendingText: "",
+    };
+
+    await appendSlackStream({ session, text: "already visible" });
+    await appendSlackStream({ session, text: "tail" });
+    expect(session.delivered).toBe(true);
+    expect(session.pendingText).toBe("tail");
+
+    markSlackStreamFallbackDelivered(session);
+    await stopSlackStream({ session });
+
+    expect(startStream).toHaveBeenCalledOnce();
+    expect(stopStream).toHaveBeenCalledWith({
+      token: undefined,
+      channel: "C123",
+      ts: "1700000000.500300",
+      chunks: [],
+    });
   });
 });
 

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -309,7 +309,7 @@ describe("stopSlackStream finalize error handling", () => {
     );
   });
 
-  it("marks fallback-delivered sessions stopped only when no native stream exists", () => {
+  it("retires fallback-delivered sessions so buffered text cannot be resent", () => {
     const neverDelivered = makeSession({});
     markSlackStreamFallbackDelivered(neverDelivered);
     expect(neverDelivered.delivered).toBe(true);
@@ -321,7 +321,7 @@ describe("stopSlackStream finalize error handling", () => {
     markSlackStreamFallbackDelivered(alreadyDelivered);
     expect(alreadyDelivered.delivered).toBe(true);
     expect(alreadyDelivered.pendingText).toBe("");
-    expect(alreadyDelivered.stopped).toBe(false);
+    expect(alreadyDelivered.stopped).toBe(true);
   });
 });
 

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./streaming.js";
 
 type AppendImpl = () => Promise<unknown>;
-type StopImpl = (args?: unknown) => Promise<void>;
+type StopImpl = (args?: unknown) => Promise<unknown>;
 
 function makeSession(params: { appendImpl?: AppendImpl; stopImpl?: StopImpl }): SlackStreamSession {
   return {
@@ -94,7 +94,7 @@ describe("stopSlackStream finalize error handling", () => {
     await appendSlackStream({ session, text: "some text that Slack saw" });
     expect(session.delivered).toBe(true);
 
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(session.stopped).toBe(true);
   });
 
@@ -202,7 +202,7 @@ describe("stopSlackStream finalize error handling", () => {
       },
     });
     await appendSlackStream({ session, text: "chars" });
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(session.stopped).toBe(true);
   });
 
@@ -239,7 +239,7 @@ describe("stopSlackStream finalize error handling", () => {
       delivered: false,
       pendingText: "",
     };
-    await expect(stopSlackStream({ session })).resolves.toBeUndefined();
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
     expect(stop).not.toHaveBeenCalled();
   });
 
@@ -253,6 +253,37 @@ describe("stopSlackStream finalize error handling", () => {
     await stopSlackStream({ session });
     expect(session.delivered).toBe(true);
     expect(session.pendingText).toBe("");
+  });
+
+  it("returns the finalized message ts as messageId on a successful stop()", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true, ts: "1700000000.500100" }),
+    });
+    await appendSlackStream({ session, text: "short" });
+    await expect(stopSlackStream({ session })).resolves.toEqual({
+      messageId: "1700000000.500100",
+    });
+  });
+
+  it("falls back to message.ts when chat.stopStream omits the top-level ts", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true, message: { ts: "1700000000.500200" } }),
+    });
+    await appendSlackStream({ session, text: "short" });
+    await expect(stopSlackStream({ session })).resolves.toEqual({
+      messageId: "1700000000.500200",
+    });
+  });
+
+  it("returns an empty result when chat.stopStream reports no ts", async () => {
+    const session = makeSession({
+      appendImpl: async () => null,
+      stopImpl: async () => ({ ok: true }),
+    });
+    await appendSlackStream({ session, text: "short" });
+    await expect(stopSlackStream({ session })).resolves.toEqual({});
   });
 
   it("converts a start-time flush rejection into a pending-text fallback error", async () => {

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -353,10 +353,9 @@ export function extractSlackErrorCode(err: unknown): string | undefined {
 }
 
 export function markSlackStreamFallbackDelivered(session: SlackStreamSession): void {
-  const hadNativeDelivery = session.delivered;
   session.pendingText = "";
   session.delivered = true;
-  if (!hadNativeDelivery) {
-    session.stopped = true;
-  }
+  // The SDK retains text after a failed flush. Once normal delivery owns that
+  // text, retiring the streamer prevents a later stop from sending it again.
+  session.stopped = true;
 }

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -218,6 +218,17 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
   }
 }
 
+/** Result of {@link stopSlackStream}. */
+export type StopSlackStreamResult = {
+  /**
+   * The Slack `ts` of the finalized streamed message, when `chat.stopStream`
+   * reports it. Used to populate `MessageSentEvent.messageId` for the
+   * streaming reply path. Undefined when the stream was already stopped or
+   * Slack omitted the timestamp.
+   */
+  messageId?: string;
+};
+
 /**
  * Stop (finalize) a Slack stream.
  *
@@ -235,13 +246,18 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  * text so the caller can deliver it through the normal Slack reply path.
  *
  * All other errors propagate unchanged.
+ *
+ * On success, returns the finalized message's Slack `ts` (when reported) so the
+ * caller can emit the `message_sent` hook with a populated `messageId`.
  */
-export async function stopSlackStream(params: StopSlackStreamParams): Promise<void> {
+export async function stopSlackStream(
+  params: StopSlackStreamParams,
+): Promise<StopSlackStreamResult> {
   const { session, text, chunks, metadata } = params;
 
   if (session.stopped) {
     logVerbose("slack-stream: stream already stopped, ignoring duplicate stop");
-    return;
+    return {};
   }
 
   session.stopped = true;
@@ -256,7 +272,7 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   );
 
   try {
-    await session.streamer.stop(
+    const stopResponse = await session.streamer.stop(
       text || chunks?.length || metadata
         ? {
             ...(text ? { markdown_text: text } : {}),
@@ -267,6 +283,11 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
     );
     session.delivered = true;
     session.pendingText = "";
+    logVerbose("slack-stream: stream stopped");
+    // `chat.stopStream` reports the finalized message `ts` at the top level
+    // (and on `message.ts`); prefer the former and fall back to the latter.
+    const messageId = stopResponse?.ts ?? stopResponse?.message?.ts;
+    return messageId ? { messageId } : {};
   } catch (err) {
     if (isBenignSlackFinalizeError(err)) {
       const code = extractSlackErrorCode(err) ?? "unknown";
@@ -279,13 +300,11 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
         logVerbose(
           `slack-stream: finalize rejected by Slack (${code}); prior appends delivered, treating stream as stopped`,
         );
-        return;
+        return {};
       }
     }
     throw err;
   }
-
-  logVerbose("slack-stream: stream stopped");
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -353,9 +353,12 @@ export function extractSlackErrorCode(err: unknown): string | undefined {
 }
 
 export function markSlackStreamFallbackDelivered(session: SlackStreamSession): void {
+  const nativeStreamWasStarted = session.delivered;
   session.pendingText = "";
-  session.delivered = true;
-  // The SDK retains text after a failed flush. Once normal delivery owns that
-  // text, retiring the streamer prevents a later stop from sending it again.
-  session.stopped = true;
+  // @slack/web-api 7.16.0 retains its private buffer after a failed flush.
+  // Clear fallback-owned text before retrying stop(), or the SDK resends it.
+  (session.streamer as unknown as { buffer: string }).buffer = "";
+  // A visible native stream still needs stop() to leave streaming state. If no
+  // native call succeeded, there is no Slack stream to finalize.
+  session.stopped = !nativeStreamWasStarted;
 }


### PR DESCRIPTION
## Summary

Emit terminal Slack `message_sent` plugin hooks and internal `message:sent` hooks across actual agent reply delivery paths.

The final implementation covers normal replies, media, blocks, native streaming, stream fallback, finalized previews, native slash responses, failures, and TTS supplemental media. It preserves the finalized thread session key and logical Slack target, reports the delivered Slack message ID, and emits one terminal outcome per logical payload.

Fixes #89942.

## Implementation

- Add a shared Slack sent-hook emitter for canonical event/context construction.
- Emit after successful delivery and on terminal failure for normal, media, block, preview, streaming, fallback, slash, and TTS paths.
- Aggregate multi-send and streamed outcomes so partial transport activity does not create duplicate or contradictory terminal hooks.
- Preserve physical DM delivery while reporting the logical user target to lifecycle hooks.
- Use finalized thread session keys for cross-hook correlation.
- Clear fallback-owned `ChatStreamer` buffer text, then finalize any already-visible native stream without resending the fallback payload.
- Add regression coverage for delivery cardinality, correlation, fallback, previews, slash responses, TTS, and Slack SDK return shapes.

## Verification

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/replies.test.ts extensions/slack/src/monitor/slash.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/streaming.test.ts extensions/slack/src/outbound-delivery.test.ts`
  - 5 files, 172 tests passed.
- `pnpm tsgo:extensions`
  - Passed.
- `pnpm tsgo:extensions:test`
  - Passed.
- `pnpm test:extensions:package-boundary:compile`
  - 114/114 plugins compiled.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --thinking high --stream-engine-output`
  - Clean; no actionable findings.
- Direct dependency inspection:
  - Verified installed `@slack/web-api` 7.16.0 `ChatStreamer` source and types for retained failed-flush buffers, buffer-free finalization retries, and `stop()` response message IDs.

## Real Behavior Proof

- **Behavior addressed:** Slack agent replies did not emit the documented terminal `message_sent` lifecycle hook. This change emits one terminal outcome per logical reply across normal, streaming, preview, fallback, slash, failure, and TTS delivery paths.
- **Real environment tested:** Source-built OpenClaw gateway on macOS and Node, connected through Socket Mode to a real Slack workspace with the stock Slack plugin and a local lifecycle probe plugin.
- **Exact steps or command run after this patch:** Build the branch from source, run the built gateway against an isolated OpenClaw state directory, register the probe for `message_sent`, then trigger real Slack mentions with native streaming, native-progress tool delivery, and streaming disabled.
- **Evidence after fix:** Copied live output (redacted runtime log) from the source-built gateway:

  ```text
  [mst-probe] agent_end fired sessionKey=<redacted> (turn counter reset)
  [mst-probe] message_sent FIRED #1-this-turn channelId=slack to=channel:<redacted> success=true messageId=<slack-ts-redacted> event.sessionKey=<redacted> ctx.sessionKey=<redacted>
  ```

  Equivalent captures were recorded for native streaming, native-progress delivery, and streaming disabled. Each showed `#1-this-turn`; the native-progress path therefore did not double-emit.
- **Observed result after fix:** Native streaming, native-progress delivery, and non-streaming delivery each emitted exactly one successful terminal hook after the reply appeared in Slack.
- **What was not tested:** Live failure injection, slash responses, TTS supplemental delivery, and the rare failed native-stream finalization fallback were not exercised against the workspace. These paths are covered by focused regression tests, including a test against the pinned `@slack/web-api` 7.16.0 `ChatStreamer` implementation.

## Credits

Original report, implementation, and live Slack proof by @rishitamrakar. Maintainer fixups expanded coverage to all Slack agent reply paths and reconciled terminal delivery outcomes.
