### PR TITLE
fix(doctor): merge disjoint openai-codex model entries into canonical openai provider

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -324,7 +324,7 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
-  it("does not report a skipped codex merge when blocked provider needs no mutation", () => {
+  it("reports blocked codex merges after legacy api normalization already ran", () => {
     const res = migrateLegacyConfigForTest({
       models: {
         providers: {
@@ -343,8 +343,14 @@ describe("legacy memory search config migrate", () => {
       },
     });
 
-    expect(res.config).toBeNull();
-    expect(res.changes).toEqual([]);
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expect(res.changes).toEqual([
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.params.",
+    ]);
   });
 
   it("merges distinct legacy model ids even when display names collide", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -254,6 +254,7 @@ describe("legacy memory search config migrate", () => {
             api: "openai-responses",
             apiKey: "OPENAI_API_KEY",
             baseUrl: "https://api.openai.com/v1",
+            params: { store: true },
             request: { retry: { maxAttempts: 1 } },
             models: [{ id: "text-embedding-3-small" }],
           },
@@ -270,6 +271,7 @@ describe("legacy memory search config migrate", () => {
       api: "openai-responses",
       apiKey: "OPENAI_API_KEY",
       baseUrl: "https://api.openai.com/v1",
+      params: { store: true },
       request: { retry: { maxAttempts: 1 } },
       models: [{ id: "text-embedding-3-small" }],
     });
@@ -281,7 +283,41 @@ describe("legacy memory search config migrate", () => {
     expectMigrationChangesToIncludeFragments(res.changes, [
       'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses"',
       'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
-      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.apiKey, models.providers.openai.request",
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.apiKey, models.providers.openai.params, models.providers.openai.request",
+    ]);
+  });
+
+  it("merges distinct legacy model ids even when display names collide", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5-platform", name: "GPT-5.5" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai?.models).toEqual([
+      { id: "gpt-5.5-platform", name: "GPT-5.5" },
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+      },
+    ]);
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5",
     ]);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -218,7 +218,6 @@ describe("legacy memory search config migrate", () => {
             maxTokens: 8192,
             params: { store: false },
             agentRuntime: { id: "codex" },
-            headers: { "x-openclaw-test": "codex" },
             models: [{ id: "gpt-5.5" }],
           },
         },
@@ -237,7 +236,6 @@ describe("legacy memory search config migrate", () => {
         maxTokens: 8192,
         params: { store: false },
         agentRuntime: { id: "codex" },
-        headers: { "x-openclaw-test": "codex" },
       },
     ]);
     expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
@@ -284,6 +282,45 @@ describe("legacy memory search config migrate", () => {
       'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses"',
       'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
       "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.apiKey, models.providers.openai.params, models.providers.openai.request",
+    ]);
+  });
+
+  it("keeps legacy codex provider when legacy auth or headers cannot be model-scoped", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            auth: "oauth",
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            headers: { Authorization: "Bearer token" },
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [{ id: "text-embedding-3-small" }],
+    });
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      headers: { Authorization: "Bearer token" },
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses"',
+      'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai-codex.auth, models.providers.openai-codex.headers",
     ]);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -201,6 +201,90 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("preserves model-scoped legacy provider defaults when merging codex models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            contextWindow: 200000,
+            contextTokens: 180000,
+            maxTokens: 8192,
+            params: { store: false },
+            agentRuntime: { id: "codex" },
+            headers: { "x-openclaw-test": "codex" },
+            models: [{ id: "gpt-5.5" }],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai?.models).toEqual([
+      { id: "text-embedding-3-small" },
+      {
+        id: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        contextWindow: 200000,
+        contextTokens: 180000,
+        maxTokens: 8192,
+        params: { store: false },
+        agentRuntime: { id: "codex" },
+        headers: { "x-openclaw-test": "codex" },
+      },
+    ]);
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5",
+    ]);
+  });
+
+  it("keeps legacy codex provider when existing openai defaults would leak into merged models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            apiKey: "OPENAI_API_KEY",
+            baseUrl: "https://api.openai.com/v1",
+            request: { retry: { maxAttempts: 1 } },
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-responses",
+      apiKey: "OPENAI_API_KEY",
+      baseUrl: "https://api.openai.com/v1",
+      request: { retry: { maxAttempts: 1 } },
+      models: [{ id: "text-embedding-3-small" }],
+    });
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+    });
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses"',
+      'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
+      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.apiKey, models.providers.openai.request",
+    ]);
+  });
+
   it("removes openai-codex when all its models already exist in canonical openai", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -331,6 +331,9 @@ describe("legacy memory search config migrate", () => {
       'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
       "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.apiKey, models.providers.openai.params, models.providers.openai.request",
     ]);
+    expect(findLegacyConfigIssues(res.config).map((issue) => issue.path)).not.toContain(
+      "models.providers",
+    );
   });
 
   it("keeps legacy codex provider when legacy auth or headers cannot be model-scoped", () => {
@@ -372,8 +375,8 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
-  it("reports blocked codex merges after legacy api normalization already ran", () => {
-    const res = migrateLegacyConfigForTest({
+  it("does not report a fixable legacy issue after blocked codex merge normalization already ran", () => {
+    const raw = {
       models: {
         providers: {
           openai: {
@@ -389,16 +392,14 @@ describe("legacy memory search config migrate", () => {
           },
         },
       },
-    });
+    };
+    const res = migrateLegacyConfigForTest(raw);
 
-    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
-      api: "openai-chatgpt-responses",
-      baseUrl: "https://chatgpt.com/backend-api",
-      models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
-    });
-    expect(res.changes).toEqual([
-      "Skipped merging models.providers.openai-codex into models.providers.openai because provider-level defaults cannot be represented safely on merged models: models.providers.openai.params.",
-    ]);
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).not.toContain(
+      "models.providers",
+    );
   });
 
   it("merges distinct legacy model ids even when display names collide", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -128,6 +128,106 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("merges disjoint model entries from legacy codex into canonical openai and preserves legacy baseUrl (#90047)", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    // Legacy codex model must be merged with legacy provider baseUrl stamped on it
+    // so it routes to https://chatgpt.com/backend-api, not https://api.openai.com/v1.
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai?.models).toEqual([
+      { id: "text-embedding-3-small" },
+      {
+        id: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+      },
+    ]);
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5",
+    ]);
+  });
+
+  it("skips already-present model ids when merging legacy codex into canonical openai", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    // gpt-5.5 already in canonical → skip; gpt-5.4 is new → merged with legacy provider baseUrl/api
+    expect((openai?.models as unknown[])?.length).toBe(2);
+    expect(openai?.models).toEqual(
+      expect.arrayContaining([
+        { id: "gpt-5.5" },
+        {
+          id: "gpt-5.4",
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api",
+        },
+      ]),
+    );
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.4",
+    ]);
+  });
+
+  it("removes openai-codex when all its models already exist in canonical openai", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    // All legacy models are already present; canonical provider unchanged
+    expect(openai?.models).toEqual([{ id: "gpt-5.5" }, { id: "gpt-5.4" }]);
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expect(res.changes).toContain(
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    );
+  });
+
   it("rewrites top-level legacy auto provider after moving memorySearch into agent defaults", () => {
     const raw = {
       memorySearch: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -201,6 +201,45 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("keeps merged codex models when later canonical openai normalization runs", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+          },
+          openai: {
+            api: "openai-codex-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small", api: "openai-codex-responses" }],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [
+        { id: "text-embedding-3-small", api: "openai-chatgpt-responses" },
+        {
+          id: "gpt-5.5",
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api",
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai.api "openai-codex-responses" → "openai-chatgpt-responses"',
+      'Moved models.providers.openai.models[0].api "openai-codex-responses" → "openai-chatgpt-responses"',
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5",
+    ]);
+  });
+
   it("preserves model-scoped legacy provider defaults when merging codex models", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -244,6 +244,46 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("merges legacy provider params into model params when merging codex models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            params: { store: false, reasoning: { effort: "medium" } },
+            models: [
+              {
+                id: "gpt-5.5",
+                params: { reasoning: { effort: "high" }, verbosity: "low" },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai?.models).toEqual([
+      { id: "text-embedding-3-small" },
+      {
+        id: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+        params: {
+          store: false,
+          reasoning: { effort: "high" },
+          verbosity: "low",
+        },
+      },
+    ]);
+  });
+
   it("preserves legacy models-add metadata marker when merging codex models", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -244,6 +244,54 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("preserves legacy models-add metadata marker when merging codex models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [
+              {
+                id: "gpt-5.5",
+                api: "openai-chatgpt-responses",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+                contextWindow: 400_000,
+                contextTokens: 272_000,
+                maxTokens: 128_000,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const openai = res.config?.models?.providers?.openai as Record<string, unknown> | undefined;
+    expect(openai?.models).toEqual([
+      { id: "text-embedding-3-small" },
+      {
+        id: "gpt-5.5",
+        api: "openai-chatgpt-responses",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+        contextWindow: 400_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+        baseUrl: "https://chatgpt.com/backend-api",
+        metadataSource: "models-add",
+      },
+    ]);
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+  });
+
   it("keeps legacy codex provider when existing openai defaults would leak into merged models", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -324,6 +324,29 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("does not report a skipped codex merge when blocked provider needs no mutation", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            params: { store: true },
+            models: [{ id: "text-embedding-3-small" }],
+          },
+          "openai-codex": {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://chatgpt.com/backend-api",
+            models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+          },
+        },
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
   it("merges distinct legacy model ids even when display names collide", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1001,9 +1001,83 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         `Moved models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} → models.providers.${OPENAI_PROVIDER_ID}.`,
       );
     } else {
-      changes.push(
-        `Removed models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} because models.providers.${OPENAI_PROVIDER_ID} already exists.`,
-      );
+      // Canonical openai provider already exists. Merge non-conflicting model
+      // entries from the legacy provider so disjoint models (e.g. a chat model
+      // on the Codex OAuth path alongside an embeddings-only openai provider)
+      // are preserved instead of silently dropped. (#90047)
+      const legacyModels: unknown[] = Array.isArray(normalized.value.models)
+        ? (normalized.value.models as unknown[])
+        : [];
+      const canonicalKey =
+        Object.keys(providers).find((k) => normalizeProviderId(k) === OPENAI_PROVIDER_ID) ??
+        OPENAI_PROVIDER_ID;
+      const canonical = getRecord(providers[canonicalKey]) ?? {};
+      const canonicalModels: unknown[] = Array.isArray(canonical.models)
+        ? (canonical.models as unknown[])
+        : [];
+      const canonicalModelIds = new Set<string>();
+      const canonicalModelNames = new Set<string>();
+      for (const m of canonicalModels) {
+        const mr = getRecord(m);
+        if (typeof mr?.id === "string" && mr.id) {
+          canonicalModelIds.add(mr.id);
+        }
+        if (typeof mr?.name === "string" && mr.name) {
+          canonicalModelNames.add(mr.name);
+        }
+      }
+      const modelsToMerge = legacyModels.filter((m) => {
+        const mr = getRecord(m);
+        if (!mr) {
+          return false;
+        }
+        const id = typeof mr.id === "string" ? mr.id : undefined;
+        const name = typeof mr.name === "string" ? mr.name : undefined;
+        if (!id && !name) {
+          return false;
+        }
+        return (!id || !canonicalModelIds.has(id)) && (!name || !canonicalModelNames.has(name));
+      });
+      // Stamp legacy provider-level baseUrl and api onto each merged model that
+      // lacks its own, so the model continues to route to the correct endpoint
+      // instead of inheriting the canonical provider's (e.g. api.openai.com).
+      const legacyBaseUrl =
+        typeof normalized.value.baseUrl === "string" ? normalized.value.baseUrl : undefined;
+      const legacyApi = typeof normalized.value.api === "string" ? normalized.value.api : undefined;
+      const stamped = modelsToMerge.map((m) => {
+        const mr = getRecord(m);
+        if (!mr) {
+          return m;
+        }
+        const patch: Record<string, unknown> = {};
+        if (legacyBaseUrl && !mr.baseUrl) {
+          patch.baseUrl = legacyBaseUrl;
+        }
+        if (legacyApi && !mr.api) {
+          patch.api = legacyApi;
+        }
+        return Object.keys(patch).length > 0 ? Object.assign({}, mr, patch) : m;
+      });
+      if (stamped.length > 0) {
+        providers[canonicalKey] = { ...canonical, models: [...canonicalModels, ...stamped] };
+        const mergedIds = stamped
+          .map((m) => {
+            const mr = getRecord(m);
+            return typeof mr?.id === "string" && mr.id
+              ? mr.id
+              : typeof mr?.name === "string" && mr.name
+                ? mr.name
+                : "unknown";
+          })
+          .join(", ");
+        changes.push(
+          `Merged ${stamped.length} model(s) from models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID}: ${mergedIds}.`,
+        );
+      } else {
+        changes.push(
+          `Removed models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} because models.providers.${OPENAI_PROVIDER_ID} already exists.`,
+        );
+      }
     }
     delete providers[providerId];
     providersChanged = true;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1098,6 +1098,45 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
   return false;
 }
 
