### PR TITLE
fix(plugins): guard metadata snapshot owner rows

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -228,6 +228,20 @@ function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
   return { plugins: [plugin], diagnostics: [] };
 }
 
+function withThrowingMetadataField(
+  plugin: PluginManifestRecord,
+  field: keyof PluginManifestRecord,
+  message: string,
+): PluginManifestRecord {
+  Object.defineProperty(plugin, field, {
+    configurable: true,
+    get() {
+      throw new Error(message);
+    },
+  });
+  return plugin;
+}
+
 describe("loadPluginMetadataSnapshot process memo", () => {
   beforeEach(() => {
     clearLoadPluginMetadataSnapshotMemo();
@@ -538,6 +552,57 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(() => {
       snapshotRecord.pluginId = "snapshot-mutated";
     }).toThrow();
+  });
+
+  it("skips unreadable owner metadata fields while preserving healthy owners", () => {
+    const stateDir = tempStateDir();
+    const index = makeIndex();
+    const providerAuthAliases = { "poisoned-alias-ok": "poisoned-provider" };
+    Object.defineProperty(providerAuthAliases, "poisoned-alias-bad", {
+      enumerable: true,
+      get() {
+        throw new Error("plugin metadata owner provider alias exploded");
+      },
+    });
+    const poisoned = withThrowingMetadataField(
+      withThrowingMetadataField(
+        {
+          ...makeManifestRegistry("poisoned").plugins[0]!,
+          channels: ["poisoned-channel"],
+          providers: ["poisoned-provider"],
+          providerAuthAliases,
+          cliBackends: ["poisoned-cli"],
+        },
+        "modelCatalog",
+        "plugin metadata owner model catalog exploded",
+      ),
+      "commandAliases",
+      "plugin metadata owner command aliases exploded",
+    );
+    const healthy = {
+      ...makeManifestRegistry("healthy").plugins[0]!,
+      modelCatalog: { providers: { "healthy-catalog": {} }, aliases: {} },
+      setup: { providers: [{ id: "healthy-setup", authMethods: [] }], cliBackends: [] },
+    } satisfies PluginManifestRecord;
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "provided",
+      snapshot: index,
+      diagnostics: [],
+    });
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [poisoned, healthy],
+      diagnostics: [],
+    });
+
+    const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index, stateDir });
+
+    expect(snapshot.owners.channels.get("poisoned-channel")).toEqual(["poisoned"]);
+    expect(snapshot.owners.providers.get("poisoned-provider")).toEqual(["poisoned"]);
+    expect(snapshot.owners.providers.get("poisoned-alias-ok")).toEqual(["poisoned"]);
+    expect(snapshot.owners.cliBackends.get("poisoned-cli")).toEqual(["poisoned"]);
+    expect(snapshot.owners.modelCatalogProviders.get("healthy-catalog")).toEqual(["healthy"]);
+    expect(snapshot.owners.setupProviders.get("healthy-setup")).toEqual(["healthy"]);
+    expect(snapshot.owners.commandAliases.get("healthy-command")).toEqual(["healthy"]);
   });
 
   it("memoizes policy-stale derived snapshots within the process", () => {

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -173,10 +173,26 @@ function freezeSnapshotValue<T>(value: T, seen = new WeakSet<object>()): T {
     });
     return Object.freeze(value);
   }
