### PR TITLE
fix(plugins): isolate CLI descriptor rows

### DIFF
--- a/src/plugins/register-plugin-cli-command-groups.test.ts
+++ b/src/plugins/register-plugin-cli-command-groups.test.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import {
+  registerPluginCliCommandGroups,
+  type PluginCliCommandGroupEntry,
+} from "./register-plugin-cli-command-groups.js";
+
+describe("registerPluginCliCommandGroups", () => {
+  it("skips unreadable CLI descriptor rows while preserving healthy lazy commands", async () => {
+    const placeholders = [
+      { name: "broken", description: "broken", hasSubcommands: false },
+      Object.defineProperty(
+        { name: "broken-name", description: "broken name", hasSubcommands: false },
+        "name",
+        {
+          get() {
+            throw new Error("plugin CLI descriptor name exploded");
+          },
+        },
+      ),
+      { name: "healthy", description: "healthy", hasSubcommands: false },
+    ];
+    Object.defineProperty(placeholders, "0", {
+      get() {
+        throw new Error("plugin CLI descriptor row exploded");
+      },
+    });
+    const register = vi.fn();
+    const entry: PluginCliCommandGroupEntry = {
+      pluginId: "cli-plugin",
+      names: ["healthy"],
+      placeholders,
+      register,
+    };
+    const program = new Command("openclaw");
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await registerPluginCliCommandGroups(program, [entry], {
+      mode: "lazy",
+      existingCommands: new Set(),
+      logger,
+    });
+
+    expect(program.commands.map((command) => command.name())).toEqual(["healthy"]);
+    expect(register).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/register-plugin-cli-command-groups.ts
+++ b/src/plugins/register-plugin-cli-command-groups.ts
@@ -15,15 +15,48 @@ export type PluginCliCommandGroupEntry = CommandGroupEntry & {
 
 export type PluginCliCommandGroupMode = "eager" | "lazy";
 
+function listReadableCliPlaceholders(
+  entry: PluginCliCommandGroupEntry,
+): OpenClawPluginCliCommandDescriptor[] {
+  const placeholders = entry.placeholders as readonly OpenClawPluginCliCommandDescriptor[];
+  const readable: OpenClawPluginCliCommandDescriptor[] = [];
+  let placeholderCount: number;
+  try {
+    placeholderCount = placeholders.length;
+  } catch {
+    return readable;
+  }
+  for (let index = 0; index < placeholderCount; index += 1) {
+    try {
+      const placeholder = placeholders[index];
+      if (
+        placeholder &&
+        typeof placeholder.name === "string" &&
+        typeof placeholder.description === "string"
+      ) {
+        readable.push(placeholder);
+      }
+    } catch {
+      // CLI descriptors are plugin-owned metadata. A malformed descriptor row
+      // must not block healthy command roots from registering lazily.
+    }
+  }
+  return readable;
+}
+
 function canRegisterPluginCliLazily(entry: PluginCliCommandGroupEntry): boolean {
-  if (entry.placeholders.length === 0) {
+  const placeholders = listReadableCliPlaceholders(entry);
+  if (placeholders.length === 0) {
     return false;
   }
-  const descriptorNames = new Set(
-    (entry.placeholders as readonly OpenClawPluginCliCommandDescriptor[]).map(
-      (descriptor) => descriptor.name,
-    ),
-  );
+  const descriptorNames = new Set<string>();
+  for (const descriptor of placeholders) {
+    try {
+      descriptorNames.add(descriptor.name);
+    } catch {
+      // Skip only the unreadable descriptor.
+    }
+  }
   return getCommandGroupNames(entry).every((command) => descriptorNames.has(command));
 }
 
@@ -96,7 +129,7 @@ export async function registerPluginCliCommandGroups(
 
     try {
       if (params.mode === "lazy" && canRegisterPluginCliLazily(entry)) {
-        for (const placeholder of entry.placeholders) {
+        for (const placeholder of listReadableCliPlaceholders(entry)) {
           registerLazyCommandGroup(targetProgram, entry, placeholder);
         }
         continue;


### PR DESCRIPTION
## Summary

- isolate plugin-owned CLI descriptor rows during lazy plugin CLI registration
- skip unreadable descriptor rows and descriptors with unreadable required fields while preserving healthy lazy command roots
- add focused regression coverage for poisoned descriptor rows and descriptor `name` getters

## Verification

- Red repro:
  `node scripts/run-vitest.mjs src/plugins/register-plugin-cli-command-groups.test.ts`
  - failed before the fix because the healthy `healthy` lazy command was not registered
- Focused test:
  `node scripts/run-vitest.mjs src/plugins/register-plugin-cli-command-groups.test.ts`
  - passed 1 Vitest shard, 1 file, 1 test
- Format:
  `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/register-plugin-cli-command-groups.ts src/plugins/register-plugin-cli-command-groups.test.ts`
- Lint:
  `./node_modules/.bin/oxlint src/plugins/register-plugin-cli-command-groups.ts src/plugins/register-plugin-cli-command-groups.test.ts`
- Diff check:
  `git diff --check`
  `git diff --check origin/main...HEAD`
- Autoreview:
  `.agents/skills/autoreview/scripts/autoreview --mode local`
  - clean, `overall: patch is correct (0.84)`
  `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - first run found descriptor objects with unreadable fields could still abort lazy registration, fixed
  - final branch run clean, `overall: patch is correct (0.86)`

## Real behavior proof

Behavior addressed: a malformed plugin CLI descriptor row can no longer prevent healthy lazy CLI command roots from being registered.

Real environment tested: local linked Codex worktree from current `origin/main`, using the repo Vitest wrapper for the focused plugin CLI registration test file.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/register-plugin-cli-command-groups.test.ts`.

Evidence after fix: the focused plugin shard passed with 1 file and 1 test, including the poisoned CLI descriptor regression.

Observed result after fix: unreadable descriptor rows and descriptor `name` getters are skipped while the healthy `healthy` lazy command is registered and the plugin registration function is not eagerly invoked.

What was not tested: full `pnpm check:changed`; Crabbox changed gate failed before sync/lease because `/Users/m1/.cache/openclaw/crabbox-sync` had only 477.5 MiB free and requires 1.00 GiB.
