### PR TITLE
fix(macos): LaunchAgent starts gateway on external home volumes

### DIFF
--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -11,6 +11,7 @@ export const LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS = 20;
 export const LAUNCH_AGENT_UMASK_DECIMAL = 0o077;
 export const LAUNCH_AGENT_PROCESS_TYPE = "Interactive";
 export const LAUNCH_AGENT_STDIN_PATH = "/dev/null";
+export const LAUNCH_AGENT_ENV_WRAPPER_SHELL = "/bin/sh";
 
 const plistEscape = (value: string): string =>
   value
@@ -68,12 +69,11 @@ function resolveSiblingGeneratedEnvFilePath(
   return `${envFilePath.slice(0, serviceEnvDirEnd)}/${label}.env`;
 }
 
-function isGeneratedEnvWrapperArgs(
-  programArguments: string[],
+function isExpectedGeneratedEnvWrapperPair(
+  wrapperPath: string | undefined,
+  envFilePath: string | undefined,
   options?: ReadLaunchAgentProgramArgumentsOptions,
 ): boolean {
-  const wrapperPath = programArguments[0];
-  const envFilePath = programArguments[1];
   if (!wrapperPath || !envFilePath) {
     return false;
   }
@@ -102,14 +102,34 @@ function isGeneratedEnvWrapperArgs(
   );
 }
 
+function resolveGeneratedEnvWrapperLayout(
+  programArguments: string[],
+  options?: ReadLaunchAgentProgramArgumentsOptions,
+): { envFilePath: string; commandStartIndex: number } | null {
+  if (programArguments[0] === LAUNCH_AGENT_ENV_WRAPPER_SHELL) {
+    const wrapperPath = programArguments[1];
+    const envFilePath = programArguments[2];
+    if (isExpectedGeneratedEnvWrapperPair(wrapperPath, envFilePath, options) && envFilePath) {
+      return { envFilePath, commandStartIndex: 3 };
+    }
+  }
+  const wrapperPath = programArguments[0];
+  const envFilePath = programArguments[1];
+  if (isExpectedGeneratedEnvWrapperPair(wrapperPath, envFilePath, options) && envFilePath) {
+    return { envFilePath, commandStartIndex: 2 };
+  }
+  return null;
+}
+
 async function readLaunchAgentEnvironmentFile(
   programArguments: string[],
   options?: ReadLaunchAgentProgramArgumentsOptions,
 ): Promise<Record<string, string>> {
-  const envFilePath = programArguments[1];
-  if (!isGeneratedEnvWrapperArgs(programArguments, options) || !envFilePath) {
+  const layout = resolveGeneratedEnvWrapperLayout(programArguments, options);
+  if (!layout) {
     return {};
   }
+  const envFilePath = layout.envFilePath;
   let content = "";
   const candidateEnvFilePaths = Array.from(
     new Set(
@@ -157,10 +177,11 @@ function unwrapGeneratedEnvWrapperArgs(
   programArguments: string[],
   options?: ReadLaunchAgentProgramArgumentsOptions,
 ): string[] {
-  if (!isGeneratedEnvWrapperArgs(programArguments, options)) {
+  const layout = resolveGeneratedEnvWrapperLayout(programArguments, options);
+  if (!layout) {
     return programArguments;
   }
-  return programArguments.slice(2);
+  return programArguments.slice(layout.commandStartIndex);
 }
 
 const renderEnvDict = (env: Record<string, string | undefined> | undefined): string => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
 import {
+  LAUNCH_AGENT_ENV_WRAPPER_SHELL,
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
   LAUNCH_AGENT_PROCESS_TYPE,
   LAUNCH_AGENT_STDIN_PATH,
@@ -79,6 +80,13 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean):
     }
   }
   return count;
+}
+
+function readPlistProgramArgumentStrings(plist: string): string[] {
+  const match = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/i);
+  return Array.from((match?.[1] ?? "").matchAll(/<string>([\s\S]*?)<\/string>/gi)).map(
+    (item) => item[1] ?? "",
+  );
 }
 
 function createDefaultLaunchdEnv(): Record<string, string | undefined> {
@@ -838,8 +846,12 @@ describe("launchd install", () => {
     const plist = state.files.get(plistPath) ?? "";
     expect(plist).not.toContain("<key>EnvironmentVariables</key>");
     expect(plist).not.toContain(apiKey);
-    expect(plist).toContain(`<string>${wrapperPath}</string>`);
-    expect(plist).toContain(`<string>${envFilePath}</string>`);
+    expect(readPlistProgramArgumentStrings(plist)).toEqual([
+      LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+      wrapperPath,
+      envFilePath,
+      ...defaultProgramArguments,
+    ]);
     const envFile = state.files.get(envFilePath) ?? "";
     expect(envFile).toContain(`export TMPDIR='${tmpDir}'`);
     expect(envFile).toContain(`export OPENAI_API_KEY='${apiKey}'`);
@@ -930,6 +942,49 @@ describe("launchd install", () => {
     expect(state.files.get(wrapperPath)).toBe(generatedWrapper);
   });
 
+  it("rewrites legacy LaunchAgent environment wrappers to a system shell executable", async () => {
+    const env = createDefaultLaunchdEnv();
+    const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
+    const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: { OPENCLAW_GATEWAY_PORT: "19007" },
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const legacyPlist = (state.files.get(plistPath) ?? "").replace(
+      [
+        `<string>${LAUNCH_AGENT_ENV_WRAPPER_SHELL}</string>`,
+        `<string>${wrapperPath}</string>`,
+        `<string>${envFilePath}</string>`,
+      ].join("\n      "),
+      [`<string>${wrapperPath}</string>`, `<string>${envFilePath}</string>`].join("\n      "),
+    );
+    expect(readPlistProgramArgumentStrings(legacyPlist)).toEqual([
+      wrapperPath,
+      envFilePath,
+      ...defaultProgramArguments,
+    ]);
+    state.files.set(plistPath, legacyPlist);
+    state.launchctlCalls.length = 0;
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const rewritten = state.files.get(plistPath) ?? "";
+    expect(readPlistProgramArgumentStrings(rewritten)).toEqual([
+      LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+      wrapperPath,
+      envFilePath,
+      ...defaultProgramArguments,
+    ]);
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19007);
+  });
+
   it("repairs a mangled label-derived service-env wrapper path on restart", async () => {
     const callerEnv = createDefaultLaunchdEnv();
     const serviceEnv = {
@@ -976,8 +1031,12 @@ describe("launchd install", () => {
     });
 
     const rewritten = state.files.get(plistPath) ?? "";
-    expect(rewritten).toContain(`<string>${callerWrapperPath}</string>`);
-    expect(rewritten).toContain(`<string>${callerEnvFilePath}</string>`);
+    expect(readPlistProgramArgumentStrings(rewritten)).toEqual([
+      LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+      callerWrapperPath,
+      callerEnvFilePath,
+      ...defaultProgramArguments,
+    ]);
     expect(rewritten).not.toContain(mangledEnvFilePath);
     expect(rewritten).not.toContain(mangledWrapperPath);
     const rewrittenEnv = state.files.get(callerEnvFilePath) ?? "";

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -22,6 +22,7 @@ import {
 import { execFileUtf8 } from "./exec-file.js";
 import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 import {
+  LAUNCH_AGENT_ENV_WRAPPER_SHELL,
   buildLaunchAgentPlist as buildLaunchAgentPlistImpl,
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
   readLaunchAgentProgramArgumentsFromFile,
@@ -219,8 +220,11 @@ function isLaunchAgentEnvironmentWrapperArgs(params: {
   wrapperPath: string;
 }): boolean {
   return (
-    params.programArguments[0] === params.wrapperPath &&
-    params.programArguments[1] === params.envFilePath
+    (params.programArguments[0] === params.wrapperPath &&
+      params.programArguments[1] === params.envFilePath) ||
+    (params.programArguments[0] === LAUNCH_AGENT_ENV_WRAPPER_SHELL &&
+      params.programArguments[1] === params.wrapperPath &&
+      params.programArguments[2] === params.envFilePath)
   );
 }
 
@@ -274,7 +278,12 @@ async function prepareLaunchAgentProgramArguments(params: {
   }
 
   return {
-    programArguments: [wrapperPath, envFilePath, ...params.programArguments],
+    programArguments: [
+      LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+      wrapperPath,
+      envFilePath,
+      ...params.programArguments,
+    ],
   };
 }
 


### PR DESCRIPTION
Fixes #87199

## Summary

- Problem: macOS LaunchAgent plists with service environment entries made the generated env-wrapper script the executable that launchd spawned; on permission-constrained home/state volumes that can fail at `posix_spawn` before the gateway starts.
- Solution: Generate shell-first LaunchAgent `ProgramArguments` (`/bin/sh`, wrapper path, env file path, then the gateway command) and keep legacy wrapper-first plists readable/rewriteable.
- What changed: `src/daemon/launchd.ts`, `src/daemon/launchd-plist.ts`, and `src/daemon/launchd.test.ts` now share the shell-first env-wrapper contract.
- What did NOT change: Service environment values still live in the owner-only generated env file, not in the plist; gateway CLI command construction remains the existing supported `gateway --port <port>` run path.

## Real behavior proof

- **Behavior or issue addressed:** A generated macOS LaunchAgent must no longer directly spawn the generated env-wrapper from the user's home/state volume. The LaunchAgent should bootstrap and kickstart under macOS launchd, load the env file, start the gateway, and answer gateway health/status without `Permission denied`, `EX_CONFIG`, or `posix_spawn` failure.
- **Real environment tested:** macOS Darwin 25.5.0 arm64, Node v24.15.0, OpenClaw 2026.6.2 from PR worktree SHA `e977dc1fc177`. The proof used a temporary HOME/OPENCLAW_HOME/OPENCLAW_STATE_DIR and unique label `ai.openclaw.launchd-proof-fa9d9c1f`, then changed the generated wrapper mode from `0700` to `0600` before `launchctl bootstrap` to exercise the direct-wrapper-spawn permission surface.
- **Exact steps or command run after this patch:**
  ```bash
  PROOF_REPO=/Users/zhangguiping/daily_pr_work/openclaw-87199-proof \
  PROOF_PORT=19532 \
  PROOF_PRINT_CLEANUP=1 \
    node --import tsx /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-87199-evidence/macos-launchd-live-proof.mjs \
      > /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-87199-evidence/macos-launchd-live-proof-2.out \
      2> /Users/zhangguiping/daily_pr_work/proofs/openclaw-issue-87199-evidence/macos-launchd-live-proof-2.err

  launchctl bootout gui/501/ai.openclaw.launchd-proof-fa9d9c1f
  launchctl bootstrap gui/501 /var/folders/76/w5rbbmt53d9f9wzqs3kzq3580000gn/T/openclaw-launchd-proof-fa9d9c1f-As3pt8/Library/LaunchAgents/ai.openclaw.launchd-proof-fa9d9c1f.plist
  launchctl enable gui/501/ai.openclaw.launchd-proof-fa9d9c1f
  launchctl kickstart -k gui/501/ai.openclaw.launchd-proof-fa9d9c1f
  launchctl print gui/501/ai.openclaw.launchd-proof-fa9d9c1f
  node --import tsx src/entry.ts gateway call health --json --url ws://127.0.0.1:19532 --token <redacted> --timeout 5000
  node --import tsx src/entry.ts gateway status --json --url ws://127.0.0.1:19532 --token <redacted>
  launchctl bootout gui/501/ai.openclaw.launchd-proof-fa9d9c1f

  node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/daemon/program-args.test.ts src/commands/daemon-install-helpers.test.ts
  pnpm format:check src/daemon/launchd.ts src/daemon/launchd-plist.ts src/daemon/launchd.test.ts
  node scripts/run-oxlint.mjs src/daemon/launchd.ts src/daemon/launchd-plist.ts src/daemon/launchd.test.ts
  git diff --check
  ```
- **Evidence after fix:** Live macOS launchd proof output from `macos-launchd-live-proof-2.out`:
  ```json
  {
    "platform": "Darwin 25.5.0",
    "arch": "arm64",
    "node": "v24.15.0",
    "head": "e977dc1fc177",
    "label": "ai.openclaw.launchd-proof-fa9d9c1f",
    "serviceTarget": "gui/501/ai.openclaw.launchd-proof-fa9d9c1f",
    "port": 19532,
    "programArguments": [
      "/bin/sh",
      "/var/folders/.../.openclaw-state/service-env/ai.openclaw.launchd-proof-fa9d9c1f-env-wrapper.sh",
      "/var/folders/.../.openclaw-state/service-env/ai.openclaw.launchd-proof-fa9d9c1f.env",
      "/Users/zhangguiping/.nvm/versions/node/v24.15.0/bin/node",
      "--import",
      "tsx",
      "/Users/zhangguiping/daily_pr_work/openclaw-87199-proof/src/entry.ts",
      "gateway",
      "--port",
      "19532",
      "--allow-unconfigured"
    ],
    "plistExecutable": "/bin/sh",
    "secretInPlist": false,
    "envFileExists": true,
    "envFileContainsToken": true,
    "wrapperModeBefore": "0700",
    "wrapperModeAfter": "0600",
    "bootstrap": { "code": 0 },
    "enable": { "code": 0 },
    "kickstart": { "code": 0 },
    "runtime": { "status": "running", "state": "active", "pid": 85513, "cachedLabel": false },
    "gatewayHealth": { "code": 0, "stdout": { "ok": true } },
    "gatewayStatus": { "code": 0, "rpc": { "ok": true } },
    "gatewayStatusRpcOk": true,
    "noPermissionDenied": true
  }
  ```

  `launchctl print gui/501/ai.openclaw.launchd-proof-fa9d9c1f` showed the real service running from `/bin/sh`:
  ```text
  state = running
  program = /bin/sh
  arguments = {
    /bin/sh
    /var/folders/.../.openclaw-state/service-env/ai.openclaw.launchd-proof-fa9d9c1f-env-wrapper.sh
    /var/folders/.../.openclaw-state/service-env/ai.openclaw.launchd-proof-fa9d9c1f.env
    /Users/zhangguiping/.nvm/versions/node/v24.15.0/bin/node
    --import
    tsx
    /Users/zhangguiping/daily_pr_work/openclaw-87199-proof/src/entry.ts
    gateway
    --port
    19532
    --allow-unconfigured
  }
  working directory = /Users/zhangguiping/daily_pr_work/openclaw-87199-proof
  pid = 85513
  ```

  Gateway RPC proof from the launchd-started process:
  ```text
  gateway call health: code=0, ok=true, durationMs=43
  gateway status: code=0, service.runtime.status=running, service.runtime.state=active, rpc.ok=true, port.listeners[0].pid=85513, ppid=1
  launchd stdout tail: [gateway] ready; [heartbeat] started; [ws] ⇄ res ✓ health 50ms cached=true
  cleanup: launchctl bootout gui/501/ai.openclaw.launchd-proof-fa9d9c1f code=0
  ```
- **Observed result after fix:** macOS launchd successfully bootstrapped and kickstarted the generated LaunchAgent even after the generated wrapper was made non-executable (`0600`). The service ran as `/bin/sh`, loaded environment values from the generated env file, started the gateway on port 19532, and `gateway call health` plus `gateway status` both succeeded against the launchd-owned process. The live proof also confirms secrets stayed out of the plist (`secretInPlist=false`) while the env file contained the token (`envFileContainsToken=true`). The gateway command remains the existing supported `gateway --port <port>` form; this PR does not change it to a literal `gateway run` subcommand, and the launchd health/status proof shows that command starts the gateway correctly.
- **What was not tested:** I did not mount a separate external home volume. Instead, the proof used a temporary macOS HOME/state directory and changed the generated wrapper to `0600` before launchd bootstrap to cover the same direct-spawn permission failure surface that this patch removes. No other known gaps.
- **Fix classification:** Root cause fix.

## Review findings addressed

- The LaunchAgent proof now runs on macOS with real `launchctl bootstrap`, `launchctl kickstart`, `launchctl print`, `gateway call health`, and `gateway status` against the generated service.
- The proof verifies the raw plist shape launchd consumes, confirms `/bin/sh` is the program launchd starts, confirms owner-only env-file loading, and confirms there is no `Permission denied`, `EX_CONFIG`, or `posix_spawn` failure in the launchd-started gateway path.

## Regression Test Plan

- Coverage level: Unit test plus live macOS launchd proof.
- Target test file: `src/daemon/launchd.test.ts`.
- Scenario locked in: A LaunchAgent with service environment entries serializes raw `ProgramArguments` as `/bin/sh`, generated wrapper path, generated env file path, then the original gateway command; an old wrapper-first plist reads back and restart-rewrites into that same shell-first shape.
- Why this is the smallest reliable guardrail: The unit regression sits at the plist writer/readback boundary that launchd consumes, while the live proof exercises the macOS launchd runtime path without mocking launchd.
- `src/daemon/program-args.test.ts` remains green to confirm the existing `gateway --port <port>` command form is unchanged.
- `src/commands/daemon-install-helpers.test.ts` remains green to confirm service env planning still passes wrapper/env values through correctly.

## Root Cause

- Root cause: When service environment entries existed, LaunchAgent generation wrote `ProgramArguments` as `[wrapperPath, envFilePath, ...gatewayCommand]`. On macOS setups where the generated wrapper lives on a permission-constrained home/state volume, launchd could fail at `posix_spawn` before the wrapper loaded the env file or execed the gateway. Status/readback code normalized the command for display, which hid the raw plist shape that launchd actually executes.
- Missing detection / guardrail: Tests asserted normalized program arguments but did not assert the raw generated plist array, and the earlier proof did not run real macOS `launchctl bootstrap`/`kickstart` against the generated LaunchAgent.

## Merge risk

- **Why it matters / User impact:** Affected macOS users with service env entries, especially external-home setups, can get an immediately exiting gateway LaunchAgent. This keeps the gateway unavailable after install/restart.
- **What did NOT change:** This only changes macOS LaunchAgent env-wrapper serialization/readback; it does not change gateway CLI command construction, service env collection, provider auth, plist inline `EnvironmentVariables`, Linux/Windows service behavior, or the `gateway --port <port>` command shape.
- **Architecture / source-of-truth check:** The source-of-truth boundary is `prepareLaunchAgentProgramArguments` plus `readLaunchAgentProgramArgumentsFromFile`; generation and restart repair now share the same canonical shell-first wrapper contract while legacy wrapper-first plists are normalized only during read/rewrite.
- **Risk labels considered:** `merge-risk:platform`, `merge-risk:compatibility`.
- **Risk explanation:** The change affects macOS LaunchAgent plist generation and legacy plist rewrite behavior. It does not change gateway CLI command construction or embed env values into the plist.
- **Why acceptable:** The patch is limited to the launchd env-wrapper boundary, keeps old wrapper-first plists readable, preserves owner-only env-file loading, and now has focused tests plus a live macOS launchd proof for the generated command shape.
- **Maintainer-ready confidence:** High for the LaunchAgent env-wrapper root cause. The only remaining scope note is intentional: the gateway command remains the existing supported `gateway --port <port>` run path rather than changing CLI command construction in this PR.
- **Patch quality notes:** Minimal root-cause change at the LaunchAgent generation/readback source of truth; no fallback, retry, timeout, or status-only workaround.
