### PR TITLE
fix(plugins): isolate unreadable tool registrations

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3812,6 +3812,55 @@ module.exports = { id: "throws-after-import", register() {} };`,
     ).toBe(true);
   });
 
+  it("skips plugin tools with unreadable direct names during registration", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "unreadable-tool-name",
+      filename: "unreadable-tool-name.cjs",
+      body: `module.exports = {
+        id: "unreadable-tool-name",
+        register(api) {
+          api.registerTool({
+            get name() {
+              throw new Error("plugin tool name exploded");
+            },
+            description: "Broken tool",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "broken" }] }),
+          });
+          api.registerTool({
+            name: "healthy_tool",
+            description: "Healthy tool",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+    });
+    updatePluginManifest(plugin, { contracts: { tools: ["healthy_tool"] } });
+
+    const registry = loadOpenClawPlugins({
+      activate: false,
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["unreadable-tool-name"],
+        },
+      },
+    });
+
+    expect(registry.tools.flatMap((entry) => entry.names)).toEqual(["healthy_tool"]);
+    expect(
+      registry.diagnostics.some(
+        (entry) =>
+          entry.pluginId === "unreadable-tool-name" &&
+          entry.message === "plugin tool registration failed: unreadable tool name",
+      ),
+    ).toBe(true);
+  });
+
   it("caches non-activating snapshots without restoring global side effects", () => {
     useNoBundledPlugins();
     clearPluginCommands();

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -617,7 +617,17 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       typeof tool === "function" ? tool : (_ctx: OpenClawPluginToolContext) => tool;
 
     if (typeof tool !== "function") {
-      names.push(tool.name);
+      try {
+        names.push(tool.name);
+      } catch {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: "plugin tool registration failed: unreadable tool name",
+        });
+        return;
+      }
     }
 
     const normalized = normalizePluginToolNames(names);


### PR DESCRIPTION
## Summary

This PR keeps plugin registration resilient when one direct tool object exposes an unreadable `name`.

- Convert a throwing direct tool-name getter into a plugin diagnostic.
- Skip only the malformed tool registration so later healthy registrations from the same plugin still survive.
- Add a loader regression with a poisoned tool followed by a healthy manifest-declared tool.

## Linked context

Related to the tool schema fuzzing hardening sweep.

## Real behavior proof

- Behavior addressed: a malformed plugin-owned direct tool can no longer abort plugin registration before later healthy tools are registered.
- Real environment tested: local OpenClaw Codex worktree with linked repo dependencies.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/loader.test.ts --reporter=dot -t "skips plugin tools with unreadable direct names during registration"`
- Evidence after fix: focused Vitest passed 1 shard, 1 file, 1 test, 152 skipped.
- Observed result after fix: the unreadable direct tool produces a plugin diagnostic and the healthy `healthy_tool` registration remains present.
- What was not tested: remote `pnpm check:changed` because the Crabbox coordinator rejected lease creation with HTTP 401 before remote sync or execution.
- Proof limitations or environment constraints: Crabbox wrapper selected provider `azure`; latest coordinator lease slug was `crimson-krill`; Blacksmith CLI is unauthenticated locally.
- Before evidence: the same focused regression failed before the fix because the first bad `registerTool()` call prevented `healthy_tool` from registering.

## Tests and validation

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts --reporter=dot -t "skips plugin tools with unreadable direct names during registration"`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/registry.ts src/plugins/loader.test.ts`
- `./node_modules/.bin/oxlint src/plugins/registry.ts src/plugins/loader.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` failed before lease with coordinator HTTP 401.

Additional note: `node scripts/run-vitest.mjs src/plugins/loader.test.ts --reporter=dot` passed 152 tests and failed the unrelated existing diagnostic-events subscription case; rerunning that exact failing test passed.

## Risk checklist

- Did user-visible behavior change? `No`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- Highest-risk area: plugin registration diagnostics.
- Mitigation: readable tool names still follow the existing manifest contract validation path; only unreadable direct tool names are skipped with an explicit diagnostic.

## Current review state

- Next action: maintainer review and CI.
- Waiting on: remote changed-gate proof once Crabbox/Testbox auth is available.
- Bot/reviewer comments addressed: local and branch autoreview both returned no accepted/actionable findings.
