### PR TITLE
fix(gateway): pass managed inbound PDFs through chat.send

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -95,6 +95,9 @@ const mockState = vi.hoisted(() => ({
   // stageSandboxMedia silently skips over-cap files.
   unstagedSources: null as string[] | null,
   deleteMediaBufferCalls: [] as Array<{ id: string; subdir?: string }>,
+  // Paths the mocked resolveInboundMediaReference treats as managed inbound
+  // media-store entries (drives the #90097 managed-PDF staging-fallback tests).
+  managedInboundPaths: null as string[] | null,
 }));
 
 function readTranscriptJsonLines(transcriptPath: string): Array<Record<string, unknown>> {
@@ -403,6 +406,22 @@ vi.mock("../../media/store.js", async () => {
         mockState.activeSaveMediaCalls -= 1;
       }
     }),
+  };
+});
+
+vi.mock("../../media/media-reference.js", async () => {
+  const original = await vi.importActual<typeof import("../../media/media-reference.js")>(
+    "../../media/media-reference.js",
+  );
+  return {
+    ...original,
+    // Treat only test-declared paths as managed inbound media, so the #90097
+    // managed-PDF fallback can be exercised without a real on-disk media store.
+    resolveInboundMediaReference: vi.fn(async (source: string) =>
+      mockState.managedInboundPaths?.includes(source)
+        ? { id: source, normalizedSource: source, physicalPath: source, sourceType: "path" }
+        : null,
+    ),
   };
 });
 
@@ -807,6 +826,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.stagedRelativePaths = null;
     mockState.unstagedSources = null;
     mockState.deleteMediaBufferCalls = [];
+    mockState.managedInboundPaths = null;
     mockState.hasBeforeAgentRunHooks = false;
     mockState.beforeMessageWriteBlock = false;
     mockState.beforeMessageWriteContent = null;
@@ -4514,6 +4534,147 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(error?.code).toBe(ErrorCodes.UNAVAILABLE);
     expect(responseErrorMessage(error)).toMatch(/staging incomplete/i);
     // Both media-store entries are cleaned up before the 5xx surfaces.
+    expect(mockState.deleteMediaBufferCalls.map((c) => c.id).toSorted()).toEqual([
+      "saved-media",
+      "saved-media",
+    ]);
+  });
+
+  it("falls back to the managed inbound PDF path when sandbox staging is incomplete (#90097)", async () => {
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-incomplete-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    const managedPath = "/home/user/.openclaw/media/inbound/report.pdf";
+    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    // Staging returns an incomplete map (the file silently fell out).
+    mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
+    mockState.unstagedSources = [managedPath];
+    mockState.managedInboundPaths = [managedPath];
+    const respond = vi.fn();
+    const context = createChatContext();
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-incomplete",
+      message: "read this",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    // Send proceeds with the absolute managed path; buffers are NOT deleted.
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe(managedPath);
+    expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["application/pdf"]);
+    // Host-side readable: no sandbox workspace dir is carried for the fallback.
+    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
+    // Marker still blocks the dispatch pipeline from re-running staging.
+    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+  });
+
+  it("falls back to the managed inbound PDF path when sandbox staging throws (#90097)", async () => {
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-throw-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    const managedPath = "/home/user/.openclaw/media/inbound/report.pdf";
+    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.stageSandboxMediaError = new Error("ENOSPC: no space left on device");
+    mockState.managedInboundPaths = [managedPath];
+    const respond = vi.fn();
+    const context = createChatContext();
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-throw",
+      message: "read this",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
+    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+  });
+
+  it("does not fall back when not every offloaded ref is a managed PDF (#90097)", async () => {
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-mixed-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = { modelProvider: "test-provider", model: "vision-model" };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    const managedPdf = "/home/user/.openclaw/media/inbound/report.pdf";
+    const managedZip = "/home/user/.openclaw/media/inbound/data.zip";
+    mockState.savedMediaResults = [
+      { path: managedPdf, contentType: "application/pdf" },
+      { path: managedZip, contentType: "application/zip" },
+    ];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/data.zip"];
+    mockState.unstagedSources = [managedPdf];
+    // Both managed, but the non-PDF ref must block the all-or-nothing fallback.
+    mockState.managedInboundPaths = [managedPdf, managedZip];
+    const respond = vi.fn();
+    const context = createChatContext();
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+    const zip = Buffer.from("PKdata").toString("base64");
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-mixed",
+      message: "read these",
+      requestParams: {
+        attachments: [
+          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
+          { type: "file", mimeType: "application/zip", fileName: "data.zip", content: zip },
+        ],
+      },
+      expectBroadcast: false,
+      waitFor: "none",
+    });
+
+    // Mixed batch keeps the existing delete + 5xx behavior (no silent passthrough).
+    expect(mockState.lastDispatchCtx).toBeUndefined();
+    const [ok, , error] = lastRespondCall(respond) ?? [];
+    expect(ok).toBe(false);
+    expect(error?.code).toBe(ErrorCodes.UNAVAILABLE);
     expect(mockState.deleteMediaBufferCalls.map((c) => c.id).toSorted()).toEqual([
       "saved-media",
       "saved-media",

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4681,6 +4681,57 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ]);
   });
 
