### PR TITLE
fix(auth): guard preferred provider metadata

### DIFF
--- a/src/commands/auth-choice.preferred-provider.test.ts
+++ b/src/commands/auth-choice.preferred-provider.test.ts
@@ -131,4 +131,38 @@ describe("resolvePreferredProviderForAuthChoice", () => {
     expect(pluginProviderOptions?.mode).toBe("setup");
     expect(pluginProviderOptions?.includeUntrustedWorkspacePlugins).toBe(false);
   });
+
+  it("skips unreadable plugin provider ids during setup-provider fallback lookup", async () => {
+    const poisonedProvider = Object.defineProperty(
+      {
+        label: "Poisoned Provider",
+        auth: [{ id: "api-key", label: "API key", kind: "api_key" }],
+      },
+      "id",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("auth choice preferred provider id exploded");
+        },
+      },
+    );
+    const healthyProvider = {
+      id: "healthy",
+      label: "Healthy Provider",
+      auth: [{ id: "api-key", label: "API key", kind: "api_key" }],
+    };
+    resolvePluginProviders.mockReturnValue([poisonedProvider, healthyProvider] as never);
+    resolveProviderPluginChoice.mockImplementation(({ providers, choice }) => {
+      for (const provider of providers) {
+        if (provider.id === choice && provider.auth[0]) {
+          return { provider, method: provider.auth[0] };
+        }
+      }
+      return null;
+    });
+
+    await expect(resolvePreferredProviderForAuthChoice({ choice: "healthy" })).resolves.toBe(
+      "healthy",
+    );
+  });
 });

--- a/src/plugins/provider-auth-choice-preference.ts
+++ b/src/plugins/provider-auth-choice-preference.ts
@@ -1,9 +1,117 @@
 import { normalizeLegacyOnboardAuthChoice } from "../commands/auth-choice-legacy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveManifestProviderAuthChoice } from "./provider-auth-choices.js";
