### PR TITLE
fix(plugins): isolate CLI metadata rows

### DIFF
--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -953,6 +953,126 @@ module.exports = {
     ]);
   });
 
+  it("skips unreadable plugin CLI descriptor rows without dropping healthy commands", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "poisoned-cli-descriptors",
+      filename: "poisoned-cli-descriptors.cjs",
+      body: `module.exports = {
+  id: "poisoned-cli-descriptors",
+  register(api) {
+    const descriptors = [
+      {
+        name: "unreadable-row",
+        description: "Unreadable row",
+        hasSubcommands: false,
+      },
+      {
+        get name() {
+          throw new Error("cli descriptor name exploded");
+        },
+        description: "Bad descriptor name",
+        hasSubcommands: false,
+      },
+      {
+        name: "bad-description",
+        get description() {
+          throw new Error("cli descriptor description exploded");
+        },
+        hasSubcommands: false,
+      },
+      {
+        name: "healthy-cli",
+        description: "Healthy CLI metadata",
+        hasSubcommands: true,
+      },
+    ];
+    Object.defineProperty(descriptors, "0", {
+      get() {
+        throw new Error("cli descriptor row exploded");
+      },
+    });
+    api.registerCli(() => {}, { descriptors });
+  },
+};`,
+    });
+
+    const registry = await loadOpenClawPluginCliRegistry({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.dir] },
+          allow: ["poisoned-cli-descriptors"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "poisoned-cli-descriptors")?.status).toBe(
+      "loaded",
+    );
+    expect(registry.cliRegistrars).toHaveLength(1);
+    expect(registry.cliRegistrars[0]?.commands).toEqual(["healthy-cli"]);
+    expect(registry.cliRegistrars[0]?.descriptors).toEqual([
+      {
+        name: "healthy-cli",
+        description: "Healthy CLI metadata",
+        hasSubcommands: true,
+      },
+    ]);
+    expect(registry.diagnostics.map((diag) => diag.message)).toEqual([
+      "invalid cli descriptor metadata: cli descriptor row exploded",
+      "invalid cli descriptor metadata: cli descriptor name exploded",
+      "invalid cli descriptor metadata: cli descriptor description exploded",
+    ]);
+  });
+
+  it("rejects unreadable plugin CLI parent paths instead of shortening command roots", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "poisoned-cli-parent-path",
+      filename: "poisoned-cli-parent-path.cjs",
+      body: `module.exports = {
+  id: "poisoned-cli-parent-path",
+  register(api) {
+    const parentPath = ["nodes"];
+    Object.defineProperty(parentPath, "0", {
+      get() {
+        throw new Error("cli parent path exploded");
+      },
+    });
+    api.registerCli(() => {}, {
+      parentPath,
+      descriptors: [
+        {
+          name: "healthy-node",
+          description: "Healthy node CLI metadata",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+    });
+
+    const registry = await loadOpenClawPluginCliRegistry({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.dir] },
+          allow: ["poisoned-cli-parent-path"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "poisoned-cli-parent-path")?.status).toBe(
+      "loaded",
+    );
+    expect(registry.cliRegistrars).toEqual([]);
+    expect(registry.diagnostics.map((diag) => diag.message)).toEqual([
+      "invalid cli command metadata: cli parent path exploded",
+    ]);
+  });
+
   it("rejects async plugin registration when collecting CLI metadata", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1473,34 +1473,83 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       }
       return normalized;
     };
-    const parentPath = (opts?.parentPath ?? []).map((segment) =>
-      normalizeCommandRoot(segment, "command"),
-    );
-    if (parentPath.some((segment) => segment === null)) {
+    const pushInvalidCliMetadataDiagnostic = (source: "command" | "descriptor", error: unknown) => {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `invalid cli ${source} metadata: ${formatErrorMessage(error)}`,
+      });
+    };
+    const normalizeCommandRoots = (
+      values: readonly string[],
+      source: "command" | "descriptor",
+      options?: { invalidatesRegistration?: boolean },
+    ) => {
+      const roots: string[] = [];
+      let invalid = false;
+      let index = 0;
+      while (index < values.length) {
+        let value: string;
+        try {
+          value = values[index] as string;
+        } catch (error) {
+          pushInvalidCliMetadataDiagnostic(source, error);
+          invalid ||= options?.invalidatesRegistration === true;
+          index += 1;
+          continue;
+        }
+        if (typeof value !== "string") {
+          pushInvalidCliMetadataDiagnostic(source, new Error("expected string"));
+          invalid ||= options?.invalidatesRegistration === true;
+          index += 1;
+          continue;
+        }
+        const normalized = normalizeCommandRoot(value, source);
+        if (normalized) {
+          roots.push(normalized);
+        } else {
+          invalid = true;
+        }
+        index += 1;
+      }
+      return { invalid, roots };
+    };
+    const parentPathResult = normalizeCommandRoots(opts?.parentPath ?? [], "command", {
+      invalidatesRegistration: true,
+    });
+    if (parentPathResult.invalid) {
       return;
     }
-    const normalizedParentPath = parentPath as string[];
-    const descriptors = (opts?.descriptors ?? [])
-      .map((descriptor) => {
+    const normalizedParentPath = parentPathResult.roots;
+    const descriptors: OpenClawPluginCliCommandDescriptor[] = [];
+    const rawDescriptors = opts?.descriptors ?? [];
+    let descriptorIndex = 0;
+    while (descriptorIndex < rawDescriptors.length) {
+      try {
+        const descriptor = rawDescriptors[descriptorIndex];
+        if (!descriptor) {
+          descriptorIndex += 1;
+          continue;
+        }
         const name = normalizeCommandRoot(descriptor.name, "descriptor");
         const description = sanitizeCommandDescriptorDescription(descriptor.description);
-        return name && description
-          ? {
-              name,
-              description,
-              hasSubcommands: descriptor.hasSubcommands,
-            }
-          : null;
-      })
-      .filter(
-        (descriptor): descriptor is OpenClawPluginCliCommandDescriptor => descriptor !== null,
-      );
+        if (name && description) {
+          descriptors.push({
+            name,
+            description,
+            hasSubcommands: descriptor.hasSubcommands,
+          });
+        }
+      } catch (error) {
+        pushInvalidCliMetadataDiagnostic("descriptor", error);
+      }
+      descriptorIndex += 1;
+    }
     const commands = [
-      ...(opts?.commands ?? []),
+      ...normalizeCommandRoots(opts?.commands ?? [], "command").roots,
       ...descriptors.map((descriptor) => descriptor.name),
-    ]
-      .map((cmd) => normalizeCommandRoot(cmd, "command"))
-      .filter((command): command is string => command !== null);
+    ];
     if (commands.length === 0) {
       pushDiagnostic({
         level: "error",


### PR DESCRIPTION
## Summary

- isolate plugin-owned CLI metadata rows during `api.registerCli()` normalization
- preserve healthy descriptor-backed CLI commands when sibling descriptor rows or fields throw
- reject unreadable CLI parent paths instead of registering commands under shortened roots

## Verification

- `node scripts/run-vitest.mjs src/plugins/loader.cli-metadata.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/registry.ts src/plugins/loader.cli-metadata.test.ts`
- `./node_modules/.bin/oxlint src/plugins/registry.ts src/plugins/loader.cli-metadata.test.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: A plugin with malformed CLI descriptor metadata could fail its whole CLI metadata registration before later healthy command descriptors were preserved.

Real environment tested: Local linked OpenClaw worktree on branch `fuzz-tool-schema-next144-20260603`, Node/Vitest through `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/loader.cli-metadata.test.ts`.

Evidence after fix: The focused plugin loader CLI metadata suite passed 1 Vitest shard, 1 file, and 18 tests.

Observed result after fix: Unreadable descriptor rows, throwing descriptor fields, and unreadable parent path rows are isolated; healthy descriptor-backed CLI commands still register, while malformed parent paths do not get shortened into root commands.

What was not tested: Full `pnpm check:changed` was not run. Testbox is not authenticated, and the Crabbox changed-gate attempt failed before execution with coordinator HTTP 401 unauthorized.
