### PR TITLE
fix(gateway): guard model pricing metadata

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -649,6 +649,50 @@ describe("model-pricing-cache", () => {
     });
   });
 
+  it("skips malformed manifest model-pricing metadata while preserving healthy policies", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "custom/gpt-remote" },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-completions",
+            models: [{ id: "gpt-remote" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const poisoned = createManifestRecord({ id: "poisoned-pricing" });
+    Object.defineProperty(poisoned, "modelPricing", {
+      get() {
+        throw new Error("model pricing metadata exploded");
+      },
+    });
+    const healthy = createManifestRecord({
+      id: "healthy-pricing",
+      modelPricing: {
+        providers: {
+          custom: { external: false },
+        },
+      },
+    });
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      refreshGatewayModelPricingCache({
+        config,
+        fetchImpl,
+        manifestRegistry: { diagnostics: [], plugins: [poisoned, healthy] },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("loads openrouter pricing and maps provider aliases, wrappers, and anthropic dotted ids", async () => {
     const config = {
       agents: {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -1,4 +1,8 @@
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
+import {
+  normalizeOptionalString,
+  resolvePrimaryStringValue,
+} from "../../packages/normalization-core/src/string-coerce.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -26,7 +30,6 @@ import {
 } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataRegistryView } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistrySnapshot } from "../plugins/plugin-registry.js";
-import { normalizeOptionalString, resolvePrimaryStringValue } from "../../packages/normalization-core/src/string-coerce.js";
 import {
   clearGatewayModelPricingCacheState,
   clearGatewayModelPricingFailures,
@@ -433,6 +436,45 @@ function normalizeExternalPricingPolicy(
   };
 }
 
+function listManifestModelPricingPolicies(
+  plugin: PluginManifestRecord,
+): Array<{ provider: string; policy: PluginManifestModelPricingProvider }> {
+  let providers: Record<string, PluginManifestModelPricingProvider> | undefined;
+  try {
+    providers = plugin.modelPricing?.providers;
+  } catch {
+    return [];
+  }
+  if (!providers || typeof providers !== "object") {
+    return [];
+  }
+  let providerIds: string[];
+  try {
+    providerIds = Object.keys(providers);
+  } catch {
+    return [];
+  }
+  return providerIds.flatMap((provider) => {
+    try {
+      const policy = providers[provider];
+      return policy ? [{ provider, policy }] : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function normalizeManifestModelPricingPolicy(
+  value: PluginManifestModelPricingProvider,
+  options: PricingModelNormalizationOptions,
+): ExternalPricingPolicy | undefined {
+  try {
+    return normalizeExternalPricingPolicy(value, options);
+  } catch {
+    return undefined;
+  }
+}
+
 function filterActiveManifestRegistry(params: {
   registry: PluginManifestRegistry;
   index: PluginRegistrySnapshot;
@@ -504,8 +546,8 @@ function loadManifestPricingContext(
 } {
   const policies = new Map<string, ExternalPricingPolicy>();
   for (const plugin of registry.plugins) {
-    for (const [provider, rawPolicy] of Object.entries(plugin.modelPricing?.providers ?? {})) {
-      const policy = normalizeExternalPricingPolicy(rawPolicy, normalizationOptions);
+    for (const { provider, policy: rawPolicy } of listManifestModelPricingPolicies(plugin)) {
+      const policy = normalizeManifestModelPricingPolicy(rawPolicy, normalizationOptions);
       if (policy) {
         policies.set(provider, policy);
       }


### PR DESCRIPTION
## Summary

- Guard manifest `modelPricing.providers` reads while the gateway builds pricing policy context.
- Skip malformed pricing metadata for one plugin without dropping healthy sibling policies.
- Add a regression proving a poisoned manifest row no longer blocks a later `external: false` policy from suppressing remote catalog fetches.

## Real behavior proof

Behavior addressed: malformed plugin model-pricing metadata can no longer crash gateway pricing refresh before healthy plugin pricing policy is applied.

Real environment tested: local linked Codex worktree; broad remote changed gate attempted through Blacksmith Testbox and Crabbox but blocked by missing auth/coordinator authorization.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/gateway/model-pricing-cache.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/model-pricing-cache.ts src/gateway/model-pricing-cache.test.ts`
- `./node_modules/.bin/oxlint src/gateway/model-pricing-cache.ts src/gateway/model-pricing-cache.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

Evidence after fix: the focused model-pricing cache test shard passed with 4 files / 96 tests, including the new regression across gateway core, server, and client projects. Formatter, lint, diff check, and local/branch autoreview were clean.

Observed result after fix: `refreshGatewayModelPricingCache()` resolves when the first manifest row throws from `modelPricing`, and the later healthy `custom: { external: false }` policy still prevents remote pricing fetches.

What was not tested: `pnpm check:changed` did not run. Blacksmith Testbox was unavailable locally (`not authenticated`), and Crabbox failed before lease creation with coordinator 401.
