### PR TITLE
fix(crestodian): retry local gateway startup probe

### DIFF
--- a/src/crestodian/overview.test.ts
+++ b/src/crestodian/overview.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/config.js";
 import {
   formatCrestodianOverview,
   formatCrestodianStartupMessage,
   loadCrestodianOverview,
 } from "./overview.js";
+
+function buildConfigSnapshot(runtimeConfig: OpenClawConfig): ConfigFileSnapshot {
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: runtimeConfig,
+    sourceConfig: runtimeConfig,
+    resolved: runtimeConfig,
+    valid: true,
+    runtimeConfig,
+    config: runtimeConfig,
+    hash: "test-hash",
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("loadCrestodianOverview", () => {
   it("summarizes config, agents, model, tools, and gateway", async () => {
@@ -18,21 +41,7 @@ describe("loadCrestodianOverview", () => {
       },
       gateway: { port: 19001 },
     };
-    const snapshot: ConfigFileSnapshot = {
-      path: "/tmp/openclaw.json",
-      exists: true,
-      raw: "{}",
-      parsed: runtimeConfig,
-      sourceConfig: runtimeConfig,
-      resolved: runtimeConfig,
-      valid: true,
-      runtimeConfig,
-      config: runtimeConfig,
-      hash: "test-hash",
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    };
+    const snapshot = buildConfigSnapshot(runtimeConfig);
     const overview = await loadCrestodianOverview({
       env: { OPENCLAW_TEST_FAST: "1" },
       deps: {
@@ -40,8 +49,8 @@ describe("loadCrestodianOverview", () => {
         resolveConfigPath: () => "/tmp/openclaw.json",
         resolveGatewayPort: (cfg) => cfg?.gateway?.port ?? 8765,
         buildGatewayConnectionDetails: (input) => ({
-          url: `ws://127.0.0.1:${input.config.gateway?.port ?? 8765}`,
-          urlSource: "local loopback",
+          url: `wss://gateway.example.test:${input.config.gateway?.port ?? 8765}`,
+          urlSource: "remote config",
         }),
         probeLocalCommand: async (command) => ({
           command,
@@ -59,7 +68,7 @@ describe("loadCrestodianOverview", () => {
     expect(overview.agents.map((agent) => agent.id)).toEqual(["main", "work"]);
     expect(overview.tools.codex.found).toBe(true);
     expect(overview.tools.claude.found).toBe(false);
-    expect(overview.gateway.url).toBe("ws://127.0.0.1:19001");
+    expect(overview.gateway.url).toBe("wss://gateway.example.test:19001");
     expect(overview.gateway.reachable).toBe(false);
     expect(overview.references.docsPath).toMatch(/docs$/);
     expect(overview.references.sourceUrl).toBe("https://github.com/openclaw/openclaw");
@@ -74,5 +83,143 @@ describe("loadCrestodianOverview", () => {
     expect(startup).not.toContain("Codex:");
     expect(startup).not.toContain("Claude Code:");
     expect(startup).not.toContain("API keys:");
+  });
+
+  it.each(["ws://127.0.0.1:19001", "ws://127.0.1.1:19001", "ws://[::ffff:127.0.0.1]:19001"])(
+    "retries a local gateway startup probe before reporting the banner status for %s",
+    async (gatewayUrl) => {
+      vi.useFakeTimers();
+      const runtimeConfig: OpenClawConfig = {
+        agents: {
+          defaults: { model: { primary: "openai/gpt-5.2" } },
+          list: [{ id: "main", default: true }],
+        },
+        gateway: { port: 19001 },
+      };
+      const snapshot = buildConfigSnapshot(runtimeConfig);
+      const probeGatewayUrl = vi
+        .fn(
+          async (
+            url: string,
+            _opts?: { timeoutMs?: number },
+          ): Promise<{ reachable: boolean; url: string; error?: string }> => ({
+            reachable: false,
+            url,
+            error: "starting",
+          }),
+        )
+        .mockResolvedValueOnce({
+          reachable: false,
+          url: gatewayUrl,
+          error: "This operation was aborted",
+        })
+        .mockResolvedValueOnce({ reachable: true, url: gatewayUrl });
+
+      const overviewPromise = loadCrestodianOverview({
+        env: { OPENCLAW_TEST_FAST: "1" },
+        deps: {
+          readConfigFileSnapshot: async () => snapshot,
+          resolveConfigPath: () => "/tmp/openclaw.json",
+          buildGatewayConnectionDetails: () => ({
+            url: gatewayUrl,
+            urlSource: "local loopback",
+          }),
+          probeLocalCommand: async (command) => ({
+            command,
+            found: true,
+            version: `${command} 1.0.0`,
+          }),
+          probeGatewayUrl,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const overview = await overviewPromise;
+
+      expect(probeGatewayUrl).toHaveBeenCalledTimes(2);
+      expect(probeGatewayUrl).toHaveBeenNthCalledWith(2, gatewayUrl, {
+        timeoutMs: 1_500,
+      });
+      expect(overview.gateway.reachable).toBe(true);
+      expect(formatCrestodianStartupMessage(overview)).toContain("Gateway: reachable");
+    },
+  );
+
+  it("does not retry fast local gateway failures", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.2" } },
+        list: [{ id: "main", default: true }],
+      },
+      gateway: { port: 19001 },
+    };
+    const snapshot = buildConfigSnapshot(runtimeConfig);
+    const probeGatewayUrl = vi.fn(
+      async (url: string): Promise<{ reachable: boolean; url: string; error?: string }> => ({
+        reachable: false,
+        url,
+        error: "fetch failed",
+      }),
+    );
+
+    const overview = await loadCrestodianOverview({
+      env: { OPENCLAW_TEST_FAST: "1" },
+      deps: {
+        readConfigFileSnapshot: async () => snapshot,
+        resolveConfigPath: () => "/tmp/openclaw.json",
+        buildGatewayConnectionDetails: () => ({
+          url: "ws://127.0.0.1:19001",
+          urlSource: "local loopback",
+        }),
+        probeLocalCommand: async (command) => ({
+          command,
+          found: true,
+          version: `${command} 1.0.0`,
+        }),
+        probeGatewayUrl,
+      },
+    });
+
+    expect(probeGatewayUrl).toHaveBeenCalledTimes(1);
+    expect(overview.gateway.reachable).toBe(false);
+  });
+
+  it("does not retry remote gateway probes", async () => {
+    const runtimeConfig: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.2" } },
+        list: [{ id: "main", default: true }],
+      },
+      gateway: { port: 443 },
+    };
+    const snapshot = buildConfigSnapshot(runtimeConfig);
+    const probeGatewayUrl = vi.fn(
+      async (url: string): Promise<{ reachable: boolean; url: string; error?: string }> => ({
+        reachable: false,
+        url,
+        error: "offline",
+      }),
+    );
+
+    const overview = await loadCrestodianOverview({
+      env: { OPENCLAW_TEST_FAST: "1" },
+      deps: {
+        readConfigFileSnapshot: async () => snapshot,
+        resolveConfigPath: () => "/tmp/openclaw.json",
+        buildGatewayConnectionDetails: () => ({
+          url: "wss://gateway.example.test",
+          urlSource: "remote config",
+        }),
+        probeLocalCommand: async (command) => ({
+          command,
+          found: true,
+          version: `${command} 1.0.0`,
+        }),
+        probeGatewayUrl,
+      },
+    });
+
+    expect(probeGatewayUrl).toHaveBeenCalledTimes(1);
+    expect(overview.gateway.reachable).toBe(false);
   });
 });

--- a/src/crestodian/overview.ts
+++ b/src/crestodian/overview.ts
@@ -1,4 +1,5 @@
 // Crestodian overview gathers config, agent, tool, docs, source, and gateway status.
+import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   listAgentEntries,
   resolveAgentEffectiveModelPrimary,
@@ -82,6 +83,12 @@ type CrestodianOverviewDependencies = {
   resolveOpenClawReferencePaths?: typeof resolveOpenClawReferencePaths;
 };
 
+type GatewayProbe = typeof probeGatewayUrl;
+type GatewayProbeResult = Awaited<ReturnType<GatewayProbe>>;
+
+const CRESTODIAN_GATEWAY_STARTUP_RETRY_DELAY_MS = 1_000;
+const CRESTODIAN_GATEWAY_STARTUP_RETRY_TIMEOUT_MS = 1_500;
+
 function issueMessages(snapshot: ConfigFileSnapshot): string[] {
   return snapshot.issues.map((issue) => {
     const path = issue.path ? `${issue.path}: ` : "";
@@ -140,6 +147,43 @@ function resolveFastTestReferences(env: NodeJS.ProcessEnv): OpenClawReferencePat
   };
 }
 
+function isLoopbackGatewayUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    const unbracketed =
+      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
+  } catch {
+    return false;
+  }
+}
+
+function isStartupRaceProbeFailure(result: GatewayProbeResult): boolean {
+  const error = result.error?.toLowerCase() ?? "";
+  return error.includes("abort") || error.includes("timeout") || error.includes("timed out");
+}
+
+async function waitForGatewayStartupRetryDelay(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, CRESTODIAN_GATEWAY_STARTUP_RETRY_DELAY_MS);
+  });
+}
+
+async function probeStartupGatewayUrl(
+  probe: GatewayProbe,
+  url: string,
+): Promise<GatewayProbeResult> {
+  const first = await probe(url);
+  if (first.reachable || !isLoopbackGatewayUrl(url) || !isStartupRaceProbeFailure(first)) {
+    return first;
+  }
+  await waitForGatewayStartupRetryDelay();
+  const second = await probe(url, {
+    timeoutMs: CRESTODIAN_GATEWAY_STARTUP_RETRY_TIMEOUT_MS,
+  });
+  return second.reachable ? second : first;
+}
+
 export async function loadCrestodianOverview(
   opts: { env?: NodeJS.ProcessEnv; deps?: CrestodianOverviewDependencies } = {},
 ): Promise<CrestodianOverview> {
@@ -169,11 +213,12 @@ export async function loadCrestodianOverview(
   }
   const resolveReferences = deps.resolveOpenClawReferencePaths ?? resolveOpenClawReferencePaths;
   const commandProbe = deps.probeLocalCommand ?? probeLocalCommand;
+  const gatewayProbe = deps.probeGatewayUrl ?? probeGatewayUrl;
   const [codex, claude, gateway, references] = await Promise.all([
     // Probes run in parallel; each individual probe is timeout-bounded in probes.ts.
     commandProbe("codex"),
     commandProbe("claude"),
-    (deps.probeGatewayUrl ?? probeGatewayUrl)(gatewayUrl),
+    probeStartupGatewayUrl(gatewayProbe, gatewayUrl),
     resolveFastTestReferences(env) ??
       resolveReferences({
         argv1: process.argv[1],
@@ -311,7 +356,7 @@ function formatStartupGatewayStatus(overview: CrestodianOverview): string {
   if (overview.gateway.reachable) {
     return `Gateway: reachable at ${overview.gateway.url}.`;
   }
-  return `Gateway: not reachable at ${overview.gateway.url}; I already did the first probe.`;
+  return `Gateway: not reachable at ${overview.gateway.url}; the startup probe did not reach it.`;
 }
 
 function formatStartupAction(overview: CrestodianOverview): string {


### PR DESCRIPTION
## Summary
- retry local-loopback Crestodian Gateway startup probes once after a short delay
- keep remote Gateway probes single-shot, and keep probing `/healthz`
- cover retry/no-retry behavior for loopback, IPv4-mapped loopback, and remote URLs

Fixes #88254

## Verification
- `node scripts/run-vitest.mjs src/crestodian/probes.test.ts src/crestodian/overview.test.ts` (passed; 2 Vitest shards, overview 5 tests; probes 2 passed / 1 skipped)
- `git diff --check origin/main` (passed)
- `pnpm docs:list` (passed during `codex review --base origin/main`)
- `codex review --uncommitted` (clean after accepted local-loopback helper refinement)
- `codex review --base origin/main` (clean: no discrete correctness, security, or maintainability regression found)
- local delayed `/healthz` proof below

## Real behavior proof
Behavior addressed: Bare `openclaw` / Crestodian startup could show Gateway not reachable when the first loopback `/healthz` probe missed a just-starting local Gateway.

Real environment tested: Windows local checkout, Node v24.9.0, local HTTP server bound to `127.0.0.1` with a delayed first `/healthz` response.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs src/crestodian/probes.test.ts src/crestodian/overview.test.ts`
- stdin Node proof script that starts a local server, delays the first `/healthz` response past the 900ms probe budget, then calls `loadCrestodianOverview()`.

Evidence after fix:
```json
{
  "healthzHits": 2,
  "reachable": true,
  "elapsedMs": 1956,
  "startupGatewayLine": "- Gateway: reachable at ws://127.0.0.1:62843."
}
```

Observed result after fix: Crestodian retried the local Gateway startup probe, hit `/healthz` twice, and reported the Gateway as reachable instead of showing the false not-reachable banner.

What was not tested: Full local test suite and `pnpm test:docker:crestodian-first-run` were not run locally; this PR was validated with the focused Crestodian probe/overview shard, docs listing, diff check, code review gates, and a live local delayed-`/healthz` proof.