+  it("passes sandbox-oversized managed inbound PDFs through instead of rejecting them (#90097)", async () => {
+    createTranscriptFixture("openclaw-chat-send-managed-pdf-oversize-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      modelProvider: "test-provider",
+      model: "vision-model",
+    };
+    mockState.modelCatalog = [
+      {
+        provider: "test-provider",
+        id: "vision-model",
+        name: "Vision model",
+        input: ["text", "image"],
+      },
+    ];
+    const managedPath = "/home/user/.openclaw/media/inbound/huge.pdf";
+    mockState.savedMediaResults = [{ path: managedPath, contentType: "application/pdf" }];
+    mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.managedInboundPaths = [managedPath];
+    const respond = vi.fn();
+    const context = createChatContext();
+    const oversized = Buffer.alloc(6 * 1024 * 1024);
+    oversized.set(Buffer.from("%PDF-1.4\n"), 0);
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-managed-pdf-oversize",
+      message: "read this",
+      requestParams: {
+        attachments: [
+          {
+            type: "file",
+            mimeType: "application/pdf",
+            fileName: "huge.pdf",
+            content: oversized.toString("base64"),
+          },
+        ],
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
+    expect(mockState.lastDispatchCtx?.MediaPath).toBe(managedPath);
+    expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([managedPath]);
+    expect(mockState.lastDispatchCtx?.MediaType).toBe("application/pdf");
+    expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["application/pdf"]);
+    expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBeUndefined();
+    expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+  });
+
   it("rejects sandbox-oversized non-image attachments as 4xx before staging", async () => {
     // Regression: resolveChatAttachmentMaxBytes defaults to 20MB, but
     // stageSandboxMedia caps each file at STAGED_MEDIA_MAX_BYTES (5MB) and
@@ -4703,15 +4754,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/huge.pdf", contentType: "application/pdf" },
+      {
+        path: "/home/user/.openclaw/media/inbound/huge.bin",
+        contentType: "application/octet-stream",
+      },
     ];
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     const respond = vi.fn();
     const context = createChatContext();
     // 6MB buffer — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
-    oversized.set(Buffer.from("%PDF-1.4\n"), 0);
-    const pdf = oversized.toString("base64");
+    oversized.set(Buffer.from("OPENCLAW-BINARY\n"), 0);
+    const oversizedPayload = oversized.toString("base64");
 
     await runNonStreamingChatSend({
       context,
@@ -4720,7 +4774,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read this",
       requestParams: {
         attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "huge.pdf", content: pdf },
+          {
+            type: "file",
+            mimeType: "application/octet-stream",
+            fileName: "huge.bin",
+            content: oversizedPayload,
+          },
         ],
       },
       expectBroadcast: false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -64,6 +64,7 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
+import { resolveInboundMediaReference } from "../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import {
   deleteMediaBuffer,
@@ -1217,6 +1218,32 @@ function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[
 // Returned paths are absolute media-store paths when no sandbox is active, or
 // sandbox-relative paths plus `workspaceDir` when sandboxing is active. Host-side
 // media-understanding uses MediaWorkspaceDir to resolve those relative paths.
+// Optional sandbox staging is a convenience copy into the container; a managed
+// inbound media-store PDF is already host-readable (the managed media dir is a
+// default media-understanding local root, resolved via the absolute path when
+// MediaWorkspaceDir is unset). When staging is unavailable/incomplete we can
+// therefore pass those absolute managed paths through instead of deleting the
+// buffers and failing the send (#90097). Gated all-or-nothing to managed-inbound
+// PDFs so a single non-managed or non-PDF ref cannot bypass staging; reuses the
+// same resolveInboundMediaReference allow-check stageSandboxMedia applies.
+async function resolveManagedInboundPdfFallback(
+  refs: readonly OffloadedRef[],
+): Promise<{ paths: string[]; types: string[] } | null> {
+  for (const ref of refs) {
+    if (ref.mimeType !== "application/pdf") {
+      return null;
+    }
+    const managed = await resolveInboundMediaReference(ref.path).catch(() => null);
+    if (!managed) {
+      return null;
+    }
+  }
+  return {
+    paths: refs.map((ref) => ref.path),
+    types: refs.map((ref) => ref.mimeType),
+  };
+}
+
 async function prestageMediaPathOffloads(params: {
   offloadedRefs: OffloadedRef[];
   includeImageRefs?: boolean;
@@ -1268,13 +1295,24 @@ async function prestageMediaPathOffloads(params: {
       MediaType: mediaPathRefs[0].mimeType,
       MediaTypes: mediaPathRefs.map((ref) => ref.mimeType),
     };
-    const stageResult = await stageSandboxMedia({
-      ctx: stagingCtx,
-      sessionCtx: stagingCtx as TemplateContext,
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      workspaceDir,
-    });
+    let stageResult: Awaited<ReturnType<typeof stageSandboxMedia>>;
+    try {
+      stageResult = await stageSandboxMedia({
+        ctx: stagingCtx,
+        sessionCtx: stagingCtx as TemplateContext,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        workspaceDir,
+      });
+    } catch (stageErr) {
+      // Staging is optional; pass managed-inbound PDFs through rather than
+      // deleting buffers + failing the send. Rethrow otherwise (#90097).
+      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
+      if (managedPdfFallback) {
+        return managedPdfFallback;
+      }
+      throw stageErr;
+    }
 
     // stageSandboxMedia silently keeps unstaged entries as their original
     // absolute path, so length parity with `nonImage` does not prove every
@@ -1285,6 +1323,12 @@ async function prestageMediaPathOffloads(params: {
     const stagedSources = stageResult.staged;
     const missing = mediaPathRefs.filter((ref) => !stagedSources.has(ref.path));
     if (missing.length > 0) {
+      // Incomplete staging: pass managed-inbound PDFs through (host-readable)
+      // rather than failing the send. Fail otherwise as before (#90097).
+      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
+      if (managedPdfFallback) {
+        return managedPdfFallback;
+      }
       throw new Error(
         `attachment staging incomplete: ${stagedSources.size}/${mediaPathRefs.length} paths staged into sandbox workspace (missing: ${missing.map((ref) => ref.path).join(", ")})`,
       );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1277,9 +1277,14 @@ async function prestageMediaPathOffloads(params: {
     // (resolveChatAttachmentMaxBytes, default 20MB) is higher, so a sandboxed
     // session receiving a file between the two caps would otherwise
     // pass parse, fail staging, and surface as a retryable 5xx even though
-    // retry cannot succeed. Reject here as a client-side 4xx instead.
+    // retry cannot succeed. Managed inbound PDFs are already host-readable, so
+    // let the managed-PDF fallback handle them before rejecting everything else.
     const oversizedForSandbox = mediaPathRefs.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
     if (oversizedForSandbox.length > 0) {
+      const managedPdfFallback = await resolveManagedInboundPdfFallback(mediaPathRefs);
+      if (managedPdfFallback) {
+        return managedPdfFallback;
+      }
       const details = oversizedForSandbox
         .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
         .join(", ");


### PR DESCRIPTION
## Summary

Fixes #90097.

`chat.send` offloads large attachments to the managed inbound media store, then for a sandboxed session may copy non-image refs into the sandbox through `stageSandboxMedia`. That sandbox copy is optional for already-managed inbound PDFs: the managed media directory is host-readable by media understanding, so the gateway can pass the managed path through as `MediaPath`/`MediaPaths` without granting locked-down agents broader filesystem access.

This PR keeps the fix scoped to the #90097 gateway path:

- Falls back to absolute managed inbound PDF paths when sandbox staging throws or is incomplete.
- Lets trusted managed inbound PDFs above the 5 MB sandbox staging cap pass through instead of being rejected before fallback can run.
- Keeps the behavior all-or-nothing: every offloaded non-image ref must be a managed inbound `application/pdf`, or the previous fail-closed path remains.
- Preserves non-PDF and untrusted oversize rejection as a client-side 4xx; managed buffers are not deleted on the PDF pass-through path.

> AI-assisted: this change was prepared with AI assistance. I have reviewed and understand the diff and own it. Happy to share prompt/session detail on request.

## Collision check

Direct competing PR checked:

- #90111 also covers #90097, and it correctly identifies the sandbox staging cap as part of the large-PDF path. It is much broader, though: it also targets issues #90096 and #90098 and touches PDF text extraction, gateway attachment parsing, embedded runner/auto-reply prompt context, Control UI parsing, and queued-send cleanup. Its current review blocker is a separate 10-20 MB extraction size-contract mismatch.
- This PR intentionally stays narrower: only `chat.send` managed-inbound PDF pass-through/fallback for #90097, with focused gateway regression coverage for staging throw, incomplete staging, mixed-batch rejection, and the 5-20 MB sandbox-cap case.

## Safety model

Rolling a managed PDF through this path requires both checks:

- `resolveInboundMediaReference(ref.path)` accepts the saved path as managed inbound media.
- `ref.mimeType === "application/pdf"` for every offloaded non-image ref in the batch.

A single non-managed path, non-PDF mime type, or unresolved media ref keeps the previous delete + failure behavior. The sandboxed agent still receives `MediaStaged: true`; for the pass-through path, `MediaWorkspaceDir` is unset so host-side media understanding resolves the absolute managed path instead of treating it as a sandbox-relative file.

## Real behavior proof

Behavior addressed: an already-managed inbound PDF send can fail or be rejected before the agent sees it when optional sandbox staging is unavailable, incomplete, or over the 5 MB staging cap (#90097). The fix reaches a managed-PDF fallback inside `prestageMediaPathOffloads` that passes refs through only when every ref is `application/pdf` and every path is accepted by the `resolveInboundMediaReference` managed-inbound trust predicate; anything else stays fail-closed. The two merge-risk flags on this PR (message-delivery and security-boundary) hinge on that path, so the proof drives it two ways at real-filesystem runtime: Leg 1 runs the real `prestageMediaPathOffloads` end-to-end so the oversize branch actually fires; Leg 2 exercises the trust gate across the boundary cases.

Real environment tested: a real Node v22.19.0 process ran the code committed by this PR against a real on-disk managed media store (`OPENCLAW_STATE_DIR` pointed at a scratch directory holding a real `media/inbound/` tree). Leg 1 drove the real `prestageMediaPathOffloads` (`src/gateway/server-methods/chat.ts`) with a host-only sandbox (`sandbox.mode: "all"`, `workspaceAccess: "rw"` — `ensureSandboxWorkspaceForSession` resolves a host workspace with no Docker daemon, so the real oversize branch is genuinely reached rather than skipped). Leg 2 drove the managed-PDF gate and the real, already-exported `resolveInboundMediaReference` predicate against on-disk files: a 6.29 MB managed inbound PDF, a non-PDF, a nested-path PDF, an absolute PDF outside the store, and a symlink inside `inbound/` pointing outside it. Nothing was stubbed — the predicate's real path-containment and `fs.realpath`/symlink checks ran against the real filesystem. Both legs are driven by functions that are module-internal in the committed source; to import them, a throwaway `export` keyword was added in the worktree and reverted afterward, so the executed function bodies are byte-for-byte the committed code at de87445b1a and the branch diff stays the shipped 2 files.

Exact steps or command run after this patch: wrote the real media store to disk (`<media>/inbound/report.pdf` 6.29 MB, a 6.29 MB non-PDF `big.bin`, `archive.zip`, `sub/nested.pdf`, an outside-store `evil.pdf`, and a `link.pdf` symlink to it), then ran two harnesses in real Node processes — `OPENCLAW_STATE_DIR=<root>/state node --import tsx integration-harness.mjs` (Leg 1, drives `prestageMediaPathOffloads`) and `OPENCLAW_STATE_DIR=<root>/state node --import tsx harness.mjs` (Leg 2, drives the gate + predicate). Reproducing this requires temporarily re-adding `export` to `prestageMediaPathOffloads` and `resolveManagedInboundPdfFallback` in `chat.ts` (both are module-internal); the executed bodies are otherwise unchanged from de87445b1a, and every per-ref ACCEPTED/REJECTED decision in Leg 2 can also be reproduced with zero source edits via the already-exported `resolveInboundMediaReference`.

Evidence after fix (copied live console output from the real Node runs):

Leg 1 — real `prestageMediaPathOffloads`, host sandbox active, oversize branch fires:

```text
[env] node=v22.19.0  source=de87445b1a (committed branch head)
[env] sandbox mode=all workspaceAccess=rw (host workspace, no Docker)

[case 1] managed inbound PDF <media>/inbound/report.pdf (6291472 bytes > 5 MB cap)
[case 1] RETURNED (no throw):
           paths: ["<media>/inbound/report.pdf"]
           types: ["application/pdf"]
           workspaceDir: undefined (host pass-through, not sandbox-staged)
           => managed-PDF fallback fired; the send proceeds with the managed path

[case 2] managed inbound non-PDF <media>/inbound/big.bin (6291456 bytes > 5 MB cap)
[case 2] REJECTED (4xx): UnsupportedAttachmentError: attachments exceed sandbox staging limit (5242880 bytes): big.bin (6291456 bytes)
           => non-PDF over the cap stays fail-closed; only managed PDFs pass through
```

Leg 2 — managed-PDF gate + real trust predicate across the boundary cases:

```text
[env] OPENCLAW_STATE_DIR=<root>/state
[env] node=v22.19.0  source=de87445b1a (committed branch head)

=== Case A: managed inbound PDF, 6.29 MB (over the 5 MB sandbox cap) — DELIVERY path
    ref <media>/inbound/report.pdf [application/pdf] -> trust predicate: ACCEPTED (managed inbound)
    resolveManagedInboundPdfFallback -> { paths: [<media>/inbound/report.pdf], types: [application/pdf] }
    => PASS-THROUGH (refs delivered)   [expected pass-through: OK]

=== Case B: non-PDF (zip) sitting in inbound — BOUNDARY
    ref <media>/inbound/archive.zip [application/zip] -> trust predicate: ACCEPTED (managed inbound)
    resolveManagedInboundPdfFallback -> null
    => FAIL-CLOSED (null -> normal rejection)   [expected fail-closed: OK]

=== Case C: mixed: managed PDF + one non-PDF — BOUNDARY (all-or-nothing)
    ref <media>/inbound/report.pdf [application/pdf] -> trust predicate: ACCEPTED (managed inbound)
    ref <media>/inbound/archive.zip [application/zip] -> trust predicate: ACCEPTED (managed inbound)
    resolveManagedInboundPdfFallback -> null
    => FAIL-CLOSED (null -> normal rejection)   [expected fail-closed: OK]

=== Case D: nested path inbound/sub/nested.pdf — BOUNDARY (not a first-level inbound file)
    ref <media>/inbound/sub/nested.pdf [application/pdf] -> trust predicate: REJECTED (not a managed inbound file)
    resolveManagedInboundPdfFallback -> null
    => FAIL-CLOSED (null -> normal rejection)   [expected fail-closed: OK]

=== Case E: absolute PDF outside the inbound store — BOUNDARY
    ref <outside-store>/evil.pdf [application/pdf] -> trust predicate: REJECTED (not a managed inbound file)
    resolveManagedInboundPdfFallback -> null
    => FAIL-CLOSED (null -> normal rejection)   [expected fail-closed: OK]

=== Case F: symlink inbound/link.pdf -> outside target — BOUNDARY (symlink escape)
    ref <media>/inbound/link.pdf [application/pdf] -> trust predicate: REJECTED (not a managed inbound file)
    resolveManagedInboundPdfFallback -> null
    => FAIL-CLOSED (null -> normal rejection)   [expected fail-closed: OK]

[summary] 6/6 cases matched expectation
```

Observed result after fix: Leg 1 confirms the real call site — with a host sandbox resolved (so the oversize branch is reached, not skipped by the no-sandbox early return), the 6.29 MB managed inbound PDF returns the fallback `{ paths: [managed path], types: ["application/pdf"] }` with `workspaceDir: undefined`. That `undefined` uniquely identifies the managed-PDF fallback firing rather than the staging path (the post-staging return always sets a workspace dir), so the send proceeds with the PDF delivered. The 6.29 MB non-PDF over the same cap throws the real `UnsupportedAttachmentError` ("attachments exceed sandbox staging limit") as a client-side 4xx — fail-closed. Leg 2 confirms the trust gate across the boundary: the managed PDF (Case A) is delivered, and a non-PDF in inbound (B), a mixed batch (C), a nested-path PDF (D), an absolute PDF outside the store (E), and a symlink inside inbound pointing outside it (F) all resolve to `null`, keeping the prior delete-and-reject path. Case F is the key security-boundary check — a managed-looking path that resolves outside `inbound/` via a symlink is rejected, so the pass-through cannot be used to read host files outside the managed store.

What was not tested: the live oversize branch was driven above; the staging-throw and incomplete-staging branches that also route into the fallback were not driven against a live `stageSandboxMedia` here (no containerized Docker sandbox runtime is available) and remain covered by the existing gateway regression suite listed under Regression coverage. The final announce transport hop over a real external channel was likewise not exercised.

## Supplemental checks

- `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts` → 2 files, 214 cases green (gateway suite, supplemental).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.test.src.json` → clean.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/chat.ts src/gateway/server-methods/chat.directive-tags.test.ts` → clean.
- `node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/chat.ts src/gateway/server-methods/chat.directive-tags.test.ts` → clean.
- `git diff --check` → clean.

## Regression coverage

- `src/gateway/server-methods/chat.directive-tags.test.ts`: fallback on incomplete sandbox staging.
- `src/gateway/server-methods/chat.directive-tags.test.ts`: fallback on sandbox staging throw.
- `src/gateway/server-methods/chat.directive-tags.test.ts`: 6 MB managed inbound PDF passes through instead of hitting the staging cap rejection.
- `src/gateway/server-methods/chat.directive-tags.test.ts`: mixed PDF + non-PDF managed batch still fails closed and deletes media buffers.
- `src/gateway/server-methods/chat.directive-tags.test.ts`: 6 MB non-PDF still returns a 4xx sandbox staging limit error.

## Files

- `src/gateway/server-methods/chat.ts` — managed-inbound-PDF fallback in `prestageMediaPathOffloads`, now reached before sandbox-size rejection.
- `src/gateway/server-methods/chat.directive-tags.test.ts` — focused `chat.send` regression coverage for fallback, oversize pass-through, and fail-closed cases.
