### PR TITLE
fix(agents): bound abort-path session lock release; force-release on unsettled retained writes

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -163,6 +163,73 @@ describe("embedded attempt session lock lifecycle", () => {
     }
   });
 
+  it("force-releases the held lock when a retained write never settles (tulgey#225)", async () => {
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockStuck = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockStuck,
+      lockOptions,
+      abortReleaseTimeoutMs: 20,
+    });
+
+    let markWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      markWriteStarted = resolve;
+    });
+    // A retained-lock write pinned behind a provider call that never settles
+    // (hung stream that ignores abort).
+    void controller.withSessionWriteLock(async () => {
+      markWriteStarted();
+      await new Promise<void>(() => {});
+    });
+    await writeStarted;
+
+    await controller.releaseHeldLockForAbort();
+
+    expect(release).toHaveBeenCalledTimes(1);
+    // The aborted run lost ownership; later writes from it must not tear the
+    // session file out from under the next turn's lock.
+    await expect(controller.withSessionWriteLock(async () => {})).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    await controller.dispose();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("abort release stays graceful when retained writes settle within the bound (tulgey#225)", async () => {
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockSettles = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockSettles,
+      lockOptions,
+      abortReleaseTimeoutMs: 5_000,
+    });
+
+    let finishWrite!: () => void;
+    const writeCanFinish = new Promise<void>((resolve) => {
+      finishWrite = resolve;
+    });
+    let markWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => {
+      markWriteStarted = resolve;
+    });
+    const activeWrite = controller.withSessionWriteLock(async () => {
+      markWriteStarted();
+      await writeCanFinish;
+    });
+    await writeStarted;
+
+    const abortRelease = controller.releaseHeldLockForAbort();
+    finishWrite();
+    await activeWrite;
+    await abortRelease;
+
+    expect(release).toHaveBeenCalledTimes(1);
+    // Graceful release keeps the fence active — no takeover poisoning.
+    await expect(controller.withSessionWriteLock(async () => {})).resolves.toBeUndefined();
+    await controller.dispose();
+  });
+
   it("releaseHeldLockForAbort and dispose are idempotent in succession (#86816)", async () => {
     const release = vi.fn(async () => {});
     const acquireSessionWriteLockLocal26 = vi.fn(async () => ({ release }));

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -8,6 +8,7 @@ import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
 import { resolveEmbeddedSessionFileKey } from "../session-file-key.js";
+import { resolveEmbeddedAbortSettleTimeoutMs } from "./attempt.abort-settle-timeout.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
@@ -586,6 +587,8 @@ export type EmbeddedAttemptSessionLockController = {
 export async function createEmbeddedAttemptSessionLockController(params: {
   acquireSessionWriteLock: AcquireSessionWriteLock;
   lockOptions: LockOptions;
+  /** Bounded wait before an abort release force-releases the held lock. */
+  abortReleaseTimeoutMs?: number;
 }): Promise<EmbeddedAttemptSessionLockController> {
   const acquireLock = async (): Promise<SessionLock> =>
     await params.acquireSessionWriteLock({
@@ -823,6 +826,97 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
+  /**
+   * Abort-path release. Races the graceful fence release against a bounded
+   * settle window. A retained-lock write pinned behind an unsettled provider
+   * call (a hung stream that ignores abort) keeps `waitForRetainedLockIdle`
+   * pending forever; without the bound, the lock is only reclaimed by the
+   * `maxHoldMs` watchdog and every turn in between fails with
+   * `SessionWriteLockTimeoutError` (tulgey#225, upstream #86816 family).
+   * On timeout the underlying file lock is force-released and the controller
+   * is poisoned (`takeoverDetected`) so the aborted run cannot perform torn
+   * writes after losing ownership.
+   */
+  async function releaseHeldLockForAbortBounded(): Promise<void> {
+    if (!heldLock) {
+      await waitForHeldLockDrain();
+      return;
+    }
+    const boundMs = params.abortReleaseTimeoutMs ?? resolveEmbeddedAbortSettleTimeoutMs();
+    const raceWithBound = async <T>(promise: Promise<T>): Promise<T | "abort-bound"> => {
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<"abort-bound">((resolve) => {
+            timer = setTimeout(() => resolve("abort-bound"), boundMs);
+            timer.unref?.();
+          }),
+        ]);
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    };
+    const forceRelease = async (): Promise<void> => {
+      if (!heldLock) {
+        return;
+      }
+      const lock = heldLock;
+      heldLock = undefined;
+      takeoverDetected = true;
+      await lock.release();
+    };
+
+    const drainAcquisition = beginHeldLockDrain();
+    const drainOwner = await raceWithBound(drainAcquisition);
+    if (drainOwner === "abort-bound") {
+      // Another release path owns the drain and is itself stuck. Take release
+      // ownership directly (clearing `heldLock` makes the stuck path no-op when
+      // it resumes) and hand the eventually-acquired drain straight back.
+      void drainAcquisition.then((owner) => finishHeldLockDrain(owner));
+      await forceRelease();
+      return;
+    }
+    try {
+      const idle = await raceWithBound(waitForRetainedLockIdle());
+      if (!heldLock) {
+        return;
+      }
+      if (idle === true) {
+        // Retained writes settled in time: keep the graceful fence semantics.
+        const lock = heldLock;
+        heldLock = undefined;
+        try {
+          const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+          const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+          const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
+          fenceFingerprint = fingerprint;
+          fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+          fenceGeneration =
+            ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+              ? ownedWrite.generation
+              : (trustedGeneration ?? fenceGeneration);
+          fenceActive = true;
+        } finally {
+          await lock.release();
+        }
+        return;
+      }
+      if (idle === false) {
+        // Abort issued from inside an active write context; mirror the
+        // graceful path and leave release to that write's unwind.
+        return;
+      }
+      // Bounded wait expired: a retained write is pinned behind an unsettled
+      // provider call. Force-release so the next turn can acquire the lock.
+      await forceRelease();
+    } finally {
+      finishHeldLockDrain(drainOwner);
+    }
+  }
+
   async function takeHeldLockAfterRetainedIdle(): Promise<SessionLock | undefined> {
     if (!heldLock) {
       return undefined;
@@ -902,7 +996,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       await releaseHeldLockWithFence();
     },
     async releaseHeldLockForAbort(): Promise<void> {
-      await releaseHeldLockWithFence();
+      await releaseHeldLockForAbortBounded();
     },
     refreshAfterOwnedSessionWrite(): void {
       if (fenceActive && !takeoverDetected) {


### PR DESCRIPTION
## Problem

A turn timeout aborts the embedded run, but the abort-path session-lock release is unbounded. On a deployment running a release that already contains #87278 (release lock on timeout abort), every embedded-run timeout still turned into 5–30 minutes of total unresponsiveness: each subsequent turn failed instantly with `SessionWriteLockTimeoutError` ("Something went wrong while processing your request"), until the `maxHoldMs` watchdog finally reclaimed the session `.jsonl` lock. Starting a fresh session only helped until that session hit its own timeout.

Representative trace:

```text
[agent/embedded] embedded run timeout: runId=… sessionId=… timeoutMs=120000
[agent/embedded] embedded abort settle timed out: runId=… timeoutMs=2000
[diagnostic] lane task error: lane=main durationMs=61545
  error="SessionWriteLockTimeoutError: session file locked (timeout 60000ms): pid=… .../sessions/…jsonl.lock"
Embedded agent failed before reply: session file locked (timeout 60000ms)
```

The trigger was a flaky provider endpoint that accepts the connection and then hangs the stream (`streamGenerateContent` that never settles even after `runAbortController.abort()`), but any provider hang reproduces it.

## The gap #87278 left

`releaseHeldLockForAbort` delegates to the graceful fence release, whose `waitForRetainedLockIdle` is **unbounded**. A retained-lock transcript write pinned behind a hung provider stream keeps the retained-use count nonzero forever, so the abort release never reaches `lock.release()`. #87278 / #88623 / #89811 all release on aborts that *settle*; nothing covered an abort that a hung provider call never lets settle.

## Fix

`releaseHeldLockForAbort` now runs a bounded variant:

- Drain acquisition and the retained-idle wait are each raced against the abort settle bound (`OPENCLAW_EMBEDDED_ABORT_SETTLE_TIMEOUT_MS`, default 2s / 250ms under `OPENCLAW_TEST_FAST`), overridable per controller via `abortReleaseTimeoutMs`.
- Retained writes that settle within the bound keep the existing graceful fence semantics — fence stays active, no behavior change (covered by the existing #86816 tests).
- When the bound expires, the underlying file lock is **force-released** and the controller is poisoned via `takeoverDetected`, so the aborted run cannot perform torn writes after losing ownership: its later `withSessionWriteLock` throws `EmbeddedAttemptSessionTakeoverError` and cleanup degrades to the noop lock — the same posture as a real takeover.
- If another release path owns the drain and is itself stuck, the abort path takes release ownership directly and hands the eventually-acquired drain straight back (no `heldLockDraining` leak; `dispose()` stays unblocked).

## Relationship to #89673

Complementary, not overlapping. #89673 is the cross-process, contender-side `maxHoldMs` reclaim in `session-write-lock.ts` (let a contender reclaim a lock past the holder's own recorded `maxHoldMs`). This PR is the in-process abort path in `attempt.session-lock.ts`: it bounds the damage window at the source so the holder releases promptly on abort, rather than relying on a contender or the watchdog to reclaim minutes later. Both can land; together they close the live-but-stuck-holder hole from both sides.

Abort *propagation* (cancelling the provider fetch/stream itself) is the other complementary half; the signal plumbing already exists in `fetch-guard.ts`. This PR bounds the damage window regardless of provider behavior — the chokepoint fix.

## Tests

Human-run on my own setup (`OPENCLAW_TEST_FAST=1 pnpm vitest run src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`):

- `force-releases the held lock when a retained write never settles` — the repro: never-settling retained write, bounded abort release, lock released once, controller poisoned.
- `abort release stays graceful when retained writes settle within the bound` — no poisoning on the happy path.
- Full `attempt.session-lock.test.ts` suite: **90/90**.
- tsgo typecheck (`node scripts/run-tsgo.mjs -p tsconfig.json --noEmit`): clean.

AI-assisted (Claude Code). The tests above and the typecheck were run locally against my own OpenClaw instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
