### PR TITLE
docs: explain message tool turn termination

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -131,6 +131,20 @@ surfaces, while Codex native hooks remain a separate lower-level Codex mechanism
 - Tool results are sanitized for size and image payloads before logging/emitting.
 - Messaging tool sends are tracked to suppress duplicate assistant confirmations.
 
+### Message-tool-only turn termination
+
+When a session uses `messages.visibleReplies: "message_tool"` or
+`messages.groupChat.visibleReplies: "message_tool"`, OpenClaw converts the
+turn to `sourceReplyDeliveryMode: "message_tool_only"`. In this mode, a
+successful implicit current-source `message(action="send")` is treated as the
+visible reply and terminates the agent turn immediately.
+
+This matters for skills, prompts, and orchestration patterns that use the
+`message` tool for progress updates before doing more work. If the send should
+not end the turn, include an explicit route such as `channel`, `target`, `to`,
+`channelId`, or `provider`. Reserve the implicit current-source send for the
+final visible reply that should end the turn.
+
 ## Reply shaping + suppression
 
 - Final payloads are assembled from:

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -82,6 +82,12 @@ whether a user-facing update is needed.
     - If an active requester cannot be woken, OpenClaw falls back to a requester-agent handoff with the same completion context instead of dropping the announce.
     - A successful parent handoff completes sub-agent delivery even when the parent decides no visible user update is needed.
     - Native sub-agents do not get the message tool. They return plain assistant text to the parent/requester agent; human-visible replies are owned by the parent/requester agent's normal delivery policy.
+    - When the requester session uses `visibleReplies: "message_tool"`,
+      the requester agent is in message-tool-only delivery. An implicit
+      current-source `message(action="send")` ends that requester turn
+      immediately, so skills or orchestration prompts that send progress updates
+      must include an explicit route (`channel`, `target`, `to`, `channelId`, or
+      `provider`) and reserve the implicit send for the final visible update.
     - If direct handoff cannot be used, it falls back to queue routing.
     - If queue routing is still not available, the announce is retried with a short exponential backoff before final give-up.
     - Completion delivery keeps the resolved requester route: thread-bound or conversation-bound completion routes win when available; if the completion origin only provides a channel, OpenClaw fills the missing target/account from the requester session's resolved route (`lastChannel` / `lastTo` / `lastAccountId`) so direct delivery still works.


### PR DESCRIPTION
Summary:
- Document that `visibleReplies: "message_tool"` maps to message-tool-only delivery.
- Explain that successful implicit current-source `message(action="send")` calls terminate the turn.
- Add sub-agent guidance to use explicit routing for intermediate skill/progress sends.

Verification:
- `node scripts/docs-list.js`
- `node scripts/check-docs-mdx.mjs docs README.md`
- `node scripts/format-docs.mjs --check`
- `git diff --check -- docs/concepts/agent-loop.md docs/tools/subagents.md`
