### PR TITLE
fix(plugins): isolate tool metadata projection

### DIFF
--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -5,6 +5,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { buildReadablePluginToolMetadataMap } from "../plugins/tool-metadata-projection.js";
 import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.js";
 import { getChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
@@ -159,11 +160,8 @@ export function buildEffectiveToolInventoryEntries(
 ): EffectiveToolInventoryEntry[] {
   // Key metadata by plugin ownership and tool name so only the owning plugin can
   // project display/risk metadata for its own tool.
-  const pluginToolMetadata = new Map(
-    (getActivePluginRegistry()?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
+  const pluginToolMetadata = buildReadablePluginToolMetadataMap(
+    getActivePluginRegistry()?.toolMetadata,
   );
 
   return disambiguateLabels(

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -280,7 +280,21 @@ describe("resolveEffectiveToolInventory", () => {
 
   it("projects plugin tool metadata into the effective inventory", async () => {
     const registry = createEmptyPluginRegistry();
+    const unreadableMetadata = Object.defineProperty(
+      {
+        pluginId: "broken-plugin",
+        pluginName: "Broken Plugin",
+        source: "fixture",
+      },
+      "metadata",
+      {
+        get() {
+          throw new Error("plugin tool metadata row exploded");
+        },
+      },
+    );
     registry.toolMetadata = [
+      unreadableMetadata as never,
       {
         pluginId: "docs",
         pluginName: "Docs",

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   ensureStandalonePluginToolRegistryLoaded,
   resolvePluginTools,
@@ -105,6 +107,7 @@ function expectCatalogPayload(respond: ReturnType<typeof vi.fn>): CatalogPayload
 
 describe("tools.catalog handler", () => {
   beforeEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
     pluginToolMetaState.clear();
     pluginToolMetaState.set("voice_call", { pluginId: "voice-call", optional: true });
     pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
@@ -152,6 +155,57 @@ describe("tools.catalog handler", () => {
       risk: undefined,
       tags: undefined,
       defaultProfiles: [],
+    });
+  });
+
+  it("ignores unreadable plugin tool metadata rows when building plugin groups", async () => {
+    const registry = createEmptyPluginRegistry();
+    const unreadableMetadata = Object.defineProperty(
+      {
+        pluginId: "broken-plugin",
+        pluginName: "Broken Plugin",
+        source: "fixture",
+      },
+      "metadata",
+      {
+        get() {
+          throw new Error("plugin tool metadata row exploded");
+        },
+      },
+    );
+    registry.toolMetadata = [
+      unreadableMetadata as never,
+      {
+        pluginId: "voice-call",
+        pluginName: "Voice Call",
+        source: "fixture",
+        metadata: {
+          toolName: "voice_call",
+          displayName: "Voice Call",
+          description: "Managed voice call.",
+          risk: "medium",
+          tags: ["voice", "calling"],
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+    const { respond, invoke } = createInvokeParams({});
+
+    await invoke();
+
+    const payload = expectCatalogPayload(respond);
+    const voiceCall = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools)
+      .find((tool) => tool.id === "voice_call");
+    expect(voiceCall).toMatchObject({
+      id: "voice_call",
+      label: "Voice Call",
+      description: "Managed voice call.",
+      source: "plugin",
+      pluginId: "voice-call",
+      risk: "medium",
+      tags: ["voice", "calling"],
     });
   });
 

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -19,6 +19,7 @@ import {
 import { summarizeToolDescriptionText } from "../../agents/tool-description-summary.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { buildReadablePluginToolMetadataMap } from "../../plugins/tool-metadata-projection.js";
 import {
   buildPluginToolMetadataKey,
   ensureStandalonePluginToolRegistryLoaded,
@@ -98,12 +99,7 @@ function buildPluginGroups(params: {
   // was registered BY the tool's owning plugin. Without this scoping, plugin-X
   // could override the catalog label/description/risk/tags for another plugin's
   // tool by registering metadata with the same toolName.
-  const pluginToolMetadata = new Map(
-    (activeRegistry?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
-  );
+  const pluginToolMetadata = buildReadablePluginToolMetadataMap(activeRegistry?.toolMetadata);
   const seenToolIds = new Set<string>();
   for (const tool of pluginTools) {
     const meta = getPluginToolMeta(tool);

--- a/src/plugins/tool-metadata-projection.ts
+++ b/src/plugins/tool-metadata-projection.ts
@@ -1,0 +1,93 @@
+import { buildPluginToolMetadataKey } from "./tools.js";
+
+export type ReadablePluginToolMetadata = {
+  toolName: string;
+  displayName?: string;
+  description?: string;
+  risk?: "low" | "medium" | "high";
+  tags?: string[];
+};
+
+function readObjectField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  try {
+    const field = (value as Record<string, unknown>)[key];
+    return field && typeof field === "object" && !Array.isArray(field)
+      ? (field as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  try {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === "string" ? field : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRiskField(value: unknown): "low" | "medium" | "high" | undefined {
+  const risk = readStringField(value, "risk");
+  return risk === "low" || risk === "medium" || risk === "high" ? risk : undefined;
+}
+
+function readTagsField(value: unknown): string[] | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  try {
+    const tags = (value as Record<string, unknown>).tags;
+    return Array.isArray(tags) && tags.every((tag) => typeof tag === "string")
+      ? [...tags]
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readEntry(entries: readonly unknown[], index: number): unknown {
+  try {
+    return entries[index];
+  } catch {
+    return undefined;
+  }
+}
+
+/** Builds stable plugin tool metadata rows without trusting plugin-owned accessors. */
+export function buildReadablePluginToolMetadataMap(
+  entries: unknown,
+): ReadonlyMap<string, ReadablePluginToolMetadata> {
+  const metadataByKey = new Map<string, ReadablePluginToolMetadata>();
+  if (!Array.isArray(entries)) {
+    return metadataByKey;
+  }
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = readEntry(entries, index);
+    const pluginId = readStringField(entry, "pluginId");
+    const metadata = readObjectField(entry, "metadata");
+    const toolName = readStringField(metadata, "toolName");
+    if (!pluginId || !toolName) {
+      continue;
+    }
+    const displayName = readStringField(metadata, "displayName");
+    const description = readStringField(metadata, "description");
+    const risk = readRiskField(metadata);
+    const tags = readTagsField(metadata);
+    metadataByKey.set(buildPluginToolMetadataKey(pluginId, toolName), {
+      toolName,
+      ...(displayName !== undefined ? { displayName } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(risk !== undefined ? { risk } : {}),
+      ...(tags !== undefined ? { tags } : {}),
+    });
+  }
+  return metadataByKey;
+}


### PR DESCRIPTION
## Summary

- Add a guarded plugin tool metadata projection helper that snapshots readable metadata rows.
- Use the helper from both `tools.catalog` and effective tool inventory so malformed registry rows cannot crash either view.
- Cover poisoned plugin metadata rows while preserving owner-scoped metadata lookup for healthy rows.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs src/gateway/server-methods/tools-catalog.test.ts src/agents/tools-effective-inventory.test.ts` failed with `plugin tool metadata row exploded`.
- `node scripts/run-vitest.mjs src/gateway/server-methods/tools-catalog.test.ts src/agents/tools-effective-inventory.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tool-metadata-projection.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts`
- `./node_modules/.bin/oxlint src/plugins/tool-metadata-projection.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed plugin tool metadata rows can no longer throw while building the gateway tools catalog or effective tool inventory before healthy sibling metadata is projected.

Real environment tested: local Codex worktree using the repo Vitest wrapper; broad Crabbox changed gate attempted but blocked before execution by coordinator auth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/tools-catalog.test.ts src/agents/tools-effective-inventory.test.ts`

Evidence after fix: focused Vitest passed 2 shards covering gateway and agents; local and branch autoreview both reported no accepted/actionable findings.

Observed result after fix: unreadable plugin metadata rows are skipped, readable owner-scoped metadata still overrides labels/descriptions/risk/tags for matching plugin tools, and cross-plugin metadata spoofing remains scoped out.

What was not tested: `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` did not execute because the Crabbox coordinator returned HTTP 401 unauthorized while creating the run/lease.
