### PR TITLE
[plugin sdk] Allow declared installed trusted hooks

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -417,7 +417,7 @@ openclaw plugins inspect <id> --runtime
 openclaw plugins inspect <id> --json
 ```
 
-Inspect shows identity, load status, source, manifest capabilities, policy flags, diagnostics, install metadata, bundle capabilities, and any detected MCP or LSP server support without importing plugin runtime by default. Add `--runtime` to load the plugin module and include registered hooks, tools, commands, services, gateway methods, and HTTP routes. Runtime inspection reports missing plugin dependencies directly; installs and repairs stay in `openclaw plugins install`, `openclaw plugins update`, and `openclaw doctor --fix`.
+Inspect shows identity, load status, source, manifest capabilities, policy flags, diagnostics, install metadata, bundle capabilities, and any detected MCP or LSP server support without importing plugin runtime by default. JSON output includes the plugin manifest contracts, such as `contracts.agentToolResultMiddleware` and `contracts.trustedToolPolicies`, so operators can audit trusted-surface declarations before enabling or restarting a plugin. Add `--runtime` to load the plugin module and include registered hooks, tools, commands, services, gateway methods, and HTTP routes. Runtime inspection reports missing plugin dependencies directly; installs and repairs stay in `openclaw plugins install`, `openclaw plugins update`, and `openclaw doctor --fix`.
 
 Plugin-owned CLI commands are usually installed as root `openclaw` command groups, but plugins may also register nested commands under a core parent such as `openclaw nodes`. After `inspect --runtime` shows a command under `cliCommands`, run it at the listed path; for example a plugin that registers `demo-git` can be verified with `openclaw demo-git ping`.
 

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -106,9 +106,10 @@ local proof.
     eagerly loading every plugin runtime. Set `activation.onStartup`
     intentionally. This example starts on Gateway startup.
 
-    Host-trusted plugin surfaces are also manifest-gated. If an installed
-    plugin registers `api.registerAgentToolResultMiddleware(...)`, declare each
-    target runtime in `contracts.agentToolResultMiddleware`. If it registers
+    Host-trusted plugin surfaces are also manifest-gated and require explicit
+    enablement for installed plugins. If an installed plugin registers
+    `api.registerAgentToolResultMiddleware(...)`, declare each target runtime in
+    `contracts.agentToolResultMiddleware`. If it registers
     `api.registerTrustedToolPolicy(...)`, declare each policy id in
     `contracts.trustedToolPolicies`. These declarations keep install-time
     inspection and runtime registration aligned.

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -106,6 +106,13 @@ local proof.
     eagerly loading every plugin runtime. Set `activation.onStartup`
     intentionally. This example starts on Gateway startup.
 
+    Host-trusted plugin surfaces are also manifest-gated. If an installed
+    plugin registers `api.registerAgentToolResultMiddleware(...)`, declare each
+    target runtime in `contracts.agentToolResultMiddleware`. If it registers
+    `api.registerTrustedToolPolicy(...)`, declare each policy id in
+    `contracts.trustedToolPolicies`. These declarations keep install-time
+    inspection and runtime registration aligned.
+
     For every manifest field, see [Plugin manifest](/plugins/manifest).
 
   </Step>

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -234,8 +234,9 @@ policies run first; installed-plugin trusted policies run next in plugin-load
 order; ordinary `before_tool_call` hooks run after them. Bundled plugins keep
 the existing trusted-policy path. Installed plugins must declare every policy id
 in `contracts.trustedToolPolicies`; undeclared ids are rejected before
-registration. Use this tier only for host-trusted gates such as workspace
-policy, budget enforcement, or reserved workflow safety.
+registration. Policy ids are scoped to the registering plugin, so different
+plugins may reuse the same local id. Use this tier only for host-trusted gates
+such as workspace policy, budget enforcement, or reserved workflow safety.
 
 ### Exec environment hook
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -227,12 +227,15 @@ See [Plugin permission requests](/plugins/plugin-permission-requests) for
 approval routing, decision behavior, and when to use `requireApproval` instead
 of optional tools or exec approvals.
 
-Bundled plugins that need host-level policy can register trusted tool policies
-with `api.registerTrustedToolPolicy(...)`. These run before ordinary
-`before_tool_call` hooks and before external plugin decisions. Use them only
-for host-trusted gates such as workspace policy, budget enforcement, or
-reserved workflow safety. External plugins should use normal `before_tool_call`
-hooks.
+Plugins that need host-level policy can register trusted tool policies with
+`api.registerTrustedToolPolicy(...)`. These run before ordinary
+`before_tool_call` hooks and before normal hook decisions. Bundled trusted
+policies run first; installed-plugin trusted policies run next in plugin-load
+order; ordinary `before_tool_call` hooks run after them. Bundled plugins keep
+the existing trusted-policy path. Installed plugins must declare every policy id
+in `contracts.trustedToolPolicies`; undeclared ids are rejected before
+registration. Use this tier only for host-trusted gates such as workspace
+policy, budget enforcement, or reserved workflow safety.
 
 ### Exec environment hook
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -232,11 +232,12 @@ Plugins that need host-level policy can register trusted tool policies with
 `before_tool_call` hooks and before normal hook decisions. Bundled trusted
 policies run first; installed-plugin trusted policies run next in plugin-load
 order; ordinary `before_tool_call` hooks run after them. Bundled plugins keep
-the existing trusted-policy path. Installed plugins must declare every policy id
-in `contracts.trustedToolPolicies`; undeclared ids are rejected before
-registration. Policy ids are scoped to the registering plugin, so different
-plugins may reuse the same local id. Use this tier only for host-trusted gates
-such as workspace policy, budget enforcement, or reserved workflow safety.
+the existing trusted-policy path. Installed plugins must be explicitly enabled
+and declare every policy id in `contracts.trustedToolPolicies`; undeclared ids
+are rejected before registration. Policy ids are scoped to the registering
+plugin, so different plugins may reuse the same local id. Use this tier only
+for host-trusted gates such as workspace policy, budget enforcement, or
+reserved workflow safety.
 
 ### Exec environment hook
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -677,15 +677,16 @@ Each list is optional:
 app-server-only extension factories. Bundled tool-result transforms should
 declare `contracts.agentToolResultMiddleware` and register with
 `api.registerAgentToolResultMiddleware(...)` instead. Installed plugins may use
-the same middleware seam only for runtimes they declare in
-`contracts.agentToolResultMiddleware`.
+the same middleware seam only when explicitly enabled and only for runtimes they
+declare in `contracts.agentToolResultMiddleware`.
 
 Installed plugins that need the host-trusted pre-tool policy tier must declare
-each registered local id in `contracts.trustedToolPolicies`. Bundled plugins
-keep the existing trusted-policy path, but installed plugins with undeclared
-policy ids are rejected before registration. Policy ids are scoped to the
-registering plugin, so two plugins may both declare and register
-`workflow-budget`; a single plugin may not register the same local id twice.
+each registered local id in `contracts.trustedToolPolicies` and be explicitly
+enabled. Bundled plugins keep the existing trusted-policy path, but installed
+plugins with undeclared policy ids are rejected before registration. Policy ids
+are scoped to the registering plugin, so two plugins may both declare and
+register `workflow-budget`; a single plugin may not register the same local id
+twice.
 
 Runtime `api.registerTool(...)` registrations must match `contracts.tools`.
 Tool discovery uses this list to load only the plugin runtimes that can own the

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -631,6 +631,7 @@ read without importing the plugin runtime.
 {
   "contracts": {
     "agentToolResultMiddleware": ["openclaw", "codex"],
+    "trustedToolPolicies": ["workflow-budget"],
     "externalAuthProviders": ["acme-ai"],
     "embeddingProviders": ["openai-compatible"],
     "speechProviders": ["openai"],
@@ -651,32 +652,38 @@ read without importing the plugin runtime.
 
 Each list is optional:
 
-| Field                            | Type       | What it means                                                                                        |
-| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
-| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                |
-| `agentToolResultMiddleware`      | `string[]` | Runtime ids a bundled plugin may register tool-result middleware for.                                |
-| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                      |
-| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory. |
-| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                |
-| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                |
-| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                        |
-| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                  |
-| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                   |
-| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                     |
-| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                      |
-| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                      |
-| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                             |
-| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                            |
-| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                         |
-| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.  |
-| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                   |
+| Field                            | Type       | What it means                                                                                                           |
+| -------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                                   |
+| `agentToolResultMiddleware`      | `string[]` | Runtime ids this plugin may register tool-result middleware for.                                                        |
+| `trustedToolPolicies`            | `string[]` | Trusted pre-tool policy ids an installed plugin may register. Bundled plugins may register policies without this field. |
+| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                                         |
+| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory.                    |
+| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                                   |
+| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                                   |
+| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                                           |
+| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                                     |
+| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                                      |
+| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                                        |
+| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                                         |
+| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                                         |
+| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                                                |
+| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                                               |
+| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                                            |
+| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.                     |
+| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                                      |
 
 `contracts.embeddedExtensionFactories` is retained for bundled Codex
 app-server-only extension factories. Bundled tool-result transforms should
 declare `contracts.agentToolResultMiddleware` and register with
-`api.registerAgentToolResultMiddleware(...)` instead. External plugins cannot
-register tool-result middleware because the seam can rewrite high-trust tool
-output before the model sees it.
+`api.registerAgentToolResultMiddleware(...)` instead. Installed plugins may use
+the same middleware seam only for runtimes they declare in
+`contracts.agentToolResultMiddleware`.
+
+Installed plugins that need the host-trusted pre-tool policy tier must declare
+each registered id in `contracts.trustedToolPolicies`. Bundled plugins keep the
+existing trusted-policy path, but installed plugins with undeclared policy ids
+are rejected before registration.
 
 Runtime `api.registerTool(...)` registrations must match `contracts.tools`.
 Tool discovery uses this list to load only the plugin runtimes that can own the

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -652,26 +652,26 @@ read without importing the plugin runtime.
 
 Each list is optional:
 
-| Field                            | Type       | What it means                                                                                                           |
-| -------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                                   |
-| `agentToolResultMiddleware`      | `string[]` | Runtime ids this plugin may register tool-result middleware for.                                                        |
-| `trustedToolPolicies`            | `string[]` | Trusted pre-tool policy ids an installed plugin may register. Bundled plugins may register policies without this field. |
-| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                                         |
-| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory.                    |
-| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                                   |
-| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                                   |
-| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                                           |
-| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                                     |
-| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                                      |
-| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                                        |
-| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                                         |
-| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                                         |
-| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                                                |
-| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                                               |
-| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                                            |
-| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.                     |
-| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                                      |
+| Field                            | Type       | What it means                                                                                                                        |
+| -------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                                                |
+| `agentToolResultMiddleware`      | `string[]` | Runtime ids this plugin may register tool-result middleware for.                                                                     |
+| `trustedToolPolicies`            | `string[]` | Plugin-local trusted pre-tool policy ids an installed plugin may register. Bundled plugins may register policies without this field. |
+| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                                                      |
+| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory.                                 |
+| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                                                |
+| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                                                |
+| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                                                        |
+| `memoryEmbeddingProviders`       | `string[]` | Deprecated memory-specific embedding provider ids this plugin owns.                                                                  |
+| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                                                   |
+| `transcriptSourceProviders`      | `string[]` | Transcript source provider ids this plugin owns.                                                                                     |
+| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                                                      |
+| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                                                      |
+| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                                                             |
+| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                                                            |
+| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                                                         |
+| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.                                  |
+| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                                                   |
 
 `contracts.embeddedExtensionFactories` is retained for bundled Codex
 app-server-only extension factories. Bundled tool-result transforms should
@@ -681,9 +681,11 @@ the same middleware seam only for runtimes they declare in
 `contracts.agentToolResultMiddleware`.
 
 Installed plugins that need the host-trusted pre-tool policy tier must declare
-each registered id in `contracts.trustedToolPolicies`. Bundled plugins keep the
-existing trusted-policy path, but installed plugins with undeclared policy ids
-are rejected before registration.
+each registered local id in `contracts.trustedToolPolicies`. Bundled plugins
+keep the existing trusted-policy path, but installed plugins with undeclared
+policy ids are rejected before registration. Policy ids are scoped to the
+registering plugin, so two plugins may both declare and register
+`workflow-budget`; a single plugin may not register the same local id twice.
 
 Runtime `api.registerTool(...)` registrations must match `contracts.tools`.
 Tool discovery uses this list to load only the plugin runtimes that can own the

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -160,11 +160,12 @@ Codex `0.124.0`, while pinning OpenClaw to the newer tested stable line.
 
 ### Tool-result middleware
 
-Bundled plugins can attach runtime-neutral tool-result middleware through
+Bundled plugins and installed plugins with matching manifest contracts can
+attach runtime-neutral tool-result middleware through
 `api.registerAgentToolResultMiddleware(...)` when their manifest declares the
 targeted runtime ids in `contracts.agentToolResultMiddleware`. This trusted
-seam is for async tool-result transforms that must run before OpenClaw or Codex feeds
-tool output back into the model.
+seam is for async tool-result transforms that must run before OpenClaw or Codex
+feeds tool output back into the model.
 
 Legacy bundled plugins can still use
 `api.registerCodexAppServerExtensionFactory(...)` for Codex app-server-only

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -160,8 +160,8 @@ Codex `0.124.0`, while pinning OpenClaw to the newer tested stable line.
 
 ### Tool-result middleware
 
-Bundled plugins and installed plugins with matching manifest contracts can
-attach runtime-neutral tool-result middleware through
+Bundled plugins and explicitly enabled installed plugins with matching manifest
+contracts can attach runtime-neutral tool-result middleware through
 `api.registerAgentToolResultMiddleware(...)` when their manifest declares the
 targeted runtime ids in `contracts.agentToolResultMiddleware`. This trusted
 seam is for async tool-result transforms that must run before OpenClaw or Codex

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -318,8 +318,10 @@ releases.
     }
     ```
 
