### PR TITLE
fix(plugins): isolate capability provider rows

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -451,6 +451,78 @@ describe("resolvePluginCapabilityProviders", () => {
     expectInitialRuntimeRegistryLookup();
   });
 
+  it("skips malformed active capability provider rows during direct lookup", () => {
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push(
+      {
+        pluginId: "bad",
+        pluginName: "Bad",
+        source: "test",
+        provider: {
+          get id() {
+            throw new Error("poison provider id");
+          },
+          label: "Bad",
+        },
+      } as never,
+      {
+        pluginId: "healthy",
+        pluginName: "Healthy",
+        source: "test",
+        provider: {
+          id: "healthy",
+          label: "Healthy",
+          isConfigured: () => true,
+          synthesize: async () => ({
+            audioBuffer: Buffer.from("x"),
+            outputFormat: "mp3",
+            voiceCompatible: false,
+            fileExtension: ".mp3",
+          }),
+        },
+      } as never,
+    );
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+
+    expect(
+      resolvePluginCapabilityProvider({
+        key: "speechProviders",
+        providerId: "healthy",
+      })?.id,
+    ).toBe("healthy");
+  });
+
+  it("keeps direct capability provider lookup when aliases are unreadable", () => {
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push({
+      pluginId: "healthy",
+      pluginName: "Healthy",
+      source: "test",
+      provider: {
+        id: "healthy",
+        label: "Healthy",
+        get aliases() {
+          throw new Error("poison aliases");
+        },
+        isConfigured: () => true,
+        synthesize: async () => ({
+          audioBuffer: Buffer.from("x"),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        }),
+      },
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+
+    expect(
+      resolvePluginCapabilityProvider({
+        key: "speechProviders",
+        providerId: "healthy",
+      })?.id,
+    ).toBe("healthy");
+  });
+
   it("targets enabled external capability plugins without bundled fallback capture", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.imageGenerationProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -51,6 +51,14 @@ type CapabilityContractKey =
 
 type CapabilityProviderForKey<K extends CapabilityProviderRegistryKey> =
   PluginRegistry[K][number] extends { provider: infer T } ? T : never;
+type CapabilityProviderEntryForKey<K extends CapabilityProviderRegistryKey> =
+  PluginRegistry[K][number];
+type ReadableCapabilityProviderEntry<K extends CapabilityProviderRegistryKey> = {
+  entry: CapabilityProviderEntryForKey<K>;
+  provider: CapabilityProviderForKey<K> & { id?: unknown; aliases?: unknown };
+  id?: string;
+  aliases: readonly unknown[];
+};
 type CapabilityProviderEntries = PluginRegistry[CapabilityProviderRegistryKey];
 type CapabilityPluginResolution = {
   runtimePluginIds: string[];
@@ -221,15 +229,61 @@ function findProviderById<K extends CapabilityProviderRegistryKey>(
   entries: PluginRegistry[K],
   providerId: string,
 ): CapabilityProviderForKey<K> | undefined {
-  const providerEntries = entries as unknown as Array<{
-    provider: CapabilityProviderForKey<K> & { id?: unknown };
-  }>;
-  for (const entry of providerEntries) {
-    if (entry.provider.id === providerId) {
-      return entry.provider;
+  for (const entry of entries) {
+    const readable = readCapabilityProviderEntry(entry);
+    if (readable?.id === providerId) {
+      return readable.provider;
     }
   }
   return undefined;
+}
+
+function readCapabilityProviderEntry<K extends CapabilityProviderRegistryKey>(
+  entry: CapabilityProviderEntryForKey<K>,
+): ReadableCapabilityProviderEntry<K> | null {
+  try {
+    const provider = (entry as { provider?: unknown }).provider;
+    if (!provider || typeof provider !== "object") {
+      return null;
+    }
+    const providerRecord = provider as CapabilityProviderForKey<K> & {
+      id?: unknown;
+      aliases?: unknown;
+    };
+    let id: unknown;
+    try {
+      id = providerRecord.id;
+    } catch {
+      return null;
+    }
+    let aliases: unknown;
+    try {
+      aliases = providerRecord.aliases;
+    } catch {
+      aliases = undefined;
+    }
+    return {
+      entry,
+      provider: providerRecord,
+      ...(typeof id === "string" ? { id } : {}),
+      aliases: Array.isArray(aliases) ? aliases : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function listReadableCapabilityProviders<K extends CapabilityProviderRegistryKey>(
+  entries: PluginRegistry[K],
+): CapabilityProviderForKey<K>[] {
+  const providers: CapabilityProviderForKey<K>[] = [];
+  for (const entry of entries) {
+    const readable = readCapabilityProviderEntry(entry);
+    if (readable) {
+      providers.push(readable.provider);
+    }
+  }
+  return providers;
 }
 
 function mergeCapabilityProviders<K extends CapabilityProviderRegistryKey>(
@@ -240,13 +294,16 @@ function mergeCapabilityProviders<K extends CapabilityProviderRegistryKey>(
   const unnamed: CapabilityProviderForKey<K>[] = [];
   const addEntries = (entries: PluginRegistry[K]) => {
     for (const entry of entries) {
-      const provider = entry.provider as CapabilityProviderForKey<K> & { id?: string };
-      if (!provider.id) {
-        unnamed.push(provider);
+      const readable = readCapabilityProviderEntry(entry);
+      if (!readable) {
         continue;
       }
-      if (!merged.has(provider.id)) {
-        merged.set(provider.id, provider);
+      if (!readable.id) {
+        unnamed.push(readable.provider);
+        continue;
+      }
+      if (!merged.has(readable.id)) {
+        merged.set(readable.id, readable.provider);
       }
     }
   };
@@ -264,13 +321,16 @@ function mergeCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>
   const unnamed: Array<PluginRegistry[K][number]> = [];
   const addEntries = (entries: PluginRegistry[K]) => {
     for (const entry of entries) {
-      const provider = entry.provider as { id?: string };
-      if (!provider.id) {
-        unnamed.push(entry);
+      const readable = readCapabilityProviderEntry(entry);
+      if (!readable) {
         continue;
       }
-      if (!merged.has(provider.id)) {
-        merged.set(provider.id, entry);
+      if (!readable.id) {
+        unnamed.push(readable.entry);
+        continue;
+      }
+      if (!merged.has(readable.id)) {
+        merged.set(readable.id, readable.entry);
       }
     }
   };
@@ -392,16 +452,17 @@ function shouldScopeCapabilityLoadToRequestedProviders(
 }
 
 function removeActiveProviderIds(requested: Set<string>, entries: readonly unknown[]): void {
-  for (const entry of entries as Array<{ provider: { id?: unknown; aliases?: unknown } }>) {
-    const provider = entry.provider as { id?: unknown; aliases?: unknown };
-    if (typeof provider.id === "string") {
-      requested.delete(provider.id.toLowerCase());
+  for (const entry of entries as PluginRegistry[CapabilityProviderRegistryKey]) {
+    const readable = readCapabilityProviderEntry(entry);
+    if (!readable) {
+      continue;
     }
-    if (Array.isArray(provider.aliases)) {
-      for (const alias of provider.aliases) {
-        if (typeof alias === "string") {
-          requested.delete(alias.toLowerCase());
-        }
+    if (readable.id) {
+      requested.delete(readable.id.toLowerCase());
+    }
+    for (const alias of readable.aliases) {
+      if (typeof alias === "string") {
+        requested.delete(alias.toLowerCase());
       }
     }
   }
@@ -424,16 +485,16 @@ function filterLoadedProvidersForRequestedConfig<K extends CapabilityProviderReg
     return [] as unknown as PluginRegistry[K];
   }
   return params.entries.filter((entry) => {
-    const provider = entry.provider as { id?: unknown; aliases?: unknown };
-    if (typeof provider.id === "string" && params.requested.has(provider.id.toLowerCase())) {
+    const readable = readCapabilityProviderEntry(entry);
+    if (!readable) {
+      return false;
+    }
+    if (readable.id && params.requested.has(readable.id.toLowerCase())) {
       return true;
     }
-    if (Array.isArray(provider.aliases)) {
-      return provider.aliases.some(
-        (alias) => typeof alias === "string" && params.requested.has(alias.toLowerCase()),
-      );
-    }
-    return false;
+    return readable.aliases.some(
+      (alias) => typeof alias === "string" && params.requested.has(alias.toLowerCase()),
+    );
   }) as PluginRegistry[K];
 }
 
@@ -604,12 +665,12 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
       : undefined;
   if (activeProviders.length > 0 && params.key !== "memoryEmbeddingProviders") {
     if (!missingRequestedProviders && !shouldMergeManifestProvidersWhenActive(params.key)) {
-      return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+      return listReadableCapabilityProviders(activeProviders);
     }
     if (missingRequestedProviders) {
       removeActiveProviderIds(missingRequestedProviders, activeProviders);
       if (missingRequestedProviders.size === 0) {
-        return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+        return listReadableCapabilityProviders(activeProviders);
       }
     }
   }

--- a/src/plugins/provider-registry-shared.test.ts
+++ b/src/plugins/provider-registry-shared.test.ts
@@ -18,4 +18,30 @@ describe("provider registry shared", () => {
     expect(aliases.get("ms")?.id).toBe("Microsoft");
     expect(aliases.get("openai")?.id).toBe("OpenAI");
   });
+
+  it("skips providers with unreadable ids", () => {
+    const broken = Object.defineProperty({ aliases: ["bad"] }, "id", {
+      get() {
+        throw new Error("provider id exploded");
+      },
+    });
+
+    const { canonical, aliases } = buildCapabilityProviderMaps([broken as never, { id: "OpenAI" }]);
+
+    expect([...canonical.keys()]).toEqual(["openai"]);
+    expect([...aliases.keys()]).toEqual(["openai"]);
+  });
+
+  it("keeps canonical providers when aliases are unreadable", () => {
+    const provider = Object.defineProperty({ id: "OpenAI" }, "aliases", {
+      get() {
+        throw new Error("provider aliases exploded");
+      },
+    });
+
+    const { canonical, aliases } = buildCapabilityProviderMaps([provider as never]);
+
+    expect([...canonical.keys()]).toEqual(["openai"]);
+    expect([...aliases.keys()]).toEqual(["openai"]);
+  });
 });

--- a/src/plugins/provider-registry-shared.ts
+++ b/src/plugins/provider-registry-shared.ts
@@ -17,13 +17,24 @@ export function buildCapabilityProviderMaps<T extends { id: string; aliases?: re
   const aliases = new Map<string, T>();
 
   for (const provider of providers) {
-    const id = normalizeId(provider.id);
+    let id: string | undefined;
+    let rawAliases: readonly string[] | undefined;
+    try {
+      id = normalizeId(provider.id);
+    } catch {
+      continue;
+    }
+    try {
+      rawAliases = provider.aliases;
+    } catch {
+      rawAliases = undefined;
+    }
     if (!id) {
       continue;
     }
     canonical.set(id, provider);
     aliases.set(id, provider);
-    for (const alias of provider.aliases ?? []) {
+    for (const alias of rawAliases ?? []) {
       const normalizedAlias = normalizeId(alias);
       if (normalizedAlias) {
         aliases.set(normalizedAlias, provider);


### PR DESCRIPTION
## Summary

- guard capability provider registry rows before reading provider ids or aliases
- skip malformed provider rows while preserving direct lookup for providers whose aliases are unreadable
- apply the same boundary behavior to the shared capability provider map builder

## Verification

- `node scripts/run-vitest.mjs src/plugins/capability-provider-runtime.test.ts src/plugins/provider-registry-shared.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/capability-provider-runtime.ts src/plugins/capability-provider-runtime.test.ts src/plugins/provider-registry-shared.ts src/plugins/provider-registry-shared.test.ts`
- `./node_modules/.bin/oxlint src/plugins/capability-provider-runtime.ts src/plugins/capability-provider-runtime.test.ts src/plugins/provider-registry-shared.ts src/plugins/provider-registry-shared.test.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed active capability provider rows can no longer crash direct provider lookup or shared provider map construction before healthy providers are considered.

Real environment tested: local OpenClaw Codex worktree with linked repo dependencies.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/capability-provider-runtime.test.ts src/plugins/provider-registry-shared.test.ts`

Evidence after fix: focused Vitest passed 2 shards: `src/plugins/provider-registry-shared.test.ts` and `src/plugins/capability-provider-runtime.test.ts`.

Observed result after fix: unreadable provider ids are skipped, unreadable aliases do not drop otherwise valid providers, and healthy providers remain discoverable.

What was not tested: remote `pnpm check:changed` could not lease a Crabbox runner because the coordinator returned HTTP 401 before lease creation; provider was azure, slug was `amber-barnacle`.
