### PR TITLE
fix(diagnostics-otel): populate Langfuse trace-level input/output from model calls

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -4021,6 +4021,71 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("sibling runs sharing one OTel trace do not cross-stamp captured I/O", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: true,
+      captureContent: { enabled: true, inputMessages: true, outputMessages: true },
+    });
+    await service.start(ctx);
+
+    // Two distinct runs whose spans share one OTel trace id (the mock hands every span the same
+    // traceId) — the exact shape that trace-id-keyed stamping would cross-contaminate.
+    emitTrustedDiagnosticEvent({
+      type: "run.started",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      trace: { traceId: TRACE_ID, spanId: CHILD_SPAN_ID, parentSpanId: SPAN_ID, traceFlags: "01" },
+    });
+    emitTrustedDiagnosticEvent({
+      type: "run.started",
+      runId: "run-2",
+      provider: "openai",
+      model: "gpt-5.4",
+      trace: {
+        traceId: TRACE_ID,
+        spanId: GRANDCHILD_SPAN_ID,
+        parentSpanId: SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    emitTrustedModelCallCompletedWithContent(
+      { runId: "run-1", callId: "call-1", provider: "openai", model: "gpt-5.4", durationMs: 50 },
+      { inputMessages: ["run one prompt"], outputMessages: ["run one reply"] },
+    );
+    emitTrustedModelCallCompletedWithContent(
+      { runId: "run-2", callId: "call-2", provider: "openai", model: "gpt-5.4", durationMs: 50 },
+      { inputMessages: ["run two prompt"], outputMessages: ["run two reply"] },
+    );
+    await flushDiagnosticEvents();
+
+    const runSpans = telemetryState.spans.filter((s) => s.name === "openclaw.run");
+    expect(runSpans).toHaveLength(2);
+    const mergedAttrs = (span: (typeof runSpans)[number]) =>
+      Object.assign(
+        {},
+        ...span.setAttributes.mock.calls.map((call) => call[0] as Record<string, unknown>),
+      ) as Record<string, unknown>;
+    const run1Attrs = mergedAttrs(runSpans[0]);
+    const run2Attrs = mergedAttrs(runSpans[1]);
+
+    // Each run's root span carries ONLY its own conversation, at both trace and observation level.
+    expect(String(run1Attrs["langfuse.trace.input"])).toContain("run one prompt");
+    expect(String(run1Attrs["input.value"])).toContain("run one prompt");
+    expect(String(run1Attrs["langfuse.trace.output"])).toContain("run one reply");
+    expect(String(run1Attrs["output.value"])).toContain("run one reply");
+    expect(JSON.stringify(run1Attrs)).not.toContain("run two");
+
+    expect(String(run2Attrs["langfuse.trace.input"])).toContain("run two prompt");
+    expect(String(run2Attrs["input.value"])).toContain("run two prompt");
+    expect(String(run2Attrs["output.value"])).toContain("run two reply");
+    expect(JSON.stringify(run2Attrs)).not.toContain("run one");
+
+    await service.stop?.(ctx);
+  });
+
   test("exports bounded redacted content when capture fields are opted in", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -90,6 +90,9 @@ const GEN_AI_OPERATION_DURATION_BUCKETS = [
 ];
 const MAX_RETAINED_TRUSTED_SPAN_CONTEXTS = 1024;
 const RETAINED_TRUSTED_SPAN_CONTEXT_TIMEOUT_MS = 5_000;
+// Bound on the per-OTel-trace root-run-span map used to project model-call I/O onto the trace's
+// root span (see rootRunSpanByOtelTrace). LRU-evicts so a leaked/never-finalized run can't grow it.
+const MAX_TRACKED_ROOT_RUN_SPANS = 20_000;
 
 type OtelContentCapturePolicy = {
   inputMessages: boolean;
@@ -1254,6 +1257,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         { spanContext: SpanContext; token: symbol; owner?: TrustedSpanAliasOwner }
       >();
       const retainedTrustedSpanContextCleanupTimers = new Set<ReturnType<typeof setTimeout>>();
+      // Root openclaw.run span per OTel trace id, so a completed model call can stamp the
+      // conversation onto the trace's root span as langfuse.trace.input/output (see
+      // recordModelCallCompleted). traceIoInputStamped keeps the FIRST input per trace.
+      const rootRunSpanByOtelTrace = new Map<string, ReturnType<typeof tracer.startSpan>>();
+      const traceIoInputStamped = new Set<string>();
       stopActiveTrustedSpans = () => {
         const stopAt = Date.now();
         for (const handle of retainedTrustedSpanContextCleanupTimers) {
@@ -1269,6 +1277,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         activeTrustedSpans.clear();
         activeTrustedSpanAliases.clear();
+        rootRunSpanByOtelTrace.clear();
+        traceIoInputStamped.clear();
       };
 
       const tokensCounter = meter.createCounter("openclaw.tokens", {
@@ -2334,6 +2344,19 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             startTimeMs: evt.ts,
           }),
         );
+        // Remember this run span as the root for its OTel trace so model-call completions can
+        // project their I/O onto it (langfuse.trace.input/output). First run per trace wins.
+        const rootTraceId = span.spanContext().traceId;
+        if (!rootRunSpanByOtelTrace.has(rootTraceId)) {
+          rootRunSpanByOtelTrace.set(rootTraceId, span);
+          if (rootRunSpanByOtelTrace.size > MAX_TRACKED_ROOT_RUN_SPANS) {
+            const oldest = rootRunSpanByOtelTrace.keys().next().value;
+            if (oldest !== undefined) {
+              rootRunSpanByOtelTrace.delete(oldest);
+              traceIoInputStamped.delete(oldest);
+            }
+          }
+        }
         const parentSpanId = trustedTraceContext(evt, metadata)?.parentSpanId;
         if (parentSpanId && !activeTrustedSpans.has(parentSpanId)) {
           const owner: TrustedSpanAliasOwner = { kind: "run", id: evt.runId };
@@ -2915,6 +2938,23 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           });
         setSpanAttrs(span, spanAttrs);
         addUpstreamRequestIdSpanEvent(span, evt.upstreamRequestIdHash);
+        // Langfuse derives a TRACE's input/output from its ROOT span's langfuse.trace.input/output
+        // attributes — but the openclaw.run root span carries no I/O, so the Traces list and trace
+        // header read blank even though the conversation is on this nested model-call span. Mirror
+        // the model-call I/O onto the tracked root run span: first call's input, latest call's output.
+        const rootRunSpan = rootRunSpanByOtelTrace.get(span.spanContext().traceId);
+        if (rootRunSpan && rootRunSpan !== span) {
+          const traceId = span.spanContext().traceId;
+          const inputValue = spanAttrs["input.value"];
+          const outputValue = spanAttrs["output.value"];
+          if (typeof inputValue === "string" && !traceIoInputStamped.has(traceId)) {
+            rootRunSpan.setAttribute("langfuse.trace.input", inputValue);
+            traceIoInputStamped.add(traceId);
+          }
+          if (typeof outputValue === "string") {
+            rootRunSpan.setAttribute("langfuse.trace.output", outputValue);
+          }
+        }
         span.end(evt.ts);
       };
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -90,8 +90,9 @@ const GEN_AI_OPERATION_DURATION_BUCKETS = [
 ];
 const MAX_RETAINED_TRUSTED_SPAN_CONTEXTS = 1024;
 const RETAINED_TRUSTED_SPAN_CONTEXT_TIMEOUT_MS = 5_000;
-// Bound on the per-OTel-trace root-run-span map used to project model-call I/O onto the trace's
-// root span (see rootRunSpanByOtelTrace). LRU-evicts so a leaked/never-finalized run can't grow it.
+// Backstop bound on the per-run root-run-span map used to project model-call I/O onto the run's
+// root span (see rootRunSpanByRunId). Entries are normally removed on run completion; this evicts
+// the oldest only if a run never finalizes, so a leak can't grow the map unbounded.
 const MAX_TRACKED_ROOT_RUN_SPANS = 20_000;
 
 type OtelContentCapturePolicy = {
@@ -1257,11 +1258,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         { spanContext: SpanContext; token: symbol; owner?: TrustedSpanAliasOwner }
       >();
       const retainedTrustedSpanContextCleanupTimers = new Set<ReturnType<typeof setTimeout>>();
-      // Root openclaw.run span per OTel trace id, so a completed model call can stamp the
-      // conversation onto the trace's root span as langfuse.trace.input/output (see
-      // recordModelCallCompleted). traceIoInputStamped keeps the FIRST input per trace.
-      const rootRunSpanByOtelTrace = new Map<string, ReturnType<typeof tracer.startSpan>>();
-      const traceIoInputStamped = new Set<string>();
+      // Root openclaw.run span per RUN id, so a completed model call can stamp the conversation onto
+      // its own run's root span (see recordModelCallCompleted). Keyed by runId, NOT OTel trace id:
+      // sibling runs can share one OTel trace, and trace-id keying would cross-stamp one run's
+      // prompt/response onto another. traceIoInputStampedByRunId keeps the FIRST input per run.
+      const rootRunSpanByRunId = new Map<string, ReturnType<typeof tracer.startSpan>>();
+      const traceIoInputStampedByRunId = new Set<string>();
       stopActiveTrustedSpans = () => {
         const stopAt = Date.now();
         for (const handle of retainedTrustedSpanContextCleanupTimers) {
@@ -1277,8 +1279,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         activeTrustedSpans.clear();
         activeTrustedSpanAliases.clear();
-        rootRunSpanByOtelTrace.clear();
-        traceIoInputStamped.clear();
+        rootRunSpanByRunId.clear();
+        traceIoInputStampedByRunId.clear();
       };
 
       const tokensCounter = meter.createCounter("openclaw.tokens", {
@@ -2344,16 +2346,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             startTimeMs: evt.ts,
           }),
         );
-        // Remember this run span as the root for its OTel trace so model-call completions can
-        // project their I/O onto it (langfuse.trace.input/output). First run per trace wins.
-        const rootTraceId = span.spanContext().traceId;
-        if (!rootRunSpanByOtelTrace.has(rootTraceId)) {
-          rootRunSpanByOtelTrace.set(rootTraceId, span);
-          if (rootRunSpanByOtelTrace.size > MAX_TRACKED_ROOT_RUN_SPANS) {
-            const oldest = rootRunSpanByOtelTrace.keys().next().value;
+        // Remember this run span keyed by its run id, so model-call completions can project their
+        // I/O onto their OWN run's root span (langfuse.trace.input/output + input.value/output.value).
+        const runOwner = trustedSpanAliasOwner(evt);
+        if (runOwner && !rootRunSpanByRunId.has(runOwner.id)) {
+          rootRunSpanByRunId.set(runOwner.id, span);
+          if (rootRunSpanByRunId.size > MAX_TRACKED_ROOT_RUN_SPANS) {
+            const oldest = rootRunSpanByRunId.keys().next().value;
             if (oldest !== undefined) {
-              rootRunSpanByOtelTrace.delete(oldest);
-              traceIoInputStamped.delete(oldest);
+              rootRunSpanByRunId.delete(oldest);
+              traceIoInputStampedByRunId.delete(oldest);
             }
           }
         }
@@ -2641,6 +2643,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             code: SpanStatusCode.ERROR,
             ...(evt.errorCategory ? { message: redactSensitiveText(evt.errorCategory) } : {}),
           });
+        }
+        // Run finished — drop its root-span tracking entry (all its model calls have completed).
+        const completedRunOwner = trustedSpanAliasOwner(evt);
+        if (completedRunOwner) {
+          rootRunSpanByRunId.delete(completedRunOwner.id);
+          traceIoInputStampedByRunId.delete(completedRunOwner.id);
         }
         if (trackedSpan && trustedTrace?.spanId) {
           completeTrackedLifecycleSpan(trustedTrace.spanId, trackedSpan, evt.ts);
@@ -2938,25 +2946,31 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           });
         setSpanAttrs(span, spanAttrs);
         addUpstreamRequestIdSpanEvent(span, evt.upstreamRequestIdHash);
