### PR TITLE
fix(gateway): guard channel method descriptor projection

### DIFF
--- a/src/gateway/channel-gateway-methods.test.ts
+++ b/src/gateway/channel-gateway-methods.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  channelGatewayMethodNamesInclude,
+  listChannelGatewayMethodNames,
+} from "./channel-gateway-methods.js";
+
+describe("channel gateway method projection", () => {
+  it("keeps legacy names and descriptor names in registration order", () => {
+    expect(
+      listChannelGatewayMethodNames({
+        gatewayMethods: ["legacy.start"],
+        gatewayMethodDescriptors: [{ name: "descriptor.wait" }],
+      }),
+    ).toEqual(["legacy.start", "descriptor.wait"]);
+  });
+
+  it("ignores unreadable channel gateway descriptors", () => {
+    const unreadableDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("channel gateway descriptor name getter exploded");
+      },
+    });
+
+    expect(
+      listChannelGatewayMethodNames({
+        gatewayMethods: ["legacy.start"],
+        gatewayMethodDescriptors: [unreadableDescriptor, { name: "descriptor.wait" }],
+      }),
+    ).toEqual(["legacy.start", "descriptor.wait"]);
+  });
+
+  it("treats unreadable method arrays as absent", () => {
+    const plugin = Object.defineProperty({}, "gatewayMethodDescriptors", {
+      get() {
+        throw new Error("channel gateway descriptors getter exploded");
+      },
+    });
+
+    expect(listChannelGatewayMethodNames(plugin)).toEqual([]);
+  });
+
+  it("matches readable names without throwing on unreadable descriptors", () => {
+    const unreadableDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("channel gateway descriptor name getter exploded");
+      },
+    });
+
+    expect(
+      channelGatewayMethodNamesInclude(
+        {
+          gatewayMethodDescriptors: [unreadableDescriptor, { name: "web.login.start" }],
+        },
+        new Set(["web.login.start"]),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/gateway/channel-gateway-methods.ts
+++ b/src/gateway/channel-gateway-methods.ts
@@ -1,0 +1,53 @@
+type ChannelGatewayMethodDescriptorLike = {
+  name?: unknown;
+};
+
+function readMaybeArray<T>(
+  plugin: unknown,
+  key: "gatewayMethods" | "gatewayMethodDescriptors",
+): readonly T[] {
+  if (!plugin || typeof plugin !== "object") {
+    return [];
+  }
+  try {
+    const value = (plugin as Record<string, unknown>)[key];
+    return Array.isArray(value) ? (value as readonly T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function readDescriptorName(descriptor: ChannelGatewayMethodDescriptorLike): string | undefined {
+  try {
+    return typeof descriptor.name === "string" ? descriptor.name : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Lists readable channel-owned gateway method names without trusting plugin metadata accessors. */
+export function listChannelGatewayMethodNames(plugin: unknown): string[] {
+  const methods: string[] = [];
+  for (const method of readMaybeArray<unknown>(plugin, "gatewayMethods")) {
+    if (typeof method === "string") {
+      methods.push(method);
+    }
+  }
+  for (const descriptor of readMaybeArray<ChannelGatewayMethodDescriptorLike>(
+    plugin,
+    "gatewayMethodDescriptors",
+  )) {
+    const name = readDescriptorName(descriptor);
+    if (name !== undefined) {
+      methods.push(name);
+    }
+  }
+  return methods;
+}
+
+export function channelGatewayMethodNamesInclude(
+  plugin: unknown,
+  names: ReadonlySet<string>,
+): boolean {
+  return listChannelGatewayMethodNames(plugin).some((method) => names.has(method));
+}

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,12 +1,8 @@
 import { listLoadedChannelPlugins } from "../channels/plugins/registry-loaded.js";
+import { listChannelGatewayMethodNames } from "./channel-gateway-methods.js";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 import { listCoreAdvertisedGatewayMethodNames } from "./methods/core-descriptors.js";
 import { GATEWAY_AUX_METHODS } from "./server-aux-methods.js";
-
-type GatewayMethodChannelPlugin = {
-  gatewayMethods?: readonly string[];
-  gatewayMethodDescriptors?: readonly { name: string }[];
-};
 
 /** Lists core methods intentionally advertised to gateway clients. */
 export function listCoreGatewayMethods(): string[] {
@@ -15,13 +11,10 @@ export function listCoreGatewayMethods(): string[] {
 
 function listChannelGatewayMethods(): string[] {
   const methods: string[] = [];
-  for (const plugin of listLoadedChannelPlugins() as GatewayMethodChannelPlugin[]) {
+  for (const plugin of listLoadedChannelPlugins()) {
     // Plugins may still expose legacy names while newer plugins expose descriptors.
     // Merge both so method discovery stays compatible during descriptor adoption.
-    methods.push(...(plugin.gatewayMethods ?? []));
-    for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-      methods.push(descriptor.name);
-    }
+    methods.push(...listChannelGatewayMethodNames(plugin));
   }
   return methods;
 }

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -177,6 +177,55 @@ describe("webHandlers web.login.start", () => {
       undefined,
     );
   });
+
+  it("ignores unreadable channel gateway descriptors when resolving the login provider", async () => {
+    const loginWithQrStart = vi.fn().mockResolvedValue({
+      connected: true,
+      message: "connected",
+    });
+    const unreadableDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("channel gateway descriptor name getter exploded");
+      },
+    });
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "broken-channel",
+        gatewayMethodDescriptors: [unreadableDescriptor],
+        gateway: { loginWithQrStart: vi.fn() },
+      },
+      {
+        id: "whatsapp",
+        gatewayMethodDescriptors: [{ name: "web.login.start" }],
+        gateway: { loginWithQrStart },
+      },
+    ]);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+        },
+      ),
+    );
+
+    expect(loginWithQrStart).toHaveBeenCalledWith({
+      accountId: "default",
+      force: false,
+      timeoutMs: undefined,
+      verbose: false,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        connected: true,
+        message: "connected",
+      },
+      undefined,
+    );
+  });
 });
 
 describe("webHandlers web.login.wait", () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { channelGatewayMethodNamesInclude } from "../channel-gateway-methods.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -15,10 +16,7 @@ const WEB_LOGIN_METHODS = new Set(["web.login.start", "web.login.wait"]);
 /** Resolves the channel plugin that currently owns web QR-login methods. */
 const resolveWebLoginProvider = () =>
   listChannelPlugins().find((plugin) =>
-    [
-      ...(plugin.gatewayMethods ?? []),
-      ...(plugin.gatewayMethodDescriptors ?? []).map((descriptor) => descriptor.name),
-    ].some((method) => WEB_LOGIN_METHODS.has(method)),
+    channelGatewayMethodNamesInclude(plugin, WEB_LOGIN_METHODS),
   ) ?? null;
 
 type WebLoginProvider = NonNullable<ReturnType<typeof resolveWebLoginProvider>>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -54,6 +54,7 @@ import {
 } from "../secrets/runtime-state.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { resolveGatewayAuth } from "./auth.js";
+import { listChannelGatewayMethodNames } from "./channel-gateway-methods.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import {
   STARTUP_UNAVAILABLE_GATEWAY_METHODS,
@@ -729,10 +730,7 @@ export async function startGatewayServer(
   const listStartupChannelGatewayMethods = () => {
     const methods: string[] = [];
     for (const plugin of listGatewayStartupChannelPlugins()) {
-      methods.push(...(plugin.gatewayMethods ?? []));
-      for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-        methods.push(descriptor.name);
-      }
+      methods.push(...listChannelGatewayMethodNames(plugin));
     }
     return methods;
   };


### PR DESCRIPTION
## Summary

- Add a shared channel gateway method-name projection helper that ignores unreadable plugin metadata accessors.
- Route web-login provider discovery, advertised gateway method listing, and startup channel method listing through the guarded projection.
- Cover unreadable channel gateway descriptors without changing legacy method-name ordering.

## Verification

- `node scripts/run-vitest.mjs src/gateway/channel-gateway-methods.test.ts src/gateway/server-methods/web.start.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/channel-gateway-methods.ts src/gateway/channel-gateway-methods.test.ts src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts src/gateway/server-methods-list.ts src/gateway/server.impl.ts`
- `./node_modules/.bin/oxlint src/gateway/channel-gateway-methods.ts src/gateway/channel-gateway-methods.test.ts src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts src/gateway/server-methods-list.ts src/gateway/server.impl.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed channel gateway method metadata can no longer throw while gateway method discovery or web-login provider resolution walks channel-owned descriptors.

Real environment tested: local Codex worktree using the repo Vitest wrapper; broad Crabbox changed gate attempted but blocked before execution by coordinator auth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/channel-gateway-methods.test.ts src/gateway/server-methods/web.start.test.ts`

Evidence after fix: focused Vitest passed 6 files / 26 tests after rebase onto `origin/main`; local and branch autoreview both reported no accepted/actionable findings.

Observed result after fix: unreadable descriptor and descriptor-list accessors are ignored, readable legacy names and descriptor names keep their existing discovery order, and web-login provider resolution continues to select the readable matching provider.

What was not tested: `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` did not execute because the Crabbox coordinator returned HTTP 401 unauthorized while creating the run/lease.
