### PR TITLE
fix(gateway): isolate method list rows

### DIFF
--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -1,5 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockLoadedChannelPlugin = {
+  id: string;
+  gatewayMethods?: readonly string[];
+  gatewayMethodDescriptors?: readonly { name: string }[];
+};
+
+const mocks = vi.hoisted(() => ({
+  listLoadedChannelPlugins: vi.fn((): MockLoadedChannelPlugin[] => []),
+}));
+
+vi.mock("../channels/plugins/registry-loaded.js", () => ({
+  listLoadedChannelPlugins: mocks.listLoadedChannelPlugins,
+}));
+
 import { GATEWAY_EVENTS, listGatewayMethods } from "./server-methods-list.js";
+
+beforeEach(() => {
+  mocks.listLoadedChannelPlugins.mockReturnValue([]);
+});
 
 describe("GATEWAY_EVENTS", () => {
   it("advertises Talk event streams in hello features", () => {
@@ -61,5 +80,49 @@ describe("listGatewayMethods", () => {
     expect(methods).toContain("talk.session.submitToolResult");
     expect(methods).toContain("talk.session.steer");
     expect(methods).toContain("talk.session.close");
+  });
+
+  it("skips unreadable plugin gateway method rows while preserving healthy methods", () => {
+    const poisonedMethods = Object.defineProperty([], "0", {
+      get() {
+        throw new Error("gateway method row exploded");
+      },
+    }) as string[];
+    poisonedMethods.length = 1;
+    const poisonedDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("gateway method descriptor name exploded");
+      },
+    }) as { name: string };
+    const poisonedDescriptorRows = Object.defineProperty([], "0", {
+      get() {
+        throw new Error("gateway method descriptor row exploded");
+      },
+    }) as { name: string }[];
+    poisonedDescriptorRows.length = 1;
+    mocks.listLoadedChannelPlugins.mockReturnValue([
+      {
+        id: "broken-method",
+        gatewayMethods: poisonedMethods,
+      },
+      {
+        id: "broken-descriptor",
+        gatewayMethodDescriptors: [poisonedDescriptor],
+      },
+      {
+        id: "broken-descriptor-row",
+        gatewayMethodDescriptors: poisonedDescriptorRows,
+      },
+      {
+        id: "healthy",
+        gatewayMethods: ["healthy.legacy"],
+        gatewayMethodDescriptors: [{ name: "healthy.descriptor" }],
+      },
+    ]);
+
+    const methods = listGatewayMethods();
+
+    expect(methods).toContain("healthy.legacy");
+    expect(methods).toContain("healthy.descriptor");
   });
 });

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -3,10 +3,49 @@ import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 import { listCoreAdvertisedGatewayMethodNames } from "./methods/core-descriptors.js";
 import { GATEWAY_AUX_METHODS } from "./server-aux-methods.js";
 