-  for (const entry of Object.values(value)) {
+  let keys: string[];
+  try {
+    keys = Object.keys(value);
+  } catch {
+    keys = [];
+  }
+  for (const key of keys) {
+    let entry: unknown;
+    try {
+      entry = (value as Record<string, unknown>)[key];
+    } catch {
+      continue;
+    }
     freezeSnapshotValue(entry, seen);
   }
-  return Object.freeze(value);
+  try {
+    return Object.freeze(value);
+  } catch {
+    return value;
+  }
 }
 
 function freezePluginMetadataSnapshot(snapshot: PluginMetadataSnapshot): PluginMetadataSnapshot {
@@ -483,10 +499,121 @@ function appendOwner(owners: Map<string, string[]>, ownedId: string, pluginId: s
   owners.set(ownedId, [pluginId]);
 }
 
+function readPluginOwnerId(plugin: PluginManifestRecord): string | null {
+  try {
+    return typeof plugin.id === "string" && plugin.id ? plugin.id : null;
+  } catch {
+    return null;
+  }
+}
+
+function readArray(read: () => readonly unknown[] | undefined): readonly unknown[] {
+  let values: readonly unknown[] | undefined;
+  try {
+    values = read();
+  } catch {
+    return [];
+  }
+  return Array.isArray(values) ? values : [];
+}
+
+function readStringArray(read: () => readonly unknown[] | undefined): string[] {
+  const values = readArray(read);
+  const normalized: string[] = [];
+  for (const index of values.keys()) {
+    let value: unknown;
+    try {
+      value = values[index];
+    } catch {
+      continue;
+    }
+    if (typeof value === "string") {
+      normalized.push(value);
+    }
+  }
+  return normalized;
+}
+
+function readRecordStringFields(
+  read: () => readonly unknown[] | undefined,
+  field: string,
+): string[] {
+  const values = readArray(read);
+  const fields: string[] = [];
+  for (const index of values.keys()) {
+    try {
+      const value = values[index];
+      if (isRecord(value) && typeof value[field] === "string") {
+        fields.push(value[field]);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return fields;
+}
+
+function readRecordKeys(read: () => unknown): string[] {
+  let value: unknown;
+  try {
+    value = read();
+  } catch {
+    return [];
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  try {
+    return Object.keys(value);
+  } catch {
+    return [];
+  }
+}
+
+function readRecordEntries(read: () => unknown): [string, unknown][] {
+  let value: unknown;
+  try {
+    value = read();
+  } catch {
+    return [];
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  let keys: string[];
+  try {
+    keys = Object.keys(value);
+  } catch {
+    return [];
+  }
+  const entries: [string, unknown][] = [];
+  for (const key of keys) {
+    try {
+      entries.push([key, value[key]]);
+    } catch {
+      continue;
+    }
+  }
+  return entries;
+}
+
 function freezeOwnerMap(owners: Map<string, string[]>): ReadonlyMap<string, readonly string[]> {
   return new Map(
     [...owners.entries()].map(([ownedId, pluginIds]) => [ownedId, Object.freeze([...pluginIds])]),
   );
+}
+
+function buildPluginMetadataByPluginId(
+  plugins: readonly PluginManifestRecord[],
+): ReadonlyMap<string, PluginManifestRecord> {
+  const byPluginId = new Map<string, PluginManifestRecord>();
+  for (const plugin of plugins) {
+    const pluginId = readPluginOwnerId(plugin);
+    if (pluginId) {
+      byPluginId.set(pluginId, plugin);
+    }
+  }
+  return byPluginId;
 }
 
 function buildPluginMetadataOwnerMaps(
@@ -502,49 +629,56 @@ function buildPluginMetadataOwnerMaps(
   const contracts = new Map<string, string[]>();
 
   for (const plugin of plugins) {
-    for (const channelId of plugin.channels ?? []) {
-      appendOwner(channels, channelId, plugin.id);
+    const pluginId = readPluginOwnerId(plugin);
+    if (!pluginId) {
+      continue;
     }
-    for (const channelId of Object.keys(plugin.channelConfigs ?? {})) {
-      appendOwner(channelConfigs, channelId, plugin.id);
+    const providerIds = readStringArray(() => plugin.providers);
+
+    for (const channelId of readStringArray(() => plugin.channels)) {
+      appendOwner(channels, channelId, pluginId);
     }
-    for (const providerId of plugin.providers ?? []) {
-      appendOwner(providers, providerId, plugin.id);
+    for (const channelId of readRecordKeys(() => plugin.channelConfigs)) {
+      appendOwner(channelConfigs, channelId, pluginId);
     }
-    for (const [rawAlias, target] of Object.entries(plugin.providerAuthAliases ?? {})) {
+    for (const providerId of providerIds) {
+      appendOwner(providers, providerId, pluginId);
+    }
+    for (const [rawAlias, target] of readRecordEntries(() => plugin.providerAuthAliases)) {
+      if (typeof target !== "string") {
+        continue;
+      }
       const alias = normalizeProviderId(rawAlias);
       const targetProvider = normalizeProviderId(target);
       if (
         alias &&
         targetProvider &&
-        (plugin.providers ?? []).some(
-          (providerId) => normalizeProviderId(providerId) === targetProvider,
-        )
+        providerIds.some((providerId) => normalizeProviderId(providerId) === targetProvider)
       ) {
-        appendOwner(providers, alias, plugin.id);
+        appendOwner(providers, alias, pluginId);
       }
     }
-    for (const providerId of Object.keys(plugin.modelCatalog?.providers ?? {})) {
-      appendOwner(modelCatalogProviders, providerId, plugin.id);
+    for (const providerId of readRecordKeys(() => plugin.modelCatalog?.providers)) {
+      appendOwner(modelCatalogProviders, providerId, pluginId);
     }
-    for (const providerId of Object.keys(plugin.modelCatalog?.aliases ?? {})) {
-      appendOwner(modelCatalogProviders, providerId, plugin.id);
+    for (const providerId of readRecordKeys(() => plugin.modelCatalog?.aliases)) {
+      appendOwner(modelCatalogProviders, providerId, pluginId);
     }
-    for (const cliBackendId of plugin.cliBackends ?? []) {
-      appendOwner(cliBackends, cliBackendId, plugin.id);
+    for (const cliBackendId of readStringArray(() => plugin.cliBackends)) {
+      appendOwner(cliBackends, cliBackendId, pluginId);
     }
-    for (const cliBackendId of plugin.setup?.cliBackends ?? []) {
-      appendOwner(cliBackends, cliBackendId, plugin.id);
+    for (const cliBackendId of readStringArray(() => plugin.setup?.cliBackends)) {
+      appendOwner(cliBackends, cliBackendId, pluginId);
     }
-    for (const setupProvider of plugin.setup?.providers ?? []) {
-      appendOwner(setupProviders, setupProvider.id, plugin.id);
+    for (const setupProviderId of readRecordStringFields(() => plugin.setup?.providers, "id")) {
+      appendOwner(setupProviders, setupProviderId, pluginId);
     }
-    for (const commandAlias of plugin.commandAliases ?? []) {
-      appendOwner(commandAliases, commandAlias.name, plugin.id);
+    for (const commandAlias of readRecordStringFields(() => plugin.commandAliases, "name")) {
+      appendOwner(commandAliases, commandAlias, pluginId);
     }
-    for (const [contract, values] of Object.entries(plugin.contracts ?? {})) {
+    for (const [contract, values] of readRecordEntries(() => plugin.contracts)) {
       if (Array.isArray(values) && values.length > 0) {
-        appendOwner(contracts, contract, plugin.id);
+        appendOwner(contracts, contract, pluginId);
       }
     }
   }
@@ -743,7 +877,7 @@ function loadPluginMetadataSnapshotImpl(params: LoadPluginMetadataSnapshotParams
         });
   const manifestRegistryMs = performance.now() - manifestStartedAt;
   const normalizePluginId = createPluginRegistryIdNormalizer(index, { manifestRegistry });
-  const byPluginId = new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
+  const byPluginId = buildPluginMetadataByPluginId(manifestRegistry.plugins);
   const ownerMapsStartedAt = performance.now();
   const owners = buildPluginMetadataOwnerMaps(manifestRegistry.plugins);
   const ownerMapsMs = performance.now() - ownerMapsStartedAt;

--- a/src/plugins/plugin-registry-id-normalizer.ts
+++ b/src/plugins/plugin-registry-id-normalizer.ts
@@ -16,22 +16,95 @@ function normalizePluginRegistryAliasKey(value: string): string {
   return normalizePluginRegistryAlias(value).toLowerCase();
 }
 
-function collectObjectKeys(value: Record<string, unknown> | undefined): readonly string[] {
-  return value ? Object.keys(value) : [];
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function listPluginRegistryNormalizerAliases(plugin: PluginManifestRecord): readonly string[] {
+function readPluginRegistryArray(read: () => readonly unknown[] | undefined): readonly unknown[] {
+  let values: readonly unknown[] | undefined;
+  try {
+    values = read();
+  } catch {
+    return [];
+  }
+  return Array.isArray(values) ? values : [];
+}
+
+function readPluginRegistryStringArray(read: () => readonly unknown[] | undefined): string[] {
+  const values = readPluginRegistryArray(read);
+  const strings: string[] = [];
+  for (const index of values.keys()) {
+    try {
+      const value = values[index];
+      if (typeof value === "string") {
+        strings.push(value);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return strings;
+}
+
+function collectObjectKeys(read: () => unknown): readonly string[] {
+  let value: unknown;
+  try {
+    value = read();
+  } catch {
+    return [];
+  }
+  if (!isRecordValue(value)) {
+    return [];
+  }
+  try {
+    return Object.keys(value);
+  } catch {
+    return [];
+  }
+}
+
+function readRecordStringFields(
+  read: () => readonly unknown[] | undefined,
+  field: string,
+): string[] {
+  const records = readPluginRegistryArray(read);
+  const fields: string[] = [];
+  for (const index of records.keys()) {
+    try {
+      const record = records[index];
+      if (isRecordValue(record) && typeof record[field] === "string") {
+        fields.push(record[field]);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return fields;
+}
+
+function readPluginRegistryId(plugin: PluginManifestRecord): string | null {
+  try {
+    return typeof plugin.id === "string" && plugin.id ? plugin.id : null;
+  } catch {
+    return null;
+  }
+}
+
+function listPluginRegistryNormalizerAliases(
+  plugin: PluginManifestRecord,
+  pluginId: string,
+): readonly string[] {
   return [
-    plugin.id,
-    ...(plugin.providers ?? []),
-    ...(plugin.channels ?? []),
-    ...(plugin.setup?.providers?.map((provider) => provider.id) ?? []),
-    ...(plugin.cliBackends ?? []),
-    ...(plugin.setup?.cliBackends ?? []),
-    ...collectObjectKeys(plugin.modelCatalog?.providers),
-    ...collectObjectKeys(plugin.modelCatalog?.aliases),
-    ...collectObjectKeys(plugin.providerAuthAliases),
-    ...(plugin.legacyPluginIds ?? []),
+    pluginId,
+    ...readPluginRegistryStringArray(() => plugin.providers),
+    ...readPluginRegistryStringArray(() => plugin.channels),
+    ...readRecordStringFields(() => plugin.setup?.providers, "id"),
+    ...readPluginRegistryStringArray(() => plugin.cliBackends),
+    ...readPluginRegistryStringArray(() => plugin.setup?.cliBackends),
+    ...collectObjectKeys(() => plugin.modelCatalog?.providers),
+    ...collectObjectKeys(() => plugin.modelCatalog?.aliases),
+    ...collectObjectKeys(() => plugin.providerAuthAliases),
+    ...readPluginRegistryStringArray(() => plugin.legacyPluginIds),
   ];
 }
 
@@ -57,15 +130,19 @@ export function createPluginRegistryIdNormalizer(
       index,
       includeDisabled: true,
     });
-  for (const plugin of [...registry.plugins].toSorted((left, right) =>
-    left.id.localeCompare(right.id),
-  )) {
-    const pluginId = normalizePluginRegistryAlias(plugin.id);
+  const registryPlugins = registry.plugins
+    .flatMap((plugin) => {
+      const pluginId = readPluginRegistryId(plugin);
+      return pluginId ? [{ plugin, pluginId }] : [];
+    })
+    .toSorted((left, right) => left.pluginId.localeCompare(right.pluginId));
+  for (const { plugin, pluginId: rawPluginId } of registryPlugins) {
+    const pluginId = normalizePluginRegistryAlias(rawPluginId);
     if (!pluginId) {
       continue;
     }
-    aliases.set(normalizePluginRegistryAliasKey(pluginId), plugin.id);
-    for (const alias of listPluginRegistryNormalizerAliases(plugin)) {
+    aliases.set(normalizePluginRegistryAliasKey(pluginId), rawPluginId);
+    for (const alias of listPluginRegistryNormalizerAliases(plugin, rawPluginId)) {
       const normalizedAlias = normalizePluginRegistryAlias(alias);
       const normalizedAliasKey = normalizePluginRegistryAliasKey(alias);
       if (normalizedAlias && !aliases.has(normalizedAliasKey)) {


### PR DESCRIPTION
## Summary

- Guard plugin metadata snapshot freezing, owner-map construction, and registry id normalization against unreadable manifest metadata fields.
- Preserve healthy owner aliases/providers/channels/CLI/setup/model-catalog rows when sibling metadata fields or record values throw.
- Add a focused regression for poisoned owner metadata before a healthy manifest row.

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-id-normalizer.ts`: passed
- `./node_modules/.bin/oxlint src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/plugin-registry-id-normalizer.ts`: passed
- `git diff --check origin/main...HEAD`: passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, `overall: patch is correct (0.86)`
- Focused Vitest command attempted repeatedly but hung locally with no test result:
  `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=10000 node scripts/run-vitest.mjs run src/plugins/plugin-metadata-snapshot.memo.test.ts --reporter=verbose -t "skips unreadable owner metadata fields"`
- Remote changed gate attempted:
  `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

Behavior addressed: malformed plugin manifest metadata can no longer abort snapshot owner-map or id-normalizer setup before healthy rows are considered.

Real environment tested: local linked OpenClaw worktree with Node wrapper tooling; Crabbox remote gate attempted through provider `azure`.

Exact steps or command run after this patch: oxfmt check, oxlint, git diff check, branch autoreview, focused Vitest attempt, Crabbox changed-gate attempt, Blacksmith auth check.

Evidence after fix: static checks and branch autoreview passed. Crabbox failed before lease creation with coordinator `401 unauthorized` using slug `violet-hermit`; Blacksmith Testbox reported `not authenticated`.

Observed result after fix: guarded metadata readers preserve healthy owner/alias rows in the regression path according to code review, and no formatting/lint/diff/review issues remain.

What was not tested: focused Vitest did not complete locally because the worker hung; full `pnpm check:changed` did not run because Crabbox and Blacksmith runner auth are unavailable in this environment.
