### PR TITLE
fix(plugins): guard provider auth choice metadata

### DIFF
--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -58,6 +58,19 @@ function createProviderAuthChoice(overrides: Record<string, unknown>) {
   return overrides;
 }
 
+function createPoisonedManifestPlugin(
+  id: string,
+  field: "providerAuthChoices" | "setup",
+): Record<string, unknown> {
+  const plugin = { id };
+  Object.defineProperty(plugin, field, {
+    get() {
+      throw new Error(`provider auth choice ${field} metadata exploded`);
+    },
+  });
+  return plugin;
+}
+
 function setManifestPlugins(plugins: Array<Record<string, unknown>>) {
   pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
     plugins,
@@ -155,6 +168,32 @@ describe("provider auth choice manifest helpers", () => {
       ],
       resolvedProviderIds: { "openai-api-key": "openai" },
     });
+  });
+
+  it("skips unreadable auth choice metadata while resolving manifest choices", () => {
+    setManifestPlugins([
+      createPoisonedManifestPlugin("bad-provider-auth-choices", "providerAuthChoices"),
+      createPoisonedManifestPlugin("bad-setup-auth-choices", "setup"),
+      createManifestPlugin("openai", [
+        createProviderAuthChoice({
+          provider: "openai",
+          method: "api-key",
+          choiceId: "openai-api-key",
+          choiceLabel: "OpenAI API key",
+        }),
+      ]),
+    ]);
+
+    expect(resolveManifestProviderAuthChoices()).toEqual([
+      {
+        pluginId: "openai",
+        providerId: "openai",
+        methodId: "api-key",
+        choiceId: "openai-api-key",
+        choiceLabel: "OpenAI API key",
+      },
+    ]);
+    expect(resolveManifestProviderAuthChoice("openai-api-key")?.providerId).toBe("openai");
   });
 
   it.each([

--- a/src/plugins/provider-auth-choices.ts
+++ b/src/plugins/provider-auth-choices.ts
@@ -171,6 +171,43 @@ function listSetupProviderAuthChoiceCandidates(plugin: PluginManifestRecord) {
   });
 }
 
+function listManifestProviderAuthChoiceCandidatesForPlugin(params: {
+  plugin: PluginManifestRecord;
+  config?: OpenClawConfig;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  includeUntrustedWorkspacePlugins?: boolean;
+}): ProviderAuthChoiceCandidate[] {
+  const { plugin } = params;
+  try {
+    if (
+      plugin.origin === "workspace" &&
+      params.includeUntrustedWorkspacePlugins === false &&
+      !resolveEffectiveEnableState({
+        id: plugin.id,
+        origin: plugin.origin,
+        config: params.normalizedConfig,
+        rootConfig: params.config,
+      }).enabled
+    ) {
+      return [];
+    }
+    const choices: ProviderAuthChoiceCandidate[] = [];
+    for (const choice of plugin.providerAuthChoices ?? []) {
+      choices.push(
+        toProviderAuthChoiceCandidate({
+          pluginId: plugin.id,
+          origin: plugin.origin,
+          choice,
+        }),
+      );
+    }
+    choices.push(...listSetupProviderAuthChoiceCandidates(plugin));
+    return choices;
+  } catch {
+    return [];
+  }
+}
+
 function stripChoiceOrigin(choice: ProviderAuthChoiceCandidate): ProviderAuthChoiceMetadata {
   const { origin: _origin, ...metadata } = choice;
   return metadata;
@@ -189,32 +226,14 @@ function resolveManifestProviderAuthChoiceCandidates(params?: {
   });
   const registry = metadataSnapshot.manifestRegistry;
   const normalizedConfig = normalizePluginsConfig(params?.config?.plugins);
-  return registry.plugins.flatMap((plugin) => {
-    if (
-      plugin.origin === "workspace" &&
-      params?.includeUntrustedWorkspacePlugins === false &&
-      !resolveEffectiveEnableState({
-        id: plugin.id,
-        origin: plugin.origin,
-        config: normalizedConfig,
-        rootConfig: params?.config,
-      }).enabled
-    ) {
-      return [];
-    }
-    const choices: ProviderAuthChoiceCandidate[] = [];
-    for (const choice of plugin.providerAuthChoices ?? []) {
-      choices.push(
-        toProviderAuthChoiceCandidate({
-          pluginId: plugin.id,
-          origin: plugin.origin,
-          choice,
-        }),
-      );
-    }
-    choices.push(...listSetupProviderAuthChoiceCandidates(plugin));
-    return choices;
-  });
+  return registry.plugins.flatMap((plugin) =>
+    listManifestProviderAuthChoiceCandidatesForPlugin({
+      plugin,
+      config: params?.config,
+      normalizedConfig,
+      includeUntrustedWorkspacePlugins: params?.includeUntrustedWorkspacePlugins,
+    }),
+  );
 }
 
 function pickPreferredManifestAuthChoice(


### PR DESCRIPTION
## Summary
- Guard manifest provider-auth choice extraction against unreadable per-plugin metadata.
- Skip only the malformed manifest row while preserving healthy explicit auth choices, setup-derived choices, and existing onboarding resolution.
- Add regression coverage for poisoned `providerAuthChoices` and `setup` metadata.

## Verification
- Red proof: `node scripts/run-vitest.mjs src/plugins/provider-auth-choices.test.ts` failed before the fix with `provider auth choice providerAuthChoices metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/provider-auth-choices.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`
- `./node_modules/.bin/oxlint src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall `patch is correct (0.84)`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall `patch is correct (0.84)`
- Broad gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`; blocked before lease by coordinator auth: provider `azure`, slug `blue-krill`, `coordinator POST /v1/leases: http 401: {"error":"unauthorized"}`.

## Real behavior proof
Behavior addressed: provider auth choice resolution no longer crashes when one manifest plugin row has unreadable auth-choice or setup metadata.
Real environment tested: local OpenClaw worktree with symlinked repo dependencies; Crabbox remote changed gate attempted but blocked by coordinator auth.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/provider-auth-choices.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`; `./node_modules/.bin/oxlint src/plugins/provider-auth-choices.ts src/plugins/provider-auth-choices.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 13 provider-auth-choice tests; oxfmt, oxlint, diff-check, and branch autoreview passed.
Observed result after fix: poisoned manifest rows for `providerAuthChoices` and `setup` are skipped, and the healthy `openai-api-key` choice still resolves to provider `openai`.
What was not tested: full `pnpm check:changed`, because Crabbox coordinator auth returned HTTP 401 before lease creation.
