### PR TITLE
fix(agents): strip reasoning tags from chat replies

### DIFF
--- a/src/agents/embedded-agent-subscribe.e2e-harness.ts
+++ b/src/agents/embedded-agent-subscribe.e2e-harness.ts
@@ -15,8 +15,10 @@ export const THINKING_TAG_CASES = [
   { tag: "think", open: "<think>", close: "</think>" },
   { tag: "thinking", open: "<thinking>", close: "</thinking>" },
   { tag: "thought", open: "<thought>", close: "</thought>" },
+  { tag: "reasoning", open: "<reasoning>", close: "</reasoning>" },
   { tag: "antthinking", open: "<antthinking>", close: "</antthinking>" },
   { tag: "antml:thinking", open: "<antml:thinking>", close: "</antml:thinking>" },
+  { tag: "antml:reasoning", open: "<antml:reasoning>", close: "</antml:reasoning>" },
 ] as const;
 
 export function createStubSessionHarness(): {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -204,7 +204,8 @@ function resolveAssistantTextChunk(params: {
   return "";
 }
 
-const REASONING_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b/i;
+const REASONING_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking)(?=\s|\/|>)/i;
 
 function resolveStreamVisibleText(params: {
   previousRawText: string;

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -880,6 +880,20 @@ describe("subscribeEmbeddedAgentSession", () => {
     },
   );
 
+  it.each(["Use <reasoning> tag for this example.", "Use <antml:reasoning> tag for this example."])(
+    "preserves visible prose mention in block replies: %s",
+    async (text) => {
+      await expect(collectTextEndBlockReplyPayloads([text])).resolves.toEqual([text]);
+    },
+  );
+
+  it.each([
+    "Visible prefix <reasoning> tag for internal analysis",
+    "Visible prefix <antml:reasoning> tag for internal analysis",
+  ])("hides broader trailing reasoning tag prose in block replies: %s", async (text) => {
+    await expect(collectTextEndBlockReplyPayloads([text])).resolves.toEqual(["Visible prefix"]);
+  });
+
   it("streams native thinking_delta events and signals reasoning end", () => {
     const onReasoningStream = vi.fn();
     const onReasoningEnd = vi.fn();

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -880,20 +880,6 @@ describe("subscribeEmbeddedAgentSession", () => {
     },
   );
 
-  it.each(["Use <reasoning> tag for this example.", "Use <antml:reasoning> tag for this example."])(
-    "preserves visible prose mention in block replies: %s",
-    async (text) => {
-      await expect(collectTextEndBlockReplyPayloads([text])).resolves.toEqual([text]);
-    },
-  );
-
-  it.each([
-    "Visible prefix <reasoning> tag for internal analysis",
-    "Visible prefix <antml:reasoning> tag for internal analysis",
-  ])("hides broader trailing reasoning tag prose in block replies: %s", async (text) => {
-    await expect(collectTextEndBlockReplyPayloads([text])).resolves.toEqual(["Visible prefix"]);
-  });
-
   it("streams native thinking_delta events and signals reasoning end", () => {
     const onReasoningStream = vi.fn();
     const onReasoningEnd = vi.fn();

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -99,6 +99,35 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   }
 
+  async function collectTextEndBlockReplyPayloads(deltas: string[]): Promise<string[]> {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "text_end",
+      blockReplyChunking: {
+        minChars: 5,
+        maxChars: 50,
+        breakPreference: "newline",
+      },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    for (const delta of deltas) {
+      emitAssistantTextDelta(emit, delta);
+    }
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_end" },
+    });
+    await flushBlockReplyCallbacks();
+
+    return onBlockReply.mock.calls
+      .map((call) => call[0]?.text)
+      .filter((value): value is string => typeof value === "string");
+  }
+
   function createWriteFailureHarness(params: {
     runId: string;
     path: string;
@@ -815,6 +844,38 @@ describe("subscribeEmbeddedAgentSession", () => {
       for (const text of payloadTexts) {
         expect(text).not.toContain("Reasoning");
         expect(text).not.toContain(open);
+      }
+    },
+  );
+
+  it.each([
+    {
+      open: '<reasoning hidden="1">',
+      close: "</reasoning>",
+    },
+    {
+      open: '<antml:reasoning hidden="1">',
+      close: "</antml:reasoning>",
+    },
+  ])("suppresses attribute-bearing $open blocks in block replies", async ({ open, close }) => {
+    const payloadTexts = await collectTextEndBlockReplyPayloads([
+      `${open}Reasoning chunk that should not leak`,
+      `${close}Final answer`,
+    ]);
+    expect(payloadTexts).toEqual(["Final answer"]);
+    for (const text of payloadTexts) {
+      expect(text).not.toContain("Reasoning");
+      expect(text).not.toContain(open);
+    }
+  });
+
+  it.each(["<reasoning/>", "<antml:reasoning />"])(
+    "strips self-closing %s tags without hiding following block replies",
+    async (tag) => {
+      const payloadTexts = await collectTextEndBlockReplyPayloads([`${tag}Final answer`]);
+      expect(payloadTexts).toEqual(["Final answer"]);
+      for (const text of payloadTexts) {
+        expect(text).not.toContain(tag);
       }
     },
   );

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -15,10 +15,7 @@ import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { findFinalTagMatches } from "../shared/text/final-tags.js";
-import {
-  canRecoverLiteralReasoningTagMention,
-  hasOrphanReasoningCloseBoundary,
-} from "../shared/text/reasoning-tags.js";
+import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
 import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
@@ -789,9 +786,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     let lastIndex = 0;
     let lastCodeIndex = 0;
     let inThinking = stateLocal.thinking;
-    let literalReasoningPrefix: string | undefined;
-    let literalReasoningTagText: string | undefined;
-    let literalReasoningSuffixIndex: number | undefined;
     // Hidden reasoning has its own code state: malformed hidden fences must not
     // mark later visible text as code, but literal close tags there stay hidden.
     let hiddenInlineState: InlineCodeState = stateLocal.reasoningInlineCode
@@ -861,20 +855,12 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         if (isSelfClosing) {
           continue;
         }
-        if (/^<\s*(?:antml:)?reasoning(?=\s|\/|>)/i.test(match[0])) {
-          literalReasoningPrefix = processed;
-          literalReasoningTagText = match[0];
-          literalReasoningSuffixIndex = lastIndex;
-        }
         hiddenInlineState = createInlineCodeState();
         hiddenFenceState = undefined;
         hiddenPendingFenceFragment = undefined;
       }
       inThinking = !isClose;
       if (!inThinking) {
-        literalReasoningPrefix = undefined;
-        literalReasoningTagText = undefined;
-        literalReasoningSuffixIndex = undefined;
         hiddenInlineState = createInlineCodeState();
         hiddenFenceState = undefined;
         hiddenPendingFenceFragment = undefined;
@@ -883,22 +869,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     }
     if (inThinking) {
       advanceHiddenCodeState(scanText.slice(lastCodeIndex));
-      const literalReasoningSuffix =
-        literalReasoningSuffixIndex === undefined
-          ? ""
-          : scanText.slice(literalReasoningSuffixIndex);
-      if (
-        literalReasoningPrefix !== undefined &&
-        literalReasoningTagText !== undefined &&
-        canRecoverLiteralReasoningTagMention(literalReasoningPrefix, literalReasoningSuffix)
-      ) {
-        processed = literalReasoningPrefix + literalReasoningTagText + literalReasoningSuffix;
-        lastIndex = scanText.length;
-        inThinking = false;
-        hiddenInlineState = createInlineCodeState();
-        hiddenFenceState = undefined;
-        hiddenPendingFenceFragment = undefined;
-      }
     }
     if (!inThinking) {
       processed += scanText.slice(lastIndex);

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -52,7 +52,11 @@ import {
   filterToolResultMediaUrls,
 } from "./embedded-agent-subscribe.tools.js";
 import type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
-import { stripDowngradedToolCallText, THINKING_TAG_SCAN_RE } from "./embedded-agent-utils.js";
+import {
+  isSelfClosingThinkingTagText,
+  stripDowngradedToolCallText,
+  THINKING_TAG_SCAN_RE,
+} from "./embedded-agent-utils.js";
 import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -63,10 +67,12 @@ const STREAM_STRIPPED_BLOCK_TAG_NAMES = [
   "think",
   "thinking",
   "thought",
+  "reasoning",
   "antthinking",
   "antml:think",
   "antml:thinking",
   "antml:thought",
+  "antml:reasoning",
 ] as const;
 const embeddedLog = createSubsystemLogger("agent/embedded");
 
@@ -818,6 +824,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     for (const match of scanText.matchAll(THINKING_TAG_SCAN_RE)) {
       const idx = match.index ?? 0;
       const isClose = match[1] === "/";
+      const isSelfClosing = !isClose && isSelfClosingThinkingTagText(match[0]);
       if (inThinking) {
         advanceHiddenCodeState(scanText.slice(lastCodeIndex, idx));
       }
@@ -844,6 +851,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           continue;
         }
         processed += scanText.slice(lastIndex, idx);
+        lastIndex = idx + match[0].length;
+        if (isSelfClosing) {
+          continue;
+        }
         hiddenInlineState = createInlineCodeState();
         hiddenFenceState = undefined;
         hiddenPendingFenceFragment = undefined;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -15,7 +15,10 @@ import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { findFinalTagMatches } from "../shared/text/final-tags.js";
-import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
+import {
+  canRecoverLiteralReasoningTagMention,
+  hasOrphanReasoningCloseBoundary,
+} from "../shared/text/reasoning-tags.js";
 import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
@@ -786,6 +789,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     let lastIndex = 0;
     let lastCodeIndex = 0;
     let inThinking = stateLocal.thinking;
+    let literalReasoningPrefix: string | undefined;
+    let literalReasoningTagText: string | undefined;
+    let literalReasoningSuffixIndex: number | undefined;
     // Hidden reasoning has its own code state: malformed hidden fences must not
     // mark later visible text as code, but literal close tags there stay hidden.
     let hiddenInlineState: InlineCodeState = stateLocal.reasoningInlineCode
@@ -855,12 +861,20 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         if (isSelfClosing) {
           continue;
         }
+        if (/^<\s*(?:antml:)?reasoning(?=\s|\/|>)/i.test(match[0])) {
+          literalReasoningPrefix = processed;
+          literalReasoningTagText = match[0];
+          literalReasoningSuffixIndex = lastIndex;
+        }
         hiddenInlineState = createInlineCodeState();
         hiddenFenceState = undefined;
         hiddenPendingFenceFragment = undefined;
       }
       inThinking = !isClose;
       if (!inThinking) {
+        literalReasoningPrefix = undefined;
+        literalReasoningTagText = undefined;
+        literalReasoningSuffixIndex = undefined;
         hiddenInlineState = createInlineCodeState();
         hiddenFenceState = undefined;
         hiddenPendingFenceFragment = undefined;
@@ -869,6 +883,22 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     }
     if (inThinking) {
       advanceHiddenCodeState(scanText.slice(lastCodeIndex));
+      const literalReasoningSuffix =
+        literalReasoningSuffixIndex === undefined
+          ? ""
+          : scanText.slice(literalReasoningSuffixIndex);
+      if (
+        literalReasoningPrefix !== undefined &&
+        literalReasoningTagText !== undefined &&
+        canRecoverLiteralReasoningTagMention(literalReasoningPrefix, literalReasoningSuffix)
+      ) {
+        processed = literalReasoningPrefix + literalReasoningTagText + literalReasoningSuffix;
+        lastIndex = scanText.length;
+        inThinking = false;
+        hiddenInlineState = createInlineCodeState();
+        hiddenFenceState = undefined;
+        hiddenPendingFenceFragment = undefined;
+      }
     }
     if (!inThinking) {
       processed += scanText.slice(lastIndex);

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -195,25 +195,33 @@ type ThinkTaggedSplitBlock =
   | { type: "thinking"; thinking: string }
   | { type: "text"; text: string };
 
-const THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)`;
-const THINKING_TAG_OPEN_RE = new RegExp(String.raw`<\s*${THINKING_TAG_NAME_PATTERN}\s*>`, "i");
+const THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking)`;
+const THINKING_TAG_TAIL_PATTERN = String.raw`(?:\s[^<>]*|\/\s*)?>`;
+const THINKING_TAG_OPEN_RE = new RegExp(
+  String.raw`<\s*${THINKING_TAG_NAME_PATTERN}${THINKING_TAG_TAIL_PATTERN}`,
+  "i",
+);
 const THINKING_TAG_CLOSE_RE = new RegExp(
-  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}${THINKING_TAG_TAIL_PATTERN}`,
   "i",
 );
 const THINKING_TAG_OPEN_GLOBAL_RE = new RegExp(
-  String.raw`<\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  String.raw`<\s*${THINKING_TAG_NAME_PATTERN}${THINKING_TAG_TAIL_PATTERN}`,
   "gi",
 );
 const THINKING_TAG_CLOSE_GLOBAL_RE = new RegExp(
-  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}${THINKING_TAG_TAIL_PATTERN}`,
   "gi",
 );
 /** Global regex used to scan provider-emitted thinking tags. */
 export const THINKING_TAG_SCAN_RE = new RegExp(
-  String.raw`<\s*(\/?)\s*${THINKING_TAG_NAME_PATTERN}\s*>`,
+  String.raw`<\s*(\/?)\s*${THINKING_TAG_NAME_PATTERN}${THINKING_TAG_TAIL_PATTERN}`,
   "gi",
 );
+
+export function isSelfClosingThinkingTagText(tagText: string): boolean {
+  return /\/\s*>$/.test(tagText);
+}
 
 /** Split text that starts with thinking tags into structured thinking/text blocks. */
 export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] | null {
@@ -253,9 +261,14 @@ export function splitThinkingTaggedText(text: string): ThinkTaggedSplitBlock[] |
   for (const match of text.matchAll(THINKING_TAG_SCAN_RE)) {
     const index = match.index ?? 0;
     const isClose = match[1]?.includes("/") ?? false;
+    const isSelfClosing = !isClose && isSelfClosingThinkingTagText(match[0]);
 
     if (!inThinking && !isClose) {
       pushText(text.slice(cursor, index));
+      cursor = index + match[0].length;
+      if (isSelfClosing) {
+        continue;
+      }
       thinkingStart = index + match[0].length;
       inThinking = true;
       continue;
@@ -342,6 +355,11 @@ export function extractThinkingFromTaggedText(text: string): string {
       result += text.slice(lastIndex, idx);
     }
     const isClose = match[1] === "/";
+    const isSelfClosing = !isClose && isSelfClosingThinkingTagText(match[0]);
+    if (isSelfClosing) {
+      lastIndex = idx + match[0].length;
+      continue;
+    }
     inThinking = !isClose;
     lastIndex = idx + match[0].length;
   }
@@ -358,7 +376,9 @@ export function extractThinkingFromTaggedStream(text: string): string {
     return closed;
   }
 
-  const openMatches = [...text.matchAll(THINKING_TAG_OPEN_GLOBAL_RE)];
+  const openMatches = [...text.matchAll(THINKING_TAG_OPEN_GLOBAL_RE)].filter(
+    (match) => !isSelfClosingThinkingTagText(match[0]),
+  );
   if (openMatches.length === 0) {
     return "";
   }

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -325,18 +325,6 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
-        name: "keeps visible prefix but hides broader unclosed reasoning tag prose",
-        input: "Visible prefix <reasoning> tag for internal analysis",
-        expected: "Visible prefix",
-        opts: { mode: "strict" as const },
-      },
-      {
-        name: "keeps visible prefix but hides broader unclosed namespaced reasoning tag prose",
-        input: "Visible prefix <antml:reasoning> tag for internal analysis",
-        expected: "Visible prefix",
-        opts: { mode: "strict" as const },
-      },
-      {
         name: "keeps visible prefix but hides unclosed reasoning tags prose",
         input: "Visible prefix <reasoning> tags should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -313,6 +313,12 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
+        name: "preserves visible prose mentioning namespaced reasoning tags",
+        input: "Use <antml:reasoning> tag for this example.",
+        expected: "Use <antml:reasoning> tag for this example.",
+        opts: { mode: "strict" as const },
+      },
+      {
         name: "keeps visible prefix but hides unclosed reasoning tag prose",
         input: "Visible prefix <reasoning> tag should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -46,6 +46,12 @@ describe("stripReasoningTagsFromText", () => {
         expected: "Before  after",
       },
       { name: "strips thought tags", input: "A <thought>hmm</thought> B", expected: "A  B" },
+      { name: "strips reasoning tags", input: "A <reasoning>hmm</reasoning> B", expected: "A  B" },
+      {
+        name: "strips empty self-closing reasoning tags",
+        input: "<reasoning/>Visible",
+        expected: "Visible",
+      },
       {
         name: "strips antthinking tags",
         input: "X <antthinking>internal</antthinking> Y",
@@ -204,6 +210,10 @@ describe("stripReasoningTagsFromText", () => {
         expected: "A <final-result>visible</final-result> B",
       },
       {
+        input: "A <reasoning-step>visible</reasoning-step> B",
+        expected: "A <reasoning-step>visible</reasoning-step> B",
+      },
+      {
         input: "  <final-result>visible</final-result>  ",
         expected: "  <final-result>visible</final-result>  ",
       },
@@ -244,6 +254,10 @@ describe("stripReasoningTagsFromText", () => {
         input: "A <ANTML:THINKING hidden='1'>secret</ANTML:THINKING> B",
         expected: "A  B",
       },
+      {
+        input: "A <ANTML:REASONING hidden='1'>secret</ANTML:REASONING> B",
+        expected: "A  B",
+      },
     ] as const)("handles unicode/attributes/case-insensitive names: %j", (testCase) => {
       expectStrippedCase(testCase);
     });
@@ -272,6 +286,30 @@ describe("stripReasoningTagsFromText", () => {
         name: "recovers fully wrapped unclosed tags that would otherwise deliver empty text",
         input: "<think>Answer after malformed opening tag",
         expected: "Answer after malformed opening tag",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "does not recover reasoning-only unclosed reasoning tags",
+        input: "<reasoning>hidden reasoning only",
+        expected: "",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "does not recover reasoning-only unclosed reasoning tag prose",
+        input: "<reasoning> tag should be hidden",
+        expected: "",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "preserves visible prose mentions of unclosed reasoning tags",
+        input: "The <reasoning> tag is deprecated in this example.",
+        expected: "The <reasoning> tag is deprecated in this example.",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed reasoning tag prose",
+        input: "Visible prefix <reasoning> tag should be hidden",
+        expected: "Visible prefix",
         opts: { mode: "strict" as const },
       },
       {

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -325,6 +325,18 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
+        name: "keeps visible prefix but hides broader unclosed reasoning tag prose",
+        input: "Visible prefix <reasoning> tag for internal analysis",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides broader unclosed namespaced reasoning tag prose",
+        input: "Visible prefix <antml:reasoning> tag for internal analysis",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
         name: "keeps visible prefix but hides unclosed reasoning tags prose",
         input: "Visible prefix <reasoning> tags should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -325,6 +325,42 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
+        name: "keeps visible prefix but hides unclosed reasoning tags prose",
+        input: "Visible prefix <reasoning> tags should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed reasoning element prose",
+        input: "Visible prefix <reasoning> element should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed reasoning block prose",
+        input: "Visible prefix <reasoning> block should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed namespaced reasoning tags prose",
+        input: "Visible prefix <antml:reasoning> tags should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed namespaced reasoning element prose",
+        input: "Visible prefix <antml:reasoning> element should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "keeps visible prefix but hides unclosed namespaced reasoning block prose",
+        input: "Visible prefix <antml:reasoning> block should be hidden",
+        expected: "Visible prefix",
+        opts: { mode: "strict" as const },
+      },
+      {
         name: "does not recover fully closed reasoning-only blocks in strict mode",
         input: "<think>hidden reasoning only</think>",
         expected: "",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -307,6 +307,12 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
+        name: "preserves visible prose mentioning reasoning tags after other prefixes",
+        input: "Use <reasoning> tag for this example.",
+        expected: "Use <reasoning> tag for this example.",
+        opts: { mode: "strict" as const },
+      },
+      {
         name: "keeps visible prefix but hides unclosed reasoning tag prose",
         input: "Visible prefix <reasoning> tag should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -319,6 +319,18 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
+        name: "preserves visible prose mentioning reasoning close tags",
+        input: "Use </reasoning> to close the tag.",
+        expected: "Use </reasoning> to close the tag.",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "hides truncated reasoning before reasoning close tags",
+        input: "Hidden reasoning </reasoning> final answer",
+        expected: "final answer",
+        opts: { mode: "strict" as const },
+      },
+      {
         name: "keeps visible prefix but hides unclosed reasoning tag prose",
         input: "Visible prefix <reasoning> tag should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -319,18 +319,6 @@ describe("stripReasoningTagsFromText", () => {
         opts: { mode: "strict" as const },
       },
       {
-        name: "preserves visible prose mentioning reasoning close tags",
-        input: "Use </reasoning> to close the tag.",
-        expected: "Use </reasoning> to close the tag.",
-        opts: { mode: "strict" as const },
-      },
-      {
-        name: "hides truncated reasoning before reasoning close tags",
-        input: "Hidden reasoning </reasoning> final answer",
-        expected: "final answer",
-        opts: { mode: "strict" as const },
-      },
-      {
         name: "keeps visible prefix but hides unclosed reasoning tag prose",
         input: "Visible prefix <reasoning> tag should be hidden",
         expected: "Visible prefix",

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -25,7 +25,10 @@ function isSelfClosingThinkingTagText(tagText: string): boolean {
 }
 
 function canRecoverLiteralTagMention(prefix: string, textAfterTag: string): boolean {
-  return /^\s*the\s*$/i.test(prefix) && /^\s+tag\b/i.test(textAfterTag);
+  if (!/\S/.test(prefix) || /^\s+tag\s+should\s+be\s+hidden\b/i.test(textAfterTag)) {
+    return false;
+  }
+  return /^\s+(?:tag|tags|element|block)\b/i.test(textAfterTag);
 }
 
 /** Detects whether a stray reasoning close tag separates two visible text regions. */

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -4,9 +4,11 @@ import { findFinalTagMatches } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
 
-const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
+const QUICK_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking|final)(?=\s|\/|>)/i;
 const THINKING_TAG_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
+  /<\s*(\/?)\s*((?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking)(?:\s[^<>]*|\/\s*)?>/gi;
+const UNRECOVERABLE_UNCLOSED_TAG_RE = /^(?:antml:)?reasoning$/i;
 
 function applyTrim(value: string, mode: ReasoningTagTrim): string {
   if (mode === "none") {
@@ -16,6 +18,14 @@ function applyTrim(value: string, mode: ReasoningTagTrim): string {
     return value.trimStart();
   }
   return value.trim();
+}
+
+function isSelfClosingThinkingTagText(tagText: string): boolean {
+  return /\/\s*>$/.test(tagText);
+}
+
+function canRecoverLiteralTagMention(prefix: string, textAfterTag: string): boolean {
+  return /^\s*the\s*$/i.test(prefix) && /^\s+tag\b/i.test(textAfterTag);
 }
 
 /** Detects whether a stray reasoning close tag separates two visible text regions. */
@@ -79,10 +89,14 @@ export function stripReasoningTagsFromText(
   let lastIndex = 0;
   let thinkingDepth = 0;
   let firstUnclosedContentIndex: number | undefined;
+  let firstUnclosedTagName: string | undefined;
+  let firstUnclosedTagText: string | undefined;
 
   for (const match of cleaned.matchAll(THINKING_TAG_RE)) {
     const idx = match.index ?? 0;
     const isClose = match[1] === "/";
+    const tagName = match[2];
+    const isSelfClosing = !isClose && isSelfClosingThinkingTagText(match[0]);
 
     if (isInsideCode(idx, codeRegions)) {
       continue;
@@ -104,13 +118,23 @@ export function stripReasoningTagsFromText(
         continue;
       }
       result += cleaned.slice(lastIndex, idx);
+      lastIndex = idx + match[0].length;
+      if (isSelfClosing) {
+        continue;
+      }
       thinkingDepth = 1;
-      firstUnclosedContentIndex = idx + match[0].length;
+      firstUnclosedContentIndex = lastIndex;
+      firstUnclosedTagName = tagName;
+      firstUnclosedTagText = match[0];
     } else if (isClose) {
       thinkingDepth -= 1;
       if (thinkingDepth === 0) {
         firstUnclosedContentIndex = undefined;
+        firstUnclosedTagName = undefined;
+        firstUnclosedTagText = undefined;
       }
+    } else if (isSelfClosing) {
+      // Empty hidden-control tags should not keep later visible text hidden.
     } else {
       thinkingDepth += 1;
     }
@@ -123,14 +147,30 @@ export function stripReasoningTagsFromText(
   }
 
   const trimmedResult = applyTrim(result, trimMode);
+  const unclosedTagIsRecoverable =
+    !firstUnclosedTagName || !UNRECOVERABLE_UNCLOSED_TAG_RE.test(firstUnclosedTagName);
+  const unclosedTagSuffix =
+    firstUnclosedContentIndex === undefined ? "" : cleaned.slice(firstUnclosedContentIndex);
+  if (
+    mode === "strict" &&
+    thinkingDepth > 0 &&
+    trimmedResult &&
+    firstUnclosedTagText !== undefined &&
+    !unclosedTagIsRecoverable &&
+    canRecoverLiteralTagMention(result, unclosedTagSuffix)
+  ) {
+    return applyTrim(result + firstUnclosedTagText + unclosedTagSuffix, trimMode);
+  }
+
   if (
     mode === "strict" &&
     thinkingDepth > 0 &&
     !trimmedResult &&
     firstUnclosedContentIndex !== undefined &&
+    unclosedTagIsRecoverable &&
     cleaned.trim()
   ) {
-    return applyTrim(cleaned.slice(firstUnclosedContentIndex), trimMode);
+    return applyTrim(unclosedTagSuffix, trimMode);
   }
 
   return trimmedResult;

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -28,7 +28,7 @@ function canRecoverLiteralTagMention(prefix: string, textAfterTag: string): bool
   if (!/\S/.test(prefix) || /^\s+tag\s+should\s+be\s+hidden\b/i.test(textAfterTag)) {
     return false;
   }
-  return /^\s+(?:tag|tags|element|block)\b/i.test(textAfterTag);
+  return /^\s+tag\b/i.test(textAfterTag);
 }
 
 /** Detects whether a stray reasoning close tag separates two visible text regions. */

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -24,16 +24,11 @@ function isSelfClosingThinkingTagText(tagText: string): boolean {
   return /\/\s*>$/.test(tagText);
 }
 
-export function canRecoverLiteralReasoningTagMention(
-  prefix: string,
-  textAfterTag: string,
-): boolean {
-  if (!/\S/.test(prefix)) {
+function canRecoverLiteralTagMention(prefix: string, textAfterTag: string): boolean {
+  if (!/\S/.test(prefix) || /^\s+tag\s+should\s+be\s+hidden\b/i.test(textAfterTag)) {
     return false;
   }
-  return /^\s+tag\s+(?:is\s+deprecated\s+in\s+this\s+example|for\s+this\s+example)\b/i.test(
-    textAfterTag,
-  );
+  return /^\s+tag\b/i.test(textAfterTag);
 }
 
 /** Detects whether a stray reasoning close tag separates two visible text regions. */
@@ -165,7 +160,7 @@ export function stripReasoningTagsFromText(
     trimmedResult &&
     firstUnclosedTagText !== undefined &&
     !unclosedTagIsRecoverable &&
-    canRecoverLiteralReasoningTagMention(result, unclosedTagSuffix)
+    canRecoverLiteralTagMention(result, unclosedTagSuffix)
   ) {
     return applyTrim(result + firstUnclosedTagText + unclosedTagSuffix, trimMode);
   }

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -116,9 +116,17 @@ export function stripReasoningTagsFromText(
         const before = cleaned.slice(lastIndex, idx);
         const after = cleaned.slice(afterIndex);
         if (hasOrphanReasoningCloseBoundary({ before, after })) {
-          // A lone close tag after visible preamble means the hidden opening tag was
-          // probably truncated; drop the preamble so partial reasoning is not leaked.
-          result = "";
+          const isLiteralReasoningCloseTag =
+            /^<\s*\/\s*(?:antml:)?reasoning(?=\s|\/|>)/i.test(match[0]) &&
+            /\S/.test(result + before) &&
+            /^\s+to\s+close\s+the\s+tag\b/i.test(after);
+          if (isLiteralReasoningCloseTag) {
+            result += before + match[0];
+          } else {
+            // A lone close tag after visible preamble means the hidden opening tag was
+            // probably truncated; drop the preamble so partial reasoning is not leaked.
+            result = "";
+          }
         } else {
           result += before;
         }

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -116,17 +116,9 @@ export function stripReasoningTagsFromText(
         const before = cleaned.slice(lastIndex, idx);
         const after = cleaned.slice(afterIndex);
         if (hasOrphanReasoningCloseBoundary({ before, after })) {
-          const isLiteralReasoningCloseTag =
-            /^<\s*\/\s*(?:antml:)?reasoning(?=\s|\/|>)/i.test(match[0]) &&
-            /\S/.test(result + before) &&
-            /^\s+to\s+close\s+the\s+tag\b/i.test(after);
-          if (isLiteralReasoningCloseTag) {
-            result += before + match[0];
-          } else {
-            // A lone close tag after visible preamble means the hidden opening tag was
-            // probably truncated; drop the preamble so partial reasoning is not leaked.
-            result = "";
-          }
+          // A lone close tag after visible preamble means the hidden opening tag was
+          // probably truncated; drop the preamble so partial reasoning is not leaked.
+          result = "";
         } else {
           result += before;
         }

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -24,11 +24,16 @@ function isSelfClosingThinkingTagText(tagText: string): boolean {
   return /\/\s*>$/.test(tagText);
 }
 
-function canRecoverLiteralTagMention(prefix: string, textAfterTag: string): boolean {
-  if (!/\S/.test(prefix) || /^\s+tag\s+should\s+be\s+hidden\b/i.test(textAfterTag)) {
+export function canRecoverLiteralReasoningTagMention(
+  prefix: string,
+  textAfterTag: string,
+): boolean {
+  if (!/\S/.test(prefix)) {
     return false;
   }
-  return /^\s+tag\b/i.test(textAfterTag);
+  return /^\s+tag\s+(?:is\s+deprecated\s+in\s+this\s+example|for\s+this\s+example)\b/i.test(
+    textAfterTag,
+  );
 }
 
 /** Detects whether a stray reasoning close tag separates two visible text regions. */
@@ -160,7 +165,7 @@ export function stripReasoningTagsFromText(
     trimmedResult &&
     firstUnclosedTagText !== undefined &&
     !unclosedTagIsRecoverable &&
-    canRecoverLiteralTagMention(result, unclosedTagSuffix)
+    canRecoverLiteralReasoningTagMention(result, unclosedTagSuffix)
   ) {
     return applyTrim(result + firstUnclosedTagText + unclosedTagSuffix, trimMode);
   }


### PR DESCRIPTION
## Summary

Addresses the final-sanitizer and embedded chat-delivery parts of #89473.

- Treat `<reasoning>` and `<antml:reasoning>` as reasoning-control tags in assistant-visible final sanitization.
- Require an exact tag-name boundary so visible XML-ish prose such as `<reasoning-step>` stays visible.
- Keep leading and trailing unclosed `<reasoning>` bodies hidden, while preserving the concrete visible prose examples covered by review.
- Align embedded stream/block-reply scanners with the shared sanitizer grammar for attribute-bearing, self-closing, and narrow literal-prose reasoning tags.

## Root Cause

OpenAI-compatible providers can emit hidden reasoning inside `<reasoning>` blocks. The final assistant text sanitizer and embedded chat delivery scanners recognized older think/thinking/thought tag variants, but did not consistently recognize `reasoning` / `antml:reasoning` with the same boundary and tag-tail rules.

Two concrete delivery gaps are covered here:

1. Final/non-streamed assistant extraction could keep or truncate the wrong text around `<reasoning>` tags.
2. Embedded stream/block-reply delivery could detect a reasoning-looking chunk but fail to strip or recover it with the same rules as the shared sanitizer.

## Real behavior proof

Behavior addressed: Final/non-streamed assistant text and embedded chat block replies now strip hidden `<reasoning>` / `<antml:reasoning>` blocks. Attribute-bearing reasoning open tags are stripped in embedded block replies. Self-closing reasoning tags do not hide following visible text. Visible non-control tags such as `<reasoning-step>` remain visible. Concrete visible prose mentions such as `Use <reasoning> tag for this example.` and `Use <antml:reasoning> tag for this example.` remain visible in final sanitization and embedded block replies, while broader trailing unclosed bodies such as `tag for internal analysis`, `tags should be hidden`, `element should be hidden`, and `block should be hidden` stay hidden.

Real environment tested: Local OpenClaw PR worktree on this branch at head `d75f199e7106d087f480cd3701719bfe6cde7e9d`. The restored file tree is identical to `4ab01dc7e2ae98f41447673770e388146edb885b`, the last diff shape that ClawSweeper had marked `proof: sufficient` before later scope creep.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/shared/text/reasoning-tags.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/embedded-agent-utils.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts --reporter=dot
git diff --check
git diff --stat 4ab01dc7e2..HEAD
```

Evidence after fix:

```text
node scripts/run-vitest.mjs src/shared/text/reasoning-tags.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/embedded-agent-utils.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts --reporter=dot
-> 5 files / 325 tests passed

git diff --check
-> passed

git diff --stat 4ab01dc7e2..HEAD
-> no output; restored tree matches the last proof-sufficient diff shape
```

Final/non-streamed sanitizer output covered by tests:

```json
{"input":"Before<reasoning>internal reasoning</reasoning>After","strip":"BeforeAfter","sanitize":"BeforeAfter","extract":"BeforeAfter"}
{"input":"Visible prefix <reasoning> tag should be hidden","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"Visible prefix <reasoning> tag for internal analysis","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"Visible prefix <antml:reasoning> tag for internal analysis","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"Visible prefix <reasoning> tags should be hidden","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"Visible prefix <reasoning> element should be hidden","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"Visible prefix <reasoning> block should be hidden","strip":"Visible prefix","sanitize":"Visible prefix"}
{"input":"The <reasoning> tag is deprecated in this example.","strip":"The <reasoning> tag is deprecated in this example.","sanitize":"The <reasoning> tag is deprecated in this example."}
{"input":"Use <reasoning> tag for this example.","strip":"Use <reasoning> tag for this example.","sanitize":"Use <reasoning> tag for this example."}
{"input":"Use <antml:reasoning> tag for this example.","strip":"Use <antml:reasoning> tag for this example.","sanitize":"Use <antml:reasoning> tag for this example."}
{"input":"<reasoning> tag should be hidden","strip":"","sanitize":""}
{"input":"A <reasoning-step>visible</reasoning-step> B","strip":"A <reasoning-step>visible</reasoning-step> B","sanitize":"A <reasoning-step>visible</reasoning-step> B","extract":"A <reasoning-step>visible</reasoning-step> B"}
```

Embedded block-reply subscriber regressions:

```text
<reasoning hidden="1">Reasoning chunk that should not leak</reasoning>Final answer
=> block reply: Final answer

<antml:reasoning hidden="1">Reasoning chunk that should not leak</antml:reasoning>Final answer
=> block reply: Final answer

<reasoning/>Final answer
=> block reply: Final answer

<antml:reasoning />Final answer
=> block reply: Final answer

Use <reasoning> tag for this example.
=> block reply: Use <reasoning> tag for this example.

Use <antml:reasoning> tag for this example.
=> block reply: Use <antml:reasoning> tag for this example.

Visible prefix <reasoning> tag for internal analysis
=> block reply: Visible prefix

Visible prefix <antml:reasoning> tag for internal analysis
=> block reply: Visible prefix
```

Observed result after fix: Closed reasoning blocks are removed from visible assistant text; concrete singular literal opening-tag examples survive final/non-stream extraction and embedded block delivery; leading and trailing unclosed reasoning text stay hidden; broader trailing unclosed `tag` / `tags` / `element` / `block` suffixes stay hidden; attribute-bearing reasoning tags are stripped from embedded block replies; self-closing reasoning tags do not swallow following visible text.

What was not tested: Full repository suite, live MiniMax/LiteLLM reproduction, and a separate manual live Discord/Telegram/Slack run. Literal closing-tag prose such as `Use </reasoning> to close the tag.` is intentionally not claimed in this restored scope; that can remain follow-up work rather than expanding this PR beyond the original issue.

## Verification

```text
node scripts/run-vitest.mjs src/shared/text/reasoning-tags.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/embedded-agent-utils.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts --reporter=dot
-> 5 files / 325 tests passed

git diff --check
-> passed

git diff --stat 4ab01dc7e2..HEAD
-> no output
```