### PR TITLE
fix: skip qmd zero-hit sync retry in memory_search

### DIFF
--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -291,6 +291,30 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemorySyncMockCalls()).toBe(0);
   });
 
+  it("does not force a sync retry for qmd zero-hit searches", async () => {
+    let searchCalls = 0;
+    setMemoryBackend("qmd");
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      return [];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: {
+          backend: "qmd",
+          citations: "off",
+          qmd: { searchMode: "search" },
+        },
+      },
+    });
+    const result = await tool.execute("zero-hit-qmd", { query: "hidden thread codename" });
+
+    expect((result.details as { results?: unknown[] }).results ?? []).toEqual([]);
+    expect(searchCalls).toBe(1);
+  });
+
   it("returns structured search debug metadata for qmd results", async () => {
     setMemoryBackend("qmd");
     setMemorySearchImpl(async (opts) => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -477,7 +477,11 @@ export function createMemorySearchTool(options: {
                 if (pausedIndexIdentityReason) {
                   return;
                 }
-                if (rawResults.length === 0 && activeMemory.manager.sync) {
+                if (
+                  rawResults.length === 0 &&
+                  activeMemory.manager.sync &&
+                  statusBeforeRetry.backend !== "qmd"
+                ) {
                   await activeMemory.manager.sync({ reason: "search", force: true });
                   rawResults = await activeMemory.manager.search(query, searchOptions);
                   pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(


### PR DESCRIPTION
## Summary
- skip the forced sync-and-retry path when `memory.backend = "qmd"` returns zero hits
- keep the existing retry behavior for other backends
- add a regression test covering qmd zero-hit searches

## Testing
- pnpm vitest run extensions/memory-core/src/tools.test.ts

Closes #90023