### PR TITLE
fix: suppress Telegram fallback after message-tool-only turns

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2776,6 +2776,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(sendMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not add empty-response fallback after message-tool-only delivery skips final text", async () => {
+    setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({ text: "NO_REPLY" }, { kind: "final", reason: "silent" });
+      dispatcherOptions.onSkip?.(
+        { text: "automatic final suppressed" },
+        { kind: "final", reason: "cancelled" },
+      );
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -100123, type: "supergroup" } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: 456,
+        } as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+      }),
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
+  });
+
   it("runs ambient room events as tool-only invisible turns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2209,6 +2209,7 @@ export const dispatchTelegramMessage = async ({
     !isRoomEvent &&
     (dispatchError ||
       (!deliverySummary.delivered &&
+        !suppressSilentReplyFallback &&
         (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
   if (shouldSendFailureFallback) {
     const fallbackText = dispatchError


### PR DESCRIPTION
## Summary

- Prevent Telegram from sending the generic empty-response fallback when a turn is intentionally `message_tool_only`.
- Add a Telegram regression that exercises a message-tool-only group turn where final text is skipped/silent and verifies no extra Telegram fallback is sent.

Fixes openclaw/openclaw#90076.

## Before/After Proof

Before: `extensions/telegram/src/bot-message-dispatch.ts` treated any non-silent skipped/failed Telegram delivery lane payload as eligible for `No response generated. Please try again.`, even when `sourceReplyDeliveryMode` was `message_tool_only` and the visible reply was expected to happen through the message tool.

After: the empty-response fallback path now respects the existing `suppressSilentReplyFallback` guard for message-tool-only turns, so skipped automatic final text does not create a second fallback reply.

## Real Behavior Proof

Behavior addressed: Telegram group turns that send visible output through the message tool and finish with `NO_REPLY` no longer emit the empty-response fallback when the automatic Telegram final-delivery lane records a skipped non-silent payload.

Real environment tested: local OpenClaw source checkout on Linux, hydrated with `pnpm install --frozen-lockfile`, running the patched Telegram dispatch path from this branch.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts`

Evidence after fix: terminal capture from the patched OpenClaw checkout:

```text
$ node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts
[test] starting test/vitest/vitest.extension-telegram.config.ts
RUN  v4.1.7 /root/.openclaw/workspace/openclaw-pr-90076
Test Files  1 passed (1)
Tests  104 passed (104)
[test] passed 1 Vitest shard in 24.43s
```

Observed result after fix: the new Telegram dispatch case keeps `deliverReplies`, `editMessageTelegram`, and `sendMessageTelegram` uncalled for the message-tool-only empty-response fallback path, so no `No response generated. Please try again.` fallback is emitted.

What was not tested: live Telegram API delivery; this change is covered at the Telegram dispatch level in a local OpenClaw checkout.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
