### PR TITLE
fix(plugins): guard plugin id alias metadata

### DIFF
--- a/src/plugins/plugin-registry-id-normalizer.ts
+++ b/src/plugins/plugin-registry-id-normalizer.ts
@@ -34,6 +34,30 @@ function listPluginRegistryNormalizerAliases(plugin: PluginManifestRecord): read
   ];
 }
 
+type PluginRegistryNormalizerAliasEntry = {
+  pluginId: string;
+  registryId: string;
+  aliases: readonly string[];
+};
+
+function readPluginRegistryNormalizerAliasEntry(
+  plugin: PluginManifestRecord,
+): PluginRegistryNormalizerAliasEntry | undefined {
+  try {
+    const pluginId = normalizePluginRegistryAlias(plugin.id);
+    if (!pluginId) {
+      return undefined;
+    }
+    return {
+      pluginId,
+      registryId: plugin.id,
+      aliases: listPluginRegistryNormalizerAliases(plugin),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 export function createPluginRegistryIdNormalizer(
   index: InstalledPluginIndex,
   options: PluginRegistryIdNormalizerOptions = {},
@@ -55,19 +79,17 @@ export function createPluginRegistryIdNormalizer(
       index,
       includeDisabled: true,
     });
-  for (const plugin of [...registry.plugins].toSorted((left, right) =>
-    left.id.localeCompare(right.id),
-  )) {
-    const pluginId = normalizePluginRegistryAlias(plugin.id);
-    if (!pluginId) {
-      continue;
-    }
-    aliases.set(normalizePluginRegistryAliasKey(pluginId), plugin.id);
-    for (const alias of listPluginRegistryNormalizerAliases(plugin)) {
+  const manifestAliasEntries = registry.plugins
+    .map((plugin) => readPluginRegistryNormalizerAliasEntry(plugin))
+    .filter((entry): entry is PluginRegistryNormalizerAliasEntry => Boolean(entry))
+    .toSorted((left, right) => left.pluginId.localeCompare(right.pluginId));
+  for (const entry of manifestAliasEntries) {
+    aliases.set(normalizePluginRegistryAliasKey(entry.pluginId), entry.registryId);
+    for (const alias of entry.aliases) {
       const normalizedAlias = normalizePluginRegistryAlias(alias);
       const normalizedAliasKey = normalizePluginRegistryAliasKey(alias);
       if (normalizedAlias && !aliases.has(normalizedAliasKey)) {
-        aliases.set(normalizedAliasKey, pluginId);
+        aliases.set(normalizedAliasKey, entry.pluginId);
       }
     }
   }

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -15,6 +15,7 @@ import {
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
 } from "./installed-plugin-index.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { loadPluginLookUpTable } from "./plugin-lookup-table.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
@@ -163,6 +164,36 @@ function createPersistableIndex(pluginId: string): InstalledPluginIndex {
     ...index,
     plugins,
   };
+}
+
+function createManifestRecord(
+  fields: Partial<PluginManifestRecord> & Pick<PluginManifestRecord, "id">,
+): PluginManifestRecord {
+  return {
+    channels: [],
+    cliBackends: [],
+    hooks: [],
+    manifestPath: `/tmp/${fields.id}/openclaw.plugin.json`,
+    origin: "global",
+    providers: [],
+    rootDir: `/tmp/${fields.id}`,
+    skills: [],
+    source: `/tmp/${fields.id}/index.js`,
+    ...fields,
+  };
+}
+
+function createPoisonedNormalizerAliasRecord(
+  id: string,
+  field: "id" | "providers" | "providerAuthAliases",
+): PluginManifestRecord {
+  const record = createManifestRecord({ id });
+  Object.defineProperty(record, field, {
+    get() {
+      throw new Error(`plugin registry ${field} alias metadata exploded`);
+    },
+  });
+  return record;
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
@@ -450,6 +481,36 @@ describe("plugin registry facade", () => {
       { manifestRegistry: lookUpTable.manifestRegistry },
     );
     expect(normalizedConfig.allow).toEqual(["demo"]);
+  });
+
+  it("skips unreadable manifest alias metadata while normalizing plugin config ids", () => {
+    const index = createIndex("healthy", {
+      plugins: [
+        {
+          ...createIndex("healthy").plugins[0],
+          pluginId: "healthy",
+          rootDir: "/tmp/healthy",
+        },
+      ],
+    });
+    const manifestRegistry = {
+      plugins: [
+        createPoisonedNormalizerAliasRecord("bad-id", "id"),
+        createPoisonedNormalizerAliasRecord("bad-aliases", "providerAuthAliases"),
+        createPoisonedNormalizerAliasRecord("bad-providers", "providers"),
+        createManifestRecord({
+          id: "healthy",
+          channels: ["healthy-chat"],
+          providers: ["healthy-provider"],
+        }),
+      ],
+      diagnostics: [],
+    };
+
+    const normalizePluginId = createPluginRegistryIdNormalizer(index, { manifestRegistry });
+
+    expect(normalizePluginId("healthy-chat")).toBe("healthy");
+    expect(normalizePluginId("healthy-provider")).toBe("healthy");
   });
 
   it("reads the persisted registry before deriving from discovered candidates", async () => {


### PR DESCRIPTION
## Summary
- Guard plugin-registry config id alias collection against unreadable manifest metadata.
- Skip only the malformed manifest alias row, while preserving healthy channel/provider aliases for config id normalization.
- Add regression coverage for poisoned `id`, `providers`, and `providerAuthAliases` manifest records.

## Verification
- Red proof: `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts` failed before the fix with `plugin registry providerAuthAliases alias metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/plugin-registry-id-normalizer.ts src/plugins/plugin-registry.test.ts`
- `./node_modules/.bin/oxlint src/plugins/plugin-registry-id-normalizer.ts src/plugins/plugin-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall `patch is correct (0.87)`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall `patch is correct (0.86)`
- Broad gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`; blocked before lease by coordinator auth: provider `azure`, slug `crimson-prawn`, `coordinator POST /v1/leases: http 401: {"error":"unauthorized"}`.

## Real behavior proof
Behavior addressed: plugin config id normalization no longer crashes when one manifest record has unreadable alias metadata.
Real environment tested: local OpenClaw worktree with symlinked repo dependencies; Crabbox remote changed gate attempted but blocked by coordinator auth.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/plugin-registry-id-normalizer.ts src/plugins/plugin-registry.test.ts`; `./node_modules/.bin/oxlint src/plugins/plugin-registry-id-normalizer.ts src/plugins/plugin-registry.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 25 plugin-registry tests; oxfmt, oxlint, diff-check, and branch autoreview passed.
Observed result after fix: poisoned manifest rows for `id`, `providers`, and `providerAuthAliases` are skipped, and healthy aliases `healthy-chat` and `healthy-provider` still normalize to `healthy`.
What was not tested: full `pnpm check:changed`, because Crabbox coordinator auth returned HTTP 401 before lease creation.
