### PR TITLE
fix(discord): fall back to text when voice delivery fails

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -402,6 +402,52 @@ describe("discordOutbound", () => {
     ).toEqual(["reply-1", "reply-1"]);
   });
 
+  it.each([
+    {
+      name: "visible text",
+      payload: {
+        text: "voice note",
+        mediaUrls: ["https://example.com/voice.ogg"],
+        audioAsVoice: true,
+      },
+      expectedText: "voice note",
+    },
+    {
+      name: "TTS supplement text",
+      payload: {
+        mediaUrls: ["https://example.com/voice.ogg"],
+        audioAsVoice: true,
+        ttsSupplement: {
+          spokenText: "spoken answer",
+        },
+      },
+      expectedText: "spoken answer",
+    },
+  ])("falls back to $name when audioAsVoice delivery fails", async ({ payload, expectedText }) => {
+    hoisted.sendVoiceMessageDiscordMock.mockRejectedValueOnce(new Error("ffmpeg unavailable"));
+
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload,
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledOnce();
+    const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
+    expect(messageCall[0]).toBe("channel:123456");
+    expect(messageCall[1]).toBe(expectedText);
+    expect(result).toEqual({
+      channel: "discord",
+      messageId: "msg-1",
+      channelId: "ch-1",
+    });
+  });
+
   it("keeps replyToId on every internal audioAsVoice send when replyToMode is all", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -484,6 +484,28 @@ describe("discordOutbound", () => {
     });
   });
 
+  it("does not treat delivery progress failures as voice delivery failures", async () => {
+    await expect(
+      discordOutbound.sendPayload?.({
+        cfg: {},
+        to: "channel:123456",
+        text: "",
+        payload: {
+          text: "voice note",
+          mediaUrls: ["https://example.com/voice.ogg"],
+          audioAsVoice: true,
+        },
+        accountId: "default",
+        onDeliveryResult: async () => {
+          throw new Error("progress unavailable");
+        },
+      }),
+    ).rejects.toThrow("progress unavailable");
+
+    expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
+    expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+  });
+
   it("keeps replyToId on every internal audioAsVoice send when replyToMode is all", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -451,6 +451,39 @@ describe("discordOutbound", () => {
     });
   });
 
