### PR TITLE
fix(gateway): isolate web login descriptor rows

### DIFF
--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -177,6 +177,70 @@ describe("webHandlers web.login.start", () => {
       undefined,
     );
   });
+
+  it("skips unreadable web login gateway descriptor rows while preserving healthy providers", async () => {
+    const poisonedDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("web login descriptor name exploded");
+      },
+    }) as { name: string };
+    const poisonedDescriptorRows = Object.defineProperty([], "0", {
+      get() {
+        throw new Error("web login descriptor row exploded");
+      },
+    }) as { name: string }[];
+    poisonedDescriptorRows.length = 1;
+    const loginWithQrStart = vi.fn().mockResolvedValue({
+      connected: true,
+      message: "connected",
+    });
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "broken",
+        gatewayMethodDescriptors: [poisonedDescriptor],
+        gateway: {
+          loginWithQrStart: vi.fn(),
+        },
+      },
+      {
+        id: "broken-row",
+        gatewayMethodDescriptors: poisonedDescriptorRows,
+        gateway: {
+          loginWithQrStart: vi.fn(),
+        },
+      },
+      {
+        id: "whatsapp",
+        gatewayMethodDescriptors: [{ name: "web.login.start" }],
+        gateway: { loginWithQrStart },
+      },
+    ]);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+        },
+      ),
+    );
+
+    expect(loginWithQrStart).toHaveBeenCalledWith({
+      accountId: "default",
+      force: false,
+      timeoutMs: undefined,
+      verbose: false,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        connected: true,
+        message: "connected",
+      },
+      undefined,
+    );
+  });
 });
 
 describe("webHandlers web.login.wait", () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -12,13 +12,52 @@ import { assertValidParams } from "./validation.js";
 
 const WEB_LOGIN_METHODS = new Set(["web.login.start", "web.login.wait"]);
 
+type WebLoginChannelPlugin = ReturnType<typeof listChannelPlugins>[number];
+
+function listGatewayMethodNames(plugin: WebLoginChannelPlugin): string[] {
+  const names: string[] = [];
+  let methodCount = 0;
+  try {
+    methodCount = plugin.gatewayMethods?.length ?? 0;
+  } catch {
+    // Web login discovery must not let one plugin-owned metadata row hide a
+    // later healthy provider that can complete the login flow.
+  }
+  for (let index = 0; index < methodCount; index += 1) {
+    try {
+      const method = plugin.gatewayMethods?.[index];
+      if (typeof method === "string") {
+        names.push(method);
+      }
+    } catch {
+      // Skip only the unreadable method row.
+    }
+  }
+  let descriptorCount = 0;
+  try {
+    descriptorCount = plugin.gatewayMethodDescriptors?.length ?? 0;
+  } catch {
+    // Web login discovery must not let one plugin-owned metadata row hide a
+    // later healthy provider that can complete the login flow.
+  }
+  for (let index = 0; index < descriptorCount; index += 1) {
+    try {
+      const descriptor = plugin.gatewayMethodDescriptors?.[index];
+      const name = descriptor?.name;
+      if (typeof name === "string") {
+        names.push(name);
+      }
+    } catch {
+      // Skip only the unreadable descriptor row.
+    }
+  }
+  return names;
+}
+
 /** Resolves the channel plugin that currently owns web QR-login methods. */
 const resolveWebLoginProvider = () =>
   listChannelPlugins().find((plugin) =>
-    [
-      ...(plugin.gatewayMethods ?? []),
-      ...(plugin.gatewayMethodDescriptors ?? []).map((descriptor) => descriptor.name),
-    ].some((method) => WEB_LOGIN_METHODS.has(method)),
+    listGatewayMethodNames(plugin).some((method) => WEB_LOGIN_METHODS.has(method)),
   ) ?? null;
 
 type WebLoginProvider = NonNullable<ReturnType<typeof resolveWebLoginProvider>>;


### PR DESCRIPTION
## Summary

- isolate plugin-owned web login gateway method discovery so malformed descriptor rows do not hide later healthy providers
- add a regression covering a throwing descriptor `name` getter and an unreadable descriptor array row before a valid web-login provider

## Verification

- Red repro:
  `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts`
  - failed before the fix because the healthy `loginWithQrStart` provider was never called
- Focused test:
  `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts`
  - passed 1 Vitest shard, 2 files, 10 tests
- Format:
  `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts`
- Lint:
  `./node_modules/.bin/oxlint src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts`
- Diff check:
  `git diff --check`
  `git diff --check origin/main...HEAD`
- Autoreview:
  `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean, `overall: patch is correct (0.86)`
  `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - clean, `overall: patch is correct (0.86)`

## Real behavior proof

Behavior addressed: a malformed channel plugin gateway method descriptor can no longer prevent `web.login.start` discovery from reaching a later healthy provider.

Real environment tested: local linked Codex worktree from current `origin/main`, using the repo Vitest wrapper for the focused gateway server-method test file.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts`.

Evidence after fix: the focused gateway shard passed with 2 files and 10 tests, including the poisoned descriptor regression.

Observed result after fix: the web-login handler skips unreadable plugin-owned gateway method rows and calls the healthy provider's `loginWithQrStart`.

What was not tested: full `pnpm check:changed`; Crabbox changed gate failed before sync/lease because `/Users/m1/.cache/openclaw/crabbox-sync` had only 719.5 MiB free and requires 1.00 GiB.
