### PR TITLE
fix(discord): surface failed bulk reaction removals instead of false success

### DIFF
--- a/extensions/discord/src/send.reactions.ts
+++ b/extensions/discord/src/send.reactions.ts
@@ -87,17 +87,13 @@ export async function removeOwnReactionsDiscord(
   if (identifiers.size === 0) {
     return { ok: true, removed: [] };
   }
-  const removed: string[] = [];
-  await Promise.allSettled(
-    Array.from(identifiers, (identifier) => {
-      removed.push(identifier);
-      return deleteOwnMessageReaction(
-        rest,
-        channelId,
-        messageId,
-        normalizeReactionEmoji(identifier),
-      );
-    }),
+  const removed = Array.from(identifiers);
+  // Promise.all so a rejected delete propagates: allSettled would swallow the
+  // failure and falsely report every identifier as removed.
+  await Promise.all(
+    removed.map((identifier) =>
+      deleteOwnMessageReaction(rest, channelId, messageId, normalizeReactionEmoji(identifier)),
+    ),
   );
   return { ok: true, removed };
 }

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -789,6 +789,24 @@ describe("removeOwnReactionsDiscord", () => {
       Routes.channelMessageOwnReaction("chan1", "msg1", "party_blob%3A123"),
     );
   });
+
+  it("surfaces a failed deletion instead of reporting false success", async () => {
+    const { rest, getMock, deleteMock } = makeDiscordRest();
+    getMock.mockResolvedValue({
+      reactions: [
+        { emoji: { name: "✅", id: null } },
+        { emoji: { name: "party_blob", id: "123" } },
+      ],
+    });
+    const apiError = new Error("Discord API 500");
+    deleteMock.mockResolvedValueOnce(undefined);
+    deleteMock.mockRejectedValueOnce(apiError);
+    await expect(
+      removeOwnReactionsDiscord("chan1", "msg1", { rest, token: "t", cfg: DISCORD_TEST_CFG }),
+    ).rejects.toThrow("Discord API 500");
+    // Both deletions are still attempted; the rejection just propagates.
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("fetchReactionsDiscord", () => {


### PR DESCRIPTION
## Summary

`removeOwnReactionsDiscord` reported success even when Discord reaction
deletions failed. It pushed every reaction identifier into `removed` before the
`deleteOwnMessageReaction` promise settled, ran the deletes with
`Promise.allSettled` (which never rejects), and always returned
`{ ok: true, removed }`. A failed delete was returned to the agent as a removed
reaction.

This surfaces through the `react` action with an empty emoji (clear-all):
`extensions/discord/src/actions/runtime.messaging.reactions.ts` returns
`{ ok: true, removed }` directly, so the agent's tool result claims success on a
no-op or partial failure.

## Root cause

`extensions/discord/src/send.reactions.ts` — `removed.push(identifier)` ran
synchronously inside the map callback (before the delete settled), and
`Promise.allSettled` swallowed rejections.

## User impact

False success / misleading agent result: an agent told to clear its reactions
is told it succeeded while the reactions remain on the message.

## Fix

Use `Promise.all` so a rejected delete propagates instead of being swallowed —
parity with the single-reaction siblings `removeReactionDiscord` /
`reactMessageDiscord`, which already throw on API failure. `removed` is the
identifier list, returned only on full success. No caller changes; happy-path
shape `{ ok: true, removed }` is unchanged.

## Tests

Added a focused failure-injection test in the existing
`removeOwnReactionsDiscord` suite that drives the real production function: two
own reactions, one deletion rejects; asserts the operation now rejects instead
of falsely returning ok. Confirmed it fails on current `main` and passes with
the fix.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/actions/runtime.test.ts` — 135 passed
- `pnpm tsgo:extensions` / `pnpm tsgo:extensions:test` — clean
- `pnpm exec oxfmt --check` — clean

## Non-scope

No cross-channel reaction refactor, no reaction feature expansion, no change to
the single-reaction or fetch paths. Caller-facing API shape unchanged; surfacing
partial-vs-total failure as a structured result is a possible follow-up.

## Real behavior proof

Behavior addressed: Discord bulk reaction removal falsely reporting success when a per-reaction DELETE fails.

Real environment tested: the real `removeOwnReactionsDiscord` is driven end-to-end through the real Discord `RequestClient` transport (`createDiscordRequestClient`), whose only injected seam is `fetch` — a production-supported dependency-injection point (`RequestClientOptions.fetch`). The injected `fetch` returns real WHATWG `Response` objects: HTTP 200 for the channel-message GET (two of the bot's own reactions) and HTTP 403 `Missing Permissions` (code 50013) for each reaction DELETE. The client's own error mapping raises a real `DiscordError`. There is no `vi.mock`/stub of the function under test — only the network peer is substituted, because no live Discord bot token / permission-restricted server is available in this environment.

Exact steps or command run after this patch:

```
# after fix (Promise.all)
PROOF_VARIANT=AFTER node --import tsx proof-harness.mts
# before, with send.reactions.ts reverted to base Promise.allSettled
PROOF_VARIANT=BEFORE node --import tsx proof-harness.mts
```

Evidence before fix (base `Promise.allSettled`) — the failed DELETE is swallowed and the call falsely returns success:

```
[BEFORE] RETURNED (no throw): {"ok":true,"removed":["✅","party_blob:123"]}
[BEFORE] transport calls: ["GET .../messages/msg1","DELETE .../reactions/%E2%9C%85/@me","DELETE .../reactions/party_blob%3A123/@me"]
```

Evidence after fix (`Promise.all`) — the failed DELETE propagates instead of a success envelope:

```
[AFTER] THREW: DiscordError: Missing Permissions
[AFTER] transport calls: ["GET .../messages/msg1","DELETE .../reactions/%E2%9C%85/@me","DELETE .../reactions/party_blob%3A123/@me"]
```

Observed result after fix: a failed reaction deletion surfaces as a thrown `DiscordError` rather than `{ ok: true, removed: [...] }`. Both DELETEs are still attempted (same transport calls in both runs); the only behavioral change is that failure is no longer hidden.

What was not tested: a live end-to-end roundtrip against discord.com (requires a real bot token on a server where the bot may list but not delete reactions — unavailable here). The failure path itself is exercised with the real client and a real 403 response.
