### PR TITLE
fix(llm): apply model.compat.sendSessionAffinityHeaders at openai-tra…

### DIFF
--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -40,6 +40,9 @@
             "input": ["text", "image"],
             "contextWindow": 262144,
             "maxTokens": 262144,
+            "compat": {
+              "sendSessionAffinityHeaders": true
+            },
             "cost": {
               "input": 0.95,
               "output": 4,
@@ -54,7 +57,8 @@
             "contextWindow": 256000,
             "maxTokens": 256000,
             "compat": {
-              "unsupportedToolSchemaKeywords": ["not"]
+              "unsupportedToolSchemaKeywords": ["not"],
+              "sendSessionAffinityHeaders": true
             },
             "cost": {
               "input": 0,

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -130,6 +130,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       authProfileId: params.authProfileId,
       authStorage: params.authStorage,
       providerId: params.model.provider,
+      sessionId: params.sessionId,
       promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
@@ -190,6 +191,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
         authProfileId: params.authProfileId,
         authStorage: params.authStorage,
         providerId: params.model.provider,
+        sessionId: params.sessionId,
         promptCacheKey: params.promptCacheKey,
       });
     }
@@ -205,6 +207,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     authProfileId: undefined,
     authStorage: undefined,
     providerId: params.model.provider,
