### PR TITLE
fix(plugins): isolate tool metadata rows

### DIFF
--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -5,7 +5,11 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.js";
+import {
+  buildPluginToolMetadataKey,
+  buildReadablePluginToolMetadataMap,
+  getPluginToolMeta,
+} from "../plugins/tools.js";
 import { getChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { summarizeToolDescriptionText } from "./tool-description-summary.js";
@@ -159,11 +163,8 @@ export function buildEffectiveToolInventoryEntries(
 ): EffectiveToolInventoryEntry[] {
   // Key metadata by plugin ownership and tool name so only the owning plugin can
   // project display/risk metadata for its own tool.
-  const pluginToolMetadata = new Map(
-    (getActivePluginRegistry()?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
+  const pluginToolMetadata = buildReadablePluginToolMetadataMap(
+    getActivePluginRegistry()?.toolMetadata,
   );
 
   return disambiguateLabels(

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -60,6 +60,21 @@ vi.mock("../plugins/tools.js", () => ({
   getPluginToolMeta: (tool: { name: string }) => effectiveInventoryState.pluginMeta[tool.name],
   buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
     JSON.stringify([pluginId, toolName]),
+  buildReadablePluginToolMetadataMap: (entries: readonly unknown[] | undefined) => {
+    const map = new Map<string, unknown>();
+    for (const entry of entries ?? []) {
+      try {
+        const pluginId = (entry as { pluginId?: unknown }).pluginId;
+        const metadata = (entry as { metadata?: { toolName?: unknown } }).metadata;
+        if (typeof pluginId === "string" && typeof metadata?.toolName === "string") {
+          map.set(JSON.stringify([pluginId, metadata.toolName]), metadata);
+        }
+      } catch {
+        // Malformed plugin-owned rows are isolated per entry.
+      }
+    }
+    return map;
+  },
 }));
 
 vi.mock("./channel-tools.js", () => ({
@@ -281,6 +296,14 @@ describe("resolveEffectiveToolInventory", () => {
   it("projects plugin tool metadata into the effective inventory", async () => {
     const registry = createEmptyPluginRegistry();
     registry.toolMetadata = [
+      {
+        pluginId: "bad",
+        pluginName: "Bad",
+        source: "fixture",
+        get metadata() {
+          throw new Error("unreadable tool metadata");
+        },
+      } as never,
       {
         pluginId: "docs",
         pluginName: "Docs",

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -3,6 +3,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   ensureStandalonePluginToolRegistryLoaded,
   resolvePluginTools,
@@ -25,6 +27,21 @@ const pluginToolMetaState = new Map<string, { pluginId: string; optional: boolea
 vi.mock("../../plugins/tools.js", () => ({
   buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
     JSON.stringify([pluginId, toolName]),
+  buildReadablePluginToolMetadataMap: (entries: readonly unknown[] | undefined) => {
+    const map = new Map<string, unknown>();
+    for (const entry of entries ?? []) {
+      try {
+        const pluginId = (entry as { pluginId?: unknown }).pluginId;
+        const metadata = (entry as { metadata?: { toolName?: unknown } }).metadata;
+        if (typeof pluginId === "string" && typeof metadata?.toolName === "string") {
+          map.set(JSON.stringify([pluginId, metadata.toolName]), metadata);
+        }
+      } catch {
+        // Malformed plugin-owned rows are isolated per entry.
+      }
+    }
+    return map;
+  },
   ensureStandalonePluginToolRegistryLoaded: vi.fn(),
   resolvePluginTools: vi.fn(() => [
     { name: "voice_call", label: "voice_call", description: "Plugin calling tool" },
@@ -111,6 +128,7 @@ describe("tools.catalog handler", () => {
     pluginToolMetaState.clear();
     pluginToolMetaState.set("voice_call", { pluginId: "voice-call", optional: true });
     pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
+    setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
   it("rejects invalid params", async () => {
@@ -155,6 +173,51 @@ describe("tools.catalog handler", () => {
       risk: undefined,
       tags: undefined,
       defaultProfiles: [],
+    });
+  });
+
+  it("skips unreadable plugin tool metadata rows", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.toolMetadata = [
+      {
+        pluginId: "bad",
+        pluginName: "Bad",
+        source: "fixture",
+        get metadata() {
+          throw new Error("unreadable tool metadata");
+        },
+      } as never,
+      {
+        pluginId: "voice-call",
+        pluginName: "Voice Call",
+        source: "fixture",
+        metadata: {
+          toolName: "voice_call",
+          displayName: "Voice Call",
+          description: "Call through the voice plugin.",
+          risk: "medium",
+          tags: ["voice", "call"],
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+    const { respond, invoke } = createInvokeParams({});
+
+    await invoke();
+
+    const payload = expectCatalogPayload(respond);
+    const voiceCall = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools)
+      .find((tool) => tool.id === "voice_call");
+    expect(voiceCall).toMatchObject({
+      id: "voice_call",
+      label: "Voice Call",
+      description: "Call through the voice plugin.",
+      source: "plugin",
+      pluginId: "voice-call",
+      risk: "medium",
+      tags: ["voice", "call"],
     });
   });
 

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -22,6 +22,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   buildPluginToolMetadataKey,
+  buildReadablePluginToolMetadataMap,
   ensureStandalonePluginToolRegistryLoaded,
   getPluginToolMeta,
   resolvePluginTools,
@@ -99,12 +100,7 @@ function buildPluginGroups(params: {
   // was registered BY the tool's owning plugin. Without this scoping, plugin-X
   // could override the catalog label/description/risk/tags for another plugin's
   // tool by registering metadata with the same toolName.
-  const pluginToolMetadata = new Map(
-    (activeRegistry?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
-  );
+  const pluginToolMetadata = buildReadablePluginToolMetadataMap(activeRegistry?.toolMetadata);
   const seenToolIds = new Set<string>();
   for (const tool of pluginTools) {
     const meta = getPluginToolMeta(tool);

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -32,6 +32,7 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
 let resolvePluginTools: typeof import("./tools.js").resolvePluginTools;
 let ensureStandalonePluginToolRegistryLoaded: typeof import("./tools.js").ensureStandalonePluginToolRegistryLoaded;
 let buildPluginToolMetadataKey: typeof import("./tools.js").buildPluginToolMetadataKey;
+let buildReadablePluginToolMetadataMap: typeof import("./tools.js").buildReadablePluginToolMetadataMap;
 let getPluginToolMeta: typeof import("./tools.js").getPluginToolMeta;
 let resetPluginToolFactoryCache: typeof import("./tools.js").resetPluginToolFactoryCache;
 let getActivePluginRegistry: typeof import("./runtime.js").getActivePluginRegistry;
@@ -2900,7 +2901,8 @@ describe("resolvePluginTools optional tools", () => {
 
 describe("buildPluginToolMetadataKey", () => {
   beforeAll(async () => {
-    ({ buildPluginToolMetadataKey } = await import("./tools.js"));
+    ({ buildPluginToolMetadataKey, buildReadablePluginToolMetadataMap } =
+      await import("./tools.js"));
   });
 
   it("does not collide when ids or names contain separator-like characters", () => {
@@ -2910,5 +2912,43 @@ describe("buildPluginToolMetadataKey", () => {
     expect(buildPluginToolMetadataKey("plugin", "a\u0000b")).not.toBe(
       buildPluginToolMetadataKey("plugin\u0000a", "b"),
     );
+  });
+
+  it("builds readable plugin tool metadata maps row-locally", () => {
+    const unreadableRow = {
+      pluginId: "bad",
+      get metadata() {
+        throw new Error("unreadable metadata");
+      },
+    };
+    const unreadableFieldRow = {
+      pluginId: "docs",
+      metadata: {
+        toolName: "docs_lookup",
+        get displayName() {
+          throw new Error("unreadable display name");
+        },
+      },
+    };
+    const healthyRow = {
+      pluginId: "docs",
+      metadata: {
+        toolName: "docs_lookup",
+        displayName: "Docs Search",
+        description: "Curated docs lookup.",
+        risk: "low",
+        tags: ["docs"],
+      },
+    };
+
+    const map = buildReadablePluginToolMetadataMap([unreadableRow, unreadableFieldRow, healthyRow]);
+
+    expect(map.get(buildPluginToolMetadataKey("docs", "docs_lookup"))).toEqual({
+      toolName: "docs_lookup",
+      displayName: "Docs Search",
+      description: "Curated docs lookup.",
+      risk: "low",
+      tags: ["docs"],
+    });
   });
 });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -34,7 +34,7 @@ import {
   type PluginToolDescriptorConfigCacheKeyMemo,
   writeCachedPluginToolDescriptors,
 } from "./tool-descriptor-cache.js";
-import type { OpenClawPluginToolContext } from "./types.js";
+import type { OpenClawPluginToolContext, PluginToolMetadataRegistration } from "./types.js";
 
 export {
   resetPluginToolDescriptorCache,
@@ -200,6 +200,62 @@ function resolvePluginToolFactory(entry: PluginToolRegistration, ctx: OpenClawPl
  */
 export function buildPluginToolMetadataKey(pluginId: string, toolName: string): string {
   return JSON.stringify([pluginId, toolName]);
+}
+
+function readPluginToolMetadataValue(metadata: object): PluginToolMetadataRegistration | undefined {
+  let toolName: unknown;
+  let displayName: unknown;
+  let description: unknown;
+  let risk: unknown;
+  let tags: unknown;
+  try {
+    toolName = (metadata as { toolName?: unknown }).toolName;
+    displayName = (metadata as { displayName?: unknown }).displayName;
+    description = (metadata as { description?: unknown }).description;
+    risk = (metadata as { risk?: unknown }).risk;
+    tags = (metadata as { tags?: unknown }).tags;
+  } catch {
+    return undefined;
+  }
+  if (typeof toolName !== "string" || !toolName) {
+    return undefined;
+  }
+  return {
+    toolName,
+    ...(typeof displayName === "string" ? { displayName } : {}),
+    ...(typeof description === "string" ? { description } : {}),
+    ...(risk === "low" || risk === "medium" || risk === "high" ? { risk } : {}),
+    ...(Array.isArray(tags) && tags.every((tag) => typeof tag === "string") ? { tags } : {}),
+  };
+}
+
+/** Builds plugin-owned tool metadata keyed by owning plugin and tool name. */
+export function buildReadablePluginToolMetadataMap(
+  entries: readonly unknown[] | undefined,
+): Map<string, PluginToolMetadataRegistration> {
+  const metadataByTool = new Map<string, PluginToolMetadataRegistration>();
+  for (const entry of entries ?? []) {
+    let pluginId: unknown;
+    let metadata: unknown;
+    try {
+      pluginId = (entry as { pluginId?: unknown }).pluginId;
+      metadata = (entry as { metadata?: unknown }).metadata;
+    } catch {
+      continue;
+    }
+    if (typeof pluginId !== "string" || !metadata || typeof metadata !== "object") {
+      continue;
+    }
+    const readableMetadata = readPluginToolMetadataValue(metadata);
+    if (!readableMetadata) {
+      continue;
+    }
+    metadataByTool.set(
+      buildPluginToolMetadataKey(pluginId, readableMetadata.toolName),
+      readableMetadata,
+    );
+  }
+  return metadataByTool;
 }
 
 function normalizeAllowlist(list?: string[]) {


### PR DESCRIPTION
## Summary

- centralize plugin tool metadata map construction behind a guarded row reader
- keep effective inventory and Control UI catalog metadata scoped by owning plugin plus tool name
- skip malformed metadata rows and unreadable metadata fields instead of crashing before healthy tool metadata is projected

## Verification

- `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-catalog.test.ts src/plugins/tools.optional.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/tools.ts src/plugins/tools.optional.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts`
- `./node_modules/.bin/oxlint src/plugins/tools.ts src/plugins/tools.optional.test.ts src/agents/tools-effective-inventory-build.ts src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-catalog.ts src/gateway/server-methods/tools-catalog.test.ts`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed plugin-owned tool metadata rows can no longer crash effective tool inventory or Control UI tool catalog projection before healthy metadata rows are processed.

Real environment tested: local OpenClaw Codex worktree with linked repo dependencies.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-catalog.test.ts src/plugins/tools.optional.test.ts`

Evidence after fix: focused Vitest passed 3 shards: gateway, agents, and plugins.

Observed result after fix: unreadable metadata rows are skipped, healthy owned metadata still decorates plugin tools, and plugin-owner scoping remains keyed by plugin id plus tool name.

What was not tested: remote `pnpm check:changed` could not lease a Crabbox runner because the coordinator returned HTTP 401 before lease creation; provider was azure, slug was `harbor-hermit`.
