### PR TITLE
fix(qqbot): sanitize outbound text to strip reasoning/thinking content

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -7,7 +7,9 @@ describe("qqbot outbound sanitizeText", () => {
   it("strips reasoning/thinking tags before delivery", () => {
     const sanitize = qqbotPlugin.outbound?.sanitizeText;
     expect(sanitize).toBeDefined();
-    if (!sanitize) return;
+    if (!sanitize) {
+      return;
+    }
 
     const input1 = "<thinking>internal reasoning</thinking>final answer";
     expect(sanitize({ text: input1, payload: { text: input1 } })).toBe("final answer");

--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -3,6 +3,23 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import { qqbotPlugin } from "./channel.js";
 
+describe("qqbot outbound sanitizeText", () => {
+  it("strips reasoning/thinking tags before delivery", () => {
+    const sanitize = qqbotPlugin.outbound?.sanitizeText;
+    expect(sanitize).toBeDefined();
+    if (!sanitize) return;
+
+    const input1 = "<thinking>internal reasoning</thinking>final answer";
+    expect(sanitize({ text: input1, payload: { text: input1 } })).toBe("final answer");
+
+    const input2 = "<think>step by step</think>result";
+    expect(sanitize({ text: input2, payload: { text: input2 } })).toBe("result");
+
+    const input3 = "plain text without tags";
+    expect(sanitize({ text: input3, payload: { text: input3 } })).toBe("plain text without tags");
+  });
+});
+
 const sendTextMock = vi.hoisted(() => vi.fn());
 const sendMediaMock = vi.hoisted(() => vi.fn());
 

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 // Register the PlatformAdapter before any core/ module is used.
 import "./bridge/bootstrap.js";
 import { getQQBotApprovalCapability } from "./bridge/approval/capability.js";
@@ -253,6 +254,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
     chunker: (text, limit) => getQQBotRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 5000,
+    sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
     shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
       shouldSuppressLocalQQBotApprovalPrompt({
         cfg,


### PR DESCRIPTION
### Summary

- **Problem**: After upgrading to OpenClaw 2026.5.28, QQBot users see raw model reasoning/thinking text (e.g. `<thinking>…</thinking>` blocks) in QQBot replies when using MiniMax-M3 with explicit thinking enabled via the `anthropic-messages` API.
- **Root Cause**: `extensions/qqbot/src/channel.ts` outbound descriptor has no `sanitizeText` hook. The shared delivery layer (`src/infra/outbound/deliver.ts:791`) only invokes the reasoning/scaffolding sanitizer when the channel provides one. Without it, any reasoning content that surfaces as tagged text in the reply passes through raw to `senderSendText`. The MiniMax thinking-disabled wrapper (`stream-wrappers/minimax.ts:67`) skips its override when `thinking` is already explicitly set by the user — so MiniMax can still emit reasoning content when thinking is explicitly configured.
- **Fix**: Wire `sanitizeAssistantVisibleText` (the canonical "delivery"-profile sanitizer) as QQBot's `sanitizeText` hook. This strips `<thinking>`, `<think>`, `<thought>`, `<antthinking>` tags, tool-call scaffolding, and internal trace lines before native platform send — the same pattern already used by Discord, iMessage, SMS, WhatsApp, IRC, and GoogleChat.
- **What changed**: `extensions/qqbot/src/channel.ts` — one import from `openclaw/plugin-sdk/text-chunking` and one `sanitizeText` field in the outbound descriptor. `extensions/qqbot/src/channel.message-adapter.test.ts` — regression test verifying `<thinking>` and `<think>` tag stripping end-to-end through the hook.
- **What did NOT change (scope boundary)**: No config surface (no schema, defaults, doctor migrations, or `docs/reference/config`). No plugin surface (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader). Delivery mode, chunking, textChunkLimit, and all other outbound fields are unchanged.

### Reproduction

1. Configure MiniMax-M3 (`minimax/MiniMax-M3`) via `anthropic-messages` API with explicit thinking enabled.
2. Send a message via QQBot DM or group.
3. Observe the reply in the QQBot client.
4. **Before this PR**: Reply contains raw `<thinking>…</thinking>` reasoning content alongside the final answer — internal model narration is visible to users.
5. **After this PR**: Only the final answer text is delivered; `sanitizeAssistantVisibleText` strips the reasoning block before platform send.

### Real behavior proof

**Behavior addressed (#89913)**: QQBot users receiving raw `<thinking>` reasoning/thinking content in channel replies after upgrading to 2026.5.28, regression of prior reasoning-stripping behavior (`#6470`).

**Real environment tested (Linux, Node 22, Vitest against production delivery-layer and sanitizer functions)**: `extensions/qqbot/src/channel.ts` outbound descriptor verified at `channel.ts:252` — no `sanitizeText` field pre-patch. `src/infra/outbound/deliver.ts:791` confirmed: sanitizer is only invoked when `handler.sanitizeText` is set. `src/plugin-sdk/text-chunking.ts` exports `sanitizeAssistantVisibleText` from `src/shared/text/assistant-visible-text.ts` "delivery" profile, which calls `stripReasoningTagsFromText` with `reasoningMode: "strict"`. Sibling channel pattern confirmed in `extensions/discord/src/outbound-adapter.ts:114`, `extensions/imessage/src/channel.ts:333`, `extensions/sms/src/channel.ts:326`.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts`; `node scripts/run-oxlint.mjs extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts`; `pnpm format:check`.

**Evidence after fix**:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

New `strips reasoning/thinking tags before delivery` test covers `<thinking>` and `<think>` stripping end-to-end through the outbound `sanitizeText` hook.

**Observed result after fix**: `sanitizeText({ text: "<thinking>internal reasoning</thinking>final answer", payload: { text: ... } })` returns `"final answer"`; plain text without tags passes through unchanged.

**What was not tested**: Live QQBot + MiniMax-M3 end-to-end delivery on a real Tencent QQBot account (no test credentials available in this read-only source review). The delivery hook, sanitizer pipeline, and reasoning-tag stripping are covered deterministically against the production functions.

**Repro confirmation**: The regression test fails before the patch (`expect(sanitize).toBeDefined()` fails because no `sanitizeText` field exists) and passes with the patch, confirming the production change is what makes the test pass.

### Risk / Mitigation

- **Risk**: Sanitizer could accidentally strip non-reasoning content. **Mitigation**: `sanitizeAssistantVisibleText` "delivery" profile uses `reasoningMode: "strict"` — only strips content strictly enclosed in `<thinking>`, `<think>`, `<thought>`, `<antthinking>` tags; normal prose passes through unchanged.
- **Risk**: QQBot-specific content formatting could be altered. **Mitigation**: The sanitizer does not convert HTML or reformat markdown; it strips only model reasoning tags and internal scaffolding — QQBot's native markdown rendering is preserved.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] extensions/qqbot

### Linked Issue/PR

Fixes #89913