### PR TITLE
docs: clarify legacy openai-codex auth

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -17,9 +17,17 @@ is now:
   told us this usage is allowed again
 
 OpenAI Codex OAuth is explicitly supported for use in external tools like
-OpenClaw. This page explains:
+OpenClaw.
+
+OpenClaw stores both OpenAI API-key auth and ChatGPT/Codex OAuth under the
+canonical provider id `openai`. Older `openai-codex:*` profile ids and
+`auth.order.openai-codex` entries are legacy state repaired by
+`openclaw doctor --fix`; use `openai:*` profile ids and `auth.order.openai` for
+new config.
 
 For Anthropic in production, API key auth is the safer recommended path.
+
+This page explains:
 
 - how the OAuth **token exchange** works (PKCE)
 - where tokens are **stored** (and why)
@@ -121,6 +129,16 @@ Flow shape:
 ### OpenAI Codex (ChatGPT OAuth)
 
 OpenAI Codex OAuth is explicitly supported for use outside the Codex CLI, including OpenClaw workflows.
+
+The login command still uses the canonical OpenAI provider id:
+
+```bash
+openclaw models auth login --provider openai
+```
+
+Use `--profile-id openai:<name>` for multiple ChatGPT/Codex OAuth accounts in
+one agent. Do not use `openai-codex:<name>` for new profiles; doctor migrates
+that older prefix to `openai:<name>`.
 
 Flow shape (PKCE):
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -137,8 +137,10 @@ openclaw models auth login --provider openai
 ```
 
 Use `--profile-id openai:<name>` for multiple ChatGPT/Codex OAuth accounts in
-one agent. Do not use `openai-codex:<name>` for new profiles; doctor migrates
-that older prefix to `openai:<name>`.
+one agent. Do not use `openai-codex:<name>` for new profiles. Doctor migrates
+that older prefix to a collision-free `openai:*` profile id; run
+`openclaw models auth list --provider openai` after repair before copying
+profile ids into `auth.order` or `/model ...@<profileId>`.
 
 Flow shape (PKCE):
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -193,6 +193,25 @@ key in the provider dashboard when you need provider-side invalidation.
 
 ## Controlling which credential is used
 
+### OpenAI and legacy `openai-codex` ids
+
+OpenAI API-key profiles and ChatGPT/Codex OAuth profiles both use the canonical
+provider id `openai`. New config should use `openai:*` profile ids and
+`auth.order.openai`.
+
+If you see `openai-codex` in older config, auth profile ids, or
+`auth.order.openai-codex`, treat it as legacy migration input. Do not create new
+`openai-codex` profiles. Run:
+
+```bash
+openclaw doctor --fix
+openclaw models auth list --provider openai
+```
+
+Doctor rewrites legacy `openai-codex:*` profile ids and
+`auth.order.openai-codex` entries to the canonical `openai` auth route. For
+OpenAI-specific model/runtime routing, see [OpenAI](/providers/openai).
+
 ### During login (CLI)
 
 Use `openclaw models auth login --provider <id> --profile-id <profileId>` for


### PR DESCRIPTION
## What
Clarifies that OpenAI API-key profiles and ChatGPT/Codex OAuth profiles now both use the canonical `openai` provider id, while `openai-codex` is legacy migration input handled by doctor.

## Why
Users searching for the old `openai-codex` auth provider wording could find doctor migration notes, but the general OAuth and authentication docs did not explicitly bridge that legacy name to current `openai` auth profile setup.

## Changes
- Add auth reference guidance
- Add OAuth concept guidance
- Document doctor migration path

## Testing
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
