### PR TITLE
fix(plugins): isolate bundle config rows

### DIFF
--- a/src/plugins/bundle-config-shared.ts
+++ b/src/plugins/bundle-config-shared.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { matchRootFileOpenFailure, type RootFileOpenFailure } from "../infra/boundary-file-read.js";
 import { readRootJsonObjectSync } from "../infra/json-files.js";
 import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
-import type { PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginBundleFormat } from "./manifest-types.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
 
@@ -80,6 +80,25 @@ export function inspectBundleServerRuntimeSupport<TConfig>(params: {
   };
 }
 
+type EnabledBundleRecord = {
+  pluginId: string;
+  origin: PluginManifestRecord["origin"];
+  rootDir: string;
+  bundleFormat: PluginBundleFormat;
+};
+
+function resolveEnabledBundleRecord(record: PluginManifestRecord): EnabledBundleRecord | null {
+  if (record.format !== "bundle" || !record.bundleFormat) {
+    return null;
+  }
+  return {
+    pluginId: record.id,
+    origin: record.origin,
+    rootDir: record.rootDir,
+    bundleFormat: record.bundleFormat,
+  };
+}
+
 export function loadEnabledBundleConfig<TConfig, TDiagnostic>(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
@@ -108,12 +127,20 @@ export function loadEnabledBundleConfig<TConfig, TDiagnostic>(params: {
   let merged = params.createEmptyConfig();
 
   for (const record of registry.plugins) {
-    if (record.format !== "bundle" || !record.bundleFormat) {
+    let bundleRecord: EnabledBundleRecord | null;
+    try {
+      bundleRecord = resolveEnabledBundleRecord(record);
+    } catch {
+      // Bundle config rows come from plugin-owned metadata. One unreadable row
+      // must not block unrelated enabled bundle config from loading.
+      continue;
+    }
+    if (!bundleRecord) {
       continue;
     }
     const activationState = resolveEffectivePluginActivationState({
-      id: record.id,
-      origin: record.origin,
+      id: bundleRecord.pluginId,
+      origin: bundleRecord.origin,
       config: normalizedPlugins,
       rootConfig: params.cfg,
     });
@@ -122,13 +149,13 @@ export function loadEnabledBundleConfig<TConfig, TDiagnostic>(params: {
     }
 
     const loaded = params.loadBundleConfig({
-      pluginId: record.id,
-      rootDir: record.rootDir,
-      bundleFormat: record.bundleFormat,
+      pluginId: bundleRecord.pluginId,
+      rootDir: bundleRecord.rootDir,
+      bundleFormat: bundleRecord.bundleFormat,
     });
     merged = applyMergePatch(merged, loaded.config) as TConfig;
     for (const message of loaded.diagnostics) {
-      diagnostics.push(params.createDiagnostic(record.id, message));
+      diagnostics.push(params.createDiagnostic(bundleRecord.pluginId, message));
     }
   }
 

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -14,6 +14,7 @@ import {
   writeClaudeBundleManifest,
   resolveBundlePluginRoot,
 } from "./bundle-mcp.test-support.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 
 function getServerArgs(value: unknown): unknown[] | undefined {
   return isRecord(value) && Array.isArray(value.args) ? value.args : undefined;
@@ -151,6 +152,65 @@ describe("loadEnabledBundleMcpConfig", () => {
             rootDir: await fs.realpath(pluginRoot),
             source: "test",
             manifestPath: path.join(pluginRoot, ".claude-plugin", "plugin.json"),
+          },
+        ],
+      },
+    });
+
+    expectNoDiagnostics(loaded.diagnostics);
+    expect(loaded.config.mcpServers.bundleProbe).toMatchObject({
+      command: "node",
+    });
+  });
+
+  it("skips unreadable bundle manifest rows from provided registries", async () => {
+    const homeDir = await tempHarness.createTempDir("openclaw-bundle-mcp-home-");
+    const workspaceDir = await tempHarness.createTempDir("openclaw-bundle-mcp-workspace-");
+    const { pluginRoot } = await createBundleProbePlugin(homeDir);
+    const manifestPath = path.join(pluginRoot, ".claude-plugin", "plugin.json");
+    const poisonedFormatRecord = {
+      id: "poisoned-format",
+      get format() {
+        throw new Error("bundle config format exploded");
+      },
+    } as unknown as PluginManifestRecord;
+    const poisonedRootRecord = {
+      id: "poisoned-root",
+      origin: "global",
+      format: "bundle",
+      bundleFormat: "claude",
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      get rootDir() {
+        throw new Error("bundle config root exploded");
+      },
+      source: "test",
+      manifestPath,
+    } as unknown as PluginManifestRecord;
+
+    const loaded = loadEnabledBundleMcpConfig({
+      workspaceDir,
+      cfg: createEnabledBundleConfig(["poisoned-root", "bundle-probe"]),
+      manifestRegistry: {
+        plugins: [
+          poisonedFormatRecord,
+          poisonedRootRecord,
+          {
+            id: "bundle-probe",
+            origin: "global",
+            format: "bundle",
+            bundleFormat: "claude",
+            channels: [],
+            providers: [],
+            cliBackends: [],
+            skills: [],
+            hooks: [],
+            rootDir: await fs.realpath(pluginRoot),
+            source: "test",
+            manifestPath,
           },
         ],
       },


### PR DESCRIPTION
## Summary

- isolate unreadable manifest registry rows while loading enabled bundle config
- preserve existing bundle activation, config loading, merge, and diagnostic behavior for readable rows
- add a provided-registry MCP regression with poisoned bundle metadata before a healthy bundle row

## Verification

- `node scripts/run-vitest.mjs src/plugins/bundle-mcp.test.ts` failed pre-fix with `bundle config format exploded`
- `node scripts/run-vitest.mjs src/plugins/bundle-mcp.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/bundle-config-shared.ts src/plugins/bundle-mcp.test.ts`
- `./node_modules/.bin/oxlint src/plugins/bundle-config-shared.ts src/plugins/bundle-mcp.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before sync/lease because the Crabbox sparse-sync root had `892.0 MiB` free and requires `1.00 GiB`

## Real behavior proof

Behavior addressed: enabled bundle MCP/LSP config loading now skips unreadable plugin-owned manifest rows instead of aborting before later healthy bundle rows load.

Real environment tested: linked OpenClaw Codex worktree on branch `fuzz-tool-schema-next135-20260603`, rebased onto latest `origin/main`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/bundle-mcp.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/bundle-config-shared.ts src/plugins/bundle-mcp.test.ts`; `./node_modules/.bin/oxlint src/plugins/bundle-config-shared.ts src/plugins/bundle-mcp.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 1 file / 8 tests after rebase; formatting and lint checks passed; diff whitespace check passed; branch autoreview reported no accepted/actionable findings and `overall: patch is correct (0.83)`.

Observed result after fix: provided bundle registries with poisoned `format` and `rootDir` rows still load the later healthy `bundle-probe` MCP server.

What was not tested: full `pnpm check:changed`; the required Crabbox/Testbox broad gate could not start because local disk was below the Crabbox sparse-sync preflight minimum.
