### PR TITLE
docs: add firecrawl.dev links on the Firecrawl tool page

### DIFF
--- a/docs/tools/firecrawl.md
+++ b/docs/tools/firecrawl.md
@@ -8,7 +8,7 @@ read_when:
 title: "Firecrawl"
 ---
 
-OpenClaw can use **Firecrawl** in three ways:
+OpenClaw can use **[Firecrawl](https://www.firecrawl.dev)** in three ways:
 
 - as the `web_search` provider
 - as explicit plugin tools: `firecrawl_search` and `firecrawl_scrape`
@@ -19,7 +19,7 @@ which helps with JS-heavy sites or pages that block plain HTTP fetches.
 
 ## Get an API key
 
-1. Create a Firecrawl account and generate an API key.
+1. Create a [Firecrawl account](https://www.firecrawl.dev/app/api-keys) and generate an API key.
 2. Store it in config or set `FIRECRAWL_API_KEY` in the gateway environment.
 
 ## Configure Firecrawl search


### PR DESCRIPTION
The Firecrawl tool page mentioned Firecrawl only as plain text (the only URLs were `api.firecrawl.dev` API endpoints inside code blocks). This adds two links to `docs/tools/firecrawl.md`:
- the first **Firecrawl** brand mention in the intro → https://www.firecrawl.dev
- the "Get an API key" step → https://www.firecrawl.dev/app/api-keys

The `api.firecrawl.dev` references are API endpoints and were left unchanged. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)