### PR TITLE
fix(sessions): preserve user /model override across daily/idle session rollover (#90119)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -880,6 +880,111 @@ describe("initSessionState RawBody", () => {
     expect(peekSystemEvents(existingSessionId)).toStrictEqual([]);
   });
 
+  it("preserves a user model override across an implicit daily stale rollover (#90119)", async () => {
+    // Regression: a user-set /model override persisted on a session that then
+    // goes stale at the daily reset boundary must survive the implicit
+    // rollover. Previously the carryover was gated on resetTriggered, so the
+    // next non-/new turn dropped the override and reverted to the default
+    // model despite the "Model set to ... for this session" ack.
+    const root = await makeCaseDir("openclaw-daily-rollover-model-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:daily-rollover";
+    const existingSessionId = "session-before-daily-reset";
+    // Stale under the default daily reset (atHour 4): started ~48h ago so
+    // sessionStartedAt < today's reset boundary.
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+        // User-driven override (the thing /model writes).
+        providerOverride: "minimax",
+        modelOverride: "m2.7",
+        modelOverrideSource: "user",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        // Ordinary message — NOT a reset trigger.
+        RawBody: "hello again",
+        ChatType: "channel",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The session rolled over implicitly (stale), not via /new.
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // The user override must survive.
+    expect(result.sessionEntry.providerOverride).toBe("minimax");
+    expect(result.sessionEntry.modelOverride).toBe("m2.7");
+    expect(result.sessionEntry.modelOverrideSource).toBe("user");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { providerOverride?: string; modelOverride?: string; modelOverrideSource?: string }
+    >;
+    expect(store[sessionKey]?.modelOverride).toBe("m2.7");
+    expect(store[sessionKey]?.modelOverrideSource).toBe("user");
+  });
+
+  it("clears an auto-fallback model override on an implicit daily stale rollover (#90119)", async () => {
+    // Counterpart: auto-created fallback overrides must still be cleared on a
+    // daily rollover so stale sessions return to the configured default.
+    const root = await makeCaseDir("openclaw-daily-rollover-fallback-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:daily-rollover-fallback";
+    const existingSessionId = "session-before-daily-reset-fallback";
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+        // Auto-fallback override (rate-limit/auto-pin), not user-driven.
+        providerOverride: "minimax",
+        modelOverride: "m2.7",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-4o-mini",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "hello again",
+        ChatType: "channel",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+  });
+
   it("rotates local session state for /new on bound ACP sessions", async () => {
     const root = await makeCaseDir("openclaw-rawbody-acp-reset-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -510,6 +510,26 @@ export async function initSessionState(params: {
     isNewSession = true;
     systemSent = false;
     abortedLastRun = false;
+    // Preserve user-driven model/auth overrides across ANY rollover that mints
+    // a new session from an existing entry — explicit /new and /reset AND
+    // implicit stale rollovers (daily/idle reset boundary). Auto-created
+    // fallback overrides (rate-limit auth rotation, model auto-pin) are still
+    // cleared by resolveResetPreservedSelection so resets return to the
+    // configured default. Previously this was gated on `resetTriggered`, so a
+    // user `/model` override set after the daily reset hour was silently
+    // dropped on the next turn (the rollover took this branch with
+    // resetTriggered === false), reverting the session to the default model
+    // despite the `Model set to ... for this session` ack (#90119, #69301).
+    if (entry) {
+      const preservedSelection = resolveResetPreservedSelection({ entry });
+      persistedModelOverride = preservedSelection.modelOverride;
+      persistedProviderOverride = preservedSelection.providerOverride;
+      persistedModelOverrideSource = preservedSelection.modelOverrideSource;
+      persistedAuthProfileOverride = preservedSelection.authProfileOverride;
+      persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
+      persistedAuthProfileOverrideCompactionCount =
+        preservedSelection.authProfileOverrideCompactionCount;
+    }
     // When a reset trigger (/new, /reset) starts a new session, carry over
     // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
     // so the user doesn't have to re-enable them every time.
@@ -519,19 +539,6 @@ export async function initSessionState(params: {
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      // Only carry over user-driven overrides on reset. Auto-created
-      // fallback overrides (e.g. rate-limit auth rotation, model auto-pin)
-      // must be cleared so /new and /reset actually return the session to
-      // the configured default instead of staying pinned to the auto pick
-      // (#69301).
-      const preservedSelection = resolveResetPreservedSelection({ entry });
-      persistedModelOverride = preservedSelection.modelOverride;
-      persistedProviderOverride = preservedSelection.providerOverride;
-      persistedModelOverrideSource = preservedSelection.modelOverrideSource;
-      persistedAuthProfileOverride = preservedSelection.authProfileOverride;
-      persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
-      persistedAuthProfileOverrideCompactionCount =
-        preservedSelection.authProfileOverrideCompactionCount;
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
       persistedLabel = entry.label;


### PR DESCRIPTION
Fixes #90119

## Problem

A user-driven `/model` (or `sessions.patch`) model override is **silently dropped** when a session rolls over at the **daily/idle reset boundary**, reverting the next turn to the configured default — despite the `Model set to ... for this session` ack. The same override correctly survives an explicit `/new` or `/reset`.

This bites always-on Discord/Telegram channel sessions routinely: switch model after the daily reset hour, get a success ack, then the very next message runs on the default.

## Root cause

In `src/auto-reply/reply/session.ts` → `initSessionState`, the new-session branch carried over the preserved model/auth selection only when `resetTriggered` was true:

```js
} else {
  sessionId = crypto.randomUUID();
  isNewSession = true;
  ...
  if (resetTriggered && entry) {            // gated on resetTriggered only
    ...
    const preservedSelection = resolveResetPreservedSelection({ entry });
    persistedModelOverride = preservedSelection.modelOverride;
    ...
  }
}
```

An implicit daily/idle stale rollover takes this branch with `resetTriggered === false`, so `resolveResetPreservedSelection` never runs. The new entry then resolves `modelOverride: persistedModelOverride ?? baseEntry?.modelOverride` → `undefined ?? undefined` → dropped.

`resolveResetPreservedSelection` already does the right thing (preserve user-driven, clear auto-fallback pins) — it simply wasn't invoked on the implicit-rollover path. This is the completion of #69301's intent.

## Fix

Run `resolveResetPreservedSelection({ entry })` for **any** rollover that mints a new session from an existing entry — explicit `/new`/`/reset` **and** implicit stale daily/idle. Behavior-level carryover (thinking/verbose/reasoning/ttsAuto) and spawn metadata remain scoped to explicit reset triggers, keeping the change tight. Because `resolveResetPreservedSelection` only preserves `modelOverrideSource: "user"` and clears auto-fallback overrides, explicit resets still return to the configured default.

## Tests

Added two regression tests in `src/auto-reply/reply/session.test.ts` (reusing the existing `initSessionState` harness):

- **user override survives a daily stale rollover** — seed an entry started ~48h ago (stale under default `atHour: 4`) with a user-driven override, send a normal (non-`/new`) message, assert `isNewSession === true`, `resetTriggered === false`, and the override (`provider/model/source`) persists in both the result and the store.
- **auto-fallback override is still cleared on a daily stale rollover** — same setup but with fallback-origin provenance instead of `user`; assert the override is dropped.

## Real behavior proof

**Behavior or issue addressed:** A user-driven `/model` override (`modelOverrideSource: "user"`) is silently dropped on an implicit daily/idle stale-session rollover (`isNewSession === true`, `resetTriggered === false`), reverting the next turn to the configured default (#90119). Auto-fallback overrides must still be cleared on that same rollover.

**Real environment tested:** macOS (Darwin), Node v25.9.0, running the patched branch `fix-model-override-daily-rollover@9c2b5e2` in a real worktree at `/Users/admin/openclaw-model-rollover`. The harness drives the **actual** `initSessionState` from `src/auto-reply/reply/session.ts` against a **real on-disk session store** (temp JSON file) — no assertion mocks, no stubbed session logic. Seeded entry started 48h ago so it is genuinely stale under the default daily reset (`atHour: 4`).

**Exact steps or command run after this patch:**

```console
$ node --import tsx /tmp/pr90128-proof/harness.mts
# harness: writes a real sessions.json with a 48h-old entry
#   { modelOverride: "claude-opus-4-8", providerOverride: "pioneer", modelOverrideSource: "user" }
# then calls the real initSessionState({ ctx: { Provider:"discord", Body:"what's the time" }, cfg, commandAuthorized:true })
# (Body is a NORMAL message, NOT /new or /reset), then re-reads the persisted store.
```

**Evidence after fix:** live stdout JSON from the `node --import tsx` harness run shows `returnedModelOverride=claude-opus-4-8` and `persistedModelOverride=claude-opus-4-8` for the user-override case (full fenced JSON below); the auto-fallback case prints all-null. Raw live stdout (user-override case):

```json
{
  "isNewSession": true,
  "resetTriggered": false,
  "returnedModelOverride": "claude-opus-4-8",
  "returnedProviderOverride": "pioneer",
  "returnedModelOverrideSource": "user",
  "persistedModelOverride": "claude-opus-4-8",
  "persistedProviderOverride": "pioneer",
  "persistedModelOverrideSource": "user"
}
```

Negative case — same stale rollover, but seed `modelOverrideSource: "fallback"` (auto-pin), live stdout:

```json
{
  "isNewSession": true,
  "resetTriggered": false,
  "returnedModelOverride": null,
  "returnedProviderOverride": null,
  "returnedModelOverrideSource": null,
  "persistedModelOverride": null,
  "persistedProviderOverride": null,
  "persistedModelOverrideSource": null
}
```

**Observed result after fix:** On a real stale daily rollover (`isNewSession: true`, `resetTriggered: false`), the **user** override survives in both the returned session state and the persisted store (`claude-opus-4-8` / `pioneer` / source `user`). The **auto-fallback** override on the identical rollover is cleared to `null`, so resets still return to the configured default. Both behaviors observed from live execution of the real `initSessionState`, not from unit-test assertions.

**What was not tested:** End-to-end through a live Discord/Telegram gateway turn (the failure is fully reproduced at the `initSessionState` seam, which is where the regression lived). The wall-clock daily-reset scheduler itself is unchanged.

---

Filed with AI assistance (OpenClaw agent). Review: @Peetiegonzalez
