### PR TITLE
fix: keep threaded Slack message sends route-bound for reply dedupe

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -10,6 +10,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
+import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import type {
   AgentApprovalEventData,
   AgentCommandOutputEventData,
@@ -1023,7 +1024,9 @@ export function handleToolExecutionStart(
       const argsRecord = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
       const isMessagingSend = isMessagingToolSendAction(toolName, argsRecord);
       if (isMessagingSend) {
-        const sendTarget = extractMessagingToolSend(toolName, argsRecord);
+        const sendTarget = extractMessagingToolSend(toolName, argsRecord, {
+          currentThreadId: parseSessionThreadInfoFast(ctx.params.sessionKey).threadId,
+        });
         if (sendTarget) {
           ctx.state.pendingMessagingTargets.set(toolCallId, sendTarget);
         }

--- a/src/agents/embedded-agent-subscribe.tools.extract.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.extract.test.ts
@@ -144,6 +144,22 @@ describe("extractMessagingToolSend", () => {
     expect(result?.threadImplicit).toBe(true);
   });
 
+  it("captures the active session thread for implicit threaded sends", () => {
+    const result = extractMessagingToolSend(
+      "message",
+      {
+        action: "send",
+        provider: "telegram",
+        to: "123",
+        content: "done",
+      },
+      { currentThreadId: "456" },
+    );
+
+    expect(result?.threadImplicit).toBe(true);
+    expect(result?.threadId).toBe("456");
+  });
+
   it("keeps provider-tool extracted thread id evidence", () => {
     const result = extractMessagingToolSend("slack", {
       action: "sendMessage",

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -612,6 +612,7 @@ function resolveMessageToolTarget(args: Record<string, unknown>): string | undef
 export function extractMessagingToolSend(
   toolName: string,
   args: Record<string, unknown>,
+  options?: { currentThreadId?: string },
 ): MessagingToolSend | undefined {
   // Provider docking: new provider tools must implement plugin.actions.extractToolSend.
   const action = normalizeOptionalString(args.action) ?? "";
@@ -636,13 +637,16 @@ export function extractMessagingToolSend(
       !threadId &&
       !threadSuppressed &&
       Boolean(providerId && getChannelPlugin(providerId)?.threading?.resolveAutoThreadId);
+    const currentThreadId = threadImplicit
+      ? normalizeOptionalString(options?.currentThreadId)
+      : undefined;
     return to
       ? {
           tool: toolName,
           provider,
           accountId,
           to,
-          ...(threadId ? { threadId } : {}),
+          ...((threadId ?? currentThreadId) ? { threadId: threadId ?? currentThreadId } : {}),
           ...(threadImplicit ? { threadImplicit: true } : {}),
           ...(threadSuppressed ? { threadSuppressed: true } : {}),
         }

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -175,6 +175,7 @@ export async function buildReplyPayloads(params: {
   originatingChannel?: OriginatingChannelType;
   originatingTo?: string;
   accountId?: string;
+  originatingThreadId?: string | number;
   extractMarkdownImages?: boolean;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
@@ -279,6 +280,7 @@ export async function buildReplyPayloads(params: {
     accountId: resolveOriginAccountId({
       originatingAccountId: params.accountId,
     }),
+    originatingThreadId: params.originatingThreadId,
   }) ?? {
     shouldDedupePayloads: shouldCheckMessagingToolDedupe && messagingToolSentTargets.length === 0,
     matchingRoute: false,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2215,6 +2215,52 @@ describe("runReplyAgent messaging tool dedupe", () => {
 
     expectReplyText(result, "hello world!");
   });
+
+  it("keeps threaded Slack replies when the messaging tool sent to another thread", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["hello world!"],
+      messagingToolSentTargets: [
+        {
+          tool: "message",
+          provider: "slack",
+          to: "channel:C1",
+          threadId: "171.333",
+          text: "hello world!",
+        },
+      ],
+      meta: {},
+    });
+
+    const result = await createRun("slack", {
+      sessionKey: "agent:main:slack:channel:C1:thread:171.222",
+    });
+
+    expectReplyText(result, "hello world!");
+  });
+
+  it("drops threaded Slack duplicates only when the messaging tool sent to the same thread", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["hello world!"],
+      messagingToolSentTargets: [
+        {
+          tool: "message",
+          provider: "slack",
+          to: "channel:C1",
+          threadId: "171.222",
+          text: "hello world!",
+        },
+      ],
+      meta: {},
+    });
+
+    const result = await createRun("slack", {
+      sessionKey: "agent:main:slack:channel:C1:thread:171.222",
+    });
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("runReplyAgent reminder commitment guard", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1543,6 +1543,7 @@ export async function runReplyAgent(params: {
           to: sessionCtx.To,
         }),
         accountId: sessionCtx.AccountId,
+        originatingThreadId: replyRouteThreadId,
         normalizeMediaPaths: replyMediaContext.normalizePayload,
       });
       const replyPayloads = payloadResult.replyPayloads.map((payload) =>
@@ -1938,6 +1939,7 @@ export async function runReplyAgent(params: {
         to: sessionCtx.To,
       }),
       accountId: sessionCtx.AccountId,
+      originatingThreadId: replyRouteThreadId,
       normalizeMediaPaths: replyMediaContext.normalizePayload,
     });
     const { replyPayloads } = payloadResult;

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -177,6 +177,49 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toStrictEqual([]);
   });
 
+  it("keeps top-level Slack replies when the messaging tool only sent into a thread", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        sentTexts: ["hello world!"],
+        sentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "171.222",
+            text: "hello world!",
+          },
+        ],
+      }),
+    ).toEqual([{ text: "hello world!" }]);
+  });
+
+  it("dedupes Slack replies only when the messaging tool sent into the same thread", () => {
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "hello world!" }],
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "171.222",
+        sentTexts: ["hello world!"],
+        sentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "171.222",
+            text: "hello world!",
+          },
+        ],
+      }),
+    ).toStrictEqual([]);
+  });
+
   it("delivers distinct replies when originating channel resolves the provider", () => {
     expect(
       resolveFollowupDeliveryPayloads({

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -31,6 +31,7 @@ export function resolveFollowupDeliveryPayloads(params: {
   originatingChannel?: string;
   originatingChatType?: string | null;
   originatingTo?: string;
+  originatingThreadId?: string | number;
   sentMediaUrls?: string[];
   sentTargets?: MessagingToolSend[];
   sentTexts?: string[];
@@ -74,6 +75,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     accountId: resolveOriginAccountId({
       originatingAccountId: params.originatingAccountId,
     }),
+    originatingThreadId: params.originatingThreadId,
   });
   const sentMediaUrlFallback = params.sentMediaUrls ?? [];
   const sentTextFallback = params.sentTexts ?? [];

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1098,6 +1098,7 @@ export function createFollowupRunner(params: {
         originatingChannel: queued.originatingChannel,
         originatingChatType: queued.originatingChatType,
         originatingTo: queued.originatingTo,
+        originatingThreadId: queued.originatingThreadId,
         sentMediaUrls: runResult.messagingToolSentMediaUrls,
         sentTargets: runResult.messagingToolSentTargets,
         sentTexts: runResult.messagingToolSentTexts,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -127,7 +127,7 @@ function normalizeProviderForComparison(value?: string): string | undefined {
   return lowered;
 }
 
-function normalizeThreadIdForComparison(value?: string): string | undefined {
+function normalizeThreadIdForComparison(value?: unknown): string | undefined {
   return stringifyRouteThreadId(value);
 }
 
@@ -181,6 +181,7 @@ function targetsMatchForDedupe(params: {
   provider: string;
   originTarget: string;
   targetKey: string;
+  originThreadId?: string;
   targetThreadId?: string;
 }): boolean {
   const pluginMatch = getChannelPlugin(params.provider)?.outbound?.targetsMatchForReplySuppression;
@@ -191,6 +192,9 @@ function targetsMatchForDedupe(params: {
       targetThreadId: normalizeThreadIdForComparison(params.targetThreadId),
     });
   }
+  if (params.originThreadId || params.targetThreadId) {
+    return false;
+  }
   return params.targetKey === params.originTarget;
 }
 
@@ -199,6 +203,7 @@ export function shouldDedupeMessagingToolRepliesForRoute(params: {
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
   accountId?: string;
+  originatingThreadId?: string | number;
 }): boolean {
   return getMatchingMessagingToolReplyTargets(params).length > 0;
 }
@@ -208,6 +213,7 @@ export function getMatchingMessagingToolReplyTargets(params: {
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
   accountId?: string;
+  originatingThreadId?: string | number;
 }): MessagingToolSend[] {
   const provider = normalizeProviderForComparison(params.messageProvider);
   if (!provider) {
@@ -237,6 +243,7 @@ export function getMatchingMessagingToolReplyTargets(params: {
       provider,
       rawTarget: originRawTarget,
       accountId: routeAccount,
+      threadId: stringifyRouteThreadId(params.originatingThreadId),
     });
     if (!originRoute) {
       return false;
@@ -257,6 +264,7 @@ export function getMatchingMessagingToolReplyTargets(params: {
       provider,
       originTarget: originRoute.to,
       targetKey: targetRoute.to,
+      originThreadId: normalizeThreadIdForComparison(originRoute.threadId),
       targetThreadId: target.threadId,
     });
   });
@@ -276,6 +284,7 @@ export function resolveMessagingToolPayloadDedupe(params: {
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
   accountId?: string;
+  originatingThreadId?: string | number;
 }): MessagingToolPayloadDedupeDecision {
   const sentTargets = params.messagingToolSentTargets ?? [];
   const matchingTargets = getMatchingMessagingToolReplyTargets({
@@ -283,6 +292,7 @@ export function resolveMessagingToolPayloadDedupe(params: {
     messagingToolSentTargets: sentTargets,
     originatingTo: params.originatingTo,
     accountId: params.accountId,
+    originatingThreadId: params.originatingThreadId,
   });
   const matchingRoute = matchingTargets.length > 0;
   const routeSentTexts = matchingTargets.flatMap((target) =>

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -349,6 +349,64 @@ describe("resolveMessagingToolPayloadDedupe", () => {
     });
   });
 
+  it("does not treat a Slack thread send as matching a top-level route", () => {
+    expect(
+      resolveMessagingToolPayloadDedupe({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "171.222",
+            text: "thread text",
+          },
+        ],
+      }),
+    ).toEqual({
+      shouldDedupePayloads: false,
+      matchingRoute: false,
+      routeSentTexts: [],
+      routeSentMediaUrls: [],
+      useGlobalSentTextEvidenceFallback: false,
+      useGlobalSentMediaUrlEvidenceFallback: false,
+    });
+  });
+
+  it("matches only the same Slack thread route", () => {
+    expect(
+      resolveMessagingToolPayloadDedupe({
+        messageProvider: "slack",
+        originatingTo: "channel:C1",
+        originatingThreadId: "171.222",
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "171.222",
+            text: "thread text",
+          },
+          {
+            tool: "message",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "171.333",
+            text: "other thread",
+          },
+        ],
+      }),
+    ).toEqual({
+      shouldDedupePayloads: true,
+      matchingRoute: true,
+      routeSentTexts: ["thread text"],
+      routeSentMediaUrls: [],
+      useGlobalSentTextEvidenceFallback: false,
+      useGlobalSentMediaUrlEvidenceFallback: true,
+    });
+  });
+
   it("keeps final payloads intact when a messaging tool sent to another route", () => {
     expect(
       resolveMessagingToolPayloadDedupe({


### PR DESCRIPTION
## Summary
- preserve the active thread id when the generic `message` tool implicitly sends into the current Slack thread
- make reply-payload dedupe compare threaded routes exactly so a thread-scoped send no longer suppresses later channel or other-thread replies
- add regression coverage for extraction, main reply delivery, and followup delivery while keeping existing Telegram topic suppression behavior intact

## Verification
- `pnpm tsgo:core`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.tools.extract.test.ts src/auto-reply/reply/reply-payloads.test.ts src/auto-reply/reply/followup-delivery.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`

Closes #90044