### PR TITLE
fix: restore Skill Workshop current chat toggle

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:23.359Z",
+  "generatedAt": "2026-06-03T22:35:02.692Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:21.786Z",
+  "generatedAt": "2026-06-03T22:35:01.407Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:22.097Z",
+  "generatedAt": "2026-06-03T22:35:01.661Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:26.307Z",
+  "generatedAt": "2026-06-03T22:35:05.014Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:23.053Z",
+  "generatedAt": "2026-06-03T22:35:02.432Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:24.706Z",
+  "generatedAt": "2026-06-03T22:35:03.722Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:23.725Z",
+  "generatedAt": "2026-06-03T22:35:02.949Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:22.425Z",
+  "generatedAt": "2026-06-03T22:35:01.919Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:22.739Z",
+  "generatedAt": "2026-06-03T22:35:02.176Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:25.987Z",
+  "generatedAt": "2026-06-03T22:35:04.755Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:25.027Z",
+  "generatedAt": "2026-06-03T22:35:03.977Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:21.475Z",
+  "generatedAt": "2026-06-03T22:35:01.146Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:25.336Z",
+  "generatedAt": "2026-06-03T22:35:04.236Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:24.054Z",
+  "generatedAt": "2026-06-03T22:35:03.206Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:24.380Z",
+  "generatedAt": "2026-06-03T22:35:03.461Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:25.659Z",
+  "generatedAt": "2026-06-03T22:35:04.498Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:20.827Z",
+  "generatedAt": "2026-06-03T22:35:00.622Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,5 +1,8 @@
 {
   "fallbackKeys": [
+    "skillWorkshop.header.useCurrentChat",
+    "skillWorkshop.header.useCurrentChatAria",
+    "skillWorkshop.header.useCurrentChatTooltip",
     "workboard.dependencies",
     "workboard.dependenciesBlocked",
     "workboard.dependenciesBlockedTitle",
@@ -29,12 +32,12 @@
     "workboard.unknownStatus",
     "workboard.viewDetails"
   ],
-  "generatedAt": "2026-06-01T07:19:21.160Z",
+  "generatedAt": "2026-06-03T22:35:00.888Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "0639815f4b249fd84b5149556602c9e5da1136d73a747f26a1c12981a4319ebb",
-  "totalKeys": 1330,
+  "sourceHash": "045696b27bf36b4d0ef74cfd8ec76124de70c9bcef7ca7cb378a0d07f1bdfa61",
+  "totalKeys": 1333,
   "translatedKeys": 1302,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -448,6 +448,14 @@ export const ar: TranslationMap = {
     logs: "سجلات Gateway المباشرة.",
     dreams: "حلم الذاكرة، والدمج، والتأمل.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "النشاط",
     subtitle: "نشاط أدوات مؤقت مشتق من أحداث الجلسة المباشرة.",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -453,6 +453,14 @@ export const de: TranslationMap = {
     logs: "Live-Verfolgung der Gateway-Protokolldateien.",
     dreams: "Speicherkonsolidierung im Schlaf.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Aktivität",
     subtitle: "Flüchtige Tool-Aktivität, abgeleitet aus Live-Sitzungsereignissen.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -447,6 +447,14 @@ export const en: TranslationMap = {
     logs: "Live gateway logs.",
     dreams: "Memory dreaming, consolidation, and reflection.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Activity",
     subtitle: "Ephemeral tool activity derived from live session events.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -450,6 +450,14 @@ export const es: TranslationMap = {
     logs: "Seguimiento en vivo de los registros de la puerta de enlace.",
     dreams: "Consolidación de la memoria durante el sueño.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Actividad",
     subtitle: "Actividad efímera de herramientas derivada de eventos de sesión en vivo.",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -450,6 +450,14 @@ export const fa: TranslationMap = {
     logs: "گزارش‌های زنده Gateway.",
     dreams: "رؤیاپردازی حافظه، یکپارچه‌سازی و بازتاب.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "فعالیت",
     subtitle: "فعالیت موقتی ابزار که از رویدادهای نشست زنده استخراج شده است.",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -452,6 +452,14 @@ export const fr: TranslationMap = {
     logs: "Journaux Gateway en direct.",
     dreams: "Consolidation de la mémoire pendant le sommeil.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Activité",
     subtitle: "Activité éphémère des outils dérivée des événements de session en direct.",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -449,6 +449,14 @@ export const id: TranslationMap = {
     logs: "Log Gateway langsung.",
     dreams: "Konsolidasi memori saat tidur.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Aktivitas",
     subtitle: "Aktivitas alat sementara yang berasal dari peristiwa sesi langsung.",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -451,6 +451,14 @@ export const it: TranslationMap = {
     logs: "Log gateway live.",
     dreams: "Sogni della memoria, consolidamento e riflessione.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Attività",
     subtitle: "Attività effimera degli strumenti derivata dagli eventi della sessione live.",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -452,6 +452,14 @@ export const ja_JP: TranslationMap = {
     logs: "ライブ Gateway ログ。",
     dreams: "スリープ中のメモリ統合。",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "アクティビティ",
     subtitle: "ライブセッションイベントから生成される一時的なツールアクティビティ。",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -448,6 +448,14 @@ export const ko: TranslationMap = {
     logs: "실시간 Gateway 로그.",
     dreams: "수면 중 메모리 통합.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "활동",
     subtitle: "라이브 세션 이벤트에서 파생된 임시 도구 활동입니다.",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -451,6 +451,14 @@ export const nl: TranslationMap = {
     logs: "Live Gateway-logs.",
     dreams: "Geheugendromen, consolidatie en reflectie.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Activiteit",
     subtitle: "Tijdelijke toolactiviteit afgeleid van live sessiegebeurtenissen.",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -450,6 +450,14 @@ export const pl: TranslationMap = {
     logs: "Logi Gateway na żywo.",
     dreams: "Konsolidacja pamięci podczas snu.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Aktywność",
     subtitle: "Tymczasowa aktywność narzędzi pochodząca ze zdarzeń sesji na żywo.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -449,6 +449,14 @@ export const pt_BR: TranslationMap = {
     logs: "Logs ao vivo do gateway.",
     dreams: "Consolidação de memória durante o sono.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Atividade",
     subtitle: "Atividade efêmera de ferramentas derivada de eventos de sessão ao vivo.",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -447,6 +447,14 @@ export const th: TranslationMap = {
     logs: "บันทึกเกตเวย์แบบสด",
     dreams: "การฝันของหน่วยความจำ การรวมข้อมูล และการสะท้อนคิด",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "กิจกรรม",
     subtitle: "กิจกรรมของเครื่องมือแบบชั่วคราวที่ได้จากเหตุการณ์เซสชันสด",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -452,6 +452,14 @@ export const tr: TranslationMap = {
     logs: "Canlı Gateway günlükleri.",
     dreams: "Uyku sırasında bellek birleştirme.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Etkinlik",
     subtitle: "Canlı oturum olaylarından türetilen geçici araç etkinliği.",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -451,6 +451,14 @@ export const uk: TranslationMap = {
     logs: "Журнали шлюзу в реальному часі.",
     dreams: "Консолідація пам’яті під час сну.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Активність",
     subtitle: "Тимчасова активність інструментів, отримана з подій поточного сеансу.",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -450,6 +450,14 @@ export const vi: TranslationMap = {
     logs: "Nhật ký gateway trực tiếp.",
     dreams: "Mơ bộ nhớ, hợp nhất và phản chiếu.",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "Hoạt động",
     subtitle: "Hoạt động công cụ tạm thời được lấy từ các sự kiện phiên trực tiếp.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -446,6 +446,14 @@ export const zh_CN: TranslationMap = {
     logs: "实时网关日志。",
     dreams: "睡眠时进行记忆巩固。",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "活动",
     subtitle: "从实时会话事件派生的临时工具活动。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -446,6 +446,14 @@ export const zh_TW: TranslationMap = {
     logs: "實時網關日誌。",
     dreams: "睡眠期間的記憶整合。",
   },
+  skillWorkshop: {
+    header: {
+      useCurrentChat: "Use current chat",
+      useCurrentChatAria: "Use current chat for revision requests",
+      useCurrentChatTooltip:
+        "Send revision requests to the current chat session instead of the proposal's workshop session.",
+    },
+  },
   activity: {
     title: "活動",
     subtitle: "從即時工作階段事件衍生的暫時性工具活動。",

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -78,6 +78,7 @@ import {
   resolveSessionOptionGroups,
   resolveSessionDisplayName,
   switchChatSession,
+  switchChatSessionAndWait,
 } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -964,6 +965,80 @@ describe("createChatSession", () => {
 });
 
 describe("switchChatSession", () => {
+  it("waits for the initial history and message subscription when requested", async () => {
+    let resolveHistory!: () => void;
+    let resolveSubscription!: () => void;
+    const historyLoaded = new Promise<void>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const subscriptionSynced = new Promise<void>((resolve) => {
+      resolveSubscription = resolve;
+    });
+    const settings = createSettings();
+    const state = {
+      sessionKey: "main",
+      chatMessage: "",
+      chatAttachments: [],
+      chatMessages: [],
+      chatToolMessages: [],
+      chatStreamSegments: [],
+      chatThinkingLevel: null,
+      chatStream: null,
+      chatSideResult: null,
+      lastError: null,
+      compactionStatus: null,
+      fallbackStatus: null,
+      chatAvatarUrl: null,
+      chatQueue: [],
+      chatQueueBySession: {},
+      chatRunId: null,
+      sessionsShowArchived: false,
+      chatSideResultTerminalRuns: new Set<string>(),
+      chatStreamStartedAt: null,
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [row({ key: "main" }), row({ key: "agent:main:review" })],
+      },
+      settings,
+      announceSessionSwitch: vi.fn(),
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+      resetChatInputHistoryNavigation: vi.fn(),
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    refreshSlashCommandsMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockReturnValue(historyLoaded);
+    syncSelectedSessionMessageSubscriptionMock.mockReturnValue(subscriptionSynced);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    const switched = switchChatSessionAndWait(state, "agent:main:review");
+    let settled = false;
+    void switched.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveHistory();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveSubscription();
+    await switched;
+
+    expect(settled).toBe(true);
+    expect(state.sessionKey).toBe("agent:main:review");
+  });
+
   it("refreshes the chat avatar after clearing session-scoped state", async () => {
     const settings = createSettings();
     const state = {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -623,7 +623,11 @@ export function renderChatMobileToggle(state: AppViewState) {
   `;
 }
 
-export function switchChatSession(state: AppViewState, nextSessionKey: string) {
+function switchChatSessionInternal(
+  state: AppViewState,
+  nextSessionKey: string,
+  opts?: { awaitInitialLoad?: boolean },
+): Promise<void> | undefined {
   const previousSessionKey = state.sessionKey;
   const nextSessionRow =
     state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey) ??
@@ -644,11 +648,33 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     nextSessionKey,
     true,
   );
-  void syncSelectedSessionMessageSubscription(
+  const subscriptionSync = syncSelectedSessionMessageSubscription(
     state as unknown as AppViewState & { chatSessionMessageSubscriptionKey?: string | null },
   );
-  void loadChatHistory(state as unknown as ChatState);
-  void refreshSessionOptions(state);
+  const historyLoad = loadChatHistory(state as unknown as ChatState);
+  const sessionsRefresh = refreshSessionOptions(state);
+  if (opts?.awaitInitialLoad) {
+    void sessionsRefresh;
+    return Promise.allSettled([subscriptionSync, historyLoad]).then(() => undefined);
+  }
+  void subscriptionSync;
+  void historyLoad;
+  void sessionsRefresh;
+  return undefined;
+}
+
+export function switchChatSession(state: AppViewState, nextSessionKey: string): void {
+  void switchChatSessionInternal(state, nextSessionKey);
+}
+
+export function switchChatSessionAndWait(
+  state: AppViewState,
+  nextSessionKey: string,
+): Promise<void> {
+  return (
+    switchChatSessionInternal(state, nextSessionKey, { awaitInitialLoad: true }) ??
+    Promise.resolve()
+  );
 }
 
 export function dismissChatError(state: AppViewState) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -22,6 +22,7 @@ import {
   createChatSession,
   dismissChatError,
   switchChatSession,
+  switchChatSessionAndWait,
 } from "./app-render.helpers.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess, warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
@@ -119,6 +120,7 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import {
   branchSessionFromCheckpoint,
+  createSessionAndRefresh,
   deleteSessionsAndRefresh,
   loadSessions,
   parseSessionsFilterInteger,
@@ -218,6 +220,8 @@ function runUiTask<Args extends unknown[]>(
 }
 
 const SKILL_WORKSHOP_MODE_KEY = "openclaw:control-ui:skill-workshop-mode:v1";
+const SKILL_WORKSHOP_CURRENT_CHAT_REVISIONS_KEY =
+  "openclaw:control-ui:skill-workshop-current-chat-revisions:v1";
 
 export function loadSkillWorkshopMode(): "board" | "today" {
   try {
@@ -225,6 +229,23 @@ export function loadSkillWorkshopMode(): "board" | "today" {
     return raw === "board" ? "board" : "today";
   } catch {
     return "today";
+  }
+}
+
+export function loadSkillWorkshopUseCurrentChatForRevisions(): boolean {
+  try {
+    return getSafeLocalStorage()?.getItem(SKILL_WORKSHOP_CURRENT_CHAT_REVISIONS_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setSkillWorkshopUseCurrentChatForRevisions(state: AppViewState, enabled: boolean): void {
+  state.skillWorkshopUseCurrentChatForRevisions = enabled;
+  try {
+    getSafeLocalStorage()?.setItem(SKILL_WORKSHOP_CURRENT_CHAT_REVISIONS_KEY, String(enabled));
+  } catch {
+    // Preference persistence is optional; the active toggle still controls this handoff.
   }
 }
 
@@ -241,8 +262,26 @@ function setSkillWorkshopMode(state: AppViewState, mode: "board" | "today"): voi
 }
 
 function renderSkillWorkshopHeaderControls(state: AppViewState) {
+  const useCurrentChatLabel = t("skillWorkshop.header.useCurrentChat");
   return html`
     <div class="sw-header-controls">
+      <label
+        class="sw-revision-session-toggle"
+        title=${t("skillWorkshop.header.useCurrentChatTooltip")}
+      >
+        <input
+          type="checkbox"
+          aria-label=${t("skillWorkshop.header.useCurrentChatAria")}
+          .checked=${state.skillWorkshopUseCurrentChatForRevisions}
+          @change=${(event: Event) =>
+            setSkillWorkshopUseCurrentChatForRevisions(
+              state,
+              (event.currentTarget as HTMLInputElement).checked,
+            )}
+        />
+        <span class="sw-revision-session-toggle__track" aria-hidden="true"></span>
+        <span class="sw-revision-session-toggle__label">${useCurrentChatLabel}</span>
+      </label>
       <div
         class="sw-mode-switch"
         role="tablist"
@@ -284,6 +323,101 @@ function renderSkillWorkshopHeaderControls(state: AppViewState) {
       </div>
     </div>
   `;
+}
+
+function findSkillWorkshopRevisionSessionRow(
+  state: AppViewState,
+  sessionKey: string | undefined,
+): GatewaySessionRow | null {
+  const key = normalizeOptionalString(sessionKey);
+  if (!key) {
+    return null;
+  }
+  const current = state.sessionsResult?.sessions.find((row) => row.key === key);
+  if (current) {
+    return current;
+  }
+  for (const rows of Object.values(state.chatAgentSessionRowsByAgent ?? {})) {
+    const cached = rows.find((row) => row.key === key);
+    if (cached) {
+      return cached;
+    }
+  }
+  return null;
+}
+
+function isUsableSkillWorkshopRevisionSession(
+  row: GatewaySessionRow | null,
+): row is GatewaySessionRow {
+  return Boolean(row && !row.archived && !row.hasActiveRun);
+}
+
+async function ensureSkillWorkshopRevisionSessionsLoaded(
+  state: AppViewState,
+  agentId: string,
+): Promise<void> {
+  const resultAgentId = normalizeOptionalString(state.sessionsResultAgentId);
+  if (resultAgentId === agentId && state.sessionsResult?.sessions.length) {
+    return;
+  }
+  await loadSessions(state, {
+    ...createChatSessionsLoadOverrides(state),
+    agentId,
+  });
+}
+
+async function resolveSkillWorkshopRevisionSessionKey(
+  state: AppViewState,
+  proposal: { key: string; slug: string; origin?: { agentId?: string; sessionKey?: string } },
+): Promise<string | null> {
+  if (state.skillWorkshopUseCurrentChatForRevisions) {
+    return normalizeOptionalString(state.sessionKey) ?? null;
+  }
+
+  const agentId = normalizeAgentId(
+    proposal.origin?.agentId ?? resolveSidebarSelectedAgentId(state),
+  );
+  await ensureSkillWorkshopRevisionSessionsLoaded(state, agentId);
+
+  const originRow = findSkillWorkshopRevisionSessionRow(state, proposal.origin?.sessionKey);
+  if (isUsableSkillWorkshopRevisionSession(originRow)) {
+    return originRow.key;
+  }
+
+  return createSessionAndRefresh(
+    state as unknown as Parameters<typeof createSessionAndRefresh>[0],
+    {
+      agentId,
+      label: `Skill Workshop: ${proposal.slug || proposal.key}`.slice(0, 80),
+    },
+    {
+      ...createChatSessionsLoadOverrides(state),
+      agentId,
+    },
+  );
+}
+
+async function sendSkillWorkshopRevisionRequest(
+  state: AppViewState,
+  message: string,
+  proposal: { key: string; slug: string; origin?: { agentId?: string; sessionKey?: string } },
+): Promise<void> {
+  if (!state.client || !state.connected) {
+    throw new Error("Gateway is not connected.");
+  }
+  const sessionKey = await resolveSkillWorkshopRevisionSessionKey(state, proposal);
+  if (!sessionKey) {
+    throw new Error(state.sessionsError ?? "Could not prepare a Skill Workshop session.");
+  }
+  if (state.tab !== "chat") {
+    state.setTab("chat" as Tab);
+  }
+  if (state.sessionKey === sessionKey) {
+    await loadChatHistory(state);
+  } else {
+    await switchChatSessionAndWait(state, sessionKey);
+  }
+  await state.handleSendChat(message, { restoreDraft: true });
 }
 
 function renderSettingsSectionNav(state: AppViewState) {
@@ -3242,10 +3376,9 @@ export function renderApp(state: AppViewState) {
                   state.skillWorkshopRevisionDraft = "";
                 },
                 onRevisionSubmit: (key) =>
-                  void requestSkillWorkshopRevision(state, key, async (message) => {
-                    state.setTab("chat" as Tab);
-                    await state.handleSendChat(message, { restoreDraft: true });
-                  }),
+                  void requestSkillWorkshopRevision(state, key, (message, proposal) =>
+                    sendSkillWorkshopRevisionRequest(state, message, proposal),
+                  ),
                 onPreviewFile: (key, path) => {
                   state.skillWorkshopSelectedKey = key;
                   state.skillWorkshopFilePreviewKey = path;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -42,7 +42,11 @@ import {
 } from "./app-lifecycle.ts";
 import { initNativeBridge } from "./app-native-bridge.ts";
 import { createChatSession as createChatSessionInternal } from "./app-render.helpers.ts";
-import { loadSkillWorkshopMode, renderApp } from "./app-render.ts";
+import {
+  loadSkillWorkshopMode,
+  loadSkillWorkshopUseCurrentChatForRevisions,
+  renderApp,
+} from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleActivityScroll as handleActivityScrollInternal,
@@ -644,6 +648,7 @@ export class OpenClawApp extends LitElement {
   @state() skillWorkshopFilePreviewQuery = "";
   @state() skillWorkshopQueueWidth = 360;
   @state() skillWorkshopMode: SkillWorkshopState["skillWorkshopMode"] = loadSkillWorkshopMode();
+  @state() skillWorkshopUseCurrentChatForRevisions = loadSkillWorkshopUseCurrentChatForRevisions();
 
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -92,6 +92,7 @@ export type SkillWorkshopState = {
   skillWorkshopFilePreviewQuery: string;
   skillWorkshopQueueWidth: number;
   skillWorkshopMode: SkillWorkshopMode;
+  skillWorkshopUseCurrentChatForRevisions: boolean;
 };
 
 function getErrorMessage(err: unknown): string {


### PR DESCRIPTION
## Summary

Restore the Skill Workshop `Use current chat` toggle for revision requests.

When enabled, revision handoffs are sent to the currently selected chat session. When disabled, they return to the proposal’s originating/workshop session, or create a scoped Skill Workshop session if no usable origin session is available.

This also adds an awaitable chat-session switch path so revision sends wait for the target session’s initial history and message subscription before calling `handleSendChat`.

Release note context: Restores the Skill Workshop current-chat revision toggle. Thanks @shakkernerd.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.node.test.ts`
- `pnpm ui:i18n:check`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-current-chat-toggle.tsbuildinfo`
- `node scripts/run-oxlint.mjs ui/src/ui/app-render.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app.ts ui/src/ui/controllers/skill-workshop.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/i18n/locales/en.ts`
- `git diff --check origin/main...HEAD`
- Testbox-through-Crabbox: `tbx_01kt7tajjm2gqjrpdqm6wrm2e8`, `ui/src/ui/app-render.helpers.node.test.ts` passed 67 tests
