### PR TITLE
fix(slack): persist inbound ingress before dispatch

### DIFF
--- a/extensions/slack/src/monitor/inbound-delivery-state.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.ts
@@ -1,4 +1,7 @@
-import { createDurableInboundReceiveJournal } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createDurableInboundReceiveJournal,
+  type DurableInboundReceivePendingRecord,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { getOptionalSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
@@ -47,6 +50,16 @@ type SlackInboundIngressCompletedMetadata = SlackInboundIngressMetadata & {
   outcome: "delivered" | "dropped" | "duplicate-delivered" | "error";
   reason?: string;
 };
+
+export type SlackInboundIngressAcceptResult = {
+  kind: "accepted" | "pending" | "completed" | "unavailable";
+  id?: string;
+};
+
+export type SlackInboundIngressPendingRecord = DurableInboundReceivePendingRecord<
+  SlackInboundIngressPayload,
+  SlackInboundIngressMetadata
+>;
 
 const deliveredMessages = resolveGlobalDedupeCache(SLACK_INBOUND_DELIVERIES_KEY, {
   ttlMs: TTL_MS,
@@ -243,16 +256,16 @@ export async function acceptSlackInboundMessageIngress(params: {
     source: "message" | "app_mention";
     wasMentioned?: boolean;
   };
-}): Promise<{ accepted: boolean; id?: string }> {
+}): Promise<SlackInboundIngressAcceptResult> {
   const metadata = makeIngressMetadata(params);
   if (!metadata) {
-    return { accepted: false };
+    return { kind: "unavailable" };
   }
   const journal = getPersistentInboundIngressJournal();
-  if (!journal) {
-    return { accepted: false, id: makeKey(metadata.accountId, metadata.channelId, metadata.ts) };
-  }
   const id = makeKey(metadata.accountId, metadata.channelId, metadata.ts);
+  if (!journal) {
+    return { kind: "unavailable", id };
+  }
   try {
     const receivedAt = Date.now();
     const result = await journal.accept(
@@ -267,10 +280,25 @@ export async function acceptSlackInboundMessageIngress(params: {
         receivedAt,
       },
     );
-    return { accepted: result.kind === "accepted", id };
+    return { kind: result.kind, id };
   } catch (error) {
     disablePersistentIngressJournal(error);
-    return { accepted: false, id };
+    return { kind: "unavailable", id };
+  }
+}
+
+export async function listPendingSlackInboundMessageIngress(): Promise<
+  SlackInboundIngressPendingRecord[]
+> {
+  const journal = getPersistentInboundIngressJournal();
+  if (!journal) {
+    return [];
+  }
+  try {
+    return await journal.pending();
+  } catch (error) {
+    disablePersistentIngressJournal(error);
+    return [];
   }
 }
 

--- a/extensions/slack/src/monitor/inbound-delivery-state.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.ts
@@ -1,3 +1,4 @@
+import { createDurableInboundReceiveJournal } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { getOptionalSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
@@ -6,6 +7,11 @@ const TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_ENTRIES = 20_000;
 const PERSISTENT_MAX_ENTRIES = 20_000;
 const PERSISTENT_NAMESPACE = "slack.inbound-deliveries";
+const INGRESS_PENDING_NAMESPACE = "slack.inbound-ingress.v1.pending";
+const INGRESS_COMPLETED_NAMESPACE = "slack.inbound-ingress.v1.completed";
+const INGRESS_PENDING_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const INGRESS_COMPLETED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const INGRESS_MAX_ENTRIES = 20_000;
 const SLACK_INBOUND_DELIVERIES_KEY = Symbol.for("openclaw.slackInboundDeliveries");
 
 type SlackInboundDeliveryRecord = {
@@ -21,6 +27,27 @@ type SlackInboundDeliveryStore = {
   lookup(key: string): Promise<SlackInboundDeliveryRecord | undefined>;
 };
 
+type SlackInboundIngressPayload = {
+  message: SlackMessageEvent;
+  opts: {
+    source: "message" | "app_mention";
+    wasMentioned?: boolean;
+  };
+  receivedAt: number;
+};
+
+type SlackInboundIngressMetadata = {
+  accountId: string;
+  channelId: string;
+  ts: string;
+  threadTs?: string;
+};
+
+type SlackInboundIngressCompletedMetadata = SlackInboundIngressMetadata & {
+  outcome: "delivered" | "dropped" | "duplicate-delivered" | "error";
+  reason?: string;
+};
+
 const deliveredMessages = resolveGlobalDedupeCache(SLACK_INBOUND_DELIVERIES_KEY, {
   ttlMs: TTL_MS,
   maxSize: MAX_ENTRIES,
@@ -28,9 +55,34 @@ const deliveredMessages = resolveGlobalDedupeCache(SLACK_INBOUND_DELIVERIES_KEY,
 
 let persistentStore: SlackInboundDeliveryStore | undefined;
 let persistentStoreDisabled = false;
+let ingressJournal:
+  | ReturnType<
+      typeof createDurableInboundReceiveJournal<
+        SlackInboundIngressPayload,
+        SlackInboundIngressMetadata,
+        SlackInboundIngressCompletedMetadata
+      >
+    >
+  | undefined;
+let ingressJournalDisabled = false;
 
 function makeKey(accountId: string, channelId: string, ts: string): string {
   return `${accountId}:${channelId}:${ts}`;
+}
+
+function makeIngressMetadata(params: {
+  accountId: string;
+  message: SlackMessageEvent;
+}): SlackInboundIngressMetadata | null {
+  if (!params.accountId || !params.message.channel || !params.message.ts) {
+    return null;
+  }
+  return {
+    accountId: params.accountId,
+    channelId: params.message.channel,
+    ts: params.message.ts,
+    ...(params.message.thread_ts ? { threadTs: params.message.thread_ts } : {}),
+  };
 }
 
 function reportPersistentInboundDeliveryError(error: unknown): void {
@@ -46,6 +98,12 @@ function reportPersistentInboundDeliveryError(error: unknown): void {
 function disablePersistentInboundDelivery(error: unknown): void {
   persistentStoreDisabled = true;
   persistentStore = undefined;
+  reportPersistentInboundDeliveryError(error);
+}
+
+function disablePersistentIngressJournal(error: unknown): void {
+  ingressJournalDisabled = true;
+  ingressJournal = undefined;
   reportPersistentInboundDeliveryError(error);
 }
 
@@ -69,6 +127,43 @@ function getPersistentInboundDeliveryStore(): SlackInboundDeliveryStore | undefi
     return persistentStore;
   } catch (error) {
     disablePersistentInboundDelivery(error);
+    return undefined;
+  }
+}
+
+function getPersistentInboundIngressJournal(): typeof ingressJournal {
+  if (ingressJournalDisabled) {
+    return undefined;
+  }
+  if (ingressJournal) {
+    return ingressJournal;
+  }
+  const runtime = getOptionalSlackRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    ingressJournal = createDurableInboundReceiveJournal<
+      SlackInboundIngressPayload,
+      SlackInboundIngressMetadata,
+      SlackInboundIngressCompletedMetadata
+    >({
+      pendingStore: runtime.state.openKeyedStore({
+        namespace: INGRESS_PENDING_NAMESPACE,
+        maxEntries: INGRESS_MAX_ENTRIES,
+        defaultTtlMs: INGRESS_PENDING_TTL_MS,
+      }),
+      completedStore: runtime.state.openKeyedStore({
+        namespace: INGRESS_COMPLETED_NAMESPACE,
+        maxEntries: INGRESS_MAX_ENTRIES,
+        defaultTtlMs: INGRESS_COMPLETED_TTL_MS,
+      }),
+      pendingTtlMs: INGRESS_PENDING_TTL_MS,
+      completedTtlMs: INGRESS_COMPLETED_TTL_MS,
+    });
+    return ingressJournal;
+  } catch (error) {
+    disablePersistentIngressJournal(error);
     return undefined;
   }
 }
@@ -141,8 +236,91 @@ export async function recordSlackInboundMessageDeliveries(params: {
   await Promise.all(Array.from(keys, (key) => rememberPersistentInboundDelivery(key, deliveredAt)));
 }
 
+export async function acceptSlackInboundMessageIngress(params: {
+  accountId: string;
+  message: SlackMessageEvent;
+  opts: {
+    source: "message" | "app_mention";
+    wasMentioned?: boolean;
+  };
+}): Promise<{ accepted: boolean; id?: string }> {
+  const metadata = makeIngressMetadata(params);
+  if (!metadata) {
+    return { accepted: false };
+  }
+  const journal = getPersistentInboundIngressJournal();
+  if (!journal) {
+    return { accepted: false, id: makeKey(metadata.accountId, metadata.channelId, metadata.ts) };
+  }
+  const id = makeKey(metadata.accountId, metadata.channelId, metadata.ts);
+  try {
+    const receivedAt = Date.now();
+    const result = await journal.accept(
+      id,
+      {
+        message: params.message,
+        opts: params.opts,
+        receivedAt,
+      },
+      {
+        metadata,
+        receivedAt,
+      },
+    );
+    return { accepted: result.kind === "accepted", id };
+  } catch (error) {
+    disablePersistentIngressJournal(error);
+    return { accepted: false, id };
+  }
+}
+
+export async function completeSlackInboundMessageIngress(params: {
+  accountId: string;
+  message: SlackMessageEvent;
+  outcome: SlackInboundIngressCompletedMetadata["outcome"];
+  reason?: string;
+}): Promise<void> {
+  const metadata = makeIngressMetadata(params);
+  const journal = getPersistentInboundIngressJournal();
+  if (!metadata || !journal) {
+    return;
+  }
+  try {
+    await journal.complete(makeKey(metadata.accountId, metadata.channelId, metadata.ts), {
+      metadata: {
+        ...metadata,
+        outcome: params.outcome,
+        ...(params.reason ? { reason: params.reason } : {}),
+      },
+    });
+  } catch (error) {
+    disablePersistentIngressJournal(error);
+  }
+}
+
+export async function releaseSlackInboundMessageIngress(params: {
+  accountId: string;
+  message: SlackMessageEvent;
+  reason: string;
+}): Promise<void> {
+  const metadata = makeIngressMetadata(params);
+  const journal = getPersistentInboundIngressJournal();
+  if (!metadata || !journal) {
+    return;
+  }
+  try {
+    await journal.release(makeKey(metadata.accountId, metadata.channelId, metadata.ts), {
+      lastError: params.reason,
+    });
+  } catch (error) {
+    disablePersistentIngressJournal(error);
+  }
+}
+
 export function clearSlackInboundDeliveryStateForTest(): void {
   deliveredMessages.clear();
   persistentStore = undefined;
   persistentStoreDisabled = false;
+  ingressJournal = undefined;
+  ingressJournalDisabled = false;
 }

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
 const flushKeyMock = vi.fn(async (_key: string) => {});
+const acceptIngressMock = vi.fn(async () => ({ accepted: true, id: "default:D1:123.456" }));
+const completeIngressMock = vi.fn(async () => {});
+const releaseIngressMock = vi.fn(async () => {});
+const hasDeliveryMock = vi.fn(async () => false);
+const recordDeliveriesMock = vi.fn(async () => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
   ...message,
 }));
@@ -28,6 +33,14 @@ vi.mock("./thread-resolution.js", () => ({
   createSlackThreadTsResolver: () => ({
     resolve: (entry: { message: Record<string, unknown> }) => resolveThreadTsMock(entry),
   }),
+}));
+
+vi.mock("./inbound-delivery-state.js", () => ({
+  acceptSlackInboundMessageIngress: (...args: unknown[]) => acceptIngressMock(...args),
+  completeSlackInboundMessageIngress: (...args: unknown[]) => completeIngressMock(...args),
+  releaseSlackInboundMessageIngress: (...args: unknown[]) => releaseIngressMock(...args),
+  hasSlackInboundMessageDelivery: (...args: unknown[]) => hasDeliveryMock(...args),
+  recordSlackInboundMessageDeliveries: (...args: unknown[]) => recordDeliveriesMock(...args),
 }));
 
 function createContext(overrides?: {
@@ -79,7 +92,14 @@ describe("createSlackMessageHandler", () => {
   beforeEach(() => {
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
+    acceptIngressMock.mockClear();
+    completeIngressMock.mockClear();
+    releaseIngressMock.mockClear();
+    hasDeliveryMock.mockClear();
+    recordDeliveriesMock.mockClear();
     resolveThreadTsMock.mockClear();
+    hasDeliveryMock.mockResolvedValue(false);
+    acceptIngressMock.mockResolvedValue({ accepted: true, id: "default:D1:123.456" });
   });
 
   it("does not track invalid non-message events from the message stream", async () => {
@@ -124,6 +144,31 @@ describe("createSlackMessageHandler", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("records Slack thread mentions as durable ingress before queueing", async () => {
+    const { handler } = createHandlerWithTracker();
+    const message = {
+      type: "message",
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000300",
+      text: "<@U0B5YPJJS2Z> teste",
+      thread_ts: "1709000000.000100",
+    } as never;
+
+    await handler(message, { source: "app_mention", wasMentioned: true });
+
+    expect(acceptIngressMock).toHaveBeenCalledWith({
+      accountId: "default",
+      message,
+      opts: { source: "app_mention", wasMentioned: true },
+    });
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    expect(acceptIngressMock.mock.invocationCallOrder[0]).toBeLessThan(
+      enqueueMock.mock.invocationCallOrder[0],
+    );
+    expect(completeIngressMock).not.toHaveBeenCalled();
   });
 
   it("accepts thread_broadcast messages from the message stream", async () => {

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
 const flushKeyMock = vi.fn(async (_key: string) => {});
-const acceptIngressMock = vi.fn(async () => ({ accepted: true, id: "default:D1:123.456" }));
+const acceptIngressMock = vi.fn(async () => ({ kind: "accepted", id: "default:D1:123.456" }));
 const completeIngressMock = vi.fn(async () => {});
 const releaseIngressMock = vi.fn(async () => {});
+const listPendingIngressMock = vi.fn(async () => []);
 const hasDeliveryMock = vi.fn(async () => false);
 const recordDeliveriesMock = vi.fn(async () => {});
 const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
@@ -36,11 +37,12 @@ vi.mock("./thread-resolution.js", () => ({
 }));
 
 vi.mock("./inbound-delivery-state.js", () => ({
-  acceptSlackInboundMessageIngress: (...args: unknown[]) => acceptIngressMock(...args),
-  completeSlackInboundMessageIngress: (...args: unknown[]) => completeIngressMock(...args),
-  releaseSlackInboundMessageIngress: (...args: unknown[]) => releaseIngressMock(...args),
-  hasSlackInboundMessageDelivery: (...args: unknown[]) => hasDeliveryMock(...args),
-  recordSlackInboundMessageDeliveries: (...args: unknown[]) => recordDeliveriesMock(...args),
+  acceptSlackInboundMessageIngress: (args: unknown) => acceptIngressMock(args),
+  completeSlackInboundMessageIngress: (args: unknown) => completeIngressMock(args),
+  releaseSlackInboundMessageIngress: (args: unknown) => releaseIngressMock(args),
+  listPendingSlackInboundMessageIngress: () => listPendingIngressMock(),
+  hasSlackInboundMessageDelivery: (args: unknown) => hasDeliveryMock(args),
+  recordSlackInboundMessageDeliveries: (args: unknown) => recordDeliveriesMock(args),
 }));
 
 function createContext(overrides?: {
@@ -95,11 +97,13 @@ describe("createSlackMessageHandler", () => {
     acceptIngressMock.mockClear();
     completeIngressMock.mockClear();
     releaseIngressMock.mockClear();
+    listPendingIngressMock.mockClear();
     hasDeliveryMock.mockClear();
     recordDeliveriesMock.mockClear();
     resolveThreadTsMock.mockClear();
     hasDeliveryMock.mockResolvedValue(false);
-    acceptIngressMock.mockResolvedValue({ accepted: true, id: "default:D1:123.456" });
+    acceptIngressMock.mockResolvedValue({ kind: "accepted", id: "default:D1:123.456" });
+    listPendingIngressMock.mockResolvedValue([]);
   });
 
   it("does not track invalid non-message events from the message stream", async () => {
@@ -169,6 +173,56 @@ describe("createSlackMessageHandler", () => {
       enqueueMock.mock.invocationCallOrder[0],
     );
     expect(completeIngressMock).not.toHaveBeenCalled();
+  });
+
+  it("does not queue durable pending duplicates from live Slack events", async () => {
+    acceptIngressMock.mockResolvedValueOnce({ kind: "pending", id: "default:D1:123.456" });
+    const { handler, trackEvent } = createHandlerWithTracker();
+
+    await handleDirectMessage(handler);
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(resolveThreadTsMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("does not queue durable completed duplicates from live Slack events", async () => {
+    acceptIngressMock.mockResolvedValueOnce({ kind: "completed", id: "default:D1:123.456" });
+    const { handler, trackEvent } = createHandlerWithTracker();
+
+    await handleDirectMessage(handler);
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(resolveThreadTsMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("replays pending durable Slack ingress records when the handler starts", async () => {
+    const message = {
+      type: "message",
+      channel: "D1",
+      ts: "123.456",
+      text: "hello after restart",
+    };
+    listPendingIngressMock.mockResolvedValueOnce([
+      {
+        id: "default:D1:123.456",
+        payload: {
+          message,
+          opts: { source: "message" },
+          receivedAt: 1,
+        },
+        receivedAt: 1,
+        updatedAt: 1,
+        attempts: 1,
+      },
+    ]);
+
+    createHandlerWithTracker();
+
+    await vi.waitFor(() => expect(enqueueMock).toHaveBeenCalledTimes(1));
+    expect(acceptIngressMock).not.toHaveBeenCalled();
+    expect(enqueueMock).toHaveBeenCalledWith({ message, opts: { source: "message" } });
   });
 
   it("accepts thread_broadcast messages from the message stream", async () => {

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -11,6 +11,7 @@ import {
   acceptSlackInboundMessageIngress,
   completeSlackInboundMessageIngress,
   hasSlackInboundMessageDelivery,
+  listPendingSlackInboundMessageIngress,
   releaseSlackInboundMessageIngress,
   recordSlackInboundMessageDeliveries,
 } from "./inbound-delivery-state.js";
@@ -247,7 +248,11 @@ export function createSlackMessageHandler(params: {
     return true;
   };
 
-  return async (message, opts) => {
+  const processMessage = async (
+    message: SlackMessageEvent,
+    opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
+    options?: { durableReplay?: boolean },
+  ) => {
     if (opts.source === "message" && message.type !== "message") {
       return;
     }
@@ -261,11 +266,16 @@ export function createSlackMessageHandler(params: {
       return;
     }
     const seenMessageKey = buildSeenMessageKey(message.channel, message.ts);
-    const ingress = await acceptSlackInboundMessageIngress({
-      accountId: ctx.accountId,
-      message,
-      opts,
-    });
+    const ingress = options?.durableReplay
+      ? ({ kind: "accepted" } as const)
+      : await acceptSlackInboundMessageIngress({
+          accountId: ctx.accountId,
+          message,
+          opts,
+        });
+    if (ingress.kind === "completed" || ingress.kind === "pending") {
+      return;
+    }
     if (
       seenMessageKey &&
       (await hasSlackInboundMessageDelivery({
@@ -274,7 +284,7 @@ export function createSlackMessageHandler(params: {
         ts: message.ts,
       }))
     ) {
-      if (ingress.accepted) {
+      if (ingress.kind === "accepted") {
         await completeSlackInboundMessageIngress({
           accountId: ctx.accountId,
           message,
@@ -294,7 +304,7 @@ export function createSlackMessageHandler(params: {
       // Allow exactly one app_mention retry if the same ts was previously dropped
       // from the message stream before it reached dispatch.
       if (opts.source !== "app_mention" || !consumeAppMentionRetryKey(seenMessageKey)) {
-        if (ingress.accepted) {
+        if (ingress.kind === "accepted") {
           await completeSlackInboundMessageIngress({
             accountId: ctx.accountId,
             message,
@@ -326,4 +336,17 @@ export function createSlackMessageHandler(params: {
     }
     await debouncer.enqueue({ message: resolvedMessage, opts });
   };
+
+  const replayPendingIngress = async () => {
+    const pending = await listPendingSlackInboundMessageIngress();
+    for (const record of pending) {
+      await processMessage(record.payload.message, record.payload.opts, { durableReplay: true });
+    }
+  };
+
+  void replayPendingIngress().catch((error) => {
+    ctx.runtime.error?.(`slack inbound pending replay failed: ${formatErrorMessage(error)}`);
+  });
+
+  return async (message, opts) => processMessage(message, opts);
 }

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -8,7 +8,10 @@ import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import {
+  acceptSlackInboundMessageIngress,
+  completeSlackInboundMessageIngress,
   hasSlackInboundMessageDelivery,
+  releaseSlackInboundMessageIngress,
   recordSlackInboundMessageDeliveries,
 } from "./inbound-delivery-state.js";
 import {
@@ -117,6 +120,16 @@ export function createSlackMessageHandler(params: {
           },
         });
         if (!prepared) {
+          await Promise.all(
+            entries.map((entry) =>
+              completeSlackInboundMessageIngress({
+                accountId: ctx.accountId,
+                message: entry.message,
+                outcome: "dropped",
+                reason: "prepare-null",
+              }),
+            ),
+          );
           return;
         }
         if (seenMessageKey) {
@@ -144,16 +157,45 @@ export function createSlackMessageHandler(params: {
         }
         try {
           await dispatchPreparedSlackMessage(prepared);
+          await Promise.all(
+            entries.map((entry) =>
+              completeSlackInboundMessageIngress({
+                accountId: ctx.accountId,
+                message: entry.message,
+                outcome: "delivered",
+              }),
+            ),
+          );
           await recordSlackInboundMessageDeliveries({
             accountId: ctx.accountId,
             messages: entries.map((entry) => entry.message),
           });
         } catch (error) {
           if (!(error instanceof SlackRetryableInboundError)) {
+            await Promise.all(
+              entries.map((entry) =>
+                completeSlackInboundMessageIngress({
+                  accountId: ctx.accountId,
+                  message: entry.message,
+                  outcome: "error",
+                  reason: formatErrorMessage(error),
+                }),
+              ),
+            );
             await recordSlackInboundMessageDeliveries({
               accountId: ctx.accountId,
               messages: entries.map((entry) => entry.message),
             });
+          } else {
+            await Promise.all(
+              entries.map((entry) =>
+                releaseSlackInboundMessageIngress({
+                  accountId: ctx.accountId,
+                  message: entry.message,
+                  reason: formatErrorMessage(error),
+                }),
+              ),
+            );
           }
           throw error;
         }
@@ -219,6 +261,11 @@ export function createSlackMessageHandler(params: {
       return;
     }
     const seenMessageKey = buildSeenMessageKey(message.channel, message.ts);
+    const ingress = await acceptSlackInboundMessageIngress({
+      accountId: ctx.accountId,
+      message,
+      opts,
+    });
     if (
       seenMessageKey &&
       (await hasSlackInboundMessageDelivery({
@@ -227,6 +274,14 @@ export function createSlackMessageHandler(params: {
         ts: message.ts,
       }))
     ) {
+      if (ingress.accepted) {
+        await completeSlackInboundMessageIngress({
+          accountId: ctx.accountId,
+          message,
+          outcome: "duplicate-delivered",
+          reason: "already-delivered",
+        });
+      }
       return;
     }
     const wasSeen = seenMessageKey ? ctx.markMessageSeen(message.channel, message.ts) : false;
@@ -239,6 +294,14 @@ export function createSlackMessageHandler(params: {
       // Allow exactly one app_mention retry if the same ts was previously dropped
       // from the message stream before it reached dispatch.
       if (opts.source !== "app_mention" || !consumeAppMentionRetryKey(seenMessageKey)) {
+        if (ingress.accepted) {
+          await completeSlackInboundMessageIngress({
+            accountId: ctx.accountId,
+            message,
+            outcome: "dropped",
+            reason: "seen-duplicate",
+          });
+        }
         return;
       }
     }


### PR DESCRIPTION
Linear: SZ-1145

## Summary
- add a durable Slack inbound ingress journal before debounce/dispatch so received Slack events are replayable if the turn stalls before delivery is recorded
- mark ingress outcomes as delivered, dropped, duplicate-delivered, error, or retryable release with the drop/error reason
- keep existing Slack `requireMention` and app_mention/message race gates intact

## Why
The incident thread had a Slack session stuck in `processing` with `activeWorkKind=embedded_run` and `queueDepth=1`; recovery later aborted/drained it. A second mention then exposed that Slack ingress needed a durable pre-dispatch breadcrumb so events are not only represented by volatile seen/debounce state while a session is stuck.

## Validation
- `pnpm -s vitest run extensions/slack/src/monitor/message-handler.test.ts extensions/slack/src/monitor/inbound-delivery-state.test.ts` -> 2 files / 9 tests passed
- `pnpm exec oxfmt --check --threads=1 extensions/slack/src/monitor/message-handler.ts extensions/slack/src/monitor/message-handler.test.ts extensions/slack/src/monitor/inbound-delivery-state.ts` -> passed

## Known validation limits
- `pnpm tsgo:extensions:test` exits 1 without diagnostics in this worktree.
- `pnpm exec tsc -p test/tsconfig/tsconfig.extensions.test.json --pretty false --noEmit` OOMed at the default heap and was SIGKILLed with `NODE_OPTIONS=--max-old-space-size=8192`.
- `pnpm -s lint:extensions:channels` is blocked by an unrelated existing plugin-sdk boundary dts error: `src/plugin-sdk/approval-reaction-runtime.ts(300,12): Property 'kind' does not exist on type 'ApprovalActionView'`.