### PR TITLE
fix(ui): prevent stale skill checkbox state after filtering

### DIFF
--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -356,6 +356,80 @@ describe("renderSkills", () => {
     expect(normalizeText(container)).toContain("AgentReceipt Local trust card.");
   });
 
+  it("keeps the remaining filtered row toggle tied to that skill after a row leaves", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    const onToggle = vi.fn();
+    const disabledSkills = [
+      createSkill({
+        skillKey: "alpha",
+        name: "Alpha",
+        source: "openclaw-managed",
+        filePath: "/tmp/skills/alpha/SKILL.md",
+        disabled: true,
+      }),
+      createSkill({
+        skillKey: "beta",
+        name: "Beta",
+        source: "openclaw-managed",
+        filePath: "/tmp/skills/beta/SKILL.md",
+        disabled: true,
+      }),
+    ];
+    const report: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: disabledSkills,
+    };
+
+    render(
+      renderSkills(
+        createProps({
+          report,
+          statusFilter: "disabled",
+          onToggle,
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const firstRenderToggles = Array.from(
+      container.querySelectorAll<HTMLInputElement>(".skills-grid .skill-toggle"),
+    );
+    expect(firstRenderToggles.map((toggle) => toggle.checked)).toEqual([false, false]);
+
+    firstRenderToggles[0]!.click();
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith("alpha", true);
+
+    render(
+      renderSkills(
+        createProps({
+          report: {
+            ...report,
+            skills: [{ ...disabledSkills[0]!, disabled: false }, disabledSkills[1]!],
+          },
+          statusFilter: "disabled",
+          onToggle,
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const remainingRows = Array.from(
+      container.querySelectorAll<HTMLElement>(".skills-grid .list-item"),
+    );
+    const remainingToggle = container.querySelector<HTMLInputElement>(".skills-grid .skill-toggle");
+    expect(remainingRows.map((row) => normalizeText(row.querySelector(".list-title")!))).toEqual([
+      "Beta",
+    ]);
+    expect(remainingToggle?.checked).toBe(false);
+  });
+
   it("fails closed for inconsistent ClawHub verdict envelopes", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -361,22 +361,21 @@ describe("renderSkills", () => {
     document.body.append(container);
     dialogRestores.push(() => container.remove());
     const onToggle = vi.fn();
-    const disabledSkills = [
-      createSkill({
-        skillKey: "alpha",
-        name: "Alpha",
-        source: "openclaw-managed",
-        filePath: "/tmp/skills/alpha/SKILL.md",
-        disabled: true,
-      }),
-      createSkill({
-        skillKey: "beta",
-        name: "Beta",
-        source: "openclaw-managed",
-        filePath: "/tmp/skills/beta/SKILL.md",
-        disabled: true,
-      }),
-    ];
+    const alphaSkill = createSkill({
+      skillKey: "alpha",
+      name: "Alpha",
+      source: "openclaw-managed",
+      filePath: "/tmp/skills/alpha/SKILL.md",
+      disabled: true,
+    });
+    const betaSkill = createSkill({
+      skillKey: "beta",
+      name: "Beta",
+      source: "openclaw-managed",
+      filePath: "/tmp/skills/beta/SKILL.md",
+      disabled: true,
+    });
+    const disabledSkills = [alphaSkill, betaSkill];
     const report: SkillStatusReport = {
       workspaceDir: "/tmp/workspace",
       managedSkillsDir: "/tmp/skills",
@@ -400,7 +399,11 @@ describe("renderSkills", () => {
     );
     expect(firstRenderToggles.map((toggle) => toggle.checked)).toEqual([false, false]);
 
-    firstRenderToggles[0]!.click();
+    const alphaToggle = firstRenderToggles[0];
+    if (!alphaToggle) {
+      throw new Error("Expected Alpha skill toggle to render.");
+    }
+    alphaToggle.click();
 
     expect(onToggle).toHaveBeenCalledTimes(1);
     expect(onToggle).toHaveBeenCalledWith("alpha", true);
@@ -410,7 +413,7 @@ describe("renderSkills", () => {
         createProps({
           report: {
             ...report,
-            skills: [{ ...disabledSkills[0]!, disabled: false }, disabledSkills[1]!],
+            skills: [{ ...alphaSkill, disabled: false }, betaSkill],
           },
           statusFilter: "disabled",
           onToggle,

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -1,5 +1,7 @@
 import { html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
 import { ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
@@ -307,7 +309,11 @@ export function renderSkills(props: SkillsProps) {
                       <span class="muted">${group.skills.length}</span>
                     </summary>
                     <div class="list skills-grid">
-                      ${group.skills.map((skill) => renderSkill(skill, props))}
+                      ${repeat(
+                        group.skills,
+                        (skill) => skill.skillKey,
+                        (skill) => renderSkill(skill, props),
+                      )}
                     </div>
                   </details>
                 `;
@@ -476,7 +482,7 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
           <input
             type="checkbox"
             class="skill-toggle"
-            .checked=${!skill.disabled}
+            .checked=${live(!skill.disabled)}
             ?disabled=${busy}
             @change=${(e: Event) => {
               e.stopPropagation();


### PR DESCRIPTION
## Summary

Fixes a stale checkbox state in the Skills UI when switching filtered tabs after toggling a skill.

The list rows are now keyed by skill identity, and the checkbox state is bound to the live value so reused DOM does not keep an old user-mutated checked state.

Fixes #89661.

## Testing

- `node scripts/run-vitest.mjs ui/src/ui/views/skills.test.ts`
- `git diff --check -- ui/src/ui/views/skills.ts ui/src/ui/views/skills.test.ts`


## Real behavior proof
- Behavior addressed: Skills tab Disabled filter no longer carries a toggled checkbox state from Alpha to Beta after Alpha leaves the filtered list.
- Real environment tested: Control UI running in Chromium against the PR head, with deterministic Gateway skill-status responses for the Skills tab.
- Exact steps or command run after this patch: `node --import tsx .artifacts/control-ui-e2e/skills-filter-proof/proof-runner.mjs`
- Evidence after fix: Before screenshot: https://github.com/kumarpriyanshu09/openclaw/releases/download/proof-pr-89947-94c64f0/skills-disabled-before.png; after screenshot: https://github.com/kumarpriyanshu09/openclaw/releases/download/proof-pr-89947-94c64f0/skills-disabled-after.png; screen recording: https://github.com/kumarpriyanshu09/openclaw/releases/download/proof-pr-89947-94c64f0/page%400460d9241c6b74e3540594c7079e296e.webm.
- Observed result after fix: After enabling Alpha in the Disabled filter, Alpha left the filtered list, the Disabled count changed from 2 to 1, only Beta remained visible, and Beta's checkbox stayed unchecked.
- What was not tested: Live provider/channel credentials; this proof is a deterministic Control UI browser run for the Skills tab state transition.