### PR TITLE
fix(plugins): guard manifest activation planning

### DIFF
--- a/src/plugins/activation-planner.test.ts
+++ b/src/plugins/activation-planner.test.ts
@@ -307,6 +307,93 @@ describe("activation planner", () => {
     ]);
   });
 
+  it("skips unreadable manifest activation rows before healthy command owners", () => {
+    const poisonedPlugin = {
+      id: "poisoned-plugin",
+      origin: "workspace" as const,
+      providers: [],
+      channels: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      commandAliases: [{ name: "poisoned-command" }],
+      get activation(): { onCommands: string[] } {
+        throw new Error("manifest activation metadata exploded");
+      },
+    };
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "healthy-plugin",
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          activation: {
+            onCommands: ["healthy-command"],
+          },
+          origin: "workspace",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "command",
+          command: "healthy-command",
+        },
+      }),
+    ).toEqual(["healthy-plugin"]);
+  });
+
+  it("skips unreadable manifest id rows before healthy tool owners", () => {
+    const poisonedPlugin = {
+      get id(): string {
+        throw new Error("manifest activation plugin id exploded");
+      },
+      origin: "workspace" as const,
+      providers: [],
+      channels: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      contracts: {
+        tools: ["poisoned-tool"],
+      },
+    };
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        poisonedPlugin,
+        {
+          id: "healthy-tool-owner",
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          contracts: {
+            tools: ["healthy-tool"],
+          },
+          origin: "workspace",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "capability",
+          capability: "tool",
+        },
+      }),
+    ).toEqual(["healthy-tool-owner"]);
+  });
+
   it("returns capability reasons from explicit hints and manifest ownership", () => {
     mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
       plugins: [

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -1,5 +1,9 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.js";
 import { normalizePluginsConfig } from "./config-state.js";
@@ -63,6 +67,32 @@ type ResolveManifestActivationPlanParams = {
   allowRestrictiveAllowlistBypass?: boolean;
 };
 
+type ActivationPlannerManifestRecord = Pick<PluginManifestRecord, "id" | "origin"> & {
+  activation?: {
+    onAgentHarnesses?: readonly string[];
+    onCapabilities?: readonly PluginManifestActivationCapability[];
+    onChannels?: readonly string[];
+    onCommands?: readonly string[];
+    onProviders?: readonly string[];
+    onRoutes?: readonly string[];
+  };
+  channels: readonly string[];
+  commandAliases?: readonly {
+    cliCommand?: string;
+    name?: string;
+  }[];
+  contracts?: {
+    tools?: readonly string[];
+  };
+  hooks: readonly string[];
+  providers: readonly string[];
+  setup?: {
+    providers?: readonly {
+      id: string;
+    }[];
+  };
+};
+
 export function resolveManifestActivationPlan(
   params: ResolveManifestActivationPlanParams,
 ): PluginActivationPlan {
@@ -77,7 +107,11 @@ export function resolveManifestActivationPlan(
         includeDisabled: true,
       });
   const entries = registry.plugins
-    .flatMap((plugin) => {
+    .flatMap((manifestRecord) => {
+      const plugin = createActivationPlannerManifestRecord(manifestRecord);
+      if (!plugin) {
+        return [];
+      }
       if (params.origin && plugin.origin !== params.origin) {
         return [];
       }
@@ -122,7 +156,7 @@ export function resolveManifestActivationPluginIds(
 }
 
 function listManifestActivationTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   trigger: PluginActivationPlannerTrigger,
 ): PluginActivationPlannerReason[] {
   switch (trigger.kind) {
@@ -144,7 +178,7 @@ function listManifestActivationTriggerReasons(
 }
 
 function listAgentHarnessTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   runtime: string,
 ): PluginActivationPlannerReason[] {
   return listHasNormalizedValue(plugin.activation?.onAgentHarnesses, runtime, normalizeCommandId)
@@ -153,25 +187,21 @@ function listAgentHarnessTriggerReasons(
 }
 
 function listCommandTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   command: string,
 ): PluginActivationPlannerReason[] {
   return dedupeReasons([
     listHasNormalizedValue(plugin.activation?.onCommands, command, normalizeCommandId)
       ? "activation-command-hint"
       : null,
-    listHasNormalizedValue(
-      (plugin.commandAliases ?? []).flatMap((alias) => alias.cliCommand ?? alias.name),
-      command,
-      normalizeCommandId,
-    )
+    listHasNormalizedValue(listCommandAliasIds(plugin.commandAliases), command, normalizeCommandId)
       ? "manifest-command-alias"
       : null,
   ]);
 }
 
 function listProviderTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   provider: string,
 ): PluginActivationPlannerReason[] {
   return dedupeReasons([
@@ -191,8 +221,16 @@ function listProviderTriggerReasons(
   ]);
 }
 
+function listCommandAliasIds(
+  commandAliases: ActivationPlannerManifestRecord["commandAliases"],
+): string[] {
+  return (commandAliases ?? [])
+    .map((alias) => alias.cliCommand ?? alias.name)
+    .filter((value): value is string => Boolean(value));
+}
+
 function listChannelTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   channel: string,
 ): PluginActivationPlannerReason[] {
   return dedupeReasons([
@@ -206,7 +244,7 @@ function listChannelTriggerReasons(
 }
 
 function listRouteTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   route: string,
 ): PluginActivationPlannerReason[] {
   return listHasNormalizedValue(plugin.activation?.onRoutes, route, normalizeCommandId)
@@ -215,7 +253,7 @@ function listRouteTriggerReasons(
 }
 
 function listCapabilityTriggerReasons(
-  plugin: PluginManifestRecord,
+  plugin: ActivationPlannerManifestRecord,
   capability: PluginManifestActivationCapability,
 ): PluginActivationPlannerReason[] {
   switch (capability) {
@@ -279,4 +317,140 @@ function dedupeReasons(
 
 function normalizeCommandId(value: string | undefined): string {
   return normalizeOptionalLowercaseString(value) ?? "";
+}
+
+function createActivationPlannerManifestRecord(
+  plugin: PluginManifestRecord,
+): ActivationPlannerManifestRecord | null {
+  const id = normalizeOptionalString(readRecordValue(plugin, "id"));
+  const origin = normalizePluginOrigin(readRecordValue(plugin, "origin"));
+  if (!id || !origin) {
+    return null;
+  }
+
+  const activation = readActivationMetadata(readRecordValue(plugin, "activation"));
+  return {
+    id,
+    origin,
+    activation,
+    channels: readStringArray(readRecordValue(plugin, "channels")),
+    commandAliases: readCommandAliases(readRecordValue(plugin, "commandAliases")),
+    contracts: readContracts(readRecordValue(plugin, "contracts")),
+    hooks: readStringArray(readRecordValue(plugin, "hooks")),
+    providers: readStringArray(readRecordValue(plugin, "providers")),
+    setup: readSetup(readRecordValue(plugin, "setup")),
+  };
+}
+
+function readActivationMetadata(
+  value: unknown,
+): ActivationPlannerManifestRecord["activation"] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    onAgentHarnesses: readStringArray(readRecordValue(value, "onAgentHarnesses")),
+    onCapabilities: readCapabilityArray(readRecordValue(value, "onCapabilities")),
+    onChannels: readStringArray(readRecordValue(value, "onChannels")),
+    onCommands: readStringArray(readRecordValue(value, "onCommands")),
+    onProviders: readStringArray(readRecordValue(value, "onProviders")),
+    onRoutes: readStringArray(readRecordValue(value, "onRoutes")),
+  };
+}
+
+function readCommandAliases(value: unknown): ActivationPlannerManifestRecord["commandAliases"] {
+  return readArrayEntries(value)
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return null;
+      }
+      const name = normalizeOptionalString(readRecordValue(entry, "name"));
+      const cliCommand = normalizeOptionalString(readRecordValue(entry, "cliCommand"));
+      return name || cliCommand ? { name, cliCommand } : null;
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+}
+
+function readContracts(value: unknown): ActivationPlannerManifestRecord["contracts"] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return {
+    tools: readStringArray(readRecordValue(value, "tools")),
+  };
+}
+
+function readSetup(value: unknown): ActivationPlannerManifestRecord["setup"] | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const providers = readArrayEntries(readRecordValue(value, "providers"))
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return null;
+      }
+      const id = normalizeOptionalString(readRecordValue(entry, "id"));
+      return id ? { id } : null;
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+
+  return { providers };
+}
+
+function readStringArray(value: unknown): string[] {
+  return readArrayEntries(value)
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function readCapabilityArray(value: unknown): PluginManifestActivationCapability[] {
+  return readStringArray(value).filter(isPluginManifestActivationCapability);
+}
+
+function readArrayEntries(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  let length: number;
+  try {
+    length = value.length;
+  } catch {
+    return [];
+  }
+
+  const entries: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      entries.push(value[index]);
+    } catch {
+      // A poisoned manifest entry should not prevent later healthy owners from planning.
+    }
+  }
+  return entries;
+}
+
+function readRecordValue(value: unknown, key: string): unknown {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizePluginOrigin(value: unknown): PluginOrigin | undefined {
+  return value === "bundled" || value === "global" || value === "workspace" || value === "config"
+    ? value
+    : undefined;
+}
+
+function isPluginManifestActivationCapability(
+  value: string,
+): value is PluginManifestActivationCapability {
+  return value === "provider" || value === "channel" || value === "tool" || value === "hook";
 }


### PR DESCRIPTION
## Summary

- Guards manifest activation planning against unreadable manifest rows before owner policy or trigger matching runs.
- Preserves existing activation trigger behavior by snapshotting only the fields the planner already reads: id, origin, activation hints, command aliases, provider/channel/setup/tool/hook ownership.
- Adds regression coverage for poisoned activation metadata and poisoned plugin ids so one malformed row cannot block later healthy owners.
- Out of scope: changing manifest registry parsing, plugin config policy, or plugin load semantics.

## Linked context

No linked issue.

Related PRs:
- https://github.com/openclaw/openclaw/pull/90130
- https://github.com/openclaw/openclaw/pull/90135

Requested by maintainer fuzzing sweep for plugin/tool/schema/metadata crash paths.

## Real behavior proof (required for external PRs)

- Behavior addressed: manifest activation planning no longer throws when an unreadable manifest row appears before a healthy command or tool owner.
- Real environment tested: local linked OpenClaw worktree on macOS with the repo Vitest wrapper and repo oxlint wrapper.
- Exact steps or command run after this patch:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next172-rebased nodenv exec node scripts/run-vitest.mjs run src/plugins/activation-planner.test.ts --reporter=verbose`
  - `node scripts/run-oxlint.mjs src/plugins/activation-planner.ts src/plugins/activation-planner.test.ts`
  - `git diff --check origin/main...HEAD`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - `node scripts/crabbox-wrapper.mjs run -provider aws -label next172-check-changed -shell -- "pnpm check:changed"`
- Evidence after fix: activation planner test file passed with 10 tests; oxlint returned clean; diff whitespace check returned clean; autoreview reported no accepted/actionable findings.
- Observed result after fix: poisoned manifest activation/id rows are skipped and the healthy command/tool owners are still returned.
- What was not tested: full `pnpm check:changed` did not run because remote validation auth is unavailable in this environment.
- Proof limitations or environment constraints: Crabbox AWS failed before lease with coordinator `POST /v1/runs` and `POST /v1/leases` HTTP 401 unauthorized. Blacksmith Testbox also failed with `not authenticated - run 'blacksmith auth login' first`.
- Before evidence (optional but encouraged): the focused red repro failed before the fix with `manifest activation metadata exploded` and `manifest activation plugin id exploded`.

## Tests and validation

Commands run:
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next172-red nodenv exec node scripts/run-vitest.mjs run src/plugins/activation-planner.test.ts --testNamePattern="skips unreadable" --reporter=verbose` failed before the fix with the two poisoned accessor errors.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next172-rebased nodenv exec node scripts/run-vitest.mjs run src/plugins/activation-planner.test.ts --reporter=verbose` passed after rebase.
- `node scripts/run-oxlint.mjs src/plugins/activation-planner.ts src/plugins/activation-planner.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings.

Regression coverage added:
- unreadable manifest `activation` metadata before a healthy command owner
- unreadable manifest `id` before a healthy tool owner

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Malformed/unreadable manifest rows are skipped for activation planning instead of crashing the planning pass.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?
Dropping valid activation ownership metadata while sanitizing unreadable manifest rows.

How is that risk mitigated?
The snapshot keeps the planner's existing trigger and owner fields, and the full activation planner test still passes across command, provider, harness, channel, route, capability, and scoped-empty cases.

## Current review state

What is the next action?
Run CI and maintainer remote changed gate when Crabbox/Testbox auth is available.

What is still waiting on author, maintainer, CI, or external proof?
Remote `pnpm check:changed` proof is blocked by Crabbox coordinator 401 and missing Blacksmith auth.

Which bot or reviewer comments were addressed?
Local autoreview reported no accepted/actionable findings.
