### PR TITLE
fix(cli): protect protocol stdout during startup

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -45,6 +45,10 @@ export type CliCommandPathPolicy = {
 export type CliCommandCatalogEntry = {
   commandPath: readonly string[];
   exact?: boolean;
+  argvMatch?: {
+    booleanFlags?: readonly string[];
+    valueFlags?: readonly string[];
+  };
   policy?: Partial<CliCommandPathPolicy>;
   route?: {
     id: CliRoutedCommandId;
@@ -259,7 +263,24 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   { commandPath: ["acp"], policy: { networkProxy: "bypass" } },
-  { commandPath: ["acp"], exact: true, policy: { ownsProtocolStdout: true } },
+  {
+    commandPath: ["acp"],
+    exact: true,
+    argvMatch: {
+      booleanFlags: ["--require-existing", "--reset-session", "--no-prefix-cwd", "--verbose", "-v"],
+      valueFlags: [
+        "--url",
+        "--token",
+        "--token-file",
+        "--password",
+        "--password-file",
+        "--session",
+        "--session-label",
+        "--provenance",
+      ],
+    },
+    policy: { ownsProtocolStdout: true },
+  },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
   { commandPath: ["backup"], policy: { bypassConfigGuard: true, networkProxy: "bypass" } },
   { commandPath: ["chat"], policy: { networkProxy: "bypass" } },

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -36,6 +36,7 @@ export type CliCommandPathPolicy = {
   routeConfigGuard: CliRouteConfigGuardPolicy;
   loadPlugins: CliCommandPluginLoadPolicy;
   pluginRegistry: CliPluginRegistryPolicy;
+  ownsProtocolStdout: boolean;
   hideBanner: boolean;
   ensureCliPath: boolean;
   networkProxy: CliNetworkProxyPolicyResolver;
@@ -258,6 +259,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   { commandPath: ["acp"], policy: { networkProxy: "bypass" } },
+  { commandPath: ["acp"], exact: true, policy: { ownsProtocolStdout: true } },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
   { commandPath: ["backup"], policy: { bypassConfigGuard: true, networkProxy: "bypass" } },
   { commandPath: ["chat"], policy: { networkProxy: "bypass" } },
@@ -282,6 +284,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["hooks"], policy: { networkProxy: "bypass" } },
   { commandPath: ["logs"], policy: { networkProxy: "bypass" } },
   { commandPath: ["mcp"], policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["mcp", "serve"],
+    exact: true,
+    policy: { ownsProtocolStdout: true },
+  },
   {
     commandPath: ["node"],
     policy: { networkProxy: "bypass" },

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -45,10 +45,6 @@ export type CliCommandPathPolicy = {
 export type CliCommandCatalogEntry = {
   commandPath: readonly string[];
   exact?: boolean;
-  argvMatch?: {
-    booleanFlags?: readonly string[];
-    valueFlags?: readonly string[];
-  };
   policy?: Partial<CliCommandPathPolicy>;
   route?: {
     id: CliRoutedCommandId;
@@ -266,19 +262,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["acp"],
     exact: true,
-    argvMatch: {
-      booleanFlags: ["--require-existing", "--reset-session", "--no-prefix-cwd", "--verbose", "-v"],
-      valueFlags: [
-        "--url",
-        "--token",
-        "--token-file",
-        "--password",
-        "--password-file",
-        "--session",
-        "--session-label",
-        "--provenance",
-      ],
-    },
     policy: { ownsProtocolStdout: true },
   },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -111,35 +111,23 @@ describe("command-execution-startup", () => {
     ).toBe(true);
   });
 
-  it("distinguishes ACP bridge options from the interactive client in raw argv", () => {
-    for (const argv of [
-      ["node", "openclaw", "acp", "--url", "wss://gateway.example.test"],
-      ["node", "openclaw", "acp", "--session", "client"],
-      ["node", "openclaw", "--profile", "work", "acp", "--reset-session", "--verbose"],
-    ]) {
-      expect(
-        mod.resolveCliExecutionStartupContext({
-          argv,
-          jsonOutputMode: false,
-          env: {},
-        }).startupPolicy.suppressDoctorStdout,
-        argv.join(" "),
-      ).toBe(true);
-    }
-
-    for (const argv of [
-      ["node", "openclaw", "acp", "client", "--cwd", "/tmp/workspace"],
-      ["node", "openclaw", "acp", "--verbose", "client", "--server", "openclaw"],
-    ]) {
-      expect(
-        mod.resolveCliExecutionStartupContext({
-          argv,
-          jsonOutputMode: false,
-          env: {},
-        }).startupPolicy.suppressDoctorStdout,
-        argv.join(" "),
-      ).toBe(false);
-    }
+  it("uses the resolved action command path for protocol startup policy", () => {
+    expect(
+      mod.resolveCliExecutionStartupContext({
+        argv: ["node", "openclaw", "acp", "--token", "-secret"],
+        protocolCommandPath: ["acp"],
+        jsonOutputMode: false,
+        env: {},
+      }).startupPolicy.suppressDoctorStdout,
+    ).toBe(true);
+    expect(
+      mod.resolveCliExecutionStartupContext({
+        argv: ["node", "openclaw", "acp", "--verbose", "client"],
+        protocolCommandPath: ["acp", "client"],
+        jsonOutputMode: false,
+        env: {},
+      }).startupPolicy.suppressDoctorStdout,
+    ).toBe(false);
   });
 
   it("routes logs to stderr and emits banner only when allowed", async () => {

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -111,6 +111,37 @@ describe("command-execution-startup", () => {
     ).toBe(true);
   });
 
+  it("distinguishes ACP bridge options from the interactive client in raw argv", () => {
+    for (const argv of [
+      ["node", "openclaw", "acp", "--url", "wss://gateway.example.test"],
+      ["node", "openclaw", "acp", "--session", "client"],
+      ["node", "openclaw", "--profile", "work", "acp", "--reset-session", "--verbose"],
+    ]) {
+      expect(
+        mod.resolveCliExecutionStartupContext({
+          argv,
+          jsonOutputMode: false,
+          env: {},
+        }).startupPolicy.suppressDoctorStdout,
+        argv.join(" "),
+      ).toBe(true);
+    }
+
+    for (const argv of [
+      ["node", "openclaw", "acp", "client", "--cwd", "/tmp/workspace"],
+      ["node", "openclaw", "acp", "--verbose", "client", "--server", "openclaw"],
+    ]) {
+      expect(
+        mod.resolveCliExecutionStartupContext({
+          argv,
+          jsonOutputMode: false,
+          env: {},
+        }).startupPolicy.suppressDoctorStdout,
+        argv.join(" "),
+      ).toBe(false);
+    }
+  });
+
   it("routes logs to stderr and emits banner only when allowed", async () => {
     await mod.applyCliExecutionStartupPresentation({
       startupPolicy: {

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -43,7 +43,7 @@ export async function applyCliExecutionStartupPresentation(params: {
   showBanner?: boolean;
   version?: string;
 }) {
-  // JSON-mode commands must keep stdout machine-readable; route diagnostics away first.
+  // Machine-readable commands must route diagnostics away before startup can print.
   if (params.startupPolicy.suppressDoctorStdout && params.routeLogsToStderrOnSuppress !== false) {
     routeLogsToStderr();
   }

--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -16,6 +16,7 @@ const hasVersionFlag = (argv: readonly string[]) =>
 
 export function resolveCliExecutionStartupContext(params: {
   argv: string[];
+  protocolCommandPath?: string[];
   jsonOutputMode: boolean;
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
@@ -29,6 +30,7 @@ export function resolveCliExecutionStartupContext(params: {
     startupPolicy: resolveCliStartupPolicy({
       argv: params.argv,
       commandPath,
+      protocolCommandPath: params.protocolCommandPath,
       jsonOutputMode: params.jsonOutputMode,
       env: params.env,
       routeMode: params.routeMode,

--- a/src/cli/command-path-matches.test.ts
+++ b/src/cli/command-path-matches.test.ts
@@ -1,6 +1,6 @@
 // Command path match tests cover CLI command path matching and normalization.
 import { describe, expect, it } from "vitest";
-import { matchesCommandPath } from "./command-path-matches.js";
+import { matchesArgvCommandPath, matchesCommandPath } from "./command-path-matches.js";
 
 describe("command-path-matches", () => {
   it("matches prefix and exact command paths", () => {
@@ -10,4 +10,33 @@ describe("command-path-matches", () => {
     expect(matchesCommandPath(["config", "get"], ["config", "get"], { exact: true })).toBe(true);
   });
 
+  it("matches exact argv command paths without mistaking option values for subcommands", () => {
+    const matchOptions = {
+      exact: true,
+      booleanFlags: ["--verbose"],
+      valueFlags: ["--url", "--session"],
+    } as const;
+
+    expect(
+      matchesArgvCommandPath(
+        ["node", "openclaw", "acp", "--url", "wss://gateway.example.test"],
+        ["acp"],
+        matchOptions,
+      ),
+    ).toBe(true);
+    expect(
+      matchesArgvCommandPath(
+        ["node", "openclaw", "acp", "--session", "client"],
+        ["acp"],
+        matchOptions,
+      ),
+    ).toBe(true);
+    expect(
+      matchesArgvCommandPath(
+        ["node", "openclaw", "acp", "--verbose", "client"],
+        ["acp"],
+        matchOptions,
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/cli/command-path-matches.test.ts
+++ b/src/cli/command-path-matches.test.ts
@@ -1,6 +1,6 @@
 // Command path match tests cover CLI command path matching and normalization.
 import { describe, expect, it } from "vitest";
-import { matchesArgvCommandPath, matchesCommandPath } from "./command-path-matches.js";
+import { matchesCommandPath } from "./command-path-matches.js";
 
 describe("command-path-matches", () => {
   it("matches prefix and exact command paths", () => {
@@ -8,35 +8,5 @@ describe("command-path-matches", () => {
     expect(matchesCommandPath(["status", "watch"], ["status"])).toBe(true);
     expect(matchesCommandPath(["status", "watch"], ["status"], { exact: true })).toBe(false);
     expect(matchesCommandPath(["config", "get"], ["config", "get"], { exact: true })).toBe(true);
-  });
-
-  it("matches exact argv command paths without mistaking option values for subcommands", () => {
-    const matchOptions = {
-      exact: true,
-      booleanFlags: ["--verbose"],
-      valueFlags: ["--url", "--session"],
-    } as const;
-
-    expect(
-      matchesArgvCommandPath(
-        ["node", "openclaw", "acp", "--url", "wss://gateway.example.test"],
-        ["acp"],
-        matchOptions,
-      ),
-    ).toBe(true);
-    expect(
-      matchesArgvCommandPath(
-        ["node", "openclaw", "acp", "--session", "client"],
-        ["acp"],
-        matchOptions,
-      ),
-    ).toBe(true);
-    expect(
-      matchesArgvCommandPath(
-        ["node", "openclaw", "acp", "--verbose", "client"],
-        ["acp"],
-        matchOptions,
-      ),
-    ).toBe(false);
   });
 });

--- a/src/cli/command-path-matches.ts
+++ b/src/cli/command-path-matches.ts
@@ -1,4 +1,5 @@
 // Shared command-path matching helpers for CLI startup and registration policy.
+import { getCommandPositionalsWithRootOptions } from "./argv.js";
 
 /** Matches a command path prefix, or the full path when `exact` is requested. */
 export function matchesCommandPath(
@@ -10,4 +11,25 @@ export function matchesCommandPath(
     return false;
   }
   return !params?.exact || commandPath.length === pattern.length;
+}
+
+/** Matches a raw argv command path while consuming known command option values. */
+export function matchesArgvCommandPath(
+  argv: string[],
+  pattern: readonly string[],
+  params?: {
+    exact?: boolean;
+    booleanFlags?: readonly string[];
+    valueFlags?: readonly string[];
+  },
+): boolean {
+  const positionals = getCommandPositionalsWithRootOptions(argv, {
+    commandPath: pattern,
+    booleanFlags: params?.booleanFlags,
+    valueFlags: params?.valueFlags,
+  });
+  if (positionals === null) {
+    return false;
+  }
+  return !params?.exact || positionals.length === 0;
 }

--- a/src/cli/command-path-matches.ts
+++ b/src/cli/command-path-matches.ts
@@ -1,5 +1,4 @@
 // Shared command-path matching helpers for CLI startup and registration policy.
-import { getCommandPositionalsWithRootOptions } from "./argv.js";
 
 /** Matches a command path prefix, or the full path when `exact` is requested. */
 export function matchesCommandPath(
@@ -11,25 +10,4 @@ export function matchesCommandPath(
     return false;
   }
   return !params?.exact || commandPath.length === pattern.length;
-}
-
-/** Matches a raw argv command path while consuming known command option values. */
-export function matchesArgvCommandPath(
-  argv: string[],
-  pattern: readonly string[],
-  params?: {
-    exact?: boolean;
-    booleanFlags?: readonly string[];
-    valueFlags?: readonly string[];
-  },
-): boolean {
-  const positionals = getCommandPositionalsWithRootOptions(argv, {
-    commandPath: pattern,
-    booleanFlags: params?.booleanFlags,
-    valueFlags: params?.valueFlags,
-  });
-  if (positionals === null) {
-    return false;
-  }
-  return !params?.exact || positionals.length === 0;
 }

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -13,6 +13,7 @@ const DEFAULT_EXPECTED_POLICY: CliCommandPathPolicy = {
   routeConfigGuard: "never",
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
+  ownsProtocolStdout: false,
   hideBanner: false,
   ensureCliPath: true,
   networkProxy: "default",

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -14,6 +14,7 @@ const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   routeConfigGuard: "never",
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
+  ownsProtocolStdout: false,
   hideBanner: false,
   ensureCliPath: true,
   networkProxy: "default",

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -6,7 +6,7 @@ import {
   type CliCommandPathPolicy,
   type CliNetworkProxyPolicy,
 } from "./command-catalog.js";
-import { matchesArgvCommandPath, matchesCommandPath } from "./command-path-matches.js";
+import { matchesCommandPath } from "./command-path-matches.js";
 import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
 
 const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
@@ -20,24 +20,14 @@ const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   networkProxy: "default",
 };
 
-export function resolveCliCommandPathPolicy(
-  commandPath: string[],
-  argv?: string[],
-): CliCommandPathPolicy {
+export function resolveCliCommandPathPolicy(commandPath: string[]): CliCommandPathPolicy {
   // Later catalog entries can refine broader root policies with exact subcommand overrides.
   const resolvedPolicy: CliCommandPathPolicy = { ...DEFAULT_CLI_COMMAND_PATH_POLICY };
   for (const entry of cliCommandCatalog) {
     if (!entry.policy) {
       continue;
     }
-    const matchesEntry =
-      argv && entry.argvMatch
-        ? matchesArgvCommandPath(argv, entry.commandPath, {
-            exact: entry.exact,
-            ...entry.argvMatch,
-          })
-        : matchesCommandPath(commandPath, entry.commandPath, { exact: entry.exact });
-    if (!matchesEntry) {
+    if (!matchesCommandPath(commandPath, entry.commandPath, { exact: entry.exact })) {
       continue;
     }
     Object.assign(resolvedPolicy, entry.policy);

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -6,7 +6,7 @@ import {
   type CliCommandPathPolicy,
   type CliNetworkProxyPolicy,
 } from "./command-catalog.js";
-import { matchesCommandPath } from "./command-path-matches.js";
+import { matchesArgvCommandPath, matchesCommandPath } from "./command-path-matches.js";
 import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
 
 const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
@@ -20,14 +20,24 @@ const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   networkProxy: "default",
 };
 
-export function resolveCliCommandPathPolicy(commandPath: string[]): CliCommandPathPolicy {
+export function resolveCliCommandPathPolicy(
+  commandPath: string[],
+  argv?: string[],
+): CliCommandPathPolicy {
   // Later catalog entries can refine broader root policies with exact subcommand overrides.
   const resolvedPolicy: CliCommandPathPolicy = { ...DEFAULT_CLI_COMMAND_PATH_POLICY };
   for (const entry of cliCommandCatalog) {
     if (!entry.policy) {
       continue;
     }
-    if (!matchesCommandPath(commandPath, entry.commandPath, { exact: entry.exact })) {
+    const matchesEntry =
+      argv && entry.argvMatch
+        ? matchesArgvCommandPath(argv, entry.commandPath, {
+            exact: entry.exact,
+            ...entry.argvMatch,
+          })
+        : matchesCommandPath(commandPath, entry.commandPath, { exact: entry.exact });
+    if (!matchesEntry) {
       continue;
     }
     Object.assign(resolvedPolicy, entry.policy);

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -234,7 +234,9 @@ describe("command-startup-policy", () => {
       loadPlugins: false,
       pluginRegistry: { scope: "channels" },
     });
+  });
 
+  it("treats mcp serve as stdout-clean protocol startup", () => {
     expect(
       resolveCliStartupPolicy({
         commandPath: ["mcp", "serve"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -234,5 +234,19 @@ describe("command-startup-policy", () => {
       loadPlugins: false,
       pluginRegistry: { scope: "channels" },
     });
+
+    expect(
+      resolveCliStartupPolicy({
+        commandPath: ["mcp", "serve"],
+        jsonOutputMode: false,
+        env: {},
+      }),
+    ).toEqual({
+      suppressDoctorStdout: true,
+      hideBanner: false,
+      skipConfigGuard: false,
+      loadPlugins: false,
+      pluginRegistry: { scope: "all" },
+    });
   });
 });

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -236,19 +236,17 @@ describe("command-startup-policy", () => {
     });
   });
 
-  it("treats mcp serve as stdout-clean protocol startup", () => {
-    expect(
-      resolveCliStartupPolicy({
-        commandPath: ["mcp", "serve"],
-        jsonOutputMode: false,
-        env: {},
-      }),
-    ).toEqual({
-      suppressDoctorStdout: true,
-      hideBanner: false,
-      skipConfigGuard: false,
-      loadPlugins: false,
-      pluginRegistry: { scope: "all" },
-    });
+  it("suppresses startup stdout for the mcp serve protocol", () => {
+    expect(resolvePolicy({ commandPath: ["mcp", "serve"] }).suppressDoctorStdout).toBe(true);
+  });
+
+  it("suppresses startup stdout for the bare acp protocol", () => {
+    expect(resolvePolicy({ commandPath: ["acp"] }).suppressDoctorStdout).toBe(true);
+  });
+
+  it("keeps startup stdout for non-protocol commands", () => {
+    expect(resolvePolicy({ commandPath: ["mcp", "list"] }).suppressDoctorStdout).toBe(false);
+    expect(resolvePolicy({ commandPath: ["acp", "client"] }).suppressDoctorStdout).toBe(false);
+    expect(resolvePolicy({ commandPath: ["status"] }).suppressDoctorStdout).toBe(false);
   });
 });

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -32,9 +32,9 @@ export function resolveCliStartupPolicy(params: {
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const mcpServeMode = params.commandPath[0] === "mcp" && params.commandPath[1] === "serve";
-  const suppressDoctorStdout = params.jsonOutputMode || mcpServeMode;
   const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
+  // Protocol commands own stdout from process startup, before their action installs later routing.
+  const suppressDoctorStdout = params.jsonOutputMode || commandPolicy.ownsProtocolStdout;
   const env = params.env ?? process.env;
   return {
     suppressDoctorStdout,

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -32,7 +32,7 @@ export function resolveCliStartupPolicy(params: {
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
+  const commandPolicy = resolveCliCommandPathPolicy(params.commandPath, params.argv);
   // Protocol commands own stdout from process startup, before their action installs later routing.
   const suppressDoctorStdout = params.jsonOutputMode || commandPolicy.ownsProtocolStdout;
   const env = params.env ?? process.env;

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -28,13 +28,19 @@ function shouldLoadPlugins(params: {
 export function resolveCliStartupPolicy(params: {
   argv?: string[];
   commandPath: string[];
+  protocolCommandPath?: string[];
   jsonOutputMode: boolean;
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const commandPolicy = resolveCliCommandPathPolicy(params.commandPath, params.argv);
+  const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
+  // Commander resolves required option values before selecting the action command, so this path
+  // remains authoritative when a protocol option value itself begins with "-".
+  const ownsProtocolStdout = params.protocolCommandPath
+    ? resolveCliCommandPathPolicy(params.protocolCommandPath).ownsProtocolStdout
+    : commandPolicy.ownsProtocolStdout;
   // Protocol commands own stdout from process startup, before their action installs later routing.
-  const suppressDoctorStdout = params.jsonOutputMode || commandPolicy.ownsProtocolStdout;
+  const suppressDoctorStdout = params.jsonOutputMode || ownsProtocolStdout;
   const env = params.env ?? process.env;
   return {
     suppressDoctorStdout,

--- a/src/cli/command-startup-policy.ts
+++ b/src/cli/command-startup-policy.ts
@@ -32,7 +32,8 @@ export function resolveCliStartupPolicy(params: {
   env?: NodeJS.ProcessEnv;
   routeMode?: boolean;
 }) {
-  const suppressDoctorStdout = params.jsonOutputMode;
+  const mcpServeMode = params.commandPath[0] === "mcp" && params.commandPath[1] === "serve";
+  const suppressDoctorStdout = params.jsonOutputMode || mcpServeMode;
   const commandPolicy = resolveCliCommandPathPolicy(params.commandPath);
   const env = params.env ?? process.env;
   return {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -146,6 +146,19 @@ describe("registerPreActionHooks", () => {
       .command("status")
       .option("--json")
       .action(() => {});
+    const acp = programLocal
+      .command("acp")
+      .option("--token <token>")
+      .option("--verbose")
+      .action(() => {});
+    acp
+      .command("client")
+      .option("--cwd <dir>")
+      .action(() => {});
+    programLocal
+      .command("mcp")
+      .command("serve")
+      .action(() => {});
     const gateway = programLocal
       .command("gateway")
       .option("--force")
@@ -605,6 +618,45 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the Commander action path for protocol stdout ownership", async () => {
+    await runPreAction({
+      parseArgv: ["acp"],
+      processArgv: ["node", "openclaw", "acp", "--token", "-secret"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["acp"],
+      suppressDoctorStdout: true,
+    });
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["acp", "client"],
+      processArgv: ["node", "openclaw", "acp", "--verbose", "client"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["acp", "client"],
+    });
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["mcp", "serve"],
+      processArgv: ["node", "openclaw", "mcp", "serve"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["mcp", "serve"],
+      suppressDoctorStdout: true,
+    });
   });
 
   it("does not preload plugins for agents list JSON output", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -53,6 +53,16 @@ function getRootCommand(command: Command): Command {
   return current;
 }
 
+function getActionCommandPath(actionCommand: Command): string[] {
+  const commandPath: string[] = [];
+  let current: Command | null = actionCommand;
+  while (current.parent) {
+    commandPath.unshift(current.name());
+    current = current.parent;
+  }
+  return commandPath;
+}
+
 function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
   const root = getRootCommand(actionCommand);
   if (typeof root.getOptionValueSource !== "function") {
@@ -119,6 +129,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     const jsonOutputMode = isCommandJsonOutputMode(actionCommand, argv);
     const { commandPath, startupPolicy } = resolveCliExecutionStartupContext({
       argv,
+      protocolCommandPath: getActionCommandPath(actionCommand),
       jsonOutputMode,
       env: process.env,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes startup output corruption for commands that own stdout as a machine protocol. Config migration or doctor notes could print before `openclaw mcp serve` starts JSON-RPC, and `openclaw acp` had the same pre-action gap before its later stderr routing.

## Why This Change Was Made

The CLI command catalog now marks exact protocol-stdout owners. Startup policy suppresses doctor stdout for exact `mcp serve` and bare `acp`, while preserving existing JSON-mode suppression and normal command behavior. This keeps the policy at the early shared startup boundary instead of duplicating server-layer routing.

## User Impact

MCP and ACP clients can start without non-protocol warning text corrupting their stdout streams.

## Evidence

- Original live MCP reproduction:
  - before: `openclaw mcp serve` emitted 740 stdout bytes of config-warning output
  - after: startup emitted 0 stdout bytes
  - affected clients stopped accumulating fresh `Failed to parse JSONRPC message` errors after restart
- Focused policy coverage for MCP, ACP, and non-protocol negative controls: 28 tests passed across 3 files.
- Targeted `oxfmt --check` passed.
- `git diff --check` passed.
- Rebased through the guarded fork-update path onto current main.
- Fresh exact-head hosted CI is running on `367693f8c01e34d231d39b780789bf9d87236bd4`.

The contributor PR and authorship are preserved; the maintainer repair extends the same startup-policy fix to the sibling ACP protocol path.