-    External plugins cannot register tool-result middleware because it can
-    rewrite high-trust tool output before the model sees it.
+    Installed plugins can also register tool-result middleware when they are
+    explicitly enabled and declare every targeted runtime in
+    `contracts.agentToolResultMiddleware`. Undeclared installed middleware
+    registrations are rejected.
 
   </Step>
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -178,7 +178,7 @@ plugins.
 | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `api.session.state.registerSessionExtension(...)`                                    | Plugin-owned, JSON-compatible session state projected through Gateway sessions                                                    |
 | `api.session.workflow.enqueueNextTurnInjection(...)`                                 | Durable exactly-once context injected into the next agent turn for one session                                                    |
-| `api.registerTrustedToolPolicy(...)`                                                 | Bundled/trusted pre-plugin tool policy that can block or rewrite tool params                                                      |
+| `api.registerTrustedToolPolicy(...)`                                                 | Manifest-gated trusted pre-plugin tool policy that can block or rewrite tool params                                               |
 | `api.registerToolMetadata(...)`                                                      | Tool catalog display metadata without changing the tool implementation                                                            |
 | `api.registerCommand(...)`                                                           | Scoped plugin commands; command results can set `continueAgent: true`; Discord native commands support `descriptionLocalizations` |
 | `api.session.controls.registerControlUiDescriptor(...)`                              | Control UI contribution descriptors for session, tool, run, or settings surfaces                                                  |
@@ -226,7 +226,9 @@ The contracts intentionally split authority:
 - External plugins can own session extensions, UI descriptors, commands, tool
   metadata, next-turn injections, and normal hooks.
 - Trusted tool policies run before ordinary `before_tool_call` hooks and are
-  bundled-only because they participate in host safety policy.
+  host-trusted. Bundled policies run first; installed-plugin policies require
+  their ids in `contracts.trustedToolPolicies` and run next in plugin-load
+  order.
 - Reserved command ownership is bundled-only. External plugins should use their
   own command names or aliases.
 - `allowPromptInjection=false` disables prompt-mutating hooks including
@@ -251,16 +253,17 @@ Examples of non-Plan consumers:
 </Note>
 
 <Accordion title="When to use tool-result middleware">
-  Bundled plugins can use `api.registerAgentToolResultMiddleware(...)` when
-  they need to rewrite a tool result after execution and before the runtime
-  feeds that result back into the model. This is the trusted runtime-neutral
-  seam for async output reducers such as tokenjuice.
+  Bundled plugins and installed plugins with matching manifest contracts can
+  use `api.registerAgentToolResultMiddleware(...)` when they need to rewrite a
+  tool result after execution and before the runtime feeds that result back into
+  the model. This is the trusted runtime-neutral seam for async output reducers
+  such as tokenjuice.
 
-Bundled plugins must declare `contracts.agentToolResultMiddleware` for each
-targeted runtime, for example `["openclaw", "codex"]`. External plugins
-cannot register this middleware; keep normal OpenClaw plugin hooks for work
-that does not need pre-model tool-result timing. The old embedded-runner-only
-extension factory registration path has been removed.
+Plugins must declare `contracts.agentToolResultMiddleware` for each targeted
+runtime, for example `["openclaw", "codex"]`. Installed plugins without that
+contract cannot register this middleware; keep normal OpenClaw plugin hooks for
+work that does not need pre-model tool-result timing. The old
+embedded-runner-only extension factory registration path has been removed.
 </Accordion>
 
 ### Gateway discovery registration

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -227,8 +227,9 @@ The contracts intentionally split authority:
   metadata, next-turn injections, and normal hooks.
 - Trusted tool policies run before ordinary `before_tool_call` hooks and are
   host-trusted. Bundled policies run first; installed-plugin policies require
-  their local ids in `contracts.trustedToolPolicies` and run next in
-  plugin-load order. Policy ids are scoped to the registering plugin.
+  explicit enablement plus their local ids in
+  `contracts.trustedToolPolicies`, and run next in plugin-load order. Policy ids
+  are scoped to the registering plugin.
 - Reserved command ownership is bundled-only. External plugins should use their
   own command names or aliases.
 - `allowPromptInjection=false` disables prompt-mutating hooks including
@@ -253,16 +254,17 @@ Examples of non-Plan consumers:
 </Note>
 
 <Accordion title="When to use tool-result middleware">
-  Bundled plugins and installed plugins with matching manifest contracts can
-  use `api.registerAgentToolResultMiddleware(...)` when they need to rewrite a
-  tool result after execution and before the runtime feeds that result back into
-  the model. This is the trusted runtime-neutral seam for async output reducers
-  such as tokenjuice.
+  Bundled plugins and explicitly enabled installed plugins with matching
+  manifest contracts can use `api.registerAgentToolResultMiddleware(...)` when
+  they need to rewrite a tool result after execution and before the runtime
+  feeds that result back into the model. This is the trusted runtime-neutral
+  seam for async output reducers such as tokenjuice.
 
 Plugins must declare `contracts.agentToolResultMiddleware` for each targeted
 runtime, for example `["openclaw", "codex"]`. Installed plugins without that
-contract cannot register this middleware; keep normal OpenClaw plugin hooks for
-work that does not need pre-model tool-result timing. The old
+contract, or without explicit enablement, cannot register this middleware; keep
+normal OpenClaw plugin hooks for work that does not need pre-model tool-result
+timing. The old
 embedded-runner-only extension factory registration path has been removed.
 </Accordion>
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -227,8 +227,8 @@ The contracts intentionally split authority:
   metadata, next-turn injections, and normal hooks.
 - Trusted tool policies run before ordinary `before_tool_call` hooks and are
   host-trusted. Bundled policies run first; installed-plugin policies require
