### PR TITLE
fix(plugins): guard runtime boundary manifest rows

### DIFF
--- a/src/plugins/runtime/runtime-plugin-boundary.test.ts
+++ b/src/plugins/runtime/runtime-plugin-boundary.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  registry: {
+    diagnostics: [],
+    plugins: [] as unknown[],
+  },
+}));
+
+vi.mock("../manifest-registry.js", () => ({
+  loadPluginManifestRegistry: () => mocks.registry,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  getRuntimeConfig: () => ({}),
+}));
+
+import {
+  resolvePluginRuntimeRecord,
+  resolvePluginRuntimeRecordByEntryBaseNames,
+} from "./runtime-plugin-boundary.js";
+
+const tempDirs: string[] = [];
+
+function makeRuntimePluginFixture(pluginId: string) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-runtime-boundary-"));
+  tempDirs.push(rootDir);
+  const source = path.join(rootDir, "index.js");
+  fs.writeFileSync(source, "export default {};\n", "utf8");
+  fs.writeFileSync(path.join(rootDir, "light-runtime-api.js"), "export {};\n", "utf8");
+  fs.writeFileSync(path.join(rootDir, "runtime-api.js"), "export {};\n", "utf8");
+  return {
+    id: pluginId,
+    origin: "global",
+    rootDir,
+    source,
+  };
+}
+
+function expectHealthyRuntimeRecord(plugin: ReturnType<typeof makeRuntimePluginFixture>) {
+  expect(resolvePluginRuntimeRecord(plugin.id)).toEqual({
+    origin: "global",
+    rootDir: plugin.rootDir,
+    source: plugin.source,
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+  mocks.registry.plugins = [];
+});
+
+describe("runtime plugin boundary manifest lookup", () => {
+  it("skips unreadable manifest rows when resolving a runtime record by plugin id", () => {
+    const healthyPlugin = makeRuntimePluginFixture("healthy-runtime");
+    const poisonedPlugin = Object.defineProperty({}, "id", {
+      get() {
+        throw new Error("runtime boundary manifest id exploded");
+      },
+    });
+
+    mocks.registry.plugins = [poisonedPlugin, healthyPlugin];
+
+    expectHealthyRuntimeRecord(healthyPlugin);
+  });
+
+  it("skips unreadable manifest rows when resolving by runtime entry base names", () => {
+    const healthyPlugin = makeRuntimePluginFixture("healthy-web-channel-runtime");
+    const poisonedPlugin = {
+      id: "poisoned-runtime",
+      rootDir: healthyPlugin.rootDir,
+      get source() {
+        throw new Error("runtime boundary manifest source exploded");
+      },
+    };
+
+    mocks.registry.plugins = [poisonedPlugin, healthyPlugin];
+
+    expect(
+      resolvePluginRuntimeRecordByEntryBaseNames(["light-runtime-api", "runtime-api"]),
+    ).toEqual({
+      origin: "global",
+      rootDir: healthyPlugin.rootDir,
+      source: healthyPlugin.source,
+    });
+  });
+});

--- a/src/plugins/runtime/runtime-plugin-boundary.ts
+++ b/src/plugins/runtime/runtime-plugin-boundary.ts
@@ -18,6 +18,10 @@ type PluginRuntimeRecord = {
   source: string;
 };
 
+type ManifestRuntimePluginRecord = PluginRuntimeRecord & {
+  id: string;
+};
+
 export function readPluginBoundaryConfigSafely() {
   try {
     return getRuntimeConfig();
@@ -33,18 +37,16 @@ export function resolvePluginRuntimeRecord(
   const manifestRegistry = loadPluginManifestRegistry({
     config: readPluginBoundaryConfigSafely(),
   });
-  const record = manifestRegistry.plugins.find((plugin) => plugin.id === pluginId);
-  if (!record?.source) {
-    if (onMissing) {
-      onMissing();
+  for (const plugin of manifestRegistry.plugins) {
+    const record = readManifestRuntimePluginRecord(plugin);
+    if (record?.id === pluginId) {
+      return toPluginRuntimeRecord(record);
     }
-    return null;
   }
-  return {
-    ...(record.origin ? { origin: record.origin } : {}),
-    rootDir: record.rootDir,
-    source: record.source,
-  };
+  if (onMissing) {
+    onMissing();
+  }
+  return null;
 }
 
 export function resolvePluginRuntimeRecordByEntryBaseNames(
@@ -54,18 +56,13 @@ export function resolvePluginRuntimeRecordByEntryBaseNames(
   const manifestRegistry = loadPluginManifestRegistry({
     config: readPluginBoundaryConfigSafely(),
   });
-  const matches = manifestRegistry.plugins.filter((plugin) => {
-    if (!plugin?.source) {
-      return false;
+  const matches: ManifestRuntimePluginRecord[] = [];
+  for (const plugin of manifestRegistry.plugins) {
+    const record = readManifestRuntimePluginRecord(plugin);
+    if (record && hasRuntimeEntryBaseNames(record, entryBaseNames)) {
+      matches.push(record);
     }
-    const record = {
-      rootDir: plugin.rootDir,
-      source: plugin.source,
-    };
-    return entryBaseNames.every(
-      (entryBaseName) => resolvePluginRuntimeModulePath(record, entryBaseName) !== null,
-    );
-  });
+  }
   if (matches.length === 0) {
     if (onMissing) {
       onMissing();
@@ -79,6 +76,57 @@ export function resolvePluginRuntimeRecordByEntryBaseNames(
     );
   }
   const record = matches[0];
+  return toPluginRuntimeRecord(record);
+}
+
+function readManifestRuntimePluginRecord(plugin: unknown): ManifestRuntimePluginRecord | null {
+  if (!plugin || typeof plugin !== "object") {
+    return null;
+  }
+
+  try {
+    const candidate = plugin as {
+      id?: unknown;
+      origin?: unknown;
+      rootDir?: unknown;
+      source?: unknown;
+    };
+    const { id, origin, rootDir, source } = candidate;
+    if (typeof id !== "string" || id.length === 0) {
+      return null;
+    }
+    if (typeof source !== "string" || source.length === 0) {
+      return null;
+    }
+    return {
+      id,
+      ...(isPluginOrigin(origin) ? { origin } : {}),
+      ...(typeof rootDir === "string" && rootDir.length > 0 ? { rootDir } : {}),
+      source,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isPluginOrigin(value: unknown): value is PluginOrigin {
+  return value === "bundled" || value === "global" || value === "workspace" || value === "config";
+}
+
+function hasRuntimeEntryBaseNames(
+  record: Pick<PluginRuntimeRecord, "rootDir" | "source">,
+  entryBaseNames: string[],
+) {
+  try {
+    return entryBaseNames.every(
+      (entryBaseName) => resolvePluginRuntimeModulePath(record, entryBaseName) !== null,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function toPluginRuntimeRecord(record: PluginRuntimeRecord): PluginRuntimeRecord {
   return {
     ...(record.origin ? { origin: record.origin } : {}),
     rootDir: record.rootDir,


### PR DESCRIPTION
## Summary

- Harden runtime plugin boundary lookup so malformed manifest rows are skipped per row instead of aborting healthy runtime resolution.
- Add focused regression coverage for poisoned manifest accessors in both plugin-id lookup and runtime entry-base-name lookup.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs src/plugins/runtime/runtime-plugin-boundary.test.ts --reporter=verbose` failed with `runtime boundary manifest id exploded` and `runtime boundary manifest source exploded`.
- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-plugin-boundary.test.ts src/plugins/runtime-plugin-boundary.whatsapp.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/plugins/runtime/runtime-plugin-boundary.ts src/plugins/runtime/runtime-plugin-boundary.test.ts`
- `./node_modules/.bin/oxlint src/plugins/runtime/runtime-plugin-boundary.ts src/plugins/runtime/runtime-plugin-boundary.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: a stale or malformed plugin manifest row with an unreadable `id` or `source` accessor could throw during runtime boundary lookup and prevent a later healthy plugin runtime from resolving.

Real environment tested: local linked OpenClaw worktree using the repo Vitest wrapper and focused plugin runtime boundary fixtures.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/runtime/runtime-plugin-boundary.test.ts src/plugins/runtime-plugin-boundary.whatsapp.test.ts --reporter=dot`

Evidence after fix: the focused shard passed with 2 files and 5 tests after the fix, and branch autoreview reported `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: runtime boundary lookup skips poisoned manifest rows and still resolves the healthy plugin runtime record by plugin id and by `light-runtime-api` / `runtime-api` entry names.

What was not tested: `pnpm check:changed` could not run remotely because Blacksmith is not authenticated in this shell and Crabbox coordinator requests returned HTTP 401 before lease creation.
