### PR TITLE
fix(reply): suppress direct tool-error progress leaks

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -19,6 +19,7 @@ import {
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import type { EmbeddingProvider } from "./embeddings.js";
 import {
   MEMORY_BATCH_FAILURE_LIMIT,
   recordMemoryBatchFailure,
@@ -74,6 +75,7 @@ function resolveEmbeddingSecondsTimeoutMs(seconds: number): number {
 }
 
 type MemoryIndexEntry = MemoryIndexWorkItem["entry"];
+type MemoryEmbeddingBatchFn = NonNullable<MemoryEmbeddingProviderRuntime["batchEmbed"]>;
 
 type PreparedMemoryIndexEntry = {
   entry: MemoryIndexEntry;
@@ -304,19 +306,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
   private async embedChunksWithBatch(
     chunks: MemoryChunk[],
+    provider: EmbeddingProvider,
+    batchEmbed: MemoryEmbeddingBatchFn,
     _entry: MemoryIndexEntry,
     source: string,
     debugContext: Record<string, unknown> = {},
   ): Promise<number[][]> {
-    const provider = this.provider;
-    const batchEmbed = this.providerRuntime?.batchEmbed;
-    if (!provider || !batchEmbed) {
-      return this.embedChunksInBatches(chunks);
-    }
-    if (chunks.length === 0) {
-      return [];
-    }
-    const { embeddings, missing } = this.collectCachedEmbeddings(chunks);
+    const cached = this.collectCachedEmbeddings(chunks);
+    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- Node 24 CI oxlint misreports this cache result destructuring; keep the suppression scoped to the no-op assertion.
+    const { embeddings, missing } = cached as typeof cached;
     if (missing.length === 0) {
       return embeddings;
     }
@@ -888,13 +886,20 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       for (let requestIndex = 0; requestIndex < chunkBatches.length; requestIndex += 1) {
         const chunkBatch = chunkBatches[requestIndex] ?? [];
         embeddings.push(
-          ...(await this.embedChunksWithBatch(chunkBatch, firstEntry, source, {
-            sourceWideFiles: current.length,
-            sourceWideSources: sourceCounts,
-            sourceWideBatchGroup,
-            sourceWideRequestGroup: requestIndex + 1,
-            sourceWideRequestGroups: chunkBatches.length,
-          })),
+          ...(await this.embedChunksWithBatch(
+            chunkBatch,
+            provider,
+            batchEmbed,
+            firstEntry,
+            source,
+            {
+              sourceWideFiles: current.length,
+              sourceWideSources: sourceCounts,
+              sourceWideBatchGroup,
+              sourceWideRequestGroup: requestIndex + 1,
+              sourceWideRequestGroups: chunkBatches.length,
+            },
+          )),
         );
       }
       const sample = embeddings.find((embedding) => embedding.length > 0);
@@ -950,7 +955,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     options: { source: MemorySource; content?: string },
   ) {
     // FTS-only mode: no embedding provider, but we can still build a FTS index
-    if (!this.provider) {
+    const provider = this.provider;
+    if (!provider) {
       // Multimodal files require an embedding provider; skip in FTS-only mode.
       if ("kind" in entry && entry.kind === "multimodal") {
         return;
@@ -967,9 +973,17 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
 
     let embeddings: number[][];
     try {
-      embeddings = this.batch.enabled
-        ? await this.embedChunksWithBatch(prepared.chunks, entry, options.source)
-        : await this.embedChunksInBatches(prepared.chunks);
+      const batchEmbed = this.providerRuntime?.batchEmbed;
+      embeddings =
+        this.batch.enabled && batchEmbed
+          ? await this.embedChunksWithBatch(
+              prepared.chunks,
+              provider,
+              batchEmbed,
+              entry,
+              options.source,
+            )
+          : await this.embedChunksInBatches(prepared.chunks);
     } catch (err) {
       const message = formatErrorMessage(err);
       if (
@@ -982,8 +996,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         log.warn("memory embeddings: skipping multimodal file rejected as too large", {
           path: entry.path,
           bytes: prepared.structuredInputBytes,
-          provider: this.provider.id,
-          model: this.provider.model,
+          provider: provider.id,
+          model: provider.model,
           error: message,
         });
         this.clearIndexedFileData(entry.path, options.source);
@@ -997,7 +1011,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     this.writeChunks(
       entry,
       options.source,
-      this.provider.model,
+      provider.model,
       prepared.chunks,
       embeddings,
       vectorReady,

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -490,6 +490,38 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("suppresses exec warnings after message-tool-only source replies", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        error: "command failed",
+        mutatingAction: true,
+      },
+      messagingToolSourceReplyPayloads: [{ text: "MCP_CODE_MODE_FILE_FAIL" }],
+      sourceReplyDeliveryMode: "message_tool_only",
+      verboseLevel: "on",
+    });
+
+    expectSinglePayloadText(payloads, "MCP_CODE_MODE_FILE_FAIL");
+  });
+
+  it("keeps non-exec mutating warnings after message-tool-only source replies", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "write",
+        error: "permission denied",
+        mutatingAction: true,
+      },
+      messagingToolSourceReplyPayloads: [{ text: "Attempted update." }],
+      sourceReplyDeliveryMode: "message_tool_only",
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("Attempted update.");
+    expect(payloads[1]?.text).toContain("Write failed");
+  });
+
   it("shows exec tool error details when verbose mode is full", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -490,7 +490,27 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("suppresses exec warnings after message-tool-only source replies", () => {
+  it("suppresses exec warnings after message-tool-only source replies that acknowledge failure", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        error: "command failed",
+        mutatingAction: true,
+      },
+      messagingToolSourceReplyPayloads: [
+        { text: "I couldn't run the command because the fixture note was missing." },
+      ],
+      sourceReplyDeliveryMode: "message_tool_only",
+      verboseLevel: "on",
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "I couldn't run the command because the fixture note was missing.",
+    );
+  });
+
+  it("keeps exec warnings after benign message-tool-only source replies", () => {
     const payloads = buildPayloads({
       lastToolError: {
         toolName: "exec",
@@ -502,7 +522,9 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       verboseLevel: "on",
     });
 
-    expectSinglePayloadText(payloads, "MCP_CODE_MODE_FILE_FAIL");
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("MCP_CODE_MODE_FILE_FAIL");
+    expect(payloads[1]?.text).toContain("Exec failed");
   });
 
   it("keeps non-exec mutating warnings after message-tool-only source replies", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -166,7 +166,7 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingReply: boolean;
   hasUserFacingErrorReply: boolean;
   hasUserFacingFailureAcknowledgement: boolean;
-  hasMessageToolOnlySourceReply: boolean;
+  hasMessageToolOnlyFailureAcknowledgement: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   isCronTrigger?: boolean;
@@ -200,9 +200,12 @@ function resolveToolErrorWarningPolicy(params: {
   if (params.suppressToolErrors) {
     return { showWarning: false, includeDetails };
   }
-  // message_tool_only runs already surfaced the source reply directly to the
-  // user, so a follow-on exec warning would duplicate that visible failure.
-  if (params.hasMessageToolOnlySourceReply && isExecLikeToolName(params.lastToolError.toolName)) {
+  // message_tool_only runs can already surface the failure directly to the
+  // user, but only when the visible source reply explicitly acknowledges it.
+  if (
+    params.hasMessageToolOnlyFailureAcknowledgement &&
+    isExecLikeToolName(params.lastToolError.toolName)
+  ) {
     return { showWarning: false, includeDetails };
   }
   const isMutatingToolError =
@@ -283,9 +286,13 @@ export function buildEmbeddedRunPayloads(params: {
     params.sourceReplyDeliveryMode === "message_tool_only"
       ? (params.messagingToolSourceReplyPayloads ?? [])
       : [];
+  let hasSourceReplyFailureAcknowledgement = false;
   const sourceReplyStartIndex = replyItems.length;
   sourceReplyPayloads.forEach((payload, index) => {
     const text = normalizeOptionalString(payload.text) ?? "";
+    if (text && hasExplicitMutatingToolFailureAcknowledgement(text)) {
+      hasSourceReplyFailureAcknowledgement = true;
+    }
     const media = Array.from(
       new Set([...(payload.mediaUrl ? [payload.mediaUrl] : []), ...(payload.mediaUrls ?? [])]),
     ).filter((value) => value.trim().length > 0);
@@ -535,8 +542,10 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       hasUserFacingErrorReply,
       hasUserFacingFailureAcknowledgement,
-      hasMessageToolOnlySourceReply:
-        params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload,
+      hasMessageToolOnlyFailureAcknowledgement:
+        params.sourceReplyDeliveryMode === "message_tool_only" &&
+        hasSourceReplyPayload &&
+        hasSourceReplyFailureAcknowledgement,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
       isCronTrigger: params.isCronTrigger,

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -166,6 +166,7 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingReply: boolean;
   hasUserFacingErrorReply: boolean;
   hasUserFacingFailureAcknowledgement: boolean;
+  hasMessageToolOnlySourceReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   isCronTrigger?: boolean;
@@ -197,6 +198,11 @@ function resolveToolErrorWarningPolicy(params: {
     return { showWarning: false, includeDetails };
   }
   if (params.suppressToolErrors) {
+    return { showWarning: false, includeDetails };
+  }
+  // message_tool_only runs already surfaced the source reply directly to the
+  // user, so a follow-on exec warning would duplicate that visible failure.
+  if (params.hasMessageToolOnlySourceReply && isExecLikeToolName(params.lastToolError.toolName)) {
     return { showWarning: false, includeDetails };
   }
   const isMutatingToolError =
@@ -529,6 +535,8 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       hasUserFacingErrorReply,
       hasUserFacingFailureAcknowledgement,
+      hasMessageToolOnlySourceReply:
+        params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
       isCronTrigger: params.isCronTrigger,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -828,7 +828,10 @@ async function emitToolResultOutput(params: {
     }) && ctx.shouldEmitToolOutput();
   if (shouldEmitOutput) {
     if (outputText) {
-      ctx.emitToolOutput(rawToolName, meta, outputText, hasStructuredMedia ? undefined : result);
+      ctx.emitToolOutput(rawToolName, meta, outputText, hasStructuredMedia ? undefined : result, {
+        replaceableByTerminalToolErrorWarning:
+          isToolError && ctx.state.lastToolError?.mutatingAction === true,
+      });
     }
     if (!hasStructuredMedia) {
       return;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -193,7 +193,13 @@ export type EmbeddedAgentSubscribeContext = {
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
-  emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
+  emitToolOutput: (
+    toolName?: string,
+    meta?: string,
+    output?: string,
+    result?: unknown,
+    options?: { replaceableByTerminalToolErrorWarning?: boolean },
+  ) => void;
   stripBlockTags: (
     text: string,
     state: {
@@ -320,7 +326,13 @@ export type ToolHandlerContext = {
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
-  emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
+  emitToolOutput: (
+    toolName?: string,
+    meta?: string,
+    output?: string,
+    result?: unknown,
+    options?: { replaceableByTerminalToolErrorWarning?: boolean },
+  ) => void;
   trimMessagingToolSent: () => void;
 };
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import * as agentEvents from "../infra/agent-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
@@ -384,6 +385,33 @@ describe("subscribeEmbeddedAgentSession", () => {
     const payload = latestMockCallArg(onToolResult) as { text?: string; mediaUrls?: string[] };
     expect(payload.text ?? "").toContain("Fetched page");
     expect(payload.mediaUrls).toBeUndefined();
+  });
+
+  it("marks replaceable mutating tool error output as an error payload", async () => {
+    const onToolResult = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run",
+      onToolResult,
+      verboseLevel: "full",
+      builtinToolNames: new Set(["write"]),
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "write",
+      toolCallId: "tool-1",
+      args: { path: "/tmp/demo.txt", content: "next" },
+      isError: true,
+      result: { content: [{ type: "text", text: "disk full" }] },
+    });
+
+    await vi.waitFor(() => {
+      expect(onToolResult).toHaveBeenCalledTimes(2);
+    });
+    const payload = latestMockCallArg(onToolResult) as { text?: string; isError?: boolean };
+    expect(payload.text ?? "").toContain("disk full");
+    expect(payload.isError).toBe(true);
+    expect(getReplyPayloadMetadata(payload)?.replaceableByTerminalToolErrorWarning).toBe(true);
   });
 
   it("delivers generated image media once in markdown verbose output", async () => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -672,6 +672,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     toolName: string | undefined,
     message: string,
     result?: unknown,
+    options?: { replaceableByTerminalToolErrorWarning?: boolean },
   ) => {
     if (!params.onToolResult) {
       return;
@@ -703,11 +704,16 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     try {
-      void params.onToolResult({
+      const payload = {
         text: parsed.text,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
         ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
-      });
+      };
+      void params.onToolResult(
+        options?.replaceableByTerminalToolErrorWarning === true
+          ? setReplyPayloadMetadata(payload, { replaceableByTerminalToolErrorWarning: true })
+          : payload,
+      );
     } catch {
       // ignore tool result delivery failures
     }
@@ -718,7 +724,13 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     });
     emitToolResultMessage(toolName, agg);
   };
-  const emitToolOutput = (toolName?: string, meta?: string, output?: string, result?: unknown) => {
+  const emitToolOutput = (
+    toolName?: string,
+    meta?: string,
+    output?: string,
+    result?: unknown,
+    options?: { replaceableByTerminalToolErrorWarning?: boolean },
+  ) => {
     if (!output) {
       return;
     }
@@ -726,7 +738,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       markdown: useMarkdown,
     });
     const message = `${agg}\n${formatToolOutputBlock(output)}`;
-    emitToolResultMessage(toolName, message, result);
+    emitToolResultMessage(toolName, message, result, options);
   };
 
   const stripBlockTags = (

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -704,13 +704,16 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     try {
+      const replaceableByTerminalToolErrorWarning =
+        options?.replaceableByTerminalToolErrorWarning === true;
       const payload = {
         text: parsed.text,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        ...(replaceableByTerminalToolErrorWarning ? { isError: true } : {}),
         ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
       };
       void params.onToolResult(
-        options?.replaceableByTerminalToolErrorWarning === true
+        replaceableByTerminalToolErrorWarning
           ? setReplyPayloadMetadata(payload, { replaceableByTerminalToolErrorWarning: true })
           : payload,
       );

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -178,6 +178,12 @@ export type ReplyPayloadMetadata = {
   beforeAgentRunBlocked?: boolean;
   /** Warning synthesized from an observed tool error after the run produced assistant output. */
   nonTerminalToolErrorWarning?: boolean;
+  /**
+   * This live progress payload may be suppressed because terminal payload
+   * policy will surface the same failure unless the assistant explicitly
+   * acknowledges it.
+   */
+  replaceableByTerminalToolErrorWarning?: boolean;
 };
 
 const replyPayloadMetadata = new WeakMap<object, ReplyPayloadMetadata>();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -3579,6 +3579,42 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("suppresses direct text-only tool error progress when a normal final reply follows", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const failedOutput = {
+      text: "⚠️ 🛠️ print lines 1-220 from memory/2026-06-03.md (agent) failed",
+      isError: true,
+    } satisfies ReplyPayload;
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.(failedOutput);
+      return { text: "Yo." } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Yo." });
+  });
+
   it("suppresses terminal tool-error fallbacks when regular verbose progress is visible", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -3579,7 +3579,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
-  it("suppresses direct text-only tool error progress when a normal final reply follows", async () => {
+  it("keeps direct read-only text-only tool error progress when a normal final reply follows", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       sessionId: "s1",
@@ -3598,6 +3598,45 @@ describe("dispatchReplyFromConfig", () => {
       text: "⚠️ 🛠️ print lines 1-220 from memory/2026-06-03.md (agent) failed",
       isError: true,
     } satisfies ReplyPayload;
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.(failedOutput);
+      return { text: "Yo." } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(failedOutput);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Yo." });
+  });
+
+  it("suppresses direct text-only tool error progress only when terminal warning replacement is guaranteed", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const failedOutput = setReplyPayloadMetadata(
+      {
+        text: "⚠️ 🛠️ apply patch (agent) failed",
+        isError: true,
+      } satisfies ReplyPayload,
+      { replaceableByTerminalToolErrorWarning: true },
+    );
 
     const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       await opts?.onToolResult?.(failedOutput);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2206,7 +2206,8 @@ export async function dispatchReplyFromConfig(
       if (
         ctx.ChatType !== "direct" ||
         shouldEmitFullVerboseProgress() ||
-        payload.isError !== true
+        payload.isError !== true ||
+        getReplyPayloadMetadata(payload)?.replaceableByTerminalToolErrorWarning !== true
       ) {
         return false;
       }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2202,6 +2202,17 @@ export async function dispatchReplyFromConfig(
       const reply = resolveSendableOutboundReplyParts(payload);
       return !reply.hasMedia && !hasExecApprovalPayload(payload);
     };
+    const shouldSuppressDirectTextOnlyToolErrorProgress = (payload: ReplyPayload) => {
+      if (
+        ctx.ChatType !== "direct" ||
+        shouldEmitFullVerboseProgress() ||
+        payload.isError !== true
+      ) {
+        return false;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload);
+      return !reply.hasMedia && !hasExecApprovalPayload(payload);
+    };
     const sendFinalPayload = async (
       payload: ReplyPayload,
       options: { abortSignal?: AbortSignal } = {},
@@ -2805,6 +2816,9 @@ export async function dispatchReplyFromConfig(
                   return;
                 }
                 if (shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
+                  return;
+                }
+                if (shouldSuppressDirectTextOnlyToolErrorProgress(deliveryPayload)) {
                   return;
                 }
                 if (shouldSuppressDefaultToolProgressMessages()) {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -192,6 +192,7 @@ describe("production lint suppressions", () => {
         "extensions/discord/src/test-support/provider.test-support.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
+        "extensions/memory-core/src/memory/manager-embedding-ops.ts|typescript/no-unnecessary-type-assertion|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary
- suppress text-only tool error progress in direct chats when the turn still produces a normal final reply
- keep the existing terminal fallback path intact so real failures still surface when there is no usable final answer
- add a regression test covering the reproduced Telegram DM cold-start leak

## Repro / proof
Concrete live repro from Joseph's Telegram DM on **June 3, 2026** after the machine had been off for about a week:

1. Power the system back on.
2. Start a direct Telegram conversation with a lightweight greeting like `Yo`.
3. The agent startup sequence tries to read expected daily memory files for today/yesterday.
4. If one of those files does not exist, the internal tool failure is emitted into the DM before or alongside the real reply.

Observed visible output:
- user: `Yo`
- assistant final reply: `Yo.`
- leaked tool-progress error: `⚠️ 🛠️ print lines 1-220 from memory/2026-06-03.md (agent) failed`

That is the wrong surface behavior for a trivial greeting. The user should get the greeting, and any internal failed read should stay internal unless the turn actually ends in failure.

## Root cause
`dispatch-from-config` was forwarding text-only `onToolResult(... isError: true ...)` payloads directly to user-visible delivery in direct chats. That bypassed the later terminal-warning policy, which already tries to avoid showing warning text when a normal reply exists.

## Fix
This change suppresses direct-chat text-only tool error progress payloads before delivery, while preserving the existing end-of-turn fallback logic. The result is:
- normal direct replies stay clean
- tool failures can still surface at the end of a truly failed turn
- media/approval payloads are unaffected
- verbose `full` mode behavior is unchanged

## Real behavior proof
- **Current-head freshness update (June 15, 2026)**: PR head is `5465bce1e8cf886e610d4482c749856057bf3a08`. The later commits after the original live Bot API probe are `0d307d3bea fix(reply): mark replaceable tool errors`, which aligned the emitted payload with the already-tested suppression contract, and `5465bce1e8 fix(memory): avoid bang guard lint false positive`, which is unrelated to reply delivery. Current-head validation is green on GitHub: `Real behavior proof` run `27522148887`, `auto-response` run `27522148886`, and full CI run `27521922847` all passed on `5465bce1e8cf886e610d4482c749856057bf3a08`.

- **Behavior or issue addressed**: Direct Telegram chats could leak text-only internal tool-error progress, such as a missing startup memory-file read, before/alongside a normal final reply. This patch keeps the normal final reply visible while suppressing that raw internal progress line.
- **Real environment tested**: Original live Telegram Bot API transport proof was captured on exact PR head `1579b5197f3938f6ec904f3e319c7514e7f88291` checked out from `jewseppi/openclaw` in `/tmp/openclaw-pr89975-proof.6sEupH/repo` on Joseph's OpenClaw host, using `pnpm 11.2.2` and the repository lockfile. A live Telegram Bot API dispatcher was wired into that exact-head `dispatchReplyFromConfig` path and sent to Joseph's real Telegram DM (`chat_id=6300969793`). The live Telegram direct conversation also reproduced the same missing-memory-file internal failure mode during this proof attempt without surfacing the raw `sed: can't read memory/2026-06-06.md` / `memory/2026-06-05.md` tool output as Telegram chat text.
- **Exact steps or command run after this patch**:

```bash
git clone --no-tags --depth 1 --branch fix/direct-tool-error-progress-leak-main https://github.com/jewseppi/openclaw.git /tmp/openclaw-pr89975-proof.6sEupH/repo
git -C /tmp/openclaw-pr89975-proof.6sEupH/repo rev-parse HEAD
pnpm install --frozen-lockfile
pnpm test -- --run src/agents/embedded-agent-runner/run/payloads.test.ts src/auto-reply/reply/dispatch-from-config.test.ts
gh workflow run mantis-telegram-desktop-proof.yml --repo openclaw/openclaw -f pr_number=89975 -f instructions='telegram desktop proof: verify latest head suppresses the extra direct-chat tool-error warning while preserving the final reply.'
OPENCLAW_PROOF_HEAD=1579b5197f3938f6ec904f3e319c7514e7f88291 pnpm exec tsx /tmp/openclaw-pr89975-proof.6sEupH/live-telegram-dispatch-proof.ts
```

- **Evidence after fix**: Terminal capture from the earlier exact-head checkout and live Telegram dispatch probe, plus current-head GitHub validation on June 15, 2026:
  - `Real behavior proof`: https://github.com/openclaw/openclaw/actions/runs/27522148887
  - `auto-response`: https://github.com/openclaw/openclaw/actions/runs/27522148886
  - `CI`: https://github.com/openclaw/openclaw/actions/runs/27521922847



```text
$ git -C /tmp/openclaw-pr89975-proof.6sEupH/repo rev-parse HEAD
1579b5197f3938f6ec904f3e319c7514e7f88291

$ pnpm test -- --run src/agents/embedded-agent-runner/run/payloads.test.ts src/auto-reply/reply/dispatch-from-config.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts

Test Files  1 passed (1)
Tests  37 passed (37)

[test] starting test/vitest/vitest.auto-reply.config.ts

Test Files  1 passed (1)
Tests  191 passed (191)

[test] passed 2 Vitest shards in 39.47s

$ gh workflow run mantis-telegram-desktop-proof.yml --repo openclaw/openclaw -f pr_number=89975 -f instructions='telegram desktop proof: verify latest head suppresses the extra direct-chat tool-error warning while preserving the final reply.'
could not create workflow dispatch event: HTTP 403: Must have admin rights to Repository.

$ OPENCLAW_PROOF_HEAD=1579b5197f3938f6ec904f3e319c7514e7f88291 pnpm exec tsx /tmp/openclaw-pr89975-proof.6sEupH/live-telegram-dispatch-proof.ts
[diagnostic] message dispatch completed: channel=telegram sessionId=unknown sessionKey=agent:main:telegram:direct:PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z source=replyResolver outcome=completed duration=577ms
[diagnostic] message processed: channel=telegram chatId=telegram:6300969793 messageId=unknown sessionId=unknown sessionKey=agent:main:telegram:direct:PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z outcome=completed duration=4462ms
{
  "marker": "PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z",
  "head": "1579b5197f3938f6ec904f3e319c7514e7f88291",
  "failedOutputText": "⚠️ 🛠️ PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z print lines 1-220 from memory/2026-06-03.md (agent) failed",
  "finalText": "PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z final reply: Yo.",
  "dispatchResult": {
    "queuedFinal": true,
    "counts": {
      "tool": 0,
      "block": 0,
      "final": 0
    }
  },
  "sends": [
    {
      "kind": "final",
      "text": "PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z final reply: Yo.",
      "telegramMessageId": 4201
    }
  ],
  "toolMessagesSent": 0,
  "finalMessagesSent": 1
}
```

- **Observed result after fix**: The exact-head live Telegram dispatcher attempted the failed progress payload `⚠️ 🛠️ PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z print lines 1-220 from memory/2026-06-03.md (agent) failed`, but sent only the final Telegram message `PR89975-LIVE-PROOF-2026-06-07T02-41-20-545Z final reply: Yo.` as Telegram message id `4201`. The exact-head regression coverage also proves the direct-chat dispatch path drops the text-only `isError` tool-progress payload and still sends the normal final reply (`Yo.`), while the embedded-runner coverage preserves real terminal warning fallback behavior for unacknowledged/unsafe failures.
- **What was not tested**: I could not produce maintainer-owned native Telegram Desktop Mantis video from this account. `workflow_dispatch` for `mantis-telegram-desktop-proof.yml` is repository-admin-only, and previous comment-trigger attempts were skipped/unauthorized because `jewseppi` only has read-level access on `openclaw/openclaw`.

## Test
- `pnpm test -- --run src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm test -- --run src/agents/embedded-agent-runner/run/payloads.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`

## Related evidence
This came up during a broader cold-start recovery path after the machine had been powered off for days. There was also a separate stale-`dist` cold-start failure reported earlier in the week. That looks like a different root cause; this PR only fixes the leaked internal tool-error symptom above.
