### PR TITLE
fix(config): isolate provider auto-enable rows

### DIFF
--- a/src/config/plugin-auto-enable.providers.test.ts
+++ b/src/config/plugin-auto-enable.providers.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import {
   applyPluginAutoEnable,
   materializePluginAutoEnableCandidates,
@@ -305,6 +306,43 @@ describe("applyPluginAutoEnable providers", () => {
     });
 
     expect(result.config.plugins?.entries?.acme?.enabled).toBe(true);
+  });
+
+  it("skips unreadable provider auto-enable manifest rows", () => {
+    const poisonedRecord = {
+      id: "poisoned-provider-auto-enable",
+      get autoEnableWhenConfiguredProviders() {
+        throw new Error("provider auto-enable metadata exploded");
+      },
+    } as unknown as PluginManifestRecord;
+    const healthyRegistry = makeRegistry([
+      {
+        id: "acme",
+        channels: [],
+        autoEnableWhenConfiguredProviders: ["acme-oauth"],
+      },
+    ]);
+
+    const result = applyPluginAutoEnable({
+      config: {
+        auth: {
+          profiles: {
+            "acme-oauth:default": {
+              provider: "acme-oauth",
+              mode: "oauth",
+            },
+          },
+        },
+      },
+      env,
+      manifestRegistry: {
+        plugins: [poisonedRecord, ...healthyRegistry.plugins],
+        diagnostics: [],
+      },
+    });
+
+    expect(result.config.plugins?.entries?.acme?.enabled).toBe(true);
+    expect(result.changes).toContain("acme-oauth auth configured, enabled automatically.");
   });
 
   it("auto-enables third-party provider plugins when manifest-owned web search config exists", () => {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -44,9 +44,19 @@ function resolveAutoEnableProviderPluginIds(
 ): Readonly<Record<string, string>> {
   const entries = new Map<string, string>();
   for (const plugin of registry.plugins) {
-    for (const providerId of plugin.autoEnableWhenConfiguredProviders ?? []) {
+    let providerIds: readonly string[];
+    let pluginId: string;
+    try {
+      providerIds = plugin.autoEnableWhenConfiguredProviders ?? [];
+      pluginId = plugin.id;
+    } catch {
+      // Provider auto-enable metadata is plugin-owned. One unreadable row must
+      // not block configured auth from enabling unrelated provider plugins.
+      continue;
+    }
+    for (const providerId of providerIds) {
       if (!entries.has(providerId)) {
-        entries.set(providerId, plugin.id);
+        entries.set(providerId, pluginId);
       }
     }
   }


### PR DESCRIPTION
## Summary

- isolate unreadable provider auto-enable manifest rows
- preserve first-owner wins behavior for readable provider auto-enable metadata
- add a provider auth auto-enable regression with a poisoned manifest row before a healthy provider plugin row

## Verification

- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.providers.test.ts` failed pre-fix with `provider auto-enable metadata exploded`
- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.providers.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.providers.test.ts`
- `./node_modules/.bin/oxlint src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.providers.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before sync/lease because the Crabbox sparse-sync root had `798.9 MiB` free and requires `1.00 GiB`

## Real behavior proof

Behavior addressed: provider auth auto-enable candidate detection now skips unreadable plugin-owned provider metadata rows instead of aborting before later healthy provider plugins are considered.

Real environment tested: linked OpenClaw Codex worktree on branch `fuzz-tool-schema-next136-20260603`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/plugin-auto-enable.providers.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.providers.test.ts`; `./node_modules/.bin/oxlint src/config/plugin-auto-enable.shared.ts src/config/plugin-auto-enable.providers.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 1 file / 15 tests; formatting and lint checks passed; diff whitespace check passed; branch autoreview reported no accepted/actionable findings and `overall: patch is correct (0.82)`.

Observed result after fix: a provided registry with a poisoned `autoEnableWhenConfiguredProviders` row still auto-enables the later healthy `acme` provider plugin from configured auth.

What was not tested: full `pnpm check:changed`; the required Crabbox/Testbox broad gate could not start because local disk was below the Crabbox sparse-sync preflight minimum.
