### PR TITLE
fix(agent): infer agent from fresh session keys

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3779,6 +3779,88 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("infers the key agent id for fresh explicit cron session runs", async () => {
+    const sessionKey = "agent:main:cron-fresh";
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: undefined,
+      canonicalKey: sessionKey,
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "cron turn",
+        sessionKey,
+        bootstrapContextRunKind: "cron",
+        idempotencyKey: "fresh-explicit-agent-session-cron",
+      },
+      { reqId: "fresh-explicit-agent-session-cron" },
+    );
+
+    const call = await waitForAgentCommandCall<{
+      agentId?: string;
+      sessionKey?: string;
+    }>();
+    expect(call.agentId).toBe("main");
+    expect(call.sessionKey).toBe(sessionKey);
+  });
+
+  it("rejects fresh explicit agent sessions when agent id disagrees with the session key", async () => {
+    mocks.listAgentIds.mockReturnValue(["main", "work"]);
+    mocks.loadConfigReturn = {
+      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+    };
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "first turn",
+        agentId: "work",
+        sessionKey: "agent:main:probe-fresh",
+        idempotencyKey: "fresh-agent-session-mismatch",
+      },
+      { reqId: "fresh-agent-session-mismatch", flushDispatch: false },
+    );
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    const error = expectRespondError(respond, {});
+    expectStringFieldContains(
+      error,
+      "message",
+      'agent "work" does not match session key agent "main"',
+    );
+  });
+
+  it("rejects an unconfigured agent in a non-global fresh session key", async () => {
+    mocks.listAgentIds.mockReturnValue(["main"]);
+    mocks.loadConfigReturn = {
+      agents: { list: [{ id: "main", default: true }] },
+    };
+    mocks.agentCommand.mockClear();
+
+    const respond = await invokeAgent(
+      {
+        message: "first turn",
+        sessionKey: "agent:ghost:probe-fresh",
+        idempotencyKey: "fresh-agent-session-unknown-nonglobal",
+      },
+      { reqId: "fresh-agent-session-unknown-nonglobal", flushDispatch: false },
+    );
+
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    const error = expectRespondError(respond, {});
+    expectStringFieldContains(error, "message", 'unknown agent id "ghost"');
+  });
+
   it("does not let --agent force the agent main session when --session-id is provided", async () => {
     mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:main:main");
     mockMainSessionEntry({ sessionId: "resume-whatsapp-session" });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3734,6 +3734,51 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("dispatches a fresh explicit agent session with the key agent id", async () => {
+    const sessionKey = "agent:main:probe-fresh";
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: undefined,
+      canonicalKey: sessionKey,
+    });
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      const result = await updater(store);
+      capturedEntry = store[sessionKey] as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "first turn",
+        sessionKey,
+        idempotencyKey: "fresh-explicit-agent-session",
+      },
+      { reqId: "fresh-explicit-agent-session" },
+    );
+
+    const call = await waitForAgentCommandCall<{
+      agentId?: string;
+      sessionId?: string;
+      sessionKey?: string;
+    }>();
+    expect(call.agentId).toBe("main");
+    expect(call.sessionKey).toBe(sessionKey);
+    expect(call.sessionId).toEqual(expect.any(String));
+    expect(call.sessionId).not.toBe("");
+    expect(capturedEntry).toMatchObject({
+      sessionId: call.sessionId,
+      sessionStartedAt: expect.any(Number),
+      lastInteractionAt: expect.any(Number),
+    });
+  });
+
   it("does not let --agent force the agent main session when --session-id is provided", async () => {
     mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:main:main");
     mockMainSessionEntry({ sessionId: "resume-whatsapp-session" });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1418,27 +1418,21 @@ export const agentHandlers: GatewayRequestHandlers = {
     const parsedRequestedSessionKey = requestedSessionKeyRaw
       ? parseAgentSessionKey(requestedSessionKeyRaw)
       : null;
-    const requestedSessionResolvesGlobal =
-      parsedRequestedSessionKey &&
-      resolveSessionStoreKey({ cfg, sessionKey: requestedSessionKeyRaw }) === "global";
     if (!agentId && parsedRequestedSessionKey) {
       const inferredAgentId = normalizeAgentId(parsedRequestedSessionKey.agentId);
       if (inferredAgentId) {
         if (!knownAgents.includes(inferredAgentId)) {
-          if (requestedSessionResolvesGlobal) {
-            respond(
-              false,
-              undefined,
-              errorShape(
-                ErrorCodes.INVALID_REQUEST,
-                `invalid agent params: unknown agent id "${parsedRequestedSessionKey.agentId}"`,
-              ),
-            );
-            return;
-          }
-        } else {
-          agentId = inferredAgentId;
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              `invalid agent params: unknown agent id "${parsedRequestedSessionKey.agentId}"`,
+            ),
+          );
+          return;
         }
+        agentId = inferredAgentId;
       }
     }
     // Drop an exec-approval followup whose session key was rebound by /new or

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1415,25 +1415,30 @@ export const agentHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    if (!agentId && requestedSessionKeyRaw) {
-      const parsed = parseAgentSessionKey(requestedSessionKeyRaw);
-      const inferredAgentId =
-        parsed && resolveSessionStoreKey({ cfg, sessionKey: requestedSessionKeyRaw }) === "global"
-          ? normalizeAgentId(parsed.agentId)
-          : undefined;
+    const parsedRequestedSessionKey = requestedSessionKeyRaw
+      ? parseAgentSessionKey(requestedSessionKeyRaw)
+      : null;
+    const requestedSessionResolvesGlobal =
+      parsedRequestedSessionKey &&
+      resolveSessionStoreKey({ cfg, sessionKey: requestedSessionKeyRaw }) === "global";
+    if (!agentId && parsedRequestedSessionKey) {
+      const inferredAgentId = normalizeAgentId(parsedRequestedSessionKey.agentId);
       if (inferredAgentId) {
         if (!knownAgents.includes(inferredAgentId)) {
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `invalid agent params: unknown agent id "${parsed?.agentId}"`,
-            ),
-          );
-          return;
+          if (requestedSessionResolvesGlobal) {
+            respond(
+              false,
+              undefined,
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                `invalid agent params: unknown agent id "${parsedRequestedSessionKey.agentId}"`,
+              ),
+            );
+            return;
+          }
+        } else {
+          agentId = inferredAgentId;
         }
-        agentId = inferredAgentId;
       }
     }
     // Drop an exec-approval followup whose session key was rebound by /new or