+    sessionId: params.sessionId,
     promptCacheKey,
   });
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1108,6 +1108,68 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("gates OpenAI-compatible session affinity headers without overriding caller headers", () => {
+    const model = {
+      id: "accounts/fireworks/models/kimi-k2p6",
+      name: "Kimi K2.6",
+      api: "openai-completions",
+      provider: "fireworks",
+      baseUrl: "https://api.fireworks.ai/inference/v1",
+      compat: { sendSessionAffinityHeaders: true },
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 262144,
+      maxTokens: 262144,
+    } satisfies Model<"openai-completions">;
+    const context = { systemPrompt: "system", messages: [], tools: [] } as never;
+    const cacheSessionId = testing.resolveAffinityHeadersValue({
+      sessionId: "session-123",
+      promptCacheKey: "cron-cache-key",
+      cacheRetention: "short",
+    });
+
+    const headers = testing.buildOpenAICompletionsClientConfig(
+      model,
+      context,
+      undefined,
+      cacheSessionId,
+    ).defaultHeaders;
+    const callerHeaders = testing.buildOpenAICompletionsClientConfig(
+      model,
+      context,
+      {
+        session_id: "caller-session",
+        "x-client-request-id": "caller-request",
+        "x-session-affinity": "caller-affinity",
+      },
+      cacheSessionId,
+    ).defaultHeaders;
+    const disabledHeaders = testing.buildOpenAICompletionsClientConfig(
+      model,
+      context,
+      undefined,
+      testing.resolveAffinityHeadersValue({
+        sessionId: "session-123",
+        cacheRetention: "none",
+      }),
+    ).defaultHeaders;
+
+    expectRecordFields(headers, {
+      session_id: "cron-cache-key",
+      "x-client-request-id": "cron-cache-key",
+      "x-session-affinity": "cron-cache-key",
+    });
+    expectRecordFields(callerHeaders, {
+      session_id: "caller-session",
+      "x-client-request-id": "caller-request",
+      "x-session-affinity": "caller-affinity",
+    });
+    expect(disabledHeaders).not.toHaveProperty("session_id");
+    expect(disabledHeaders).not.toHaveProperty("x-client-request-id");
+    expect(disabledHeaders).not.toHaveProperty("x-session-affinity");
+  });
+
   it("refuses ModelStudio chat streams with no user or assistant payload turns", async () => {
     const model = {
       id: "qwen-coder-plus",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1773,6 +1773,7 @@ function buildOpenAIClientHeaders(
   context: Context,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  affinityHeadersValue?: string,
 ): Record<string, string> {
   const providerHeaders = { ...model.headers };
   if (model.provider === "github-copilot") {
@@ -1785,6 +1786,13 @@ function buildOpenAIClientHeaders(
     );
   }
   const callerHeaders = { ...optionHeaders, ...turnHeaders };
+
+  if (affinityHeadersValue) {
+    providerHeaders["x-session-affinity"] = affinityHeadersValue;
+    providerHeaders["x-client-request-id"] = affinityHeadersValue;
+    providerHeaders["session_id"] = affinityHeadersValue;
+  }
+
   const headers = resolveProviderRequestPolicyConfig({
     provider: model.provider,
     api: model.api,
@@ -1998,6 +2006,13 @@ function resolvePromptCacheKey(
     return undefined;
   }
   return clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId);
+}
+
+function resolveAffinityHeadersValue(
+  options: Pick<BaseStreamOptions, "cacheRetention" | "promptCacheKey" | "sessionId"> | undefined,
+): string | undefined {
+  const cacheRetention = resolveCacheRetention(options?.cacheRetention);
+  return resolvePromptCacheKey(options, cacheRetention);
 }
 
 function getPromptCacheRetention(
@@ -2481,8 +2496,14 @@ function createOpenAICompletionsClient(
   context: Context,
   apiKey: string,
   optionHeaders?: Record<string, string>,
+  affinityHeadersValue?: string,
 ) {
-  const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders);
+  const clientConfig = buildOpenAICompletionsClientConfig(
+    model,
+    context,
+    optionHeaders,
+    affinityHeadersValue,
+  );
   return new OpenAI({
     apiKey,
     baseURL: clientConfig.baseURL,
@@ -2506,12 +2527,20 @@ function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
   optionHeaders?: Record<string, string>,
+  affinityHeadersValue?: string,
 ): {
   baseURL: string;
   defaultHeaders: Record<string, string>;
   defaultQuery?: Record<string, string>;
 } {
-  const headers = buildOpenAIClientHeaders(model, context, optionHeaders);
+  const compat = getCompat(model);
+  const headers = buildOpenAIClientHeaders(
+    model,
+    context,
+    optionHeaders,
+    undefined,
+    compat.sendSessionAffinityHeaders ? affinityHeadersValue : undefined,
+  );
   const defaultQuery: Record<string, string> = {};
   let baseURL = model.baseUrl;
   let isAzureHost = false;
@@ -2574,7 +2603,14 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       };
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        const affinityHeadersValue = resolveAffinityHeadersValue(options);
+        const client = createOpenAICompletionsClient(
+          model,
+          context,
+          apiKey,
+          options?.headers,
+          affinityHeadersValue,
+        );
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,
@@ -3367,6 +3403,7 @@ function detectCompat(model: OpenAIModeModel) {
     requiresToolResultName: false,
     requiresAssistantAfterToolResult: false,
     requiresThinkingAsText: false,
+    sendSessionAffinityHeaders: false,
     thinkingFormat: compatDefaults.thinkingFormat,
     visibleReasoningDetailTypes: compatDefaults.visibleReasoningDetailTypes,
     openRouterRouting: {},
@@ -3393,6 +3430,7 @@ function getCompat(model: OpenAIModeModel): {
   vercelGatewayRouting: Record<string, unknown>;
   supportsStrictMode: boolean;
   supportsPromptCacheKey: boolean;
+  sendSessionAffinityHeaders: boolean;
   supportsLongCacheRetention: boolean;
   requiresStringContent: boolean;
   strictMessageKeys: boolean;
@@ -3425,6 +3463,8 @@ function getCompat(model: OpenAIModeModel): {
       (compat.vercelGatewayRouting as Record<string, unknown> | undefined) ??
       detected.vercelGatewayRouting,
     supportsStrictMode: compat.supportsStrictMode ?? detected.supportsStrictMode,
+    sendSessionAffinityHeaders:
+      compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
     supportsPromptCacheKey: compat.supportsPromptCacheKey === true,
     supportsLongCacheRetention: compat.supportsLongCacheRetention !== false,
     requiresStringContent: compat.requiresStringContent ?? false,
@@ -4287,6 +4327,7 @@ export const testing = {
   enforceCodeModeResponsesToolSurface,
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
+  resolveAffinityHeadersValue,
   processOpenAICompletionsStream,
   processResponsesStream,
   shouldEmitOpenAICompletionsReasoningForModel,


### PR DESCRIPTION
## Summary

* Fix a regression where [model.compat.sendSessionAffinityHeaders](https://github.com/openclaw/openclaw/blob/main/packages/llm-core/src/types.ts#L403-L404) stopped being honored after the major inference “gate” moved from `src/llm/providers/openai-completions.ts` to `src/agents/openai-transport-stream.ts`.
* Restore the existing affinity-header behavior without losing functionality already provided by [src/llm/providers/anthropic.ts](https://github.com/openclaw/openclaw/blob/main/src/llm/providers/anthropic.ts) and [src/agents/openai-completions-compat.ts](https://github.com/openclaw/openclaw/blob/main/src/agents/openai-completions-compat.ts).
* Enable `compat.sendSessionAffinityHeaders: true` for the Fireworks model configurations in `openclaw.plugin.json`, because Fireworks prompt caching supports session-affinity routing for repeated session traffic.
* Success looks like: `x-session-affinity`, `x-client-request-id`, and `session_id` header injection is gated on `compat.sendSessionAffinityHeaders` plus a resolved cache/session value, while caller-supplied headers still win through the existing provider request-policy merge.
* Out of scope: changing provider auth, cache-retention semantics, or session-affinity behavior for providers that do not opt into `compat.sendSessionAffinityHeaders`.

* Pass sessionId to all `wrapEmbeddedAgentStreamFn` calls in [resolveEmbeddedAgentStreamFn](https://github.com/openclaw/openclaw/blob/main/src/agents/embedded-agent-runner/stream-resolution.ts)
The codex path already forwarded params.sessionId to wrapEmbeddedAgentStreamFn, but three other call sites omitted it:
    - providerStreamFn path — when a model has proxy/tls configured, registerProviderStreamForModel returns a transport-aware stream fn (e.g. createOpenAICompletionsTransportStreamFn) that reads options.sessionId to inject session affinity headers via buildOpenAIClientHeaders. Without sessionId in options, the transport stream never adds x-session-affinity / x-client-request-id / session_id.
    - boundary-aware path — the default path for models with a resolved API key and a supported API (e.g. all Fireworks models). Same transport stream underneath, same options.sessionId dependency.
    - promptCacheKey fallback — wraps currentStreamFn ?? streamSimple. The streamSimple path goes through openai-completions.ts which reads options.sessionId for its own session affinity header injection (gated by compat.sendSessionAffinityHeaders).


## Linked context

Closes: N/A

Related:

* Fireworks prompt caching documentation:

  * Human-readable docs: https://docs.fireworks.ai/guides/prompt-caching
  * Markdown docs: https://docs.fireworks.ai/guides/prompt-caching.md

## Real behavior proof

- Behavior or issue addressed: Tested with Fireworks Kimi K2.6, a provider/model path where session-affinity headers are used as the prompt-cache routing mechanism. Temporary proof logging was added locally to confirm that the affinity headers are applied on a real OpenClaw request. The proof logging is not part of the PR diff.

- Real environment tested:
  - OpenClaw checkout: https://github.com/obuchowski/openclaw/commit/37348787eecf772a0349a4858a2741d072a59ede
  - Provider/model: Fireworks Kimi K2.6 `fireworks/accounts/fireworks/models/kimi-k2p6`
  - Runtime: local gateway
  - Auth: real Fireworks API key configured locally

- Exact steps or command run after this patch:
terminal1:
```
git fetch origin fix/session-affinity-headers && \
git reset --hard origin/fix/session-affinity-headers && \
sed -i '2607i\        console.error("[fw-req] affinity=" + JSON.stringify(affinityHeadersValue) + " sessionId=" + JSON.stringify(options?.sessionId) + " sendAffinity=" + JSON.stringify(!!(affinityHeadersValue \&\& model.compat?.sendSessionAffinityHeaders)) + " Model Config=" + JSON.stringify(model));' src/agents/openai-transport-stream.ts && \
rm -rf dist && \
node scripts/tsdown-build.mjs --no-clean && \
openclaw gateway --port 18789
....
```

terminal2:
```
$ openclaw agent --agent main --model "fireworks/accounts/fireworks/models/kimi-k2p6" --message "reply exactly with OK"
```

Expected proof shape:
[fw-req] affinity="***" sessionId="***" sendAffinity=true

Evidence after fix:
> 22:09:09 [fw-req] affinity="9140d7bd-8527-406f-acc3-717f636f861a" sessionId="9140d7bd-8527-406f-acc3-717f636f861a" **sendAffinity=true** Model Config={"id":"accounts/fireworks/models/kimi-k2p6","name":"accounts/fireworks/models/kimi-k2p6","provider":"fireworks","api":"openai-completions","baseUrl":"https://api.fireworks.ai/inference/v1","reasoning":false,"input":["text","image"],"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0},"contextWindow":256000,"maxTokens":256000,"compat":{"sendSessionAffinityHeaders":true,"supportsDeveloperRole":false,"supportsUsageInStreaming":false,"supportsStrictMode":false},"requestTimeoutMs":120000}
> 22:09:14 OK

<img width="1281" height="674" alt="image" src="https://github.com/user-attachments/assets/86bbb879-0a5a-4854-b3e6-da771422c189" />

- Observed result after fix:

The real Fireworks request completed successfully.
The proof log showed that OpenClaw generated the session-affinity headers for the Fireworks request when compat.sendSessionAffinityHeaders was enabled.
Caller-provided request headers remain protected by the existing request-policy merge behavior.

What was not tested:

I did not verify Fireworks billing/cache-hit accounting or provider-side cache-hit metrics.

Proof limitations or environment constraints:

This proof verifies real OpenClaw request shaping and affinity-header emission.
It does not prove measured cache-hit improvement inside Fireworks infrastructure, because that depends on provider-side cache accounting and replica behavior.

Before evidence:

Before this patch, the Fireworks model configuration did not opt into compat.sendSessionAffinityHeaders, and the moved OpenAI-compatible transport path no longer honored the compat flag for Fireworks requests.

## Tests and validation

```text
> .agents/skills/autoreview/scripts/autoreview --reviewers codex:gpt-5.5:high
autoreview target: local
branch: fireworks-session-affinity-header
reviewers: codex model=gpt-5.5 thinking=high
tools: on
web_search: on
bundle: 19235 chars
review still running: codex elapsed=60s pid=12562
review still running: codex elapsed=120s pid=12562
review still running: codex elapsed=180s pid=12562
review still running: codex elapsed=240s pid=12562
review still running: codex elapsed=300s pid=12562
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)

The change is scoped to opt-in affinity headers for OpenAI-compatible completions models and adds the Fireworks catalog flags needed to exercise it. Header merging keeps caller-provided values winning, cacheRetention none suppresses generated affinity headers, and the model compat normalization path already accepts the new flag. I did not find an actionable regression in the provided bundle.
```

```text
> env CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm test src/agents/openai-transport-stream.test.ts
$ node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/evgeni/WebstormProjects/openclaw

 ✓  agents  src/agents/openai-transport-stream.test.ts (241 tests) 370ms

 Test Files  1 passed (1)
      Tests  241 passed (241)
   Start at  21:59:08
   Duration  3.93s (transform 2.66s, setup 271ms, import 3.15s, tests 370ms, environment 0ms)

[test] passed 1 Vitest shard in 7.77s
```

```text
> pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 46ms on 2 files using 8 threads
```

```text
> pnpm lint:core -- src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
<paste output>
```

```text
> git diff --check
<paste output, or note that it completed with no output>
```

## Risk checklist
Did user-visible behavior change? (Yes/No)

No. OpenAI-compatible requests can now include session-affinity headers when the model opts into `compat.sendSessionAffinityHeaders` and OpenClaw has a resolved cache/session value but that's not directly visible to user, except smaller cost could be expected. 

Did config, environment, or migration behavior change? (Yes/No)

No.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

Yes, network request headers can change for opted-in Fireworks model calls. There are no auth or secret-handling changes.

What is the highest-risk area?

OpenAI-compatible request-header shaping.

How is that risk mitigated?

The change is gated on compat.sendSessionAffinityHeaders, preserves the existing request-policy merge behavior so caller-provided headers win, and adds focused regression coverage for the OpenAI-compatible transport path.

## Current review state

What is the next action?

Review the updated Fireworks affinity-header behavior and confirm that the real behavior proof is sufficient.

What is still waiting on author, maintainer, CI, or external proof?

- CI
- Maintainer review