### PR TITLE
test(codex): pin completion-idle timeout thread reset

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -19,6 +19,7 @@ import type { CodexServerNotification } from "./protocol.js";
 import { readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import {
   createParams,
+  createResumeHarness,
   extractRelayIdFromThreadRequest,
   createRuntimeDynamicTool,
   createStartedThreadHarness,
@@ -33,7 +34,11 @@ import {
   turnStartResult,
 } from "./run-attempt-test-harness.js";
 import { testing } from "./run-attempt.js";
-import { resolveCodexAppServerBindingPath } from "./session-binding.js";
+import {
+  readCodexAppServerBinding,
+  resolveCodexAppServerBindingPath,
+  writeCodexAppServerBinding,
+} from "./session-binding.js";
 
 setupRunAttemptTestHooks();
 
@@ -2862,6 +2867,54 @@ describe("runCodexAppServerAttempt turn watches", () => {
         turnId: "turn-1",
       }),
     );
+  });
+
+  it("clears the thread binding after a completion-idle timeout so the next turn starts fresh", async () => {
+    // Regression for openclaw#89974. The "user interrupted the previous turn on
+    // purpose" wording is Codex's generic <turn_aborted> rollout marker, written
+    // whenever a turn is interrupted (including OpenClaw's own watchdog abort).
+    // OpenClaw cannot change that text (turn/interrupt carries no reason); it can
+    // only avoid replaying it. This proves a turn_completion_idle_timeout clears
+    // the timed-out thread's binding so the next turn starts a fresh thread
+    // rather than resuming the thread that may hold that marker.
+    vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const sessionFile = path.join(tempDir, "session-89974.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-89974");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+    });
+
+    // Turn 1: resume an existing thread, then never deliver turn/completed.
+    const firstHarness = createResumeHarness();
+    const firstParams = createParams(sessionFile, workspaceDir);
+    firstParams.timeoutMs = 200;
+    const firstRun = runCodexAppServerAttempt(firstParams, { turnCompletionIdleTimeoutMs: 15 });
+    await firstHarness.waitForMethod("turn/start");
+    expect(firstHarness.requests.some((entry) => entry.method === "thread/resume")).toBe(true);
+
+    const firstResult = await firstRun;
+    expect(firstResult.timedOut).toBe(true);
+    expect(firstResult.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(firstResult.codexAppServerFailure?.kind).toBe("turn_completion_idle_timeout");
+    expect(firstResult.codexAppServerFailure?.turnWatchTimeoutKind).toBe("completion");
+    // The timed-out thread's binding is gone, so it cannot be resumed.
+    expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
+
+    // Turn 2: with no binding, OpenClaw starts a brand-new thread instead of
+    // resuming the timed-out one, so Codex's interrupt marker never replays.
+    const secondHarness = createStartedThreadHarness();
+    const secondRun = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await secondHarness.waitForMethod("turn/start");
+    expect(secondHarness.requests.some((entry) => entry.method === "thread/start")).toBe(true);
+    expect(secondHarness.requests.some((entry) => entry.method === "thread/resume")).toBe(false);
+    await secondHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await secondRun;
   });
 
   it("yields a macrotask before processing queued app-server notifications", async () => {


### PR DESCRIPTION
## Summary

Regression coverage for issue 89974 ("Codex app-server turn idle timeout is surfaced as user interruption"). **No runtime behavior changes.**

- Confirms that after a `turn_completion_idle_timeout`, OpenClaw clears the timed-out Codex app-server thread binding.
- Confirms the next turn starts a fresh thread (`thread/start`) instead of resuming the thread that may still contain Codex's generic `<turn_aborted>` / user-interrupted marker.

The "user interrupted the previous turn on purpose" wording is Codex's own `<turn_aborted>` rollout marker; OpenClaw cannot change it (`turn/interrupt` carries no reason), only avoid replaying it. The behavior that abandons the timed-out thread landed in #87781; this test pins it for the exact issue shape.

## Collision and current state

- No direct competing PR currently claims or closes issue 89974; this PR is the only direct regression-coverage PR found for that issue.
- #87781 already fixed the runtime thread-abandonment behavior this PR covers. This PR is intentionally a test-only guardrail, not a second runtime fix.
- This PR intentionally avoids a closing keyword for issue 89974 because it pins one already-fixed path and should not by itself close the broader issue.

## Proof and merge path

This verifies the behavior at the **code/test level**; no live end-to-end repro was run. Because the PR is test-only and introduces no new runtime behavior, the remaining proof-policy blocker needs maintainer judgment, a `proof: override` label, or separately supplied redacted live logs showing the after-timeout next turn starts fresh.

I am not broadening this PR into a runtime classification/copy fix: that would change the scope, require a different proof lane, and is separate from pinning the #87781 thread-reset behavior.

## Validation

- new regression test: **passed**
- `run-attempt.turn-watches.test.ts`: **56 passed**
- `run.codex-app-server-recovery.test.ts`: **10 passed**
- oxfmt / oxlint / tsgo / `git diff --check`: **passed**

Refs issue 89974. Behavior fixed by #87781.
