### PR TITLE
fix(sandbox): use config-resolved workspace for skill sync fallback

### DIFF
--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -566,4 +566,52 @@ describe("resolveSandboxContext", () => {
     expect(syncOptions?.agentId).toBe("main");
     expect(syncOptions?.eligibility).toEqual({ remote: { note: "test-remote" } });
   }, 15_000);
+
+  it("uses config-resolved workspace for skill sync when workspaceDir is empty string", async () => {
+    syncSkillsToWorkspaceMock.mockClear();
+    const bundledDir = await createSandboxFixtureDir("bundled");
+    const configuredWorkspace = await createSandboxFixtureDir("configured-workspace-empty");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: configuredWorkspace,
+          sandbox: {
+            mode: "all",
+            scope: "session",
+            workspaceAccess: "ro",
+            workspaceRoot: path.join(bundledDir, "sandboxes"),
+          },
+        },
+      },
+    };
+
+    const result = await ensureSandboxWorkspaceForSession({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      workspaceDir: "",
+    });
+
+    if (!result) {
+      throw new Error("expected sandbox workspace resolution");
+    }
+    expect(typeof result.workspaceDir).toBe("string");
+    const syncCalls = syncSkillsToWorkspaceMock.mock.calls as unknown as Array<
+      [
+        {
+          sourceWorkspaceDir?: string;
+          targetWorkspaceDir?: string;
+          config?: OpenClawConfig;
+          agentId?: string;
+          eligibility?: unknown;
+        },
+      ]
+    >;
+    const [syncOptions] = syncCalls[0] ?? [];
+    expect(syncOptions?.sourceWorkspaceDir).toBe(configuredWorkspace);
+    expect(syncOptions?.targetWorkspaceDir).toBe(result.workspaceDir);
+    expect(syncOptions?.config).toBe(cfg);
+    expect(syncOptions?.agentId).toBe("main");
+    expect(syncOptions?.eligibility).toEqual({ remote: { note: "test-remote" } });
+  }, 15_000);
 });

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -519,4 +519,51 @@ describe("resolveSandboxContext", () => {
       fs.readFile(path.join(userOwnedSandboxSkillsDir, "SKILL.md"), "utf8"),
     ).resolves.toBe("# User owned\n");
   }, 15_000);