-  their ids in `contracts.trustedToolPolicies` and run next in plugin-load
-  order.
+  their local ids in `contracts.trustedToolPolicies` and run next in
+  plugin-load order. Policy ids are scoped to the registering plugin.
 - Reserved command ownership is bundled-only. External plugins should use their
   own command names or aliases.
 - `allowPromptInjection=false` disables prompt-mutating hooks including

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -401,7 +401,10 @@ describe("qa scenario catalog", () => {
       "kitchen-sink-realtime-voice-provider",
     );
     expect(config?.expectedAdversarialDiagnostics).toContain(
-      "only bundled plugins can register agent tool result middleware",
+      "agent tool result middleware must be a function",
+    );
+    expect(config?.expectedAdversarialDiagnostics).toContain(
+      "trusted tool policy registration requires id, description, and evaluate()",
     );
     expect(config?.expectedAdversarialDiagnostics).toContain(
       "control UI descriptor registration requires id, surface, label, and valid optional fields",

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.md
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.md
@@ -87,7 +87,7 @@ execution:
     livePrompt: "Kitchen Sink OpenAI marker. Reply exactly: KITCHEN-SINK-OPENAI-OK"
     expectedAdversarialDiagnostics:
       - agent event subscription registration requires id and handle
-      - only bundled plugins can register agent tool result middleware
+      - agent tool result middleware must be a function
       - agent harness "kitchen-sink-agent-harness" registration missing required runtime methods
       - channel "kitchen-sink-channel-probe" registration missing required config helpers
       - cli registration missing explicit commands metadata
@@ -99,6 +99,7 @@ execution:
       - "http route registration missing or invalid auth: /kitchen-sink/http-route"
       - "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider"
       - "plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: kitchen-sink-memory-embedding-provider"
+      - "trusted tool policy registration requires id, description, and evaluate()"
       - memory prompt supplement registration missing builder
       - model catalog provider registration missing provider
       - node invoke policy registration missing commands
@@ -106,7 +107,6 @@ execution:
       - session scheduler job registration requires unique id, sessionKey, and kind
       - "plugin must declare contracts.tools for: kitchen-sink-tool"
       - tool metadata registration missing toolName
-      - only bundled plugins can register trusted tool policies
 ```
 
 ```yaml qa-flow

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -203,7 +203,8 @@ const expectMissing = (listValue, expected, field) => {
 
 const INVALID_PROBE_DIAGNOSTIC_SURFACE_MODES = new Set(["full", "conformance", "adversarial"]);
 const requiredFullDiagnosticCanaries = new Set([
-  "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
+  "agent tool result middleware must be a function",
+  "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
   'channel "kitchen-sink-channel-probe" registration missing required config helpers',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
@@ -214,14 +215,14 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
   const expectedErrorMessages = new Set([
     "cli registration missing explicit commands metadata",
     "only bundled plugins can register Codex app-server extension factories",
-    "only bundled plugins can register agent tool result middleware",
+    "agent tool result middleware must be a function",
     'compaction provider "kitchen-sink-compaction-provider" registration missing summarize',
     "context engine registration missing id",
     "control UI descriptor registration requires id, surface, label, and valid optional fields",
     "hosted media resolver registration missing resolver",
     "http route registration missing or invalid auth: /kitchen-sink/http-route",
     "node invoke policy registration missing commands",
-    "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
+    "trusted tool policy registration requires id, description, and evaluate()",
     "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider",
     "plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: kitchen-sink-memory-embedding-provider",
     "plugin must declare contracts.tools for: kitchen-sink-tool",

--- a/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
+++ b/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs
@@ -203,7 +203,7 @@ const expectMissing = (listValue, expected, field) => {
 
 const INVALID_PROBE_DIAGNOSTIC_SURFACE_MODES = new Set(["full", "conformance", "adversarial"]);
 const requiredFullDiagnosticCanaries = new Set([
-  "only bundled plugins can register trusted tool policies",
+  "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
   'channel "kitchen-sink-channel-probe" registration missing required config helpers',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
@@ -221,7 +221,7 @@ function assertExpectedDiagnostics(surfaceMode, errorMessages) {
     "hosted media resolver registration missing resolver",
     "http route registration missing or invalid auth: /kitchen-sink/http-route",
     "node invoke policy registration missing commands",
-    "only bundled plugins can register trusted tool policies",
+    "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
     "plugin must declare contracts.embeddingProviders for adapter: kitchen-sink-embedding-provider",
     "plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: kitchen-sink-memory-embedding-provider",
     "plugin must declare contracts.tools for: kitchen-sink-tool",

--- a/src/agents/codex-app-server.extensions.test.ts
+++ b/src/agents/codex-app-server.extensions.test.ts
@@ -149,7 +149,7 @@ describe("agent tool result middleware", () => {
     expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
   });
 
-  it("rejects middleware from non-bundled plugins even when they declare the contract", () => {
+  it("allows middleware from installed plugins when they declare the runtime contract", () => {
     const tmp = createTempDir();
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
 
@@ -162,12 +162,14 @@ describe("agent tool result middleware", () => {
         },
       },
       body: `export default { id: "tool-result-middleware", register(api) {
-  api.registerAgentToolResultMiddleware(() => undefined, { runtimes: ["codex"] });
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.toolName + " installed compacted" }] }
+  }), { runtimes: ["codex"] });
 } };`,
     });
 
-    // Contract declaration is necessary but not sufficient; Codex middleware is
-    // limited to bundled plugins so external plugins cannot reshape tool output.
+    // Installed plugins can register Codex middleware only when explicitly
+    // enabled and when their manifest declares the targeted runtime contract.
     const registry = loadOpenClawPlugins({
       workspaceDir: tmp,
       onlyPluginIds: ["tool-result-middleware"],
@@ -179,13 +181,13 @@ describe("agent tool result middleware", () => {
       },
     });
 
-    const diagnostic = findDiagnostic(
-      registry.diagnostics,
-      "tool-result-middleware",
-      "only bundled plugins can register agent tool result middleware",
+    expect(registry.diagnostics).not.toContainEqual(
+      expect.objectContaining({
+        pluginId: "tool-result-middleware",
+        message: "only bundled plugins can register agent tool result middleware",
+      }),
     );
-    expect(diagnostic?.level).toBe("error");
-    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(1);
   });
 
   it("merges runtimes when a plugin registers the same middleware function twice", () => {
@@ -274,6 +276,52 @@ export default { id: "tool-result-middleware", register(api) {
     });
 
     expect(result.content).toEqual([{ type: "text", text: "exec lazily compacted" }]);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+  });
+
+  it("lazily loads installed middleware owners from manifest contracts", async () => {
+    const tmp = createTempDir();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const pluginFile = writeTempPlugin({
+      dir: tmp,
+      id: "tool-result-middleware",
+      manifest: {
+        activation: {
+          onStartup: false,
+        },
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "tool-result-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.toolName + " installed lazily compacted" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+
+    setRuntimeConfigSnapshot({
+      plugins: {
+        load: { paths: [pluginFile] },
+        allow: ["tool-result-middleware"],
+      },
+    });
+    resetActivePluginRegistryForTest();
+
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" });
+    const result = await runner.applyToolResultMiddleware({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: { command: "git status" },
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "exec installed lazily compacted" }]);
     expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
   });
 });

--- a/src/agents/codex-app-server.extensions.test.ts
+++ b/src/agents/codex-app-server.extensions.test.ts
@@ -1,4 +1,5 @@
 // Verifies plugin extension points that are exposed to the Codex app server.
+import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -322,6 +323,184 @@ export default { id: "tool-result-middleware", register(api) {
     });
 
     expect(result.content).toEqual([{ type: "text", text: "exec installed lazily compacted" }]);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+  });
+
+  it("does not lazily load installed middleware owners without explicit opt-in", async () => {
+    const tmp = createTempDir();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const pluginFile = writeTempPlugin({
+      dir: tmp,
+      id: "tool-result-middleware",
+      manifest: {
+        activation: {
+          onStartup: false,
+        },
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "tool-result-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.toolName + " should not run" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+
+    setRuntimeConfigSnapshot({
+      plugins: {
+        load: { paths: [pluginFile] },
+      },
+    });
+    resetActivePluginRegistryForTest();
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" });
+    const result = await runner.applyToolResultMiddleware({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: { command: "git status" },
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "raw" }]);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+  });
+
+  it("does not treat auto-enabled runtime config as explicit middleware opt-in", async () => {
+    const tmp = createTempDir();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const pluginFile = writeTempPlugin({
+      dir: tmp,
+      id: "tool-result-middleware",
+      manifest: {
+        activation: {
+          onStartup: false,
+        },
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "tool-result-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.toolName + " should not run" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+
+    const sourceConfig = {
+      plugins: {
+        load: { paths: [pluginFile] },
+      },
+    };
+    setRuntimeConfigSnapshot(
+      {
+        plugins: {
+          load: { paths: [pluginFile] },
+          entries: {
+            "tool-result-middleware": {
+              enabled: true,
+            },
+          },
+        },
+      },
+      sourceConfig,
+    );
+    resetActivePluginRegistryForTest();
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" });
+    const result = await runner.applyToolResultMiddleware({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: { command: "git status" },
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "raw" }]);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+  });
+
+  it("forces full runtime load for setup-loaded installed middleware owners", async () => {
+    const tmp = createTempDir();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    const pluginFile = writeTempPlugin({
+      dir: tmp,
+      id: "setup-channel-middleware",
+      manifest: {
+        channels: ["setup-channel-middleware"],
+        channelConfigs: {
+          "setup-channel-middleware": {
+            schema: { type: "object", additionalProperties: false, properties: {} },
+          },
+        },
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "setup-channel-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.toolName + " setup-owner compacted" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+    const pluginDir = path.dirname(pluginFile);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "setup-channel-middleware",
+          version: "0.0.0",
+          type: "module",
+          openclaw: {
+            extensions: [path.basename(pluginFile)],
+            setupEntry: "setup.mjs",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "setup.mjs"),
+      `export const plugin = {
+  id: "setup-channel-middleware",
+  meta: { id: "setup-channel-middleware", label: "Setup Channel Middleware" },
+  config: {
+    listAccountIds: () => [],
+    resolveAccount: () => undefined
+  }
+};`,
+      "utf-8",
+    );
+    const config = {
+      plugins: {
+        load: { paths: [pluginDir] },
+        allow: ["setup-channel-middleware"],
+      },
+    };
+
+    loadOpenClawPlugins({ config });
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
+    setRuntimeConfigSnapshot(config);
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" });
+    const result = await runner.applyToolResultMiddleware({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: { command: "git status" },
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "exec setup-owner compacted" }]);
     expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
   });
 

--- a/src/agents/codex-app-server.extensions.test.ts
+++ b/src/agents/codex-app-server.extensions.test.ts
@@ -324,6 +324,79 @@ export default { id: "tool-result-middleware", register(api) {
     expect(result.content).toEqual([{ type: "text", text: "exec installed lazily compacted" }]);
     expect(listAgentToolResultMiddlewares("codex")).toHaveLength(0);
   });
+
+  it("loads missing installed middleware when bundled middleware is already active", async () => {
+    const bundledDir = createBundledTempDir();
+    const installedDir = createTempDir();
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    writeTempPlugin({
+      dir: bundledDir,
+      id: "bundled-tool-result-middleware",
+      filename: "index.mjs",
+      manifest: {
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "bundled-tool-result-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.result.content[0].text + " | bundled" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+    const installedPluginFile = writeTempPlugin({
+      dir: installedDir,
+      id: "installed-tool-result-middleware",
+      manifest: {
+        activation: {
+          onStartup: false,
+        },
+        contracts: {
+          agentToolResultMiddleware: ["codex"],
+        },
+      },
+      body: `export default { id: "installed-tool-result-middleware", register(api) {
+  api.registerAgentToolResultMiddleware(async (event) => ({
+    result: { ...event.result, content: [{ type: "text", text: event.result.content[0].text + " | installed" }] }
+  }), { runtimes: ["codex"] });
+} };`,
+    });
+
+    loadOpenClawPlugins({
+      onlyPluginIds: ["bundled-tool-result-middleware"],
+      config: {
+        plugins: {
+          entries: {
+            "bundled-tool-result-middleware": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+    setRuntimeConfigSnapshot({
+      plugins: {
+        load: { paths: [installedPluginFile] },
+        allow: ["installed-tool-result-middleware"],
+      },
+    });
+
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(1);
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" });
+    const result = await runner.applyToolResultMiddleware({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: { command: "git status" },
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "raw | bundled | installed" }]);
+    expect(listAgentToolResultMiddlewares("codex")).toHaveLength(1);
+  });
 });
 
 describe("Codex app-server extension factories", () => {

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -111,6 +111,7 @@ describe("ensureRuntimePluginsLoaded", () => {
         config,
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["telegram", "memory-core"],
+        forceFullRuntimeForChannelPlugins: true,
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
@@ -138,6 +139,7 @@ describe("ensureRuntimePluginsLoaded", () => {
         config: {} as never,
         onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
+        forceFullRuntimeForChannelPlugins: true,
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
@@ -174,6 +176,7 @@ describe("ensureRuntimePluginsLoaded", () => {
         config,
         onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
+        forceFullRuntimeForChannelPlugins: true,
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -58,6 +58,7 @@ export function ensureRuntimePluginsLoaded(params: {
       config: params.config,
       workspaceDir,
       ...(startupPluginIds === undefined ? {} : { onlyPluginIds: startupPluginIds }),
+      ...(startupPluginIds === undefined ? {} : { forceFullRuntimeForChannelPlugins: true }),
       runtimeOptions: allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,

--- a/src/plugins/agent-tool-result-middleware-loader.ts
+++ b/src/plugins/agent-tool-result-middleware-loader.ts
@@ -10,23 +10,56 @@ import {
   listAgentToolResultMiddlewares,
   normalizeAgentToolResultMiddlewareRuntimeIds,
 } from "./agent-tool-result-middleware.js";
+import {
+  createPluginActivationSource,
+  normalizePluginsConfig,
+  resolveEffectivePluginActivationState,
+  type NormalizedPluginsConfig,
+  type PluginActivationConfigSource,
+} from "./config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { loadOpenClawPlugins } from "./loader.js";
-import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
+import {
+  loadPluginManifestRegistry,
+  type PluginManifestRecord,
+  type PluginManifestRegistry,
+} from "./manifest-registry.js";
+import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 
 const log = createSubsystemLogger("plugins/agent-tool-result-middleware");
 
-async function resolveRuntimeConfig(): Promise<OpenClawConfig> {
-  const { getRuntimeConfig } = await import("../config/config.js");
-  return getRuntimeConfig();
+async function resolveRuntimeConfigContext(): Promise<{
+  config: OpenClawConfig;
+  activationSourceConfig: OpenClawConfig;
+}> {
+  const { getRuntimeConfig, getRuntimeConfigSourceSnapshot } = await import("../config/config.js");
+  const config = getRuntimeConfig();
+  return {
+    config,
+    activationSourceConfig: getRuntimeConfigSourceSnapshot() ?? config,
+  };
 }
 
 function listMiddlewareOwnerPluginIds(params: {
   manifestRegistry: PluginManifestRegistry;
   runtime: AgentToolResultMiddlewareRuntime;
+  config: OpenClawConfig;
+  pluginsConfig: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
 }): string[] {
   const pluginIds: string[] = [];
   for (const record of params.manifestRegistry.plugins) {
+    if (
+      !canLazyLoadMiddlewareOwner({
+        record,
+        config: params.config,
+        pluginsConfig: params.pluginsConfig,
+        activationSource: params.activationSource,
+      })
+    ) {
+      continue;
+    }
     const runtimes = normalizeAgentToolResultMiddlewareRuntimeIds(
       record.contracts?.agentToolResultMiddleware,
     );
@@ -37,11 +70,32 @@ function listMiddlewareOwnerPluginIds(params: {
   return pluginIds;
 }
 
-function listActiveMiddlewareOwnerPluginIds(
+function canLazyLoadMiddlewareOwner(params: {
+  record: PluginManifestRecord;
+  config: OpenClawConfig;
+  pluginsConfig: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
+}): boolean {
+  if (params.record.origin === "bundled") {
+    return true;
+  }
+  const activationState = resolveEffectivePluginActivationState({
+    id: params.record.id,
+    origin: params.record.origin,
+    config: params.pluginsConfig,
+    rootConfig: params.config,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(params.record),
+    activationSource: params.activationSource,
+  });
+  return activationState.enabled && activationState.explicitlyEnabled;
+}
+
+function listRuntimeMiddlewareOwnerPluginIds(
+  registry: PluginRegistry | null | undefined,
   runtime: AgentToolResultMiddlewareRuntime,
 ): Set<string> {
   const pluginIds = new Set<string>();
-  for (const entry of getActivePluginRegistry()?.agentToolResultMiddlewares ?? []) {
+  for (const entry of registry?.agentToolResultMiddlewares ?? []) {
     if (entry.runtimes.includes(runtime)) {
       pluginIds.add(entry.pluginId);
     }
@@ -49,9 +103,28 @@ function listActiveMiddlewareOwnerPluginIds(
   return pluginIds;
 }
 
+function listActiveMiddlewareOwnerPluginIds(
+  runtime: AgentToolResultMiddlewareRuntime,
+): Set<string> {
+  return listRuntimeMiddlewareOwnerPluginIds(getActivePluginRegistry(), runtime);
+}
+
+function registryHasMiddlewareOwners(params: {
+  registry: PluginRegistry | undefined;
+  pluginIds: readonly string[];
+  runtime: AgentToolResultMiddlewareRuntime;
+}): boolean {
+  if (!params.registry) {
+    return false;
+  }
+  const ownerPluginIds = listRuntimeMiddlewareOwnerPluginIds(params.registry, params.runtime);
+  return params.pluginIds.every((pluginId) => ownerPluginIds.has(pluginId));
+}
+
 export async function loadAgentToolResultMiddlewaresForRuntime(params: {
   runtime: AgentToolResultMiddlewareRuntime;
   config?: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
@@ -59,7 +132,12 @@ export async function loadAgentToolResultMiddlewaresForRuntime(params: {
   const activeHandlers = listAgentToolResultMiddlewares(params.runtime);
 
   try {
-    const config = params.config ?? (await resolveRuntimeConfig());
+    const runtimeContext = params.config
+      ? { config: params.config, activationSourceConfig: params.config }
+      : await resolveRuntimeConfigContext();
+    const config = runtimeContext.config;
+    const activationSourceConfig =
+      params.activationSourceConfig ?? runtimeContext.activationSourceConfig;
     const env = params.env ?? process.env;
     const manifestRegistry =
       params.manifestRegistry ??
@@ -68,9 +146,18 @@ export async function loadAgentToolResultMiddlewaresForRuntime(params: {
         workspaceDir: params.workspaceDir,
         env,
       });
+    const pluginsConfig = normalizePluginsConfig(config.plugins);
+    const activationSourcePlugins = normalizePluginsConfig(activationSourceConfig.plugins);
+    const activationSource = createPluginActivationSource({
+      config: activationSourceConfig,
+      plugins: activationSourcePlugins,
+    });
     const pluginIds = listMiddlewareOwnerPluginIds({
       manifestRegistry,
       runtime: params.runtime,
+      config,
+      pluginsConfig,
+      activationSource,
     });
     if (pluginIds.length === 0) {
       return activeHandlers;
@@ -82,20 +169,28 @@ export async function loadAgentToolResultMiddlewaresForRuntime(params: {
     }
     const missingPluginIdSet = new Set(missingPluginIds);
 
+    const loadedRegistry = getLoadedRuntimePluginRegistry({
+      workspaceDir: params.workspaceDir,
+      env,
+      requiredPluginIds: missingPluginIds,
+    });
     const runtimeRegistry =
-      getLoadedRuntimePluginRegistry({
-        workspaceDir: params.workspaceDir,
-        env,
-        requiredPluginIds: missingPluginIds,
-      }) ??
-      loadOpenClawPlugins({
-        config,
-        workspaceDir: params.workspaceDir,
-        env,
-        onlyPluginIds: missingPluginIds,
-        manifestRegistry,
-        activate: false,
-      });
+      loadedRegistry &&
+      registryHasMiddlewareOwners({
+        registry: loadedRegistry,
+        pluginIds: missingPluginIds,
+        runtime: params.runtime,
+      })
+        ? loadedRegistry
+        : loadOpenClawPlugins({
+            config,
+            workspaceDir: params.workspaceDir,
+            env,
+            onlyPluginIds: missingPluginIds,
+            manifestRegistry,
+            activate: false,
+            forceFullRuntimeForChannelPlugins: true,
+          });
 
     const missingHandlers = runtimeRegistry.agentToolResultMiddlewares
       .filter(

--- a/src/plugins/agent-tool-result-middleware-loader.ts
+++ b/src/plugins/agent-tool-result-middleware-loader.ts
@@ -26,9 +26,6 @@ function listMiddlewareOwnerPluginIds(params: {
 }): string[] {
   const pluginIds: string[] = [];
   for (const record of params.manifestRegistry.plugins) {
-    if (record.origin !== "bundled") {
-      continue;
-    }
     const runtimes = normalizeAgentToolResultMiddlewareRuntimeIds(
       record.contracts?.agentToolResultMiddleware,
     );

--- a/src/plugins/agent-tool-result-middleware-loader.ts
+++ b/src/plugins/agent-tool-result-middleware-loader.ts
@@ -12,6 +12,7 @@ import {
 } from "./agent-tool-result-middleware.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
+import { getActivePluginRegistry } from "./runtime.js";
 
 const log = createSubsystemLogger("plugins/agent-tool-result-middleware");
 
@@ -36,6 +37,18 @@ function listMiddlewareOwnerPluginIds(params: {
   return pluginIds;
 }
 
+function listActiveMiddlewareOwnerPluginIds(
+  runtime: AgentToolResultMiddlewareRuntime,
+): Set<string> {
+  const pluginIds = new Set<string>();
+  for (const entry of getActivePluginRegistry()?.agentToolResultMiddlewares ?? []) {
+    if (entry.runtimes.includes(runtime)) {
+      pluginIds.add(entry.pluginId);
+    }
+  }
+  return pluginIds;
+}
+
 export async function loadAgentToolResultMiddlewaresForRuntime(params: {
   runtime: AgentToolResultMiddlewareRuntime;
   config?: OpenClawConfig;
@@ -44,9 +57,6 @@ export async function loadAgentToolResultMiddlewaresForRuntime(params: {
   manifestRegistry?: PluginManifestRegistry;
 }): Promise<AgentToolResultMiddleware[]> {
   const activeHandlers = listAgentToolResultMiddlewares(params.runtime);
-  if (activeHandlers.length > 0) {
-    return activeHandlers;
-  }
 
   try {
     const config = params.config ?? (await resolveRuntimeConfig());
@@ -63,27 +73,37 @@ export async function loadAgentToolResultMiddlewaresForRuntime(params: {
       runtime: params.runtime,
     });
     if (pluginIds.length === 0) {
-      return [];
+      return activeHandlers;
     }
+    const activePluginIds = listActiveMiddlewareOwnerPluginIds(params.runtime);
+    const missingPluginIds = pluginIds.filter((pluginId) => !activePluginIds.has(pluginId));
+    if (missingPluginIds.length === 0) {
+      return activeHandlers;
+    }
+    const missingPluginIdSet = new Set(missingPluginIds);
 
     const runtimeRegistry =
       getLoadedRuntimePluginRegistry({
         workspaceDir: params.workspaceDir,
         env,
-        requiredPluginIds: pluginIds,
+        requiredPluginIds: missingPluginIds,
       }) ??
       loadOpenClawPlugins({
         config,
         workspaceDir: params.workspaceDir,
         env,
-        onlyPluginIds: pluginIds,
+        onlyPluginIds: missingPluginIds,
         manifestRegistry,
         activate: false,
       });
 
-    return runtimeRegistry.agentToolResultMiddlewares
-      .filter((entry) => entry.runtimes.includes(params.runtime))
+    const missingHandlers = runtimeRegistry.agentToolResultMiddlewares
+      .filter(
+        (entry) =>
+          missingPluginIdSet.has(entry.pluginId) && entry.runtimes.includes(params.runtime),
+      )
       .map((entry) => entry.handler);
+    return [...activeHandlers, ...missingHandlers];
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     log.warn(`[${params.runtime}] failed to load tool result middleware plugins: ${detail}`);

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -374,6 +374,17 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         cliBackends: [],
       },
       {
+        id: "external-trusted-policy",
+        channels: [],
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+        contracts: {
+          trustedToolPolicies: ["workflow-budget"],
+        },
+      },
+      {
         id: "lossless-claw",
         kind: "context-engine",
         channels: [],
@@ -1153,6 +1164,17 @@ describe("resolveGatewayStartupPluginIds", () => {
         memorySlot: "none",
       }),
       expected: ["demo-global-explicit-startup"],
+    });
+  });
+
+  it("loads explicit trusted policy plugins at startup", () => {
+    expectStartupPluginIdsCase({
+      config: createStartupConfig({
+        allowPluginIds: ["external-trusted-policy"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: ["external-trusted-policy"],
     });
   });
 

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -191,7 +191,38 @@ describe("host-hook fixture plugin contract", () => {
     expect(diagnostics[1]?.message).toContain("only bundled plugins can claim reserved command");
   });
 
-  it("allows declared external trusted policy registration without reserved command ownership", () => {
+  it("rejects declared external trusted policy registration without explicit opt-in", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-policy",
+        name: "External Policy",
+        origin: "workspace",
+        contracts: { trustedToolPolicies: ["deny"] },
+        explicitlyEnabled: false,
+        activationSource: "default",
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "deny",
+          description: "Declared external policy",
+          evaluate: () => ({ block: true, blockReason: "blocked by external policy" }),
+        });
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(0);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
+      {
+        pluginId: "external-policy",
+        message: "plugin must be explicitly enabled to register trusted tool policy: deny",
+      },
+    ]);
+  });
+
+  it("allows explicitly enabled declared external trusted policy registration without reserved command ownership", () => {
     const { config, registry } = createPluginRegistryFixture();
     registerTestPlugin({
       registry,
@@ -224,6 +255,64 @@ describe("host-hook fixture plugin contract", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.pluginId).toBe("external-policy");
     expect(diagnostics[0]?.message).toContain("only bundled plugins can claim reserved command");
+  });
+
+  it("rejects declared external tool-result middleware registration without explicit opt-in", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-middleware",
+        name: "External Middleware",
+        origin: "workspace",
+        contracts: { agentToolResultMiddleware: ["codex"] },
+        explicitlyEnabled: false,
+        activationSource: "default",
+      }),
+      register(api) {
+        api.registerAgentToolResultMiddleware(async (event) => ({ result: event.result }), {
+          runtimes: ["codex"],
+        });
+      },
+    });
+
+    expect(registry.registry.agentToolResultMiddlewares ?? []).toHaveLength(0);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
+      {
+        pluginId: "external-middleware",
+        message: "plugin must be explicitly enabled to register agent tool result middleware",
+      },
+    ]);
+  });
+
+  it("diagnoses malformed trusted policy registrations", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "malformed-policy",
+        name: "Malformed Policy",
+        origin: "workspace",
+      }),
+      register(api) {
+        Reflect.apply(api.registerTrustedToolPolicy, api, [null]);
+        Reflect.apply(api.registerTrustedToolPolicy, api, [undefined]);
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(0);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
+      {
+        pluginId: "malformed-policy",
+        message: "trusted tool policy registration requires id, description, and evaluate()",
+      },
+      {
+        pluginId: "malformed-policy",
+        message: "trusted tool policy registration requires id, description, and evaluate()",
+      },
+    ]);
   });
 
   it("scopes installed trusted policy ids to the registering plugin", () => {

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -226,6 +226,74 @@ describe("host-hook fixture plugin contract", () => {
     expect(diagnostics[0]?.message).toContain("only bundled plugins can claim reserved command");
   });
 
+  it("scopes installed trusted policy ids to the registering plugin", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    for (const pluginId of ["budget-policy-a", "budget-policy-b"]) {
+      registerTestPlugin({
+        registry,
+        config,
+        record: createPluginRecord({
+          id: pluginId,
+          name: pluginId,
+          origin: "workspace",
+          contracts: { trustedToolPolicies: ["workflow-budget"] },
+        }),
+        register(api) {
+          api.registerTrustedToolPolicy({
+            id: "workflow-budget",
+            description: `${pluginId} workflow budget policy`,
+            evaluate: () => undefined,
+          });
+        },
+      });
+    }
+
+    expect(
+      (registry.registry.trustedToolPolicies ?? []).map((entry) => [
+        entry.pluginId,
+        entry.policy.id,
+      ]),
+    ).toEqual([
+      ["budget-policy-a", "workflow-budget"],
+      ["budget-policy-b", "workflow-budget"],
+    ]);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([]);
+  });
+
+  it("rejects duplicate trusted policy ids from the same plugin", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "duplicate-policy",
+        name: "Duplicate Policy",
+        origin: "workspace",
+        contracts: { trustedToolPolicies: ["workflow-budget"] },
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "workflow-budget",
+          description: "First workflow budget policy",
+          evaluate: () => undefined,
+        });
+        api.registerTrustedToolPolicy({
+          id: "workflow-budget",
+          description: "Duplicate workflow budget policy",
+          evaluate: () => undefined,
+        });
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(1);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
+      {
+        pluginId: "duplicate-policy",
+        message: "trusted tool policy already registered: workflow-budget (duplicate-policy)",
+      },
+    ]);
+  });
+
   it("runs bundled trusted policies before declared external trusted policies", async () => {
     const { config, registry } = createPluginRegistryFixture();
     registerTestPlugin({
@@ -271,7 +339,7 @@ describe("host-hook fixture plugin contract", () => {
     expect(result?.blockReason).toBe("bundled policy");
   });
 
-  it("lets bundled trusted policies replace declared external policies with the same id", async () => {
+  it("keeps same-id bundled and installed trusted policies owner-scoped", async () => {
     const { config, registry } = createPluginRegistryFixture();
     registerTestPlugin({
       registry,
@@ -308,15 +376,13 @@ describe("host-hook fixture plugin contract", () => {
     });
     setActivePluginRegistry(registry.registry);
 
-    expect(registry.registry.trustedToolPolicies).toHaveLength(1);
-    expect(registry.registry.trustedToolPolicies?.[0]?.pluginId).toBe("bundled-policy");
-    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
-      {
-        pluginId: "external-policy",
-        message:
-          "trusted tool policy shared-deny from external-policy was replaced by bundled policy bundled-policy",
-      },
+    expect(
+      registry.registry.trustedToolPolicies?.map((entry) => [entry.pluginId, entry.policy.id]),
+    ).toEqual([
+      ["bundled-policy", "shared-deny"],
+      ["external-policy", "shared-deny"],
     ]);
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([]);
 
     const result = await runTrustedToolPolicies(
       { toolName: "exec", params: {} },

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -184,9 +184,91 @@ describe("host-hook fixture plugin contract", () => {
     const diagnostics = diagnosticSummaries(registry.registry.diagnostics);
     expect(diagnostics).toHaveLength(2);
     expect(diagnostics[0]?.pluginId).toBe("external-policy");
-    expect(diagnostics[0]?.message).toContain("only bundled plugins can register trusted tool");
+    expect(diagnostics[0]?.message).toContain(
+      "plugin must declare contracts.trustedToolPolicies for: deny",
+    );
     expect(diagnostics[1]?.pluginId).toBe("external-policy");
     expect(diagnostics[1]?.message).toContain("only bundled plugins can claim reserved command");
+  });
+
+  it("allows declared external trusted policy registration without reserved command ownership", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-policy",
+        name: "External Policy",
+        origin: "workspace",
+        contracts: { trustedToolPolicies: ["deny"] },
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "deny",
+          description: "Declared external policy",
+          evaluate: () => ({ block: true, blockReason: "blocked by external policy" }),
+        });
+        api.registerCommand({
+          name: "status",
+          description: "Should not be accepted",
+          ownership: "reserved",
+          handler: async () => ({ text: "no" }),
+        });
+      },
+    });
+
+    expect(registry.registry.trustedToolPolicies ?? []).toHaveLength(1);
+    expect(registry.registry.trustedToolPolicies?.[0]?.policy.id).toBe("deny");
+    expect(registry.registry.commands).toHaveLength(0);
+    const diagnostics = diagnosticSummaries(registry.registry.diagnostics);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.pluginId).toBe("external-policy");
+    expect(diagnostics[0]?.message).toContain("only bundled plugins can claim reserved command");
+  });
+
+  it("runs bundled trusted policies before declared external trusted policies", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-policy",
+        name: "External Policy",
+        origin: "workspace",
+        contracts: { trustedToolPolicies: ["external-deny"] },
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "external-deny",
+          description: "Declared external policy",
+          evaluate: () => ({ block: true, blockReason: "external policy" }),
+        });
+      },
+    });
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "bundled-policy",
+        name: "Bundled Policy",
+        origin: "bundled",
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "bundled-deny",
+          description: "Bundled policy",
+          evaluate: () => ({ block: true, blockReason: "bundled policy" }),
+        });
+      },
+    });
+    setActivePluginRegistry(registry.registry);
+
+    const result = await runTrustedToolPolicies(
+      { toolName: "exec", params: {} },
+      { toolName: "exec" },
+    );
+
+    expect(result?.blockReason).toBe("bundled policy");
   });
 
   it("allows the official npm Codex plugin to keep /codex command ownership", () => {

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -271,6 +271,61 @@ describe("host-hook fixture plugin contract", () => {
     expect(result?.blockReason).toBe("bundled policy");
   });
 
+  it("lets bundled trusted policies replace declared external policies with the same id", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "external-policy",
+        name: "External Policy",
+        origin: "workspace",
+        contracts: { trustedToolPolicies: ["shared-deny"] },
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "shared-deny",
+          description: "Declared external policy",
+          evaluate: () => ({ allow: true }),
+        });
+      },
+    });
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "bundled-policy",
+        name: "Bundled Policy",
+        origin: "bundled",
+      }),
+      register(api) {
+        api.registerTrustedToolPolicy({
+          id: "shared-deny",
+          description: "Bundled policy",
+          evaluate: () => ({ block: true, blockReason: "bundled policy" }),
+        });
+      },
+    });
+    setActivePluginRegistry(registry.registry);
+
+    expect(registry.registry.trustedToolPolicies).toHaveLength(1);
+    expect(registry.registry.trustedToolPolicies?.[0]?.pluginId).toBe("bundled-policy");
+    expect(diagnosticSummaries(registry.registry.diagnostics)).toEqual([
+      {
+        pluginId: "external-policy",
+        message:
+          "trusted tool policy shared-deny from external-policy was replaced by bundled policy bundled-policy",
+      },
+    ]);
+
+    const result = await runTrustedToolPolicies(
+      { toolName: "exec", params: {} },
+      { toolName: "exec" },
+    );
+
+    expect(result?.blockReason).toBe("bundled policy");
+  });
+
   it("allows the official npm Codex plugin to keep /codex command ownership", () => {
     const { config, registry } = createPluginRegistryFixture();
     const codexRoot = path.join("/tmp", ".openclaw", "npm", "node_modules", "@openclaw", "codex");

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -1415,6 +1415,49 @@ function canStartExplicitHookPlugin(params: {
   return activationState.enabled && (activationState.explicitlyEnabled || hasHookPolicyIntent);
 }
 
+function canStartTrustedToolPolicyPlugin(params: {
+  plugin: InstalledPluginIndexRecord;
+  manifest: PluginManifestRecord | undefined;
+  config: OpenClawConfig;
+  pluginsConfig: NormalizedPluginsConfig;
+  activationSource: {
+    plugins: NormalizedPluginsConfig;
+    rootConfig?: OpenClawConfig;
+  };
+  platform?: NodeJS.Platform;
+}): boolean {
+  if ((params.manifest?.contracts?.trustedToolPolicies?.length ?? 0) === 0) {
+    return false;
+  }
+  if (!params.pluginsConfig.enabled || !params.activationSource.plugins.enabled) {
+    return false;
+  }
+  if (
+    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
+    params.activationSource.plugins.deny.includes(params.plugin.pluginId)
+  ) {
+    return false;
+  }
+  if (
+    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
+    params.activationSource.plugins.entries[params.plugin.pluginId]?.enabled === false
+  ) {
+    return false;
+  }
+  const activationState = resolveEffectivePluginActivationState({
+    id: params.plugin.pluginId,
+    origin: params.plugin.origin,
+    config: params.pluginsConfig,
+    rootConfig: params.config,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin, params.platform),
+    activationSource: params.activationSource,
+  });
+  return (
+    activationState.enabled &&
+    (params.plugin.origin === "bundled" || activationState.explicitlyEnabled)
+  );
+}
+
 function canStartConfiguredChannelPlugin(params: {
   plugin: InstalledPluginIndexRecord;
   config: OpenClawConfig;
@@ -1739,6 +1782,19 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         pluginsConfig,
         activationSource,
         activationSourcePlugins,
+        platform: params.platform,
+      })
+    ) {
+      pluginIds.push(plugin.pluginId);
+      continue;
+    }
+    if (
+      canStartTrustedToolPolicyPlugin({
+        plugin,
+        manifest,
+        config: params.config,
+        pluginsConfig,
+        activationSource,
         platform: params.platform,
       })
     ) {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1178,6 +1178,43 @@ describe("loadOpenClawPlugins", () => {
     expect(registerFailMetrics.loadAndRegisterMs).toEqual(expect.any(Number));
   });
 
+  it("rolls back trusted policies when plugin register fails", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "trusted-policy-register-fail",
+      filename: "trusted-policy-register-fail.cjs",
+      body: `module.exports = { id: "trusted-policy-register-fail", register(api) {
+  api.registerTrustedToolPolicy({
+    id: "failed-policy",
+    description: "Must be removed after register failure",
+    evaluate: () => ({ block: true, blockReason: "stale failed policy" })
+  });
+  throw new Error("register boom");
+} };`,
+    });
+    updatePluginManifest(plugin, {
+      contracts: { trustedToolPolicies: ["failed-policy"] },
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["trusted-policy-register-fail"],
+      },
+    });
+
+    expect(registry.trustedToolPolicies ?? []).toHaveLength(0);
+    const loaded = registry.plugins.find((entry) => entry.id === "trusted-policy-register-fail");
+    expect(loaded?.status).toBe("error");
+    expect(loaded?.error).toContain("register boom");
+    expectDiagnosticContaining({
+      registry,
+      level: "error",
+      pluginId: "trusted-policy-register-fail",
+      message: "plugin failed during register: Error: register boom",
+    });
+  });
+
   it("can load scoped plugins from a supplied manifest registry without rereading manifests", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1215,6 +1215,91 @@ describe("loadOpenClawPlugins", () => {
     });
   });
 
+  it("loads declared installed trusted policies through plugin manifests", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "trusted-policy-success",
+      filename: "trusted-policy-success.cjs",
+      body: `module.exports = { id: "trusted-policy-success", register(api) {
+  api.registerTrustedToolPolicy({
+    id: "declared-policy",
+    description: "Declared installed policy",
+    evaluate: () => ({ allow: true })
+  });
+} };`,
+    });
+    updatePluginManifest(plugin, {
+      contracts: { trustedToolPolicies: ["declared-policy"] },
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["trusted-policy-success"],
+      },
+    });
+
+    expect(
+      (registry.trustedToolPolicies ?? []).map((entry) => [entry.pluginId, entry.policy.id]),
+    ).toEqual([["trusted-policy-success", "declared-policy"]]);
+    expect(registry.diagnostics).not.toContainEqual(
+      expect.objectContaining({
+        pluginId: "trusted-policy-success",
+        message: "plugin must declare contracts.trustedToolPolicies for: declared-policy",
+      }),
+    );
+  });
+
+  it("keeps earlier trusted policies when a later plugin register fails", () => {
+    useNoBundledPlugins();
+    const stablePlugin = writePlugin({
+      id: "stable-trusted-policy",
+      filename: "stable-trusted-policy.cjs",
+      body: `module.exports = { id: "stable-trusted-policy", register(api) {
+  api.registerTrustedToolPolicy({
+    id: "stable-policy",
+    description: "Stable policy must survive later failures",
+    evaluate: () => ({ allow: true })
+  });
+} };`,
+    });
+    updatePluginManifest(stablePlugin, {
+      contracts: { trustedToolPolicies: ["stable-policy"] },
+    });
+    const failingPlugin = writePlugin({
+      id: "later-trusted-policy-register-fail",
+      filename: "later-trusted-policy-register-fail.cjs",
+      body: `module.exports = { id: "later-trusted-policy-register-fail", register(api) {
+  api.registerTrustedToolPolicy({
+    id: "failed-policy",
+    description: "Must be removed after register failure",
+    evaluate: () => ({ block: true, blockReason: "stale failed policy" })
+  });
+  throw new Error("register boom");
+} };`,
+    });
+    updatePluginManifest(failingPlugin, {
+      contracts: { trustedToolPolicies: ["failed-policy"] },
+    });
+
+    const registry = loadRegistryFromAllowedPlugins([stablePlugin, failingPlugin]);
+
+    expect(
+      (registry.trustedToolPolicies ?? []).map((entry) => [entry.pluginId, entry.policy.id]),
+    ).toEqual([["stable-trusted-policy", "stable-policy"]]);
+    const failed = registry.plugins.find(
+      (entry) => entry.id === "later-trusted-policy-register-fail",
+    );
+    expect(failed?.status).toBe("error");
+    expect(failed?.error).toContain("register boom");
+    expectDiagnosticContaining({
+      registry,
+      level: "error",
+      pluginId: "later-trusted-policy-register-fail",
+      message: "plugin failed during register: Error: register boom",
+    });
+  });
+
   it("can load scoped plugins from a supplied manifest registry without rereading manifests", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -394,6 +394,7 @@ type PluginRegistrySnapshot = {
     migrationProviders: PluginRegistry["migrationProviders"];
     codexAppServerExtensionFactories: PluginRegistry["codexAppServerExtensionFactories"];
     agentToolResultMiddlewares: PluginRegistry["agentToolResultMiddlewares"];
+    trustedToolPolicies: NonNullable<PluginRegistry["trustedToolPolicies"]>;
     memoryEmbeddingProviders: PluginRegistry["memoryEmbeddingProviders"];
     agentHarnesses: PluginRegistry["agentHarnesses"];
     httpRoutes: PluginRegistry["httpRoutes"];
@@ -439,6 +440,7 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistrySnapsho
       migrationProviders: [...registry.migrationProviders],
       codexAppServerExtensionFactories: [...registry.codexAppServerExtensionFactories],
       agentToolResultMiddlewares: [...registry.agentToolResultMiddlewares],
+      trustedToolPolicies: [...(registry.trustedToolPolicies ?? [])],
       memoryEmbeddingProviders: [...registry.memoryEmbeddingProviders],
       agentHarnesses: [...registry.agentHarnesses],
       httpRoutes: [...registry.httpRoutes],
@@ -483,6 +485,7 @@ function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistr
   registry.migrationProviders = snapshot.arrays.migrationProviders;
   registry.codexAppServerExtensionFactories = snapshot.arrays.codexAppServerExtensionFactories;
   registry.agentToolResultMiddlewares = snapshot.arrays.agentToolResultMiddlewares;
+  registry.trustedToolPolicies = snapshot.arrays.trustedToolPolicies;
   registry.memoryEmbeddingProviders = snapshot.arrays.memoryEmbeddingProviders;
   registry.agentHarnesses = snapshot.arrays.agentHarnesses;
   registry.httpRoutes = snapshot.arrays.httpRoutes;

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -5,7 +5,10 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
 import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import {
+  __testing as manifestRegistryTesting,
+  loadPluginManifestRegistry,
+} from "./manifest-registry.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -1982,6 +1985,46 @@ describe("loadPluginManifestRegistry", () => {
 
     expect(registry.plugins[0]?.contracts).toEqual({
       externalAuthProviders: ["acme-ai"],
+    });
+  });
+
+  it("preserves host-trusted plugin contracts from plugin manifests", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "workflow-harness",
+      contracts: {
+        agentToolResultMiddleware: ["openclaw", "codex"],
+        trustedToolPolicies: ["workflow-budget"],
+      },
+      configSchema: { type: "object" },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "workflow-harness",
+      rootDir: dir,
+      origin: "workspace",
+    });
+
+    expect(registry.plugins[0]?.contracts).toEqual({
+      agentToolResultMiddleware: ["openclaw", "codex"],
+      trustedToolPolicies: ["workflow-budget"],
+    });
+  });
+
+  it("preserves host-trusted plugin contracts from catalog overlays", () => {
+    const contracts = manifestRegistryTesting.mergeManifestContracts(
+      {
+        agentToolResultMiddleware: ["openclaw"],
+      },
+      {
+        agentToolResultMiddleware: ["codex"],
+        trustedToolPolicies: ["workflow-budget"],
+      },
+    );
+
+    expect(contracts).toEqual({
+      agentToolResultMiddleware: ["openclaw", "codex"],
+      trustedToolPolicies: ["workflow-budget"],
     });
   });
 

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -383,6 +383,7 @@ function mergeManifestContracts(
   for (const key of [
     "embeddedExtensionFactories",
     "agentToolResultMiddleware",
+    "trustedToolPolicies",
     "externalAuthProviders",
     "embeddingProviders",
     "memoryEmbeddingProviders",
@@ -1203,3 +1204,8 @@ export function loadPluginManifestRegistry(
   const registry = { plugins: records, diagnostics: dedupePluginDiagnostics(diagnostics) };
   return registry;
 }
+
+export const testing = {
+  mergeManifestContracts,
+};
+export { testing as __testing };

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -424,6 +424,7 @@ export type PluginManifest = {
 export type PluginManifestContracts = {
   embeddedExtensionFactories?: string[];
   agentToolResultMiddleware?: string[];
+  trustedToolPolicies?: string[];
   /**
    * Provider ids whose external auth profile hook can contribute runtime-only
    * credentials. Declaring this lets auth-store overlays load only the owning
@@ -862,6 +863,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
 
   const embeddedExtensionFactories = normalizeTrimmedStringList(value.embeddedExtensionFactories);
   const agentToolResultMiddleware = normalizeTrimmedStringList(value.agentToolResultMiddleware);
+  const trustedToolPolicies = normalizeTrimmedStringList(value.trustedToolPolicies);
   const externalAuthProviders = normalizeTrimmedStringList(value.externalAuthProviders);
   const embeddingProviders = normalizeTrimmedStringList(value.embeddingProviders);
   const memoryEmbeddingProviders = normalizeTrimmedStringList(value.memoryEmbeddingProviders);
@@ -885,6 +887,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),
+    ...(trustedToolPolicies.length > 0 ? { trustedToolPolicies } : {}),
     ...(externalAuthProviders.length > 0 ? { externalAuthProviders } : {}),
     ...(embeddingProviders.length > 0 ? { embeddingProviders } : {}),
     ...(memoryEmbeddingProviders.length > 0 ? { memoryEmbeddingProviders } : {}),

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -306,6 +306,7 @@ export type PluginTrustedToolPolicyRegistryRegistration = {
   pluginId: string;
   pluginName?: string;
   policy: PluginTrustedToolPolicyRegistration;
+  origin?: PluginRecord["origin"];
   source: string;
   rootDir?: string;
 };

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2040,9 +2040,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
     const policies = (registry.trustedToolPolicies ??= []);
-    const existingPolicyIndex = policies.findIndex((entry) => entry.policy.id === id);
-    const existing = existingPolicyIndex >= 0 ? policies[existingPolicyIndex] : undefined;
-    if (existing && (record.origin !== "bundled" || existing.origin === "bundled")) {
+    const existing = policies.find(
+      (entry) => entry.pluginId === record.id && entry.policy.id === id,
+    );
+    if (existing) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
@@ -2050,17 +2051,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         message: `trusted tool policy already registered: ${id} (${existing.pluginId})`,
       });
       return;
-    }
-    if (existing) {
-      policies.splice(existingPolicyIndex, 1);
-      const message = `trusted tool policy ${id} from ${existing.pluginId} was replaced by bundled policy ${record.id}`;
-      pushDiagnostic({
-        level: "warn",
-        pluginId: existing.pluginId,
-        source: existing.source,
-        message,
-      });
-      registryParams.logger.warn(`[plugins] ${message}`);
     }
     const registration: PluginTrustedToolPolicyRegistryRegistration = {
       pluginId: record.id,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -235,6 +235,10 @@ function formatDeprecatedTypedHookDiagnostic(hookName: PluginHookName): string |
   );
 }
 
+function canRegisterInstalledTrustedHook(record: PluginRecord): boolean {
+  return record.origin === "bundled" || (record.enabled && record.explicitlyEnabled === true);
+}
+
 type PluginOwnedProviderRegistration<T extends { id: string }> = {
   pluginId: string;
   pluginName?: string;
@@ -555,6 +559,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId: record.id,
         source: record.source,
         message: `plugin must declare contracts.agentToolResultMiddleware for: ${missing.join(", ")}`,
+      });
+      return;
+    }
+    if (!canRegisterInstalledTrustedHook(record)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "plugin must be explicitly enabled to register agent tool result middleware",
       });
       return;
     }
@@ -2016,6 +2029,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     record: PluginRecord,
     policy: PluginTrustedToolPolicyRegistration,
   ) => {
+    if (!policy || typeof policy !== "object") {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: "trusted tool policy registration requires id, description, and evaluate()",
+      });
+      return;
+    }
     const id = normalizeHostHookString(policy.id);
     const description = normalizeHostHookString(policy.description);
     if (!id || !description || typeof policy.evaluate !== "function") {
@@ -2036,6 +2058,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId: record.id,
         source: record.source,
         message: `plugin must declare contracts.trustedToolPolicies for: ${id}`,
+      });
+      return;
+    }
+    if (!canRegisterInstalledTrustedHook(record)) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `plugin must be explicitly enabled to register trusted tool policy: ${id}`,
       });
       return;
     }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2039,8 +2039,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
-    const existing = (registry.trustedToolPolicies ?? []).find((entry) => entry.policy.id === id);
-    if (existing) {
+    const policies = (registry.trustedToolPolicies ??= []);
+    const existingPolicyIndex = policies.findIndex((entry) => entry.policy.id === id);
+    const existing = existingPolicyIndex >= 0 ? policies[existingPolicyIndex] : undefined;
+    if (existing && (record.origin !== "bundled" || existing.origin === "bundled")) {
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
@@ -2048,6 +2050,17 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         message: `trusted tool policy already registered: ${id} (${existing.pluginId})`,
       });
       return;
+    }
+    if (existing) {
+      policies.splice(existingPolicyIndex, 1);
+      const message = `trusted tool policy ${id} from ${existing.pluginId} was replaced by bundled policy ${record.id}`;
+      pushDiagnostic({
+        level: "warn",
+        pluginId: existing.pluginId,
+        source: existing.source,
+        message,
+      });
+      registryParams.logger.warn(`[plugins] ${message}`);
     }
     const registration: PluginTrustedToolPolicyRegistryRegistration = {
       pluginId: record.id,
@@ -2061,7 +2074,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       source: record.source,
       rootDir: record.rootDir,
     };
-    const policies = (registry.trustedToolPolicies ??= []);
     if (record.origin === "bundled") {
       const firstInstalledPolicyIndex = policies.findIndex((entry) => entry.origin !== "bundled");
       if (firstInstalledPolicyIndex === -1) {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -132,6 +132,7 @@ import type {
   PluginRegistryParams,
   PluginSessionActionRegistryRegistration,
   PluginTextTransformsRegistration,
+  PluginTrustedToolPolicyRegistryRegistration,
 } from "./registry-types.js";
 export type {
   PluginReloadRegistration,
@@ -525,15 +526,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     handler: Parameters<OpenClawPluginApi["registerAgentToolResultMiddleware"]>[0],
     options: Parameters<OpenClawPluginApi["registerAgentToolResultMiddleware"]>[1],
   ) => {
-    if (record.origin !== "bundled") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "only bundled plugins can register agent tool result middleware",
-      });
-      return;
-    }
     if (typeof (handler as unknown) !== "function") {
       pushDiagnostic({
         level: "error",
@@ -2024,15 +2016,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     record: PluginRecord,
     policy: PluginTrustedToolPolicyRegistration,
   ) => {
-    if (record.origin !== "bundled") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "only bundled plugins can register trusted tool policies",
-      });
-      return;
-    }
     const id = normalizeHostHookString(policy.id);
     const description = normalizeHostHookString(policy.description);
     if (!id || !description || typeof policy.evaluate !== "function") {
@@ -2041,6 +2024,18 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         pluginId: record.id,
         source: record.source,
         message: "trusted tool policy registration requires id, description, and evaluate()",
+      });
+      return;
+    }
+    if (
+      record.origin !== "bundled" &&
+      !(record.contracts?.trustedToolPolicies ?? []).includes(id)
+    ) {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `plugin must declare contracts.trustedToolPolicies for: ${id}`,
       });
       return;
     }
@@ -2054,7 +2049,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
-    (registry.trustedToolPolicies ??= []).push({
+    const registration: PluginTrustedToolPolicyRegistryRegistration = {
       pluginId: record.id,
       pluginName: record.name,
       policy: {
@@ -2062,9 +2057,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         id,
         description,
       },
+      origin: record.origin,
       source: record.source,
       rootDir: record.rootDir,
-    });
+    };
+    const policies = (registry.trustedToolPolicies ??= []);
+    if (record.origin === "bundled") {
+      const firstInstalledPolicyIndex = policies.findIndex((entry) => entry.origin !== "bundled");
+      if (firstInstalledPolicyIndex === -1) {
+        policies.push(registration);
+      } else {
+        policies.splice(firstInstalledPolicyIndex, 0, registration);
+      }
+      return;
+    }
+    policies.push(registration);
   };
 
   const registerToolMetadata = (record: PluginRecord, metadata: PluginToolMetadataRegistration) => {

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -117,7 +117,7 @@ function buildPluginRecordFromInstalledIndex(
     httpRoutes: 0,
     hookCount: 0,
     configSchema: false,
-    contracts: { ...(manifest?.contracts ?? {}) },
+    contracts: manifest?.contracts,
     dependencyStatus: buildSnapshotPluginDependencyStatus({
       rootDir: plugin.rootDir,
       dependencies: manifest?.packageDependencies,

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -117,7 +117,7 @@ function buildPluginRecordFromInstalledIndex(
     httpRoutes: 0,
     hookCount: 0,
     configSchema: false,
-    contracts: {},
+    contracts: { ...(manifest?.contracts ?? {}) },
     dependencyStatus: buildSnapshotPluginDependencyStatus({
       rootDir: plugin.rootDir,
       dependencies: manifest?.packageDependencies,

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -131,9 +131,11 @@ describe("buildPluginRegistrySnapshotReport", () => {
         version: "1.2.3",
         providers: ["indexed-provider"],
         contracts: {
+          agentToolResultMiddleware: ["openclaw", "codex"],
           speechProviders: ["indexed-speech-provider"],
           realtimeTranscriptionProviders: ["indexed-transcription-provider"],
           realtimeVoiceProviders: ["indexed-voice-provider"],
+          trustedToolPolicies: ["workflow-budget"],
         },
         commandAliases: [{ name: "indexed-demo" }],
         configSchema: {
@@ -162,6 +164,13 @@ describe("buildPluginRegistrySnapshotReport", () => {
       speechProviderIds: ["indexed-speech-provider"],
       realtimeTranscriptionProviderIds: ["indexed-transcription-provider"],
       realtimeVoiceProviderIds: ["indexed-voice-provider"],
+      contracts: {
+        agentToolResultMiddleware: ["openclaw", "codex"],
+        speechProviders: ["indexed-speech-provider"],
+        realtimeTranscriptionProviders: ["indexed-transcription-provider"],
+        realtimeVoiceProviders: ["indexed-voice-provider"],
+        trustedToolPolicies: ["workflow-budget"],
+      },
       commands: ["indexed-demo"],
       source: fs.realpathSync(fixture.runtimeSource),
       status: "loaded",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2769,8 +2769,8 @@ export type OpenClawPluginApi = {
     injection: PluginNextTurnInjection,
   ) => Promise<PluginNextTurnInjectionEnqueueResult>;
   /**
-   * Register a trusted pre-tool policy. Only bundled plugins may use this
-   * before-tool-call policy tier.
+   * Register a trusted pre-tool policy. Installed plugins must declare the
+   * policy id in `contracts.trustedToolPolicies`.
    */
   registerTrustedToolPolicy: (policy: PluginTrustedToolPolicyRegistration) => void;
   /**

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -16,7 +16,8 @@ import { describe, expect, it } from "vitest";
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs";
 const SWEEP_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh";
 const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
-  "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
+  "agent tool result middleware must be a function",
+  "trusted tool policy registration requires id, description, and evaluate()",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
   'channel "kitchen-sink-channel-probe" registration missing required config helpers',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs";
 const SWEEP_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh";
 const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
-  "only bundled plugins can register trusted tool policies",
+  "plugin must declare contracts.trustedToolPolicies for: kitchen-sink-trusted-tool-policy",
   "plugin must declare contracts.tools for: kitchen-sink-tool",
   'channel "kitchen-sink-channel-probe" registration missing required config helpers',
   'agent harness "kitchen-sink-agent-harness" registration missing required runtime methods',
@@ -107,6 +107,7 @@ function runAssertInstalled({
         ...spawnEnv,
         ...env,
         HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
         KITCHEN_SINK_ID: pluginId,
         KITCHEN_SINK_LABEL: label,
         KITCHEN_SINK_SOURCE: "npm",
@@ -173,6 +174,7 @@ function runAssertClawhubInstalled({
       env: {
         ...process.env,
         HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
         KITCHEN_SINK_ID: pluginId,
         KITCHEN_SINK_LABEL: label,
         KITCHEN_SINK_SOURCE: "clawhub",


### PR DESCRIPTION
## Summary

- Allow installed plugins to register `api.registerAgentToolResultMiddleware(...)` when their manifest declares the targeted runtimes in `contracts.agentToolResultMiddleware`.
- Add `contracts.trustedToolPolicies[]` so installed plugins can opt into named trusted pre-tool policies while undeclared policy ids still fail closed.
- Preserve bundled trusted-policy priority ahead of installed trusted policies and prevent installed trusted-policy id shadowing of bundled guards.
- Document the manifest, inspect, and audit contract, and keep `contracts.trustedToolPolicies` through official external catalog contract merges.

Closes #87735.

## Current-Main Source Evidence

Current main still has the bundled-only gates that the canonical issue reports:

- `src/plugins/registry.ts` rejects installed/non-bundled `api.registerAgentToolResultMiddleware(...)` registrations with `only bundled plugins can register agent tool result middleware`.
- `src/plugins/registry.ts` rejects installed/non-bundled `api.registerTrustedToolPolicy(...)` registrations with `only bundled plugins can register trusted tool policies`.
- `src/plugins/agent-tool-result-middleware-loader.ts` skips every manifest record where `record.origin !== "bundled"`, so installed plugins declaring `contracts.agentToolResultMiddleware` cannot be lazy-loaded as middleware owners.
- #87735 includes concrete first-party Tokenjuice external-install evidence on OpenClaw `2026.5.28` showing this bundled-only middleware gate is exposed as a broken official-plugin install flow.

## Security / Trust Posture

- This is not a blanket external-plugin trust grant: installed plugins must declare exact runtime ids or trusted policy ids in `openclaw.plugin.json` before registration is accepted.
- Bundled trusted policies keep the existing path and are ordered before installed trusted policies.
- Installed plugins cannot shadow bundled trusted-policy ids: installed duplicates are rejected, and if a bundled policy later registers an id already claimed by an installed plugin, the bundled registration replaces the installed one while emitting a warning diagnostic/log.
- Author-side code/proof work is complete as far as we can tell; the remaining decision is maintainer/security review of the manifest-gated installed-plugin trust boundary.

## Real Behavior Proof

- **Behavior addressed:** Installed/official plugins that declare host-trusted contracts can now register tool-result middleware and named trusted pre-tool policies instead of being rejected solely because their origin is not `bundled`.
- **Real environment tested:** Local Windows source checkout on this PR branch with isolated OpenClaw homes/configs, plus a Blacksmith Testbox changed-gate run on a warmed Linux Testbox. No production OpenClaw state, VPS state, or user secrets were touched.
- **Exact steps or command run after this patch:** Ran isolated installed-plugin runtime inspect, NPM Tokenjuice install + runtime inspect, ClawHub Tokenjuice install + runtime inspect, the focused plugin/host-hook/Codex middleware regression suites, lint/type/diff gates, and the repository changed gate on Blacksmith Testbox `tbx_01ktm4xc6e4yqawy9wck02f46n` using `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed`.
- **Evidence after fix:** Terminal output from the real `node --import tsx src/entry.ts plugins inspect ... --runtime --json` runs showed installed/official Tokenjuice loaded from both npm and ClawHub with `enabled: true`, `imported: true`, `trustedOfficialInstall: true`, `diagnostics: []`, and `contracts.agentToolResultMiddleware: ["openclaw", "codex"]`. The isolated installed-plugin proof also retained `contracts.trustedToolPolicies: ["issue-87735-proof-policy"]` with `diagnostics: []`. The Blacksmith Testbox changed gate completed on `tbx_01ktm4xc6e4yqawy9wck02f46n` with `TESTBOX_EXIT=0`; warmup Actions run: https://github.com/openclaw/openclaw/actions/runs/27155636123. PR head `f990ec4fcf3d390740dd48b30adbb767dc94d9bc` is a no-op CI requeue commit on the same tree as the tested `53cfddad43c7a16cd461289588af86b5c5c4507b` head.
- **Observed result after fix:** Installed official/declared plugins can register the intended host-trusted contracts, undeclared trusted policy ids still fail closed, bundled trusted policies stay ahead of installed trusted policies, and installed plugins can no longer shadow bundled trusted policy ids by registering first.
- **What was not tested:** A production Gateway/VPS Tokenjuice turn was not rerun on this PR branch; full `pnpm check` was not run. The final review used focused runtime/plugin/Codex middleware gates, Blacksmith Testbox `check:changed`, ClawSweeper review, and manual diff review.

Isolated installed-plugin command:

```powershell
$env:OPENCLAW_HOME = "C:\oc-work\oc-87735\.artifacts\issue-87735-proof\home"
$env:OPENCLAW_CONFIG_PATH = "C:\oc-work\oc-87735\.artifacts\issue-87735-proof\home\.openclaw\openclaw.json"
$env:OPENCLAW_BUNDLED_PLUGINS_DIR = "C:\oc-work\oc-87735\.artifacts\issue-87735-proof\no-bundled-plugins"
$env:OPENCLAW_DISABLE_BUNDLED_PLUGINS = "1"
node --import tsx src/entry.ts plugins inspect issue-87735-installed-proof --runtime --json
```

The isolated installed-plugin inspect command reported the installed plugin as loaded/imported with no diagnostics and retained the trusted-surface contracts:

```json
{
  "contracts": {
    "agentToolResultMiddleware": ["codex"],
    "trustedToolPolicies": ["issue-87735-proof-policy"]
  },
  "diagnostics": []
}
```

NPM Tokenjuice package command:

```powershell
$env:OPENCLAW_HOME = "C:\oc-work\oc-87735\.artifacts\tokenjuice-packaged-proof\home"
$env:OPENCLAW_CONFIG_PATH = "C:\oc-work\oc-87735\.artifacts\tokenjuice-packaged-proof\home\.openclaw\openclaw.json"
$env:OPENCLAW_BUNDLED_PLUGINS_DIR = "C:\oc-work\oc-87735\.artifacts\tokenjuice-packaged-proof\no-bundled-plugins"
node --import tsx src/entry.ts plugins install npm:@openclaw/tokenjuice@2026.6.1 --pin
node --import tsx src/entry.ts plugins inspect tokenjuice --runtime --json
```

NPM Tokenjuice runtime inspect reported `install.source: "npm"`, `trustedOfficialInstall: true`, `enabled: true`, `explicitlyEnabled: true`, `status: "loaded"`, `imported: true`, `diagnostics: []`, and `contracts.agentToolResultMiddleware: ["openclaw", "codex"]`.

ClawHub Tokenjuice package command:

```powershell
$env:OPENCLAW_HOME = "C:\oc-work\oc-87735\.artifacts\tokenjuice-clawhub-proof\home"
$env:OPENCLAW_CONFIG_PATH = "C:\oc-work\oc-87735\.artifacts\tokenjuice-clawhub-proof\home\.openclaw\openclaw.json"
$env:OPENCLAW_BUNDLED_PLUGINS_DIR = "C:\oc-work\oc-87735\.artifacts\tokenjuice-clawhub-proof\no-bundled-plugins"
node --import tsx src/entry.ts plugins search tokenjuice
node --import tsx src/entry.ts plugins install clawhub:@openclaw/tokenjuice@2026.6.1 --pin
node --import tsx src/entry.ts plugins inspect tokenjuice --runtime --json
```

ClawHub Tokenjuice runtime inspect reported `install.source: "clawhub"`, `clawhubChannel: "official"`, `trustedOfficialInstall: true`, `enabled: true`, `explicitlyEnabled: true`, `status: "loaded"`, `imported: true`, `diagnostics: []`, and `contracts.agentToolResultMiddleware: ["openclaw", "codex"]`.

Maintainer-review follow-up: after maintainer review pointed out that an installed plugin could register a built-in trusted policy id before the bundled policy and win the duplicate check, PR head `b2677eef2c` removed the earlier installed registration when the later registration is bundled, logs/records a warning for the displaced plugin, and keeps the bundled policy as the only active policy for that id. The focused regression `lets bundled trusted policies replace declared external policies with the same id` proves the installed fake policy is displaced and the bundled policy blocks the tool call.

## Verification

Original PR validation:

- `NODE_OPTIONS=--max-old-space-size=8192 node scripts/run-vitest.mjs src/agents/codex-app-server.extensions.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/manifest-registry.test.ts`
- `corepack pnpm build:plugin-sdk:strict-smoke`
- `corepack pnpm tsgo:prod`
- `corepack pnpm check:test-types`
- `corepack pnpm lint --threads=8`
- `corepack pnpm exec oxfmt --check src/plugins/manifest.ts src/plugins/registry.ts src/plugins/agent-tool-result-middleware-loader.ts src/plugins/types.ts src/plugins/registry-types.ts src/agents/codex-app-server.extensions.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/manifest-registry.test.ts`
- `corepack pnpm exec oxfmt --check docs/plugins/sdk-overview.md docs/plugins/sdk-agent-harness.md docs/plugins/hooks.md docs/plugins/manifest.md docs/plugins/building-plugins.md docs/cli/plugins.md`
- `corepack pnpm docs:check-mdx`
- `corepack pnpm docs:check-i18n-glossary`
- `corepack pnpm docs:check-links`
- `git diff --check`
- Rebased onto current origin/main and reran the focused ClawSweeper acceptance set on PR head `6ea717e3572ba4a9f0ab370202ae4c8835cadb5a`.

Maintainer-review follow-up validation on PR head `b2677eef2c`:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/host-hooks.contract.test.ts -t "lets bundled trusted"`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/host-hooks.contract.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core`
- `pnpm exec oxlint src/plugins/registry.ts src/plugins/contracts/host-hooks.contract.test.ts`
- `git diff --check`

Additional follow-up validation on PR head `53cfddad43c7a16cd461289588af86b5c5c4507b`:

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "rolls back trusted policies when plugin register fails"`
- `node scripts/run-vitest.mjs test/scripts/kitchen-sink-plugin-assertions.test.ts -t "accepts" --reporter=verbose`
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/agents/codex-app-server.extensions.test.ts`
- `node scripts/run-vitest.mjs src/agents/codex-app-server.extensions.test.ts -t "loads missing installed middleware" --reporter=verbose`
- `pnpm exec oxlint` on focused plugin, loader, host-hook, Codex middleware, and kitchen-sink files
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core`
- `git diff --check`
- `codex-review --mode branch` through the local codex-review helper: clean; no accepted/actionable findings.

Blacksmith/Testbox changed gate:

- PR head tested: `53cfddad43c7a16cd461289588af86b5c5c4507b`
- Current PR head: `f990ec4fcf3d390740dd48b30adbb767dc94d9bc` (no-op CI requeue commit on the same tree)
- Blacksmith Testbox: `tbx_01ktm4xc6e4yqawy9wck02f46n`
- Warmup Actions run: https://github.com/openclaw/openclaw/actions/runs/27155636123
- Command:

```sh
env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed
```

Result: passed with `TESTBOX_EXIT=0`.