### PR TITLE
fix(gateway): isolate session action scope lookup

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -175,6 +175,50 @@ describe("method scope resolution", () => {
     ).toEqual({ allowed: false, missingScope: "operator.approvals" });
   });
 
+  it("skips unreadable plugin session action rows while resolving scopes", () => {
+    const registry = createEmptyPluginRegistry();
+    const unreadableAction = Object.defineProperty(
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+      },
+      "action",
+      {
+        get() {
+          throw new Error("plugin session action row exploded");
+        },
+      },
+    );
+    registry.sessionActions = [
+      unreadableAction as never,
+      {
+        pluginId: "scope-plugin",
+        pluginName: "Scope Plugin",
+        source: "test",
+        action: {
+          id: "approve",
+          requiredScopes: ["operator.approvals"],
+          handler: () => ({ result: { ok: true } }),
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual(["operator.approvals"]);
+    expect(
+      authorizeOperatorScopesForMethod("plugins.sessionAction", ["operator.approvals"], {
+        pluginId: "scope-plugin",
+        actionId: "approve",
+      }),
+    ).toEqual({ allowed: true });
+  });
+
   it("falls back to broad operator scopes when a dynamic session action is not locally registered", () => {
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -17,6 +17,7 @@ import {
   isOperatorScope,
   type OperatorScope,
 } from "./operator-scopes.js";
+import { findReadablePluginSessionActionRegistration } from "./plugin-session-action-registrations.js";
 
 export {
   ADMIN_SCOPE,
@@ -100,14 +101,15 @@ function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] 
   if (!pluginId || !actionId) {
     return undefined;
   }
-  const registration = getPluginRegistryState()?.activeRegistry?.sessionActions?.find(
-    (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-  );
+  const registration = findReadablePluginSessionActionRegistration({
+    registrations: getPluginRegistryState()?.activeRegistry?.sessionActions,
+    pluginId,
+    actionId,
+  });
   if (!registration) {
     return undefined;
   }
-  const requiredScopes = registration.action.requiredScopes;
-  return requiredScopes && requiredScopes.length > 0 ? [...requiredScopes] : [WRITE_SCOPE];
+  return [...registration.requiredScopes];
 }
 
 function resolveSessionActionLeastPrivilegeScopes(params: unknown): OperatorScope[] {

--- a/src/gateway/plugin-session-action-registrations.ts
+++ b/src/gateway/plugin-session-action-registrations.ts
@@ -1,0 +1,102 @@
+import type { PluginSessionActionRegistryRegistration } from "../plugins/registry-types.js";
+import { isOperatorScope, WRITE_SCOPE, type OperatorScope } from "./operator-scopes.js";
+
+export type ReadablePluginSessionActionRegistration = {
+  registration: PluginSessionActionRegistryRegistration;
+  requiredScopes: OperatorScope[];
+};
+
+function readObjectField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  try {
+    const field = (value as Record<string, unknown>)[key];
+    return field && typeof field === "object" && !Array.isArray(field)
+      ? (field as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  try {
+    const field = (value as Record<string, unknown>)[key];
+    return typeof field === "string" ? field : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRequiredScopes(action: unknown): OperatorScope[] | undefined {
+  if (!action || typeof action !== "object") {
+    return undefined;
+  }
+  let rawScopes: unknown;
+  try {
+    rawScopes = (action as Record<string, unknown>).requiredScopes;
+  } catch {
+    return undefined;
+  }
+  if (rawScopes === undefined) {
+    return [WRITE_SCOPE];
+  }
+  if (!Array.isArray(rawScopes)) {
+    return undefined;
+  }
+  const scopes: OperatorScope[] = [];
+  for (let index = 0; index < rawScopes.length; index += 1) {
+    if (!Object.hasOwn(rawScopes, index)) {
+      continue;
+    }
+    const scope = rawScopes[index];
+    if (!isOperatorScope(scope)) {
+      return undefined;
+    }
+    scopes.push(scope);
+  }
+  return scopes.length > 0 ? scopes : [WRITE_SCOPE];
+}
+
+function readEntry(entries: readonly unknown[], index: number): unknown {
+  try {
+    return entries[index];
+  } catch {
+    return undefined;
+  }
+}
+
+/** Finds a readable plugin session action row without trusting plugin-owned accessors. */
+export function findReadablePluginSessionActionRegistration(params: {
+  registrations: unknown;
+  pluginId: string;
+  actionId: string;
+}): ReadablePluginSessionActionRegistration | undefined {
+  const entries = params.registrations;
+  if (!Array.isArray(entries)) {
+    return undefined;
+  }
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = readEntry(entries, index);
+    if (readStringField(entry, "pluginId") !== params.pluginId) {
+      continue;
+    }
+    const action = readObjectField(entry, "action");
+    if (readStringField(action, "id") !== params.actionId) {
+      continue;
+    }
+    const requiredScopes = readRequiredScopes(action);
+    if (!requiredScopes) {
+      continue;
+    }
+    return {
+      registration: entry as PluginSessionActionRegistryRegistration,
+      requiredScopes,
+    };
+  }
+  return undefined;
+}

--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -18,6 +18,7 @@ import {
   type JsonSchemaValue,
 } from "../../plugins/schema-validator.js";
 import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
+import { findReadablePluginSessionActionRegistration } from "../plugin-session-action-registrations.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 const log = createSubsystemLogger("gateway/plugin-host-hooks");
@@ -90,10 +91,12 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
     const pluginLoaded = Boolean(
       registry?.plugins.some((plugin) => plugin.id === pluginId && plugin.status === "loaded"),
     );
-    const registration = (registry?.sessionActions ?? []).find(
-      (entry) => entry.pluginId === pluginId && entry.action.id === actionId,
-    );
-    if (!registration || !pluginLoaded) {
+    const sessionAction = findReadablePluginSessionActionRegistration({
+      registrations: registry?.sessionActions,
+      pluginId,
+      actionId,
+    });
+    if (!sessionAction || !pluginLoaded) {
       respond(
         false,
         undefined,
@@ -104,12 +107,10 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const registration = sessionAction.registration;
     const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
     const hasAdmin = scopes.includes(ADMIN_SCOPE);
-    const requiredScopes =
-      registration.action.requiredScopes && registration.action.requiredScopes.length > 0
-        ? registration.action.requiredScopes
-        : [WRITE_SCOPE];
+    const requiredScopes = sessionAction.requiredScopes;
     // Plugin actions default to write access, while read-only actions can opt
     // down. Admin bypasses all checks and write includes read for UI callers.
     const missingScope = requiredScopes.find(

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -651,6 +651,107 @@ describe("plugin session actions", () => {
     expect(originalScopes).toEqual([READ_SCOPE]);
   });
 
+  it("skips unreadable session action rows when dispatching through the gateway", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(() => ({ result: { ok: true } }));
+    const unreadableAction = Object.defineProperty(
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+      },
+      "action",
+      {
+        get() {
+          throw new Error("plugin session action row exploded");
+        },
+      },
+    );
+    registry.sessionActions = [
+      unreadableAction as never,
+      {
+        pluginId: "session-action-fixture",
+        pluginName: "Session Action Fixture",
+        source: "test",
+        action: {
+          id: "view",
+          requiredScopes: [READ_SCOPE],
+          handler,
+        },
+      },
+    ];
+    registry.plugins = [
+      createPluginRecord({
+        id: "session-action-fixture",
+        name: "Session Action Fixture",
+      }),
+    ];
+    setActivePluginRegistry(registry);
+
+    await expect(
+      callRegisteredSessionActionThroughGatewayForTest({
+        pluginId: "session-action-fixture",
+        actionId: "view",
+        scopes: [READ_SCOPE],
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      payload: { ok: true, result: { ok: true } },
+      error: undefined,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not authorize session actions with sparse requiredScopes", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(() => ({ result: { ok: true } }));
+    const sparseRequiredScopes = [] as string[];
+    sparseRequiredScopes.length = 1;
+    registry.sessionActions = [
+      {
+        pluginId: "sparse-scope-fixture",
+        pluginName: "Sparse Scope Fixture",
+        source: "test",
+        action: {
+          id: "run",
+          requiredScopes: sparseRequiredScopes as never,
+          handler,
+        },
+      },
+    ];
+    registry.plugins = [
+      createPluginRecord({
+        id: "sparse-scope-fixture",
+        name: "Sparse Scope Fixture",
+      }),
+    ];
+    setActivePluginRegistry(registry);
+
+    const response = await callRegisteredSessionActionThroughGatewayForTest({
+      pluginId: "sparse-scope-fixture",
+      actionId: "run",
+      scopes: [],
+    });
+
+    const error = requireHookError(response);
+    expect(error.code).toBe("INVALID_REQUEST");
+    expect(error.message).toBe(`missing scope: ${WRITE_SCOPE}`);
+    expect(handler).not.toHaveBeenCalled();
+
+    await expect(
+      callRegisteredSessionActionThroughGatewayForTest({
+        pluginId: "sparse-scope-fixture",
+        actionId: "run",
+        scopes: [WRITE_SCOPE],
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      payload: { ok: true, result: { ok: true } },
+      error: undefined,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
   it("does not dispatch session actions for plugins that are not loaded", async () => {
     const handler = vi.fn(() => ({ result: { stale: true } }));
     const registry = createEmptyPluginRegistry();


### PR DESCRIPTION
## Summary

- Add a guarded session-action registration lookup helper for gateway authorization and dispatch.
- Skip unreadable plugin session-action rows while preserving the default write-scope behavior for missing, empty, or sparse `requiredScopes`.
- Cover unreadable rows and sparse scope arrays so malformed action metadata cannot crash or fail open.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts src/plugins/contracts/session-actions.contract.test.ts` failed with `plugin session action row exploded`.
- `node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts src/plugins/contracts/session-actions.contract.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/plugin-session-action-registrations.ts src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `./node_modules/.bin/oxlint src/gateway/plugin-session-action-registrations.ts src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/plugin-host-hooks.ts src/plugins/contracts/session-actions.contract.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed plugin session-action rows can no longer throw during dynamic operator-scope resolution or gateway session-action dispatch before a healthy sibling row is reached.

Real environment tested: local Codex worktree using the repo Vitest wrapper; broad Crabbox changed gate attempted but blocked before execution by coordinator auth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/method-scopes.test.ts src/plugins/contracts/session-actions.contract.test.ts`

Evidence after fix: focused Vitest passed 2 shards covering gateway method scopes and plugin session-action contracts; local and branch autoreview both reported no accepted/actionable findings.

Observed result after fix: unreadable session-action rows are skipped, healthy action rows still resolve their declared scopes and dispatch, sparse `requiredScopes` no longer fails open, and sparse/empty scope lists keep the default write-scope requirement.

What was not tested: `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` did not execute because the Crabbox coordinator returned HTTP 401 unauthorized while creating the run/lease.