+
+  it("uses config-resolved workspace for skill sync when workspaceDir is not provided", async () => {
+    syncSkillsToWorkspaceMock.mockClear();
+    const bundledDir = await createSandboxFixtureDir("bundled");
+    const configuredWorkspace = await createSandboxFixtureDir("configured-workspace");
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: configuredWorkspace,
+          sandbox: {
+            mode: "all",
+            scope: "session",
+            workspaceAccess: "ro",
+            workspaceRoot: path.join(bundledDir, "sandboxes"),
+          },
+        },
+      },
+    };
+
+    const result = await ensureSandboxWorkspaceForSession({
+      config: cfg,
+      sessionKey: "agent:main:main",
+    });
+
+    if (!result) {
+      throw new Error("expected sandbox workspace resolution");
+    }
+    expect(typeof result.workspaceDir).toBe("string");
+    const syncCalls = syncSkillsToWorkspaceMock.mock.calls as unknown as Array<
+      [
+        {
+          sourceWorkspaceDir?: string;
+          targetWorkspaceDir?: string;
+          config?: OpenClawConfig;
+          agentId?: string;
+          eligibility?: unknown;
+        },
+      ]
+    >;
+    const [syncOptions] = syncCalls[0] ?? [];
+    expect(syncOptions?.sourceWorkspaceDir).toBe(configuredWorkspace);
+    expect(syncOptions?.targetWorkspaceDir).toBe(result.workspaceDir);
+    expect(syncOptions?.config).toBe(cfg);
+    expect(syncOptions?.agentId).toBe("main");
+    expect(syncOptions?.eligibility).toEqual({ remote: { note: "test-remote" } });
+  }, 15_000);
 });

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -17,7 +17,7 @@ import {
 import { defaultRuntime } from "../../runtime.js";
 import type { SkillEligibilityContext } from "../../skills/types.js";
 import { resolveUserPath } from "../../utils.js";
-import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
+import { resolveAgentWorkspaceDir } from "../agent-scope.js";
 import { getSandboxBackendWorkdirResolver, requireSandboxBackendFactory } from "./backend.js";
 import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
@@ -85,7 +85,7 @@ async function ensureSandboxWorkspaceLayout(params: {
   const { cfg, rawSessionKey } = params;
 
   const agentWorkspaceDir = resolveUserPath(
-    params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR,
+    params.workspaceDir?.trim() || resolveAgentWorkspaceDir(params.config ?? {}, params.agentId),
   );
   const workspaceRoot = resolveUserPath(cfg.workspaceRoot);
   const scopeKey = resolveSandboxScopeKey(cfg.scope, rawSessionKey);


### PR DESCRIPTION
## Summary

When sandbox skill sync runs and no explicit `workspaceDir` is provided, `ensureSandboxWorkspaceLayout` was falling back to the hardcoded `DEFAULT_AGENT_WORKSPACE_DIR` (which only checks the `OPENCLAW_WORKSPACE_DIR` environment variable) instead of resolving the workspace from the user's config via `resolveAgentWorkspaceDir`.

This caused skills to be loaded from the wrong source directory when a custom workspace was configured in `openclaw.json` (e.g. `agents.defaults.workspace`).

## Changes

- `src/agents/sandbox/context.ts`: Changed the fallback in `ensureSandboxWorkspaceLayout` from `DEFAULT_AGENT_WORKSPACE_DIR` to `resolveAgentWorkspaceDir(params.config ?? {}, params.agentId)` so the configured workspace is respected.
- `src/agents/sandbox.resolveSandboxContext.test.ts`: Added a test that verifies `syncSkillsToWorkspace` receives the config-resolved workspace when `workspaceDir` is not explicitly provided to `ensureSandboxWorkspaceForSession`.

## Real behavior proof

Behavior addressed: sandbox skill sync falling back to the hardcoded default workspace instead of the config-resolved workspace when `workspaceDir` is omitted.

Real environment tested: Linux x86_64 local checkout, Node 22.19+, pnpm workspace.

Exact steps or command run after this patch:
- `node --import tsx scripts/repro/issue-89743-sandbox-workspace-config-proof.mts`
- `node scripts/run-vitest.mjs src/agents/sandbox.resolveSandboxContext.test.ts`
- `node scripts/run-vitest.mjs src/skills/loading/workspace-sync.test.ts`
- `npx oxlint --import-plugin --config .oxlintrc.json src/agents/sandbox/context.ts src/agents/sandbox.resolveSandboxContext.test.ts`
- `pnpm build`

Evidence after fix:
```text
=== Reproduction for issue #89743 ===
Custom workspace: /tmp/openclaw-repro-89743-XXXXXX/custom-workspace
Sandbox root: /tmp/openclaw-repro-89743-XXXXXX/sandbox-root

Sandbox workspace resolved: /tmp/openclaw-repro-89743-XXXXXX/sandbox-root/agent-main-task-3f973123
Container workdir: /workspace

=== Results ===
DEFAULT_AGENT_WORKSPACE_DIR (old fallback): /home/0668000666/.openclaw/workspace
Config-resolved workspace (new fallback): /tmp/openclaw-repro-89743-XXXXXX/custom-workspace
Match? false
Sandbox workspace exists under sandboxRoot? true
Skill synced to sandbox? true

Synced skill content preview: --- name: Test Proof Skill description: Proves sandbox sync uses configured workspace. ---  # Test P
Cleanup done.

PASS: Sandbox skill sync correctly uses config-resolved workspace.
```
The reproduction script creates a temporary custom workspace with a skill, configures `agents.defaults.workspace` to point to it, calls `ensureSandboxWorkspaceForSession` with a sandboxed session key, and verifies the skill is copied into the sandbox workspace — confirming the fix routes skill sync through the config-resolved workspace instead of the hardcoded default.

Observed result after fix: When `workspaceDir` is omitted, `ensureSandboxWorkspaceLayout` now resolves the workspace from config via `resolveAgentWorkspaceDir` instead of falling back to `DEFAULT_AGENT_WORKSPACE_DIR`. The sandbox skill sync correctly copies skills from the configured custom workspace into the sandbox workspace. Unit tests pass, lint passes, and build completes successfully.

Unit test evidence:
- `src/agents/sandbox.resolveSandboxContext.test.ts`: `Test Files 1 passed (1)`, `Tests 8 passed (8)`.
- `src/skills/loading/workspace-sync.test.ts`: `Test Files 1 passed (1)`, `Tests 9 passed (9)`.

Build/lint evidence:
- Direct oxlint of changed files: completed with no errors.
- `pnpm build`: completed successfully (`[build-all] phase timings: total 613.6s`).

What was not tested: A full packaged OpenClaw desktop/manual UI workflow. The fix is scoped to the sandbox workspace resolution fallback path.

## Verification

- `node --import tsx scripts/repro/issue-89743-sandbox-workspace-config-proof.mts` passes (real custom-workspace sandbox sync run)
- `node scripts/run-vitest.mjs src/agents/sandbox.resolveSandboxContext.test.ts` passes (8/8 tests)
- `node scripts/run-vitest.mjs src/skills/loading/workspace-sync.test.ts` passes (9/9 tests)
- Direct oxlint of changed files passes with no errors (repo-wide `pnpm lint` reports pre-existing errors in `extensions/` unrelated to this change)
- `pnpm build` passes

Fixes #89743