### PR TITLE
fix(plugins): isolate setup manifest rows

### DIFF
--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -648,6 +648,83 @@ describe("setup-registry module loader", () => {
     expect(resolvePluginSetupRegistry({ env: {} }).diagnostics).toStrictEqual([]);
   });
 
+  it("skips unreadable manifest rows while building the setup registry", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          get setup() {
+            throw new Error("setup registry setup exploded");
+          },
+        } as never,
+        {
+          id: "openai",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "openai" }],
+            requiresRuntime: true,
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.createJiti.mockImplementation(() => {
+      return () => ({
+        default: {
+          register(api: {
+            registerProvider: (provider: { id: string; label: string; auth: [] }) => void;
+          }) {
+            api.registerProvider({ id: "openai", label: "OpenAI", auth: [] });
+          },
+        },
+      });
+    });
+
+    expect(resolvePluginSetupRegistry({ env: {} }).providers).toEqual([
+      {
+        pluginId: "openai",
+        provider: { id: "openai", label: "OpenAI", auth: [] },
+      },
+    ]);
+  });
+
+  it("skips unreadable manifest rows during setup owner lookup", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          get setup() {
+            throw new Error("setup owner setup exploded");
+          },
+        } as never,
+        {
+          id: "openai",
+          rootDir: pluginRoot,
+          setup: {
+            providers: [{ id: "openai" }],
+            requiresRuntime: true,
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.createJiti.mockImplementation(() => {
+      return () => ({
+        default: {
+          register(api: {
+            registerProvider: (provider: { id: string; label: string; auth: [] }) => void;
+          }) {
+            api.registerProvider({ id: "openai", label: "OpenAI", auth: [] });
+          },
+        },
+      });
+    });
+
+    expect(resolvePluginSetupProvider({ provider: "openai", env: {} })?.id).toBe("openai");
+  });
+
   it("does not load setup-api modules from the current working directory", () => {
     const pluginRoot = makeTempDir();
     const workspaceRoot = makeTempDir();

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -177,20 +177,26 @@ function resolveRelevantSetupMigrationPluginIds(params: {
     env: params.env,
   });
   for (const plugin of registry.plugins) {
-    const paths = plugin.configContracts?.compatibilityMigrationPaths;
-    if (!paths?.length) {
+    try {
+      const paths = plugin.configContracts?.compatibilityMigrationPaths;
+      if (!paths?.length) {
+        continue;
+      }
+      if (
+        paths.some(
+          (pathPattern) =>
+            collectPluginConfigContractMatches({
+              root: params.config,
+              pathPattern,
+            }).length > 0,
+        )
+      ) {
+        ids.add(plugin.id);
+      }
+    } catch {
+      // Manifest rows are plugin-owned metadata. One unreadable setup row must
+      // not block migrations or setup lookup for unrelated plugins.
       continue;
-    }
-    if (
-      paths.some(
-        (pathPattern) =>
-          collectPluginConfigContractMatches({
-            root: params.config,
-            pathPattern,
-          }).length > 0,
-      )
-    ) {
-      ids.add(plugin.id);
     }
   }
   return [...ids].toSorted();
@@ -356,9 +362,18 @@ function findUniqueSetupManifestOwner(params: {
   normalizedId: string;
   listIds: (record: PluginManifestRecord) => readonly string[];
 }): PluginManifestRecord | undefined {
-  const matches = params.registry.plugins.filter((entry) =>
-    params.listIds(entry).some((id) => normalizeProviderId(id) === params.normalizedId),
-  );
+  const matches: PluginManifestRecord[] = [];
+  for (const entry of params.registry.plugins) {
+    try {
+      if (params.listIds(entry).some((id) => normalizeProviderId(id) === params.normalizedId)) {
+        matches.push(entry);
+      }
+    } catch {
+      // Manifest rows are plugin-owned metadata. One unreadable setup row must
+      // not block migrations or setup lookup for unrelated plugins.
+      continue;
+    }
+  }
   if (matches.length === 0) {
     return undefined;
   }
@@ -491,81 +506,87 @@ export function resolvePluginSetupRegistry(params?: {
     });
 
   for (const record of manifestRegistry.plugins) {
-    if (scopedPluginIds && !scopedPluginIds.has(record.id)) {
-      continue;
-    }
-    if (record.setup?.requiresRuntime === false) {
-      pushDescriptorRuntimeDisabledDiagnostic({
+    try {
+      if (scopedPluginIds && !scopedPluginIds.has(record.id)) {
+        continue;
+      }
+      if (record.setup?.requiresRuntime === false) {
+        pushDescriptorRuntimeDisabledDiagnostic({
+          record,
+          diagnostics,
+        });
+        continue;
+      }
+      const setupRegistration = resolveSetupRegistration(record);
+      if (!setupRegistration) {
+        continue;
+      }
+
+      const recordProviders: ProviderPlugin[] = [];
+      const recordCliBackends: CliBackendPlugin[] = [];
+      const api = buildSetupPluginApi({
         record,
+        setupSource: setupRegistration.setupSource,
+        handlers: {
+          registerProvider(provider) {
+            const key = `${record.id}:${normalizeProviderId(provider.id)}`;
+            if (providerKeys.has(key)) {
+              return;
+            }
+            providerKeys.add(key);
+            providers.push({
+              pluginId: record.id,
+              provider,
+            });
+            recordProviders.push(provider);
+          },
+          registerCliBackend(backend) {
+            const key = `${record.id}:${normalizeProviderId(backend.id)}`;
+            if (cliBackendKeys.has(key)) {
+              return;
+            }
+            cliBackendKeys.add(key);
+            cliBackends.push({
+              pluginId: record.id,
+              backend,
+            });
+            recordCliBackends.push(backend);
+          },
+          registerConfigMigration(migrate) {
+            configMigrations.push({
+              pluginId: record.id,
+              migrate,
+            });
+          },
+          registerAutoEnableProbe(probe) {
+            autoEnableProbes.push({
+              pluginId: record.id,
+              probe,
+            });
+          },
+        },
+      });
+
+      try {
+        const result = setupRegistration.register(api);
+        if (result && typeof result.then === "function") {
+          // Keep setup registration sync-only.
+          ignoreAsyncSetupRegisterResult(result);
+        }
+      } catch {
+        continue;
+      }
+      pushSetupDescriptorDriftDiagnostics({
+        record,
+        providers: recordProviders,
+        cliBackends: recordCliBackends,
         diagnostics,
       });
-      continue;
-    }
-    const setupRegistration = resolveSetupRegistration(record);
-    if (!setupRegistration) {
-      continue;
-    }
-
-    const recordProviders: ProviderPlugin[] = [];
-    const recordCliBackends: CliBackendPlugin[] = [];
-    const api = buildSetupPluginApi({
-      record,
-      setupSource: setupRegistration.setupSource,
-      handlers: {
-        registerProvider(provider) {
-          const key = `${record.id}:${normalizeProviderId(provider.id)}`;
-          if (providerKeys.has(key)) {
-            return;
-          }
-          providerKeys.add(key);
-          providers.push({
-            pluginId: record.id,
-            provider,
-          });
-          recordProviders.push(provider);
-        },
-        registerCliBackend(backend) {
-          const key = `${record.id}:${normalizeProviderId(backend.id)}`;
-          if (cliBackendKeys.has(key)) {
-            return;
-          }
-          cliBackendKeys.add(key);
-          cliBackends.push({
-            pluginId: record.id,
-            backend,
-          });
-          recordCliBackends.push(backend);
-        },
-        registerConfigMigration(migrate) {
-          configMigrations.push({
-            pluginId: record.id,
-            migrate,
-          });
-        },
-        registerAutoEnableProbe(probe) {
-          autoEnableProbes.push({
-            pluginId: record.id,
-            probe,
-          });
-        },
-      },
-    });
-
-    try {
-      const result = setupRegistration.register(api);
-      if (result && typeof result.then === "function") {
-        // Keep setup registration sync-only.
-        ignoreAsyncSetupRegisterResult(result);
-      }
     } catch {
+      // Manifest rows are plugin-owned metadata. One unreadable setup row must
+      // not block migrations or setup lookup for unrelated plugins.
       continue;
     }
-    pushSetupDescriptorDriftDiagnostics({
-      record,
-      providers: recordProviders,
-      cliBackends: recordCliBackends,
-      diagnostics,
-    });
   }
 
   const registry = {


### PR DESCRIPTION
## Summary

- isolate unreadable setup manifest rows while collecting setup providers, CLI backends, migrations, and auto-enable probes
- keep setup owner lookup from crashing when an unrelated plugin row has a bad setup descriptor
- add focused regressions for poisoned setup manifest metadata before a healthy setup provider row

## Verification

- `node scripts/run-vitest.mjs src/plugins/setup-registry.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`
- `./node_modules/.bin/oxlint src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before lease creation: provider `azure`, slug `brisk-crab`, coordinator `401 unauthorized`

## Real behavior proof

Behavior addressed: setup registry construction and setup owner lookup now skip one unreadable plugin-owned manifest row instead of crashing before later healthy setup rows are considered.

Real environment tested: linked OpenClaw gwt worktree on `fuzz-tool-schema-next132-20260603`, Node/Vitest through `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/setup-registry.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`; `./node_modules/.bin/oxlint src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview.

Evidence after fix: the focused setup registry test file passed 25/25 tests, including poisoned setup getter regressions for full registry collection and setup provider owner lookup.

Observed result after fix: a healthy OpenAI setup provider still registers/resolves even when an earlier manifest row throws from its setup descriptor.

What was not tested: broad `pnpm check:changed`; Crabbox/Testbox proof is blocked by coordinator 401 before lease creation in this environment.
