### PR TITLE
fix(config): isolate channel metadata rows

### DIFF
--- a/src/config/channel-config-metadata.test.ts
+++ b/src/config/channel-config-metadata.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import {
+  collectChannelSchemaMetadata,
+  collectPluginSchemaMetadata,
+} from "./channel-config-metadata.js";
+
+function createRegistry(plugins: PluginManifestRegistry["plugins"]): PluginManifestRegistry {
+  return { plugins, diagnostics: [] };
+}
+
+function createPluginRecord(
+  overrides: Pick<PluginManifestRecord, "id" | "origin"> & Partial<PluginManifestRecord>,
+): PluginManifestRecord {
+  return {
+    id: overrides.id,
+    origin: overrides.origin,
+    rootDir: `/tmp/${overrides.id}`,
+    manifestPath: `/tmp/${overrides.id}/openclaw.plugin.json`,
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    source: `/tmp/${overrides.id}/index.js`,
+    ...overrides,
+  };
+}
+
+describe("channel config metadata", () => {
+  it("skips unreadable plugin schema rows without dropping healthy rows", () => {
+    const unreadable = createPluginRecord({
+      id: "broken-plugin",
+      origin: "workspace",
+    });
+    Object.defineProperty(unreadable, "id", {
+      get() {
+        throw new Error("plugin schema metadata id exploded");
+      },
+    });
+
+    expect(
+      collectPluginSchemaMetadata(
+        createRegistry([
+          unreadable,
+          createPluginRecord({
+            id: "healthy-plugin",
+            origin: "workspace",
+            name: "Healthy plugin",
+            description: "Healthy plugin config",
+            configSchema: { type: "object" },
+          }),
+        ]),
+      ),
+    ).toStrictEqual([
+      {
+        id: "healthy-plugin",
+        name: "Healthy plugin",
+        description: "Healthy plugin config",
+        configSchema: { type: "object" },
+        configUiHints: undefined,
+      },
+    ]);
+  });
+
+  it("skips unreadable channel schema rows without dropping healthy rows", () => {
+    const unreadable = createPluginRecord({
+      id: "broken-channel-plugin",
+      origin: "workspace",
+    });
+    Object.defineProperty(unreadable, "channels", {
+      get() {
+        throw new Error("channel schema metadata channels exploded");
+      },
+    });
+
+    expect(
+      collectChannelSchemaMetadata(
+        createRegistry([
+          unreadable,
+          createPluginRecord({
+            id: "healthy-channel-plugin",
+            origin: "workspace",
+            channels: ["healthy-chat"],
+            channelCatalogMeta: {
+              id: "healthy-chat",
+              label: "Healthy Chat",
+              blurb: "Healthy channel config",
+            },
+            channelConfigs: {
+              "healthy-chat": {
+                label: "Healthy Chat Config",
+                description: "Healthy config schema",
+                schema: { type: "object" },
+              },
+            },
+          }),
+        ]),
+      ),
+    ).toStrictEqual([
+      {
+        id: "healthy-chat",
+        label: "Healthy Chat Config",
+        description: "Healthy config schema",
+        configSchema: { type: "object" },
+        configUiHints: undefined,
+      },
+    ]);
+  });
+});

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -6,6 +6,10 @@ type ChannelMetadataRecord = ChannelUiMetadata & {
   originRank: number;
 };
 
