### PR TITLE
fix(commands): guard manifest catalog filters

### DIFF
--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -119,4 +119,30 @@ describe("loadStaticManifestCatalogRowsForList", () => {
     ).toEqual(["moonshot/kimi-k2.6"]);
     expect(mocks.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
+
+  it("skips unreadable manifest rows while filtering by provider plugin id", async () => {
+    const { loadStaticManifestCatalogRowsForList } = await import("./list.manifest-catalog.js");
+    const unreadablePluginId = {
+      get id() {
+        throw new Error("manifest catalog plugin id exploded");
+      },
+    };
+    mocks.getPluginRecord.mockReturnValueOnce({ pluginId: "moonshot" });
+    mocks.isPluginEnabled.mockReturnValueOnce(true);
+
+    expect(
+      loadStaticManifestCatalogRowsForList({
+        cfg: {},
+        providerFilter: "moonshot",
+        metadataSnapshot: {
+          index: { plugins: [], diagnostics: [] },
+          manifestRegistry: {
+            plugins: [unreadablePluginId, openrouterPlugin, moonshotPlugin],
+            diagnostics: [],
+          },
+          plugins: [],
+        } as never,
+      }).map((row) => row.ref),
+    ).toEqual(["moonshot/kimi-k2.6"]);
+  });
 });

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -3,7 +3,10 @@ import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/mod
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planManifestModelCatalogRows } from "../../model-catalog/index.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
-import type { PluginManifestRegistry } from "../../plugins/manifest-registry.js";
+import type {
+  PluginManifestRecord,
+  PluginManifestRegistry,
+} from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   getPluginRecord,
@@ -13,6 +16,14 @@ import {
 } from "../../plugins/plugin-registry.js";
 
 type ManifestCatalogRowsForListMode = "static-authoritative" | "supplemental";
+
+function readManifestCatalogPluginId(plugin: PluginManifestRecord): string | undefined {
+  try {
+    return typeof plugin.id === "string" ? plugin.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function loadManifestCatalogRowsForPluginIds(params: {
   cfg: OpenClawConfig;
@@ -30,7 +41,10 @@ function loadManifestCatalogRowsForPluginIds(params: {
   const registry = pluginIdSet
     ? {
         ...params.registry,
-        plugins: params.registry.plugins.filter((plugin) => pluginIdSet.has(plugin.id)),
+        plugins: params.registry.plugins.filter((plugin) => {
+          const pluginId = readManifestCatalogPluginId(plugin);
+          return pluginId !== undefined && pluginIdSet.has(pluginId);
+        }),
       }
     : params.registry;
   const plan = planManifestModelCatalogRows({


### PR DESCRIPTION
## Summary

- Guard provider-filtered manifest model catalog loading against unreadable manifest `id` accessors.
- Skip malformed manifest rows before narrowing the registry by plugin id.
- Add a regression test proving a healthy later provider catalog still loads.

## Verification

- `node scripts/run-vitest.mjs src/commands/models/list.manifest-catalog.test.ts -t "skips unreadable manifest rows" --reporter=verbose` failed pre-fix with `manifest catalog plugin id exploded`.
- `node scripts/run-vitest.mjs src/commands/models/list.manifest-catalog.test.ts -t "skips unreadable manifest rows" --reporter=verbose`
- `node scripts/run-vitest.mjs src/commands/models/list.manifest-catalog.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/commands/models/list.manifest-catalog.ts src/commands/models/list.manifest-catalog.test.ts`
- `./node_modules/.bin/oxlint src/commands/models/list.manifest-catalog.ts src/commands/models/list.manifest-catalog.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: provider-filtered model catalog listing no longer crashes when a malformed manifest registry row has an unreadable `id` accessor before a healthy provider manifest row.

Real environment tested: local linked `gwt` worktree on the branch, using the repo Vitest wrapper for the touched command/model catalog test.

Exact steps or command run after this patch: red focused repro, focused regression test, full touched test file, oxfmt, oxlint, diff whitespace check, and local plus branch autoreview.

Evidence after fix: the focused regression test passes, and the full touched test file passes with 4 tests.

Observed result after fix: unreadable manifest rows are skipped during plugin-id narrowing, and the healthy `moonshot/kimi-k2.6` static manifest catalog row still loads.

What was not tested: remote `pnpm check:changed`; Crabbox AWS setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
