### PR TITLE
fix(plugins): guard manifest suppression metadata

### DIFF
--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -23,6 +23,19 @@ function createMetadataSnapshot(plugins: Record<string, unknown>[]) {
   };
 }
 
+function createPoisonedManifestPlugin(
+  id: string,
+  field: "origin" | "modelCatalog",
+): Record<string, unknown> {
+  const plugin = { id, providers: [id], origin: "bundled" };
+  Object.defineProperty(plugin, field, {
+    get() {
+      throw new Error(`manifest model suppression ${field} metadata exploded`);
+    },
+  });
+  return plugin;
+}
+
 describe("manifest model suppression", () => {
   beforeEach(() => {
     mocks.loadPluginMetadataSnapshot.mockReset();
@@ -104,6 +117,48 @@ describe("manifest model suppression", () => {
         env: process.env,
       }),
     ).toBeUndefined();
+  });
+
+  it("skips unreadable manifest suppression metadata while resolving healthy suppressions", () => {
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      diagnostics: [],
+      plugins: [
+        createPoisonedManifestPlugin("bad-origin", "origin"),
+        createPoisonedManifestPlugin("bad-model-catalog", "modelCatalog"),
+        {
+          id: "openai",
+          origin: "bundled",
+          providers: ["openai"],
+          modelCatalog: {
+            aliases: {
+              "azure-openai-responses": {
+                provider: "openai",
+              },
+            },
+            suppressions: [
+              {
+                provider: "azure-openai-responses",
+                model: "gpt-5.3-codex-spark",
+                reason: "Use openai/gpt-5.5.",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "azure-openai-responses",
+        id: "gpt-5.3-codex-spark",
+        env: process.env,
+      }),
+    ).toEqual({
+      suppress: true,
+      errorMessage:
+        "Unknown model: azure-openai-responses/gpt-5.3-codex-spark. Use openai/gpt-5.5.",
+    });
   });
 
   it("reads planned manifest suppressions fresh per lookup", () => {

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -9,6 +9,37 @@ import {
   isManifestPluginAvailableForControlPlane,
   loadManifestMetadataSnapshot,
 } from "./manifest-contract-eligibility.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+
+type ManifestModelCatalogSuppressionPluginRecord = Pick<
+  PluginManifestRecord,
+  "id" | "providers" | "modelCatalog"
+>;
+
+function readManifestModelCatalogSuppressionPlugin(params: {
+  snapshot: ReturnType<typeof loadManifestMetadataSnapshot>;
+  plugin: PluginManifestRecord;
+  config?: OpenClawConfig;
+}): ManifestModelCatalogSuppressionPluginRecord | undefined {
+  try {
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot: params.snapshot,
+        plugin: params.plugin,
+        config: params.config,
+      })
+    ) {
+      return undefined;
+    }
+    return {
+      id: params.plugin.id,
+      providers: params.plugin.providers,
+      modelCatalog: params.plugin.modelCatalog,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 function listManifestModelCatalogSuppressions(params: {
   config?: OpenClawConfig;
@@ -22,13 +53,15 @@ function listManifestModelCatalogSuppressions(params: {
   });
   const registry = {
     diagnostics: snapshot.diagnostics,
-    plugins: snapshot.plugins.filter((plugin) =>
-      isManifestPluginAvailableForControlPlane({
-        snapshot,
-        plugin,
-        config: params.config,
-      }),
-    ),
+    plugins: snapshot.plugins
+      .map((plugin) =>
+        readManifestModelCatalogSuppressionPlugin({
+          snapshot,
+          plugin,
+          config: params.config,
+        }),
+      )
+      .filter((plugin): plugin is ManifestModelCatalogSuppressionPluginRecord => Boolean(plugin)),
   };
   const planned = planManifestModelCatalogSuppressions({ registry });
   return planned.suppressions;


### PR DESCRIPTION
## Summary
- Guard manifest built-in model suppression planning against unreadable per-plugin metadata.
- Skip only malformed manifest rows while preserving healthy alias-owned suppression entries.
- Add regression coverage for poisoned `origin` and `modelCatalog` metadata.

## Verification
- Red proof: `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts` failed before the fix with `manifest model suppression origin metadata exploded`.
- `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`
- `./node_modules/.bin/oxlint src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, overall `patch is correct (0.82)`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, overall `patch is correct (0.86)`
- Broad gate attempted: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`; blocked before lease by coordinator auth: provider `azure`, slug `coral-shrimp`, `coordinator POST /v1/leases: http 401: {"error":"unauthorized"}`.

## Real behavior proof
Behavior addressed: manifest built-in model suppression lookup no longer crashes when one manifest plugin row has unreadable availability or model-catalog metadata.
Real environment tested: local OpenClaw worktree with symlinked repo dependencies; Crabbox remote changed gate attempted but blocked by coordinator auth.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/manifest-model-suppression.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`; `./node_modules/.bin/oxlint src/plugins/manifest-model-suppression.ts src/plugins/manifest-model-suppression.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.
Evidence after fix: focused Vitest passed 9 manifest-model-suppression tests; oxfmt, oxlint, diff-check, and branch autoreview passed.
Observed result after fix: poisoned manifest rows for `origin` and `modelCatalog` are skipped, and the healthy `azure-openai-responses/gpt-5.3-codex-spark` suppression still resolves.
What was not tested: full `pnpm check:changed`, because Crabbox coordinator auth returned HTTP 401 before lease creation.