+import type {
+  ProviderAuthMethod,
+  ProviderPlugin,
+  ProviderPluginWizard,
+  ProviderPluginWizardSetup,
+} from "./types.js";
 
 function normalizeLegacyAuthChoice(choice: string, env?: NodeJS.ProcessEnv): string {
   return normalizeLegacyOnboardAuthChoice(choice, { env }) ?? choice;
+}
+
+function readResolvedProviderId(provider: { id: unknown }): string | undefined {
+  try {
+    return typeof provider.id === "string" && provider.id.trim().length > 0
+      ? provider.id
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readProperty(record: Record<string, unknown>, key: string): unknown {
+  try {
+    return record[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readStringProperty(record: Record<string, unknown>, key: string): string | undefined {
+  const value = readProperty(record, key);
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readArrayProperty(record: Record<string, unknown>, key: string): unknown[] {
+  const value = readProperty(record, key);
+  return Array.isArray(value) ? value : [];
+}
+
+function readWizardSetup(rawSetup: unknown): ProviderPluginWizardSetup | undefined {
+  if (!isRecord(rawSetup)) {
+    return undefined;
+  }
+  const choiceId = readStringProperty(rawSetup, "choiceId");
+  const methodId = readStringProperty(rawSetup, "methodId");
+  if (!choiceId && !methodId) {
+    return undefined;
+  }
+  return {
+    ...(choiceId ? { choiceId } : {}),
+    ...(methodId ? { methodId } : {}),
+  };
+}
+
+function readProviderWizard(rawWizard: unknown): ProviderPluginWizard | undefined {
+  if (!isRecord(rawWizard)) {
+    return undefined;
+  }
+  const setup = readWizardSetup(readProperty(rawWizard, "setup"));
+  return setup ? { setup } : undefined;
+}
+
+const noopProviderAuthMethodRun: ProviderAuthMethod["run"] = async () => ({ profiles: [] });
+
+function toChoiceResolverAuthMethod(rawMethod: unknown): ProviderAuthMethod | undefined {
+  if (!isRecord(rawMethod)) {
+    return undefined;
+  }
+  const id = readStringProperty(rawMethod, "id");
+  if (!id) {
+    return undefined;
+  }
+  const wizard = readWizardSetup(readProperty(rawMethod, "wizard"));
+  return {
+    id,
+    label: id,
+    kind: "custom",
+    run: noopProviderAuthMethodRun,
+    ...(wizard ? { wizard } : {}),
+  };
+}
+
+function toChoiceResolverProvider(provider: ProviderPlugin): ProviderPlugin | undefined {
+  const rawProvider = provider as unknown;
+  if (!isRecord(rawProvider)) {
+    return undefined;
+  }
+  const id = readStringProperty(rawProvider, "id");
+  if (!id) {
+    return undefined;
+  }
+  const auth = readArrayProperty(rawProvider, "auth")
+    .map(toChoiceResolverAuthMethod)
+    .filter((method): method is ProviderAuthMethod => Boolean(method));
+  const wizard = readProviderWizard(readProperty(rawProvider, "wizard"));
+  return {
+    id,
+    label: id,
+    auth,
+    ...(wizard ? { wizard } : {}),
+  };
+}
+
+function toChoiceResolverProviders(providers: ProviderPlugin[]): ProviderPlugin[] {
+  return providers
+    .map(toChoiceResolverProvider)
+    .filter((provider): provider is ProviderPlugin => Boolean(provider));
 }
 
 export async function resolvePreferredProviderForAuthChoice(params: {
@@ -29,11 +137,11 @@ export async function resolvePreferredProviderForAuthChoice(params: {
     includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
   });
   const pluginResolved = resolveProviderPluginChoice({
-    providers,
+    providers: toChoiceResolverProviders(providers),
     choice,
   });
   if (pluginResolved) {
-    return pluginResolved.provider.id;
+    return readResolvedProviderId(pluginResolved.provider);
   }
 
   if (choice === "custom-api-key") {


### PR DESCRIPTION
## Summary

- Prevent setup-provider preferred auth-choice lookup from crashing when a plugin provider object exposes unreadable metadata.
- Pass inert provider/method snapshots into the fallback choice resolver so bad plugin objects are skipped before `provider.id`, `auth`, or wizard choice metadata can throw.
- Keep manifest-backed auth choice resolution unchanged.
- Out of scope: broad provider wizard hardening outside this preferred-provider fallback path.

## Linked context

Related to local tool-schema fuzzing sweep.

## Real behavior proof (required for external PRs)

Behavior addressed: setup-provider fallback lookup no longer crashes when one plugin provider has an unreadable `id`; it can still resolve a healthy provider choice.

Real environment tested: local linked OpenClaw worktree on Node 24.15.0, current `origin/main` after rebase.

Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next170 nodenv exec node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/auth-choice.preferred-provider.test.ts --reporter=verbose
node_modules/.bin/oxfmt --check --threads=1 src/plugins/provider-auth-choice-preference.ts src/commands/auth-choice.preferred-provider.test.ts
nodenv exec node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/provider-auth-choice-preference.ts src/commands/auth-choice.preferred-provider.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"
```

Evidence after fix: targeted command test file passed 6/6; oxfmt, oxlint, and diff check passed; local branch autoreview reported no accepted/actionable findings.

Observed result after fix: the regression test resolves the healthy provider after skipping the poisoned provider instead of rejecting from the poisoned `id` getter.

What was not tested: full `pnpm check:changed` did not complete.

Proof limitations or environment constraints: Testbox auth is unavailable locally. Crabbox AWS changed gate was attempted, but the coordinator returned HTTP 401 while creating run/lease records.

Before evidence (optional but encouraged): the earlier focused repro failed with `auth choice preferred provider id exploded`; branch autoreview also flagged that the first guard still ran after resolver dereferences.

## Tests and validation

Which commands did you run?

See the exact commands in Real behavior proof.

What regression coverage was added or updated?

`src/commands/auth-choice.preferred-provider.test.ts` now covers a poisoned provider followed by a healthy provider and verifies the healthy provider still resolves.

What failed before this fix, if known?

The fallback resolver could dereference unreadable plugin provider metadata before the preferred provider helper could guard the returned provider id.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A malformed plugin provider can no longer crash this auth-choice fallback path.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, auth setup-provider fallback behavior is hardened.

What is the highest-risk area?

Choice resolution for plugin-owned auth methods.

How is that risk mitigated?

The fallback snapshots preserve the resolver fields needed for provider id, method id, and wizard choice matching, and the existing auth-choice tests still pass.

## Current review state

What is the next action?

Review the draft PR and rerun a maintainer-authenticated changed gate.

What is still waiting on author, maintainer, CI, or external proof?

Maintainer-authenticated Crabbox/Testbox proof or CI, because local Crabbox lease creation is unauthorized.

Which bot or reviewer comments were addressed?

Local branch autoreview is clean after addressing the earlier finding that the guard ran after resolver dereference.
