### PR TITLE
fix(agents): use appropriate log levels in tools-manager and resource-loader

### DIFF
--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -61,7 +61,7 @@ function resolvePromptInput(input: string | undefined, description: string): str
     try {
       return readFileSync(input, "utf-8");
     } catch (error) {
-      console.error(
+      console.warn(
         chalk.yellow(`Warning: Could not read ${description} file ${input}: ${String(error)}`),
       );
       return input;
@@ -82,7 +82,7 @@ function loadContextFileFromDir(dir: string): { path: string; content: string } 
           content: readFileSync(filePath, "utf-8"),
         };
       } catch (error) {
-        console.error(chalk.yellow(`Warning: Could not read ${filePath}: ${String(error)}`));
+        console.warn(chalk.yellow(`Warning: Could not read ${filePath}: ${String(error)}`));
       }
     }
   }

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -399,7 +399,7 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
 
   if (isOfflineModeEnabled()) {
     if (!silent) {
-      console.log(
+      console.warn(
         chalk.yellow(`${config.name} not found. Offline mode enabled, skipping download.`),
       );
     }
@@ -411,25 +411,25 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
   if (platform() === "android") {
     const pkgName = TERMUX_PACKAGES[tool] ?? tool;
     if (!silent) {
-      console.log(chalk.yellow(`${config.name} not found. Install with: pkg install ${pkgName}`));
+      console.warn(chalk.yellow(`${config.name} not found. Install with: pkg install ${pkgName}`));
     }
     return undefined;
   }
 
   // Tool not found - download it
   if (!silent) {
-    console.log(chalk.dim(`${config.name} not found. Downloading...`));
+    console.info(chalk.dim(`${config.name} not found. Downloading...`));
   }
 
   try {
     const path = await downloadTool(tool);
     if (!silent) {
-      console.log(chalk.dim(`${config.name} installed to ${path}`));
+      console.info(chalk.dim(`${config.name} installed to ${path}`));
     }
     return path;
   } catch (e) {
     if (!silent) {
-      console.log(
+      console.warn(
         chalk.yellow(
           `Failed to download ${config.name}: ${e instanceof Error ? e.message : String(e)}`,
         ),


### PR DESCRIPTION
## Summary

Aligns log level usage with message severity in two agent utility files.

## Changes

### `src/agents/utils/tools-manager.ts`
- `console.log` → `console.warn` for user-actionable warnings:
  - Offline mode enabled (tool skipped)
  - Android/Termux package install hint
  - Download failure
- `console.log` → `console.info` for informational progress messages:
  - "Downloading..." progress
  - "installed to ..." success

### `src/agents/sessions/resource-loader.ts`
- `console.error` → `console.warn` for recoverable file-read failures (missing `AGENTS.md`/`CLAUDE.md` context files, prompt input files)

## Rationale

The previous log levels were inconsistent with the actual severity of these events:
- `console.error` for a missing context file (which is silently tolerated by falling back gracefully) overstates the severity
- `console.log` for download failure warnings loses distinction from normal operational output
- `console.log` for download progress is correct as `console.info` makes the intent clearer

## Testing

TypeScript syntax validation passed. No functional behavior change — purely log-level adjustment.