### PR TITLE
fix(plugins): guard provider discovery metadata

### DIFF
--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -155,6 +155,16 @@ function createManifestPluginWithEntryAndRuntimeDiscovery(): PluginManifestRecor
   };
 }
 
+function createPoisonedModelCatalogPlugin(id: string): PluginManifestRecord {
+  const plugin = createManifestPluginWithoutDiscovery({ id });
+  Object.defineProperty(plugin, "modelCatalog", {
+    get() {
+      throw new Error("provider discovery model catalog metadata exploded");
+    },
+  });
+  return plugin;
+}
+
 function createManifestPluginWithoutDiscovery(params: {
   id: string;
   providerAuthEnvVars?: Record<string, string[]>;
@@ -672,6 +682,26 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
         },
       },
     });
+  });
+
+  it("skips unreadable manifest model-catalog metadata during provider discovery", () => {
+    mocks.resolveDiscoveredProviderPluginIds.mockReturnValue(["openai", "poisoned", "deepseek"]);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      manifestRegistry: {
+        plugins: [
+          createManifestPluginWithModelCatalog("openai"),
+          createPoisonedModelCatalogPlugin("poisoned"),
+          createManifestPluginWithModelCatalog("deepseek"),
+        ],
+        diagnostics: [],
+      },
+    });
+
+    const providers = resolvePluginDiscoveryProvidersRuntime({ discoveryEntriesOnly: true });
+
+    expect(providers.map((provider) => provider.id)).toEqual(["openai", "deepseek"]);
+    expect(mocks.resolvePluginProviders).not.toHaveBeenCalled();
   });
 
   it("does not expose runtime-only manifest model catalogs as static discovery entries", () => {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planManifestModelCatalogRows } from "../model-catalog/manifest-planner.js";
-import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
@@ -211,28 +211,32 @@ function resolveManifestModelCatalogProviders(
 ): ProviderPlugin[] {
   const providers: ProviderPlugin[] = [];
   for (const plugin of pluginRecords) {
-    if (!plugin.modelCatalog?.providers) {
+    try {
+      if (!plugin.modelCatalog?.providers) {
+        continue;
+      }
+      const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
+      for (const entry of plan.entries) {
+        if (entry.rows.length === 0 || entry.discovery === "runtime") {
+          continue;
+        }
+        const providerConfig = providerConfigFromManifestRows(entry.rows);
+        if (!providerConfig) {
+          continue;
+        }
+        providers.push({
+          id: entry.provider,
+          pluginId: plugin.id,
+          label: entry.provider,
+          auth: [],
+          staticCatalog: {
+            order: "simple",
+            run: async () => ({ providers: { [entry.provider]: providerConfig } }),
+          },
+        });
+      }
+    } catch {
       continue;
-    }
-    const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
-    for (const entry of plan.entries) {
-      if (entry.rows.length === 0 || entry.discovery === "runtime") {
-        continue;
-      }
-      const providerConfig = providerConfigFromManifestRows(entry.rows);
-      if (!providerConfig) {
-        continue;
-      }
-      providers.push({
-        id: entry.provider,
-        pluginId: plugin.id,
-        label: entry.provider,
-        auth: [],
-        staticCatalog: {
-          order: "simple",
-          run: async () => ({ providers: { [entry.provider]: providerConfig } }),
-        },
-      });
     }
   }
   return providers;
@@ -243,23 +247,27 @@ function resolveRuntimeManifestCatalogPluginIds(
 ): Set<string> {
   const pluginIds = new Set<string>();
   for (const plugin of pluginRecords) {
-    const ownedProviders = new Set(
-      plugin.providers.map((provider) => normalizeProviderId(provider)),
-    );
-    const ownsRuntimeDiscovery = Object.entries(plugin.modelCatalog?.discovery ?? {}).some(
-      ([provider, discovery]) =>
-        discovery === "runtime" && ownedProviders.has(normalizeProviderId(provider)),
-    );
-    if (ownsRuntimeDiscovery) {
-      pluginIds.add(plugin.id);
-    }
+    try {
+      const ownedProviders = new Set(
+        plugin.providers.map((provider) => normalizeProviderId(provider)),
+      );
+      const ownsRuntimeDiscovery = Object.entries(plugin.modelCatalog?.discovery ?? {}).some(
+        ([provider, discovery]) =>
+          discovery === "runtime" && ownedProviders.has(normalizeProviderId(provider)),
+      );
+      if (ownsRuntimeDiscovery) {
+        pluginIds.add(plugin.id);
+      }
 
-    if (!plugin.modelCatalog?.providers) {
+      if (!plugin.modelCatalog?.providers) {
+        continue;
+      }
+      const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
+      if (plan.entries.some((entry) => entry.discovery === "runtime")) {
+        pluginIds.add(plugin.id);
+      }
+    } catch {
       continue;
-    }
-    const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
-    if (plan.entries.some((entry) => entry.discovery === "runtime")) {
-      pluginIds.add(plugin.id);
     }
   }
   return pluginIds;


### PR DESCRIPTION
## Summary

- Guard manifest model-catalog metadata reads during provider discovery so one unreadable plugin row is skipped instead of aborting discovery.
- Keep healthy manifest static catalog entries available before and after a bad row.
- Add a poisoned metadata regression for provider discovery.

## Verification

- Red repro: `node scripts/run-vitest.mjs src/plugins/provider-discovery.runtime.test.ts` failed pre-fix with `provider discovery model catalog metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/provider-discovery.runtime.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`
- `./node_modules/.bin/oxlint src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Broad changed gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`, blocked before lease with coordinator `401 unauthorized`.

Behavior addressed: Provider discovery now skips unreadable manifest model-catalog metadata rows instead of crashing before healthy provider entries can be returned.
Real environment tested: Local linked Codex worktree on Node/Vitest through `node scripts/run-vitest.mjs`; remote changed gate attempted through Crabbox wrapper but coordinator auth blocked lease creation.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/provider-discovery.runtime.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`; `./node_modules/.bin/oxlint src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: Focused Vitest passed 1 file / 25 tests; formatter, oxlint, diff-check, and both autoreview runs passed; Crabbox changed gate failed before lease with HTTP 401.
Observed result after fix: A poisoned `modelCatalog` getter no longer aborts `resolvePluginDiscoveryProvidersRuntime({ discoveryEntriesOnly: true })`; healthy `openai` and `deepseek` manifest catalog providers are still returned, and full plugin loading is not invoked.
What was not tested: Full `pnpm check:changed` was not completed because the Crabbox coordinator rejected lease creation with `401 unauthorized`.
