### PR TITLE
fix(plugins): isolate cached tool descriptor names

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -34,6 +34,8 @@ let ensureStandalonePluginToolRegistryLoaded: typeof import("./tools.js").ensure
 let buildPluginToolMetadataKey: typeof import("./tools.js").buildPluginToolMetadataKey;
 let getPluginToolMeta: typeof import("./tools.js").getPluginToolMeta;
 let resetPluginToolFactoryCache: typeof import("./tools.js").resetPluginToolFactoryCache;
+let buildPluginToolDescriptorCacheKey: typeof import("./tool-descriptor-cache.js").buildPluginToolDescriptorCacheKey;
+let writeCachedPluginToolDescriptors: typeof import("./tool-descriptor-cache.js").writeCachedPluginToolDescriptors;
 let getActivePluginRegistry: typeof import("./runtime.js").getActivePluginRegistry;
 let pinActivePluginChannelRegistry: typeof import("./runtime.js").pinActivePluginChannelRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
@@ -476,6 +478,8 @@ describe("resolvePluginTools optional tools", () => {
       resetPluginToolFactoryCache,
       resolvePluginTools,
     } = await import("./tools.js"));
+    ({ buildPluginToolDescriptorCacheKey, writeCachedPluginToolDescriptors } =
+      await import("./tool-descriptor-cache.js"));
     ({
       getActivePluginRegistry,
       pinActivePluginChannelRegistry,
@@ -2092,6 +2096,77 @@ describe("resolvePluginTools optional tools", () => {
       content: [{ type: "text", text: "mock-status-ok" }],
     });
     expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips poisoned cached plugin tool descriptors while preserving healthy cached tools", () => {
+    const context = {
+      ...createContext(),
+      config: {
+        ...createContext().config,
+        plugins: {
+          ...createContext().config.plugins,
+          allow: ["cache-poison"],
+        },
+      },
+    };
+    installToolManifestSnapshot({
+      config: context.config,
+      plugin: {
+        id: "cache-poison",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["healthy_cached"],
+        },
+      },
+    });
+    writeCachedPluginToolDescriptors({
+      cacheKey: buildPluginToolDescriptorCacheKey({
+        pluginId: "cache-poison",
+        source: "cache-poison",
+        contractToolNames: ["healthy_cached"],
+        ctx: context as never,
+      }),
+      descriptors: [
+        {
+          optional: false,
+          descriptor: {
+            get name() {
+              throw new Error("cached plugin tool descriptor name exploded");
+            },
+            description: "Bad cached tool",
+            inputSchema: { type: "object", properties: {} },
+            owner: { kind: "plugin", pluginId: "cache-poison" },
+            executor: {
+              kind: "plugin",
+              pluginId: "cache-poison",
+              toolName: "bad_cached",
+            },
+          },
+        } as never,
+        {
+          optional: false,
+          descriptor: {
+            name: "healthy_cached",
+            description: "Healthy cached tool",
+            inputSchema: { type: "object", properties: {} },
+            owner: { kind: "plugin", pluginId: "cache-poison" },
+            executor: {
+              kind: "plugin",
+              pluginId: "cache-poison",
+              toolName: "healthy_cached",
+            },
+          },
+        },
+      ],
+    });
+
+    const tools = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expectResolvedToolNames(tools, ["healthy_cached"]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("reuses cached plugin tool descriptors across session identity changes", async () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -647,10 +647,25 @@ function cachedDescriptorsCoverToolNames(params: {
   descriptors: readonly CachedPluginToolDescriptor[];
   toolNames: readonly string[];
 }): boolean {
-  const descriptorNames = new Set(
-    params.descriptors.map((entry) => normalizeToolName(entry.descriptor.name)),
-  );
+  const descriptorNames = new Set<string>();
+  for (const entry of params.descriptors) {
+    const name = readCachedPluginToolDescriptorName(entry);
+    if (name) {
+      descriptorNames.add(normalizeToolName(name));
+    }
+  }
   return params.toolNames.every((name) => descriptorNames.has(normalizeToolName(name)));
+}
+
+function readCachedPluginToolDescriptorName(
+  cachedDescriptor: CachedPluginToolDescriptor,
+): string | undefined {
+  try {
+    const name = cachedDescriptor.descriptor.name;
+    return typeof name === "string" && name.trim() ? name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function createCachedDescriptorPluginTool(params: {
@@ -819,10 +834,14 @@ function resolveCachedPluginTools(params: {
     let hasNameConflict = false;
     const localNormalizedNames = new Set<string>();
     for (const cachedDescriptor of cached) {
+      const cachedDescriptorName = readCachedPluginToolDescriptorName(cachedDescriptor);
+      if (!cachedDescriptorName) {
+        continue;
+      }
       if (
         !cachedDescriptor.optional &&
         !availableToolNames.some(
-          (name) => normalizeToolName(name) === normalizeToolName(cachedDescriptor.descriptor.name),
+          (name) => normalizeToolName(name) === normalizeToolName(cachedDescriptorName),
         )
       ) {
         continue;
@@ -830,18 +849,18 @@ function resolveCachedPluginTools(params: {
       if (
         cachedDescriptor.optional &&
         !isOptionalToolAllowed({
-          toolName: cachedDescriptor.descriptor.name,
+          toolName: cachedDescriptorName,
           pluginId: plugin.id,
           allowlist: params.allowlist,
         })
       ) {
         continue;
       }
-      const normalizedDescriptorName = normalizeToolName(cachedDescriptor.descriptor.name);
+      const normalizedDescriptorName = normalizeToolName(cachedDescriptorName);
       if (
         denylistBlocksPluginTool({
           pluginId: plugin.id,
-          toolName: cachedDescriptor.descriptor.name,
+          toolName: cachedDescriptorName,
           denylist: params.denylist,
         })
       ) {


### PR DESCRIPTION
## Summary

- isolate cached plugin tool descriptor name reads from poisoned accessors
- preserve healthy cached plugin tools when sibling cached descriptors are malformed
- add focused regression coverage for cached descriptor recovery without runtime reload

## Verification

- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `./node_modules/.bin/oxlint src/plugins/tools.ts src/plugins/tools.optional.test.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Cached plugin tool resolution could throw while reading a cached descriptor `name`, preventing healthy sibling cached plugin tools from resolving.

Real environment tested: Local linked OpenClaw worktree on branch `fuzz-tool-schema-next146-20260603`, Node/Vitest through `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts`.

Evidence after fix: The focused plugin tools optional suite passed 1 Vitest shard, 1 file, and 68 tests.

Observed result after fix: A poisoned cached descriptor name accessor is skipped, the healthy cached tool still resolves, and runtime plugin loading is not invoked for the covered cached path.

What was not tested: Full `pnpm check:changed` was not run. Testbox is not authenticated, and the Crabbox changed-gate attempt failed before execution with coordinator HTTP 401 unauthorized.
