### PR TITLE
fix(plugins): guard provider discovery credential metadata

### DIFF
--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -170,6 +170,19 @@ function createManifestPluginWithoutDiscovery(params: {
   };
 }
 
+function createPoisonedCredentialMetadataPlugin(params: {
+  id: string;
+  poison: "setup" | "providerAuthEnvVars";
+}): PluginManifestRecord {
+  const plugin = createManifestPluginWithoutDiscovery({ id: params.id });
+  return Object.defineProperty(plugin, params.poison, {
+    configurable: true,
+    get() {
+      throw new Error(`provider discovery ${params.poison} metadata exploded`);
+    },
+  });
+}
+
 function createProvider(params: { id: string; mode: "static" | "catalog" }): ProviderPlugin {
   const hook = {
     run: async () => ({
@@ -546,6 +559,45 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
     expect(mocks.resolvePluginProviders).toHaveBeenCalledTimes(1);
     const params = requireResolvePluginProvidersParams();
     expect(params.onlyPluginIds).toEqual(["kilocode"]);
+  });
+
+  it("skips unreadable credential metadata while selecting full-load fallbacks", () => {
+    const codexEntryProvider = createProvider({ id: "codex", mode: "catalog" });
+    const fullProviders = [createProvider({ id: "kilocode", mode: "catalog" })];
+    mocks.resolveDiscoveredProviderPluginIds.mockReturnValue([
+      "codex",
+      "broken-setup",
+      "broken-auth-vars",
+      "kilocode",
+    ]);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      manifestRegistry: {
+        plugins: [
+          createManifestPlugin("codex"),
+          createPoisonedCredentialMetadataPlugin({ id: "broken-setup", poison: "setup" }),
+          createPoisonedCredentialMetadataPlugin({
+            id: "broken-auth-vars",
+            poison: "providerAuthEnvVars",
+          }),
+          createManifestPluginWithoutDiscovery({
+            id: "kilocode",
+            setupProviders: [{ id: "kilocode", envVars: ["KILOCODE_API_KEY"] }],
+          }),
+        ],
+        diagnostics: [],
+      },
+    });
+    mocks.loadSource.mockReturnValue(codexEntryProvider);
+    mocks.resolvePluginProviders.mockReturnValue(fullProviders);
+
+    expect(
+      resolvePluginDiscoveryProvidersRuntime({
+        env: { KILOCODE_API_KEY: "sk-test" } as NodeJS.ProcessEnv,
+      }),
+    ).toEqual([{ ...codexEntryProvider, pluginId: "codex" }, ...fullProviders]);
+    expect(mocks.resolvePluginProviders).toHaveBeenCalledTimes(1);
+    expect(requireResolvePluginProvidersParams().onlyPluginIds).toEqual(["kilocode"]);
   });
 
   it("enables bundled provider Vitest compat when falling back from discovery entries", () => {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planManifestModelCatalogRows } from "../model-catalog/manifest-planner.js";
-import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
@@ -123,14 +123,18 @@ function hasProviderAuthEnvCredential(
   plugin: PluginManifestRecord,
   env: NodeJS.ProcessEnv,
 ): boolean {
-  const envVars = [
-    ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
-    ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
-  ];
-  return envVars.some((name) => {
-    const value = env[name]?.trim();
-    return value !== undefined && value !== "";
-  });
+  try {
+    const envVars = [
+      ...(plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []),
+      ...Object.values(plugin.providerAuthEnvVars ?? {}).flat(),
+    ];
+    return envVars.some((name) => {
+      const value = env[name]?.trim();
+      return value !== undefined && value !== "";
+    });
+  } catch {
+    return false;
+  }
 }
 
 function modelDefinitionCostFromManifestRow(


### PR DESCRIPTION
## Summary

- Guard provider-discovery credential probing so a malformed plugin row with unreadable `setup` or `providerAuthEnvVars` metadata is treated as having no env credential evidence.
- Add a provider-discovery regression covering poisoned credential metadata while a later healthy env-backed plugin is still selected for scoped full loading.

## Verification

Behavior addressed: Provider discovery no longer crashes during selective full-plugin fallback selection when optional credential metadata on one manifest row is unreadable; healthy later credentialed plugins are still eligible for full loading.

Real environment tested: Local linked OpenClaw worktree on Node 24.15.0 for static/module proof; remote Crabbox changed gate attempted with provider `azure`.

Exact steps or command run after this patch:
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`
- `./node_modules/.bin/oxlint src/plugins/provider-discovery.runtime.ts src/plugins/provider-discovery.runtime.test.ts`
- `git diff --check origin/main...HEAD`
- `/Users/m1/.nodenv/versions/24.15.0/bin/node ./node_modules/.bin/tsx -e '(async () => { await import("./src/plugins/provider-discovery.runtime.ts"); console.log("provider-discovery runtime import ok"); })()'`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --shell -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

Evidence after fix:
- Formatting, targeted oxlint, diff whitespace, and TSX runtime import passed after rebase onto `origin/main`.
- Local autoreview passed: `overall: patch is correct (0.82)`.
- Branch autoreview passed: `overall: patch is correct (0.88)`.

Observed result after fix: The new regression exercises poisoned `setup` and `providerAuthEnvVars` getters plus a healthy `KILOCODE_API_KEY` setup-provider fallback, expecting only `kilocode` to be scoped into full plugin loading.

What was not tested:
- Focused Vitest for `src/plugins/provider-discovery.runtime.test.ts` was attempted with the selected regression and Node 24, but the local runner produced no output and had to be killed from the current-task process group.
- Full `pnpm check:changed` did not run locally because this linked worktree routes broad pnpm gates through remote proof.
- Crabbox changed gate failed before lease creation with coordinator `401 unauthorized` for slug `blue-lobster`; Blacksmith Testbox is also unavailable because the CLI is not authenticated.
