### PR TITLE
fix(plugins): isolate command spec projection

### DIFF
--- a/src/plugins/command-specs.ts
+++ b/src/plugins/command-specs.ts
@@ -21,6 +21,13 @@ export type PluginCommandEntrySpec = {
   nativeName?: string;
 };
 
+type ProviderPluginCommandSpec = {
+  name: string;
+  description: string;
+  descriptionLocalizations?: Record<string, string>;
+  acceptsArgs: boolean;
+};
+
 function resolvePluginNativeName(
   command: OpenClawPluginCommandDefinition,
   provider?: string,
@@ -65,12 +72,7 @@ function pluginNativeCommandsEnabled(
 export function getPluginCommandSpecs(
   provider?: string,
   options: PluginCommandSpecOptions = {},
-): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+): ProviderPluginCommandSpec[] {
   const providerName = normalizeOptionalLowercaseString(provider);
   if (!pluginNativeCommandsEnabled(providerName, options)) {
     return [];
@@ -82,12 +84,7 @@ export function getPluginCommandSpecsFromRegistrations(
   commands: readonly PluginCommandRegistration[],
   provider?: string,
   options: PluginCommandSpecOptions = {},
-): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+): ProviderPluginCommandSpec[] {
   const providerName = normalizeOptionalLowercaseString(provider);
   if (!pluginNativeCommandsEnabled(providerName, options)) {
     return [];
@@ -102,7 +99,7 @@ export function getPluginCommandEntrySpecs(
   const providerName = normalizeOptionalLowercaseString(provider);
   const nativeCommandsEnabled = pluginNativeCommandsEnabled(providerName, options);
   return Array.from(pluginCommands.values())
-    .map((cmd) => serializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled))
+    .map((cmd) => safeSerializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled))
     .filter((spec): spec is PluginCommandEntrySpec => spec !== null);
 }
 
@@ -115,53 +112,75 @@ export function getPluginCommandEntrySpecsFromRegistrations(
   const nativeCommandsEnabled = pluginNativeCommandsEnabled(providerName, options);
   return commands
     .map((entry) =>
-      serializePluginCommandEntrySpec(entry.command, providerName, nativeCommandsEnabled),
+      safeProjectPluginCommandRegistration(entry, (cmd) =>
+        serializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled),
+      ),
     )
     .filter((spec): spec is PluginCommandEntrySpec => spec !== null);
 }
 
 /** Resolve plugin command specs for a provider's native naming surface without support gating. */
-export function listProviderPluginCommandSpecs(provider?: string): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+export function listProviderPluginCommandSpecs(provider?: string): ProviderPluginCommandSpec[] {
   return Array.from(pluginCommands.values())
-    .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
-    .map((cmd) => serializePluginCommandSpec(cmd, provider));
+    .map((cmd) => safeSerializeProviderPluginCommandSpec(cmd, provider))
+    .filter((spec): spec is ProviderPluginCommandSpec => spec !== null);
 }
 
 export function listProviderPluginCommandSpecsFromRegistrations(
   commands: readonly PluginCommandRegistration[],
   provider?: string,
-): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+): ProviderPluginCommandSpec[] {
   return commands
-    .map((entry) => entry.command)
-    .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
-    .map((cmd) => serializePluginCommandSpec(cmd, provider));
+    .map((entry) =>
+      safeProjectPluginCommandRegistration(entry, (cmd) =>
+        safeSerializeProviderPluginCommandSpec(cmd, provider),
+      ),
+    )
+    .filter((spec): spec is ProviderPluginCommandSpec => spec !== null);
+}
+
+function safeProjectPluginCommandRegistration<T>(
+  entry: PluginCommandRegistration,
+  project: (cmd: OpenClawPluginCommandDefinition) => T | null,
+): T | null {
+  try {
+    return project(entry.command);
+  } catch {
+    return null;
+  }
+}
+
+function safeSerializeProviderPluginCommandSpec(
+  cmd: OpenClawPluginCommandDefinition,
+  provider?: string,
+): ProviderPluginCommandSpec | null {
+  try {
+    if (!pluginCommandSupportsChannel(cmd, provider)) {
+      return null;
+    }
+    return serializePluginCommandSpec(cmd, provider);
+  } catch {
+    return null;
+  }
+}
+
+function safeSerializePluginCommandEntrySpec(
+  cmd: OpenClawPluginCommandDefinition,
+  provider: string | undefined,
+  nativeCommandsEnabled: boolean,
+): PluginCommandEntrySpec | null {
+  try {
+    return serializePluginCommandEntrySpec(cmd, provider, nativeCommandsEnabled);
+  } catch {
+    return null;
+  }
 }
 
 function serializePluginCommandSpec(
   cmd: OpenClawPluginCommandDefinition,
   provider?: string,
-): {
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-} {
-  const spec: {
-    name: string;
-    description: string;
-    descriptionLocalizations?: Record<string, string>;
-    acceptsArgs: boolean;
-  } = {
+): ProviderPluginCommandSpec {
+  const spec: ProviderPluginCommandSpec = {
     name: resolvePluginNativeName(cmd, provider),
     description: cmd.description.trim(),
     acceptsArgs: cmd.acceptsArgs ?? false,

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { listRegisteredPluginAgentPromptGuidance } from "./command-registry-state.js";
+import { getPluginCommandEntrySpecsFromRegistrations } from "./command-specs.js";
 import {
   testing,
   clearPluginCommands,
@@ -552,6 +553,51 @@ describe("registerPluginCommand", () => {
       { provider: "discord", expectedNames: [] },
     ]);
     expect(listProviderPluginCommandSpecs("discord")).toStrictEqual([]);
+  });
+
+  it("skips malformed runtime command rows when projecting command entries", () => {
+    const throwingCommand = Object.defineProperty(
+      {
+        description: "Bad command",
+        acceptsArgs: false,
+        handler: async () => ({ text: "bad" }),
+      },
+      "name",
+      {
+        get() {
+          throw new Error("boom");
+        },
+      },
+    );
+    const healthyCommand = createVoiceCommand({
+      description: "Demo command",
+      nativeNames: { discord: "discordvoice" },
+    });
+
+    expect(
+      getPluginCommandEntrySpecsFromRegistrations(
+        [
+          {
+            pluginId: "broken-plugin",
+            source: "test",
+            command: throwingCommand as never,
+          },
+          {
+            pluginId: "demo-plugin",
+            source: "test",
+            command: healthyCommand,
+          },
+        ],
+        "discord",
+      ),
+    ).toEqual([
+      {
+        name: "voice",
+        description: "Demo command",
+        acceptsArgs: false,
+        nativeName: "discordvoice",
+      },
+    ]);
   });
 
   it("allows Slack to resolve provider-native plugin specs without changing shared native gating", () => {


### PR DESCRIPTION
## Summary

- Isolate plugin command spec projection so malformed runtime command rows are skipped instead of crashing command listing or native command discovery.
- Preserve existing provider-native command naming/filtering behavior for healthy command registrations.
- Add a regression test for a throwing command descriptor in registration-backed command entry projection.

## Verification

- `node scripts/run-vitest.mjs src/plugins/commands.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/command-specs.ts src/plugins/commands.test.ts`
- `./node_modules/.bin/oxlint src/plugins/command-specs.ts src/plugins/commands.test.ts`
- `git diff --check && git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` blocked before lease creation: coordinator HTTP 401 unauthorized, provider `azure`, slug `quick-hermit`

## Real behavior proof

Behavior addressed: A malformed plugin command registration could throw during command spec projection and take down command listing/native command discovery for otherwise healthy commands.

Real environment tested: Local OpenClaw linked worktree on Node/Vitest through `node scripts/run-vitest.mjs`; Crabbox changed gate attempted through the repo wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/commands.test.ts`

Evidence after fix: The regression test injects a throwing command descriptor beside a healthy command and verifies the healthy command still projects with its provider-native name.

Observed result after fix: `src/plugins/commands.test.ts` passed with 50 tests.

What was not tested: Broad `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing a runner.
