### PR TITLE
fix(channels): clarify message receipt delivery evidence

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2361,6 +2361,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Layout and names
   - H2: Provision ignored files
   - H2: Run repository setup
+  - H2: Session worktrees
   - H2: Snapshots, cleanup, and restore
   - H2: CLI
   - H2: Gateway methods
@@ -6907,6 +6908,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /plugins/sdk-channel-outbound
 - Headings:
   - H2: Adapter
+  - H2: Delivery Evidence
   - H2: Existing outbound adapters
   - H2: Durable sends
   - H2: Compatibility dispatch

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -66,6 +66,15 @@ Only declare capabilities the native transport actually preserves. Cover
 each declared send, receipt, live-preview, and receive-ack capability with
 the contract helpers exported from this subpath.
 
+## Delivery Evidence
+
+A `MessageReceipt` records the result returned by a channel adapter. Concrete
+platform message identifiers show that the platform send path accepted the
+message; they do not prove that a recipient's device displayed or read it.
+Receipts without platform message identifiers are local receipt metadata only.
+Channels with read receipts or device-delivery state should track those facts
+through a separate channel-specific path.
+
 ## Existing outbound adapters
 
 If the channel already has a compatible `outbound` adapter, derive the
@@ -97,12 +106,12 @@ Runtime send helpers also live on `channel-outbound`:
 
 `sendDurableMessageBatch(...)` returns one explicit outcome:
 
-| Outcome          | Meaning                                                                                  |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| `sent`           | at least one visible platform message was delivered                                      |
-| `suppressed`     | no platform message should be treated as missing                                         |
-| `partial_failed` | at least one platform message was delivered before a later payload or side effect failed |
-| `failed`         | no platform receipt was produced                                                         |
+| Outcome          | Meaning                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| `sent`           | at least one visible platform message was accepted by the platform send path            |
+| `suppressed`     | no platform message should be treated as missing                                        |
+| `partial_failed` | at least one platform message was accepted before a later payload or side effect failed |
+| `failed`         | no platform receipt was produced                                                        |
 
 Use `payloadOutcomes` when a batch mixes sent, suppressed, and failed
 payloads. Do not infer hook cancellation from an empty legacy


### PR DESCRIPTION
## Summary

- Add `createMessageReceiptDeliveryEvidence(...)` for turning a `MessageReceipt` into explicit operator-facing delivery evidence.
- Re-export the helper through `openclaw/plugin-sdk/channel-outbound` for channel plugins/status surfaces.
- Document that `MessageReceipt` means platform send acceptance only when platform ids are present, not recipient device-visible/read delivery.

## Why

Non-editing chat channels can return platform message ids even when the transport does not expose a reliable device/read receipt path. Operator-facing status should not silently upgrade "send accepted by the platform" into "the recipient saw/read it".

This keeps the existing `MessageReceipt` shape intact while giving plugins and status surfaces a small helper that makes the boundary explicit. Receipts without platform ids stay explicit: `platformSendAccepted: false`, `platformSendAcceptedAt: null`, and `platformSendEvidence: "none"`.

## Real behavior proof

Behavior or issue addressed: A `MessageReceipt` created from a successful outbound platform result can be converted into explicit delivery evidence that preserves platform send acceptance only when platform ids exist, while keeping device delivery/read confirmation false. A receipt without platform ids does not claim platform send acceptance.

Real environment tested: Local OpenClaw checkout on branch `codex/message-receipt-delivery-evidence`, importing from the public package subpath `openclaw/plugin-sdk/channel-outbound` through `pnpm exec tsx`.

Exact steps or command run after the patch:

```bash
pnpm exec tsx -e 'import { createMessageReceiptDeliveryEvidence, createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound"; const withId = createMessageReceiptFromOutboundResults({ sentAt: 123, results: [{ channel: "signal", messageId: "m1" }] }); const withoutId = createMessageReceiptFromOutboundResults({ sentAt: 456, results: [] }); console.log(JSON.stringify({ withId: createMessageReceiptDeliveryEvidence(withId), withoutId: createMessageReceiptDeliveryEvidence(withoutId) }, null, 2));'
```

Evidence after fix: terminal output from the command above:

```json
{
  "withId": {
    "platformSendAccepted": true,
    "platformSendAcceptedAt": 123,
    "platformMessageIds": [
      "m1"
    ],
    "platformSendEvidence": "platform_message_ids",
    "deviceDeliveryConfirmed": false,
    "deviceDeliveryEvidence": "not_tracked_by_message_receipt"
  },
  "withoutId": {
    "platformSendAccepted": false,
    "platformSendAcceptedAt": null,
    "platformMessageIds": [],
    "platformSendEvidence": "none",
    "deviceDeliveryConfirmed": false,
    "deviceDeliveryEvidence": "not_tracked_by_message_receipt"
  }
}
```

Observed result after fix: The helper returns send-acceptance evidence for a receipt with a platform message id, does not infer device-visible/read delivery, and does not claim platform send acceptance for an empty receipt.

What was not tested: A live Signal/Telegram/Slack device read receipt path was not tested because this change intentionally does not add channel-specific device delivery tracking, retries, sends, or read-receipt polling.

## Validation

- `pnpm exec vitest run src/channels/message/receipt.test.ts src/plugin-sdk/channel-send-result.test.ts`
- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:check-exports`
- `pnpm tsgo:core`
- `pnpm exec oxfmt --check --threads=1 docs/.generated/plugin-sdk-api-baseline.sha256 docs/plugins/sdk-channel-outbound.md src/channels/message/index.ts src/channels/message/receipt.test.ts src/channels/message/receipt.ts src/plugin-sdk/channel-outbound.ts`
- `git diff --check`