+  it("does not duplicate already-delivered TTS supplement text when audioAsVoice delivery fails", async () => {
+    hoisted.sendVoiceMessageDiscordMock.mockRejectedValueOnce(new Error("ffmpeg unavailable"));
+
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload: {
+        mediaUrls: ["https://example.com/voice.ogg"],
+        audioAsVoice: true,
+        ttsSupplement: {
+          spokenText: "spoken answer",
+          visibleTextAlreadyDelivered: true,
+        },
+      },
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
+    expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      channel: "discord",
+      messageId: "",
+      channelId: "channel:123456",
+      receipt: {
+        platformMessageIds: [],
+        parts: [],
+      },
+    });
+  });
+
   it("keeps replyToId on every internal audioAsVoice send when replyToMode is all", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -441,6 +441,9 @@ describe("discordOutbound", () => {
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
     expect(messageCall[0]).toBe("channel:123456");
     expect(messageCall[1]).toBe(expectedText);
+    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).replyTo).toBe(
+      "reply-1",
+    );
     expect(result).toEqual({
       channel: "discord",
       messageId: "msg-1",

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -47,10 +47,9 @@ function createDiscordUnknownPayloadResult(target: string) {
 function resolveDiscordDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
-  options?: { replyTo?: string },
 ) {
   return {
-    replyTo: options?.replyTo ?? sendContext.resolveReplyTo(),
+    replyTo: sendContext.resolveReplyTo(),
     accountId: ctx.accountId ?? undefined,
     silent: ctx.silent ?? undefined,
     cfg: ctx.cfg,
@@ -60,10 +59,9 @@ function resolveDiscordDeliveryOptions(
 function resolveDiscordFormattedDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
-  options?: { replyTo?: string },
 ) {
   return {
-    ...resolveDiscordDeliveryOptions(ctx, sendContext, options),
+    ...resolveDiscordDeliveryOptions(ctx, sendContext),
     ...sendContext.formatting,
   };
 }
@@ -99,7 +97,7 @@ export async function sendDiscordOutboundPayload(params: {
     // Capture before helper calls consume implicit single-use reply targets.
     const voiceReplyTo = sendContext.resolveReplyTo();
     let deliveredVoice = false;
-    let lastResult;
+    let lastResult: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>;
     try {
       lastResult = await sendContext.withRetry(
         async () =>
@@ -109,7 +107,6 @@ export async function sendDiscordOutboundPayload(params: {
           }),
       );
       deliveredVoice = true;
-      await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
     } catch (err) {
       const supplement = getReplyPayloadTtsSupplement(payload);
       const visibleFallbackText = payload.text?.trim() ? payload.text : undefined;
@@ -134,6 +131,9 @@ export async function sendDiscordOutboundPayload(params: {
             }),
         );
       }
+    }
+    if (deliveredVoice) {
+      await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
     }
     if (deliveredVoice && payload.text?.trim()) {
       lastResult = await sendContext.withRetry(

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -4,6 +4,7 @@ import {
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import {
+  getReplyPayloadTtsSupplement,
   resolvePayloadMediaUrls,
   sendPayloadMediaSequenceOrFallback,
   sendTextMediaPayload,
@@ -95,15 +96,44 @@ export async function sendDiscordOutboundPayload(params: {
     // audioAsVoice emits one logical Discord reply across voice/text/media sends.
     // Capture before helper calls consume implicit single-use reply targets.
     const voiceReplyTo = sendContext.resolveReplyTo();
-    let lastResult = await sendContext.withRetry(
-      async () =>
-        await sendContext.sendVoice(sendContext.target, mediaUrls[0], {
-          ...resolveDiscordDeliveryOptions(ctx, sendContext),
-          replyTo: voiceReplyTo,
-        }),
-    );
-    await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
-    if (payload.text?.trim()) {
+    let deliveredVoice = false;
+    let lastResult;
+    try {
+      lastResult = await sendContext.withRetry(
+        async () =>
+          await sendContext.sendVoice(sendContext.target, mediaUrls[0], {
+            ...resolveDiscordDeliveryOptions(ctx, sendContext),
+            replyTo: voiceReplyTo,
+          }),
+      );
+      deliveredVoice = true;
+      await ctx.onDeliveryResult?.(attachChannelToResult("discord", lastResult));
+    } catch (err) {
+      const supplement = getReplyPayloadTtsSupplement(payload);
+      const visibleFallbackText = payload.text?.trim() ? payload.text : undefined;
+      const hiddenFallbackText = supplement?.visibleTextAlreadyDelivered
+        ? undefined
+        : supplement?.spokenText;
+      const fallbackText = visibleFallbackText ?? hiddenFallbackText;
+      if (!fallbackText) {
+        if (supplement?.visibleTextAlreadyDelivered) {
+          lastResult = createDiscordUnknownPayloadResult(sendContext.target);
+        } else {
+          throw err;
+        }
+      } else {
+        lastResult = await sendContext.withRetry(
+          async () =>
+            await sendContext.send(sendContext.target, fallbackText, {
+              verbose: false,
+              ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+              replyTo: voiceReplyTo,
+              onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+            }),
+        );
+      }
+    }
+    if (deliveredVoice && payload.text?.trim()) {
       lastResult = await sendContext.withRetry(
         async () =>
           await sendContext.send(sendContext.target, payload.text, {

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -47,9 +47,10 @@ function createDiscordUnknownPayloadResult(target: string) {
 function resolveDiscordDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
+  options?: { replyTo?: string },
 ) {
   return {
-    replyTo: sendContext.resolveReplyTo(),
+    replyTo: options?.replyTo ?? sendContext.resolveReplyTo(),
     accountId: ctx.accountId ?? undefined,
     silent: ctx.silent ?? undefined,
     cfg: ctx.cfg,
@@ -59,9 +60,10 @@ function resolveDiscordDeliveryOptions(
 function resolveDiscordFormattedDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
+  options?: { replyTo?: string },
 ) {
   return {
-    ...resolveDiscordDeliveryOptions(ctx, sendContext),
+    ...resolveDiscordDeliveryOptions(ctx, sendContext, options),
     ...sendContext.formatting,
   };
 }


### PR DESCRIPTION
## Summary

This fixes a Discord final-reply failure mode I hit locally: when an `audioAsVoice` reply failed during voice-note delivery, the reply could disappear completely instead of falling back to visible text.

- Try Discord voice-note delivery first, as before.
- If voice delivery fails and there is visible text, send that text instead.
- If the visible text was stripped into a hidden TTS supplement, use that supplement text as the fallback.
- Keep the change scoped to the Discord payload path; direct media sending and unrelated voice behavior are intentionally out of scope.

Success here is pretty simple: if Discord voice delivery fails, the user still gets the answer as text.

Reviewers should focus on the `audioAsVoice` payload ordering and fallback behavior, especially reply targets, TTS supplement handling, and avoiding duplicate text after an already-delivered supplement.

## Linked context

Closes: N/A

Related: #84952, #85173

This came from a real local OpenClaw Discord setup where a final reply tried to go out as a voice note and failed before any visible reply was sent.

Issue #84952 / PR #85173 are in the same Discord `audioAsVoice` fallback area, but they cover a different failure mode: voice adapter unavailable in cron/text-only delivery, with fallback to text+media attachment. This PR covers the final payload path where voice delivery is attempted and then rejects; the intended fallback here is visible text, including hidden TTS supplement text when that is the only available transcript.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord `audioAsVoice` final replies could fail the voice path and send no text fallback.
- Real environment tested: local OpenClaw checkout on this branch, using a real Discord bot/account and a private Discord test channel.
- Exact steps or command run after this patch: ran the patched `sendDiscordOutboundPayload` path directly with `audioAsVoice: true`, visible fallback text, and deliberately invalid audio input so the voice conversion path failed.
- Evidence after fix:

```json
{
  "voiceAttempted": true,
  "voiceFailure": "Command failed: /usr/bin/ffmpeg -y -i /tmp/openclaw/voice-src-mMImTx/input.html ...",
  "result": {
    "messageId": "1511791135129997482",
    "channelId": "1510545702881595392",
    "channel": "discord"
  },
  "fetchedStatus": 200,
  "fetchedMessage": {
    "content": "OpenClaw PR proof 2026-06-03T17:58:13.575Z: voice delivery failed on purpose, text fallback worked.",
    "attachmentCount": 0,
    "type": 0
  }
}
```

- Observed result after fix: voice delivery was attempted, ffmpeg failed during conversion, and the fallback text was still posted to Discord. Fetching the message back from Discord showed matching text and `attachmentCount: 0`, so it was a text fallback rather than a voice attachment.
- What was not tested: I did not run a full end-to-end gateway deployment with `/usr/bin/ffmpeg` removed from the host.
- Proof limitations or environment constraints: the original local failure involved ffmpeg not being available to the runtime. I could not safely rename `/usr/bin/ffmpeg` in this environment because non-interactive sudo is not available, so the live proof forces a realistic voice-delivery failure by giving ffmpeg invalid audio input instead. That still exercises the patched failure boundary: `sendVoice` rejects, then the payload path sends text.
- Before evidence: before this change, the `audioAsVoice` branch awaited voice delivery directly. If that threw, the payload send failed before visible text or hidden TTS supplement text could be sent.

## Tests and validation

Commands run:

- `CI=true pnpm test extensions/discord/src/outbound-adapter.test.ts`
- `pnpm exec tsc -p tsconfig.extensions.json --noEmit`
- `pnpm test:extension discord`
- `codex review --base origin/main`

Regression coverage added/updated:

- falls back to visible text when Discord voice delivery rejects
- falls back to hidden TTS supplement text when visible text was stripped for voice delivery
- preserves the reply target when falling back from voice to text
- suppresses duplicate TTS supplement text when it was already visibly delivered

What failed before this fix: a rejected Discord voice send in the final payload path could prevent any text reply from being delivered.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: the ordering around Discord `audioAsVoice` payloads, because voice notes cannot include text, while fallback text still needs to preserve reply threading and avoid duplicates.

How that risk is mitigated: the change is limited to the Discord payload send path, keeps successful voice delivery behavior first, and adds focused regression coverage for the fallback cases and duplicate-suppression case.

## Current review state

Next action: maintainer review.

Still waiting on: upstream CI and any maintainer preference on wording or fallback policy.

Bot/reviewer comments addressed: `codex review --base origin/main` came back clean with no findings after the latest branch state.