### PR TITLE
fix(gateway): isolate control UI descriptor rows

### DIFF
--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -26,6 +26,30 @@ function formatSessionActionPayloadSchemaErrors(errors: JsonSchemaValidationErro
   return errors.map((error) => error.text).join("; ");
 }
 
+function projectControlUiDescriptor(entry: {
+  descriptor: unknown;
+  pluginId: unknown;
+  pluginName?: unknown;
+}): Record<string, unknown> | undefined {
+  try {
+    if (!isRecord(entry.descriptor)) {
+      return undefined;
+    }
+    const pluginId = normalizeOptionalString(entry.pluginId);
+    if (!pluginId) {
+      return undefined;
+    }
+    return Object.assign({}, entry.descriptor, {
+      pluginId,
+      pluginName: normalizeOptionalString(entry.pluginName),
+    });
+  } catch {
+    // Control UI descriptors are plugin-owned metadata. A single bad row
+    // should not prevent operators from seeing healthy plugin UI surfaces.
+    return undefined;
+  }
+}
+
 /** Ensures plugin action result extension fields stay JSON-compatible on the wire. */
 function validatePluginSessionActionJsonFields(
   result: Record<string, unknown>,
@@ -52,12 +76,10 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const descriptors = (getActivePluginRegistry()?.controlUiDescriptors ?? []).map((entry) =>
-      Object.assign({}, entry.descriptor, {
-        pluginId: entry.pluginId,
-        pluginName: entry.pluginName,
-      }),
-    );
+    const descriptors = (getActivePluginRegistry()?.controlUiDescriptors ?? []).flatMap((entry) => {
+      const descriptor = projectControlUiDescriptor(entry);
+      return descriptor ? [descriptor] : [];
+    });
     respond(true, { ok: true, descriptors }, undefined);
   },
   "plugins.sessionAction": async ({ params, client, respond }) => {

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -52,6 +52,27 @@ async function callPluginSessionActionForTest(params: {
   return response ?? { ok: false, error: new Error("handler did not respond") };
 }
 
+async function callPluginUiDescriptorsForTest(
+  body: Record<string, unknown> = {},
+): Promise<HookResponse> {
+  let response: HookResponse | undefined;
+  const respond: RespondFn = (ok, payload, error) => {
+    response = { ok, payload, error };
+  };
+  await pluginHostHookHandlers["plugins.uiDescriptors"]({
+    req: { id: "test", type: "req", method: "plugins.uiDescriptors", params: body },
+    params: body,
+    client: {
+      connId: "test-client",
+      connect: { scopes: [READ_SCOPE] },
+    } as GatewayClient,
+    isWebchatConnect: () => false,
+    respond,
+    context: {} as never,
+  });
+  return response ?? { ok: false, error: new Error("handler did not respond") };
+}
+
 async function callRegisteredSessionActionForTest(params: {
   pluginId: string;
   actionId: string;
@@ -113,6 +134,17 @@ function requireHookError(response: HookResponse): { code?: unknown; message?: u
   return error;
 }
 
+function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
+  if (!record || typeof record !== "object") {
+    throw new Error("Expected record");
+  }
+  const actual = record as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    expect(actual[key]).toEqual(value);
+  }
+  return actual;
+}
+
 function requireObservedEvent(
   observed: unknown[],
   index: number,
@@ -148,6 +180,49 @@ describe("plugin session actions", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     resetAgentEventsForTest();
+  });
+
+  it("skips unreadable control UI descriptor rows while preserving healthy rows", async () => {
+    const unreadableRegistration: Record<string, unknown> = {
+      pluginId: "broken-control-ui",
+      pluginName: "Broken Control UI",
+      source: "/plugins/broken-control-ui/index.js",
+    };
+    Object.defineProperty(unreadableRegistration, "descriptor", {
+      get() {
+        throw new Error("control UI descriptor getter exploded");
+      },
+    });
+
+    const registry = createEmptyPluginRegistry();
+    registry.controlUiDescriptors = [
+      unreadableRegistration as never,
+      {
+        pluginId: "healthy-control-ui",
+        pluginName: "Healthy Control UI",
+        source: "/plugins/healthy-control-ui/index.js",
+        descriptor: {
+          id: "healthy.panel",
+          surface: "session",
+          label: "Healthy panel",
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    const response = await callPluginUiDescriptorsForTest();
+
+    expect(response.ok).toBe(true);
+    const payload = expectRecordFields(response.payload, { ok: true });
+    expect(payload.descriptors).toEqual([
+      {
+        id: "healthy.panel",
+        surface: "session",
+        label: "Healthy panel",
+        pluginId: "healthy-control-ui",
+        pluginName: "Healthy Control UI",
+      },
+    ]);
   });
 
   it("initializes and registers typed session actions", () => {


### PR DESCRIPTION
## Summary

- Guard `plugins.uiDescriptors` projection so one unreadable plugin-owned Control UI descriptor row cannot abort the whole Gateway response.
- Preserve healthy Control UI descriptor rows in the same response.
- Add a contract regression for a poisoned descriptor getter before a healthy descriptor.

## Verification

- Red repro: `node scripts/run-vitest.mjs src/plugins/contracts/session-actions.contract.test.ts` failed pre-fix with `control UI descriptor getter exploded`.
- `node scripts/run-vitest.mjs src/plugins/contracts/session-actions.contract.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `./node_modules/.bin/oxlint src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- After rebase onto current `origin/main`: focused Vitest, format/lint/diff checks, and branch autoreview were rerun and passed.
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` failed before sync/lease: Crabbox sparse-sync root had `865.7 MiB` free and requires `1.00 GiB`.

## Real behavior proof

Behavior addressed: Gateway `plugins.uiDescriptors` now skips unreadable plugin-owned Control UI descriptor rows while returning healthy descriptor rows.

Real environment tested: Local Codex gwt worktree on current `origin/main`; final branch commit `2f45b46e110`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/contracts/session-actions.contract.test.ts`; `oxfmt --check`; `oxlint`; `git diff --check`; local and branch autoreview.

Evidence after fix: Focused contract Vitest passed 1 file / 11 tests; format, lint, diff check, and both autoreviews passed. The same focused proof and branch autoreview passed again after rebasing onto current `origin/main`.

Observed result after fix: A poisoned Control UI descriptor getter no longer throws the Gateway RPC; the healthy descriptor remains in the returned descriptor list.

What was not tested: Full `pnpm check:changed`; the required Crabbox/Testbox lane was blocked by local sparse-sync disk preflight before remote execution.