+export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): string[] {
+  const models = getRecord(getRecord(raw)?.models);
+  const providers = getRecord(models?.providers);
+  const canonicalEntry = providers ? getCanonicalOpenAIProviderEntry(providers) : undefined;
+  if (!providers || !canonicalEntry) {
+    return [];
+  }
+
+  const warnings: string[] = [];
+  for (const [providerId, providerValue] of Object.entries(providers)) {
+    const provider = getRecord(providerValue);
+    if (!provider || normalizeProviderId(providerId) !== LEGACY_OPENAI_CODEX_PROVIDER_ID) {
+      continue;
+    }
+    const normalized = normalizeLegacyOpenAIResponsesApi(providerId, provider, []);
+    if (normalized.changed) {
+      continue;
+    }
+    const modelsToMerge = getMergeableLegacyOpenAIModels({
+      canonical: canonicalEntry.value,
+      legacy: normalized.value,
+    });
+    if (modelsToMerge.length === 0) {
+      continue;
+    }
+    const mergeBlockers = collectModelMergeBlockers({
+      canonical: canonicalEntry.value,
+      legacy: normalized.value,
+    });
+    if (mergeBlockers.length === 0) {
+      continue;
+    }
+    warnings.push(
+      `models.providers.${providerId} cannot be merged automatically into models.providers.${canonicalEntry.key} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}. Move the affected model/provider defaults manually before removing models.providers.${providerId}.`,
+    );
+  }
+  return warnings;
+}
+
 function buildMergedLegacyOpenAIModel(
   model: unknown,
   legacyProvider: Record<string, unknown>,

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1061,7 +1061,7 @@ function getMergeableLegacyOpenAIModels(params: {
     if (!id && !name) {
       return false;
     }
-    return id ? !canonicalModelIds.has(id) : !canonicalModelNames.has(name);
+    return id ? !canonicalModelIds.has(id) : name ? !canonicalModelNames.has(name) : false;
   });
 }
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -927,11 +927,13 @@ const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CHATGPT_RESPONSES_API = "openai-chatgpt-responses";
 const MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS = [
   "apiKey",
+  "auth",
   "request",
   "timeoutSeconds",
   "region",
   "injectNumCtxForOpenAICompat",
   "localService",
+  "headers",
   "authHeader",
 ] as const;
 const CANONICAL_PROVIDER_MODEL_LEAK_KEYS = [
@@ -1001,16 +1003,6 @@ function hasOwnDefinedProperty(record: Record<string, unknown>, key: string): bo
   return Object.hasOwn(record, key) && record[key] !== undefined;
 }
 
