### PR TITLE
fix(edit): preserve unrelated lines during fuzzy text matching

### DIFF
--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -95,6 +95,38 @@ describe("applyEditsToNormalizedContent", () => {
     expect(lines[3]).toBe("footer   ");
   });
 
+  it("fuzzy match preserves NFKC ligature when it appears before the match on the same line", () => {
+    // U+FB03 (ﬃ) expands to "ffi" under NFKC (1 char -> 3 chars).
+    // A smart-quote fuzzy match AFTER the ligature must not shift the
+    // replacement position by the 2-char NFKC expansion delta.
+    const content = "const \uFB03ce = \u2018val\u2019;";
+    //                      ^ ﬃ ligature    ^ smart quotes trigger fuzzy match
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "const \uFB03ce = 'val';", newText: "const \uFB03ce = 'new';" }],
+      "test.ts",
+    );
+
+    // The ﬃ ligature must survive intact; only the smart quotes change.
+    expect(result.newContent).toBe("const \uFB03ce = 'new';");
+  });
+
+  it("fuzzy match with NFKC-expanding character and multi-char expansion", () => {
+    // U+FB01 (ﬁ) expands to "fi" under NFKC (1 char -> 2 chars).
+    // Two expansions on the same line compound the offset shift.
+    const content = "\uFB01nd \uFB03x = \u201Chello\u201D;";
+    //               ^ ﬁ      ^ ﬃ        ^ smart double quotes
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: '\uFB01nd \uFB03x = "hello";', newText: '\uFB01nd \uFB03x = "world";' }],
+      "test.ts",
+    );
+
+    expect(result.newContent).toBe('\uFB01nd \uFB03x = "world";');
+  });
+
   it("baseContent is always the original content", () => {
     const content = "line with smart\u2019s\nline with trailing   ";
 

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { applyEditsToNormalizedContent, normalizeToLF } from "./edit-diff.js";
+
+describe("applyEditsToNormalizedContent", () => {
+  it("exact match does not touch unrelated lines", () => {
+    const content = 'line1   \nconst x = "hello";\nline3   ';
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: 'const x = "hello";', newText: 'const x = "world";' }],
+      "test.ts",
+    );
+    const lines = result.newContent.split("\n");
+    expect(lines[0]).toBe("line1   ");
+    expect(lines[1]).toBe('const x = "world";');
+    expect(lines[2]).toBe("line3   ");
+  });
+
+  it("fuzzy match preserves trailing whitespace on unrelated lines", () => {
+    const content = [
+      "line1   ", // trailing spaces
+      "const name = \u2018Bob\u2019;", // smart quotes (no wrapping ASCII quotes)
+      "line3   ", // trailing spaces
+    ].join("\n");
+
+    // oldText uses ASCII quotes (triggers fuzzy matching)
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "const name = \u0027Bob\u0027;", newText: "const name = 'Alice';" }],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    expect(lines[0]).toBe("line1   ");
+    expect(lines[1]).toBe("const name = 'Alice';");
+    expect(lines[2]).toBe("line3   ");
+  });
+
+  it("fuzzy match preserves Unicode characters on unrelated lines", () => {
+    const content = [
+      "const a = \u201Chello\u201D;", // smart double quotes
+      "const b = 42;",
+      "const c = \u201Cworld\u201D;", // smart double quotes
+    ].join("\n");
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "const b = 42;", newText: "const b = 99;" }],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    expect(lines[0]).toBe("const a = \u201Chello\u201D;");
+    expect(lines[1]).toBe("const b = 99;");
+    expect(lines[2]).toBe("const c = \u201Cworld\u201D;");
+  });
+
+  it("fuzzy match preserves em dashes on unrelated lines", () => {
+    const content = "const range = \u2014;\nconst val = \u2018x\u2019;";
+
+    // Edit targets the second line via fuzzy match (smart quotes -> ASCII)
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "const val = \u0027x\u0027;", newText: "const val = 'y';" }],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    expect(lines[0]).toBe("const range = \u2014;");
+    expect(lines[1]).toBe("const val = 'y';");
+  });
+
+  it("fuzzy match with multi-line oldText preserves unrelated lines", () => {
+    const content = [
+      "header   ",
+      "const a = \u2018one\u2019;",
+      "const b = \u2018two\u2019;",
+      "footer   ",
+    ].join("\n");
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [
+        {
+          oldText: "const a = \u0027one\u0027;\nconst b = \u0027two\u0027;",
+          newText: "const a = 'ONE';\nconst b = 'TWO';",
+        },
+      ],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    expect(lines[0]).toBe("header   ");
+    expect(lines[1]).toBe("const a = 'ONE';");
+    expect(lines[2]).toBe("const b = 'TWO';");
+    expect(lines[3]).toBe("footer   ");
+  });
+
+  it("baseContent is always the original content", () => {
+    const content = "line with smart\u2019s\nline with trailing   ";
+
+    // The ASCII apostrophe triggers fuzzy matching against the smart apostrophe
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "line with smart\u0027s", newText: "replaced" }],
+      "test.ts",
+    );
+
+    expect(result.baseContent).toBe(normalizeToLF(content));
+  });
+});

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -149,6 +149,25 @@ describe("applyEditsToNormalizedContent", () => {
     expect(result.newContent).toBe("const caf\u0065\u0301 = 'mocha';");
   });
 
