### PR TITLE
fix(memory-search): default periodic sync fallback

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -288,6 +288,17 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
   </Accordion>
 </AccordionGroup>
 
+### Periodic sync interval
+
+<ParamField path="sync.intervalMinutes" type="number" default="30">
+  How often the memory sync interval fires to rescan memory files and reindex
+  changed content. This acts as a fallback when the filesystem watcher misses
+  events.
+
+Set to `0` to disable the periodic interval entirely and rely solely on the
+filesystem watcher and trigger-based sync (`onSessionStart`, `onSearch`).
+</ParamField>
+
 ### Inline embedding timeout
 
 <ParamField path="sync.embeddingBatchTimeoutSeconds" type="number">

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -295,8 +295,9 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
   changed content. This acts as a fallback when the filesystem watcher misses
   events.
 
-Set to `0` to disable the periodic interval entirely and rely solely on the
-filesystem watcher and trigger-based sync (`onSessionStart`, `onSearch`).
+Set to `0` to disable interval-based sync; other configured triggers such as
+`onSessionStart`, `onSearch`, and watch/file-change can still reindex
+memory.
 </ParamField>
 
 ### Inline embedding timeout

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -67,7 +67,12 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
     return "test";
   }
 
-  protected async sync(): Promise<void> {}
+  async sync(): Promise<void> {}
+
+  /** Public accessor for test assertions on the protected parent dirty state. */
+  get isDirty(): boolean {
+    return this.dirty;
+  }
 
   protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
     return await promise;
@@ -109,5 +114,20 @@ describe("MemoryManagerSyncOps interval sync", () => {
     });
 
     expect(harness.batchConfig().timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("sets dirty=true and calls sync when interval fires", async () => {
+    vi.useFakeTimers();
+    const harness = new IntervalSyncHarness({ intervalMinutes: 5 });
+    const syncSpy = vi.spyOn(harness, "sync").mockResolvedValue(undefined);
+
+    harness.arm();
+
+    // Advance past the interval
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(harness.isDirty).toBe(true);
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "interval" });
+    harness.stop();
   });
 });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -737,8 +737,8 @@ export abstract class MemoryManagerSyncOps {
       }
       // Force a broad re-sync to cover the gap, then restore directory
       // coverage by reattaching to chokidar so subsequent file changes
-      // still drive watch sync (intervalMinutes defaults to 0; without
-      // a watcher the directory would stop being indexed).
+      // still drive watch sync (intervalMinutes defaults to 30;
+      // without a watcher the directory would stop being indexed).
       markDirty();
       this.attachMemoryChokidarFallback(dir, markDirty);
     });
@@ -1450,7 +1450,14 @@ export abstract class MemoryManagerSyncOps {
       return;
     }
     this.intervalTimer = setInterval(() => {
-      runDetachedMemorySync(() => this.sync({ reason: "interval" }), "interval");
+      runDetachedMemorySync(async () => {
+        // Force dirty so interval rescans memory files even when the
+        // watcher silently failed or events were missed. Without this,
+        // a silent watcher failure leaves dirty=false and the interval
+        // tick becomes a no-op.
+        this.dirty = true;
+        return this.sync({ reason: "interval" });
+      }, "interval");
     }, ms);
   }
 

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -274,6 +274,44 @@ describe("memory search config", () => {
     });
   });
 
