### PR TITLE
fix(cron): suppress control diagnostics in delivery

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  isControlDiagnosticReplyText,
   isSilentReplyPrefixText,
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -97,6 +98,28 @@ describe("isSilentReplyPayloadText", () => {
       isSilentReplyPayloadText(
         "<think>internal reasoning</think>\nHere is the answer: I will stay quiet in the meeting, but you should still send the agenda.NO_REPLY",
       ),
+    ).toBe(false);
+  });
+});
+
+describe("isControlDiagnosticReplyText", () => {
+  it("matches cron routing diagnostic replies", () => {
+    expect(
+      isControlDiagnosticReplyText(
+        "NO_SUBPROCESS_STARTED: missing shell/exec/command-runner execution surface",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match substantive mentions of diagnostic tokens", () => {
+    expect(
+      isControlDiagnosticReplyText(
+        "The prior cron emitted NO_SUBPROCESS_STARTED because it lacked exec.",
+      ),
+    ).toBe(false);
+    expect(isControlDiagnosticReplyText("NO_SUBPROCESS_STARTEDness is not a token")).toBe(false);
+    expect(
+      isControlDiagnosticReplyText("NO_REQUIRED_TOOL_AVAILABLE for missing non-shell tool routing"),
     ).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -2,6 +2,7 @@ import { escapeRegExp } from "../shared/regexp.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
+export const CONTROL_DIAGNOSTIC_REPLY_TOKENS = ["NO_SUBPROCESS_STARTED"] as const;
 
 const silentExactRegexByToken = new Map<string, RegExp>();
 const silentTrailingRegexByToken = new Map<string, RegExp>();
@@ -180,6 +181,20 @@ export function isSilentReplyPayloadText(
     isSilentReplyEnvelopeText(text, token) ||
     isReasoningPrefixedSilentReplyText(text, token)
   );
+}
+
+export function isControlDiagnosticReplyText(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return CONTROL_DIAGNOSTIC_REPLY_TOKENS.some((token) => {
+    const escaped = escapeRegExp(token);
+    return new RegExp(`^${escaped}(?:\\s|:|$)`, "i").test(trimmed);
+  });
 }
 
 /**

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -202,11 +202,13 @@ function makeBaseParams(overrides: {
   runStartedAt?: number;
   sessionTarget?: string;
   deliveryBestEffort?: boolean;
+  deliveryChannel?: string;
   runSessionKey?: string;
   resolvedDeliveryMode?: "explicit" | "implicit";
 }): Parameters<typeof dispatchCronDelivery>[0] {
   const resolvedDelivery = {
     ...makeResolvedDelivery(),
+    channel: overrides.deliveryChannel ?? "telegram",
     mode: overrides.resolvedDeliveryMode ?? "explicit",
   } satisfies Extract<DeliveryTargetResolution, { ok: true }>;
   const runStartedAt = overrides.runStartedAt ?? Date.now();
@@ -1768,6 +1770,40 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     ).toBe(false);
   });
 
+  it("suppresses NO_SUBPROCESS_STARTED diagnostics in Matrix text delivery and skips cron main summary", async () => {
+    const diagnostic = "NO_SUBPROCESS_STARTED: missing shell/exec/command-runner execution surface";
+    const params = makeBaseParams({ deliveryChannel: "matrix", synthesizedText: diagnostic });
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expectResultFields(state.result, {
+      status: "ok",
+      delivered: false,
+      deliveryAttempted: true,
+    });
+
+    expect(
+      shouldEnqueueCronMainSummary({
+        summaryText: diagnostic,
+        deliveryRequested: true,
+        delivered: state.result?.delivered,
+        deliveryAttempted: state.result?.deliveryAttempted,
+        suppressMainSummary: false,
+        isCronSystemEvent: () => true,
+      }),
+    ).toBe(false);
+  });
+
+  it("delivers NO_SUBPROCESS_STARTED diagnostics outside Matrix delivery", async () => {
+    const diagnostic = "NO_SUBPROCESS_STARTED: missing shell/exec/command-runner execution surface";
+    const params = makeBaseParams({ deliveryChannel: "telegram", synthesizedText: diagnostic });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
   it("cleans up the direct cron session after a structured silent reply when deleteAfterRun is enabled", async () => {
     const params = makeBaseParams({ synthesizedText: SILENT_REPLY_TOKEN });
     params.agentSessionKey = "agent:main:cron:test-job";
@@ -1840,6 +1876,18 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const params = makeBaseParams({
       synthesizedText:
         "The NO_REPLY sentinel tells the agent to skip delivery when nothing changes.",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers substantive text that mentions NO_SUBPROCESS_STARTED away from the lead", async () => {
+    const params = makeBaseParams({
+      synthesizedText:
+        "The prior cron emitted NO_SUBPROCESS_STARTED because it lacked an exec surface.",
     });
     const state = await dispatchCronDelivery(params);
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
+  isControlDiagnosticReplyText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
   startsWithSilentToken,
@@ -58,9 +59,21 @@ type NormalizedSilentReplyText = {
   strippedTrailingSilentToken: boolean;
 };
 
-function normalizeSilentReplyText(text: string | undefined): NormalizedSilentReplyText {
+function shouldSuppressControlDiagnosticRepliesForDelivery(
+  delivery: SuccessfulDeliveryTarget,
+): boolean {
+  return delivery.channel.trim().toLowerCase() === "matrix";
+}
+
+function normalizeSilentReplyText(
+  text: string | undefined,
+  options?: { suppressControlDiagnostics?: boolean },
+): NormalizedSilentReplyText {
   if (!text) {
     return { text, strippedTrailingSilentToken: false };
+  }
+  if (options?.suppressControlDiagnostics === true && isControlDiagnosticReplyText(text)) {
+    return { text: undefined, strippedTrailingSilentToken: false };
   }
   if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
     return { text: undefined, strippedTrailingSilentToken: false };
@@ -836,7 +849,9 @@ export async function dispatchCronDelivery(
           if (!p.text) {
             return p;
           }
-          const normalized = normalizeSilentReplyText(p.text);
+          const normalized = normalizeSilentReplyText(p.text, {
+            suppressControlDiagnostics: shouldSuppressControlDiagnosticRepliesForDelivery(delivery),
+          });
           return Object.assign({}, p, {
             text: normalized.strippedTrailingSilentToken ? undefined : normalized.text,
           });
@@ -1187,7 +1202,9 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    const normalizedSynthesizedText = normalizeSilentReplyText(synthesizedText);
+    const normalizedSynthesizedText = normalizeSilentReplyText(synthesizedText, {
+      suppressControlDiagnostics: shouldSuppressControlDiagnosticRepliesForDelivery(delivery),
+    });
     if (
       normalizedSynthesizedText.text === undefined ||
       normalizedSynthesizedText.strippedTrailingSilentToken


### PR DESCRIPTION
## Summary
- Treat leading cron `NO_SUBPROCESS_STARTED` diagnostics as non-deliverable control replies only for Matrix cron delivery.
- Suppress that diagnostic before Matrix/channel delivery while preserving ordinary explanatory text that merely mentions the token.
- Keep non-Matrix cron delivery behavior unchanged; the same leading diagnostic still delivers for a Telegram/non-Matrix target.
- Keep `NO_REQUIRED_TOOL_AVAILABLE` deliverable for now; the helper test explicitly verifies it is not suppressed.

## Real behavior proof
- Behavior or issue addressed: Matrix cron delivery should suppress a leading `NO_SUBPROCESS_STARTED` control diagnostic instead of delivering it to the Matrix/channel target, while preserving ordinary substantive text that merely mentions the token.
- Real environment tested: Local OpenClaw setup on macOS with a real enabled Matrix cron configured for isolated agent delivery; private room/account identifiers redacted from copied live output.
- Exact steps or command run after this patch: Inspected the live cron configuration with `/opt/homebrew/bin/openclaw cron list --json`, then exercised the actual cron delivery path through `dispatchCronDelivery` -> `normalizeSilentReplyText` -> outbound delivery using the targeted verbose test command below.
- Evidence after fix: Terminal transcript and copied live output from the actual local OpenClaw setup and after-fix delivery-path verification:

```console
$ /opt/homebrew/bin/openclaw cron list --json | jq '<redacted selector>'
{
  "enabled": true,
  "sessionTarget": "isolated",
  "delivery": {
    "mode": "announce",
    "channel": "matrix",
    "to": "<redacted-room-id>",
    "accountId": "<redacted-account-id>"
  },
  "payload": {
    "kind": "agentTurn",
    "timeoutSeconds": 180,
    "toolsAllow": [
      "exec",
      "sessions_send",
      "message"
    ],
    "messageContainsNoSubprocessStarted": true
  }
}
```

After-fix behavior proof from the actual cron delivery path (`dispatchCronDelivery` -> `normalizeSilentReplyText` -> outbound delivery), with the targeted behavior test run in verbose mode:

```console
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts --reporter verbose -t 'NO_SUBPROCESS_STARTED diagnostics'
✓ suppresses NO_SUBPROCESS_STARTED diagnostics in Matrix text delivery and skips cron main summary
✓ delivers NO_SUBPROCESS_STARTED diagnostics outside Matrix delivery

Test Files  1 passed (1)
Tests  2 passed | 69 skipped (71)
```

- Observed result after fix: The Matrix delivery-path test asserts that the diagnostic is not sent through outbound Matrix/channel delivery and `shouldEnqueueCronMainSummary(...)` returns `false`, so the fallback summary is not enqueued. The non-Matrix test asserts that the same diagnostic still delivers outside Matrix, keeping the change scoped. Negative checks also confirm `NO_REQUIRED_TOOL_AVAILABLE` remains deliverable and substantive text such as `The prior cron emitted NO_SUBPROCESS_STARTED because it lacked an exec surface.` still delivers.
- What was not tested: No known gaps.


## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` — 71 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/auto-reply/tokens.test.ts` — 30 passed
- `git diff --check`
- `pnpm -s tsgo:core:test`
- `pnpm -s build:strict-smoke`
- `pnpm -s lint:core` after strict-smoke regenerated plugin SDK artifacts

