### PR TITLE
fix(mattermost): merge streaming progress lines by identity instead of overwriting (#89761)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -180,7 +180,7 @@ function createRuntimeCore(
     },
     markDispatchIdle: () => {
       params.typingCallbacks?.onIdle?.();
-      params.onIdle?.();
+      void params.onIdle?.();
     },
     markRunComplete: () => {},
   });
@@ -501,7 +501,7 @@ describe("mattermost inbound user posts", () => {
         },
         markDispatchIdle: () => {
           params.typingCallbacks?.onIdle?.();
-          params.onIdle?.();
+          void params.onIdle?.();
         },
         markRunComplete: () => {},
       }),

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -6,9 +6,13 @@ import {
   resolveChannelProgressDraftMaxLines,
   type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
+import type { ReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { monitorMattermostProvider } from "./monitor.js";
 import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
+
+type CreateReplyDispatcherWithTypingFn =
+  typeof import("openclaw/plugin-sdk/reply-runtime").createReplyDispatcherWithTyping;
 
 class FakeWebSocket {
   public readonly sent: string[] = [];
@@ -165,6 +169,21 @@ function createRuntimeCore(
     createInboundDebouncer?: typeof createInboundDebouncer;
   } = {},
 ) {
+  const createReplyDispatcherWithTypingMock = (
+    params: Parameters<CreateReplyDispatcherWithTypingFn>[0],
+  ): ReturnType<CreateReplyDispatcherWithTypingFn> => ({
+    dispatcher: createReplyDispatcher(),
+    replyOptions: {
+      onReplyStart: params.onReplyStart ?? params.typingCallbacks?.onReplyStart,
+      onTypingCleanup: params.onCleanup ?? params.typingCallbacks?.onCleanup,
+      onTypingController: () => {},
+    },
+    markDispatchIdle: () => {
+      params.typingCallbacks?.onIdle?.();
+      params.onIdle?.();
+    },
+    markRunComplete: () => {},
+  });
   const dispatchPreparedForTest = vi.fn(
     async (turn: {
       storePath: string;
@@ -276,12 +295,7 @@ function createRuntimeCore(
         buildPairingReply: () => "pairing required",
       },
       reply: {
-        createReplyDispatcherWithTyping: vi.fn(() => ({
-          dispatcher: {},
-          replyOptions: {},
-          markDispatchIdle: vi.fn(),
-          markRunComplete: vi.fn(),
-        })),
+        createReplyDispatcherWithTyping: vi.fn(createReplyDispatcherWithTypingMock),
         dispatchReplyFromConfig: mockState.dispatchReplyFromConfig,
         finalizeInboundContext: (context: unknown) => context,
         formatInboundEnvelope: (params: { channel: string; from: string; body: string }) =>
@@ -340,6 +354,18 @@ function createRuntimeCore(
         resolveTextChunkLimit: () => 4000,
       },
     },
+  };
+}
+
+function createReplyDispatcher(): ReplyDispatcher {
+  return {
+    sendToolResult: () => true,
+    sendBlockReply: () => true,
+    sendFinalReply: () => true,
+    getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+    getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+    markComplete: () => {},
+    waitForIdle: async () => {},
   };
 }
 
@@ -463,12 +489,23 @@ describe("mattermost inbound user posts", () => {
     const runtimeCore = createRuntimeCore(testConfig);
     mockState.runtimeCore = runtimeCore;
 
-    runtimeCore.channel.reply.createReplyDispatcherWithTyping = vi.fn((params) => ({
-      dispatcher: {},
-      replyOptions: params.replyOptions,
-      markDispatchIdle: vi.fn(),
-      markRunComplete: vi.fn(),
-    }));
+    runtimeCore.channel.reply.createReplyDispatcherWithTyping = vi.fn(
+      (
+        params: Parameters<CreateReplyDispatcherWithTypingFn>[0],
+      ): ReturnType<CreateReplyDispatcherWithTypingFn> => ({
+        dispatcher: createReplyDispatcher(),
+        replyOptions: {
+          onReplyStart: params.onReplyStart ?? params.typingCallbacks?.onReplyStart,
+          onTypingCleanup: params.onCleanup ?? params.typingCallbacks?.onCleanup,
+          onTypingController: () => {},
+        },
+        markDispatchIdle: () => {
+          params.typingCallbacks?.onIdle?.();
+          params.onIdle?.();
+        },
+        markRunComplete: () => {},
+      }),
+    );
     mockState.dispatchReplyFromConfig.mockImplementation(async () => {
       mockState.abortController?.abort();
     });

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,4 +1,11 @@
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import {
+  buildChannelProgressDraftLineForEntry,
+  formatChannelProgressDraftText,
+  mergeChannelProgressDraftLine,
+  resolveChannelProgressDraftMaxLines,
+  type ChannelProgressDraftLine,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { monitorMattermostProvider } from "./monitor.js";
 import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
@@ -441,6 +448,161 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.MessageSid).toBe("post-1");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
+  });
+
+  it("merges interleaved draft progress lines by identity", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const draftStream = {
+      update: vi.fn(),
+      stop: vi.fn(async () => {}),
+    };
+    mockState.createMattermostDraftStream.mockReturnValue(draftStream);
+
+    const runtimeCore = createRuntimeCore(testConfig);
+    mockState.runtimeCore = runtimeCore;
+
+    runtimeCore.channel.reply.createReplyDispatcherWithTyping = vi.fn((params) => ({
+      dispatcher: {},
+      replyOptions: params.replyOptions,
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    }));
+    mockState.dispatchReplyFromConfig.mockImplementation(async () => {
+      mockState.abortController?.abort();
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-progress-1",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "show me progress",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    const replyOptions = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].replyOptions as {
+      onToolStart?: (payload: {
+        itemId?: string;
+        toolCallId?: string;
+        name?: string;
+        phase?: string;
+        args?: Record<string, unknown>;
+        detailMode?: "explain" | "raw";
+      }) => Promise<void>;
+      onItemEvent?: (payload: {
+        itemId: string;
+        kind: string;
+        title?: string;
+        name?: string;
+        phase?: string;
+        status?: string;
+        summary?: string;
+        progressText?: string;
+        meta?: Record<string, unknown>;
+      }) => Promise<void>;
+    };
+    expect(replyOptions.onToolStart).toBeTypeOf("function");
+    expect(replyOptions.onItemEvent).toBeTypeOf("function");
+
+    await replyOptions.onToolStart?.({
+      itemId: "item-a",
+      toolCallId: "call-a",
+      name: "toolA",
+      phase: "start",
+      args: { city: "Seoul" },
+    });
+    await replyOptions.onToolStart?.({
+      itemId: "item-b",
+      toolCallId: "call-b",
+      name: "toolB",
+      phase: "start",
+      args: { city: "Busan" },
+    });
+    await replyOptions.onItemEvent?.({
+      itemId: "item-a",
+      kind: "tool",
+      title: "Tool A",
+      name: "toolA",
+      phase: "running",
+      status: "running",
+      summary: "Fetched data",
+      progressText: "Fetched data",
+    });
+
+    let expectedLines: Array<string | ChannelProgressDraftLine> = [];
+    const toolALine = buildChannelProgressDraftLineForEntry(testConfig.channels?.mattermost, {
+      event: "tool",
+      itemId: "item-a",
+      toolCallId: "call-a",
+      name: "toolA",
+      phase: "start",
+      args: { city: "Seoul" },
+    });
+    const toolBLine = buildChannelProgressDraftLineForEntry(testConfig.channels?.mattermost, {
+      event: "tool",
+      itemId: "item-b",
+      toolCallId: "call-b",
+      name: "toolB",
+      phase: "start",
+      args: { city: "Busan" },
+    });
+    const toolAUpdateLine = buildChannelProgressDraftLineForEntry(testConfig.channels?.mattermost, {
+      event: "item",
+      itemId: "item-a",
+      itemKind: "tool",
+      title: "Tool A",
+      name: "toolA",
+      phase: "running",
+      status: "running",
+      summary: "Fetched data",
+      progressText: "Fetched data",
+    });
+    for (const line of [toolALine, toolBLine, toolAUpdateLine]) {
+      if (!line) {
+        continue;
+      }
+      expectedLines = mergeChannelProgressDraftLine(expectedLines, line, {
+        maxLines: resolveChannelProgressDraftMaxLines(testConfig.channels?.mattermost),
+      });
+    }
+    const expectedText = formatChannelProgressDraftText({
+      entry: testConfig.channels?.mattermost,
+      lines: expectedLines,
+      seed: "default:chan-1",
+    });
+
+    expect(draftStream.update).toHaveBeenCalledTimes(3);
+    expect(draftStream.update).toHaveBeenLastCalledWith(expectedText);
+    expect(expectedText).toContain("ToolA");
+    expect(expectedText).toContain("ToolB");
   });
 
   it("does not drop inline command-looking group text from non-command-authorized senders", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1934,7 +1934,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 maxLines: resolveChannelProgressDraftMaxLines(account.config),
                               },
                             );
-                            draftStream.update(
+                            await draftStream.update(
                               formatChannelProgressDraftText({
                                 entry: account.config,
                                 lines: progressLines,
@@ -1971,7 +1971,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 maxLines: resolveChannelProgressDraftMaxLines(account.config),
                               },
                             );
-                            draftStream.update(
+                            await draftStream.update(
                               formatChannelProgressDraftText({
                                 entry: account.config,
                                 lines: progressLines,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1906,7 +1906,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                               draftStream.update("Thinking…");
                             }
                           },
-                          onToolStart: async (payloadValue) => {
+                          onToolStart: (payloadValue) => {
                             if (!draftToolProgressEnabled) {
                               return;
                             }
@@ -1934,7 +1934,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 maxLines: resolveChannelProgressDraftMaxLines(account.config),
                               },
                             );
-                            await draftStream.update(
+                            draftStream.update(
                               formatChannelProgressDraftText({
                                 entry: account.config,
                                 lines: progressLines,
@@ -1942,7 +1942,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                               }),
                             );
                           },
-                          onItemEvent: async (payloadLocal) => {
+                          onItemEvent: (payloadLocal) => {
                             if (!draftToolProgressEnabled) {
                               return;
                             }
@@ -1971,7 +1971,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 maxLines: resolveChannelProgressDraftMaxLines(account.config),
                               },
                             );
-                            await draftStream.update(
+                            draftStream.update(
                               formatChannelProgressDraftText({
                                 entry: account.config,
                                 lines: progressLines,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1,11 +1,13 @@
 import {
+  buildChannelProgressDraftLineForEntry,
   defineFinalizableLivePreviewAdapter,
   deliverWithFinalizableLivePreviewAdapter,
+  formatChannelProgressDraftText,
+  mergeChannelProgressDraftLine,
+  resolveChannelProgressDraftMaxLines,
+  type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
-import {
-  formatChannelProgressDraftLineForEntry,
-  resolveChannelStreamingPreviewToolProgress,
-} from "openclaw/plugin-sdk/channel-outbound";
+import { resolveChannelStreamingPreviewToolProgress } from "openclaw/plugin-sdk/channel-outbound";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import {
@@ -37,7 +39,7 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import { createMattermostDraftStream } from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1681,6 +1683,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             })
           : createDisabledMattermostDraftStream();
         let lastPartialText = "";
+        let progressLines: Array<string | ChannelProgressDraftLine> = [];
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1892,9 +1895,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           },
                           onAssistantMessageStart: () => {
                             lastPartialText = "";
+                            progressLines = [];
                           },
                           onReasoningEnd: () => {
                             lastPartialText = "";
+                            progressLines = [];
                           },
                           onReasoningStream: async () => {
                             if (!lastPartialText) {
@@ -1905,10 +1910,35 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             if (!draftToolProgressEnabled) {
                               return;
                             }
+                            const progressLine = buildChannelProgressDraftLineForEntry(
+                              account.config,
+                              {
+                                event: "tool",
+                                itemId: payloadValue.itemId,
+                                toolCallId: payloadValue.toolCallId,
+                                name: payloadValue.name,
+                                phase: payloadValue.phase,
+                                args: payloadValue.args,
+                              },
+                              payloadValue.detailMode
+                                ? { detailMode: payloadValue.detailMode }
+                                : undefined,
+                            );
+                            if (!progressLine) {
+                              return;
+                            }
+                            progressLines = mergeChannelProgressDraftLine(
+                              progressLines,
+                              progressLine,
+                              {
+                                maxLines: resolveChannelProgressDraftMaxLines(account.config),
+                              },
+                            );
                             draftStream.update(
-                              buildMattermostToolStatusText({
-                                ...payloadValue,
-                                config: account.config,
+                              formatChannelProgressDraftText({
+                                entry: account.config,
+                                lines: progressLines,
+                                seed: `${account.accountId}:${channelId}`,
                               }),
                             );
                           },
@@ -1916,7 +1946,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                             if (!draftToolProgressEnabled) {
                               return;
                             }
-                            const progressText = formatChannelProgressDraftLineForEntry(
+                            const progressLine = buildChannelProgressDraftLineForEntry(
                               account.config,
                               {
                                 event: "item",
@@ -1931,9 +1961,23 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                                 meta: payloadLocal.meta,
                               },
                             );
-                            if (progressText) {
-                              draftStream.update(progressText);
+                            if (!progressLine) {
+                              return;
                             }
+                            progressLines = mergeChannelProgressDraftLine(
+                              progressLines,
+                              progressLine,
+                              {
+                                maxLines: resolveChannelProgressDraftMaxLines(account.config),
+                              },
+                            );
+                            draftStream.update(
+                              formatChannelProgressDraftText({
+                                entry: account.config,
+                                lines: progressLines,
+                                seed: `${account.accountId}:${channelId}`,
+                              }),
+                            );
                           },
                         },
                       }),


### PR DESCRIPTION
## Summary
Mattermost was overwriting its entire streaming progress preview on each tool or item frame, so interleaved tool activity clobbered earlier lines instead of keeping a stable multi-line block. This switches Mattermost to the same line-identity merge flow already used by Slack and Microsoft Teams.

## Root Cause
extensions/mattermost/src/mattermost/monitor.ts handled onToolStart and onItemEvent by formatting one line and calling draftStream.update with that single line immediately, with no per-turn progressLines state. Other channels already route these events through the shared mergeChannelProgressDraftLine helper, which updates lines by stable identity and preserves the configured max-line window.

## Changes
- update extensions/mattermost/src/mattermost/monitor.ts to keep per-turn progressLines, build tool and item draft lines with the shared helper, merge them with mergeChannelProgressDraftLine, render with formatChannelProgressDraftText, and reset progress state at assistant-message boundaries
- add a regression test in extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts that drives interleaved tool progress through the live monitor reply options and asserts the final draft update contains both merged lines

## Test
- before fix: pnpm test extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts -> failed 1 of 9 with the final draft update showing only ToolA instead of the merged block containing both ToolA and ToolB
- after fix: pnpm test extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts -> 9 passed
- pnpm test extensions/mattermost -> 460 passed

## Notes
Scope is limited to the Mattermost plugin and this one progress-draft regression. The fix reuses existing shared progress-draft helpers and does not add any new config surface.

Closes #89761
