### PR TITLE
fix(plugins): guard web search credential metadata

### DIFF
--- a/src/plugins/web-search-credential-presence.test.ts
+++ b/src/plugins/web-search-credential-presence.test.ts
@@ -1,10 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const manifestContractEligibilityMocks = vi.hoisted(() => ({
+  loadManifestMetadataSnapshot: vi.fn(),
+}));
+
+vi.mock("./manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: manifestContractEligibilityMocks.loadManifestMetadataSnapshot,
+}));
 
 let hasConfiguredWebSearchCredential: typeof import("./web-search-credential-presence.js").hasConfiguredWebSearchCredential;
 
@@ -12,7 +19,37 @@ beforeAll(async () => {
   ({ hasConfiguredWebSearchCredential } = await import("./web-search-credential-presence.js"));
 });
 
+function setManifestPlugins(plugins: Array<Record<string, unknown>>) {
+  manifestContractEligibilityMocks.loadManifestMetadataSnapshot.mockReturnValue({ plugins });
+}
+
+function createPoisonedManifestPlugin(
+  id: string,
+  field: "contracts" | "setup" | "providerAuthEnvVars",
+): Record<string, unknown> {
+  const plugin: Record<string, unknown> = {
+    id,
+    origin: "bundled",
+    contracts: { webSearchProviders: [`${id}-search`] },
+    setup: {
+      providers: [{ id, envVars: [`${id.toUpperCase().replaceAll("-", "_")}_API_KEY`] }],
+    },
+    providerAuthEnvVars: {},
+  };
+  Object.defineProperty(plugin, field, {
+    get() {
+      throw new Error(`web search credential ${field} metadata exploded`);
+    },
+  });
+  return plugin;
+}
+
 describe("hasConfiguredWebSearchCredential", () => {
+  beforeEach(() => {
+    manifestContractEligibilityMocks.loadManifestMetadataSnapshot.mockReset();
+    setManifestPlugins([]);
+  });
+
   it("does not statically import web-search runtime providers", () => {
     const source = fs.readFileSync(
       path.join(repoRoot, "src/plugins/web-search-credential-presence.ts"),
@@ -40,6 +77,31 @@ describe("hasConfiguredWebSearchCredential", () => {
           tools: { web: { search: { apiKey: "brave-key" } } },
         } as OpenClawConfig,
         env: {},
+        origin: "bundled",
+      }),
+    ).toBe(true);
+  });
+
+  it("skips unreadable manifest credential metadata while detecting env credentials", () => {
+    setManifestPlugins([
+      createPoisonedManifestPlugin("bad-contracts", "contracts"),
+      createPoisonedManifestPlugin("bad-setup", "setup"),
+      createPoisonedManifestPlugin("bad-provider-env", "providerAuthEnvVars"),
+      {
+        id: "brave",
+        origin: "bundled",
+        contracts: { webSearchProviders: ["brave"] },
+        setup: {
+          providers: [{ id: "brave", envVars: ["BRAVE_API_KEY"] }],
+        },
+        providerAuthEnvVars: {},
+      },
+    ]);
+
+    expect(
+      hasConfiguredWebSearchCredential({
+        config: {} as OpenClawConfig,
+        env: { BRAVE_API_KEY: "brave-key" },
         origin: "bundled",
       }),
     ).toBe(true);

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -33,6 +33,29 @@ function hasConfiguredPluginWebSearchCandidate(config: OpenClawConfig): boolean 
   });
 }
 
+function hasManifestPluginWebSearchEnvCredentialCandidate(params: {
+  plugin: PluginManifestRecord;
+  env: NodeJS.ProcessEnv;
+  origin?: PluginManifestRecord["origin"];
+}): boolean {
+  const { plugin } = params;
+  try {
+    if (params.origin && plugin.origin !== params.origin) {
+      return false;
+    }
+    if ((plugin.contracts?.webSearchProviders?.length ?? 0) === 0) {
+      return false;
+    }
+    const envVars = [
+      ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
+      ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
+    ];
+    return envVars.some((envVar) => hasConfiguredCredentialValue(params.env[envVar]));
+  } catch {
+    return false;
+  }
+}
+
 function hasManifestWebSearchEnvCredentialCandidate(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -45,19 +68,13 @@ function hasManifestWebSearchEnvCredentialCandidate(params: {
   return loadManifestMetadataSnapshot({
     config: params.config,
     env,
-  }).plugins.some((plugin) => {
-    if (params.origin && plugin.origin !== params.origin) {
-      return false;
-    }
-    if ((plugin.contracts?.webSearchProviders?.length ?? 0) === 0) {
-      return false;
-    }
-    const envVars = [
-      ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
-      ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
-    ];
-    return envVars.some((envVar) => hasConfiguredCredentialValue(env[envVar]));
-  });
+  }).plugins.some((plugin) =>
+    hasManifestPluginWebSearchEnvCredentialCandidate({
+      plugin,
+      env,
+      origin: params.origin,
+    }),
+  );
 }
 
 export function hasConfiguredWebSearchCredential(params: {


### PR DESCRIPTION
## Summary
- Guard manifest web-search credential probing against unreadable per-plugin metadata.
- Skip only the malformed manifest row while preserving healthy env credential detection.
- Add regression coverage for poisoned `contracts`, `setup`, and `providerAuthEnvVars` metadata.

## Verification
- Red proof: `node scripts/run-vitest.mjs src/plugins/web-search-credential-presence.test.ts` failed before the fix with `web search credential contracts metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/web-search-credential-presence.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`
- `./node_modules/.bin/oxlint src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall `patch is correct (0.86)`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall `patch is correct (0.82)`
- Broad gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`; blocked before lease by coordinator auth: provider `azure`, slug `harbor-crab`, `coordinator POST /v1/leases: http 401: {"error":"unauthorized"}`.

## Real behavior proof
Behavior addressed: web-search credential detection no longer crashes when one manifest plugin row has unreadable web-search credential metadata.
Real environment tested: local OpenClaw worktree with symlinked repo dependencies; Crabbox remote changed gate attempted but blocked by coordinator auth.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/web-search-credential-presence.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`; `./node_modules/.bin/oxlint src/plugins/web-search-credential-presence.ts src/plugins/web-search-credential-presence.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 4 web-search credential tests; oxfmt, oxlint, diff-check, and branch autoreview passed.
Observed result after fix: poisoned manifest rows for `contracts`, `setup`, and `providerAuthEnvVars` are skipped, and the healthy `BRAVE_API_KEY` env credential is still detected.
What was not tested: full `pnpm check:changed`, because Crabbox coordinator auth returned HTTP 401 before lease creation.
