### PR TITLE
fix(plugins): guard manifest owner metadata

### DIFF
--- a/src/plugins/manifest-command-aliases.test.ts
+++ b/src/plugins/manifest-command-aliases.test.ts
@@ -56,6 +56,32 @@ describe("manifest command aliases", () => {
     });
   });
 
+  it("skips unreadable command alias owner rows", () => {
+    const poisonedPlugin: {
+      id: string;
+      commandAliases: { name: string }[];
+    } = {
+      get id(): string {
+        throw new Error("manifest command alias plugin id exploded");
+      },
+      commandAliases: [{ name: "legacy-memory" }],
+    };
+    const registry = {
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "memory",
+          commandAliases: [{ name: "memory" }],
+        },
+      ],
+    };
+
+    expect(resolveManifestCommandAliasOwnerInRegistry({ command: "memory", registry })).toEqual({
+      name: "memory",
+      pluginId: "memory",
+    });
+  });
+
   it("resolves agent tool owners from contracts.tools", () => {
     const registry = {
       plugins: [
@@ -82,5 +108,34 @@ describe("manifest command aliases", () => {
       resolveManifestToolOwnerInRegistry({ toolName: "missing_tool", registry }),
     ).toBeUndefined();
     expect(resolveManifestToolOwnerInRegistry({ toolName: "", registry })).toBeUndefined();
+  });
+
+  it("skips unreadable tool owner rows", () => {
+    const poisonedPlugin = Object.defineProperty(
+      {
+        id: "poisoned-plugin",
+      },
+      "contracts",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("manifest tool owner contracts exploded");
+        },
+      },
+    );
+    const registry = {
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "healthy-plugin",
+          contracts: { tools: ["healthy_tool"] },
+        },
+      ],
+    };
+
+    expect(resolveManifestToolOwnerInRegistry({ toolName: "healthy_tool", registry })).toEqual({
+      toolName: "healthy_tool",
+      pluginId: "healthy-plugin",
+    });
   });
 });

--- a/src/plugins/manifest-command-aliases.ts
+++ b/src/plugins/manifest-command-aliases.ts
@@ -46,6 +46,69 @@ export type PluginManifestCommandAliasRegistry = {
   }[];
 };
 
