### PR TITLE
fix: add Claude Haiku 4.5 to static model catalog

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -4,7 +4,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["anthropic"],
+  "providers": [
+    "anthropic"
+  ],
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "runtimeAugment": true,
@@ -15,9 +17,16 @@
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -26,9 +35,16 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -37,9 +53,34 @@
             "id": "claude-opus-4-6",
             "name": "Claude Opus 4.6 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5 (Claude CLI)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "mediaInput": {
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -54,9 +95,16 @@
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -65,9 +113,16 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -76,9 +131,34 @@
             "id": "claude-opus-4-6",
             "name": "Claude Opus 4.6",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "mediaInput": {
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -92,7 +172,9 @@
     }
   },
   "modelSupport": {
-    "modelPrefixes": ["claude-"]
+    "modelPrefixes": [
+      "claude-"
+    ]
   },
   "modelIdNormalization": {
     "providers": {
@@ -108,7 +190,9 @@
     "providers": {
       "anthropic": {
         "openRouter": {
-          "modelIdTransforms": ["version-dots"]
+          "modelIdTransforms": [
+            "version-dots"
+          ]
         }
       }
     }
@@ -116,7 +200,9 @@
   "providerEndpoints": [
     {
       "endpointClass": "anthropic-public",
-      "hosts": ["api.anthropic.com"]
+      "hosts": [
+        "api.anthropic.com"
+      ]
     }
   ],
   "providerRequest": {
@@ -126,13 +212,20 @@
       }
     }
   },
-  "cliBackends": ["claude-cli"],
-  "syntheticAuthRefs": ["claude-cli"],
+  "cliBackends": [
+    "claude-cli"
+  ],
+  "syntheticAuthRefs": [
+    "claude-cli"
+  ],
   "setup": {
     "providers": [
       {
         "id": "anthropic",
-        "envVars": ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
+        "envVars": [
+          "ANTHROPIC_OAUTH_TOKEN",
+          "ANTHROPIC_API_KEY"
+        ]
       }
     ]
   },
@@ -141,7 +234,9 @@
       "provider": "anthropic",
       "method": "cli",
       "choiceId": "anthropic-cli",
-      "deprecatedChoiceIds": ["claude-cli"],
+      "deprecatedChoiceIds": [
+        "claude-cli"
+      ],
       "choiceLabel": "Anthropic Claude CLI",
       "choiceHint": "Reuse a local Claude CLI login on this host",
       "assistantPriority": -20,
@@ -178,18 +273,24 @@
     }
   ],
   "contracts": {
-    "mediaUnderstandingProviders": ["anthropic"]
+    "mediaUnderstandingProviders": [
+      "anthropic"
+    ]
   },
   "mediaUnderstandingProviderMetadata": {
     "anthropic": {
-      "capabilities": ["image"],
+      "capabilities": [
+        "image"
+      ],
       "defaultModels": {
         "image": "claude-opus-4-7"
       },
       "autoPriority": {
         "image": 20
       },
-      "nativeDocumentInputs": ["pdf"]
+      "nativeDocumentInputs": [
+        "pdf"
+      ]
     }
   },
   "configSchema": {


### PR DESCRIPTION
## Summary

Adds `claude-haiku-4-5-20251001` to both `anthropic` and `claude-cli` providers in `extensions/anthropic/openclaw.plugin.json` static model catalog.

### Problem

Both the `anthropic` and `claude-cli` providers use `discovery: "static"`, so no runtime discovery fills the gap when Claude Haiku 4.5 is missing from the model list.

### Fix

Adds a single model entry to each provider:
- **anthropic provider**: `Claude Haiku 4.5` (id: `claude-haiku-4-5-20251001`)
- **claude-cli provider**: `Claude Haiku 4.5 (Claude CLI)` (id: `claude-haiku-4-5-20251001`)

Both entries use `contextWindow: 200000`, `maxTokens: 64000`, `reasoning: true`, with image input support.

Closes #90088