### PR TITLE
fix(plugins): guard provider contract metadata

### DIFF
--- a/src/plugins/contracts/registry.retry.test.ts
+++ b/src/plugins/contracts/registry.retry.test.ts
@@ -35,6 +35,30 @@ function createMockRuntimeRegistry(params: {
   };
 }
 
+function createMockContractSnapshot(pluginId: string, providerIds: string[]) {
+  return {
+    pluginId,
+    cliBackendIds: [],
+    providerIds,
+    providerEnvVars: {},
+    embeddingProviderIds: [],
+    speechProviderIds: [],
+    realtimeTranscriptionProviderIds: [],
+    realtimeVoiceProviderIds: [],
+    mediaUnderstandingProviderIds: [],
+    transcriptSourceProviderIds: [],
+    documentExtractorIds: [],
+    imageGenerationProviderIds: [],
+    videoGenerationProviderIds: [],
+    musicGenerationProviderIds: [],
+    webContentExtractorIds: [],
+    webFetchProviderIds: [],
+    webSearchProviderIds: [],
+    migrationProviderIds: [],
+    toolNames: [],
+  };
+}
+
 afterEach(() => {
   vi.resetModules();
   vi.restoreAllMocks();
@@ -257,6 +281,68 @@ describe("plugin contract registry scoped retries", () => {
     ).toEqual(["openai"]);
     expect(resolveBundledExplicitProviderContractsFromPublicArtifacts).toHaveBeenCalledTimes(1);
     expect(loadBundledCapabilityRuntimeRegistry).not.toHaveBeenCalled();
+  });
+
+  it("ignores poisoned provider metadata while resolving provider aliases", async () => {
+    const poisonedProvider = Object.defineProperties(
+      {
+        label: "Poisoned",
+        docsPath: "/providers/poisoned",
+        auth: [],
+      },
+      {
+        id: {
+          enumerable: true,
+          get() {
+            throw new Error("provider contract alias metadata exploded");
+          },
+        },
+        aliases: {
+          enumerable: true,
+          get() {
+            throw new Error("provider contract aliases exploded");
+          },
+        },
+        hookAliases: {
+          enumerable: true,
+          get() {
+            throw new Error("provider contract hook aliases exploded");
+          },
+        },
+      },
+    ) as ProviderPlugin;
+    const healthyProvider = {
+      id: "healthy-provider",
+      label: "Healthy",
+      docsPath: "/providers/healthy",
+      aliases: ["healthy-alias"],
+      auth: [],
+    } as ProviderPlugin;
+    const resolveBundledExplicitProviderContractsFromPublicArtifacts = vi.fn(
+      ({ onlyPluginIds }: { onlyPluginIds: readonly string[] }) =>
+        onlyPluginIds[0] === "poisoned"
+          ? [{ pluginId: "poisoned", provider: poisonedProvider }]
+          : [{ pluginId: "healthy", provider: healthyProvider }],
+    );
+
+    vi.doMock("./inventory/bundled-capability-metadata.js", () => ({
+      BUNDLED_PLUGIN_CONTRACT_SNAPSHOTS: [
+        createMockContractSnapshot("poisoned", ["poisoned"]),
+        createMockContractSnapshot("healthy", ["healthy-provider"]),
+      ],
+    }));
+    vi.doMock("../bundled-capability-runtime.js", () => ({
+      loadBundledCapabilityRuntimeRegistry: vi.fn(() => {
+        throw new Error("provider public artifacts should be enough");
+      }),
+    }));
+    vi.doMock("../provider-contract-public-artifacts.js", () => ({
+      resolveBundledExplicitProviderContractsFromPublicArtifacts,
+    }));
+
+    const { resolveProviderContractPluginIdsForProviderAlias } = await import("./registry.js");
+
+    expect(resolveProviderContractPluginIdsForProviderAlias("healthy-alias")).toEqual(["healthy"]);
   });
 
   it("uses web search public artifacts before falling back to the bundled runtime registry", async () => {

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -391,11 +391,7 @@ function loadProviderContractRegistry(): ProviderContractEntry[] {
 }
 
 function loadUniqueProviderContractProviders(): ProviderPlugin[] {
-  return [
-    ...new Map(
-      loadProviderContractRegistry().map((entry) => [entry.provider.id, entry.provider]),
-    ).values(),
-  ];
+  return uniqueProviderContractProvidersFromEntries(loadProviderContractRegistry());
 }
 
 function loadProviderContractPluginIds(): string[] {
@@ -666,14 +662,49 @@ export const providerContractCompatPluginIds: string[] = createLazyArrayView(
   loadProviderContractCompatPluginIds,
 );
 
+function readProviderContractId(provider: ProviderPlugin): string | undefined {
+  try {
+    return typeof provider.id === "string" ? provider.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readProviderContractAliases(
+  provider: ProviderPlugin,
+  key: "aliases" | "hookAliases",
+): string[] {
+  try {
+    const aliases = provider[key];
+    return Array.isArray(aliases)
+      ? aliases.filter((alias): alias is string => typeof alias === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function uniqueProviderContractProvidersFromEntries(
+  entries: readonly ProviderContractEntry[],
+): ProviderPlugin[] {
+  const providers = new Map<string, ProviderPlugin>();
+  for (const entry of entries) {
+    const providerId = readProviderContractId(entry.provider);
+    if (providerId) {
+      providers.set(providerId, entry.provider);
+    }
+  }
+  return [...providers.values()];
+}
+
 export function requireProviderContractProvider(providerId: string): ProviderPlugin {
   const pluginIds = resolveBundledProviderContractPluginIdsByProviderId().get(providerId) ?? [];
   const entries = loadProviderContractEntriesForPluginIds(pluginIds);
-  const provider = entries.find((entry) => entry.provider.id === providerId)?.provider;
+  const provider = entries.find(
+    (entry) => readProviderContractId(entry.provider) === providerId,
+  )?.provider;
   if (!provider) {
-    const pluginScopedProviders = [
-      ...new Map(entries.map((entry) => [entry.provider.id, entry.provider])).values(),
-    ];
+    const pluginScopedProviders = uniqueProviderContractProvidersFromEntries(entries);
     if (pluginIds.length === 1 && pluginScopedProviders.length === 1) {
       return pluginScopedProviders[0];
     }
@@ -705,10 +736,10 @@ export function resolveProviderContractPluginIdsForProviderAlias(
     loadProviderContractEntriesForPluginIds(resolveBundledProviderContractPluginIds())
       .filter((entry) => {
         const providerIds = [
-          entry.provider.id,
-          ...(entry.provider.aliases ?? []),
-          ...(entry.provider.hookAliases ?? []),
-        ];
+          readProviderContractId(entry.provider),
+          ...readProviderContractAliases(entry.provider, "aliases"),
+          ...readProviderContractAliases(entry.provider, "hookAliases"),
+        ].filter((candidate): candidate is string => typeof candidate === "string");
         return providerIds.some(
           (candidate) => normalizeProviderId(candidate) === normalizedProvider,
         );
@@ -722,13 +753,11 @@ export function resolveProviderContractProvidersForPluginIds(
   pluginIds: readonly string[],
 ): ProviderPlugin[] {
   const allowed = new Set(pluginIds);
-  return [
-    ...new Map(
-      loadProviderContractEntriesForPluginIds([...allowed])
-        .filter((entry) => allowed.has(entry.pluginId))
-        .map((entry) => [entry.provider.id, entry.provider]),
-    ).values(),
-  ];
+  return uniqueProviderContractProvidersFromEntries(
+    loadProviderContractEntriesForPluginIds([...allowed]).filter((entry) =>
+      allowed.has(entry.pluginId),
+    ),
+  );
 }
 
 export const webSearchProviderContractRegistry: WebSearchProviderContractEntry[] =


### PR DESCRIPTION
## Summary

- Prevent provider contract registry helpers from crashing when one plugin returns a provider object with throwing or malformed `id`, `aliases`, or `hookAliases` metadata.
- Keep healthy provider contract entries usable for alias resolution, direct lookup, and plugin-scoped provider dedupe even when an unrelated entry is poisoned.
- Add a regression test for a poisoned provider artifact before a healthy alias match.
- Out of scope: changing provider contract loading, public artifact discovery, or runtime activation behavior.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Maintainer fuzz-hardening sweep for plugin/tool/schema metadata crash surfaces.

## Real behavior proof

Behavior addressed: Provider contract alias resolution could abort on a poisoned provider metadata accessor before considering later healthy provider aliases.

Real environment tested: OpenClaw linked worktree on current `origin/main` with repo node-wrapper Vitest proof; AWS Crabbox changed-gate lease was attempted.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs run src/plugins/contracts/registry.retry.test.ts -t "ignores poisoned provider metadata" --reporter=verbose
node scripts/run-vitest.mjs run src/plugins/contracts/registry.retry.test.ts --reporter=verbose
node_modules/.bin/oxfmt --check --threads=1 src/plugins/contracts/registry.ts src/plugins/contracts/registry.retry.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/contracts/registry.ts src/plugins/contracts/registry.retry.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode local
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"
```

Evidence after fix: The red repro failed pre-fix with `provider contract alias metadata exploded`; after the patch, the focused repro passed and the full touched test file passed with 7 tests.

Observed result after fix: `resolveProviderContractPluginIdsForProviderAlias("healthy-alias")` returns `["healthy"]` while the poisoned provider entry is ignored.

What was not tested: Full `pnpm check:changed` did not complete because the AWS Crabbox coordinator returned HTTP 401 before lease creation; Testbox is also unavailable in this environment because `blacksmith` is not authenticated.

Proof limitations or environment constraints: This linked worktree uses targeted local node-wrapper proof for Vitest; broad pnpm gates are routed through Crabbox/Testbox per maintainer policy and are blocked by remote auth.

Before evidence (optional but encouraged): Focused regression failed before the fix with `provider contract alias metadata exploded` at `src/plugins/contracts/registry.ts`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run src/plugins/contracts/registry.retry.test.ts -t "ignores poisoned provider metadata" --reporter=verbose`
- `node scripts/run-vitest.mjs run src/plugins/contracts/registry.retry.test.ts --reporter=verbose`
- `node_modules/.bin/oxfmt --check --threads=1 src/plugins/contracts/registry.ts src/plugins/contracts/registry.retry.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/contracts/registry.ts src/plugins/contracts/registry.retry.test.ts`
- `git diff --check origin/main..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- `src/plugins/contracts/registry.retry.test.ts` now covers a poisoned provider contract entry that throws from `id`, `aliases`, and `hookAliases` while a later healthy provider alias still resolves.

What failed before this fix, if known?

- The focused repro failed with `provider contract alias metadata exploded`.

If no test was added, why not?

- A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Provider contract registry lookup and dedupe behavior for malformed plugin-provided metadata.

How is that risk mitigated?

The guard is local to provider contract metadata projection and preserves existing behavior for valid provider ids and aliases. Existing provider contract retry tests plus the new poisoned-metadata regression pass.

## Current review state

What is the next action?

Maintainer review; broad changed gate can be rerun once Crabbox/Testbox auth is available.

What is still waiting on author, maintainer, CI, or external proof?

AWS Crabbox changed gate is blocked by coordinator HTTP 401 before lease creation; Testbox is blocked by missing `blacksmith` auth.

Which bot or reviewer comments were addressed?

No bot or reviewer comments yet. Local and branch autoreview both reported no accepted/actionable findings.
