### PR TITLE
Fix Discord native empty reply fallback for compact commands

### DIFF
--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -28,6 +28,24 @@ type NativeCommandEffectiveRoute = {
   agentId: string;
 };
 
+function shouldSendNoVisibleReplyFallback(dispatchResult: {
+  counts: { final?: number; block?: number; tool?: number };
+  noVisibleReplyFallbackEligible?: boolean;
+  queuedFinal?: boolean;
+  sendPolicyDenied?: boolean;
+  sourceReplyDeliveryMode?: string;
+}): boolean {
+  return (
+    dispatchResult.noVisibleReplyFallbackEligible === true &&
+    dispatchResult.queuedFinal !== true &&
+    dispatchResult.sendPolicyDenied !== true &&
+    dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" &&
+    (dispatchResult.counts.final ?? 0) === 0 &&
+    (dispatchResult.counts.block ?? 0) === 0 &&
+    (dispatchResult.counts.tool ?? 0) === 0
+  );
+}
+
 export async function dispatchDiscordNativeAgentReply(params: {
   cfg: OpenClawConfig;
   discordConfig: DiscordConfig;
@@ -106,7 +124,8 @@ export async function dispatchDiscordNativeAgentReply(params: {
     dispatchResult.queuedFinal ||
     dispatchResult.counts.final !== 0 ||
     dispatchResult.counts.block !== 0 ||
-    dispatchResult.counts.tool !== 0
+    dispatchResult.counts.tool !== 0 ||
+    !shouldSendNoVisibleReplyFallback(dispatchResult)
   ) {
     return;
   }

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -901,6 +901,7 @@ describe("Discord native plugin command dispatch", () => {
     runtimeModuleMocks.dispatchReplyWithDispatcher.mockResolvedValue({
       counts: { final: 0, block: 0, tool: 0 },
       queuedFinal: false,
+      noVisibleReplyFallbackEligible: true,
     } as never);
     const command = await createNativeCommand(cfg, {
       name: "new",
@@ -914,6 +915,27 @@ describe("Discord native plugin command dispatch", () => {
       content: "⚠️ Command produced no visible reply.",
       ephemeral: true,
     });
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when dispatch completes without a fallback-eligible visible reply", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+    runtimeModuleMocks.dispatchReplyWithDispatcher.mockResolvedValue({
+      counts: { final: 0, block: 0, tool: 0 },
+      queuedFinal: false,
+      noVisibleReplyFallbackEligible: false,
+    } as never);
+    const command = await createNativeCommand(cfg, {
+      name: "compact",
+      description: "Compact the active session.",
+      acceptsArgs: false,
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expectNoFollowUpContent(interaction, "Command produced no visible reply.");
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Gate the Discord native empty-visible-reply fallback on the shared dispatcher `noVisibleReplyFallbackEligible` signal.
- Keep the warning for genuinely fallback-eligible empty command dispatches.
- Add a Discord native `/compact` regression covering successful zero-counter dispatch results that should not emit the empty-reply warning.

## Linked context

Fixes #89950

AI-assisted: yes. I used Codex to inspect the issue, make the patch, and run focused validation. I reviewed the diff and understand the change.

## Real behavior proof

- Behavior addressed: Discord native command dispatch could send the empty visible reply warning even when shared reply dispatch completed with zero visible counters but did not mark the result as fallback-eligible. This covers the `/compact` report where compaction can succeed while the user-facing interaction still receives the empty warning.
- Real environment tested: Not tested against a live Discord bot in this workspace.
- Exact steps or command run after this patch:
  - `node --no-maglev node_modules\vitest\vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts --reporter=dot`
- Evidence after fix:
  - `Test Files  1 passed (1)`
  - `Tests  23 passed (23)`
- Observed result after fix: the focused Discord native command dispatch suite passes, including the new `/compact` zero-counter non-fallback-eligible regression.
- What was not tested: live Discord slash command execution and live Codex compaction against a real Discord interaction.
- Proof limitations or environment constraints: this Windows Codex workspace had to run Vitest directly through the local CLI because `scripts/run-vitest.mjs` no-oped under Node `v22.14.0`; dependency install also timed out on a few unrelated package downloads after hydrating enough dependencies for the focused test.
- Before evidence: issue #89950 reports the native Discord `/compact` command completed compaction but produced the empty visible reply warning instead of a visible confirmation.

## Tests and validation

- Passed: `node --no-maglev node_modules\vitest\vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts --reporter=dot`
- Passed: `git diff --check`

## Risk checklist

- [x] Small, scoped change
- [x] Tests added or updated
- [x] No unrelated refactors
- [x] No `CHANGELOG.md` edits
- [x] Live behavior proof limitations are stated

## Current review state

Draft for maintainer and Ali review because live Discord proof was not available in this workspace.
