### PR TITLE
fix(gateway): isolate method descriptor rows

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -218,6 +218,29 @@ describe("method scope resolution", () => {
     ]);
   });
 
+  it("skips unreadable plugin gateway method descriptors during scope lookup", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["browser.request"] = pluginHandler;
+    registry.gatewayMethodDescriptors.push(
+      Object.defineProperty({}, "name", {
+        get() {
+          throw new Error("gateway descriptor exploded");
+        },
+      }) as never,
+      createPluginGatewayMethodDescriptor({
+        pluginId: "browser",
+        name: "browser.request",
+        handler: pluginHandler,
+        scope: "operator.read",
+      }),
+    );
+    setActivePluginRegistry(registry);
+
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("browser.request")).toEqual([
+      "operator.read",
+    ]);
+  });
+
   it("keeps reserved admin namespaces admin-only even if a plugin scope is narrower", () => {
     setPluginGatewayMethodScope(RESERVED_ADMIN_PLUGIN_METHOD, "operator.read");
 

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -7,6 +7,7 @@ import {
   isDynamicOperatorGatewayMethod,
   resolveCoreOperatorGatewayMethodScope,
 } from "./methods/core-descriptors.js";
+import { resolveGatewayMethodDescriptorScope } from "./methods/registry.js";
 import {
   ADMIN_SCOPE,
   APPROVALS_SCOPE,
@@ -49,10 +50,10 @@ function resolveScopedMethod(method: string): OperatorScope | undefined {
   if (reservedScope) {
     return reservedScope;
   }
-  const pluginDescriptor = getPluginRegistryState()?.activeRegistry?.gatewayMethodDescriptors?.find(
-    (descriptor) => descriptor.name === method,
+  const pluginScope = resolveGatewayMethodDescriptorScope(
+    getPluginRegistryState()?.activeRegistry?.gatewayMethodDescriptors,
+    method,
   );
-  const pluginScope = pluginDescriptor?.scope;
   return pluginScope === "node" || pluginScope === "dynamic" ? undefined : pluginScope;
 }
 

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -8,6 +8,8 @@ import {
   createGatewayMethodRegistry,
   createPluginGatewayMethodDescriptors,
   createPluginGatewayMethodDescriptor,
+  listGatewayMethodDescriptorNames,
+  resolveGatewayMethodDescriptorScope,
 } from "./registry.js";
 
 const handler: GatewayRequestHandler = ({ respond }) => respond(true, { ok: true });
@@ -103,5 +105,71 @@ describe("gateway method registry", () => {
     expect(registry.listMethods()).toEqual(["legacy.ping"]);
     expect(registry.getHandler("legacy.ping")).toBe(handler);
     expect(registry.getScope("legacy.ping")).toBe(ADMIN_SCOPE);
+  });
+
+  it("skips unreadable plugin gateway method descriptor rows", () => {
+    const poisonedDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("gateway descriptor exploded");
+      },
+    });
+    const healthyDescriptor = createPluginGatewayMethodDescriptor({
+      pluginId: "healthy",
+      name: "healthy.ping",
+      handler,
+      scope: READ_SCOPE,
+    });
+
+    const descriptors = createPluginGatewayMethodDescriptors({
+      gatewayHandlers: { "healthy.ping": handler },
+      gatewayMethodDescriptors: [poisonedDescriptor as never, healthyDescriptor],
+    });
+    const registry = createGatewayMethodRegistry(descriptors);
+
+    expect(registry.listMethods()).toEqual(["healthy.ping"]);
+    expect(registry.getScope("healthy.ping")).toBe(READ_SCOPE);
+  });
+
+  it("reads gateway method descriptor names and scopes row-locally", () => {
+    const poisonedDescriptor = Object.defineProperties(
+      {},
+      {
+        name: {
+          get() {
+            throw new Error("gateway descriptor name exploded");
+          },
+        },
+        scope: {
+          get() {
+            throw new Error("gateway descriptor scope exploded");
+          },
+        },
+      },
+    );
+    const unreadableScopeDescriptor = Object.defineProperty({ name: "healthy.ping" }, "scope", {
+      get() {
+        throw new Error("gateway descriptor scope exploded");
+      },
+    });
+    const healthyDescriptor = createPluginGatewayMethodDescriptor({
+      pluginId: "healthy",
+      name: "healthy.ping",
+      handler,
+      scope: WRITE_SCOPE,
+    });
+
+    expect(
+      listGatewayMethodDescriptorNames([
+        poisonedDescriptor,
+        unreadableScopeDescriptor,
+        healthyDescriptor,
+      ]),
+    ).toEqual(["healthy.ping", "healthy.ping"]);
+    expect(
+      resolveGatewayMethodDescriptorScope(
+        [poisonedDescriptor, unreadableScopeDescriptor, healthyDescriptor],
+        "healthy.ping",
+      ),
+    ).toBe(WRITE_SCOPE);
   });
 });

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -8,6 +8,7 @@ import {
 import {
   DYNAMIC_GATEWAY_METHOD_SCOPE,
   type GatewayMethodDescriptor,
+  type GatewayMethodScope,
   type GatewayMethodHandler,
   type GatewayMethodDescriptorInput,
   type GatewayMethodOwner,
@@ -20,6 +21,33 @@ export { createCoreGatewayMethodDescriptors, isCoreGatewayMethodClassified };
 
 function normalizeMethodName(name: string): string {
   return name.trim();
+}
+
+function readGatewayMethodDescriptorName(descriptor: unknown): string | undefined {
+  try {
+    const name = (descriptor as { name?: unknown }).name;
+    return typeof name === "string" ? normalizeMethodName(name) || undefined : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readGatewayMethodDescriptorScope(descriptor: unknown): GatewayMethodScope | undefined {
+  try {
+    return (descriptor as { scope?: GatewayMethodScope }).scope;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeReadablePluginDescriptor(
+  descriptor: unknown,
+): GatewayMethodDescriptorInput | undefined {
+  try {
+    return normalizeDescriptor(descriptor as GatewayMethodDescriptorInput);
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethodDescriptor {
@@ -48,6 +76,37 @@ function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethod
     ...(input.controlPlaneWrite === true ? { controlPlaneWrite: true } : {}),
     ...(input.advertise === false ? { advertise: false } : {}),
   };
+}
+
+/** Lists readable method names from plugin/channel-owned descriptor rows. */
+export function listGatewayMethodDescriptorNames(
+  descriptors: readonly unknown[] | undefined,
+): string[] {
+  const names: string[] = [];
+  for (const descriptor of descriptors ?? []) {
+    const name = readGatewayMethodDescriptorName(descriptor);
+    if (name) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+/** Resolves the scope for a readable plugin gateway method descriptor. */
+export function resolveGatewayMethodDescriptorScope(
+  descriptors: readonly unknown[] | undefined,
+  method: string,
+): GatewayMethodScope | undefined {
+  for (const descriptor of descriptors ?? []) {
+    if (readGatewayMethodDescriptorName(descriptor) !== method) {
+      continue;
+    }
+    const scope = readGatewayMethodDescriptorScope(descriptor);
+    if (scope !== undefined) {
+      return scope;
+    }
+  }
+  return undefined;
 }
 
 /** Creates a read-only registry for gateway method lookup, listing, and policy metadata. */
@@ -123,7 +182,10 @@ export function createPluginGatewayMethodDescriptors(
 ): GatewayMethodDescriptorInput[] {
   const descriptors = registry.gatewayMethodDescriptors ?? [];
   if (descriptors.length > 0) {
-    return [...descriptors];
+    return descriptors.flatMap((descriptor) => {
+      const normalized = normalizeReadablePluginDescriptor(descriptor);
+      return normalized ? [normalized] : [];
+    });
   }
   // Older plugin registries only carried handlers, so keep them callable but assign admin scope
   // until the plugin can provide explicit descriptor metadata.

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,6 +1,7 @@
 import { listLoadedChannelPlugins } from "../channels/plugins/registry-loaded.js";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 import { listCoreAdvertisedGatewayMethodNames } from "./methods/core-descriptors.js";
+import { listGatewayMethodDescriptorNames } from "./methods/registry.js";
 import { GATEWAY_AUX_METHODS } from "./server-aux-methods.js";
 
 type GatewayMethodChannelPlugin = {
@@ -19,9 +20,7 @@ function listChannelGatewayMethods(): string[] {
     // Plugins may still expose legacy names while newer plugins expose descriptors.
     // Merge both so method discovery stays compatible during descriptor adoption.
     methods.push(...(plugin.gatewayMethods ?? []));
-    for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-      methods.push(descriptor.name);
-    }
+    methods.push(...listGatewayMethodDescriptorNames(plugin.gatewayMethodDescriptors));
   }
   return methods;
 }

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -180,6 +180,44 @@ describe("webHandlers web.login.start", () => {
       undefined,
     );
   });
+
+  it("skips unreadable gateway method descriptors while resolving the login provider", async () => {
+    const poisonedDescriptor = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("gateway descriptor exploded");
+      },
+    });
+    const loginWithQrStart = vi.fn().mockResolvedValue({ connected: true });
+    mocks.listChannelPlugins.mockReturnValue([
+      {
+        id: "bad",
+        gatewayMethodDescriptors: [poisonedDescriptor],
+      },
+      {
+        id: "whatsapp",
+        gatewayMethodDescriptors: [{ name: "web.login.start" }],
+        gateway: { loginWithQrStart },
+      },
+    ]);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+        },
+      ),
+    );
+
+    expect(loginWithQrStart).toHaveBeenCalledWith({
+      accountId: "default",
+      force: false,
+      timeoutMs: undefined,
+      verbose: false,
+    });
+    expect(respond).toHaveBeenCalledWith(true, { connected: true }, undefined);
+  });
 });
 
 describe("webHandlers web.login.wait", () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { listGatewayMethodDescriptorNames } from "../methods/registry.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -17,7 +18,7 @@ const resolveWebLoginProvider = () =>
   listChannelPlugins().find((plugin) =>
     [
       ...(plugin.gatewayMethods ?? []),
-      ...(plugin.gatewayMethodDescriptors ?? []).map((descriptor) => descriptor.name),
+      ...listGatewayMethodDescriptorNames(plugin.gatewayMethodDescriptors),
     ].some((method) => WEB_LOGIN_METHODS.has(method)),
   ) ?? null;
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -65,6 +65,7 @@ import {
   createGatewayMethodRegistry,
   createPluginGatewayMethodDescriptors,
   isCoreGatewayMethodClassified,
+  listGatewayMethodDescriptorNames,
   type GatewayMethodRegistry,
 } from "./methods/registry.js";
 import { isLoopbackHost } from "./net.js";
@@ -730,9 +731,7 @@ export async function startGatewayServer(
     const methods: string[] = [];
     for (const plugin of listGatewayStartupChannelPlugins()) {
       methods.push(...(plugin.gatewayMethods ?? []));
-      for (const descriptor of plugin.gatewayMethodDescriptors ?? []) {
-        methods.push(descriptor.name);
-      }
+      methods.push(...listGatewayMethodDescriptorNames(plugin.gatewayMethodDescriptors));
     }
     return methods;
   };


### PR DESCRIPTION
## Summary

- guard plugin/channel gateway method descriptor reads before listing method names or scopes
- skip malformed descriptor rows while preserving healthy method discovery and QR-login provider resolution
- keep plugin descriptor registry construction row-local so one bad descriptor does not drop later healthy plugin methods

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts src/gateway/methods/registry.test.ts src/gateway/method-scopes.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/methods/registry.ts src/gateway/methods/registry.test.ts src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts src/gateway/server-methods-list.ts src/gateway/server.impl.ts`
- `./node_modules/.bin/oxlint src/gateway/methods/registry.ts src/gateway/methods/registry.test.ts src/gateway/method-scopes.ts src/gateway/method-scopes.test.ts src/gateway/server-methods/web.ts src/gateway/server-methods/web.start.test.ts src/gateway/server-methods-list.ts src/gateway/server.impl.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed plugin/channel gateway method descriptor rows can no longer crash method listing, scope lookup, web-login provider resolution, or plugin method registry construction before healthy descriptors are processed.

Real environment tested: local OpenClaw Codex worktree with linked repo dependencies.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts src/gateway/methods/registry.test.ts src/gateway/method-scopes.test.ts`

Evidence after fix: focused gateway Vitest shard passed: 10 files / 342 tests.

Observed result after fix: unreadable descriptor rows are skipped, healthy gateway method descriptors still advertise and resolve, and scope lookup remains conservative for unclassified plugin methods.

What was not tested: remote `pnpm check:changed` could not lease a Crabbox runner because the coordinator returned HTTP 401 before lease creation; provider was azure, slug was `coral-hermit`.
