### PR TITLE
fix(heartbeat): debounce requests-in-flight retries

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -334,9 +334,9 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(firstDueMs + 1);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // The wake layer retries after DEFAULT_RETRY_MS (1 s).  No scheduleNext()
+    // The wake layer retries after REQUESTS_IN_FLIGHT_RETRY_MS (60 s).  No scheduleNext()
     // is called inside runOnce, so we must wait for the full cooldown.
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
 
     runner.stop();
@@ -450,10 +450,10 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(firstDueMs + 1);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Simulate 4 more retries at short intervals (wake layer retries).
+    // Simulate 4 more retries at the requests-in-flight delay (wake layer retries).
     for (let i = 0; i < 4; i++) {
       requestHeartbeat(wake("retry", { coalesceMs: 0 }));
-      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(60_000);
     }
     const scheduledSlotCallsBeforeInterval = callTimes.filter(
       (time) => time >= firstDueMs + intervalMs,
@@ -874,8 +874,8 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Wake layer retries via DEFAULT_RETRY_MS (1s). Advance past it.
-    await vi.advanceTimersByTimeAsync(1500);
+    // Wake layer retries via REQUESTS_IN_FLIGHT_RETRY_MS (60s). Advance past it.
+    await vi.advanceTimersByTimeAsync(60_500);
 
     // The retry must NOT be deferred to `not-due` or `min-spacing`. Since the
     // first attempt was a retryable busy skip, the cooldown bookkeeping was

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -34,10 +34,10 @@ describe("heartbeat-wake", () => {
     return { source, intent, reason, ...opts };
   }
 
-  function setRetryOnceHeartbeatHandler() {
+  function setRetryOnceHeartbeatHandler(skipReason: string = HEARTBEAT_SKIP_CRON_IN_PROGRESS) {
     const handler = vi
       .fn()
-      .mockResolvedValueOnce({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT })
+      .mockResolvedValueOnce({ status: "skipped", reason: skipReason })
       .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
     setHeartbeatWakeHandler(handler);
     return handler;
@@ -99,17 +99,22 @@ describe("heartbeat-wake", () => {
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
-  it("retries requests-in-flight after the default retry delay", async () => {
+  it("retries requests-in-flight after a longer retry delay to avoid blocking conversation turns", async () => {
     vi.useFakeTimers();
-    const handler = vi
-      .fn()
-      .mockResolvedValueOnce({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT })
-      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
-    await expectRetryAfterDefaultDelay({
-      handler,
-      initialReason: "interval",
-      expectedRetryReason: "interval",
-    });
+    const handler = setRetryOnceHeartbeatHandler(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT);
+    requestHeartbeat(wake("interval", { coalesceMs: 0 }));
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Should NOT fire after the default 1s retry delay
+    await vi.advanceTimersByTimeAsync(59_000);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Should fire after the full 60s requests-in-flight retry delay
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expectWakeCall(handler, 1, wake("interval"));
   });
 
   it.each([HEARTBEAT_SKIP_CRON_IN_PROGRESS, HEARTBEAT_SKIP_LANES_BUSY])(

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -92,6 +92,7 @@ let timerKind: WakeTimerKind | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
+const REQUESTS_IN_FLIGHT_RETRY_MS = 60_000;
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -237,6 +238,13 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
           const res = await active(wakeOpts);
           if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
             // The target runtime is busy; retry this wake target soon.
+            // Use a much longer delay for requests-in-flight so a heartbeat
+            // does not fire the instant the user's conversation turn ends,
+            // holding the session lock and blocking subsequent messages.
+            const retryDelayMs =
+              res.reason === HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT
+                ? REQUESTS_IN_FLIGHT_RETRY_MS
+                : DEFAULT_RETRY_MS;
             queuePendingWakeReason({
               source: pendingWake.source,
               intent: pendingWake.intent,
@@ -245,7 +253,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
               sessionKey: pendingWake.sessionKey,
               heartbeat: pendingWake.heartbeat,
             });
-            schedule(DEFAULT_RETRY_MS, "retry");
+            schedule(retryDelayMs, "retry");
           }
         }
       } catch {


### PR DESCRIPTION
Fixes #40611.

## What changed

- Adds a requests-in-flight heartbeat retry delay of 60 seconds.
- Keeps the existing 1 second retry delay for other retryable busy skips such as cron-in-progress and lanes-busy.
- Updates heartbeat wake and scheduler tests to cover the new requests-in-flight retry behavior.

## Behavior proof

Setup:

```bash
git worktree add -b tui-40611-heartbeat-busy-retry /Users/allahyar/Documents/fastino-tasks/openclaw-tui-40611 origin/main
cd /Users/allahyar/Documents/fastino-tasks/openclaw-tui-40611
```

Before this change, requests-in-flight skips used the shared wake retry delay:

```ts
const DEFAULT_RETRY_MS = 1_000;
...
schedule(DEFAULT_RETRY_MS, "retry");
```

After this change, requests-in-flight waits 60 seconds while other busy skips still use the default retry delay:

```ts
const REQUESTS_IN_FLIGHT_RETRY_MS = 60_000;
...
const retryDelayMs =
  res.reason === HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT
    ? REQUESTS_IN_FLIGHT_RETRY_MS
    : DEFAULT_RETRY_MS;
schedule(retryDelayMs, "retry");
```

The new `heartbeat-wake` test proves a requests-in-flight skip does not retry after the old 1 second path and does retry after the new 60 second path.

## Validation

```bash
node scripts/run-vitest.mjs src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
```

Result:

```text
Test Files  3 passed (3)
Tests  57 passed (57)
```

```bash
pnpm exec oxfmt --check --threads=1 src/infra/heartbeat-wake.ts src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
```

Result:

```text
All matched files use the correct format.
```

```bash
git diff --check
```

Result: no output.

Attempted the requested broader changed-files check:

```bash
node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"
pnpm check:changed
```

Both failed before running checks because the local `crabbox` binary failed its own basic `--version`/`--help` sanity checks:

```text
[crabbox] selected binary failed basic --version/--help sanity checks
```

## Platform tested

- macOS, local OpenClaw checkout.

## Limitations

- I did not run a live Telegram/Feishu/WebChat stall reproduction.
- This is source/test-backed validation for the heartbeat retry path.
