### PR TITLE
fix(agents): detect unsigned thinking-only stall when reasoning payload inflates payloadCount

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -303,6 +303,9 @@ export function resolveIncompleteTurnPayloadText(params: {
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(
     params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant,
   );
+  const unsignedThinkingOnlyAssistant = isUnsignedThinkingOnlyAssistantTurn(
+    params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant,
+  );
   const emptyResponseAssistant = isEmptyResponseAssistantTurn({
     payloadCount: params.payloadCount,
     attempt: params.attempt,
@@ -310,6 +313,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   if (
     !incompleteTerminalAssistant &&
     !reasoningOnlyAssistant &&
+    !unsignedThinkingOnlyAssistant &&
     !emptyResponseAssistant &&
     stopReason !== "error"
   ) {
@@ -508,6 +512,18 @@ function isReasoningOnlyAssistantTurn(message: unknown): boolean {
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-text";
 }
 
+function isUnsignedThinkingOnlyAssistantTurn(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const agentMessage = message as AgentMessage;
+  // Check for non-empty content array with unsigned thinking only
+  if (!agentMessage.content || agentMessage.content.length === 0) {
+    return false;
+  }
+  return assessLastAssistantMessage(agentMessage) === "incomplete-thinking";
+}
+
 function isEmptyResponseAssistantTurn(params: {
   payloadCount: number;
   attempt: Pick<
@@ -638,7 +654,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   if (assistant?.stopReason === "error") {
     return null;
   }
-  if (!isReasoningOnlyAssistantTurn(assistant)) {
+  if (!isReasoningOnlyAssistantTurn(assistant) && !isUnsignedThinkingOnlyAssistantTurn(assistant)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fixes session stalls that occur when local models (e.g. Qwen3.6-35B via llama.cpp) produce only unsigned thinking blocks with no visible text. The agent would stall indefinitely with no error and no recovery path.

## Root Cause

The `buildEmbeddedRunPayloads` extracts unsigned thinking text and pushes it into `replyItems` as `{ isReasoning: true }`, making `payloadCount = 1`. Two recovery functions failed to handle this case:

1. `resolveIncompleteTurnPayloadText`: Had early-return guard `payloadCount !== 0 && !toolUseTerminal`, returning `null` before stall detector runs
2. `resolveReasoningOnlyRetryInstruction`: Final check `!isReasoningOnlyAssistantTurn(assistant)` only matched signed thinking, so unsigned thinking wouldn't trigger retry

## Changes

- Add `isUnsignedThinkingOnlyAssistantTurn` helper function to detect unsigned thinking-only assistant turns
- Update `resolveIncompleteTurnPayloadText` to check for unsigned thinking stalls in the early-return guard
- Update `resolveReasoningOnlyRetryInstruction` to trigger retry for unsigned thinking cases

## Files Changed

- `src/agents/embedded-agent-runner/run/incomplete-turn.ts`

## Test Plan

- [x] Code compiles without errors
- [ ] Add tests for `isUnsignedThinkingOnlyAssistantTurn` helper
- [ ] Verify stall detection works for unsigned thinking payloads
- [ ] Verify retry mechanism fires correctly

## Related Issues

Fixes #89874

## Verification

After this fix, when a model produces only unsigned thinking output:
- `resolveIncompleteTurnPayloadText` will correctly detect the stall and return an error message
- `resolveReasoningOnlyRetryInstruction` will trigger the retry mechanism (up to 2 times)
- No more infinite stalls
