### PR TITLE
fix(trajectory): isolate manifest metadata rows

### DIFF
--- a/src/trajectory/metadata.test.ts
+++ b/src/trajectory/metadata.test.ts
@@ -4,6 +4,7 @@ import {
   redactPathForSupport,
   type SupportRedactionContext,
 } from "../logging/diagnostic-support-redaction.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import type { SkillSnapshot } from "../skills/types.js";
@@ -181,6 +182,53 @@ describe("trajectory metadata", () => {
     expect(plugins.entries?.map((entry) => entry.id)).toEqual(["demo-plugin"]);
     expect(skills.entries?.[0]?.id).toBe("weather");
     expect(skills.entries?.[0]?.filePath).toBe("/tmp/workspace/skills/weather/SKILL.md");
+  });
+
+  it("skips unreadable manifest rows while capturing plugin support metadata", () => {
+    const poisonedRecord = {
+      get id() {
+        throw new Error("trajectory manifest id exploded");
+      },
+    } as unknown as PluginManifestRecord;
+    loadPluginManifestRegistry.mockReturnValueOnce({
+      plugins: [
+        poisonedRecord,
+        {
+          id: "healthy-plugin",
+          name: "Healthy Plugin",
+          channels: ["healthy-channel"],
+          providers: [],
+          cliBackends: [],
+          hooks: [],
+          skills: [],
+          origin: "config",
+          rootDir: "/plugins/healthy",
+          source: "/plugins/healthy/openclaw.plugin.json",
+          manifestPath: "/plugins/healthy/openclaw.plugin.json",
+        },
+      ],
+    });
+
+    const metadata = buildTrajectoryRunMetadata({
+      workspaceDir: "/tmp/workspace",
+      sessionFile: "/tmp/workspace/session.jsonl",
+      timeoutMs: 30_000,
+    });
+
+    const plugins = metadata.plugins as {
+      source?: string;
+      entries?: Array<{ id: string; channels?: string[] }>;
+    };
+    expect(plugins.source).toBe("manifest-registry");
+    expect(plugins.entries?.map((entry) => entry.id)).toEqual(["healthy-plugin"]);
+    expect(plugins.entries?.[0]).toMatchObject({
+      id: "healthy-plugin",
+      name: "Healthy Plugin",
+      origin: "config",
+      source: "/plugins/healthy/openclaw.plugin.json",
+      rootDir: "/plugins/healthy",
+      channels: ["healthy-channel"],
+    });
   });
 
   it("tolerates skill snapshot entries with missing name/paths (symlink-escape rejects)", () => {

--- a/src/trajectory/metadata.ts
+++ b/src/trajectory/metadata.ts
@@ -146,26 +146,36 @@ function buildPluginsFromManifest(params: {
   return {
     source: "manifest-registry",
     entries: snapshot.plugins
-      .map((plugin) => ({
-        id: plugin.id,
-        name: plugin.name,
-        version: plugin.version,
-        description: plugin.description,
-        origin: plugin.origin,
-        enabledByDefault: plugin.enabledByDefault,
-        format: plugin.format,
-        bundleFormat: plugin.bundleFormat,
-        bundleCapabilities: toSortedUniqueStrings(plugin.bundleCapabilities),
-        kind: plugin.kind,
-        source: plugin.source,
-        rootDir: plugin.rootDir,
-        workspaceDir: plugin.workspaceDir,
-        channels: toSortedUniqueStrings(plugin.channels),
-        providers: toSortedUniqueStrings(plugin.providers),
-        cliBackends: toSortedUniqueStrings(plugin.cliBackends),
-        hooks: toSortedUniqueStrings(plugin.hooks),
-        skills: toSortedUniqueStrings(plugin.skills),
-      }))
+      .flatMap((plugin) => {
+        try {
+          return [
+            {
+              id: plugin.id,
+              name: plugin.name,
+              version: plugin.version,
+              description: plugin.description,
+              origin: plugin.origin,
+              enabledByDefault: plugin.enabledByDefault,
+              format: plugin.format,
+              bundleFormat: plugin.bundleFormat,
+              bundleCapabilities: toSortedUniqueStrings(plugin.bundleCapabilities),
+              kind: plugin.kind,
+              source: plugin.source,
+              rootDir: plugin.rootDir,
+              workspaceDir: plugin.workspaceDir,
+              channels: toSortedUniqueStrings(plugin.channels),
+              providers: toSortedUniqueStrings(plugin.providers),
+              cliBackends: toSortedUniqueStrings(plugin.cliBackends),
+              hooks: toSortedUniqueStrings(plugin.hooks),
+              skills: toSortedUniqueStrings(plugin.skills),
+            },
+          ];
+        } catch {
+          // Support metadata is diagnostic-only. One unreadable manifest row
+          // must not break trajectory capture for the rest of the run.
+          return [];
+        }
+      })
       .toSorted((left, right) => left.id.localeCompare(right.id)),
   };
 }


### PR DESCRIPTION
## Summary

- isolate unreadable manifest snapshot rows while building trajectory support metadata
- preserve sorted plugin support metadata for healthy rows
- add a trajectory metadata regression with a poisoned manifest row before a healthy plugin row

## Verification

- `node scripts/run-vitest.mjs src/trajectory/metadata.test.ts` failed pre-fix with `trajectory manifest id exploded`
- `node scripts/run-vitest.mjs src/trajectory/metadata.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/metadata.ts src/trajectory/metadata.test.ts`
- `./node_modules/.bin/oxlint src/trajectory/metadata.ts src/trajectory/metadata.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` failed before sync/lease because the Crabbox sparse-sync root had `746.0 MiB` free and requires `1.00 GiB`

## Real behavior proof

Behavior addressed: trajectory run metadata capture now skips unreadable plugin manifest rows instead of aborting support metadata capture for the whole run.

Real environment tested: linked OpenClaw Codex worktree on branch `fuzz-tool-schema-next137-20260603`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/trajectory/metadata.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/metadata.ts src/trajectory/metadata.test.ts`; `./node_modules/.bin/oxlint src/trajectory/metadata.ts src/trajectory/metadata.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 1 file / 7 tests; formatting and lint checks passed; diff whitespace check passed; branch autoreview reported no accepted/actionable findings and `overall: patch is correct (0.84)`.

Observed result after fix: a manifest snapshot with a poisoned `id` getter still records the later healthy plugin in `metadata.plugins`.

What was not tested: full `pnpm check:changed`; the required Crabbox/Testbox broad gate could not start because local disk was below the Crabbox sparse-sync preflight minimum.
