### PR TITLE
feat(skills): add OpenClaw config editing guard

### DIFF
--- a/skills/openclaw-config-editing/SKILL.md
+++ b/skills/openclaw-config-editing/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: openclaw-config-editing
+description: "Safely inspect, edit, dry-run, validate, or recover OpenClaw config files."
+---
+
+# OpenClaw Config Editing
+
+Use when editing `openclaw.json`, Gateway config, plugin config, channel config, or anything that might stop OpenClaw from starting.
+
+## Workflow
+
+1. Find the active config path.
+
+   ```bash
+   openclaw config file
+   ```
+
+2. Check whether the install is Nix-managed. If `OPENCLAW_NIX_MODE=1` or config writers refuse because Nix mode is active, do not edit generated `openclaw.json`; edit the Nix source instead.
+
+3. Prefer OpenClaw-owned writes over hand-editing JSON.
+
+   For one value:
+
+   ```bash
+   openclaw config set gateway.port 19001 --strict-json --dry-run
+   openclaw config set gateway.port 19001 --strict-json
+   ```
+
+   For object-shaped or multi-key edits:
+
+   ```bash
+   openclaw config patch --file ./openclaw.patch.json5 --dry-run
+   openclaw config patch --file ./openclaw.patch.json5
+   ```
+
+4. Use `--strict-json` for scalar `config set` edits that must be schema-checked. Plain value mode can accept strings that are not valid for the target field.
+
+5. After applying, validate before restart or further changes.
+
+   ```bash
+   openclaw config validate
+   ```
+
+6. If validation fails, stop. Report the exact error, do not restart the Gateway, and either fix with another dry-run-first edit or restore the previous file.
+
+## Direct File Edits
+
+Only hand-edit `openclaw.json` when the CLI cannot express the change.
+
+1. Copy a backup beside the config and harden it to owner-only permissions.
+   Example: `cp -p "$config" "$config.bak" && chmod 600 "$config.bak"`.
+2. Make the smallest possible edit.
+3. Run `openclaw config validate` immediately.
+4. Restore the backup if validation fails.
+
+If editor help is missing, refresh the local schema next to the config:
+
+```bash
+config="$(openclaw config file)"
+openclaw config schema > "$(dirname "$config")/openclaw.schema.json"
+```


### PR DESCRIPTION
## Summary

This adds a tiny first-party skill for the thing I keep nearly doing: touching `openclaw.json` and breaking the assistant that is supposed to help fix it.

The skill gives agents a simple breadcrumb:

- find the active config with `openclaw config file`
- prefer `config set` / `config patch` over hand-editing JSON
- dry-run first, using `--strict-json` where scalar values need real schema checks
- run `openclaw config validate` before restart
- avoid generated `openclaw.json` edits in Nix mode
- if direct edits are unavoidable, make a hardened `0600` backup first

Out of scope: changing config behavior or adding a new config editor. This is just shipped agent guidance.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related: #89992

Was this requested by a maintainer or owner?

Requested in Discord while discussing a follow-up to the local config schema / IntelliSense PR.

AI-assisted: yes, drafted with Codex and reviewed with `codex review --base origin/main`.

## Real behavior proof (required for external PRs)

- Behavior addressed: OpenClaw now ships a first-party `openclaw-config-editing` skill with the safe config edit workflow available to agents.
- Real environment tested: Local OpenClaw source checkout on Linux, branch `dan/openclaw-config-editing-skill`.
- Exact steps or command run after this patch:

```bash
pnpm docs:list
python3 skills/skill-creator/scripts/quick_validate.py skills/openclaw-config-editing
python3 - <<'PY'
from pathlib import Path
import yaml
for p in Path('skills').glob('*/SKILL.md'):
    text = p.read_text()
    if not text.startswith('---\n'):
        raise SystemExit(f'missing frontmatter: {p}')
    fm = text.split('---', 2)[1]
    yaml.safe_load(fm)
print('ok')
PY
git diff --check origin/main...HEAD
codex review --base origin/main
```

- Evidence after fix:

```text
Skill is valid!
ok
codex: The new skill file has valid frontmatter and its documented OpenClaw config commands align with the existing CLI/docs behavior. I did not find a discrete correctness issue introduced by this change.
```

- Observed result after fix: The new skill validates, all skill frontmatter still parses, whitespace checks pass, and Codex review came back clean after the backup-permissions note was fixed.
- What was not tested: I did not run a packaged install to inspect the skill in a fresh agent prompt.
- Proof limitations or environment constraints: This is a skill/documentation-only change, so the proof is static validation plus repo docs/CLI contract review rather than a Gateway runtime scenario.

## Tests and validation

Which commands did you run?

```bash
pnpm docs:list
python3 skills/skill-creator/scripts/quick_validate.py skills/openclaw-config-editing
python3 - <<'PY'
from pathlib import Path
import yaml
for p in Path('skills').glob('*/SKILL.md'):
    text = p.read_text()
    if not text.startswith('---\n'):
        raise SystemExit(f'missing frontmatter: {p}')
    fm = text.split('---', 2)[1]
    yaml.safe_load(fm)
print('ok')
PY
git diff --check origin/main...HEAD
codex review --base origin/main
```

What regression coverage was added or updated?

No automated regression test was added; this is one bundled `SKILL.md`.

What failed before this fix, if known?

No test failed. The gap was that OpenClaw did not ship a dedicated skill reminding agents how to safely edit OpenClaw's own config.

If no test was added, why not?

The existing skill validator and frontmatter parse cover the changed artifact. There is no runtime code path changed.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Agents can now discover a first-party safe OpenClaw config editing skill.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No runtime behavior changed. The skill does add a security reminder to harden manual config backups to `0600`.

What is the highest-risk area?

Bad guidance in the skill could teach agents to make unsafe config edits.

How is that risk mitigated?

The workflow points at existing `openclaw config` commands, dry-run/validation, Nix-mode immutability, and hardened backups. Codex review checked the guidance against current CLI/docs behavior.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review.

Which bot or reviewer comments were addressed?

Local Codex review flagged manual backup permissions; the skill now says to preserve/harden backups with `chmod 600`.
