### PR TITLE
fix(commands): guard provider catalog aliases

### DIFF
--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -481,6 +481,34 @@ describe("loadProviderCatalogModelsForList", () => {
     ).resolves.toEqual(["openai"]);
   });
 
+  it("skips unreadable provider discovery aliases while checking static catalog filters", async () => {
+    providerDiscoveryMocks.resolveProviderOwners.mockReturnValueOnce([]);
+    providerDiscoveryMocks.resolveProviderContractPluginIdsForProviderAlias.mockReturnValueOnce([
+      "openai",
+    ]);
+    providerDiscoveryMocks.resolveBundledProviderCompatPluginIds.mockReturnValueOnce(["openai"]);
+    providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValueOnce([
+      {
+        get id() {
+          throw new Error("provider static catalog id exploded");
+        },
+        pluginId: "openai",
+        label: "Broken OpenAI",
+        auth: [],
+        staticCatalog: { run: async () => null },
+      },
+      openaiProvider,
+    ]);
+
+    await expect(
+      hasProviderStaticCatalogForFilter({
+        cfg: baseParams.cfg,
+        env: baseParams.env,
+        providerFilter: "azure-openai-responses",
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("does not execute workspace provider static catalogs", async () => {
     const workspaceStaticCatalog = vi.fn(async () => ({
       provider: { baseUrl: "https://workspace.example/v1", models: [] },

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -38,11 +38,36 @@ function providerMatchesFilter(params: {
   provider: Pick<ProviderPlugin, "id" | "aliases" | "hookAliases">;
   providerFilter: string;
 }): boolean {
-  return [
-    params.provider.id,
-    ...(params.provider.aliases ?? []),
-    ...(params.provider.hookAliases ?? []),
-  ].some((providerId) => normalizeProviderId(providerId) === params.providerFilter);
+  return readProviderFilterCandidates(params.provider).some(
+    (providerId) => normalizeProviderId(providerId) === params.providerFilter,
+  );
+}
+
+function readProviderFilterCandidates(
+  provider: Pick<ProviderPlugin, "id" | "aliases" | "hookAliases">,
+): string[] {
+  const candidates: string[] = [];
+  try {
+    if (typeof provider.id === "string") {
+      candidates.push(provider.id);
+    }
+  } catch {
+    return candidates;
+  }
+  for (const key of ["aliases", "hookAliases"] as const) {
+    let values: readonly unknown[] | undefined;
+    try {
+      values = Array.isArray(provider[key]) ? provider[key] : undefined;
+    } catch {
+      continue;
+    }
+    for (const value of values ?? []) {
+      if (typeof value === "string") {
+        candidates.push(value);
+      }
+    }
+  }
+  return candidates;
 }
 
 function collectMatchingContributionOwners(


### PR DESCRIPTION
## Summary

- Guard model-list provider static-catalog filter matching against unreadable provider discovery id/alias fields.
- Skip malformed discovery provider rows while preserving healthy later provider aliases and hook aliases.
- Add a regression test for a poisoned discovery provider before a healthy OpenAI alias match.

## Verification

- `node scripts/run-vitest.mjs src/commands/models/list.provider-catalog.test.ts -t "skips unreadable provider discovery aliases" --reporter=verbose` failed pre-fix with `provider static catalog id exploded`.
- `node scripts/run-vitest.mjs src/commands/models/list.provider-catalog.test.ts -t "skips unreadable provider discovery aliases" --reporter=verbose`
- `node scripts/run-vitest.mjs src/commands/models/list.provider-catalog.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check --threads=1 src/commands/models/list.provider-catalog.ts src/commands/models/list.provider-catalog.test.ts`
- `./node_modules/.bin/oxlint src/commands/models/list.provider-catalog.ts src/commands/models/list.provider-catalog.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: static-catalog provider filter checks no longer crash when a malformed discovery provider has unreadable id or alias fields before a healthy bundled provider match.

Real environment tested: local linked `gwt` worktree on the branch, using the repo Vitest wrapper for the touched command/model provider catalog test.

Exact steps or command run after this patch: red focused repro, focused regression test, full touched test file, oxfmt, oxlint, diff whitespace check, and local plus branch autoreview.

Evidence after fix: the focused regression test passes, and the full touched test file passes with 17 tests.

Observed result after fix: unreadable discovery provider id/alias fields are skipped, and the healthy OpenAI `azure-openai-responses` alias still reports a static catalog.

What was not tested: remote `pnpm check:changed`; Crabbox AWS setup failed before lease creation with coordinator HTTP 401 on `/v1/runs` and `/v1/leases`.
