### PR TITLE
fix(plugins): isolate bundled capability capture fields

### DIFF
--- a/src/plugins/bundled-capability-runtime.test.ts
+++ b/src/plugins/bundled-capability-runtime.test.ts
@@ -1,5 +1,55 @@
-import { describe, expect, it } from "vitest";
-import { buildVitestCapabilityShimAliasMap } from "./bundled-capability-runtime.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildVitestCapabilityShimAliasMap,
+  loadBundledCapabilityRuntimeRegistry,
+} from "./bundled-capability-runtime.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeBundledRuntimePlugin(params: {
+  pluginId: string;
+  body: string;
+  contracts?: { tools?: string[] };
+}): PluginDiscoveryResult {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-capability-"));
+  tempDirs.push(rootDir);
+  const source = path.join(rootDir, "index.cjs");
+  const manifestPath = path.join(rootDir, "openclaw.plugin.json");
+  const manifest = {
+    id: params.pluginId,
+    configSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    contracts: params.contracts,
+  };
+  fs.writeFileSync(source, params.body, "utf-8");
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
+  return {
+    candidates: [
+      {
+        idHint: params.pluginId,
+        source,
+        rootDir,
+        origin: "bundled",
+        bundledManifest: manifest,
+        bundledManifestPath: manifestPath,
+      },
+    ],
+    diagnostics: [],
+  };
+}
 
 describe("buildVitestCapabilityShimAliasMap", () => {
   it("keeps scoped and unscoped capability shim aliases aligned", () => {
@@ -16,6 +66,73 @@ describe("buildVitestCapabilityShimAliasMap", () => {
     );
     expect(aliasMap["openclaw/plugin-sdk/speech-core"]).toBe(
       aliasMap["@openclaw/plugin-sdk/speech-core"],
+    );
+  });
+});
+
+describe("loadBundledCapabilityRuntimeRegistry", () => {
+  it("skips unreadable captured tool names without dropping healthy siblings", () => {
+    const pluginId = "bundled-bad-tool-name";
+    const discovery = writeBundledRuntimePlugin({
+      pluginId,
+      contracts: { tools: ["healthy_tool"] },
+      body: `
+module.exports = {
+  register(api) {
+    api.registerTool(Object.defineProperty({
+      label: "Bad",
+      description: "Bad",
+      parameters: { type: "object", additionalProperties: false, properties: {} },
+      execute: async () => ({ content: [] }),
+    }, "name", {
+      get() {
+        throw new Error("name unavailable");
+      },
+    }));
+    api.registerTool({
+      name: "healthy_tool",
+      label: "Healthy",
+      description: "Healthy",
+      parameters: { type: "object", additionalProperties: false, properties: {} },
+      execute: async () => ({ content: [] }),
+    });
+  },
+};
+`,
+    });
+
+    const registry = loadBundledCapabilityRuntimeRegistry({
+      pluginIds: [pluginId],
+      discovery,
+      env: {
+        ...process.env,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
+    });
+
+    expect(registry.plugins).toMatchObject([
+      {
+        id: pluginId,
+        status: "loaded",
+        toolNames: ["healthy_tool"],
+      },
+    ]);
+    expect(registry.tools.map((entry) => entry.names)).toEqual([["healthy_tool"]]);
+    expect(registry.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "error",
+          pluginId,
+          message: "plugin tool registration missing readable name: name unavailable",
+        }),
+      ]),
+    );
+    expect(registry.diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining("failed to load plugin"),
+        }),
+      ]),
     );
   });
 });

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -137,6 +137,7 @@ function createCapabilityPluginRecord(params: {
   source: string;
   rootDir?: string;
   workspaceDir?: string;
+  contracts?: PluginRecord["contracts"];
 }): PluginRecord {
   return {
     id: params.id,
@@ -175,6 +176,7 @@ function createCapabilityPluginRecord(params: {
     httpRoutes: 0,
     hookCount: 0,
     configSchema: true,
+    contracts: params.contracts,
   };
 }
 
@@ -193,6 +195,68 @@ function recordCapabilityLoadError(
     message: `failed to load plugin: ${message}`,
   });
   log.error(`[plugins] ${record.id} failed to load from ${record.source}: ${message}`);
+}
+
+function recordCapabilityRegistrationError(
+  registry: PluginRegistry,
+  record: PluginRecord,
+  message: string,
+): void {
+  registry.diagnostics.push({
+    level: "error",
+    pluginId: record.id,
+    source: record.source,
+    message,
+  });
+}
+
+function formatCapabilityFieldError(params: {
+  capability: string;
+  field: string;
+  error?: unknown;
+}): string {
+  const detail =
+    params.error instanceof Error
+      ? params.error.message
+      : params.error === undefined
+        ? undefined
+        : String(params.error);
+  return detail
+    ? `plugin ${params.capability} registration missing readable ${params.field}: ${detail}`
+    : `plugin ${params.capability} registration missing readable ${params.field}`;
+}
+
+function snapshotCapturedStringField<TEntry>(
+  registry: PluginRegistry,
+  record: PluginRecord,
+  capability: string,
+  field: string,
+  entries: readonly TEntry[],
+): Array<{ entry: TEntry; value: string }> {
+  const snapshots: Array<{ entry: TEntry; value: string }> = [];
+  for (const entry of entries) {
+    let value: unknown;
+    try {
+      value = (entry as Record<string, unknown>)[field];
+    } catch (error) {
+      recordCapabilityRegistrationError(
+        registry,
+        record,
+        formatCapabilityFieldError({ capability, field, error }),
+      );
+      continue;
+    }
+    if (typeof value !== "string") {
+      recordCapabilityRegistrationError(
+        registry,
+        record,
+        formatCapabilityFieldError({ capability, field }),
+      );
+      continue;
+    }
+    snapshots.push({ entry, value });
+  }
+  return snapshots;
 }
 
 export function loadBundledCapabilityRuntimeRegistry(params: {
@@ -269,6 +333,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
       name: manifest.name,
       description: manifest.description,
       version: manifest.version,
+      contracts: manifest.contracts,
       source:
         env?.VITEST && params.pluginSdkResolution === "dist"
           ? (resolveBundledPluginRepoEntryPath({
@@ -320,42 +385,110 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
     try {
       const captured = createCapturedPluginRegistration();
       register(captured.api);
-      record.cliBackendIds.push(...captured.cliBackends.map((entry) => entry.id));
-      record.providerIds.push(...captured.providers.map((entry) => entry.id));
-      record.embeddingProviderIds.push(...captured.embeddingProviders.map((entry) => entry.id));
-      record.speechProviderIds.push(...captured.speechProviders.map((entry) => entry.id));
+      const snapshot = <TEntry>(capability: string, field: string, entries: readonly TEntry[]) =>
+        snapshotCapturedStringField(registry, record, capability, field, entries);
+      const capturedCliBackends = snapshot("CLI backend", "id", captured.cliBackends);
+      const capturedProviders = snapshot("provider", "id", captured.providers);
+      const capturedEmbeddingProviders = snapshot(
+        "embedding provider",
+        "id",
+        captured.embeddingProviders,
+      );
+      const capturedSpeechProviders = snapshot("speech provider", "id", captured.speechProviders);
+      const capturedRealtimeTranscriptionProviders = snapshot(
+        "realtime transcription provider",
+        "id",
+        captured.realtimeTranscriptionProviders,
+      );
+      const capturedRealtimeVoiceProviders = snapshot(
+        "realtime voice provider",
+        "id",
+        captured.realtimeVoiceProviders,
+      );
+      const capturedMediaUnderstandingProviders = snapshot(
+        "media understanding provider",
+        "id",
+        captured.mediaUnderstandingProviders,
+      );
+      const capturedTranscriptSourceProviders = snapshot(
+        "transcript source provider",
+        "id",
+        captured.transcriptSourceProviders,
+      );
+      const capturedImageGenerationProviders = snapshot(
+        "image generation provider",
+        "id",
+        captured.imageGenerationProviders,
+      );
+      const capturedVideoGenerationProviders = snapshot(
+        "video generation provider",
+        "id",
+        captured.videoGenerationProviders,
+      );
+      const capturedMusicGenerationProviders = snapshot(
+        "music generation provider",
+        "id",
+        captured.musicGenerationProviders,
+      );
+      const capturedWebFetchProviders = snapshot(
+        "web fetch provider",
+        "id",
+        captured.webFetchProviders,
+      );
+      const capturedWebSearchProviders = snapshot(
+        "web search provider",
+        "id",
+        captured.webSearchProviders,
+      );
+      const capturedMigrationProviders = snapshot(
+        "migration provider",
+        "id",
+        captured.migrationProviders,
+      );
+      const capturedMemoryEmbeddingProviders = snapshot(
+        "memory embedding provider",
+        "id",
+        captured.memoryEmbeddingProviders,
+      );
+      const capturedAgentHarnesses = snapshot("agent harness", "id", captured.agentHarnesses);
+      const capturedTools = snapshot("tool", "name", captured.tools);
+
+      record.cliBackendIds.push(...capturedCliBackends.map((entry) => entry.value));
+      record.providerIds.push(...capturedProviders.map((entry) => entry.value));
+      record.embeddingProviderIds.push(...capturedEmbeddingProviders.map((entry) => entry.value));
+      record.speechProviderIds.push(...capturedSpeechProviders.map((entry) => entry.value));
       record.realtimeTranscriptionProviderIds.push(
-        ...captured.realtimeTranscriptionProviders.map((entry) => entry.id),
+        ...capturedRealtimeTranscriptionProviders.map((entry) => entry.value),
       );
       record.realtimeVoiceProviderIds.push(
-        ...captured.realtimeVoiceProviders.map((entry) => entry.id),
+        ...capturedRealtimeVoiceProviders.map((entry) => entry.value),
       );
       record.mediaUnderstandingProviderIds.push(
-        ...captured.mediaUnderstandingProviders.map((entry) => entry.id),
+        ...capturedMediaUnderstandingProviders.map((entry) => entry.value),
       );
       record.transcriptSourceProviderIds.push(
-        ...captured.transcriptSourceProviders.map((entry) => entry.id),
+        ...capturedTranscriptSourceProviders.map((entry) => entry.value),
       );
       record.imageGenerationProviderIds.push(
-        ...captured.imageGenerationProviders.map((entry) => entry.id),
+        ...capturedImageGenerationProviders.map((entry) => entry.value),
       );
       record.videoGenerationProviderIds.push(
-        ...captured.videoGenerationProviders.map((entry) => entry.id),
+        ...capturedVideoGenerationProviders.map((entry) => entry.value),
       );
       record.musicGenerationProviderIds.push(
-        ...captured.musicGenerationProviders.map((entry) => entry.id),
+        ...capturedMusicGenerationProviders.map((entry) => entry.value),
       );
-      record.webFetchProviderIds.push(...captured.webFetchProviders.map((entry) => entry.id));
-      record.webSearchProviderIds.push(...captured.webSearchProviders.map((entry) => entry.id));
-      record.migrationProviderIds.push(...captured.migrationProviders.map((entry) => entry.id));
+      record.webFetchProviderIds.push(...capturedWebFetchProviders.map((entry) => entry.value));
+      record.webSearchProviderIds.push(...capturedWebSearchProviders.map((entry) => entry.value));
+      record.migrationProviderIds.push(...capturedMigrationProviders.map((entry) => entry.value));
       record.memoryEmbeddingProviderIds.push(
-        ...captured.memoryEmbeddingProviders.map((entry) => entry.id),
+        ...capturedMemoryEmbeddingProviders.map((entry) => entry.value),
       );
-      record.agentHarnessIds.push(...captured.agentHarnesses.map((entry) => entry.id));
-      record.toolNames.push(...captured.tools.map((entry) => entry.name));
+      record.agentHarnessIds.push(...capturedAgentHarnesses.map((entry) => entry.value));
+      record.toolNames.push(...capturedTools.map((entry) => entry.value));
 
       registry.cliBackends?.push(
-        ...captured.cliBackends.map((backend) => ({
+        ...capturedCliBackends.map(({ entry: backend }) => ({
           pluginId: record.id,
           pluginName: record.name,
           backend,
@@ -373,7 +506,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.providers.push(
-        ...captured.providers.map((provider) => ({
+        ...capturedProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -382,7 +515,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.embeddingProviders.push(
-        ...captured.embeddingProviders.map((provider) => ({
+        ...capturedEmbeddingProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -391,7 +524,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.speechProviders.push(
-        ...captured.speechProviders.map((provider) => ({
+        ...capturedSpeechProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -400,7 +533,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.realtimeTranscriptionProviders.push(
-        ...captured.realtimeTranscriptionProviders.map((provider) => ({
+        ...capturedRealtimeTranscriptionProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -409,7 +542,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.realtimeVoiceProviders.push(
-        ...captured.realtimeVoiceProviders.map((provider) => ({
+        ...capturedRealtimeVoiceProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -418,7 +551,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.mediaUnderstandingProviders.push(
-        ...captured.mediaUnderstandingProviders.map((provider) => ({
+        ...capturedMediaUnderstandingProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -427,7 +560,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.transcriptSourceProviders.push(
-        ...captured.transcriptSourceProviders.map((provider) => ({
+        ...capturedTranscriptSourceProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -436,7 +569,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.imageGenerationProviders.push(
-        ...captured.imageGenerationProviders.map((provider) => ({
+        ...capturedImageGenerationProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -445,7 +578,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.videoGenerationProviders.push(
-        ...captured.videoGenerationProviders.map((provider) => ({
+        ...capturedVideoGenerationProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -454,7 +587,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.musicGenerationProviders.push(
-        ...captured.musicGenerationProviders.map((provider) => ({
+        ...capturedMusicGenerationProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -463,7 +596,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.webFetchProviders.push(
-        ...captured.webFetchProviders.map((provider) => ({
+        ...capturedWebFetchProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -472,7 +605,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.webSearchProviders.push(
-        ...captured.webSearchProviders.map((provider) => ({
+        ...capturedWebSearchProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -481,7 +614,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.migrationProviders.push(
-        ...captured.migrationProviders.map((provider) => ({
+        ...capturedMigrationProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -490,7 +623,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.memoryEmbeddingProviders.push(
-        ...captured.memoryEmbeddingProviders.map((provider) => ({
+        ...capturedMemoryEmbeddingProviders.map(({ entry: provider }) => ({
           pluginId: record.id,
           pluginName: record.name,
           provider,
@@ -499,7 +632,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       registry.agentHarnesses.push(
-        ...captured.agentHarnesses.map((harness) => ({
+        ...capturedAgentHarnesses.map(({ entry: harness }) => ({
           pluginId: record.id,
           pluginName: record.name,
           harness,
@@ -508,10 +641,10 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
         })),
       );
       const declaredToolNames = normalizePluginToolContractNames(record.contracts);
-      for (const tool of captured.tools) {
+      for (const { entry: tool, value: toolName } of capturedTools) {
         const undeclared = findUndeclaredPluginToolNames({
           declaredNames: declaredToolNames,
-          toolNames: [tool.name],
+          toolNames: [toolName],
         });
         if (undeclared.length > 0) {
           registry.diagnostics.push({
@@ -526,7 +659,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
           pluginId: record.id,
           pluginName: record.name,
           factory: () => tool,
-          names: [tool.name],
+          names: [toolName],
           declaredNames: declaredToolNames,
           optional: false,
           source: record.source,


### PR DESCRIPTION
## Summary

- Hardens bundled capability runtime capture so malformed captured provider/backend/harness `id` fields or tool `name` fields are diagnosed and skipped per row.
- Preserves healthy sibling captured registrations instead of failing the whole bundled runtime snapshot.
- Carries manifest `contracts` into the runtime-created plugin record so captured tools use the same manifest-declared contract enforcement as the normal plugin registry path.
- Out of scope: broad provider behavior changes, external plugin API changes, and compatibility shims for malformed non-string ids/names beyond diagnostic isolation.

Reviewers should focus on the captured registration boundary in `src/plugins/bundled-capability-runtime.ts` and the temp bundled plugin regression in `src/plugins/bundled-capability-runtime.test.ts`.

## Linked context

Related to the ongoing tool-schema/plugin SDK fuzz hardening sweep.

## Real behavior proof

- Behavior addressed: a malformed bundled capability registration with an unreadable captured `id` or tool `name` field can no longer poison the whole bundled capability runtime snapshot; healthy sibling registrations continue.
- Real environment tested: local OpenClaw linked worktree on Node/Vitest using the repo `scripts/run-vitest.mjs` wrapper.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/plugins/bundled-capability-runtime.test.ts`
- Evidence after fix: passed 1 Vitest shard, 1 file, 2 tests after the final rebase.
- Observed result after fix: the regression plugin stays loaded, emits a diagnostic for the unreadable captured tool name, and still registers `healthy_tool`.
- What was not tested: full `pnpm check:changed` did not run.
- Proof limitations or environment constraints: Crabbox changed gate failed before lease with coordinator HTTP 401 for provider `azure`; `blacksmith testbox list --all` also failed with `not authenticated`, so broad remote proof is blocked by runner auth.
- Before evidence: the focused regression initially showed the healthy captured tool was not present in `registry.tools`.

## Tests and validation

- `./node_modules/.bin/oxfmt --write --threads=1 src/plugins/bundled-capability-runtime.ts src/plugins/bundled-capability-runtime.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs run src/plugins/bundled-capability-runtime.test.ts`
- `$autoreview` local dirty-patch review: clean, `overall: patch is correct (0.86)`
- Crabbox changed gate attempted with `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`; blocked by coordinator HTTP 401 on `/v1/leases`, latest slug `pearl-krill`.

Regression coverage added in `src/plugins/bundled-capability-runtime.test.ts` for a temp bundled plugin with one captured tool whose `name` getter throws followed by a healthy manifest-declared tool.

## Risk checklist

- Did user-visible behavior change? `No`
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: plugin capability registration projection. The mitigation is that the change only filters malformed captured rows at the runtime boundary, keeps healthy rows intact, and leaves existing manifest contract validation in place.

## Current review state

Next action: maintainer review and CI.

Waiting on: CI and, if desired, maintainer-side Crabbox/Testbox changed-gate proof once runner auth is available.

Bot/reviewer comments addressed: none yet.
