### PR TITLE
fix(plugins): isolate captured CLI metadata rows

### DIFF
--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -106,6 +106,128 @@ describe("captured plugin registration", () => {
     expect(captured.api.registerMemoryEmbeddingProvider).toBeTypeOf("function");
   });
 
+  it("skips unreadable CLI descriptor rows while preserving healthy captured commands", () => {
+    const captured = capturePluginRegistration({
+      register(api) {
+        const descriptors = [
+          {
+            name: "unreadable-row",
+            description: "Unreadable row",
+            hasSubcommands: false,
+          },
+          {
+            get name() {
+              throw new Error("captured cli descriptor name exploded");
+            },
+            description: "Bad descriptor name",
+            hasSubcommands: false,
+          },
+          {
+            name: "bad-description",
+            get description() {
+              throw new Error("captured cli descriptor description exploded");
+            },
+            hasSubcommands: false,
+          },
+          {
+            name: "bad-subcommands",
+            description: "Bad subcommand marker",
+            get hasSubcommands() {
+              throw new Error("captured cli descriptor subcommands exploded");
+            },
+          },
+          {
+            name: "healthy-captured",
+            description: "Healthy captured CLI",
+            hasSubcommands: true,
+          },
+        ];
+        Object.defineProperty(descriptors, "0", {
+          get() {
+            throw new Error("captured cli descriptor row exploded");
+          },
+        });
+        api.registerCli(() => {}, { descriptors });
+      },
+    });
+
+    expect(captured.cliRegistrars).toHaveLength(1);
+    expect(captured.cliRegistrars[0]?.commands).toEqual(["healthy-captured"]);
+    expect(captured.cliRegistrars[0]?.descriptors).toEqual([
+      {
+        name: "healthy-captured",
+        description: "Healthy captured CLI",
+        hasSubcommands: true,
+      },
+    ]);
+  });
+
+  it("rejects unreadable captured CLI parent paths instead of shortening command roots", () => {
+    const captured = capturePluginRegistration({
+      register(api) {
+        const parentPath = ["nodes"];
+        Object.defineProperty(parentPath, "0", {
+          get() {
+            throw new Error("captured cli parent path exploded");
+          },
+        });
+        api.registerCli(() => {}, {
+          parentPath,
+          descriptors: [
+            {
+              name: "healthy-node",
+              description: "Healthy node CLI",
+              hasSubcommands: true,
+            },
+          ],
+        });
+      },
+    });
+
+    expect(captured.cliRegistrars).toEqual([]);
+  });
+
+  it("skips sparse captured CLI metadata slots without stringifying holes", () => {
+    const captured = capturePluginRegistration({
+      register(api) {
+        const parentPath = ["nodes"];
+        delete parentPath[0];
+        const commands = ["missing", "healthy-command"];
+        delete commands[0];
+        const descriptors = [
+          {
+            name: "missing-descriptor",
+            description: "Missing descriptor",
+            hasSubcommands: false,
+          },
+          {
+            name: "healthy-descriptor",
+            description: "Healthy descriptor",
+            hasSubcommands: true,
+          },
+        ];
+        delete descriptors[0];
+
+        api.registerCli(() => {}, {
+          parentPath,
+          commands,
+          descriptors,
+        });
+      },
+    });
+
+    expect(captured.cliRegistrars).toHaveLength(1);
+    expect(captured.cliRegistrars[0]?.parentPath).toEqual([]);
+    expect(captured.cliRegistrars[0]?.commands).toEqual(["healthy-command", "healthy-descriptor"]);
+    expect(captured.cliRegistrars[0]?.descriptors).toEqual([
+      {
+        name: "healthy-descriptor",
+        description: "Healthy descriptor",
+        hasSubcommands: true,
+      },
+    ]);
+  });
+
   it("returns synthetic scheduled-turn ids independent of human-readable names", async () => {
     let scheduleSessionTurn: OpenClawPluginApi["scheduleSessionTurn"] | undefined;
     let registerSessionSchedulerJob: OpenClawPluginApi["registerSessionSchedulerJob"] | undefined;

--- a/src/plugins/captured-registration.ts
+++ b/src/plugins/captured-registration.ts
@@ -51,6 +51,61 @@ type CapturedPluginCliRegistration = {
   descriptors: OpenClawPluginCliCommandDescriptor[];
 };
 
+function normalizeCapturedStringEntries(list?: ReadonlyArray<unknown>) {
+  const entries: string[] = [];
+  let unreadable = false;
+  const values = list ?? [];
+  let index = 0;
+  while (index < values.length) {
+    if (!(index in values)) {
+      index += 1;
+      continue;
+    }
+    try {
+      entries.push(...normalizeStringEntries([values[index]]));
+    } catch {
+      unreadable = true;
+    }
+    index += 1;
+  }
+  return { entries, unreadable };
+}
+
+function normalizeCapturedCliDescriptors(
+  descriptors: readonly OpenClawPluginCliCommandDescriptor[],
+) {
+  const normalized: OpenClawPluginCliCommandDescriptor[] = [];
+  let index = 0;
+  while (index < descriptors.length) {
+    if (!(index in descriptors)) {
+      index += 1;
+      continue;
+    }
+    try {
+      const descriptor = descriptors[index];
+      if (!descriptor) {
+        index += 1;
+        continue;
+      }
+      const name = descriptor.name.trim();
+      const description = descriptor.description.trim();
+      if (name && description) {
+        normalized.push({
+          name,
+          description,
+          hasSubcommands: descriptor.hasSubcommands,
+        });
+      }
+    } catch {
+      // Captured registrations are best-effort metadata snapshots. A poisoned
+      // plugin-owned descriptor should not prevent later healthy rows from
+      // being captured for bundled capability planning.
+    }
+    index += 1;
+  }
+  return normalized;
+}
+
 export type CapturedPluginRegistration = {
   api: OpenClawPluginApi;
   providers: ProviderPlugin[];
@@ -175,24 +230,22 @@ export function createCapturedPluginRegistration(params?: {
       resolvePath: (input) => input,
       handlers: {
         registerCli(registrar, opts) {
-          const parentPath = normalizeStringEntries(opts?.parentPath ?? []);
-          const descriptors = (opts?.descriptors ?? [])
-            .map((descriptor) => ({
-              name: descriptor.name.trim(),
-              description: descriptor.description.trim(),
-              hasSubcommands: descriptor.hasSubcommands,
-            }))
-            .filter((descriptor) => descriptor.name && descriptor.description);
-          const commands = normalizeStringEntries([
-            ...(opts?.commands ?? []),
+          const parentPath = normalizeCapturedStringEntries(opts?.parentPath ?? []);
+          if (parentPath.unreadable) {
+            return;
+          }
+          const descriptors = normalizeCapturedCliDescriptors(opts?.descriptors ?? []);
+          const commandRoots = normalizeCapturedStringEntries(opts?.commands ?? []);
+          const commands = [
+            ...commandRoots.entries,
             ...descriptors.map((descriptor) => descriptor.name),
-          ]);
+          ];
           if (commands.length === 0) {
             return;
           }
           cliRegistrars.push({
             register: registrar,
-            parentPath,
+            parentPath: parentPath.entries,
             commands,
             descriptors,
           });


### PR DESCRIPTION
## Summary

- isolate captured plugin CLI metadata rows from poisoned descriptor arrays and fields
- keep healthy captured CLI descriptors available for bundled capability planning
- reject unreadable captured CLI parent paths instead of shortening nested command roots
- preserve sparse array behavior so holes are skipped rather than stringified

## Verification

- `node scripts/run-vitest.mjs src/plugins/captured-registration.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/captured-registration.ts src/plugins/captured-registration.test.ts`
- `./node_modules/.bin/oxlint src/plugins/captured-registration.ts src/plugins/captured-registration.test.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Captured plugin registration could throw while reading plugin-owned CLI descriptor metadata, preventing later healthy captured CLI command descriptors from being preserved.

Real environment tested: Local linked OpenClaw worktree on branch `fuzz-tool-schema-next145-20260603`, Node/Vitest through `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/captured-registration.test.ts`.

Evidence after fix: The focused captured-registration suite passed 1 Vitest shard, 1 file, and 5 tests.

Observed result after fix: Unreadable captured CLI descriptor rows and throwing descriptor fields are skipped while healthy descriptors still register; unreadable parent paths reject the captured CLI registration; sparse metadata slots are skipped rather than becoming `undefined` command/path entries.

What was not tested: Full `pnpm check:changed` was not run. Testbox is not authenticated, and the Crabbox changed-gate attempt failed before execution with coordinator HTTP 401 unauthorized.