-        // Mirror this model call's I/O onto the trace's ROOT openclaw.run span so the conversation
-        // shows at the trace level — first call's input (kept), latest call's output. We set BOTH:
+        // Mirror this model call's I/O onto its OWN run's root openclaw.run span so the conversation
+        // shows at the trace level — first call's input (kept), latest call's output. Look the root
+        // span up by RUN id (not OTel trace id): sibling runs can share a trace, and trace-id keying
+        // would stamp one run's captured content onto another. We set BOTH levels:
         //   - langfuse.trace.input/output: drives the Langfuse Traces list + the synthetic trace node.
         //   - input.value/output.value: the OpenInference observation attrs, so the openclaw.run node
         //     itself renders the conversation (Langfuse's IOPreview reads trace.input only for the
         //     trace node; the root observation would otherwise be blank until you drill into a child).
-        const rootRunSpan = rootRunSpanByOtelTrace.get(span.spanContext().traceId);
-        if (rootRunSpan && rootRunSpan !== span) {
-          const traceId = span.spanContext().traceId;
+        const runOwner = trustedSpanAliasOwner(evt);
+        const rootRunSpan = runOwner ? rootRunSpanByRunId.get(runOwner.id) : undefined;
+        if (runOwner && rootRunSpan && rootRunSpan !== span) {
           const inputValue = spanAttrs["input.value"];
           const outputValue = spanAttrs["output.value"];
-          if (typeof inputValue === "string" && !traceIoInputStamped.has(traceId)) {
-            rootRunSpan.setAttribute("langfuse.trace.input", inputValue);
-            rootRunSpan.setAttribute("input.value", inputValue);
-            traceIoInputStamped.add(traceId);
+          const rootAttrs: Record<string, string> = {};
+          if (typeof inputValue === "string" && !traceIoInputStampedByRunId.has(runOwner.id)) {
+            rootAttrs["langfuse.trace.input"] = inputValue;
+            rootAttrs["input.value"] = inputValue;
+            traceIoInputStampedByRunId.add(runOwner.id);
           }
           if (typeof outputValue === "string") {
-            rootRunSpan.setAttribute("langfuse.trace.output", outputValue);
-            rootRunSpan.setAttribute("output.value", outputValue);
+            rootAttrs["langfuse.trace.output"] = outputValue;
+            rootAttrs["output.value"] = outputValue;
+          }
+          if (Object.keys(rootAttrs).length > 0) {
+            rootRunSpan.setAttributes(rootAttrs);
           }
         }
         span.end(evt.ts);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2938,10 +2938,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           });
         setSpanAttrs(span, spanAttrs);
         addUpstreamRequestIdSpanEvent(span, evt.upstreamRequestIdHash);
