### PR TITLE
fix(channels): guard read-only command metadata rows

### DIFF
--- a/src/channels/plugins/read-only-command-defaults.test.ts
+++ b/src/channels/plugins/read-only-command-defaults.test.ts
@@ -106,4 +106,74 @@ describe("resolveReadOnlyChannelCommandDefaults", () => {
       nativeSkillsAutoEnabled: false,
     });
   });
+
+  it("skips unreadable plugin metadata rows while resolving command defaults", () => {
+    const unreadableChannels = Object.defineProperty(
+      {
+        id: "poisoned-channels",
+        origin: "global",
+      },
+      "channels",
+      {
+        get() {
+          throw new Error("read-only command channels exploded");
+        },
+      },
+    );
+    const unreadableChannelConfigs = Object.defineProperty(
+      {
+        id: "poisoned-channel-configs",
+        origin: "global",
+        channels: ["demo"],
+      },
+      "channelConfigs",
+      {
+        get() {
+          throw new Error("read-only command config exploded");
+        },
+      },
+    );
+    loadPluginMetadataSnapshot.mockReturnValue({
+      index: {
+        plugins: [
+          {
+            pluginId: "poisoned-channel-configs",
+            origin: "global",
+            enabled: true,
+            enabledByDefault: true,
+          },
+          {
+            pluginId: "healthy-demo",
+            origin: "global",
+            enabled: true,
+            enabledByDefault: true,
+          },
+        ],
+      },
+      plugins: [
+        unreadableChannels,
+        unreadableChannelConfigs,
+        {
+          id: "healthy-demo",
+          origin: "global",
+          channels: ["demo"],
+          channelConfigs: {
+            demo: {
+              commands: {
+                nativeCommandsAutoEnabled: true,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(
+      resolveReadOnlyChannelCommandDefaults("demo", {
+        config: {},
+      }),
+    ).toEqual({
+      nativeCommandsAutoEnabled: true,
+    });
+  });
 });

--- a/src/channels/plugins/read-only-command-defaults.ts
+++ b/src/channels/plugins/read-only-command-defaults.ts
@@ -22,6 +22,16 @@ export type ChannelCommandDefaults = Pick<
 
 type ManifestChannelConfigRecord = NonNullable<PluginManifestRecord["channelConfigs"]>[string];
 
+type ReadOnlyChannelCommandRecord = {
+  channelCatalogMeta?: {
+    commands?: ChannelCommandDefaults;
+    id: string;
+  };
+  channelConfigs?: Record<string, unknown>;
+  channels: string[];
+  id: string;
+};
+
 /**
  * Returns whether a manifest channel id is safe for own-property lookup.
  */
@@ -92,31 +102,87 @@ export function resolveReadOnlyChannelCommandDefaults(
     allowWorkspaceScopedCurrent: true,
   });
   for (const record of resolvedSnapshot.plugins) {
-    if (!record.channels.includes(normalizedChannelId)) {
+    const commandRecord = readOnlyChannelCommandRecord(record);
+    if (!commandRecord?.channels.includes(normalizedChannelId)) {
       continue;
     }
-    if (!isInstalledPluginEnabled(resolvedSnapshot.index, record.id, options.config)) {
+    if (!isInstalledPluginEnabled(resolvedSnapshot.index, commandRecord.id, options.config)) {
       continue;
     }
-    // Manifest channelConfigs are untrusted object data, so read the channel key
-    // through the guarded helper instead of indexing directly.
-    const channelConfigValue = record.channelConfigs
-      ? readOwnRecordValue(record.channelConfigs as Record<string, unknown>, normalizedChannelId)
-      : undefined;
-    const channelConfig =
-      channelConfigValue &&
-      typeof channelConfigValue === "object" &&
-      !Array.isArray(channelConfigValue)
-        ? (channelConfigValue as ManifestChannelConfigRecord)
-        : undefined;
-    const catalogCommands =
-      record.channelCatalogMeta?.id === normalizedChannelId
-        ? record.channelCatalogMeta.commands
-        : undefined;
-    const commands = normalizeChannelCommandDefaults(channelConfig?.commands ?? catalogCommands);
+    const commands = resolveCommandDefaultsFromRecord(commandRecord, normalizedChannelId);
     if (commands) {
       return commands;
     }
   }
   return undefined;
+}
+
+function readOnlyChannelCommandRecord(record: unknown): ReadOnlyChannelCommandRecord | null {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+
+  try {
+    const candidate = record as {
+      channelCatalogMeta?: unknown;
+      channelConfigs?: unknown;
+      channels?: unknown;
+      id?: unknown;
+    };
+    const { channelCatalogMeta, channelConfigs, channels, id } = candidate;
+    if (typeof id !== "string" || id.length === 0) {
+      return null;
+    }
+    if (!Array.isArray(channels)) {
+      return null;
+    }
+    return {
+      id,
+      channels: channels.filter((channel): channel is string => typeof channel === "string"),
+      ...(isRecord(channelConfigs) ? { channelConfigs } : {}),
+      ...(isChannelCatalogMeta(channelCatalogMeta) ? { channelCatalogMeta } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isChannelCatalogMeta(
+  value: unknown,
+): value is NonNullable<ReadOnlyChannelCommandRecord["channelCatalogMeta"]> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  try {
+    return typeof value.id === "string";
+  } catch {
+    return false;
+  }
+}
+
+function resolveCommandDefaultsFromRecord(
+  record: ReadOnlyChannelCommandRecord,
+  normalizedChannelId: string,
+): ChannelCommandDefaults | undefined {
+  try {
+    // Manifest channelConfigs are untrusted object data, so read the channel key
+    // through the guarded helper instead of indexing directly.
+    const channelConfigValue = record.channelConfigs
+      ? readOwnRecordValue(record.channelConfigs, normalizedChannelId)
+      : undefined;
+    const channelConfig = isRecord(channelConfigValue)
+      ? (channelConfigValue as ManifestChannelConfigRecord)
+      : undefined;
+    const catalogCommands =
+      record.channelCatalogMeta?.id === normalizedChannelId
+        ? record.channelCatalogMeta.commands
+        : undefined;
+    return normalizeChannelCommandDefaults(channelConfig?.commands ?? catalogCommands);
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary

- Guard read-only channel command default resolution against unreadable plugin metadata rows.
- Keep later healthy plugin command defaults resolvable when an earlier plugin row has throwing `channels` or `channelConfigs` accessors.
- Add a regression test for poisoned metadata rows before a healthy channel default entry.

## Verification

- `node scripts/run-vitest.mjs src/channels/plugins/read-only-command-defaults.test.ts -t "skips unreadable plugin metadata" --reporter=verbose`
- `node scripts/run-vitest.mjs src/channels/plugins/read-only-command-defaults.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/channels/plugins/read-only-command-defaults.ts src/channels/plugins/read-only-command-defaults.test.ts`
- `./node_modules/.bin/oxlint src/channels/plugins/read-only-command-defaults.ts src/channels/plugins/read-only-command-defaults.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: malformed or poisoned plugin metadata rows no longer crash read-only command default resolution before later healthy plugin records can be checked.

Real environment tested: local linked `gwt` worktree on the branch, using the repo Vitest wrapper for the narrow touched channel test.

Exact steps or command run after this patch: focused regression test, full touched test file, oxfmt, oxlint, diff whitespace check, and local plus branch autoreview.

Evidence after fix: the focused regression test passes, and the full touched test file passes with 3 tests.

Observed result after fix: unreadable metadata rows are skipped and the healthy plugin row still resolves `nativeCommandsAutoEnabled` for the target channel.

What was not tested: remote `pnpm check:changed`; Crabbox AWS setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
