### PR TITLE
fix: add Claude Haiku 4.5 static catalog entries

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -102,6 +102,28 @@
             "maxTokens": 64000
           },
           {
+            "id": "claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6",
             "reasoning": true,

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -1,0 +1,57 @@
+// Anthropic tests cover provider manifest model catalog behavior.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type AnthropicManifest = {
+  modelCatalog?: {
+    providers?: {
+      anthropic?: {
+        models?: Array<{
+          id?: string;
+          name?: string;
+          reasoning?: boolean;
+          input?: string[];
+          mediaInput?: {
+            image?: {
+              maxSidePx?: number;
+              preferredSidePx?: number;
+              tokenMode?: string;
+            };
+          };
+          contextWindow?: number;
+          maxTokens?: number;
+        }>;
+      };
+    };
+    discovery?: Record<string, string>;
+  };
+};
+
+const manifest = JSON.parse(
+  readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
+) as AnthropicManifest;
+
+describe("Anthropic plugin manifest", () => {
+  it("resolves both official Claude Haiku 4.5 API identifiers from the static catalog", () => {
+    expect(manifest.modelCatalog?.discovery?.anthropic).toBe("static");
+
+    const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
+    for (const id of ["claude-haiku-4-5", "claude-haiku-4-5-20251001"]) {
+      expect(models.find((model) => model.id === id)).toEqual({
+        id,
+        name: "Claude Haiku 4.5",
+        reasoning: true,
+        input: ["text", "image"],
+        mediaInput: {
+          image: {
+            maxSidePx: 1568,
+            preferredSidePx: 1568,
+            tokenMode: "provider",
+          },
+        },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add the official `claude-haiku-4-5` rolling alias and `claude-haiku-4-5-20251001` pinned ID to the static Anthropic model catalog
- add a regression test covering static discovery and the exact capabilities for both IDs
- keep the change catalog-only; no Anthropic or OpenAI transport, routing, tool schema, or tool-call parsing code changes

Fixes #90088

## Verification

- `pnpm test extensions/anthropic/openclaw.plugin.test.ts src/agents/embedded-agent-runner/model.static-catalog.test.ts src/agents/model-ref-shared.test.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts`
- `pnpm format:check extensions/anthropic/openclaw.plugin.json extensions/anthropic/openclaw.plugin.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm build`
- `pnpm check:changed` in AWS Crabbox run `run_3f69a7ec42ec`
- live gateway profile lane against both Anthropic Haiku IDs and `openai/gpt-5.5`
- forced native Anthropic tool-choice probe through OpenClaw `completeSimple` for both Haiku IDs
- two fresh autoreviews: no accepted/actionable findings

## Real behavior proof

Behavior addressed: OpenClaw can resolve and run both official Claude Haiku 4.5 API identifiers from the Anthropic static catalog.

Real environment tested: Production Anthropic and OpenAI APIs through OpenClaw's live gateway and LLM provider paths; Linux changed gate in AWS Crabbox.

Exact steps or command run after this patch: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GATEWAY_PROVIDERS='anthropic,openai' OPENCLAW_LIVE_GATEWAY_MODELS='anthropic/claude-haiku-4-5,anthropic/claude-haiku-4-5-20251001,openai/gpt-5.5' OPENCLAW_LIVE_GATEWAY_MAX_MODELS=3 OPENCLAW_LIVE_GATEWAY_THINKING=off OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=600000 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=180000 pnpm test:live -- src/gateway/gateway-models.profiles.live.test.ts`; then an OpenClaw `completeSimple` probe forced Anthropic `tool_choice` to `noop` for each Haiku ID.

Evidence after fix: The live gateway suite passed 94 tests. Both Haiku IDs completed normal prompts. The forced tool probes printed `ANTHROPIC_FORCED_TOOL_PASS` with `stopReason=toolUse` and `tool=noop` for each ID. The OpenAI `gpt-5.5` lane passed prompt, read-tool, exec-tool, image, and tool-only regression checks. Crabbox run `run_3f69a7ec42ec` exited 0.

Observed result after fix: Both official Haiku IDs resolve, call Anthropic successfully, and emit normalized OpenClaw tool calls; the official OpenAI tool path remains green.

What was not tested: No UI or browser surface is involved. The Anthropic generic exec probe showed tool activity but its optional nonce assertion was nondeterministic; the separate forced native tool-choice probes provide deterministic tool-call proof.
