### PR TITLE
fix(plugins): isolate bundled channel metadata rows

### DIFF
--- a/src/plugins/bundled-channel-runtime.test.ts
+++ b/src/plugins/bundled-channel-runtime.test.ts
@@ -1,7 +1,17 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+
+const mocks = vi.hoisted(() => ({
+  loadPluginManifestRegistryForPluginRegistry: vi.fn(),
+}));
+
+vi.mock("./plugin-registry.js", () => ({
+  loadPluginManifestRegistryForPluginRegistry: mocks.loadPluginManifestRegistryForPluginRegistry,
+}));
+
 import {
   listBundledChannelPluginMetadata,
   resolveBundledChannelGeneratedPath,
@@ -16,6 +26,44 @@ function createTempRoot(): string {
   return tempRoot;
 }
 
+function createRegistry(plugins: PluginManifestRegistry["plugins"]): PluginManifestRegistry {
+  return { plugins, diagnostics: [] };
+}
+
+function createPluginRecord(
+  overrides: Pick<PluginManifestRecord, "id" | "origin"> & Partial<PluginManifestRecord>,
+): PluginManifestRecord {
+  return {
+    rootDir: `/tmp/${overrides.id}`,
+    manifestPath: `/tmp/${overrides.id}/openclaw.plugin.json`,
+    name: undefined,
+    description: undefined,
+    version: undefined,
+    enabledByDefault: undefined,
+    autoEnableWhenConfiguredProviders: undefined,
+    legacyPluginIds: undefined,
+    format: undefined,
+    bundleFormat: undefined,
+    bundleCapabilities: undefined,
+    kind: undefined,
+    channels: [],
+    providers: [],
+    modelSupport: undefined,
+    cliBackends: [],
+    channelEnvVars: undefined,
+    providerAuthAliases: undefined,
+    providerAuthChoices: undefined,
+    skills: [],
+    settingsFiles: undefined,
+    hooks: [],
+    source: `/tmp/${overrides.id}/channel.js`,
+    setupSource: undefined,
+    startupDeferConfiguredChannelFullLoadUntilAfterListen: undefined,
+    channelCatalogMeta: undefined,
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   for (const tempRoot of tempRoots.splice(0)) {
     fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -23,6 +71,11 @@ afterEach(() => {
 });
 
 describe("bundled channel runtime metadata", () => {
+  beforeEach(() => {
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue(createRegistry([]));
+  });
+
   it("preserves explicit empty bundled roots", () => {
     const tempRoot = createTempRoot();
 
@@ -81,5 +134,51 @@ describe("bundled channel runtime metadata", () => {
         builtScanRoot,
       ),
     ).toBe(path.join(pluginRoot, "dist", "index.js"));
+  });
+
+  it("skips unreadable bundled channel rows without dropping healthy rows", () => {
+    const unreadable = createPluginRecord({
+      id: "broken-channel",
+      origin: "bundled",
+      channels: ["broken-channel"],
+    });
+    Object.defineProperty(unreadable, "rootDir", {
+      get() {
+        throw new Error("bundled channel root metadata exploded");
+      },
+    });
+
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue(
+      createRegistry([
+        unreadable,
+        createPluginRecord({
+          id: "slack",
+          origin: "bundled",
+          channels: ["slack"],
+          rootDir: "/tmp/extensions/slack",
+          source: "/tmp/extensions/slack/channel.js",
+          setupSource: "/tmp/extensions/slack/setup.js",
+        }),
+      ]),
+    );
+
+    expect(listBundledChannelPluginMetadata()).toStrictEqual([
+      {
+        dirName: "slack",
+        source: {
+          source: "/tmp/extensions/slack/channel.js",
+          built: "/tmp/extensions/slack/channel.js",
+        },
+        setupSource: {
+          source: "/tmp/extensions/slack/setup.js",
+          built: "/tmp/extensions/slack/setup.js",
+        },
+        manifest: {
+          id: "slack",
+          channels: ["slack"],
+        },
+        rootDir: "/tmp/extensions/slack",
+      },
+    ]);
   });
 });

--- a/src/plugins/bundled-channel-runtime.ts
+++ b/src/plugins/bundled-channel-runtime.ts
@@ -92,6 +92,16 @@ function toBundledChannelPluginMetadata(
   };
 }
 
+function tryBundledChannelPluginMetadata(
+  record: PluginManifestRecord,
+): BundledChannelPluginMetadata | null {
+  try {
+    return toBundledChannelPluginMetadata(record);
+  } catch {
+    return null;
+  }
+}
+
 export function listBundledChannelPluginMetadata(params?: {
   rootDir?: string;
   scanDir?: string;
@@ -105,7 +115,7 @@ export function listBundledChannelPluginMetadata(params?: {
   return loadPluginManifestRegistryForPluginRegistry({
     env: scope.kind === "env" ? scope.env : undefined,
     includeDisabled: true,
-  }).plugins.flatMap((record) => toBundledChannelPluginMetadata(record) ?? []);
+  }).plugins.flatMap((record) => tryBundledChannelPluginMetadata(record) ?? []);
 }
 
 export function resolveBundledChannelGeneratedPath(


### PR DESCRIPTION
## Summary

- isolate malformed bundled channel manifest rows while building bundled channel runtime metadata
- keep later healthy bundled channel metadata discoverable when another row throws during metadata conversion
- add a regression test for an unreadable bundled channel record followed by a healthy row

## Verification

- red: `node scripts/run-vitest.mjs src/plugins/bundled-channel-runtime.test.ts` failed before the fix with `bundled channel root metadata exploded`
- green: `node scripts/run-vitest.mjs src/plugins/bundled-channel-runtime.test.ts`
- green: `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/bundled-channel-runtime.ts src/plugins/bundled-channel-runtime.test.ts`
- green: `./node_modules/.bin/oxlint src/plugins/bundled-channel-runtime.ts src/plugins/bundled-channel-runtime.test.ts`
- green: `git diff --check origin/main...HEAD`
- green: `.agents/skills/autoreview/scripts/autoreview --mode local`
- green: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- blocked: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before lease with Crabbox coordinator `401 unauthorized` for provider `azure`, slug `jade-hermit`

## Real behavior proof

Behavior addressed: A malformed bundled channel manifest row could throw while `listBundledChannelPluginMetadata()` converted registry records, aborting bundled channel metadata discovery before later healthy bundled rows were considered.

Real environment tested: Local linked OpenClaw worktree on Node/Vitest through `node scripts/run-vitest.mjs`; Crabbox remote changed-gate attempt reached the coordinator but failed authorization before leasing.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/bundled-channel-runtime.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/bundled-channel-runtime.ts src/plugins/bundled-channel-runtime.test.ts`; `./node_modules/.bin/oxlint src/plugins/bundled-channel-runtime.ts src/plugins/bundled-channel-runtime.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.

Evidence after fix: The focused regression test passes with 5/5 tests, file-level format/lint/whitespace checks pass, local and branch autoreview both report no accepted/actionable findings.

Observed result after fix: The unreadable bundled channel row is skipped and the healthy `slack` bundled channel row remains in the returned metadata list.

What was not tested: Full `pnpm check:changed` did not run because the Crabbox coordinator rejected the remote lease with `401 unauthorized`, and local broad pnpm checks are intentionally avoided in this linked worktree.
