### PR TITLE
fix: strip thinking signatures from entries after compaction [AI-assisted]

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -503,3 +503,82 @@ describe("shouldRotateCompactionTranscript", () => {
     ).toBe(true);
   });
 });
+
+describe("rotateTranscriptAfterCompaction strips thinking signatures", () => {
+  it("removes thinkingSignature from assistant thinking blocks in successor entries", async () => {
+    const dir = await createTmpDir();
+    const manager = SessionManager.create(dir, dir);
+    manager.appendMessage({ role: "user", content: "old user", timestamp: 1 });
+    manager.appendMessage(
+      makeAgentAssistantMessage({
+        content: [
+          {
+            type: "thinking",
+            thinking: "some reasoning",
+            thinkingSignature: "sig-abc-123",
+          } as never,
+          { type: "text", text: "old reply" },
+        ],
+        timestamp: 2,
+      }),
+    );
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept user",
+      timestamp: 3,
+    });
+    manager.appendMessage(
+      makeAgentAssistantMessage({
+        content: [
+          {
+            type: "thinking",
+            thinking: "kept reasoning",
+            thinkingSignature: "sig-def-456",
+          } as never,
+          { type: "text", text: "kept reply" },
+        ],
+        timestamp: 4,
+      }),
+    );
+    manager.appendCompaction("Summary of old.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: "post user", timestamp: 5 });
+    manager.appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "post reply" }],
+        timestamp: 6,
+      }),
+    );
+
+    const sessionFile = requireString(manager.getSessionFile(), "session file");
+    const result = await rotateTranscriptFileAfterCompaction({
+      sessionFile,
+      now: () => new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    const successorFile = requireString(result.sessionFile, "successor file");
+    const successor = SessionManager.open(successorFile);
+    const entries = successor.getEntries();
+
+    // Find all assistant message entries and verify no thinking signatures remain
+    const assistantEntries = entries.filter(
+      (e) => e.type === "message" && e.message.role === "assistant",
+    );
+    expect(assistantEntries.length).toBeGreaterThan(0);
+
+    for (const entry of assistantEntries) {
+      if (entry.type !== "message") {
+        continue;
+      }
+      const content = (entry.message as { content: unknown[] }).content;
+      for (const block of content) {
+        const record = block as Record<string, unknown>;
+        if (record.type === "thinking" || record.type === "redacted_thinking") {
+          expect(record.thinkingSignature).toBeUndefined();
+          expect(record.signature).toBeUndefined();
+          expect(record.thought_signature).toBeUndefined();
+        }
+      }
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { CompactionEntry, SessionEntry, SessionHeader } from "../sessions/index.js";
+import type {
+  CompactionEntry,
+  SessionEntry,
+  SessionHeader,
+  SessionMessageEntry,
+} from "../sessions/index.js";
 import { collectDuplicateUserMessageEntryIdsForCompaction } from "./compaction-duplicate-user-messages.js";
 import {
   readTranscriptFileState,
@@ -104,6 +109,70 @@ function findLatestCompactionIndex(entries: SessionEntry[]): number {
   return -1;
 }
 
+const THINKING_SIGNATURE_FIELDS = ["signature", "thinkingSignature", "thought_signature"] as const;
+
+/**
+ * Strip thinking signatures from all assistant message entries.
+ *
+ * After compaction, the conversation prefix changes so all pre-existing
+ * Anthropic thinking signatures become cryptographically invalid. Keeping
+ * them causes permanent `Invalid signature in thinking block` failures.
+ */
+function stripThinkingSignaturesFromEntries(entries: SessionEntry[]): SessionEntry[] {
+  let touched = false;
+  const out: SessionEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.type !== "message") {
+      out.push(entry);
+      continue;
+    }
+
+    const msgEntry = entry as SessionMessageEntry;
+    const { message } = msgEntry;
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      out.push(entry);
+      continue;
+    }
+
+    let contentChanged = false;
+    const cleanedContent = message.content.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+      const blockType = (block as { type?: unknown }).type;
+      if (blockType !== "thinking" && blockType !== "redacted_thinking") {
+        return block;
+      }
+      // Check if any signature field is present
+      const record = block as unknown as Record<string, unknown>;
+      const hasSignature = THINKING_SIGNATURE_FIELDS.some((field) => record[field] != null);
+      if (!hasSignature) {
+        return block;
+      }
+      contentChanged = true;
+      const cleaned = { ...record };
+      for (const field of THINKING_SIGNATURE_FIELDS) {
+        delete cleaned[field];
+      }
+      return cleaned;
+    });
+
+    if (!contentChanged) {
+      out.push(entry);
+      continue;
+    }
+
+    touched = true;
+    out.push({
+      ...msgEntry,
+      message: { ...message, content: cleanedContent },
+    } as SessionMessageEntry);
+  }
+
+  return touched ? out : entries;
+}
+
 function buildSuccessorEntries(params: {
   allEntries: SessionEntry[];
   branch: SessionEntry[];
@@ -176,11 +245,13 @@ function buildSuccessorEntries(params: {
     );
   }
 
-  return orderSuccessorEntries({
+  const ordered = orderSuccessorEntries({
     entries: keptEntries,
     activeBranchIds,
     originalIndexById,
   });
+
+  return stripThinkingSignaturesFromEntries(ordered);
 }
 
 function collectLatestStateEntryIds(entries: SessionEntry[]): Set<string> {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -128,7 +128,7 @@ function stripThinkingSignaturesFromEntries(entries: SessionEntry[]): SessionEnt
       continue;
     }
 
-    const msgEntry = entry as SessionMessageEntry;
+    const msgEntry = entry;
     const { message } = msgEntry;
     if (message.role !== "assistant" || !Array.isArray(message.content)) {
       out.push(entry);


### PR DESCRIPTION
## Summary

**What problem does this PR solve?**

After session compaction, pre-existing Anthropic `thinkingSignature` values become cryptographically invalid because they are bound to the original conversation prefix. The re-injected kept messages appear in a completely different conversation context, causing permanent `Invalid signature in thinking block` API failures that persist across gateway restarts.

**Why does this matter now?**

This has been observed 5+ times on OpenClaw 2026.6.1 with `claude-sonnet-4`. Sessions using extended thinking that grow large enough to trigger compaction become permanently stuck.

**What is the intended outcome?**

After compaction rotates the transcript, all thinking signatures are stripped from successor entries before writing. The next API call succeeds because unsigned thinking blocks are valid for replay.

**What is intentionally out of scope?**

- Recovery of already-corrupted session JSONL files (can be handled by `openclaw doctor` separately)
- Changes to `stripInvalidThinkingSignatures` predicate logic (the fix is at the persistence boundary, not the replay boundary)

**What does success look like?**

Sessions with extended thinking can compact without breaking subsequent API calls.

**What should reviewers focus on?**

- The `stripThinkingSignaturesFromEntries` function in `compaction-successor-transcript.ts`
- Whether all signature field variants are covered

Closes #90108

---

## Real behavior proof

Behavior addressed: After compaction, assistant thinking blocks in successor transcript entries have `thinkingSignature`/`signature`/`thought_signature` fields stripped, preventing Anthropic API rejection.

Real environment tested: macOS arm64 (Apple Silicon), Node 22, OpenClaw dev checkout (pnpm), Anthropic `claude-sonnet-4-6` with `thinking: high`

Exact steps or command run after this patch:
```bash
pnpm build
pnpm tsgo          # type-check passes
node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.ts \
  src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts   # lint passes
node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/thinking.test.ts
```

Evidence after fix:
```
✓  agents  src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts (11 tests) 54ms
   Test Files  1 passed (1)
   Tests  11 passed (11)

✓  unit-fast  src/agents/embedded-agent-runner/thinking.test.ts (34 tests) 16ms
   Test Files  1 passed (1)
   Tests  34 passed (34)
```

Observed result after fix: The new regression test creates assistant messages with `thinkingSignature` fields, runs `rotateTranscriptFileAfterCompaction()`, and asserts all signature fields (`thinkingSignature`, `signature`, `thought_signature`) are removed from thinking blocks in successor entries. All 11 compaction-successor tests pass (10 existing + 1 new).

What was not tested: Live end-to-end Anthropic API call after compaction with a real extended-thinking session. Reproducing the exact failure requires filling a context window large enough to trigger natural auto-compaction with `thinking: high` (100k+ tokens per response makes this impractical in a manual test environment). The unit test directly exercises the `buildSuccessorEntries → stripThinkingSignaturesFromEntries` code path, which is the exact persistence boundary where stale signatures were previously written.

---

*This PR was developed with AI assistance (Claude). The contributor understands the code and has verified the approach.*
