### PR TITLE
fix(plugins): isolate provider runtime rows

### DIFF
--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -24,6 +24,7 @@ import {
   resolveOwningPluginIdsForProviderRef,
   withBundledProviderVitestCompat,
 } from "./providers.js";
+import type { PluginProviderRegistration } from "./registry-types.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
@@ -305,6 +306,31 @@ function resolveRuntimeProviderPluginLoadState(
   return { loadOptions };
 }
 
+function projectPluginProviderRegistration(
+  entry: PluginProviderRegistration,
+  scope?: ReadonlySet<string>,
+): ProviderPlugin | null {
+  try {
+    const pluginId = entry.pluginId;
+    if (scope && !scope.has(pluginId)) {
+      return null;
+    }
+    return Object.assign({}, entry.provider, { pluginId });
+  } catch {
+    return null;
+  }
+}
+
+function projectPluginProviderRegistrations(
+  entries: readonly PluginProviderRegistration[],
+  onlyPluginIds?: readonly string[],
+): ProviderPlugin[] {
+  const scope = onlyPluginIds ? new Set(onlyPluginIds) : undefined;
+  return entries
+    .map((entry) => projectPluginProviderRegistration(entry, scope))
+    .filter((provider): provider is ProviderPlugin => provider !== null);
+}
+
 export function isPluginProvidersLoadInFlight(
   params: Parameters<typeof resolvePluginProviders>[0],
 ): boolean {
@@ -349,8 +375,9 @@ export function resolvePluginProviders(params: {
       return [];
     }
     const registry = loadOpenClawPlugins(loadState.loadOptions);
-    return registry.providers.map((entry) =>
-      Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
+    return projectPluginProviderRegistrations(
+      registry.providers,
+      loadState.loadOptions.onlyPluginIds,
     );
   }
   const loadState = resolveRuntimeProviderPluginLoadState(params, base, snapshot);
@@ -370,7 +397,8 @@ export function resolvePluginProviders(params: {
     return [];
   }
 
-  return registry.providers.map((entry) =>
-    Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
+  return projectPluginProviderRegistrations(
+    registry.providers,
+    loadState.loadOptions.onlyPluginIds,
   );
 }

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -787,6 +787,61 @@ describe("resolvePluginProviders", () => {
     });
   });
 
+  it("skips unreadable runtime provider rows while resolving plugin providers", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "healthy-plugin",
+        providerIds: ["healthy-provider"],
+        enabledByDefault: true,
+      }),
+    ]);
+    const registry = createEmptyPluginRegistry();
+    const brokenRegistration = Object.defineProperty(
+      {
+        pluginId: "broken-plugin",
+        source: "test",
+      },
+      "provider",
+      {
+        get() {
+          throw new Error("provider row exploded");
+        },
+      },
+    );
+    const healthyProvider: ProviderPlugin = {
+      id: "healthy-provider",
+      label: "Healthy Provider",
+      auth: [],
+    };
+    const outOfScopeProvider: ProviderPlugin = {
+      id: "out-of-scope-provider",
+      label: "Out of Scope Provider",
+      auth: [],
+    };
+    registry.providers.push(
+      { pluginId: "out-of-scope-plugin", provider: outOfScopeProvider, source: "test" },
+      brokenRegistration as never,
+      {
+        pluginId: "healthy-plugin",
+        provider: healthyProvider,
+        source: "test",
+      },
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(registry);
+
+    expect(
+      resolvePluginProviders({
+        config: {},
+        onlyPluginIds: ["healthy-plugin"],
+      }),
+    ).toEqual([
+      {
+        ...healthyProvider,
+        pluginId: "healthy-plugin",
+      },
+    ]);
+  });
+
   it("keeps bundled provider plugins enabled when they default on outside Vitest compat", () => {
     expect(resolveEnabledProviderPluginIds({ config: {}, env: {} as NodeJS.ProcessEnv })).toEqual([
       "google",


### PR DESCRIPTION
## Summary

- Isolate provider runtime row projection so malformed provider registrations are skipped instead of crashing provider resolution.
- Preserve resolved plugin scoping when reusing a wider active runtime registry.
- Add a regression test covering both an unreadable provider row and a readable out-of-scope provider row.

## Verification

- `node scripts/run-vitest.mjs src/plugins/providers.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/providers.runtime.ts src/plugins/providers.test.ts`
- `./node_modules/.bin/oxlint src/plugins/providers.runtime.ts src/plugins/providers.test.ts`
- `git diff --check && git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` blocked before lease creation: coordinator HTTP 401 unauthorized, provider `azure`, slug `jade-hermit`

## Real behavior proof

Behavior addressed: A malformed provider runtime registration could throw during provider projection and prevent later healthy provider rows from resolving; a wider reused registry could also expose provider rows outside the resolved plugin scope.

Real environment tested: Local OpenClaw linked worktree on Node/Vitest through `node scripts/run-vitest.mjs`; Crabbox changed gate attempted through the repo wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/providers.test.ts`

Evidence after fix: The regression test injects an unreadable provider row and a readable out-of-scope provider row beside a healthy scoped provider, then verifies only the healthy scoped provider is returned.

Observed result after fix: `src/plugins/providers.test.ts` passed with 60 tests.

What was not tested: Broad `pnpm check:changed` did not run because Crabbox coordinator auth returned HTTP 401 before leasing a runner.
