### PR TITLE
fix(plugins): isolate inspect gateway descriptor rows

### DIFF
--- a/src/plugins/inspect-shape.ts
+++ b/src/plugins/inspect-shape.ts
@@ -37,6 +37,34 @@ export type PluginShapeSummary = {
   usesLegacyBeforeAgentStart: boolean;
 };
 
+export function listPluginGatewayMethodNames(
+  descriptors: Pick<PluginRegistry, "gatewayMethodDescriptors">["gatewayMethodDescriptors"],
+  pluginId: string,
+): string[] {
+  const names: string[] = [];
+  let descriptorCount: number;
+  try {
+    descriptorCount = descriptors?.length ?? 0;
+  } catch {
+    return names;
+  }
+  for (let index = 0; index < descriptorCount; index += 1) {
+    try {
+      const descriptor = descriptors?.[index];
+      if (descriptor?.owner.kind === "plugin" && descriptor.owner.pluginId === pluginId) {
+        const name = descriptor.name;
+        if (typeof name === "string") {
+          names.push(name);
+        }
+      }
+    } catch {
+      // Gateway descriptors are plugin-owned metadata. A malformed row must
+      // not hide status/inspect data for healthy rows from the same plugin.
+    }
+  }
+  return names;
+}
+
 function buildPluginCapabilityEntries(
   plugin: PluginRegistry["plugins"][number],
 ): PluginCapabilityEntry[] {
@@ -112,9 +140,9 @@ export function buildPluginShapeSummary(params: {
   const toolCount = params.report.tools.filter(
     (entry) => entry.pluginId === params.plugin.id,
   ).length;
-  const gatewayMethodCount = (params.report.gatewayMethodDescriptors ?? []).filter(
-    (descriptor) =>
-      descriptor.owner.kind === "plugin" && descriptor.owner.pluginId === params.plugin.id,
+  const gatewayMethodCount = listPluginGatewayMethodNames(
+    params.report.gatewayMethodDescriptors,
+    params.plugin.id,
   ).length;
   const capabilityCount = capabilities.length;
   const shape = derivePluginInspectShape({

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -469,6 +469,44 @@ describe("plugin status reports", () => {
     });
   });
 
+  it("skips unreadable gateway method descriptor rows in inspect reports", () => {
+    const plugin = createPluginRecord({ id: "healthy" });
+    const poisonedDescriptor = Object.defineProperty({}, "owner", {
+      get() {
+        throw new Error("inspect gateway descriptor owner exploded");
+      },
+    }) as ReturnType<typeof createPluginLoadResult>["gatewayMethodDescriptors"][number];
+    const gatewayMethodDescriptors = [
+      poisonedDescriptor,
+      poisonedDescriptor,
+      {
+        name: "healthy.ping",
+        handler: () => undefined,
+        scope: "operator.read",
+        owner: { kind: "plugin", pluginId: "healthy" },
+      },
+    ] as ReturnType<typeof createPluginLoadResult>["gatewayMethodDescriptors"];
+    Object.defineProperty(gatewayMethodDescriptors, "0", {
+      get() {
+        throw new Error("inspect gateway descriptor row exploded");
+      },
+    });
+    const report = createPluginLoadResult({
+      plugins: [plugin],
+      gatewayMethodDescriptors,
+    });
+
+    const inspect = expectInspectReport("healthy", {
+      report: {
+        ...report,
+        workspaceDir: "/workspace",
+      },
+      resolvedConfig: {},
+    });
+
+    expect(inspect.gatewayMethods).toEqual(["healthy.ping"]);
+  });
+
   it("carries installed-index compatibility metadata into registry snapshot reports", () => {
     loadPluginRegistrySnapshotWithMetadataMock.mockReturnValue({
       snapshot: createInstalledPluginIndexSnapshot([

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -13,6 +13,7 @@ import { normalizePluginsConfig } from "./config-state.js";
 import { resolveEffectivePluginIds } from "./effective-plugin-ids.js";
 import {
   buildPluginShapeSummary,
+  listPluginGatewayMethodNames,
   type PluginCapabilityEntry,
   type PluginInspectShape,
 } from "./inspect-shape.js";
@@ -353,11 +354,7 @@ export function buildPluginInspectReport(params: {
   const policyEntry = normalizePluginsConfig(config.plugins).entries[plugin.id];
   const shapeSummary = buildPluginShapeSummary({ plugin, report });
   const shape = shapeSummary.shape;
-  const gatewayMethods = (report.gatewayMethodDescriptors ?? [])
-    .filter(
-      (descriptor) => descriptor.owner.kind === "plugin" && descriptor.owner.pluginId === plugin.id,
-    )
-    .map((descriptor) => descriptor.name);
+  const gatewayMethods = listPluginGatewayMethodNames(report.gatewayMethodDescriptors, plugin.id);
 
   // Populate MCP server info for bundle-format plugins with a known rootDir.
   let mcpServers: PluginInspectReport["mcpServers"] = [];


### PR DESCRIPTION
## Summary

- isolate plugin-owned gateway method descriptors used by plugin inspect/status reporting
- share the guarded descriptor projection between shape classification and inspect output
- add a regression for unreadable descriptor rows and descriptor owner getters while preserving healthy gateway methods

## Verification

- Baseline:
  `node scripts/run-vitest.mjs src/plugins/status.test.ts`
  - passed 1 Vitest shard, 1 file, 27 tests
- Red repro:
  `node scripts/run-vitest.mjs src/plugins/status.test.ts`
  - failed before the fix with `inspect gateway descriptor row exploded`
- Focused test:
  `node scripts/run-vitest.mjs src/plugins/status.test.ts`
  - passed 1 Vitest shard, 1 file, 28 tests
- Format:
  `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/inspect-shape.ts src/plugins/status.ts src/plugins/status.test.ts`
- Lint:
  `./node_modules/.bin/oxlint src/plugins/inspect-shape.ts src/plugins/status.ts src/plugins/status.test.ts`
- Diff check:
  `git diff --check`
  `git diff --check origin/main...HEAD`
- Autoreview:
  `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean, `overall: patch is correct (0.87)`
  `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - clean, `overall: patch is correct (0.84)`

## Real behavior proof

Behavior addressed: malformed plugin-owned gateway method descriptor rows can no longer crash plugin inspect/status reporting or shape classification before healthy descriptor rows are reported.

Real environment tested: local linked Codex worktree from current `origin/main`, using the repo Vitest wrapper for the focused plugin status test file.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/status.test.ts`.

Evidence after fix: the focused plugin shard passed with 1 file and 28 tests, including the poisoned gateway descriptor regression.

Observed result after fix: unreadable descriptor rows and descriptor owner getters are skipped while the healthy `healthy.ping` gateway method remains in the inspect report.

What was not tested: full `pnpm check:changed`; Crabbox changed gate failed before sync/lease because `/Users/m1/.cache/openclaw/crabbox-sync` had only 554.2 MiB free and requires 1.00 GiB.