+function readRecordValue(value: unknown, key: string): unknown {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readArrayEntries(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  let length: number;
+  try {
+    length = value.length;
+  } catch {
+    return [];
+  }
+  const entries: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      entries.push(value[index]);
+    } catch {
+      // Ignore only the unreadable row; readable siblings can still resolve.
+    }
+  }
+  return entries;
+}
+
+function readManifestPluginId(plugin: unknown): string | undefined {
+  return normalizeOptionalString(readRecordValue(plugin, "id"));
+}
+
+function readManifestCommandAlias(alias: unknown): PluginManifestCommandAlias | undefined {
+  const name = normalizeOptionalString(readRecordValue(alias, "name"));
+  if (!name) {
+    return undefined;
+  }
+  const kind = readRecordValue(alias, "kind") === "runtime-slash" ? "runtime-slash" : undefined;
+  const cliCommand = normalizeOptionalString(readRecordValue(alias, "cliCommand"));
+  return {
+    name,
+    ...(kind ? { kind } : {}),
+    ...(cliCommand ? { cliCommand } : {}),
+  };
+}
+
+function readManifestCommandAliases(plugin: unknown): PluginManifestCommandAlias[] {
+  return readArrayEntries(readRecordValue(plugin, "commandAliases"))
+    .map(readManifestCommandAlias)
+    .filter((alias): alias is PluginManifestCommandAlias => Boolean(alias));
+}
+
+function readManifestToolNames(plugin: unknown): string[] {
+  const contracts = readRecordValue(plugin, "contracts");
+  return readArrayEntries(readRecordValue(contracts, "tools"))
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
 export function normalizeManifestCommandAliases(
   value: unknown,
 ): PluginManifestCommandAlias[] | undefined {
@@ -89,15 +152,18 @@ export function resolveManifestToolOwnerInRegistry(params: {
     return undefined;
   }
   for (const plugin of params.registry.plugins) {
-    const tools = plugin.contracts?.tools;
-    if (!tools || tools.length === 0) {
+    const tools = readManifestToolNames(plugin);
+    if (tools.length === 0) {
       continue;
     }
-    const match = tools.find(
-      (entry) => normalizeOptionalLowercaseString(entry) === normalizedToolName,
-    );
-    if (match) {
-      return { toolName: match, pluginId: plugin.id };
+    const pluginId = readManifestPluginId(plugin);
+    if (!pluginId) {
+      continue;
+    }
+    for (const tool of tools) {
+      if (normalizeOptionalLowercaseString(tool) === normalizedToolName) {
+        return { toolName: tool, pluginId };
+      }
     }
   }
   return undefined;
@@ -112,22 +178,27 @@ export function resolveManifestCommandAliasOwnerInRegistry(params: {
     return undefined;
   }
 
-  const commandIsPluginId = params.registry.plugins.some(
-    (plugin) => normalizeOptionalLowercaseString(plugin.id) === normalizedCommand,
-  );
+  const commandIsPluginId = params.registry.plugins.some((plugin) => {
+    const pluginId = readManifestPluginId(plugin);
+    return pluginId ? normalizeOptionalLowercaseString(pluginId) === normalizedCommand : false;
+  });
 
   for (const plugin of params.registry.plugins) {
-    const alias = plugin.commandAliases?.find(
+    const pluginId = readManifestPluginId(plugin);
+    if (!pluginId) {
+      continue;
+    }
+    const alias = readManifestCommandAliases(plugin).find(
       (entry) => normalizeOptionalLowercaseString(entry.name) === normalizedCommand,
     );
     if (alias) {
-      if (commandIsPluginId && normalizeOptionalLowercaseString(plugin.id) !== normalizedCommand) {
+      if (commandIsPluginId && normalizeOptionalLowercaseString(pluginId) !== normalizedCommand) {
         continue;
       }
       return {
         ...alias,
-        pluginId: plugin.id,
-        ...(plugin.enabledByDefault === true ? { enabledByDefault: true } : {}),
+        pluginId,
+        ...(readRecordValue(plugin, "enabledByDefault") === true ? { enabledByDefault: true } : {}),
       };
     }
   }


### PR DESCRIPTION
## Summary

- Prevent manifest command-alias and tool-owner lookup from crashing when one manifest registry row exposes unreadable metadata.
- Keep owner resolution best-effort: skip only the unreadable row and continue to healthy plugin rows.
- Preserve existing alias collision behavior where a command that is also a plugin id only resolves the same plugin's explicit alias.
- Out of scope: broad manifest registry normalization outside these pure owner lookup helpers.

## Linked context

Related to local tool-schema fuzzing sweep.

## Real behavior proof (required for external PRs)

Behavior addressed: manifest owner lookup no longer aborts when a malformed plugin row has an unreadable `id` or `contracts` field; healthy later rows can still own command aliases and tool contracts.

Real environment tested: local linked OpenClaw worktree on Node 24.15.0, current `origin/main` after rebase.

Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next171 nodenv exec node scripts/run-vitest.mjs run src/plugins/manifest-command-aliases.test.ts --reporter=verbose
node_modules/.bin/oxfmt --check --threads=1 src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts
nodenv exec node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/manifest-command-aliases.ts src/plugins/manifest-command-aliases.test.ts
git diff --check origin/main..HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
nodenv exec node scripts/crabbox-wrapper.mjs run --provider aws --shell -- "pnpm check:changed"
```

Evidence after fix: focused/full manifest command-alias test file passed 5/5; oxfmt, oxlint, and diff check passed; local branch autoreview reported no accepted/actionable findings.

Observed result after fix: poisoned command-alias and tool-owner rows are skipped, and the later healthy plugin row resolves normally.

What was not tested: full `pnpm check:changed` did not complete.

Proof limitations or environment constraints: Crabbox AWS changed gate was attempted, but the coordinator returned HTTP 401 while creating run/lease records. Testbox is unavailable locally because Blacksmith is not authenticated.

Before evidence (optional but encouraged): the focused repro failed before the fix with `manifest command alias plugin id exploded` and `manifest tool owner contracts exploded`.

## Tests and validation

Which commands did you run?

See the exact commands in Real behavior proof.

What regression coverage was added or updated?

`src/plugins/manifest-command-aliases.test.ts` now covers unreadable command-alias owner rows and unreadable tool-owner rows before healthy rows.

What failed before this fix, if known?

The pure manifest owner helpers directly read plugin `id`, `commandAliases`, and `contracts.tools` fields, so a stale or malformed plugin row could abort owner diagnostics before a healthy row was considered.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Manifest ownership diagnostics are more resilient to malformed plugin metadata.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Manifest command alias and tool-owner attribution.

How is that risk mitigated?

Normal rows keep the same resolution semantics, and tests cover existing alias collision behavior plus the new unreadable-row cases.

## Current review state

What is the next action?

Review the draft PR and rerun a maintainer-authenticated changed gate.

What is still waiting on author, maintainer, CI, or external proof?

Maintainer-authenticated Crabbox/Testbox proof or CI, because local Crabbox lease creation is unauthorized.

Which bot or reviewer comments were addressed?

Local autoreview first found a strict test fixture typing issue; the fixture now uses a typed throwing accessor. Final branch autoreview is clean.
