### PR TITLE
fix(plugins): isolate doctor contract rows

### DIFF
--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -346,6 +346,73 @@ describe("doctor-contract-registry module loader", () => {
     expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
   });
 
+  it("skips unreadable manifest rows while loading doctor contracts", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(pluginRoot, "doctor-contract-api.cjs"),
+      "module.exports = { legacyConfigRules: [{ path: ['plugins', 'entries', 'healthy', 'legacy'], message: 'healthy contract' }] };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "broken",
+          get rootDir() {
+            throw new Error("doctor contract root exploded");
+          },
+        },
+        { id: "healthy", rootDir: pluginRoot },
+      ],
+      diagnostics: [],
+    });
+
+    expect(listPluginDoctorLegacyConfigRules({ workspaceDir: "/workspace", env: {} })).toEqual([
+      {
+        path: ["plugins", "entries", "healthy", "legacy"],
+        message: "healthy contract",
+      },
+    ]);
+  });
+
+  it("skips unreadable manifest rows during scoped doctor contract lookup", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(pluginRoot, "doctor-contract-api.cjs"),
+      "module.exports = { legacyConfigRules: [{ path: ['channels', 'healthy-channel', 'legacy'], message: 'healthy channel contract' }] };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "broken",
+          get channels() {
+            throw new Error("doctor contract channels exploded");
+          },
+        },
+        {
+          id: "healthy",
+          channels: ["healthy-channel"],
+          providers: [],
+          rootDir: pluginRoot,
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(
+      listPluginDoctorLegacyConfigRules({
+        workspaceDir: "/workspace",
+        env: {},
+        pluginIds: ["healthy-channel"],
+      }),
+    ).toEqual([
+      {
+        path: ["channels", "healthy-channel", "legacy"],
+        message: "healthy channel contract",
+      },
+    ]);
+  });
+
   it("narrows touched-path doctor ids for scoped dry-run validation", () => {
     expect(
       collectRelevantDoctorPluginIdsForTouchedPaths({

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -332,6 +332,22 @@ function loadPluginDoctorContractEntry(
   };
 }
 
+function matchesDoctorContractScope(
+  record: PluginManifestRegistryRecord,
+  scopedPluginIds: Set<string> | null,
+): boolean {
+  if (!scopedPluginIds) {
+    return true;
+  }
+  if (scopedPluginIds.has(record.id)) {
+    return true;
+  }
+  if (record.channels.some((channelId) => scopedPluginIds.has(channelId))) {
+    return true;
+  }
+  return record.providers.some((providerId) => scopedPluginIds.has(providerId));
+}
+
 function resolvePluginDoctorContracts(params?: {
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -353,17 +369,18 @@ function resolvePluginDoctorContracts(params?: {
   const entries: PluginDoctorContractEntry[] = [];
   const scopedPluginIds = params?.pluginIds ? new Set(params.pluginIds) : null;
   for (const record of manifestRegistry.plugins) {
-    if (
-      scopedPluginIds &&
-      !scopedPluginIds.has(record.id) &&
-      !record.channels.some((channelId) => scopedPluginIds.has(channelId)) &&
-      !record.providers.some((providerId) => scopedPluginIds.has(providerId))
-    ) {
+    try {
+      if (!matchesDoctorContractScope(record, scopedPluginIds)) {
+        continue;
+      }
+      const entry = loadPluginDoctorContractEntry(record);
+      if (entry) {
+        entries.push(entry);
+      }
+    } catch {
+      // Manifest rows are plugin-owned metadata. One unreadable doctor row must
+      // not block doctor repairs or diagnostics from unrelated plugins.
       continue;
-    }
-    const entry = loadPluginDoctorContractEntry(record);
-    if (entry) {
-      entries.push(entry);
     }
   }
 


### PR DESCRIPTION
## Summary

- isolate per-row failures while resolving plugin doctor contracts
- preserve scoped doctor contract matching by plugin id, channel id, and provider id
- add regressions for unreadable manifest rows in unscoped and scoped doctor lookup

## Verification

- `node scripts/run-vitest.mjs src/plugins/doctor-contract-registry.test.ts` failed pre-fix with `doctor contract root exploded` and `doctor contract channels exploded`
- `node scripts/run-vitest.mjs src/plugins/doctor-contract-registry.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.test.ts`
- `./node_modules/.bin/oxlint src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before lease creation with provider `azure`, slug `harbor-prawn`, and coordinator `401 unauthorized`

## Real behavior proof

Behavior addressed: doctor contract discovery now skips an unreadable plugin-owned manifest row without blocking unrelated healthy doctor contract rows.

Real environment tested: linked OpenClaw Codex worktree on branch `fuzz-tool-schema-next134-20260603`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/doctor-contract-registry.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.test.ts`; `./node_modules/.bin/oxlint src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 1 file / 12 tests; formatting and lint checks passed; diff whitespace check passed; branch autoreview reported no accepted/actionable findings and `overall: patch is correct (0.86)`.

Observed result after fix: unscoped and scoped doctor contract lookup both continue to return healthy contract rules after earlier poisoned manifest rows throw from `rootDir` or `channels`.

What was not tested: full `pnpm check:changed`; the required Crabbox/Testbox broad gate could not start because the Crabbox coordinator returned `401 unauthorized` before lease creation.
