### PR TITLE
fix(plugins): normalize setup probe reasons

### DIFF
--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -26,6 +26,7 @@ let resolvePluginSetupRegistry: typeof import("./setup-registry.js").resolvePlug
 let resolvePluginSetupProvider: typeof import("./setup-registry.js").resolvePluginSetupProvider;
 let resolvePluginSetupCliBackend: typeof import("./setup-registry.js").resolvePluginSetupCliBackend;
 let runPluginSetupConfigMigrations: typeof import("./setup-registry.js").runPluginSetupConfigMigrations;
+let resolvePluginSetupAutoEnableReasons: typeof import("./setup-registry.js").resolvePluginSetupAutoEnableReasons;
 let setPluginSetupRegistryModuleLoaderFactoryForTest:
   | typeof import("./setup-registry.js").setPluginSetupRegistryModuleLoaderFactoryForTest
   | undefined;
@@ -256,6 +257,7 @@ describe("setup-registry module loader", () => {
       resolvePluginSetupProvider,
       resolvePluginSetupCliBackend,
       runPluginSetupConfigMigrations,
+      resolvePluginSetupAutoEnableReasons,
       setPluginSetupRegistryModuleLoaderFactoryForTest,
     } = await import("./setup-registry.js"));
     setPluginSetupRegistryModuleLoaderFactoryForTest(mocks.createJiti);
@@ -828,6 +830,54 @@ describe("setup-registry module loader", () => {
     await expectNoUnhandledRejection(() => {
       expect(resolvePluginSetupRegistry({ env: {} }).configMigrations).toHaveLength(1);
     });
+  });
+
+  it("ignores malformed setup auto-enable probe reasons", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "setup-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "browser",
+          rootDir: pluginRoot,
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.createJiti.mockImplementation(() => {
+      return () => ({
+        default: {
+          register(api: { registerAutoEnableProbe: (probe: () => unknown) => void }) {
+            api.registerAutoEnableProbe(() => [
+              {},
+              "  browser config detected  ",
+              1,
+              "",
+              "browser config detected",
+            ]);
+          },
+        },
+      });
+    });
+
+    expect(
+      resolvePluginSetupAutoEnableReasons({
+        config: {
+          plugins: {
+            entries: {
+              browser: { config: {} },
+            },
+          },
+        } as never,
+        env: {},
+        pluginIds: ["browser"],
+      }),
+    ).toEqual([
+      {
+        pluginId: "browser",
+        reason: "browser config detected",
+      },
+    ]);
   });
 
   it("fails closed when multiple plugins claim the same setup provider id", () => {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -451,6 +451,21 @@ function pushSetupDescriptorDriftDiagnostics(params: {
   }
 }
 
+function normalizeSetupAutoEnableProbeReasons(raw: unknown): string[] {
+  const values = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const reasons: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const normalized = value.trim();
+    if (normalized) {
+      reasons.push(normalized);
+    }
+  }
+  return reasons;
+}
+
 export function resolvePluginSetupRegistry(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -758,16 +773,20 @@ export function resolvePluginSetupAutoEnableReasons(params: {
     pluginIds: params.pluginIds,
     manifestRegistry: params.manifestRegistry,
   }).autoEnableProbes) {
-    const raw = entry.probe({
-      config: params.config,
-      env,
-    });
-    const values = Array.isArray(raw) ? raw : raw ? [raw] : [];
-    for (const reason of values) {
-      const normalized = reason.trim();
-      if (!normalized) {
-        continue;
-      }
+    let values: string[];
+    try {
+      // Probe returns are plugin-owned hook output; normalize them before the
+      // setup registry reasons path trusts string methods.
+      values = normalizeSetupAutoEnableProbeReasons(
+        entry.probe({
+          config: params.config,
+          env,
+        }),
+      );
+    } catch {
+      continue;
+    }
+    for (const normalized of values) {
       const key = `${entry.pluginId}:${normalized}`;
       if (seen.has(key)) {
         continue;


### PR DESCRIPTION
## Summary

- normalize plugin setup auto-enable probe output before using string methods
- ignore malformed non-string probe reasons while preserving trimming and de-duplication for valid strings
- add a focused regression for mixed malformed probe output

## Verification

- `node scripts/run-vitest.mjs src/plugins/setup-registry.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`
- `./node_modules/.bin/oxlint src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before lease creation: provider `azure`, slug `pearl-prawn`, coordinator `401 unauthorized`

## Real behavior proof

Behavior addressed: setup auto-enable reason collection no longer crashes when a plugin probe returns malformed non-string values.

Real environment tested: linked OpenClaw gwt worktree on `fuzz-tool-schema-next133-20260603`, Node/Vitest through `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/setup-registry.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`; `./node_modules/.bin/oxlint src/plugins/setup-registry.ts src/plugins/setup-registry.test.ts`; `git diff --check origin/main...HEAD`; local and branch autoreview.

Evidence after fix: the focused setup registry test file passed 24/24 tests, including the mixed malformed setup auto-enable probe output regression.

Observed result after fix: malformed object/number/empty probe entries are ignored while the valid string reason is trimmed, deduped, and returned.

What was not tested: broad `pnpm check:changed`; Crabbox/Testbox proof is blocked by coordinator 401 before lease creation in this environment.