-        // Langfuse derives a TRACE's input/output from its ROOT span's langfuse.trace.input/output
-        // attributes — but the openclaw.run root span carries no I/O, so the Traces list and trace
-        // header read blank even though the conversation is on this nested model-call span. Mirror
-        // the model-call I/O onto the tracked root run span: first call's input, latest call's output.
+        // Mirror this model call's I/O onto the trace's ROOT openclaw.run span so the conversation
+        // shows at the trace level — first call's input (kept), latest call's output. We set BOTH:
+        //   - langfuse.trace.input/output: drives the Langfuse Traces list + the synthetic trace node.
+        //   - input.value/output.value: the OpenInference observation attrs, so the openclaw.run node
+        //     itself renders the conversation (Langfuse's IOPreview reads trace.input only for the
+        //     trace node; the root observation would otherwise be blank until you drill into a child).
         const rootRunSpan = rootRunSpanByOtelTrace.get(span.spanContext().traceId);
         if (rootRunSpan && rootRunSpan !== span) {
           const traceId = span.spanContext().traceId;
@@ -2949,10 +2951,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           const outputValue = spanAttrs["output.value"];
           if (typeof inputValue === "string" && !traceIoInputStamped.has(traceId)) {
             rootRunSpan.setAttribute("langfuse.trace.input", inputValue);
+            rootRunSpan.setAttribute("input.value", inputValue);
             traceIoInputStamped.add(traceId);
           }
           if (typeof outputValue === "string") {
             rootRunSpan.setAttribute("langfuse.trace.output", outputValue);
+            rootRunSpan.setAttribute("output.value", outputValue);
           }
         }
         span.end(evt.ts);