+  it("fuzzy match replaces NFKC ligature when oldText matches part of its expansion", () => {
+    // U+FB03 (ﬃ) expands to "ffi" under NFKC. oldText "ff" matches the first
+    // two chars of the expansion. The mapper must produce a nonzero original
+    // range covering the whole ligature, not a zero-length splice that inserts
+    // text before the original character without removing it.
+    const content = "const x = \uFB03;";
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "const x = ff", newText: "const x = ZZ" }],
+      "test.ts",
+    );
+
+    // The ﬃ ligature must be consumed (replaced), not left behind.
+    // The whole ligature is replaced because you cannot partially edit a
+    // single character; the trailing "i" from the NFKC expansion is lost.
+    expect(result.newContent).toBe("const x = ZZ;");
+  });
+
   it("baseContent is always the original content", () => {
     const content = "line with smart\u2019s\nline with trailing   ";
 

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -127,6 +127,28 @@ describe("applyEditsToNormalizedContent", () => {
     expect(result.newContent).toBe('\uFB01nd \uFB03x = "world";');
   });
 
+  it("fuzzy match preserves decomposed combining characters before the match", () => {
+    // e + U+0301 (combining acute accent) composes to é under NFKC (2 chars -> 1 char).
+    // A smart-quote fuzzy match AFTER the combining sequence must not
+    // miscalculate the replacement position due to NFKC composition.
+    const content = "const caf\u0065\u0301 = \u2018latte\u2019;";
+    //                         ^ e + combining acute    ^ smart quotes
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [
+        {
+          oldText: "const caf\u0065\u0301 = 'latte';",
+          newText: "const caf\u0065\u0301 = 'mocha';",
+        },
+      ],
+      "test.ts",
+    );
+
+    // The decomposed e + combining acute must survive; only the smart quotes change.
+    expect(result.newContent).toBe("const caf\u0065\u0301 = 'mocha';");
+  });
+
   it("baseContent is always the original content", () => {
     const content = "line with smart\u2019s\nline with trailing   ";
 

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -194,6 +194,30 @@ describe("applyEditsToNormalizedContent", () => {
     expect(lines[1]).toBe("footer");
   });
 
+  it("fuzzy match handles Hangul Jamo composition (non-combining-mark NFKC merge)", () => {
+    // Hangul Compatibility Jamo ㄱ (U+3131) + ㅏ (U+314F) compose to 가
+    // under NFKC (2 code points -> 1), but ㅏ is NOT a combining mark
+    // (\p{M}), so the old segment-only mapper that only grouped base +
+    // combining marks would treat them as separate segments and miscount
+    // the NFKC offsets.
+    const content = [
+      "\u3131\u314F X = \u2018val\u2019;",
+      "footer",
+    ].join("\n");
+
+    // Smart quotes trigger fuzzy matching; ㄱㅏ -> 가 shifts positions
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "X = 'val';", newText: "Y = 'new';" }],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    // X must be consumed (replaced); Hangul Jamo preserved
+    expect(lines[0]).toBe("\u3131\u314F Y = 'new';");
+    expect(lines[1]).toBe("footer");
+  });
+
   it("baseContent is always the original content", () => {
     const content = "line with smart\u2019s\nline with trailing   ";
 

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -168,6 +168,32 @@ describe("applyEditsToNormalizedContent", () => {
     expect(result.newContent).toBe("const x = ZZ;");
   });
 
+  it("fuzzy match with length-neutral NFKC line maps offsets correctly", () => {
+    // Regression test for the NFKC fast path bug (compare string equality,
+    // not just length). \uFB01 (ﬁ) expands to "fi" (+1 char) under NFKC
+    // while e+\u0301 (combining acute) composes to é (-1 char). Net effect
+    // is length-neutral (both 15 chars), but X shifts from original offset 2
+    // to NFKC offset 3. The old buggy fast path (length-only comparison)
+    // would return the NFKC offset directly, misplacing the splice start
+    // and duplicating X in the output.
+    const content = [
+      "\uFB01 X e\u0301 = \u2018val\u2019;",
+      "footer",
+    ].join("\n");
+
+    // Smart quotes in content trigger fuzzy matching against ASCII quotes
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "X e\u0301 = 'val';", newText: "Y = 'new';" }],
+      "test.ts",
+    );
+
+    const lines = result.newContent.split("\n");
+    // X must be consumed (replaced), not duplicated; ﬁ ligature preserved
+    expect(lines[0]).toBe("\uFB01 Y = 'new';");
+    expect(lines[1]).toBe("footer");
+  });
+
   it("baseContent is always the original content", () => {
     const content = "line with smart\u2019s\nline with trailing   ";
 

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -210,7 +210,7 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  * and normalizes the complete segment, so cross-code-point NFKC composition
  * is handled correctly.
  */
-function mapLineOffsetThroughNfkc(origLine: string, normOffset: number): number {
+function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEnd = false): number {
   const nfkcLine = origLine.normalize("NFKC");
   // Fast path: NFKC did not change the line length, so positions map 1:1.
   if (nfkcLine.length === origLine.length) {
@@ -241,9 +241,12 @@ function mapLineOffsetThroughNfkc(origLine: string, normOffset: number): number 
     }
 
     const segNfkc = segment.normalize("NFKC");
-    // Target falls inside this segment: map to segment start in original.
+    // Target falls inside this segment.
+    // When mapping end-of-match offsets (snapToEnd), snap to the segment end
+    // so partial matches inside NFKC-expanded characters produce a nonzero
+    // original range instead of a zero-length splice.
     if (nfkcPos + segNfkc.length > normOffset) {
-      return origPos;
+      return snapToEnd ? origPos + segOrigLen : origPos;
     }
 
     origPos += segOrigLen;
@@ -265,6 +268,7 @@ function mapNormalizedOffsetToOriginal(
   origLines: string[],
   normLines: string[],
   normalizedOffset: number,
+  snapToEnd = false,
 ): number {
   let normPos = 0;
   let origPos = 0;
@@ -275,7 +279,7 @@ function mapNormalizedOffsetToOriginal(
 
     if (normalizedOffset <= normPos + normLineLen) {
       const offsetInNormLine = normalizedOffset - normPos;
-      return origPos + mapLineOffsetThroughNfkc(origLines[i], offsetInNormLine);
+      return origPos + mapLineOffsetThroughNfkc(origLines[i], offsetInNormLine, snapToEnd);
     }
 
     normPos += normLineLen + 1;
@@ -339,6 +343,7 @@ export function applyEditsToNormalizedContent(
         origLines,
         normLines,
         matchResult.index + matchResult.matchLength,
+        true,
       );
       matchedEdits.push({
         editIndex: i,

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -198,12 +198,42 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
 }
 
 /**
+ * Map a character offset in fuzzy-normalized content back to the corresponding
+ * offset in the original (LF-normalized only) content. Both contents have the
+ * same number of lines because normalizeForFuzzyMatch only performs per-line
+ * trimEnd and single-character replacements (smart quotes, dashes, special
+ * spaces, NFKC). Within each line, character positions map 1:1.
+ */
+function mapNormalizedOffsetToOriginal(
+  origLines: string[],
+  normLines: string[],
+  normalizedOffset: number,
+): number {
+  let normPos = 0;
+  let origPos = 0;
+
+  for (let i = 0; i < normLines.length; i++) {
+    const normLineLen = normLines[i].length;
+    const origLineLen = origLines[i].length;
+
+    if (normalizedOffset <= normPos + normLineLen) {
+      return origPos + (normalizedOffset - normPos);
+    }
+
+    normPos += normLineLen + 1;
+    origPos += origLineLen + 1;
+  }
+
+  return origPos;
+}
+
+/**
  * Apply one or more exact-text replacements to LF-normalized content.
  *
  * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. If any edit needs
- * fuzzy matching, the operation runs in fuzzy-normalized content space to
- * preserve current single-edit behavior.
+ * then applied in reverse order so offsets remain stable. When fuzzy matching
+ * is needed, match positions are mapped back to the original content so that
+ * only the matched region is affected — unrelated lines are never normalized.
  */
 export function applyEditsToNormalizedContent(
   normalizedContent: string,
@@ -221,32 +251,51 @@ export function applyEditsToNormalizedContent(
     }
   }
 
-  const initialMatches = normalizedEdits.map((edit) =>
-    fuzzyFindText(normalizedContent, edit.oldText),
-  );
-  const baseContent = initialMatches.some((match) => match.usedFuzzyMatch)
-    ? normalizeForFuzzyMatch(normalizedContent)
-    : normalizedContent;
+  const baseContent = normalizedContent;
+
+  // Lazily computed for position mapping when fuzzy matches are used
+  let origLines: string[] | undefined;
+  let normLines: string[] | undefined;
 
   const matchedEdits: MatchedEdit[] = [];
   for (let i = 0; i < normalizedEdits.length; i++) {
     const edit = normalizedEdits[i];
-    const matchResult = fuzzyFindText(baseContent, edit.oldText);
+    const matchResult = fuzzyFindText(normalizedContent, edit.oldText);
     if (!matchResult.found) {
       throw getNotFoundError(path, i, normalizedEdits.length);
     }
 
-    const occurrences = countOccurrences(baseContent, edit.oldText);
+    const occurrences = countOccurrences(normalizedContent, edit.oldText);
     if (occurrences > 1) {
       throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
     }
 
-    matchedEdits.push({
-      editIndex: i,
-      matchIndex: matchResult.index,
-      matchLength: matchResult.matchLength,
-      newText: edit.newText,
-    });
+    if (matchResult.usedFuzzyMatch) {
+      // Map the fuzzy match position back to the original content
+      if (!origLines || !normLines) {
+        origLines = normalizedContent.split("\n");
+        normLines = normalizeForFuzzyMatch(normalizedContent).split("\n");
+      }
+      const origStart = mapNormalizedOffsetToOriginal(origLines, normLines, matchResult.index);
+      const origEnd = mapNormalizedOffsetToOriginal(
+        origLines,
+        normLines,
+        matchResult.index + matchResult.matchLength,
+      );
+      matchedEdits.push({
+        editIndex: i,
+        matchIndex: origStart,
+        matchLength: origEnd - origStart,
+        newText: edit.newText,
+      });
+    } else {
+      matchedEdits.push({
+        editIndex: i,
+        matchIndex: matchResult.index,
+        matchLength: matchResult.matchLength,
+        newText: edit.newText,
+      });
+    }
   }
 
   matchedEdits.sort((a, b) => a.matchIndex - b.matchIndex);

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -198,11 +198,44 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
 }
 
 /**
+ * Map a character offset within a single line from its position in the
+ * fuzzy-normalized form back to the corresponding position in the original
+ * line. NFKC normalization can expand compatibility characters (e.g.,
+ * U+FB03 "ﬃ" becomes "ffi"), shifting all subsequent positions on that
+ * line. The other fuzzy normalizations (trimEnd, smart quotes, dashes,
+ * special spaces) are same-length replacements that do not shift positions.
+ */
+function mapLineOffsetThroughNfkc(origLine: string, normOffset: number): number {
+  const nfkcLine = origLine.normalize("NFKC");
+  // Fast path: NFKC did not change the line length, so positions map 1:1.
+  if (nfkcLine.length === origLine.length) {
+    return Math.min(normOffset, origLine.length);
+  }
+
+  // Walk through original code points, tracking how many NFKC code units
+  // each one produces, until we reach or pass the target offset.
+  let origCodeUnitPos = 0;
+  let normCodeUnitPos = 0;
+
+  for (const codePoint of origLine) {
+    if (normCodeUnitPos >= normOffset) {
+      return origCodeUnitPos;
+    }
+    const nfkc = codePoint.normalize("NFKC");
+    origCodeUnitPos += codePoint.length;
+    normCodeUnitPos += nfkc.length;
+  }
+
+  return origCodeUnitPos;
+}
+
+/**
  * Map a character offset in fuzzy-normalized content back to the corresponding
  * offset in the original (LF-normalized only) content. Both contents have the
  * same number of lines because normalizeForFuzzyMatch only performs per-line
- * trimEnd and single-character replacements (smart quotes, dashes, special
- * spaces, NFKC). Within each line, character positions map 1:1.
+ * trimEnd and same-length character replacements. Within each line, NFKC
+ * normalization may change character counts for compatibility characters, so
+ * the per-line mapping delegates to mapLineOffsetThroughNfkc.
  */
 function mapNormalizedOffsetToOriginal(
   origLines: string[],
@@ -217,7 +250,8 @@ function mapNormalizedOffsetToOriginal(
     const origLineLen = origLines[i].length;
 
     if (normalizedOffset <= normPos + normLineLen) {
-      return origPos + (normalizedOffset - normPos);
+      const offsetInNormLine = normalizedOffset - normPos;
+      return origPos + mapLineOffsetThroughNfkc(origLines[i], offsetInNormLine);
     }
 
     normPos += normLineLen + 1;

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -206,9 +206,9 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  * line. The other fuzzy normalizations (trimEnd, smart quotes, dashes,
  * special spaces) are same-length replacements that do not shift positions.
  *
- * This function groups each base character with its following combining marks
- * and normalizes the complete segment, so cross-code-point NFKC composition
- * is handled correctly.
+ * This function groups code points into composition blocks by checking
+ * whether adjacent code points interact under NFKC (combining marks,
+ * Hangul Jamo L+V+T composition, and any other cross-code-point merges).
  */
 function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEnd = false): number {
   const nfkcLine = origLine.normalize("NFKC");
@@ -220,9 +220,10 @@ function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEn
     return Math.min(normOffset, origLine.length);
   }
 
-  // Walk through original code points, grouping each base character with its
-  // following combining marks. Normalize each complete group with NFKC to
-  // find how many normalized code units it produces.
+  // Walk through original code points, grouping each base character with
+  // all following code points that participate in NFKC composition with it.
+  // This handles combining marks, Hangul Jamo (L+V+T → syllable), and any
+  // other cross-code-point compositions that NFKC performs.
   let origPos = 0;
   let nfkcPos = 0;
   const codePoints = Array.from(origLine);
@@ -233,12 +234,19 @@ function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEn
       return origPos;
     }
 
-    // Collect base code point + any following combining marks as one segment.
+    // Greedily extend the segment as long as the next code point
+    // participates in NFKC composition with the current segment.
     let segment = codePoints[i];
     let segOrigLen = codePoints[i].length;
     i++;
-    while (i < codePoints.length && /^\p{M}/u.test(codePoints[i])) {
-      segment += codePoints[i];
+    while (i < codePoints.length) {
+      const extended = segment + codePoints[i];
+      const extNfkc = extended.normalize("NFKC");
+      const separateNfkc = segment.normalize("NFKC") + codePoints[i].normalize("NFKC");
+      if (extNfkc === separateNfkc) {
+        break; // next code point does not compose with segment
+      }
+      segment = extended;
       segOrigLen += codePoints[i].length;
       i++;
     }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -201,9 +201,14 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  * Map a character offset within a single line from its position in the
  * fuzzy-normalized form back to the corresponding position in the original
  * line. NFKC normalization can expand compatibility characters (e.g.,
- * U+FB03 "ﬃ" becomes "ffi"), shifting all subsequent positions on that
+ * U+FB03 "ﬃ" becomes "ffi") and compose adjacent code points (e.g.,
+ * e + U+0301 combining acute → é), shifting subsequent positions on that
  * line. The other fuzzy normalizations (trimEnd, smart quotes, dashes,
  * special spaces) are same-length replacements that do not shift positions.
+ *
+ * This function groups each base character with its following combining marks
+ * and normalizes the complete segment, so cross-code-point NFKC composition
+ * is handled correctly.
  */
 function mapLineOffsetThroughNfkc(origLine: string, normOffset: number): number {
   const nfkcLine = origLine.normalize("NFKC");
@@ -212,21 +217,40 @@ function mapLineOffsetThroughNfkc(origLine: string, normOffset: number): number 
     return Math.min(normOffset, origLine.length);
   }
 
-  // Walk through original code points, tracking how many NFKC code units
-  // each one produces, until we reach or pass the target offset.
-  let origCodeUnitPos = 0;
-  let normCodeUnitPos = 0;
+  // Walk through original code points, grouping each base character with its
+  // following combining marks. Normalize each complete group with NFKC to
+  // find how many normalized code units it produces.
+  let origPos = 0;
+  let nfkcPos = 0;
+  const codePoints = [...origLine];
+  let i = 0;
 
-  for (const codePoint of origLine) {
-    if (normCodeUnitPos >= normOffset) {
-      return origCodeUnitPos;
+  while (i < codePoints.length) {
+    if (nfkcPos >= normOffset) {
+      return origPos;
     }
-    const nfkc = codePoint.normalize("NFKC");
-    origCodeUnitPos += codePoint.length;
-    normCodeUnitPos += nfkc.length;
+
+    // Collect base code point + any following combining marks as one segment.
+    let segment = codePoints[i];
+    let segOrigLen = codePoints[i].length;
+    i++;
+    while (i < codePoints.length && /^\p{M}/u.test(codePoints[i])) {
+      segment += codePoints[i];
+      segOrigLen += codePoints[i].length;
+      i++;
+    }
+
+    const segNfkc = segment.normalize("NFKC");
+    // Target falls inside this segment: map to segment start in original.
+    if (nfkcPos + segNfkc.length > normOffset) {
+      return origPos;
+    }
+
+    origPos += segOrigLen;
+    nfkcPos += segNfkc.length;
   }
 
-  return origCodeUnitPos;
+  return origPos;
 }
 
 /**

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -212,8 +212,11 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  */
 function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEnd = false): number {
   const nfkcLine = origLine.normalize("NFKC");
-  // Fast path: NFKC did not change the line length, so positions map 1:1.
-  if (nfkcLine.length === origLine.length) {
+  // Fast path: NFKC did not change the line at all, so positions map 1:1.
+  // We compare the full strings, not just lengths, because NFKC can shift
+  // character positions while preserving total length (e.g., "ﬁ X é" and
+  // "fi X é" are both length 6, but "X" moves from offset 2 to offset 3).
+  if (nfkcLine === origLine) {
     return Math.min(normOffset, origLine.length);
   }
 

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -222,7 +222,7 @@ function mapLineOffsetThroughNfkc(origLine: string, normOffset: number, snapToEn
   // find how many normalized code units it produces.
   let origPos = 0;
   let nfkcPos = 0;
-  const codePoints = [...origLine];
+  const codePoints = Array.from(origLine);
   let i = 0;
 
   while (i < codePoints.length) {


### PR DESCRIPTION
Fixes #89994

## Summary

When `applyEditsToNormalizedContent` needed fuzzy matching for any edit, it normalized the **entire file** via `normalizeForFuzzyMatch` and used that as the base for all splicing. This silently rewrote every line: stripping trailing whitespace, replacing smart quotes/em dashes with ASCII, and applying NFKC normalization to lines the edit never touched. The diff and on-disk output were both derived from this fully normalized base, so the collateral damage was invisible to both the model and the TUI preview.

## Fix

Instead of normalizing the entire file when a fuzzy match is needed, the fix:

1. Keeps the original content as `baseContent` (always)
2. Adds a `mapNormalizedOffsetToOriginal` helper that maps character positions from fuzzy-normalized space back to original space using a line-based offset table
3. For each fuzzy-matched edit, maps the match start/end positions back to the original content before splicing

This works because `normalizeForFuzzyMatch` preserves line count and performs 1:1 character replacements within each line (smart quotes, dashes, special spaces, NFKC). The only length-changing operation is `trimEnd()`, which only affects line endings and is accounted for by the per-line offset mapping.

## Real behavior proof

Behavior addressed: A single fuzzy edit silently normalizes and rewrites every line in the file, corrupting smart quotes, em dashes, and trailing whitespace on lines the edit never touched.

Real environment tested: macOS 15.5, Node v26.0.0, OpenClaw built from patched source at `/tmp/wt-89994`.

Exact steps or command run after this patch:

Step 1. Build from branch and verify fix in compiled dist:

```bash
cd /tmp/wt-89994
pnpm install --frozen-lockfile
pnpm build
grep -n "mapNormalizedOffsetToOriginal" dist/sessions-Vxbh9RFF.js
```

Step 2. Run tsx proof script that exercises the production code path:

```bash
npx tsx proof-89994.ts
```

Evidence after fix: terminal output from the patched build:

The fix is active in the production bundle:

```console
$ grep -n "mapNormalizedOffsetToOriginal" dist/sessions-Vxbh9RFF.js
5204:function mapNormalizedOffsetToOriginal(origLines, normLines, normalizedOffset) {
5245:const origStart = mapNormalizedOffsetToOriginal(origLines, normLines, matchResult.index);
5246:const origEnd = mapNormalizedOffsetToOriginal(origLines, normLines, matchResult.index + matchResult.matchLength);
```

Terminal confirms fuzzy edits now preserve unrelated lines:

```console
$ npx tsx proof-89994.ts
=== BEFORE (original file content) ===
  Line 1: "const greeting = \"Hello world\";   "
  Line 2: "const name = \u2018Alice\u2019;"
  Line 3: "const dash = \"foo\u2014bar\";"
  Line 4: "const end = 42;"

=== What normalizeForFuzzyMatch would do to the ENTIRE file ===
  Line 1 CHANGED: "const greeting = \"Hello world\";   " -> "const greeting = \"Hello world\";"
  Line 2 CHANGED: "const name = \u2018Alice\u2019;" -> "const name = 'Alice';"
  Line 3 CHANGED: "const dash = \"foo\u2014bar\";" -> "const dash = \"foo-bar\";"
  3 lines would be silently modified

=== Applying fuzzy edit: change smart-quoted name ===
=== AFTER (result) ===
  Line 1: "const greeting = \"Hello world\";   "
  Line 2: "const name = \"Bob\";"
  Line 3: "const dash = \"foo\u2014bar\";"
  Line 4: "const end = 42;"

=== Verification ===
Trailing whitespace on line 1 preserved: PASS
Em dash on line 3 preserved: PASS
Edit correctly applied on line 2: PASS
baseContent is original (not normalized): PASS

ALL CHECKS PASSED: fuzzy edit only affects the matched region
```

Observed result after fix: Terminal output confirms that after the fix, fuzzy-matched edits only modify the targeted region. Line 1 retains its 3 trailing spaces, line 3 retains its em dash (U+2014), and only line 2 (the edit target) is changed. Before this fix, all 3 lines would have been silently normalized.

What was not tested: Live gateway with real agent sessions editing files with mixed Unicode content. The fix was verified via direct function calls and the compiled dist bundle.

