### PR TITLE
fix(agent-runtime): guard prompt cache tool names

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -17,6 +17,25 @@ describe("prompt cache observability", () => {
     ).toEqual(["read", "write"]);
   });
 
+  it("skips unreadable tool name rows", () => {
+    const tools: Array<{ name?: string }> = [{ name: "read" }];
+    Object.defineProperty(tools, "1", {
+      get() {
+        throw new Error("prompt cache tool row exploded");
+      },
+    });
+    tools.length = 3;
+    Object.defineProperty(tools, "2", {
+      value: {
+        get name() {
+          throw new Error("prompt cache tool name exploded");
+        },
+      },
+    });
+
+    expect(collectPromptCacheToolNames(tools)).toEqual(["read"]);
+  });
+
   it("tracks cache-relevant changes and reports a real cache-read drop", () => {
     const first = beginPromptCacheObservation({
       sessionId: "session-1",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -138,7 +138,30 @@ function diffSnapshots(
 }
 
 export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): string[] {
-  return tools.map((tool) => tool.name?.trim()).filter((name): name is string => Boolean(name));
+  const names: string[] = [];
+  for (const key of Object.keys(tools)) {
+    const index = Number(key);
+    if (!Number.isInteger(index)) {
+      continue;
+    }
+    let tool: { name?: string } | undefined;
+    try {
+      tool = tools[index];
+    } catch {
+      continue;
+    }
+    let rawName: string | undefined;
+    try {
+      rawName = tool?.name;
+    } catch {
+      continue;
+    }
+    const name = rawName?.trim();
+    if (name) {
+      names.push(name);
+    }
+  }
+  return names;
 }
 
 export function beginPromptCacheObservation(params: {


### PR DESCRIPTION
## Summary

This PR keeps prompt-cache observability from crashing an agent turn when tool-name diagnostics encounter malformed tool rows.

- Guard `collectPromptCacheToolNames()` against unreadable array rows and throwing `name` getters.
- Preserve existing behavior for readable tool names: trim names, drop empty values, and keep the diagnostic tool set unchanged.
- Add focused regression coverage for a poisoned row before a healthy tool.

## Linked context

Related to the tool schema fuzzing hardening sweep.

## Real behavior proof

- Behavior addressed: malformed diagnostic-only tool rows can no longer crash prompt-cache observation before the agent turn continues.
- Real environment tested: local OpenClaw Codex worktree with linked repo dependencies.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=dot`
- Evidence after fix: focused Vitest passed 1 shard, 1 file, 8 tests.
- Observed result after fix: unreadable tool rows and throwing `name` getters are skipped while the healthy `read` tool name is still collected.
- What was not tested: remote `pnpm check:changed` because the Crabbox coordinator rejected lease creation with HTTP 401 before remote sync or execution.
- Proof limitations or environment constraints: Crabbox wrapper selected provider `azure`; coordinator lease slug was `golden-krill`; Blacksmith CLI is also unauthenticated locally.
- Before evidence: the previous projection shape `entries.map((tool) => tool.name?.trim())` throws when a tool row getter raises before later healthy rows are read.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` failed before lease with coordinator HTTP 401.

Regression coverage was added in `src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`.

## Risk checklist

- Did user-visible behavior change? `No`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- Highest-risk area: prompt-cache diagnostics could under-report a malformed tool name.
- Mitigation: this helper is observability-only; healthy tool names still collect, malformed rows are skipped, and focused tests cover the degraded path.

## Current review state

- Next action: maintainer review and CI.
- Waiting on: remote changed-gate proof once Crabbox/Testbox auth is available.
- Bot/reviewer comments addressed: local and branch autoreview both returned no accepted/actionable findings.