-function getStringRecord(value: unknown): Record<string, string> | undefined {
-  const record = getRecord(value);
-  if (!record) {
-    return undefined;
-  }
-  return Object.values(record).every((entry) => typeof entry === "string")
-    ? (record as Record<string, string>)
-    : undefined;
-}
-
 function collectModelMergeBlockers(params: {
   canonical: Record<string, unknown>;
   legacy: Record<string, unknown>;
@@ -1025,9 +1017,6 @@ function collectModelMergeBlockers(params: {
     if (hasOwnDefinedProperty(params.canonical, key)) {
       blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
     }
-  }
-  if (hasOwnDefinedProperty(params.legacy, "headers") && !getStringRecord(params.legacy.headers)) {
-    blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.headers`);
   }
   if (hasOwnDefinedProperty(params.canonical, "headers")) {
     blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.headers`);
@@ -1048,7 +1037,6 @@ function buildMergedLegacyOpenAIModel(
   const legacyBaseUrl =
     typeof legacyProvider.baseUrl === "string" ? legacyProvider.baseUrl : undefined;
   const legacyApi = typeof legacyProvider.api === "string" ? legacyProvider.api : undefined;
-  const legacyHeaders = getStringRecord(legacyProvider.headers);
   const legacyParams = getRecord(legacyProvider.params);
   const legacyAgentRuntime = getRecord(legacyProvider.agentRuntime);
 
@@ -1068,9 +1056,6 @@ function buildMergedLegacyOpenAIModel(
   }
   if (legacyAgentRuntime && modelRecord.agentRuntime === undefined) {
     patch.agentRuntime = legacyAgentRuntime;
-  }
-  if (legacyHeaders && modelRecord.headers === undefined) {
-    patch.headers = legacyHeaders;
   }
   return Object.keys(patch).length > 0 ? Object.assign({}, modelRecord, patch) : model;
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1022,6 +1022,82 @@ function collectModelMergeBlockers(params: {
   return blockers;
 }
 
+function getCanonicalOpenAIProviderEntry(
+  providers: Record<string, unknown>,
+): { key: string; value: Record<string, unknown> } | undefined {
+  const key = Object.keys(providers).find((k) => normalizeProviderId(k) === OPENAI_PROVIDER_ID);
+  const value = key ? getRecord(providers[key]) : undefined;
+  return key && value ? { key, value } : undefined;
+}
+
+function getMergeableLegacyOpenAIModels(params: {
+  canonical: Record<string, unknown>;
+  legacy: Record<string, unknown>;
+}): unknown[] {
+  const legacyModels: unknown[] = Array.isArray(params.legacy.models)
+    ? (params.legacy.models as unknown[])
+    : [];
+  const canonicalModels: unknown[] = Array.isArray(params.canonical.models)
+    ? (params.canonical.models as unknown[])
+    : [];
+  const canonicalModelIds = new Set<string>();
+  const canonicalModelNames = new Set<string>();
+  for (const m of canonicalModels) {
+    const mr = getRecord(m);
+    if (typeof mr?.id === "string" && mr.id) {
+      canonicalModelIds.add(mr.id);
+    }
+    if (typeof mr?.name === "string" && mr.name) {
+      canonicalModelNames.add(mr.name);
+    }
+  }
+  return legacyModels.filter((m) => {
+    const mr = getRecord(m);
+    if (!mr) {
+      return false;
+    }
+    const id = typeof mr.id === "string" ? mr.id : undefined;
+    const name = typeof mr.name === "string" ? mr.name : undefined;
+    if (!id && !name) {
+      return false;
+    }
+    return id ? !canonicalModelIds.has(id) : !canonicalModelNames.has(name);
+  });
+}
+
+function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boolean {
+  const providers = getRecord(providersValue);
+  if (!providers) {
+    return false;
+  }
+  const canonicalEntry = getCanonicalOpenAIProviderEntry(providers);
+  for (const [providerId, providerValue] of Object.entries(providers)) {
+    const provider = getRecord(providerValue);
+    if (!provider || normalizeProviderId(providerId) !== LEGACY_OPENAI_CODEX_PROVIDER_ID) {
+      continue;
+    }
+    const normalized = normalizeLegacyOpenAIResponsesApi(providerId, provider, []);
+    if (normalized.changed || !canonicalEntry) {
+      return true;
+    }
+    const modelsToMerge = getMergeableLegacyOpenAIModels({
+      canonical: canonicalEntry.value,
+      legacy: normalized.value,
+    });
+    if (modelsToMerge.length === 0) {
+      return true;
+    }
+    const mergeBlockers = collectModelMergeBlockers({
+      canonical: canonicalEntry.value,
+      legacy: normalized.value,
+    });
+    if (mergeBlockers.length === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function buildMergedLegacyOpenAIModel(
   model: unknown,
   legacyProvider: Record<string, unknown>,
@@ -1100,38 +1176,15 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
       // entries from the legacy provider so disjoint models (e.g. a chat model
       // on the Codex OAuth path alongside an embeddings-only openai provider)
       // are preserved instead of silently dropped. (#90047)
-      const legacyModels: unknown[] = Array.isArray(normalized.value.models)
-        ? (normalized.value.models as unknown[])
-        : [];
-      const canonicalKey =
-        Object.keys(providers).find((k) => normalizeProviderId(k) === OPENAI_PROVIDER_ID) ??
-        OPENAI_PROVIDER_ID;
-      const canonical = getRecord(providers[canonicalKey]) ?? {};
+      const canonicalEntry = getCanonicalOpenAIProviderEntry(providers);
+      const canonicalKey = canonicalEntry?.key ?? OPENAI_PROVIDER_ID;
+      const canonical = canonicalEntry?.value ?? {};
       const canonicalModels: unknown[] = Array.isArray(canonical.models)
         ? (canonical.models as unknown[])
         : [];
-      const canonicalModelIds = new Set<string>();
-      const canonicalModelNames = new Set<string>();
-      for (const m of canonicalModels) {
-        const mr = getRecord(m);
-        if (typeof mr?.id === "string" && mr.id) {
-          canonicalModelIds.add(mr.id);
-        }
-        if (typeof mr?.name === "string" && mr.name) {
-          canonicalModelNames.add(mr.name);
-        }
-      }
-      const modelsToMerge = legacyModels.filter((m) => {
-        const mr = getRecord(m);
-        if (!mr) {
-          return false;
-        }
-        const id = typeof mr.id === "string" ? mr.id : undefined;
-        const name = typeof mr.name === "string" ? mr.name : undefined;
-        if (!id && !name) {
-          return false;
-        }
-        return id ? !canonicalModelIds.has(id) : !canonicalModelNames.has(name);
+      const modelsToMerge = getMergeableLegacyOpenAIModels({
+        canonical,
+        legacy: normalized.value,
       });
       const mergeBlockers =
         modelsToMerge.length > 0
@@ -1141,10 +1194,10 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         if (normalized.changed) {
           providers[providerId] = normalized.value;
           providersChanged = true;
+          changes.push(
+            `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
+          );
         }
-        changes.push(
-          `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
-        );
         continue;
       }
       // Stamp model-scoped legacy provider defaults onto each merged model so it
@@ -1205,14 +1258,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
         path: ["models", "providers"],
         message:
           'models.providers.openai-codex is legacy; run "openclaw doctor --fix" to move it to models.providers.openai.',
-        match: (value) => {
-          const providers = getRecord(value);
-          return providers
-            ? Object.keys(providers).some(
-                (providerId) => normalizeProviderId(providerId) === LEGACY_OPENAI_CODEX_PROVIDER_ID,
-              )
-            : false;
-        },
+        match: (value) => hasAutoFixableLegacyOpenAICodexProvider(value),
       },
       {
         path: ["models", "providers"],

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1164,8 +1164,13 @@ function buildMergedLegacyOpenAIModel(
       patch[key] = legacyProvider[key];
     }
   }
-  if (legacyParams && modelRecord.params === undefined) {
-    patch.params = legacyParams;
+  if (legacyParams) {
+    const modelParams = getRecord(modelRecord.params);
+    if (modelParams) {
+      patch.params = { ...legacyParams, ...modelParams };
+    } else if (modelRecord.params === undefined) {
+      patch.params = legacyParams;
+    }
   }
   if (legacyAgentRuntime && modelRecord.agentRuntime === undefined) {
     patch.agentRuntime = legacyAgentRuntime;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1018,9 +1018,6 @@ function collectModelMergeBlockers(params: {
       blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
     }
   }
-  if (hasOwnDefinedProperty(params.canonical, "headers")) {
-    blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.headers`);
-  }
   return blockers;
 }
 
@@ -1134,10 +1131,10 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         if (normalized.changed) {
           providers[providerId] = normalized.value;
           providersChanged = true;
+          changes.push(
+            `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
+          );
         }
-        changes.push(
-          `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
-        );
         continue;
       }
       // Stamp model-scoped legacy provider defaults onto each merged model so it

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -8,7 +8,8 @@ import {
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
-import { isModelThinkingFormat } from "../../../config/types.models.js";
+import { isModelThinkingFormat, type ModelDefinitionConfig } from "../../../config/types.models.js";
+import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadata.js";
 
 const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
   "deepseek/deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
@@ -1053,6 +1054,15 @@ function buildMergedLegacyOpenAIModel(
   }
   if (legacyAgentRuntime && modelRecord.agentRuntime === undefined) {
     patch.agentRuntime = legacyAgentRuntime;
+  }
+  if (
+    modelRecord.metadataSource === undefined &&
+    isLegacyModelsAddCodexMetadataModel({
+      provider: LEGACY_OPENAI_CODEX_PROVIDER_ID,
+      model: modelRecord as Partial<ModelDefinitionConfig>,
+    })
+  ) {
+    patch.metadataSource = "models-add";
   }
   return Object.keys(patch).length > 0 ? Object.assign({}, modelRecord, patch) : model;
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1131,10 +1131,10 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         if (normalized.changed) {
           providers[providerId] = normalized.value;
           providersChanged = true;
-          changes.push(
-            `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
-          );
         }
+        changes.push(
+          `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
+        );
         continue;
       }
       // Stamp model-scoped legacy provider defaults onto each merged model so it

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -925,6 +925,15 @@ const LEGACY_OPENAI_CODEX_PROVIDER_ID = "openai-codex";
 const LEGACY_OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
 const OPENAI_PROVIDER_ID = "openai";
 const OPENAI_CHATGPT_RESPONSES_API = "openai-chatgpt-responses";
+const MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS = [
+  "apiKey",
+  "request",
+  "timeoutSeconds",
+  "region",
+  "injectNumCtxForOpenAICompat",
+  "localService",
+  "authHeader",
+] as const;
 
 function hasCanonicalOpenAIProvider(providers: Record<string, unknown>): boolean {
   return Object.keys(providers).some(
@@ -970,6 +979,82 @@ function normalizeLegacyOpenAIResponsesApi(
   }
 
   return { value: next, changed };
+}
+
+function hasOwnDefinedProperty(record: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(record, key) && record[key] !== undefined;
+}
+
+function getStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = getRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  return Object.values(record).every((entry) => typeof entry === "string")
+    ? (record as Record<string, string>)
+    : undefined;
+}
+
+function collectModelMergeBlockers(params: {
+  canonical: Record<string, unknown>;
+  legacy: Record<string, unknown>;
+}): string[] {
+  const blockers: string[] = [];
+  for (const key of MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS) {
+    if (hasOwnDefinedProperty(params.legacy, key)) {
+      blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.${key}`);
+    }
+    if (hasOwnDefinedProperty(params.canonical, key)) {
+      blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
+    }
+  }
+  if (hasOwnDefinedProperty(params.legacy, "headers") && !getStringRecord(params.legacy.headers)) {
+    blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.headers`);
+  }
+  if (hasOwnDefinedProperty(params.canonical, "headers")) {
+    blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.headers`);
+  }
+  return blockers;
+}
+
+function buildMergedLegacyOpenAIModel(
+  model: unknown,
+  legacyProvider: Record<string, unknown>,
+): unknown {
+  const modelRecord = getRecord(model);
+  if (!modelRecord) {
+    return model;
+  }
+
+  const patch: Record<string, unknown> = {};
+  const legacyBaseUrl =
+    typeof legacyProvider.baseUrl === "string" ? legacyProvider.baseUrl : undefined;
+  const legacyApi = typeof legacyProvider.api === "string" ? legacyProvider.api : undefined;
+  const legacyHeaders = getStringRecord(legacyProvider.headers);
+  const legacyParams = getRecord(legacyProvider.params);
+  const legacyAgentRuntime = getRecord(legacyProvider.agentRuntime);
+
+  if (legacyBaseUrl && !modelRecord.baseUrl) {
+    patch.baseUrl = legacyBaseUrl;
+  }
+  if (legacyApi && !modelRecord.api) {
+    patch.api = legacyApi;
+  }
+  for (const key of ["contextWindow", "contextTokens", "maxTokens"] as const) {
+    if (typeof legacyProvider[key] === "number" && modelRecord[key] === undefined) {
+      patch[key] = legacyProvider[key];
+    }
+  }
+  if (legacyParams && modelRecord.params === undefined) {
+    patch.params = legacyParams;
+  }
+  if (legacyAgentRuntime && modelRecord.agentRuntime === undefined) {
+    patch.agentRuntime = legacyAgentRuntime;
+  }
+  if (legacyHeaders && modelRecord.headers === undefined) {
+    patch.headers = legacyHeaders;
+  }
+  return Object.keys(patch).length > 0 ? Object.assign({}, modelRecord, patch) : model;
 }
 
 function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes: string[]): void {
@@ -1038,26 +1123,24 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         }
         return (!id || !canonicalModelIds.has(id)) && (!name || !canonicalModelNames.has(name));
       });
-      // Stamp legacy provider-level baseUrl and api onto each merged model that
-      // lacks its own, so the model continues to route to the correct endpoint
-      // instead of inheriting the canonical provider's (e.g. api.openai.com).
-      const legacyBaseUrl =
-        typeof normalized.value.baseUrl === "string" ? normalized.value.baseUrl : undefined;
-      const legacyApi = typeof normalized.value.api === "string" ? normalized.value.api : undefined;
-      const stamped = modelsToMerge.map((m) => {
-        const mr = getRecord(m);
-        if (!mr) {
-          return m;
+      const mergeBlockers =
+        modelsToMerge.length > 0
+          ? collectModelMergeBlockers({ canonical, legacy: normalized.value })
+          : [];
+      if (mergeBlockers.length > 0) {
+        if (normalized.changed) {
+          providers[providerId] = normalized.value;
+          providersChanged = true;
         }
-        const patch: Record<string, unknown> = {};
-        if (legacyBaseUrl && !mr.baseUrl) {
-          patch.baseUrl = legacyBaseUrl;
-        }
-        if (legacyApi && !mr.api) {
-          patch.api = legacyApi;
-        }
-        return Object.keys(patch).length > 0 ? Object.assign({}, mr, patch) : m;
-      });
+        changes.push(
+          `Skipped merging models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} into models.providers.${OPENAI_PROVIDER_ID} because provider-level defaults cannot be represented safely on merged models: ${mergeBlockers.join(", ")}.`,
+        );
+        continue;
+      }
+      // Stamp model-scoped legacy provider defaults onto each merged model so it
+      // keeps the Codex endpoint and runtime metadata instead of inheriting the
+      // canonical provider's OpenAI platform defaults.
+      const stamped = modelsToMerge.map((m) => buildMergedLegacyOpenAIModel(m, normalized.value));
       if (stamped.length > 0) {
         providers[canonicalKey] = { ...canonical, models: [...canonicalModels, ...stamped] };
         const mergedIds = stamped

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -934,6 +934,22 @@ const MODEL_UNSCOPED_PROVIDER_DEFAULT_KEYS = [
   "localService",
   "authHeader",
 ] as const;
+const CANONICAL_PROVIDER_MODEL_LEAK_KEYS = [
+  "apiKey",
+  "auth",
+  "contextWindow",
+  "contextTokens",
+  "maxTokens",
+  "timeoutSeconds",
+  "region",
+  "injectNumCtxForOpenAICompat",
+  "params",
+  "agentRuntime",
+  "localService",
+  "headers",
+  "authHeader",
+  "request",
+] as const;
 
 function hasCanonicalOpenAIProvider(providers: Record<string, unknown>): boolean {
   return Object.keys(providers).some(
@@ -1004,6 +1020,8 @@ function collectModelMergeBlockers(params: {
     if (hasOwnDefinedProperty(params.legacy, key)) {
       blockers.push(`models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.${key}`);
     }
+  }
+  for (const key of CANONICAL_PROVIDER_MODEL_LEAK_KEYS) {
     if (hasOwnDefinedProperty(params.canonical, key)) {
       blockers.push(`models.providers.${OPENAI_PROVIDER_ID}.${key}`);
     }
@@ -1121,7 +1139,7 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         if (!id && !name) {
           return false;
         }
-        return (!id || !canonicalModelIds.has(id)) && (!name || !canonicalModelNames.has(name));
+        return id ? !canonicalModelIds.has(id) : !canonicalModelNames.has(name);
       });
       const mergeBlockers =
         modelsToMerge.length > 0

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1196,7 +1196,7 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
 
   let providersChanged = false;
   for (const [providerId, providerValue] of Object.entries({ ...providers })) {
-    const provider = getRecord(providerValue);
+    const provider = getRecord(providers[providerId]) ?? getRecord(providerValue);
     if (!provider) {
       continue;
     }

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -262,7 +262,7 @@ describe("doctor preview warnings", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       doctorFixCommand: "openclaw doctor --fix",
       env: { CODEX_HOME: codexHome, HOME: root },
     });
@@ -315,7 +315,7 @@ describe("doctor preview warnings", () => {
             },
           },
         },
-      } as OpenClawConfig,
+      } as unknown as OpenClawConfig,
       doctorFixCommand: "openclaw doctor --fix",
     });
 

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -297,6 +297,36 @@ describe("doctor preview warnings", () => {
     ).toBe(true);
   });
 
+  it("warns when a normalized legacy Codex provider cannot be auto-merged", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              api: "openai-chatgpt-responses",
+              baseUrl: "https://api.openai.com/v1",
+              params: { store: true },
+              models: [{ id: "text-embedding-3-small" }],
+            },
+            "openai-codex": {
+              api: "openai-chatgpt-responses",
+              baseUrl: "https://chatgpt.com/backend-api",
+              models: [{ id: "gpt-5.5", api: "openai-chatgpt-responses" }],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      "models.providers.openai-codex cannot be merged automatically",
+    );
+    expect(warning).toContain("models.providers.openai.params");
+    expect(warning).toContain("Move the affected model/provider defaults manually");
+  });
+
   it("sanitizes empty-allowlist warning paths before returning preview output", async () => {
     const warnings = await collectDoctorPreviewWarnings({
       cfg: {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -779,6 +779,9 @@ export async function collectDoctorPreviewNotes(params: {
   warnings.push(...collectVisibleReplyToolPolicyWarnings(params.cfg));
   warnings.push(...collectChannelBoundMessageToolPolicyWarnings(params.cfg));
   warnings.push(...collectProfileConfiguredToolSectionWarnings(params.cfg));
+  const { collectBlockedLegacyOpenAICodexProviderWarnings } =
+    await import("./legacy-config-migrations.runtime.models.js");
+  warnings.push(...collectBlockedLegacyOpenAICodexProviderWarnings(params.cfg));
 
   const { collectActiveToolSchemaProjectionWarnings } =
     await import("./active-tool-schema-warnings.js");


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90047 reports that the 2026.6.1 doctor migration silently drops the entire `openai-codex` provider when any canonical `openai` provider already exists — including cases where both serve disjoint purposes (e.g. `openai` for embeddings via API key, `openai-codex` for chat via OAuth/ChatGPT backend). After a routine update, `gpt-5.5` was gone and every agent turn failed.
- **Root Cause**: In `migrateLegacyOpenAICodexProvider` (`legacy-config-migrations.runtime.models.ts:997`), the `else` branch for the shadowed-provider case recorded "Removed" and called `delete providers[providerId]`. The already-normalized `normalized.value` — containing the API-renamed model entries — was discarded without checking for model rows absent from the canonical provider. The branch assumed a canonical `openai` provider is a superset of `openai-codex`, which is false when the two served disjoint models.
- **Fix**: Replace the silent drop with a targeted merge. For each model entry in the normalized legacy provider: (1) skip those whose `id` already appears in the canonical provider's model id Set or whose `name` appears in its name Set (separate Sets to avoid cross-type false positives); (2) stamp the legacy provider's `baseUrl` and `api` onto merged models that lack their own, so they continue routing to the correct endpoint (e.g. `chatgpt.com/backend-api` not `api.openai.com/v1`); (3) skip entries with neither `id` nor `name` to avoid duplicating malformed records. Only when the filtered set is empty is the old "Removed … already exists" message emitted.
- **What changed**:
  - `src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts` — replace the `else` drop with a merge-or-remove branch; separate `canonicalModelIds`/`canonicalModelNames` Sets; stamp legacy provider `baseUrl`/`api` onto merged models that lack them.
  - `src/commands/doctor/shared/legacy-config-migrate.test.ts` — 3 new tests: disjoint merge with `baseUrl` preserved (the exact reporter scenario); partial-conflict merge (one duplicate skipped, one new entry with endpoint stamped); all-duplicate scenario still triggers the "Removed" message.
- **What did NOT change (scope boundary)**:
  - The `hasCanonicalOpenAIProvider` check and `normalizeLegacyOpenAIResponsesApi` are unchanged.
  - The move branch (`!hasCanonicalOpenAIProvider`) is unchanged.
  - Config schema, defaults, and other doctor migrations are unchanged. Plugin surface unchanged.

### Reproduction

1. Configure `models.providers.openai` (embeddings, API key, `baseUrl: https://api.openai.com/v1`) and `models.providers.openai-codex` (chat, OAuth, `baseUrl: https://chatgpt.com/backend-api`, `models: [{ id: "gpt-5.5" }]`).
2. Run `openclaw doctor --fix` or `openclaw update` on OpenClaw 2026.6.1.
3. **Before this PR**: migration deletes `openai-codex` entirely; `gpt-5.5` is gone; agents fail.
4. **After this PR**: migration merges `gpt-5.5` (api → `openai-chatgpt-responses`, `baseUrl: https://chatgpt.com/backend-api` stamped) into `openai.models[]`; both endpoints preserved; agents continue working.

### Real behavior proof

**Behavior addressed (#90047)**: `migrateLegacyOpenAICodexProvider` now merges disjoint model entries with correct endpoint metadata instead of dropping them.

**Real environment tested (Ubuntu Server Node 24, source-level — Vitest against `migrateLegacyConfigForTest` with the reporter's exact multi-provider config)**: new tests reproduce the exact upgrade scenario and assert that the merged model array contains the correct `baseUrl` and renamed `api`.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts` — 116 tests pass (113 pre-existing + 3 new). `pnpm exec oxlint` clean. `pnpm format:check` clean.

**Evidence after fix**:

```
Tests  116 passed (116)
```

New tests: `merges disjoint model entries from legacy codex into canonical openai and preserves legacy baseUrl (#90047)` — asserts `openai.models` = `[{ id: "text-embedding-3-small" }, { id: "gpt-5.5", api: "openai-chatgpt-responses", baseUrl: "https://chatgpt.com/backend-api" }]`; `skips already-present model ids when merging legacy codex into canonical openai` — one duplicate skipped, one new entry stamped with legacy `baseUrl`; `removes openai-codex when all its models already exist in canonical openai` — canonical unchanged, "Removed" message emitted.

**What was not tested**: live `openclaw doctor --fix` run against a real multi-provider config file.

**Repro confirmation**: the disjoint-merge test fails on the pre-patch tree (`openai.models` only contains the embeddings entry, `gpt-5.5` absent) and passes with the fix.

### Risk / Mitigation

- **Risk**: Wrong endpoint after merge. **Mitigation**: legacy provider `baseUrl`/`api` are stamped onto merged models that lack their own, tested by the new `baseUrl` assertion.
- **Risk**: Duplicate model rows. **Mitigation**: separate id/name Sets for dedup; cross-type false positives eliminated; all-duplicate path tested with "Removed" message assertion.
- **Risk**: Config surface change requiring Peter's approval. **Mitigation**: bug fix in an existing migration's behavior — no new config key, schema, or migration added.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Doctor / migrations

### Linked Issue/PR

Fixes #90047