### PR TITLE
fix(plugins): guard provider policy metadata

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
 
 describe("provider public artifacts", () => {
@@ -26,6 +27,36 @@ describe("provider public artifacts", () => {
     vi.doUnmock("./public-surface-loader.js");
     vi.resetModules();
   });
+
+  function createManifestRecord(
+    fields: Partial<PluginManifestRecord> & Pick<PluginManifestRecord, "id">,
+  ): PluginManifestRecord {
+    return {
+      channels: [],
+      cliBackends: [],
+      hooks: [],
+      manifestPath: `/tmp/${fields.id}/openclaw.plugin.json`,
+      origin: "bundled",
+      providers: [],
+      rootDir: `/tmp/${fields.id}`,
+      skills: [],
+      source: `/tmp/${fields.id}/index.js`,
+      ...fields,
+    };
+  }
+
+  function createPoisonedProviderPolicyRecord(
+    id: string,
+    field: "providers" | "providerAuthAliases",
+  ): PluginManifestRecord {
+    const record = createManifestRecord({ id, providers: ["other"] });
+    Object.defineProperty(record, field, {
+      get() {
+        throw new Error(`provider policy ${field} metadata exploded`);
+      },
+    });
+    return record;
+  }
 
   it("loads a lightweight bundled provider policy artifact smoke", () => {
     const surface = resolveBundledProviderPolicySurface("openai");
@@ -173,6 +204,57 @@ describe("provider public artifacts", () => {
     });
     expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
       dirName: "openai",
+      artifactBasename: "provider-policy-api.js",
+    });
+    expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+
+  it("skips unreadable provider policy ownership metadata", async () => {
+    const loadPluginManifestRegistry = vi.fn(() => {
+      throw new Error("unexpected manifest registry scan");
+    });
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
+      if (dirName !== "owner") {
+        throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
+      }
+      return {
+        resolveThinkingProfile: () => ({ levels: [{ id: dirName }] }),
+      };
+    });
+
+    vi.doMock("./manifest-registry.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./manifest-registry.js")>();
+      return {
+        ...actual,
+        loadPluginManifestRegistry,
+      };
+    });
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const { resolveBundledProviderPolicySurface: resolvePolicySurface } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=poisoned-policy-owner");
+
+    const surface = resolvePolicySurface("fixture-provider", {
+      manifestRegistry: {
+        plugins: [
+          createPoisonedProviderPolicyRecord("bad-aliases", "providerAuthAliases"),
+          createPoisonedProviderPolicyRecord("bad-providers", "providers"),
+          createManifestRecord({
+            id: "owner",
+            providers: ["fixture-provider"],
+          }),
+        ],
+      },
+    });
+
+    expect(
+      surface?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "demo" }),
+    ).toEqual({ levels: [{ id: "owner" }] });
+    expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
+      dirName: "owner",
       artifactBasename: "provider-policy-api.js",
     });
     expect(loadPluginManifestRegistry).not.toHaveBeenCalled();

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -88,11 +88,15 @@ function resolveBundledProviderPolicyPluginId(
   for (const plugin of registry.plugins.toSorted((left, right) =>
     left.id.localeCompare(right.id),
   )) {
-    if (plugin.origin !== "bundled") {
+    try {
+      if (plugin.origin !== "bundled") {
+        continue;
+      }
+      if (pluginOwnsProviderPolicyRef(plugin, normalizedProviderId)) {
+        return plugin.id;
+      }
+    } catch {
       continue;
-    }
-    if (pluginOwnsProviderPolicyRef(plugin, normalizedProviderId)) {
-      return plugin.id;
     }
   }
 


### PR DESCRIPTION
## Summary

- Guard bundled provider policy owner resolution against unreadable per-plugin metadata rows.
- Continue resolving later valid bundled provider policy owners after a malformed row.
- Add a regression covering poisoned `providers` and `providerAuthAliases` manifest metadata.

## Verification

- Red repro: `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts` failed pre-fix with `provider policy providerAuthAliases metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts`
- `./node_modules/.bin/oxlint src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- After rebase on current `origin/main`: reran focused Vitest, oxfmt check, oxlint, diff-check, and branch autoreview.
- Broad changed gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`, blocked before lease with coordinator `401 unauthorized`.

Behavior addressed: Provider policy public artifact owner resolution now skips unreadable manifest ownership metadata rows instead of crashing config/provider policy lookup.
Real environment tested: Local linked Codex worktree on Node/Vitest through `node scripts/run-vitest.mjs`; remote changed gate attempted through Crabbox wrapper but coordinator auth blocked lease creation.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/provider-public-artifacts.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts`; `./node_modules/.bin/oxlint src/plugins/provider-public-artifacts.ts src/plugins/provider-public-artifacts.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: Focused Vitest passed 1 file / 7 tests before and after rebase; formatter, oxlint, diff-check, and autoreview passed; Crabbox changed gate failed before lease with HTTP 401.
Observed result after fix: Poisoned `providers` and `providerAuthAliases` getters no longer abort `resolveBundledProviderPolicySurface`; a later valid owner still provides the bundled provider policy artifact.
What was not tested: Full `pnpm check:changed` was not completed because the Crabbox coordinator rejected lease creation with `401 unauthorized`.