+  it("defaults intervalMinutes to 30 when not configured in overrides or defaults", () => {
+    clearMemoryEmbeddingProviders();
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+            sync: {
+              onSessionStart: false,
+              onSearch: true,
+              watch: false,
+              watchDebounceMs: 25,
+              sessions: {
+                deltaBytes: 321,
+                deltaMessages: 7,
+                postCompactionForce: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolveMemorySearchSyncConfig(cfg, "main")).toEqual({
+      onSessionStart: false,
+      onSearch: true,
+      watch: false,
+      watchDebounceMs: 25,
+      intervalMinutes: 30,
+      embeddingBatchTimeoutSeconds: undefined,
+      sessions: {
+        deltaBytes: 321,
+        deltaMessages: 7,
+        postCompactionForce: false,
+      },
+    });
+  });
+
   it("uses configured embeddingBatchTimeoutSeconds when set", () => {
     const cfg = asConfig({
       agents: {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -448,7 +448,7 @@ function resolveSyncConfig(
       overrides?.sync?.watchDebounceMs ??
       defaults?.sync?.watchDebounceMs ??
       DEFAULT_WATCH_DEBOUNCE_MS,
-    intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 0,
+    intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 30,
     embeddingBatchTimeoutSeconds:
       overrides?.sync?.embeddingBatchTimeoutSeconds ?? defaults?.sync?.embeddingBatchTimeoutSeconds,
     sessions: {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -486,6 +486,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.chunking.overlap": "Memory Chunk Overlap Tokens",
   "agents.defaults.memorySearch.sync.onSessionStart": "Index on Session Start",
   "agents.defaults.memorySearch.sync.onSearch": "Index on Search (Lazy)",
+  "agents.defaults.memorySearch.sync.intervalMinutes": "Periodic Sync Interval (min)",
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
   "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds": "Embedding Batch Timeout (s)",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -542,8 +542,9 @@ export type MemorySearchConfig = {
     watchDebounceMs?: number;
     /**
      * Minutes between periodic memory sync ticks. Defaults to 30. Set to 0
-     * to disable interval-based sync entirely (only watch/file-change sync
-     * will reindex memory).
+     * to disable interval-based sync; other configured triggers such as
+     * onSessionStart, onSearch, and watch/file-change can still reindex
+     * memory.
      */
     intervalMinutes?: number;
     /**

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -540,6 +540,11 @@ export type MemorySearchConfig = {
     onSearch?: boolean;
     watch?: boolean;
     watchDebounceMs?: number;
+    /**
+     * Minutes between periodic memory sync ticks. Defaults to 30. Set to 0
+     * to disable interval-based sync entirely (only watch/file-change sync
+     * will reindex memory).
+     */
     intervalMinutes?: number;
     /**
      * Timeout in seconds for inline embedding batches during memory indexing.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -934,7 +934,14 @@ export const MemorySearchSchema = z
         onSearch: z.boolean().optional(),
         watch: z.boolean().optional(),
         watchDebounceMs: z.number().int().nonnegative().optional(),
-        intervalMinutes: z.number().int().nonnegative().optional(),
+        intervalMinutes: z
+          .number()
+          .int()
+          .nonnegative()
+          .describe(
+            "Minutes between periodic memory sync ticks. Defaults to 30. Set to 0 to disable interval-based sync entirely (only watch/file-change sync will reindex memory).",
+          )
+          .optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),
         sessions: z
           .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -939,7 +939,7 @@ export const MemorySearchSchema = z
           .int()
           .nonnegative()
           .describe(
-            "Minutes between periodic memory sync ticks. Defaults to 30. Set to 0 to disable interval-based sync entirely (only watch/file-change sync will reindex memory).",
+            "Minutes between periodic memory sync ticks. Defaults to 30. Set to 0 to disable interval-based sync; other configured triggers such as onSessionStart, onSearch, and watch/file-change can still reindex memory.",
           )
           .optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),


### PR DESCRIPTION
## What changed

- Default `memorySearch.sync.intervalMinutes` to `30` when neither agent overrides nor defaults configure it.
- Preserve explicit `intervalMinutes` values from agent overrides or defaults, including `intervalMinutes: 0` as the opt-out.
- Make the interval sync fallback mark memory dirty before the interval sync runs, so the timer path rescans memory files even when watcher events were missed and `dirty` was previously false.
- Document the 30-minute default and `0` opt-out in the config type/schema help surface, public memory config reference, and static config label surface.
- Add regression coverage for both the resolved default and the manager-level interval timer path.

Fixes #40088.

## Why

Issue #40088 reports that the chokidar memory watcher can silently stop delivering events, leaving `memory_search` backed by a stale SQLite index. The original PR only armed a periodic interval by default. Review showed that was incomplete because the interval callback called `sync({ reason: "interval" })` while `dirty` could still be false, making the timer a no-op for memory files after a silent watcher failure.

This update makes the interval tick force the lightweight dirty/hash rescan path before calling sync, while preserving the explicit `intervalMinutes: 0` opt-out.

## Exact setup

Repository:

```text
git clone https://github.com/openclaw/openclaw
git checkout origin/main
git checkout -b tui-40088-memory-watcher-fallback
```

Fastino Code was launched through the normal coding harness path against this worktree with DeepSeek V4 Flash and XML tool calling enabled.

## Real behavior proof

Behavior or issue addressed: memory watcher events can go silent, leaving `memory_search` backed by stale indexed content. This patch gives the normal interval sync path a real rescan opportunity by marking memory dirty before the interval sync runs, while keeping `intervalMinutes: 0` as the opt-out.

Real environment tested: local OpenClaw checkout on macOS Darwin 25.5.0 arm64, Node v26.0.0, pnpm 11.2.2, branch `tui-40088-memory-watcher-fallback`.

Exact steps or command run after this patch:

```text
$ node scripts/test-projects.mjs src/agents/memory-search.test.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
$ pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
$ git diff --check
$ rg "as any" extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts extensions/memory-core/src/memory/manager-sync-ops.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
$ pnpm exec oxfmt --check --threads=1 docs/reference/memory-config.md src/config/schema.labels.ts
$ git diff --check
```

Evidence after fix:

```text
$ node scripts/test-projects.mjs src/agents/memory-search.test.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
Test Files  1 passed (1)
Tests  33 passed (33)
[test] starting test/vitest/vitest.extension-memory.config.ts
Test Files  1 passed (1)
Tests  3 passed (3)
[test] passed 2 Vitest shards in 4.75s

$ pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 7ms on 6 files using 1 threads.

$ git diff --check
# no output

$ rg "as any" extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts extensions/memory-core/src/memory/manager-sync-ops.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
# no output

$ pnpm exec oxfmt --check --threads=1 docs/reference/memory-config.md src/config/schema.labels.ts
Checking formatting...
All matched files use the correct format.
Finished in 106ms on 2 files using 1 threads.

$ git diff --check
# no output
```

Additional runtime proof for the interval fallback path:

```text
$ node --import tsx /private/tmp/openclaw-memory-interval-proof.ts
setup: {
  workspaceDir: '/private/tmp/openclaw-memory-interval-proof/workspace',
  storePath: '/private/tmp/openclaw-memory-interval-proof/state/main.sqlite',
  intervalMinutes: 1
}
before search before-token: [
  {
    path: 'memory/2026-06-04.md',
    snippet: '# Daily memory\nbefore-interval-token only\n'
  }
]
file updated without manual sync/search trigger
immediate search before-token: [
  {
    path: 'memory/2026-06-04.md',
    snippet: '# Daily memory\nbefore-interval-token only\n'
  }
]
after interval search before-token: [
  {
    path: 'memory/2026-06-04.md',
    snippet: '# Daily memory\nafter-interval-token only\n'
  }
]
after interval search after-token: [
  {
    path: 'memory/2026-06-04.md',
    snippet: '# Daily memory\nafter-interval-token only\n'
  }
]
```

That proof used an isolated temp OpenClaw workspace/state dir with `memorySearch.provider: "none"`, `sync.watch: false`, `sync.onSessionStart: false`, `sync.onSearch: false`, and `sync.intervalMinutes: 1`. The script used the real memory manager runtime from this branch. It first indexed `before-interval-token`, then rewrote the memory file to `after-interval-token` without manual sync or search-triggered sync. The immediate search still returned the old indexed snippet; after the interval tick, the same manager returned the updated snippet, showing the interval fallback rescanned memory even without watcher/search triggers.

Observed result after fix: the runtime interval test exercises the timer path and observes the interval callback setting `dirty=true` before calling sync. The config regression path observes unconfigured agents resolving `memorySearch.sync.intervalMinutes` to `30`, and the format/diff checks observe a clean changed-file surface.

What was not tested: a multi-hour gateway session with an actual chokidar outage; the covered runtime path is the interval fallback that runs after such an outage leaves memory clean/stale. The live-style proof uses a short configured interval so it can complete in one run.

## Validation

```text
$ node scripts/test-projects.mjs src/agents/memory-search.test.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
Test Files  1 passed (1)
Tests  33 passed (33)
[test] starting test/vitest/vitest.extension-memory.config.ts
Test Files  1 passed (1)
Tests  3 passed (3)
[test] passed 2 Vitest shards in 4.75s
```

```text
$ pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 7ms on 6 files using 1 threads.
```

```text
$ git diff --check
# no output
```

```text
$ rg "as any" extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts src/config/types.tools.ts src/config/zod-schema.agent-runtime.ts extensions/memory-core/src/memory/manager-sync-ops.ts src/agents/memory-search.ts src/agents/memory-search.test.ts
# no output
```

Review-comment docs/help repair:

```text
$ pnpm exec oxfmt --check --threads=1 docs/reference/memory-config.md src/config/schema.labels.ts
Checking formatting...

All matched files use the correct format.
Finished in 106ms on 2 files using 1 threads.

$ git diff --check
# no output
```

## Platform tested

```text
OS: Darwin 25.5.0 arm64
Node: v26.0.0
pnpm: 11.2.2
```

## Out-of-scope follow-ups

- Multi-hour live gateway/chokidar outage reproduction.
- A live gateway `memory_search` session showing stale content refreshing after an actual watcher outage.
