### PR TITLE
fix(memory-core): skip qmd zero-hit search sync

### DIFF
--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -382,47 +382,14 @@ describe("memory_search unavailable payloads", () => {
     expect(searchCalls).toBe(2);
   });
 
-  it("merges qmd runtime debug across zero-hit retry attempts", async () => {
+  it("keeps the zero-hit bootstrap retry for one-shot qmd searches", async () => {
     setMemoryBackend("qmd");
     let searchCalls = 0;
-    setMemorySearchImpl(async (opts) => {
+    setMemorySearchImpl(async () => {
       searchCalls += 1;
       if (searchCalls === 1) {
-        opts?.onDebug?.({
-          backend: "qmd",
-          configuredMode: "search",
-          effectiveMode: "search",
-          qmd: {
-            collectionValidation: {
-              cacheState: "hit",
-              elapsedMs: 2,
-              collectionCount: 2,
-              listCalls: 0,
-              showCalls: 0,
-            },
-            multiCollectionProbe: {
-              cacheState: "hit",
-              elapsedMs: 1,
-              supported: true,
-            },
-          },
-        });
         return [];
       }
-      opts?.onDebug?.({
-        backend: "qmd",
-        configuredMode: "search",
-        effectiveMode: "query",
-        fallback: "unsupported-search-flags",
-        qmd: {
-          searchPlan: {
-            command: "query",
-            collectionCount: 2,
-            groupCount: 2,
-            sources: ["memory", "sessions"],
-          },
-        },
-      });
       return [
         {
           path: "MEMORY.md",
@@ -440,8 +407,59 @@ describe("memory_search unavailable payloads", () => {
         agents: { list: [{ id: "main", default: true }] },
         memory: { backend: "qmd", citations: "off" },
       },
+      oneShotCliRun: true,
     });
-    const result = await tool.execute("zero-hit-debug-retry", {
+    const result = await tool.execute("qmd-zero-hit-cli", {
+      query: "hidden thread codename",
+    });
+
+    expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
+      "MEMORY.md",
+    );
+    expect(searchCalls).toBe(2);
+    expect(getMemorySyncMockCalls()).toBe(1);
+  });
+
+  it("returns qmd runtime debug without forcing a zero-hit retry", async () => {
+    setMemoryBackend("qmd");
+    let searchCalls = 0;
+    setMemorySearchImpl(async (opts) => {
+      searchCalls += 1;
+      opts?.onDebug?.({
+        backend: "qmd",
+        configuredMode: "search",
+        effectiveMode: "search",
+        qmd: {
+          collectionValidation: {
+            cacheState: "hit",
+            elapsedMs: 2,
+            collectionCount: 2,
+            listCalls: 0,
+            showCalls: 0,
+          },
+          multiCollectionProbe: {
+            cacheState: "hit",
+            elapsedMs: 1,
+            supported: true,
+          },
+          searchPlan: {
+            command: "search",
+            collectionCount: 2,
+            groupCount: 2,
+            sources: ["memory", "sessions"],
+          },
+        },
+      });
+      return [];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { backend: "qmd", citations: "off" },
+      },
+    });
+    const result = await tool.execute("zero-hit-debug-single", {
       query: "hidden thread codename",
     });
     const details = result.details as {
@@ -452,9 +470,11 @@ describe("memory_search unavailable payloads", () => {
       };
     };
 
-    expect(searchCalls).toBe(2);
-    expect(details.debug?.effectiveMode).toBe("query");
-    expect(details.debug?.fallback).toBe("unsupported-search-flags");
+    expect((result.details as { results?: Array<unknown> }).results).toEqual([]);
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
+    expect(details.debug?.effectiveMode).toBe("search");
+    expect(details.debug?.fallback).toBeUndefined();
     expect(details.debug?.qmd?.collectionValidation).toMatchObject({
       cacheState: "hit",
       collectionCount: 2,
@@ -464,7 +484,7 @@ describe("memory_search unavailable payloads", () => {
       supported: true,
     });
     expect(details.debug?.qmd?.searchPlan).toEqual({
-      command: "query",
+      command: "search",
       collectionCount: 2,
       groupCount: 2,
       sources: ["memory", "sessions"],

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -566,7 +566,13 @@ export function createMemorySearchTool(options: {
                   if (pausedIndexIdentityReason) {
                     return;
                   }
-                  if (rawResults.length === 0 && activeMemory.manager.sync) {
+                  // One-shot CLI managers have no background lifecycle, so keep their bootstrap
+                  // retry. Long-lived QMD managers must not run update work in the tool hot path.
+                  if (
+                    rawResults.length === 0 &&
+                    activeMemory.manager.sync &&
+                    (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
+                  ) {
                     await activeMemory.manager.sync({ reason: "search", force: true });
                     rawResults = await activeMemory.manager.search(query, searchOptions);
                     pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(


### PR DESCRIPTION
## What Problem This Solves

Fixes #90023.

Long-lived QMD-backed `memory_search` calls can turn a normal zero-hit result into synchronous index maintenance by awaiting `manager.sync({ reason: "search", force: true })`. QMD maps that call to update/embed work, which can stall an interactive turn for tens of seconds.

## Why This Change Was Made

The generic zero-hit repair remains useful for builtin/fallback managers, but QMD already owns its search and update lifecycle. The repair is therefore backend- and lifecycle-specific:

- long-lived QMD managers return the zero-hit result without forcing synchronous update work;
- one-shot CLI QMD managers keep the bootstrap sync/retry because they do not have a background lifecycle;
- non-QMD managers keep the existing sync/retry behavior.

This is narrower than removing zero-hit repair for every backend and does not add configuration or timeout policy.

## User Impact

Interactive QMD memory misses return without entering QMD update/embed maintenance. Existing builtin/fallback freshness repair and one-shot CLI bootstrap behavior remain unchanged.

## Evidence

- Canonical issue #90023 includes repeated live QMD reports showing 69-75 second zero-hit stalls and sub-second results after bypassing the synchronous QMD update path.
- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts` - 22 passed
- Blacksmith Testbox `tbx_01kweq20wqs24wspdyf03kg2zh` - `corepack pnpm check:changed` passed
- Fresh autoreview on the final local diff - no accepted/actionable findings
- `git diff --check origin/main...HEAD` - clean

Focused coverage proves:

- long-lived QMD zero-hit search performs one search and zero forced syncs while preserving runtime debug;
- one-shot QMD zero-hit search still syncs and retries;
- non-QMD zero-hit search still syncs and retries.

Hosted CI is required on the pushed exact head before merge.