+type PluginMetadataRecord = PluginUiMetadata & {
+  originRank: number;
+};
+
 const PLUGIN_ORIGIN_RANK: Readonly<Record<PluginOrigin, number>> = {
   config: 0,
   workspace: 1,
@@ -13,28 +17,77 @@ const PLUGIN_ORIGIN_RANK: Readonly<Record<PluginOrigin, number>> = {
   bundled: 3,
 };
 
-export function collectPluginSchemaMetadata(registry: PluginManifestRegistry): PluginUiMetadata[] {
-  const deduped = new Map<
-    string,
-    PluginUiMetadata & {
-      originRank: number;
-    }
-  >();
+function collectPluginSchemaMetadataRecord(
+  record: PluginManifestRegistry["plugins"][number],
+  deduped: Map<string, PluginMetadataRecord>,
+): void {
+  const current = deduped.get(record.id);
+  const nextRank = PLUGIN_ORIGIN_RANK[record.origin] ?? Number.MAX_SAFE_INTEGER;
+  if (current && current.originRank <= nextRank) {
+    return;
+  }
+  deduped.set(record.id, {
+    id: record.id,
+    name: record.name,
+    description: record.description,
+    configUiHints: record.configUiHints,
+    configSchema: record.configSchema,
+    originRank: nextRank,
+  });
+}
 
-  for (const record of registry.plugins) {
-    const current = deduped.get(record.id);
-    const nextRank = PLUGIN_ORIGIN_RANK[record.origin] ?? Number.MAX_SAFE_INTEGER;
-    if (current && current.originRank <= nextRank) {
+function collectChannelSchemaMetadataRecord(
+  record: PluginManifestRegistry["plugins"][number],
+  byChannelId: Map<string, ChannelMetadataRecord>,
+): void {
+  const originRank = PLUGIN_ORIGIN_RANK[record.origin] ?? Number.MAX_SAFE_INTEGER;
+  const rootLabel = record.channelCatalogMeta?.label;
+  const rootDescription = record.channelCatalogMeta?.blurb;
+
+  for (const channelId of record.channels) {
+    const current = byChannelId.get(channelId);
+    if (!current || originRank <= current.originRank) {
+      byChannelId.set(channelId, {
+        id: channelId,
+        label: rootLabel ?? current?.label,
+        description: rootDescription ?? current?.description,
+        configSchema: current?.configSchema,
+        configUiHints: current?.configUiHints,
+        originRank,
+      });
+    }
+  }
+
+  for (const [channelId, channelConfig] of Object.entries(record.channelConfigs ?? {})) {
+    const current = byChannelId.get(channelId);
+    if (
+      current &&
+      current.originRank < originRank &&
+      (current.configSchema !== undefined || current.configUiHints !== undefined)
+    ) {
       continue;
     }
-    deduped.set(record.id, {
-      id: record.id,
-      name: record.name,
-      description: record.description,
-      configUiHints: record.configUiHints,
-      configSchema: record.configSchema,
-      originRank: nextRank,
+    byChannelId.set(channelId, {
+      id: channelId,
+      label: channelConfig.label ?? rootLabel ?? current?.label,
+      description: channelConfig.description ?? rootDescription ?? current?.description,
+      configSchema: channelConfig.schema,
+      configUiHints: channelConfig.uiHints as ChannelUiMetadata["configUiHints"],
+      originRank,
     });
+  }
+}
+
+export function collectPluginSchemaMetadata(registry: PluginManifestRegistry): PluginUiMetadata[] {
+  const deduped = new Map<string, PluginMetadataRecord>();
+
+  for (const record of registry.plugins) {
+    try {
+      collectPluginSchemaMetadataRecord(record, deduped);
+    } catch {
+      // Treat manifest rows as plugin-owned input. One unreadable row must not
+      // block schema metadata for other configured plugins/channels.
+    }
   }
 
   return [...deduped.values()]
@@ -48,41 +101,11 @@ export function collectChannelSchemaMetadata(
   const byChannelId = new Map<string, ChannelMetadataRecord>();
 
   for (const record of registry.plugins) {
-    const originRank = PLUGIN_ORIGIN_RANK[record.origin] ?? Number.MAX_SAFE_INTEGER;
-    const rootLabel = record.channelCatalogMeta?.label;
-    const rootDescription = record.channelCatalogMeta?.blurb;
-
-    for (const channelId of record.channels) {
-      const current = byChannelId.get(channelId);
-      if (!current || originRank <= current.originRank) {
-        byChannelId.set(channelId, {
-          id: channelId,
-          label: rootLabel ?? current?.label,
-          description: rootDescription ?? current?.description,
-          configSchema: current?.configSchema,
-          configUiHints: current?.configUiHints,
-          originRank,
-        });
-      }
-    }
-
-    for (const [channelId, channelConfig] of Object.entries(record.channelConfigs ?? {})) {
-      const current = byChannelId.get(channelId);
-      if (
-        current &&
-        current.originRank < originRank &&
-        (current.configSchema !== undefined || current.configUiHints !== undefined)
-      ) {
-        continue;
-      }
-      byChannelId.set(channelId, {
-        id: channelId,
-        label: channelConfig.label ?? rootLabel ?? current?.label,
-        description: channelConfig.description ?? rootDescription ?? current?.description,
-        configSchema: channelConfig.schema,
-        configUiHints: channelConfig.uiHints as ChannelUiMetadata["configUiHints"],
-        originRank,
-      });
+    try {
+      collectChannelSchemaMetadataRecord(record, byChannelId);
+    } catch {
+      // Treat manifest rows as plugin-owned input. One unreadable row must not
+      // block schema metadata for other configured plugins/channels.
     }
   }
 


### PR DESCRIPTION
## Summary

- isolate unreadable plugin manifest rows while collecting plugin/channel schema metadata
- preserve existing origin-rank dedupe and channel config merge behavior for healthy rows
- add focused regressions for poisoned plugin-level and channel-level metadata rows

## Verification

- red: `node scripts/run-vitest.mjs src/config/channel-config-metadata.test.ts` failed before the fix with `plugin schema metadata id exploded` and `channel schema metadata channels exploded`
- green: `node scripts/run-vitest.mjs src/config/channel-config-metadata.test.ts`
- green: `./node_modules/.bin/oxfmt --check --threads=1 src/config/channel-config-metadata.ts src/config/channel-config-metadata.test.ts`
- green: `./node_modules/.bin/oxlint src/config/channel-config-metadata.ts src/config/channel-config-metadata.test.ts`
- green: `git diff --check origin/main...HEAD`
- green: `.agents/skills/autoreview/scripts/autoreview --mode local`
- green: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- blocked: `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before lease with Crabbox coordinator `401 unauthorized` for provider `azure`, slug `brisk-crayfish`

## Real behavior proof

Behavior addressed: A malformed plugin manifest row could throw while config schema metadata was collected, aborting metadata discovery before later healthy plugin/channel rows were considered.

Real environment tested: Local linked OpenClaw worktree on Node/Vitest through `node scripts/run-vitest.mjs`; Crabbox remote changed-gate attempt reached the coordinator but failed authorization before leasing.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/channel-config-metadata.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/config/channel-config-metadata.ts src/config/channel-config-metadata.test.ts`; `./node_modules/.bin/oxlint src/config/channel-config-metadata.ts src/config/channel-config-metadata.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`.

Evidence after fix: The focused regression test passes with 2/2 tests, file-level format/lint/whitespace checks pass, and local plus branch autoreview report no accepted/actionable findings.

Observed result after fix: Unreadable manifest rows are skipped and healthy plugin/channel schema metadata remains available.

What was not tested: Full `pnpm check:changed` did not run because the Crabbox coordinator rejected the remote lease with `401 unauthorized`, and local broad pnpm checks are intentionally avoided in this linked worktree.
