### PR TITLE
test(channels): fix guardrail regex lint

### DIFF
--- a/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
+++ b/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
@@ -54,17 +54,17 @@ function isBareMissingModuleSpecifier(text: string): boolean {
   const specifier = match?.[1];
   return Boolean(
     specifier &&
-      !specifier.startsWith(".") &&
-      !specifier.startsWith("/") &&
-      !path.win32.isAbsolute(specifier),
+    !specifier.startsWith(".") &&
+    !specifier.startsWith("/") &&
+    !path.win32.isAbsolute(specifier),
   );
 }
 
 function hasExternalDistArtifactPath(text: string): boolean {
   const candidates = [
-    ...text.matchAll(/file:\/\/(\/[^\s)]+[\/\\]dist(?:-runtime)?[\/\\][^\s)]*)/gu),
+    ...text.matchAll(/file:\/\/(\/[^\s)]+[/\\]dist(?:-runtime)?[/\\][^\s)]*)/gu),
     ...text.matchAll(/(\b[A-Za-z]:\\[^\s)]+\\dist(?:-runtime)?\\[^\s)]*)/gu),
-    ...text.matchAll(/(\/[^\s)]+[\/\\]dist(?:-runtime)?[\/\\][^\s)]*)/gu),
+    ...text.matchAll(/(\/[^\s)]+[/\\]dist(?:-runtime)?[/\\][^\s)]*)/gu),
   ];
   return candidates.some((match) => {
     const candidate = match[1];


### PR DESCRIPTION
## Summary
- Remove unnecessary escaped `/` characters from bundled channel plugin loader regex character classes.
- Keeps the same Unix/Windows dist artifact path matching while satisfying oxlint's no-useless-escape rule.

## Verification
- `pnpm exec oxlint src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts --deny-warnings`
- `git diff --check origin/main...HEAD`
- `env FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true OPENCLAW_LOCAL_CHECK=0 node scripts/run-oxlint-shards.mjs --threads=8`