-type GatewayMethodChannelPlugin = {
+export type GatewayMethodChannelPlugin = {
   gatewayMethods?: readonly string[];
   gatewayMethodDescriptors?: readonly { name: string }[];
 };
+
+export function listPluginGatewayMethodNames(plugin: GatewayMethodChannelPlugin): string[] {
+  const methods: string[] = [];
+  let methodCount = 0;
+  try {
+    methodCount = plugin.gatewayMethods?.length ?? 0;
+  } catch {
+    // Gateway method advertisements are plugin-owned metadata. A malformed
+    // plugin row must not prevent clients from seeing healthy methods.
+  }
+  for (let index = 0; index < methodCount; index += 1) {
+    try {
+      const method = plugin.gatewayMethods?.[index];
+      if (typeof method === "string") {
+        methods.push(method);
+      }
+    } catch {
+      // Skip only the unreadable plugin method row.
+    }
+  }
+  let descriptorCount = 0;
+  try {
+    descriptorCount = plugin.gatewayMethodDescriptors?.length ?? 0;
+  } catch {
+    // Keep legacy names above even when descriptor metadata is malformed.
+  }
+  for (let index = 0; index < descriptorCount; index += 1) {
+    try {
+      const descriptor = plugin.gatewayMethodDescriptors?.[index];
+      const name = descriptor?.name;
+      if (typeof name === "string") {
+        methods.push(name);
+      }
+    } catch {
+      // Skip only the unreadable plugin descriptor row.
+    }
+  }
+  return methods;
+}
 
 /** Lists core methods intentionally advertised to gateway clients. */
 export function listCoreGatewayMethods(): string[] {
@@ -18,10 +57,7 @@ function listChannelGatewayMethods(): string[] {
   for (const plugin of listLoadedChannelPlugins() as GatewayMethodChannelPlugin[]) {
     // Plugins may still expose legacy names while newer plugins expose descriptors.
     // Merge both so method discovery stays compatible during descriptor adoption.
-    methods.push(...(plugin.gatewayMethods ?? []));
-    for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-      methods.push(descriptor.name);
-    }
+    methods.push(...listPluginGatewayMethodNames(plugin));
   }
   return methods;
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -85,7 +85,7 @@ import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayServerLiveState, type GatewayServerLiveState } from "./server-live-state.js";
-import { GATEWAY_EVENTS } from "./server-methods-list.js";
+import { GATEWAY_EVENTS, listPluginGatewayMethodNames } from "./server-methods-list.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
 import { setFallbackGatewayContextResolver } from "./server-plugins.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
@@ -729,10 +729,7 @@ export async function startGatewayServer(
   const listStartupChannelGatewayMethods = () => {
     const methods: string[] = [];
     for (const plugin of listGatewayStartupChannelPlugins()) {
-      methods.push(...(plugin.gatewayMethods ?? []));
-      for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-        methods.push(descriptor.name);
-      }
+      methods.push(...listPluginGatewayMethodNames(plugin));
     }
     return methods;
   };


### PR DESCRIPTION
## Summary

- isolate plugin-owned gateway method list rows so malformed channel metadata does not break advertised method catalogs
- share the guarded projection with gateway runtime startup so the live `gatewayMethods` list and method-list APIs behave consistently
- add a regression for unreadable legacy method rows, descriptor rows, and descriptor names while preserving healthy methods

## Verification

- Baseline:
  `node scripts/run-vitest.mjs src/gateway/server-methods-list.test.ts`
  - passed 1 Vitest shard, 2 files, 12 tests
- Red repro:
  `node scripts/run-vitest.mjs src/gateway/server-methods-list.test.ts`
  - failed before the fix with `gateway method row exploded`
- Focused test:
  `node scripts/run-vitest.mjs src/gateway/server-methods-list.test.ts`
  - passed 1 Vitest shard, 2 files, 14 tests
- Format:
  `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods-list.ts src/gateway/server-methods-list.test.ts src/gateway/server.impl.ts`
- Lint:
  `./node_modules/.bin/oxlint src/gateway/server-methods-list.ts src/gateway/server-methods-list.test.ts src/gateway/server.impl.ts`
- Diff check:
  `git diff --check`
  `git diff --check origin/main...HEAD`
- Autoreview:
  `.agents/skills/autoreview/scripts/autoreview --mode local`
  - first run found a typed-test mock issue, fixed
  - final local run clean, `overall: patch is correct (0.84)`
  `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - first run found the runtime startup path still used unguarded method projection, fixed
  - final branch run clean, `overall: patch is correct (0.84)`

## Real behavior proof

Behavior addressed: malformed plugin-owned gateway method metadata can no longer prevent healthy plugin methods from being advertised through method-list APIs or runtime startup `gatewayMethods`.

Real environment tested: local linked Codex worktree from current `origin/main`, using the repo Vitest wrapper for the focused gateway method-list test file.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods-list.test.ts`.

Evidence after fix: the focused gateway shard passed with 2 files and 14 tests, including the poisoned gateway method metadata regression.

Observed result after fix: unreadable legacy method rows, descriptor rows, and descriptor `name` getters are skipped while later healthy `healthy.legacy` and `healthy.descriptor` methods remain advertised.

What was not tested: full `pnpm check:changed`; Crabbox changed gate failed before sync/lease because `/Users/m1/.cache/openclaw/crabbox-sync` had only 634.7 MiB free and requires 1.00 GiB.
