### PR TITLE
fix(memory): write dream fallback without subagent runtime

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1020,20 +1020,21 @@ describe("generateAndAppendDreamNarrative", () => {
     const storePath = path.join(sessionsDir, "sessions.json");
     const orphanPath = path.join(sessionsDir, "orphan.jsonl");
     const livePath = path.join(sessionsDir, "still-live.jsonl");
+    const updatedAt = Date.now();
     await sessionStoreRuntimeModule.saveSessionStore(
       storePath,
       {
         "agent:main:dreaming-narrative-light-1": {
           sessionId: "missing",
-          updatedAt: Date.now(),
+          updatedAt,
         },
         "agent:main:kept-session": {
           sessionId: "still-live",
-          updatedAt: Date.now(),
+          updatedAt,
         },
         "agent:main:telegram:group:dreaming-narrative-room": {
           sessionId: "still-missing-non-dreaming",
-          updatedAt: Date.now(),
+          updatedAt,
         },
       },
       { skipMaintenance: true },
@@ -1090,20 +1091,21 @@ describe("generateAndAppendDreamNarrative", () => {
     // A second dreaming row whose transcript is fresh (a live/just-started run)
     // must be preserved.
     const liveTranscript = path.join(sessionsDir, "live-dreaming.jsonl");
+    const updatedAt = Date.now();
     await sessionStoreRuntimeModule.saveSessionStore(
       storePath,
       {
         "agent:main:dreaming-narrative-deep-orphan": {
           sessionId: "orphan-dreaming",
-          updatedAt: Date.now(),
+          updatedAt,
         },
         "agent:main:dreaming-narrative-deep-live": {
           sessionId: "live-dreaming",
-          updatedAt: Date.now(),
+          updatedAt,
         },
         "agent:main:kept-session": {
           sessionId: "still-live",
-          updatedAt: Date.now(),
+          updatedAt,
         },
       },
       { skipMaintenance: true },

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -152,7 +152,7 @@ function buildRequestScopedFallbackNarrative(_data: NarrativePhaseData): string 
   return "A memory trace surfaced, but details were unavailable in this run.";
 }
 
-async function appendFallbackNarrativeEntry(params: {
+export async function appendFallbackNarrativeEntry(params: {
   workspaceDir: string;
   data: NarrativePhaseData;
   nowMs: number;

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -2341,6 +2341,57 @@ describe("short-term dreaming trigger", () => {
     expect(memoryText).toContain("Move backups to S3 Glacier.");
   });
 
+  it("writes fallback dream diary prose when managed cron has no subagent runtime", async () => {
+    const logger = createLogger();
+    const workspaceDir = await createTempWorkspace("memory-dreaming-cron-no-subagent-");
+    await writeDailyMemoryNote(workspaceDir, "2026-04-02", ["Move backups to S3 Glacier."]);
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "backup policy",
+      results: [
+        {
+          path: "memory/2026-04-02.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+    });
+
+    expect(result?.handled).toBe(true);
+    const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+    expect(memoryText).toContain("Move backups to S3 Glacier.");
+    const dreamsText = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(dreamsText).toContain("<!-- openclaw:dreaming:diary:start -->");
+    expect(dreamsText).toContain(
+      "A memory trace surfaced, but details were unavailable in this run.",
+    );
+    expect(dreamsText).not.toContain("Move backups to S3 Glacier.");
+    expect(logger.info).toHaveBeenCalledWith(
+      "memory-core: narrative generation used fallback for deep phase because subagent runtime is unavailable.",
+    );
+  });
+
   it("keeps one-off recalls out of long-term memory under default thresholds", async () => {
     const logger = createLogger();
     const workspaceDir = await createTempWorkspace("memory-dreaming-strict-");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -556,7 +556,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
   const detachNarratives = params.trigger === "cron";
   const [
     { writeDeepDreamingReport },
-    { generateAndAppendDreamNarrative, runDetachedDreamNarrative },
+    { appendFallbackNarrativeEntry, generateAndAppendDreamNarrative, runDetachedDreamNarrative },
     { runDreamingSweepPhases },
     {
       applyShortTermPromotions,
@@ -652,13 +652,22 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
         storage: params.config.storage ?? { mode: "separate", separateReports: false },
       });
       // Generate dream diary narrative from promoted memories.
-      if (params.subagent && (candidates.length > 0 || applied.applied > 0)) {
+      if (candidates.length > 0 || applied.applied > 0) {
         const data: NarrativePhaseData = {
           phase: "deep",
           snippets: candidates.map((c) => c.snippet).filter(Boolean),
           promotions: applied.appliedCandidates.map((c) => c.snippet).filter(Boolean),
         };
-        if (detachNarratives) {
+        if (!params.subagent) {
+          await appendFallbackNarrativeEntry({
+            workspaceDir,
+            data,
+            nowMs: sweepNowMs,
+            timezone: params.config.timezone,
+            logger: params.logger,
+            reason: "subagent runtime is unavailable",
+          });
+        } else if (detachNarratives) {
           runDetachedDreamNarrative({
             subagent: params.subagent,
             workspaceDir,


### PR DESCRIPTION
## Summary

- write a deterministic DREAMS.md fallback entry when managed cron dreaming has candidates/promotions but no subagent runtime
- reuse the existing safe fallback prose path instead of leaking staging snippets into the dream diary
- cover the no-subagent cron path with a regression test

## Why

Managed cron currently skips dream diary generation entirely when `api.runtime?.subagent` is unavailable. The promotion path can still update MEMORY.md and dreaming phase reports, but DREAMS.md stays stale, which makes DreamAtlas appear frozen even though the cron sweep ran.

## Test plan

- `git diff --check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-narrative.test.ts`

## Real behavior proof

Behavior or issue addressed: Managed cron dreaming with ranked candidates/promotions but no available subagent runtime no longer leaves DREAMS.md stale. It now writes the existing safe fallback diary prose while preserving the MEMORY.md promotion path.

Real environment tested: Local OpenClaw checkout on branch fix/dreaming-cron-fallback, Node via repo tsx loader, fresh temporary filesystem workspace under /tmp. No mock subagent runtime was supplied; the run used real workspace files and memory-core source code from this PR.

Exact steps or command run after this patch: Ran a `node --import tsx` proof command that created `/tmp/openclaw-dream-fallback-proof-XymsP3`, wrote `memory/2026-06-04.md`, recorded a short-term recall with `recordShortTermRecalls(...)`, then called `runShortTermDreamingPromotionIfTriggered(...)` with `trigger="cron"` and no `subagent` field.

Evidence after fix: Terminal output from the after-fix local run:

```text
workspace=/tmp/openclaw-dream-fallback-proof-XymsP3
handled=true
memory_has_promotion=true
dreams_has_diary_marker=true
dreams_has_safe_fallback=true
dreams_leaked_staging_snippet=false
info: memory-core: narrative generation used fallback for deep phase because subagent runtime is unavailable.
--- DREAMS.md excerpt ---
# Dream Diary

<!-- openclaw:dreaming:diary:start -->
---

*June 4, 2026 at 4:22 AM GMT+2*

A memory trace surfaced, but details were unavailable in this run.

<!-- openclaw:dreaming:diary:end -->
```

Observed result after fix: The promotion call returned `handled=true`, MEMORY.md contained the promoted memory, DREAMS.md contained the dream diary marker and safe fallback prose, and DREAMS.md did not contain the raw staging snippet.

What was not tested: Full overnight gateway cron scheduling was not rerun in production; this proof exercises the managed cron promotion code path directly on a fresh local OpenClaw workspace after the patch.