@@ -1483,7 +1488,6 @@ export const agentHandlers: GatewayRequestHandlers = {
           })
         : undefined);
     if (agentId && requestedSessionKeyRaw) {
-      const parsedRequestedSessionKey = parseAgentSessionKey(requestedSessionKeyRaw);
       const requestedCanonicalKey = resolveSessionStoreKey({
         cfg,
         sessionKey: requestedSessionKeyRaw,


### PR DESCRIPTION
## Summary

Fixes #89746.

Gateway `agent` requests that supplied a fresh explicit session key such as `agent:main:probe-*` could reach dispatch without carrying the agent id embedded in the key. Existing session resolution could still create the session row, but the dispatch path did not consistently preserve the key's agent owner for a never-before-seen session.

This change infers the configured agent id from well-formed agent-prefixed session keys before gateway dispatch, and rejects explicit agent-prefixed session keys whose embedded agent id is not configured instead of falling back to an unowned/default dispatch path.

## What changed

- Infer `agentId` from `agent:<id>:<key>` when `<id>` is a configured agent and no explicit `agentId` was supplied.
- Keep the existing selected-global unknown-agent rejection behavior.
- Add a regression test proving a fresh explicit session key is persisted and dispatched with the key's agent id.

## Public surface

No public config options, plugin APIs, or protocol fields are added or changed.

## Real behavior proof

Behavior or issue addressed:
Fresh Gateway `agent` dispatches with an explicit agent-prefixed session key now infer the intended configured agent before creating/persisting the new session and provider request.

Real environment tested:
WSL Ubuntu 24.04, OpenClaw checkout `/root/src/openclaw-90062-proof`, PR head `b07f56876e72f292bd33c097d635c750f1161418`, source Gateway harness with real `startGatewayServer`, real `node scripts/run-node.mjs agent` CLI child process, QA mock OpenAI provider, temp config/state/home dirs, Gateway auth disabled only for the local proof server.

Exact steps or command run after this patch:
1. Started QA mock OpenAI provider with `/debug/requests` enabled.
2. Wrote a temp OpenClaw config with Gateway on loopback, one configured default `main` agent, mock provider auth staged for `main`, memory disabled, and supported `minimal` tool profile.
3. Started a real Gateway process in-process with `startGatewayServer(<free loopback port>, { host: "127.0.0.1", auth: { mode: "none" }, controlUiEnabled: false })`.
4. Ran the real CLI command path as a child process: `node scripts/run-node.mjs agent --session-key agent:main:probe-mqlb00jt --message "fresh explicit session proof: reply with the exact marker FRESH_SESSION_PROOF_OK" --json --timeout 120`.
5. Fetched the mock provider `/debug/requests` after the CLI run and scanned the temp state dir for the exact session key.
6. Ran focused regression coverage: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -t "dispatches a fresh explicit agent session with the key agent id" --reporter=dot`.
7. Ran changed-file lint/checks: `pnpm exec oxlint src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts` and `git diff --check`.

Evidence after fix:
```json
{
  "ok": true,
  "gatewayUrl": "http://127.0.0.1:45933",
  "sessionKey": "agent:main:probe-mqlb00jt",
  "cliExit": 0,
  "cliJsonStatus": "ok",
  "cliJsonRunId": "ab5314dd-bb4d-4b4c-be87-bf352728b051",
  "cliPayloadText": "Protocol note: acknowledged. Continue with the QA scenario plan and report worked, failed, and blocked items.",
  "providerRequestCount": 1,
  "providerFirstModel": "gpt-5.5",
  "providerFirstVariant": "openai",
  "providerPromptIncludesMarker": true,
  "stateEvidence": [
    {
      "path": "state/agents/main/sessions/da8e4409-8335-411a-9322-0425bbb83b7e.trajectory.jsonl",
      "mentions": 11,
      "hasAgentMain": true
    },
    {
      "path": "state/agents/main/sessions/sessions.json",
      "mentions": 2,
      "hasAgentMain": true
    }
  ]
}
```

Supporting checks:
- Focused Vitest: `2 passed`, `328 skipped`, exit 0.
- `pnpm exec oxlint src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts`: `Found 0 warnings and 0 errors`.
- `git diff --check`: clean.

Observed result after fix:
The CLI completed successfully through Gateway, the mock provider received exactly one model request containing the proof marker, and the fresh explicit session key was persisted under `state/agents/main/sessions/...` with `agent:main` evidence in both the trajectory log and `sessions.json`.

What was not tested:
The proof used the repo QA mock OpenAI provider instead of a live paid provider; that keeps the dispatch/session/auth path real while avoiding external credentials. No remote Gateway, packaged installer, or non-Linux platform path was exercised for this narrow server-side dispatch fix.
