### PR TITLE
fix(agents): isolate provider attribution manifest rows

### DIFF
--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -11,7 +11,7 @@ function expectRecordFields(record: unknown, expected: Record<string, unknown>) 
   return actual;
 }
 
-const providerEndpointPlugins = vi.hoisted(() => [
+const providerEndpointPlugins = vi.hoisted((): Record<string, unknown>[] => [
   {
     providerEndpoints: [
       { endpointClass: "openai-public", hosts: ["api.openai.com"] },
@@ -56,6 +56,15 @@ const providerEndpointPlugins = vi.hoisted(() => [
         hosts: ["api.x.ai"],
       },
       {
+        endpointClass: "xiaomi-native",
+        hosts: [
+          "api.xiaomimimo.com",
+          "token-plan-ams.xiaomimimo.com",
+          "token-plan-cn.xiaomimimo.com",
+          "token-plan-sgp.xiaomimimo.com",
+        ],
+      },
+      {
         endpointClass: "nvidia-native",
         hosts: ["integrate.api.nvidia.com"],
         baseUrls: ["https://integrate.api.nvidia.com/v1"],
@@ -84,11 +93,13 @@ const providerEndpointPlugins = vi.hoisted(() => [
   },
 ]);
 
-vi.mock("../plugins/plugin-registry.js", () => ({
-  loadPluginManifestRegistryForPluginRegistry: () => ({
-    plugins: providerEndpointPlugins,
-    diagnostics: [],
-  }),
+vi.mock("../plugins/manifest-metadata-scan.js", () => ({
+  listOpenClawPluginManifestMetadata: () =>
+    providerEndpointPlugins.map((manifest, index) => ({
+      pluginDir: `/plugins/provider-attribution-${index}`,
+      manifest,
+      origin: "bundled",
+    })),
 }));
 
 import {
@@ -257,6 +268,54 @@ describe("provider attribution", () => {
       ["mistral", false, "vendor-sdk-hook-only", "custom-user-agent"],
       ["together", false, "vendor-sdk-hook-only", "default-headers"],
     ]);
+  });
+
+  it("skips unreadable manifest provider endpoint rows while preserving healthy rows", () => {
+    const poisonedManifest: Record<string, unknown> = {};
+    Object.defineProperty(poisonedManifest, "providerEndpoints", {
+      get() {
+        throw new Error("provider endpoint manifest getter exploded");
+      },
+    });
+
+    providerEndpointPlugins.unshift(poisonedManifest);
+    try {
+      expectRecordFields(resolveProviderEndpoint("https://api.openai.com/v1"), {
+        endpointClass: "openai-public",
+        hostname: "api.openai.com",
+      });
+    } finally {
+      providerEndpointPlugins.shift();
+    }
+  });
+
+  it("skips unreadable manifest provider request rows while preserving healthy rows", () => {
+    const poisonedManifest: Record<string, unknown> = {};
+    Object.defineProperty(poisonedManifest, "providerRequest", {
+      get() {
+        throw new Error("provider request manifest getter exploded");
+      },
+    });
+
+    providerEndpointPlugins.unshift(poisonedManifest);
+    try {
+      expectRecordFields(
+        resolveProviderRequestCapabilities({
+          provider: "moonshot",
+          api: "openai-completions",
+          baseUrl: "https://api.moonshot.ai/v1",
+          capability: "llm",
+          transport: "stream",
+        }),
+        {
+          endpointClass: "moonshot-native",
+          knownProviderFamily: "moonshot",
+          compatibilityFamily: "moonshot",
+        },
+      );
+    } finally {
+      providerEndpointPlugins.shift();
+    }
   });
 
   it("authorizes hidden xAI attribution on api.x.ai and the default xAI route", () => {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -175,6 +175,32 @@ type ManifestProviderRequestCacheEntry = {
 let manifestProviderEndpointCache: ManifestProviderEndpointCacheEntry[] | null = null;
 let manifestProviderRequestCache: Map<string, ManifestProviderRequestCacheEntry> | null = null;
 
+function tryReadRecordValue(record: Record<string, unknown>, key: string): unknown {
+  try {
+    return record[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function tryReadObjectEntryValues(record: Record<string, unknown>): Array<[string, unknown]> {
+  let keys: string[];
+  try {
+    keys = Object.keys(record);
+  } catch {
+    return [];
+  }
+  const entries: Array<[string, unknown]> = [];
+  for (const key of keys) {
+    try {
+      entries.push([key, record[key]]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
 function formatOpenClawUserAgent(version: string): string {
   return `${OPENCLAW_ATTRIBUTION_ORIGINATOR}/${version}`;
 }
@@ -236,38 +262,47 @@ function isManifestProviderEndpointClass(value: string): value is ProviderEndpoi
 function readManifestProviderEndpoints(
   manifest: Record<string, unknown>,
 ): ManifestProviderEndpointCacheEntry[] {
-  if (!Array.isArray(manifest.providerEndpoints)) {
+  const providerEndpoints = tryReadRecordValue(manifest, "providerEndpoints");
+  if (!Array.isArray(providerEndpoints)) {
     return [];
   }
   const entries: ManifestProviderEndpointCacheEntry[] = [];
-  for (const rawEndpoint of manifest.providerEndpoints) {
-    if (!isRecord(rawEndpoint)) {
+  for (const rawEndpoint of providerEndpoints) {
+    try {
+      if (!isRecord(rawEndpoint)) {
+        continue;
+      }
+      const endpointClassRaw = normalizeOptionalString(
+        tryReadRecordValue(rawEndpoint, "endpointClass"),
+      );
+      if (!endpointClassRaw || !isManifestProviderEndpointClass(endpointClassRaw)) {
+        continue;
+      }
+      const googleVertexRegion = normalizeOptionalString(
+        tryReadRecordValue(rawEndpoint, "googleVertexRegion"),
+      );
+      const googleVertexRegionHostSuffix = normalizeOptionalString(
+        tryReadRecordValue(rawEndpoint, "googleVertexRegionHostSuffix"),
+      );
+      entries.push({
+        endpointClass: endpointClassRaw,
+        hosts: normalizeTrimmedStringList(tryReadRecordValue(rawEndpoint, "hosts")).map((host) =>
+          host.toLowerCase(),
+        ),
+        hostSuffixes: normalizeTrimmedStringList(
+          tryReadRecordValue(rawEndpoint, "hostSuffixes"),
+        ).map((host) => host.toLowerCase()),
+        normalizedBaseUrls: normalizeTrimmedStringList(tryReadRecordValue(rawEndpoint, "baseUrls"))
+          .map((baseUrl) => normalizeComparableBaseUrl(baseUrl))
+          .filter((baseUrl): baseUrl is string => baseUrl !== undefined),
+        ...(googleVertexRegion ? { googleVertexRegion } : {}),
+        ...(googleVertexRegionHostSuffix ? { googleVertexRegionHostSuffix } : {}),
+      });
+    } catch {
+      // Provider attribution metadata is plugin-owned. One unreadable row
+      // must not disable native endpoint classification for healthy plugins.
       continue;
     }
-    const endpointClassRaw = normalizeOptionalString(rawEndpoint.endpointClass);
-    if (!endpointClassRaw || !isManifestProviderEndpointClass(endpointClassRaw)) {
-      continue;
-    }
-    entries.push({
-      endpointClass: endpointClassRaw,
-      hosts: normalizeTrimmedStringList(rawEndpoint.hosts).map((host) => host.toLowerCase()),
-      hostSuffixes: normalizeTrimmedStringList(rawEndpoint.hostSuffixes).map((host) =>
-        host.toLowerCase(),
-      ),
-      normalizedBaseUrls: normalizeTrimmedStringList(rawEndpoint.baseUrls)
-        .map((baseUrl) => normalizeComparableBaseUrl(baseUrl))
-        .filter((baseUrl): baseUrl is string => baseUrl !== undefined),
-      ...(normalizeOptionalString(rawEndpoint.googleVertexRegion)
-        ? { googleVertexRegion: normalizeOptionalString(rawEndpoint.googleVertexRegion) }
-        : {}),
-      ...(normalizeOptionalString(rawEndpoint.googleVertexRegionHostSuffix)
-        ? {
-            googleVertexRegionHostSuffix: normalizeOptionalString(
-              rawEndpoint.googleVertexRegionHostSuffix,
-            ),
-          }
-        : {}),
-    });
   }
   return entries;
 }
@@ -275,38 +310,49 @@ function readManifestProviderEndpoints(
 function readManifestProviderRequests(
   manifest: Record<string, unknown>,
 ): Array<[string, ManifestProviderRequestCacheEntry]> {
-  const providerRequest = manifest.providerRequest;
-  if (!isRecord(providerRequest) || !isRecord(providerRequest.providers)) {
+  const providerRequest = tryReadRecordValue(manifest, "providerRequest");
+  if (!isRecord(providerRequest)) {
+    return [];
+  }
+  const providers = tryReadRecordValue(providerRequest, "providers");
+  if (!isRecord(providers)) {
     return [];
   }
   const entries: Array<[string, ManifestProviderRequestCacheEntry]> = [];
-  for (const [providerRaw, requestRaw] of Object.entries(providerRequest.providers)) {
-    if (!isRecord(requestRaw)) {
-      continue;
-    }
-    const provider = normalizeLowercaseStringOrEmpty(providerRaw);
-    if (!provider) {
-      continue;
-    }
-    const compatibilityFamily =
-      normalizeOptionalString(requestRaw.compatibilityFamily) === "moonshot"
-        ? "moonshot"
+  for (const [providerRaw, requestRaw] of tryReadObjectEntryValues(providers)) {
+    try {
+      if (!isRecord(requestRaw)) {
+        continue;
+      }
+      const provider = normalizeLowercaseStringOrEmpty(providerRaw);
+      if (!provider) {
+        continue;
+      }
+      const compatibilityFamily =
+        normalizeOptionalString(tryReadRecordValue(requestRaw, "compatibilityFamily")) ===
+        "moonshot"
+          ? "moonshot"
+          : undefined;
+      const openAICompletions = tryReadRecordValue(requestRaw, "openAICompletions");
+      const supportsStreamingUsage = isRecord(openAICompletions)
+        ? tryReadRecordValue(openAICompletions, "supportsStreamingUsage")
         : undefined;
-    const supportsStreamingUsage = isRecord(requestRaw.openAICompletions)
-      ? requestRaw.openAICompletions.supportsStreamingUsage
-      : undefined;
-    entries.push([
-      provider,
-      {
-        ...(normalizeOptionalString(requestRaw.family)
-          ? { family: normalizeOptionalString(requestRaw.family) }
-          : {}),
-        ...(compatibilityFamily ? { compatibilityFamily } : {}),
-        ...(typeof supportsStreamingUsage === "boolean"
-          ? { supportsOpenAICompletionsStreamingUsageCompat: supportsStreamingUsage }
-          : {}),
-      },
-    ]);
+      const family = normalizeOptionalString(tryReadRecordValue(requestRaw, "family"));
+      entries.push([
+        provider,
+        {
+          ...(family ? { family } : {}),
+          ...(compatibilityFamily ? { compatibilityFamily } : {}),
+          ...(typeof supportsStreamingUsage === "boolean"
+            ? { supportsOpenAICompletionsStreamingUsageCompat: supportsStreamingUsage }
+            : {}),
+        },
+      ]);
+    } catch {
+      // Provider request metadata feeds shared runtime policy. Skip bad
+      // plugin-owned rows so healthy providers keep their routing facts.
+      continue;
+    }
   }
   return entries;
 }


### PR DESCRIPTION
## Summary

- Guard provider attribution manifest metadata reads so one unreadable plugin-owned provider endpoint or request row cannot abort native provider routing classification.
- Preserve healthy manifest rows for endpoint classes, provider families, and compatibility metadata.
- Add poisoned manifest regression coverage for provider endpoint and provider request metadata.

## Verification

- Red repro: `node scripts/run-vitest.mjs src/agents/provider-attribution.test.ts` failed pre-fix with `provider endpoint manifest getter exploded` and `provider request manifest getter exploded`.
- `node scripts/run-vitest.mjs src/agents/provider-attribution.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/provider-attribution.ts src/agents/provider-attribution.test.ts`
- `./node_modules/.bin/oxlint src/agents/provider-attribution.ts src/agents/provider-attribution.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` failed before sync/lease: Crabbox sparse-sync root had `962.6 MiB` free and requires `1.00 GiB`.

## Real behavior proof

Behavior addressed: Provider attribution now skips unreadable plugin-owned manifest provider endpoint/request metadata rows while keeping healthy provider routing facts available.

Real environment tested: Local Codex gwt worktree on `origin/main` at `f0237caf27d`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/provider-attribution.test.ts`; `oxfmt --check`; `oxlint`; `git diff --check`; local and branch autoreview.

Evidence after fix: Focused provider attribution Vitest passed 1 file / 33 tests; format, lint, diff check, and both autoreviews passed.

Observed result after fix: A poisoned manifest row with throwing `providerEndpoints` or `providerRequest` getters no longer prevents healthy OpenAI/Moonshot provider metadata from being classified.

What was not tested: Full `pnpm check:changed`; the required Crabbox/Testbox lane was blocked by local sparse-sync disk preflight before remote execution.
