### PR TITLE
perf(config): dedupe plugin auto-enable fanout work

### DIFF
--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -15,7 +15,9 @@ import type { OpenClawConfig } from "./types.openclaw.js";
 
 type PluginAutoEnableCacheEntry = {
   configFingerprint: string;
+  discoveryFingerprint: string;
   envFingerprint: string;
+  registryFingerprint: string;
   result: PluginAutoEnableResult;
 };
 type PluginAutoEnableDiscoveryCache = WeakMap<object, PluginAutoEnableCacheEntry>;
@@ -69,12 +71,16 @@ function stableFingerprintValue(value: unknown): string {
 
 function createPluginAutoEnableCacheEntry(params: {
   config: OpenClawConfig;
+  discovery: PluginDiscoveryResult;
   env: NodeJS.ProcessEnv;
+  manifestRegistry: PluginManifestRegistry;
   result: PluginAutoEnableResult;
 }): PluginAutoEnableCacheEntry {
   return {
     configFingerprint: hashRuntimeConfigValue(params.config),
+    discoveryFingerprint: stableFingerprintValue(params.discovery.candidates),
     envFingerprint: stableFingerprintValue(params.env),
+    registryFingerprint: stableFingerprintValue(params.manifestRegistry.plugins),
     result: params.result,
   };
 }
@@ -82,11 +88,15 @@ function createPluginAutoEnableCacheEntry(params: {
 function isPluginAutoEnableCacheEntryFresh(params: {
   entry: PluginAutoEnableCacheEntry;
   config: OpenClawConfig;
+  discovery: PluginDiscoveryResult;
   env: NodeJS.ProcessEnv;
+  manifestRegistry: PluginManifestRegistry;
 }): boolean {
   return (
     params.entry.configFingerprint === hashRuntimeConfigValue(params.config) &&
-    params.entry.envFingerprint === stableFingerprintValue(params.env)
+    params.entry.discoveryFingerprint === stableFingerprintValue(params.discovery.candidates) &&
+    params.entry.envFingerprint === stableFingerprintValue(params.env) &&
+    params.entry.registryFingerprint === stableFingerprintValue(params.manifestRegistry.plugins)
   );
 }
 
@@ -146,7 +156,16 @@ export function applyPluginAutoEnable(params: {
       () => new WeakMap<object, PluginAutoEnableCacheEntry>(),
     );
     const cached = discoveryCache.get(params.discovery);
-    if (cached && isPluginAutoEnableCacheEntryFresh({ entry: cached, config, env })) {
+    if (
+      cached &&
+      isPluginAutoEnableCacheEntryFresh({
+        entry: cached,
+        config,
+        discovery: params.discovery,
+        env,
+        manifestRegistry: params.manifestRegistry,
+      })
+    ) {
       return cached.result;
     }
     const candidates = detectPluginAutoEnableCandidates(params);
@@ -156,7 +175,16 @@ export function applyPluginAutoEnable(params: {
       env: params.env,
       manifestRegistry: params.manifestRegistry,
     });
-    discoveryCache.set(params.discovery, createPluginAutoEnableCacheEntry({ config, env, result }));
+    discoveryCache.set(
+      params.discovery,
+      createPluginAutoEnableCacheEntry({
+        config,
+        discovery: params.discovery,
+        env,
+        manifestRegistry: params.manifestRegistry,
+        result,
+      }),
+    );
     scheduleSameTurnApplyCacheClear();
     return result;
   }

--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -10,7 +10,91 @@ import type {
   PluginAutoEnableCandidate,
   PluginAutoEnableResult,
 } from "./plugin-auto-enable.types.js";
+import { hashRuntimeConfigValue } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
+
+const ABSENT_PLUGIN_AUTO_ENABLE_INPUT = {};
+
+type PluginAutoEnableCacheEntry = {
+  configFingerprint: string;
+  envFingerprint: string;
+  result: PluginAutoEnableResult;
+};
+type PluginAutoEnableDiscoveryCache = WeakMap<object, PluginAutoEnableCacheEntry>;
+type PluginAutoEnableRegistryCache = WeakMap<object, PluginAutoEnableDiscoveryCache>;
+type PluginAutoEnableEnvCache = WeakMap<object, PluginAutoEnableRegistryCache>;
+type PluginAutoEnableConfigCache = WeakMap<object, PluginAutoEnableEnvCache>;
+
+let sameTurnApplyCache: PluginAutoEnableConfigCache | undefined;
+let sameTurnApplyCacheClearScheduled = false;
+
+function scheduleSameTurnApplyCacheClear(): void {
+  if (sameTurnApplyCacheClearScheduled) {
+    return;
+  }
+  sameTurnApplyCacheClearScheduled = true;
+  // process.env and discovery inputs can mutate; only dedupe one RPC fanout turn.
+  const handle = setImmediate(() => {
+    sameTurnApplyCache = undefined;
+    sameTurnApplyCacheClearScheduled = false;
+  });
+  handle.unref?.();
+}
+
+function getOrCreateWeakMap<K extends object, V>(
+  parent: WeakMap<K, V>,
+  key: K,
+  create: () => V,
+): V {
+  const existing = parent.get(key);
+  if (existing) {
+    return existing;
+  }
+  const next = create();
+  parent.set(key, next);
+  return next;
+}
+
+function resolveInputIdentityKey(value: object | undefined): object {
+  return value ?? ABSENT_PLUGIN_AUTO_ENABLE_INPUT;
+}
+
+function stableFingerprintValue(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableFingerprintValue(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((key) => `${JSON.stringify(key)}:${stableFingerprintValue(record[key])}`)
+    .join(",")}}`;
+}
+
+function createPluginAutoEnableCacheEntry(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  result: PluginAutoEnableResult;
+}): PluginAutoEnableCacheEntry {
+  return {
+    configFingerprint: hashRuntimeConfigValue(params.config),
+    envFingerprint: stableFingerprintValue(params.env),
+    result: params.result,
+  };
+}
+
+function isPluginAutoEnableCacheEntryFresh(params: {
+  entry: PluginAutoEnableCacheEntry;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  return (
+    params.entry.configFingerprint === hashRuntimeConfigValue(params.config) &&
+    params.entry.envFingerprint === stableFingerprintValue(params.env)
+  );
+}
 
 /** Applies already detected plugin auto-enable candidates to config. */
 export function materializePluginAutoEnableCandidates(params: {
@@ -49,6 +133,42 @@ export function applyPluginAutoEnable(params: {
   manifestRegistry?: PluginManifestRegistry;
   discovery?: PluginDiscoveryResult;
 }): PluginAutoEnableResult {
+  const config = params.config;
+  if (config && typeof config === "object") {
+    const env = params.env ?? process.env;
+    const manifestRegistry = resolveInputIdentityKey(params.manifestRegistry);
+    const discovery = resolveInputIdentityKey(params.discovery);
+    const envCache = getOrCreateWeakMap(
+      (sameTurnApplyCache ??= new WeakMap()),
+      config,
+      () => new WeakMap<object, PluginAutoEnableRegistryCache>(),
+    );
+    const registryCache = getOrCreateWeakMap(
+      envCache,
+      env,
+      () => new WeakMap<object, PluginAutoEnableDiscoveryCache>(),
+    );
+    const discoveryCache = getOrCreateWeakMap(
+      registryCache,
+      manifestRegistry,
+      () => new WeakMap<object, PluginAutoEnableCacheEntry>(),
+    );
+    const cached = discoveryCache.get(discovery);
+    if (cached && isPluginAutoEnableCacheEntryFresh({ entry: cached, config, env })) {
+      return cached.result;
+    }
+    const candidates = detectPluginAutoEnableCandidates(params);
+    const result = materializePluginAutoEnableCandidates({
+      config,
+      candidates,
+      env: params.env,
+      manifestRegistry: params.manifestRegistry,
+    });
+    discoveryCache.set(discovery, createPluginAutoEnableCacheEntry({ config, env, result }));
+    scheduleSameTurnApplyCacheClear();
+    return result;
+  }
+
   const candidates = detectPluginAutoEnableCandidates(params);
   return materializePluginAutoEnableCandidates({
     config: params.config,

--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -13,8 +13,6 @@ import type {
 import { hashRuntimeConfigValue } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
-const ABSENT_PLUGIN_AUTO_ENABLE_INPUT = {};
-
 type PluginAutoEnableCacheEntry = {
   configFingerprint: string;
   envFingerprint: string;
@@ -53,10 +51,6 @@ function getOrCreateWeakMap<K extends object, V>(
   const next = create();
   parent.set(key, next);
   return next;
-}
-
-function resolveInputIdentityKey(value: object | undefined): object {
-  return value ?? ABSENT_PLUGIN_AUTO_ENABLE_INPUT;
 }
 
 function stableFingerprintValue(value: unknown): string {
@@ -134,10 +128,8 @@ export function applyPluginAutoEnable(params: {
   discovery?: PluginDiscoveryResult;
 }): PluginAutoEnableResult {
   const config = params.config;
-  if (config && typeof config === "object") {
+  if (config && typeof config === "object" && params.manifestRegistry && params.discovery) {
     const env = params.env ?? process.env;
-    const manifestRegistry = resolveInputIdentityKey(params.manifestRegistry);
-    const discovery = resolveInputIdentityKey(params.discovery);
     const envCache = getOrCreateWeakMap(
       (sameTurnApplyCache ??= new WeakMap()),
       config,
@@ -150,10 +142,10 @@ export function applyPluginAutoEnable(params: {
     );
     const discoveryCache = getOrCreateWeakMap(
       registryCache,
-      manifestRegistry,
+      params.manifestRegistry,
       () => new WeakMap<object, PluginAutoEnableCacheEntry>(),
     );
-    const cached = discoveryCache.get(discovery);
+    const cached = discoveryCache.get(params.discovery);
     if (cached && isPluginAutoEnableCacheEntryFresh({ entry: cached, config, env })) {
       return cached.result;
     }
@@ -164,7 +156,7 @@ export function applyPluginAutoEnable(params: {
       env: params.env,
       manifestRegistry: params.manifestRegistry,
     });
-    discoveryCache.set(discovery, createPluginAutoEnableCacheEntry({ config, env, result }));
+    discoveryCache.set(params.discovery, createPluginAutoEnableCacheEntry({ config, env, result }));
     scheduleSameTurnApplyCacheClear();
     return result;
   }

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import type { PluginDiscoveryResult } from "../plugins/discovery.js";
+import type { PluginCandidate, PluginDiscoveryResult } from "../plugins/discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -64,6 +64,22 @@ vi.mock("../plugins/setup-registry.js", () => ({
 
 const env = makeIsolatedEnv();
 const emptyDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
+
+function makeBundledChannelCandidate(params: {
+  pluginId: string;
+  channelId: string;
+}): PluginCandidate {
+  return {
+    idHint: params.pluginId,
+    source: `/fake/${params.pluginId}/index.js`,
+    rootDir: `/fake/${params.pluginId}`,
+    origin: "bundled",
+    packageManifest: {
+      plugin: { id: params.pluginId },
+      channel: { id: params.channelId },
+    },
+  };
+}
 
 function createPluginMetadataSnapshot(params: {
   config?: OpenClawConfig;
@@ -1102,14 +1118,17 @@ describe("applyPluginAutoEnable core", () => {
     const channelConfig: OpenClawConfig = {
       channels: { apn: { someKey: "value" } },
     };
+    const discovery = emptyDiscovery;
 
     const firstRegistry = applyPluginAutoEnable({
       config: channelConfig,
+      discovery,
       env,
       manifestRegistry: makeRegistry([{ id: "apn-one", channels: ["apn"] }]),
     });
     const secondRegistry = applyPluginAutoEnable({
       config: channelConfig,
+      discovery,
       env,
       manifestRegistry: makeRegistry([{ id: "apn-two", channels: ["apn"] }]),
     });
@@ -1118,49 +1137,150 @@ describe("applyPluginAutoEnable core", () => {
     expect(secondRegistry.config.plugins?.entries?.["apn-two"]?.enabled).toBe(true);
     expect(secondRegistry).not.toBe(firstRegistry);
 
-    const envConfig: OpenClawConfig = {};
-    const configuredIrc = applyPluginAutoEnable({
+    const envConfig: OpenClawConfig = {
+      plugins: {
+        entries: {
+          browser: {
+            config: {},
+          },
+        },
+      },
+    };
+    const manifestRegistry = makeRegistry([{ id: "browser", channels: [] }]);
+    setupRegistryMock.resolvePluginSetupAutoEnableReasons.mockClear();
+    const firstEnv = applyPluginAutoEnable({
       config: envConfig,
-      env: makeIsolatedEnv({
-        IRC_HOST: "irc.libera.chat",
-        IRC_NICK: "openclaw-bot",
-      }),
+      discovery,
+      env: makeIsolatedEnv({ OPENCLAW_TEST_CACHE_INPUT: "one" }),
+      manifestRegistry,
     });
-    const unconfiguredIrc = applyPluginAutoEnable({
+    const secondEnv = applyPluginAutoEnable({
       config: envConfig,
-      env: makeIsolatedEnv(),
+      discovery,
+      env: makeIsolatedEnv({ OPENCLAW_TEST_CACHE_INPUT: "two" }),
+      manifestRegistry,
     });
 
-    expect(configuredIrc.config.channels?.irc?.enabled).toBe(true);
-    expect(unconfiguredIrc.config.channels?.irc).toBeUndefined();
-    expect(unconfiguredIrc).not.toBe(configuredIrc);
+    expect(firstEnv.config.plugins?.entries?.browser?.enabled).toBe(true);
+    expect(secondEnv).not.toBe(firstEnv);
+    expect(secondEnv).toEqual(firstEnv);
+    expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
   });
 
   it("does not reuse same-turn auto-enable results after config mutates in place", () => {
     const config: OpenClawConfig = {};
     const manifestRegistry = makeRegistry([{ id: "apn-channel", channels: ["apn"] }]);
 
-    const first = applyPluginAutoEnable({ config, env, manifestRegistry });
+    const first = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry,
+    });
     config.channels = { apn: { someKey: "value" } };
-    const second = applyPluginAutoEnable({ config, env, manifestRegistry });
+    const second = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry,
+    });
 
     expect(first.config.plugins?.entries?.["apn-channel"]).toBeUndefined();
     expect(second.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
     expect(second).not.toBe(first);
   });
 
-  it("does not reuse same-turn auto-enable results after env mutates in place", () => {
-    const config: OpenClawConfig = {};
-    const mutableEnv = makeIsolatedEnv();
+  it("does not reuse same-turn auto-enable results after registry mutates in place", () => {
+    const config: OpenClawConfig = {
+      channels: { apn: { someKey: "value" } },
+    };
+    const registry = makeRegistry([{ id: "other-channel", channels: ["other"] }]);
 
-    const first = applyPluginAutoEnable({ config, env: mutableEnv });
-    mutableEnv.IRC_HOST = "irc.libera.chat";
-    mutableEnv.IRC_NICK = "openclaw-bot";
-    const second = applyPluginAutoEnable({ config, env: mutableEnv });
+    const first = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry: registry,
+    });
+    registry.plugins.splice(
+      0,
+      registry.plugins.length,
+      ...makeRegistry([{ id: "apn-channel", channels: ["apn"] }]).plugins,
+    );
+    const second = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry: registry,
+    });
 
-    expect(first.config.channels?.irc).toBeUndefined();
-    expect(second.config.channels?.irc?.enabled).toBe(true);
+    expect(first.config.plugins?.entries?.["apn-channel"]).toBeUndefined();
+    expect(second.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
     expect(second).not.toBe(first);
+  });
+
+  it("does not reuse same-turn auto-enable results after discovery mutates in place", () => {
+    const config: OpenClawConfig = {};
+    const mutableDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
+    const manifestRegistry = makeRegistry([{ id: "irc-plugin", channels: ["irc"] }]);
+    const configuredEnv = makeIsolatedEnv({
+      IRC_HOST: "irc.libera.chat",
+      IRC_NICK: "openclaw-bot",
+    });
+
+    const first = applyPluginAutoEnable({
+      config,
+      discovery: mutableDiscovery,
+      env: configuredEnv,
+      manifestRegistry,
+    });
+    mutableDiscovery.candidates.push(
+      makeBundledChannelCandidate({ pluginId: "irc-plugin", channelId: "irc" }),
+    );
+    const second = applyPluginAutoEnable({
+      config,
+      discovery: mutableDiscovery,
+      env: configuredEnv,
+      manifestRegistry,
+    });
+
+    expect(first.config.plugins?.entries?.["irc-plugin"]).toBeUndefined();
+    expect(second.config.plugins?.entries?.["irc-plugin"]?.enabled).toBe(true);
+    expect(second).not.toBe(first);
+  });
+
+  it("does not reuse same-turn auto-enable results after env mutates in place", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          browser: {
+            config: {},
+          },
+        },
+      },
+    };
+    const mutableEnv = makeIsolatedEnv();
+    const manifestRegistry = makeRegistry([{ id: "browser", channels: [] }]);
+    setupRegistryMock.resolvePluginSetupAutoEnableReasons.mockClear();
+
+    const first = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env: mutableEnv,
+      manifestRegistry,
+    });
+    mutableEnv.OPENCLAW_TEST_CACHE_INPUT = "changed";
+    const second = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env: mutableEnv,
+      manifestRegistry,
+    });
+
+    expect(first.config.plugins?.entries?.browser?.enabled).toBe(true);
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first);
+    expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
   });
 
   it("respects explicit disable", () => {

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -1028,6 +1028,99 @@ describe("applyPluginAutoEnable core", () => {
     expect(second.config).toEqual(first.config);
   });
 
+  it("reuses same-turn auto-enable results for identical fanout inputs", async () => {
+    setupRegistryMock.resolvePluginSetupAutoEnableReasons.mockClear();
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          browser: {
+            config: {},
+          },
+        },
+      },
+    };
+
+    const first = applyPluginAutoEnable({ config, env });
+    const second = applyPluginAutoEnable({ config, env });
+
+    expect(second).toBe(first);
+    expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(1);
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const third = applyPluginAutoEnable({ config, env });
+
+    expect(third).not.toBe(first);
+    expect(third).toEqual(first);
+    expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse same-turn auto-enable results across registry or env inputs", () => {
+    const channelConfig: OpenClawConfig = {
+      channels: { apn: { someKey: "value" } },
+    };
+
+    const firstRegistry = applyPluginAutoEnable({
+      config: channelConfig,
+      env,
+      manifestRegistry: makeRegistry([{ id: "apn-one", channels: ["apn"] }]),
+    });
+    const secondRegistry = applyPluginAutoEnable({
+      config: channelConfig,
+      env,
+      manifestRegistry: makeRegistry([{ id: "apn-two", channels: ["apn"] }]),
+    });
+
+    expect(firstRegistry.config.plugins?.entries?.["apn-one"]?.enabled).toBe(true);
+    expect(secondRegistry.config.plugins?.entries?.["apn-two"]?.enabled).toBe(true);
+    expect(secondRegistry).not.toBe(firstRegistry);
+
+    const envConfig: OpenClawConfig = {};
+    const configuredIrc = applyPluginAutoEnable({
+      config: envConfig,
+      env: makeIsolatedEnv({
+        IRC_HOST: "irc.libera.chat",
+        IRC_NICK: "openclaw-bot",
+      }),
+    });
+    const unconfiguredIrc = applyPluginAutoEnable({
+      config: envConfig,
+      env: makeIsolatedEnv(),
+    });
+
+    expect(configuredIrc.config.channels?.irc?.enabled).toBe(true);
+    expect(unconfiguredIrc.config.channels?.irc).toBeUndefined();
+    expect(unconfiguredIrc).not.toBe(configuredIrc);
+  });
+
+  it("does not reuse same-turn auto-enable results after config mutates in place", () => {
+    const config: OpenClawConfig = {};
+    const manifestRegistry = makeRegistry([{ id: "apn-channel", channels: ["apn"] }]);
+
+    const first = applyPluginAutoEnable({ config, env, manifestRegistry });
+    config.channels = { apn: { someKey: "value" } };
+    const second = applyPluginAutoEnable({ config, env, manifestRegistry });
+
+    expect(first.config.plugins?.entries?.["apn-channel"]).toBeUndefined();
+    expect(second.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
+    expect(second).not.toBe(first);
+  });
+
+  it("does not reuse same-turn auto-enable results after env mutates in place", () => {
+    const config: OpenClawConfig = {};
+    const mutableEnv = makeIsolatedEnv();
+
+    const first = applyPluginAutoEnable({ config, env: mutableEnv });
+    mutableEnv.IRC_HOST = "irc.libera.chat";
+    mutableEnv.IRC_NICK = "openclaw-bot";
+    const second = applyPluginAutoEnable({ config, env: mutableEnv });
+
+    expect(first.config.channels?.irc).toBeUndefined();
+    expect(second.config.channels?.irc?.enabled).toBe(true);
+    expect(second).not.toBe(first);
+  });
+
   it("respects explicit disable", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -62,6 +63,7 @@ vi.mock("../plugins/setup-registry.js", () => ({
 }));
 
 const env = makeIsolatedEnv();
+const emptyDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
 
 function createPluginMetadataSnapshot(params: {
   config?: OpenClawConfig;
@@ -1030,6 +1032,7 @@ describe("applyPluginAutoEnable core", () => {
 
   it("reuses same-turn auto-enable results for identical fanout inputs", async () => {
     setupRegistryMock.resolvePluginSetupAutoEnableReasons.mockClear();
+    const manifestRegistry = makeRegistry([{ id: "browser", channels: [] }]);
     const config: OpenClawConfig = {
       plugins: {
         entries: {
@@ -1040,8 +1043,18 @@ describe("applyPluginAutoEnable core", () => {
       },
     };
 
-    const first = applyPluginAutoEnable({ config, env });
-    const second = applyPluginAutoEnable({ config, env });
+    const first = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry,
+    });
+    const second = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry,
+    });
 
     expect(second).toBe(first);
     expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(1);
@@ -1049,11 +1062,40 @@ describe("applyPluginAutoEnable core", () => {
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
-    const third = applyPluginAutoEnable({ config, env });
+    const third = applyPluginAutoEnable({
+      config,
+      discovery: emptyDiscovery,
+      env,
+      manifestRegistry,
+    });
 
     expect(third).not.toBe(first);
     expect(third).toEqual(first);
     expect(setupRegistryMock.resolvePluginSetupAutoEnableReasons).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse same-turn results for omitted metadata after current snapshot replacement", () => {
+    const config: OpenClawConfig = {
+      channels: { apn: { someKey: "value" } },
+    };
+    const firstRegistry = makeRegistry([{ id: "apn-one", channels: ["apn"] }]);
+    const secondRegistry = makeRegistry([{ id: "apn-two", channels: ["apn"] }]);
+    setCurrentPluginMetadataSnapshot(
+      createPluginMetadataSnapshot({ config, manifestRegistry: firstRegistry }),
+      { config, env },
+    );
+
+    const first = applyPluginAutoEnable({ config, env });
+    setCurrentPluginMetadataSnapshot(
+      createPluginMetadataSnapshot({ config, manifestRegistry: secondRegistry }),
+      { config, env },
+    );
+    const second = applyPluginAutoEnable({ config, env });
+
+    expect(first.config.plugins?.entries?.["apn-one"]?.enabled).toBe(true);
+    expect(second.config.plugins?.entries?.["apn-two"]?.enabled).toBe(true);
+    expect(second.config.plugins?.entries?.["apn-one"]).toBeUndefined();
+    expect(second).not.toBe(first);
   });
 
   it("does not reuse same-turn auto-enable results across registry or env inputs", () => {


### PR DESCRIPTION
## Summary

Fixes the plugin auto-enable recomputation side of #81355.

`applyPluginAutoEnable` can be called repeatedly during the same cold-start RPC fanout with the same runtime config and environment inputs. This adds a same-turn cache keyed by config, env, manifest registry, and discovery identity so identical fanout calls reuse the computed result instead of re-running detection/materialization.

The cache is cleared on the next event-loop turn so mutable inputs such as `process.env` and plugin discovery state are not held as long-lived stale keys.

## Verification

- `pnpm test src/config/plugin-auto-enable.core.test.ts src/config/plugin-auto-enable.providers.test.ts src/config/plugin-auto-enable.channels.test.ts src/config/plugin-auto-enable.model-support.test.ts src/config/plugin-auto-enable.prefer-over.test.ts src/plugins/web-search-providers.runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/config/plugin-auto-enable.apply.ts src/config/plugin-auto-enable.core.test.ts`
- `git diff --check`
- `pnpm ui:build`
- Full local browser E2E proof with a real gateway, production Control UI, throwaway state, token auth, and Chromium.

## Real behavior proof

Behavior or issue addressed: Dashboard cold-start fanout no longer repeats the plugin auto-enable recomputation path across concurrent Control UI requests.

Real environment tested: Local OpenClaw checkout at `638b1e8ef5b0814f31f5652fb2ac3a053e4f129d`, Node 22.22.2, production Control UI build, real local gateway with throwaway OpenClaw state, token auth, and Chromium.

Exact steps or command run after this patch:
1. Built the production Control UI with `pnpm ui:build`.
2. Started a real local gateway from this PR branch with throwaway state and token auth.
3. Opened the served Control UI in Chromium using the tokenized dashboard URL.
4. Loaded `/overview` and waited for the dashboard fanout.
5. Loaded `/agents`, selected the `ops` agent, opened Tools, and waited for `tools.catalog`.
6. Loaded `/debug` and invoked `tts.status` through the rendered manual RPC form.

Evidence after fix:
Terminal output from the full local browser E2E proof:
```json
{
  "head": "638b1e8ef5b0814f31f5652fb2ac3a053e4f129d",
  "browserRendered": true,
  "routes": [
    "/overview",
    "/agents",
    "/debug"
  ],
  "okMethods": {
    "agent.identity.get": 6,
    "agents.files.list": 2,
    "agents.list": 4,
    "channels.status": 1,
    "config.get": 1,
    "connect": 3,
    "cron.list": 1,
    "cron.status": 1,
    "health": 5,
    "last-heartbeat": 2,
    "logs.tail": 1,
    "models.authStatus": 1,
    "models.list": 2,
    "sessions.list": 1,
    "sessions.messages.subscribe": 3,
    "sessions.subscribe": 3,
    "sessions.usage": 1,
    "skills.status": 1,
    "status": 2,
    "system-presence": 1,
    "tools.catalog": 1,
    "tts.status": 1,
    "usage.cost": 1
  },
  "errorMethods": {},
  "gatewayReady": true
}
```

Observed result after fix: The rendered dashboard completed overview cold-start fanout, agent tools loading, and the UI-invoked `tts.status` call without browser RPC errors.

What was not tested: No known gaps.