### PR DESCRIPTION
## What

OpenClaw's `openclaw.run` root span carries no input/output — the conversation only lands on the nested `openclaw.model.call` span (`input.value` / `output.value`). In Langfuse this produces **two** blank-I/O symptoms:

1. **Traces list + trace header** read blank — Langfuse derives a *trace's* I/O from its root span's `langfuse.trace.input` / `langfuse.trace.output` attributes, which nothing sets (the known gap: `faq/all/empty-trace-input-and-output`, langfuse/langfuse#9970).
2. **The `openclaw.run` node itself** reads blank when selected — Langfuse's `IOPreview` shows the *observation's* `input.value`/`output.value` for an observation node, and only `trace.input` for the synthetic trace node. So the root run observation looks empty until you drill into the model-call child.

## How

In `createDiagnosticsOtelService`:
- Track the root `openclaw.run` span per OTel trace id (`rootRunSpanByOtelTrace`), recorded in `recordRunStarted`. Bounded (LRU, `MAX_TRACKED_ROOT_RUN_SPANS`) and cleared in `stopActiveTrustedSpans`.
- On `model.call.completed`, mirror the model-call I/O onto that root span — **first** call's input (kept via `traceIoInputStamped`), **latest** call's output — setting BOTH levels so both symptoms above are fixed:
  - `langfuse.trace.input` / `langfuse.trace.output` (trace level → Traces list + trace node)
  - `input.value` / `output.value` (observation level → the run node renders the conversation directly)

The model-call span keeps its own I/O unchanged. Only active when content capture is on (`diagnostics.otel.captureContent`), since `input.value`/`output.value` are gated by that policy.

## Real behavior proof

- **Behavior addressed:** the `openclaw.run` trace shows the conversation at the trace level (Traces list + trace header), and the `openclaw.run` observation node renders it directly without drilling into a child.
- **Real environment tested:** a live EC2 gateway running `@openclaw/diagnostics-otel` with `OPENCLAW_OTEL_PRELOADED` + `captureContent` on, exporting OTLP to self-hosted **Langfuse 3.177.0**. The logic here was validated as a bake-time patch on the shipped (minified) `dist/index.js` (same edits, un-minified in this diff), deployed via a baked AMI; the full pnpm/tsgo build of this branch was not run locally (monorepo size), so the validation is of the identical runtime logic.
- **Exact steps run after the patch:** confirmed the patched plugin on-box (`grep rootRunSpanByOtelTrace dist/index.js`; gateway `/readyz` → 200), triggered one real turn (`openclaw agent --session-id aai477-traceio-probe --message "..."`), then queried the Langfuse trace API.
- **Evidence after fix** (trace `e792dc43…`, name `openclaw.run`): trace `input` present (168 chars, the user message) + `output` present (276 chars, the assistant reply: "Observability is only as good as the signals yo…"). **Baseline before the patch:** the same query returned `input: null, output: null`. The follow-up commit additionally sets the observation-level attrs so the run node (not just the synthetic trace node) renders it — re-verified on the updated build.
- **What was not tested:** the upstream `pnpm` typecheck/`vitest` suite was not run locally (maintainer CI covers it); `node --experimental-strip-types --check` on `service.ts` passes. The probe was a single model-call turn — the multi-call "first input / latest output" path is exercised by the logic but not by a multi-call run.