### PR TITLE
feat(doctor): add narrow deterministic gating check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1301,6 +1301,7 @@ jobs:
               pnpm lint:webhook:no-low-level-body-read
               pnpm lint:auth:no-pairing-store-group
               pnpm lint:auth:pairing-account-scope
+              pnpm test src/commands/doctor-lint.test.ts src/flows/doctor-lint-flow.test.ts
               pnpm check:import-cycles
               # build-artifacts already runs the tsdown/runtime build for the same Node-relevant changes.
               NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -83,6 +83,47 @@ describe("runDoctorLintChecks", () => {
       },
     ]);
   });
+
+  it("keeps lint finding order deterministic when severity/check/path tie", async () => {
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [
+        check("same", async () => [
+          {
+            checkId: "same",
+            severity: "warning",
+            path: "agents.defaults.model.primary",
+            line: 8,
+            message: "zeta",
+          },
+          {
+            checkId: "same",
+            severity: "warning",
+            path: "agents.defaults.model.primary",
+            line: 8,
+            message: "alpha",
+          },
+          {
+            checkId: "same",
+            severity: "warning",
+            path: "agents.defaults.model.primary",
+            line: 3,
+            message: "middle",
+          },
+        ]),
+      ],
+    });
+
+    expect(
+      result.findings.map(
+        (finding) =>
+          `${finding.checkId}:${finding.path ?? ""}:${finding.line ?? ""}:${finding.message}`,
+      ),
+    ).toEqual([
+      "same:agents.defaults.model.primary:3:middle",
+      "same:agents.defaults.model.primary:8:alpha",
+      "same:agents.defaults.model.primary:8:zeta",
+    ]);
+  });
 });
 
 describe("exitCodeFromFindings", () => {

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -88,7 +88,23 @@ function compareFindings(a: HealthFinding, b: HealthFinding): number {
   if (idDelta !== 0) {
     return idDelta;
   }
-  return (a.path ?? "").localeCompare(b.path ?? "");
+  const pathDelta = (a.path ?? "").localeCompare(b.path ?? "");
+  if (pathDelta !== 0) {
+    return pathDelta;
+  }
+  const lineDelta = (a.line ?? -1) - (b.line ?? -1);
+  if (lineDelta !== 0) {
+    return lineDelta;
+  }
+  const columnDelta = (a.column ?? -1) - (b.column ?? -1);
+  if (columnDelta !== 0) {
+    return columnDelta;
+  }
+  const messageDelta = a.message.localeCompare(b.message);
+  if (messageDelta !== 0) {
+    return messageDelta;
+  }
+  return (a.fixHint ?? "").localeCompare(b.fixHint ?? "");
 }
 
 /** Converts findings to a process exit code using the requested minimum severity. */

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -120,7 +120,7 @@ describe("ci workflow guards", () => {
     );
   });
 
-  it("runs dependency policy guards in PR CI preflight", () => {
+  it("runs dependency and doctor lint policy guards in PR CI preflight", () => {
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
     const preflightGuards = workflow.slice(
       workflow.indexOf("guards)"),
@@ -135,6 +135,9 @@ describe("ci workflow guards", () => {
     expect(workflow).toContain("check-shrinkwrap");
     expect(shrinkwrapGuards).toContain("pnpm deps:shrinkwrap:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
+    expect(preflightGuards).toContain(
+      "pnpm test src/commands/doctor-lint.test.ts src/flows/doctor-lint-flow.test.ts",
+    );
   });
 
   it("does not rebuild Control UI after build:ci-artifacts", () => {


### PR DESCRIPTION
## Summary
This is a narrowed replacement for prior closed broad control-plane scaffolding PRs.
It keeps only deterministic doctor/control-plane gating inside existing OpenClaw seams.
It does not add a repo-root registry, queue, ledger, dashboard, artifact hierarchy, or parallel governance plane.

Changes are limited to:
- tighten `doctor --lint` deterministic finding ordering in `src/flows/doctor-lint-flow.ts` by extending tie-breakers when severity/check/path match
- add deterministic ordering regression coverage in `src/flows/doctor-lint-flow.test.ts`
- wire an existing CI guard lane in `.github/workflows/ci.yml` to run the doctor lint determinism tests
- enforce that CI guard wiring in `test/scripts/ci-workflow-guards.test.ts`

Workflow permission posture remains read-only in existing CI seams (`contents: read` already declared in the workflow/job configuration).

## Verification
- `pnpm test src/flows/doctor-lint-flow.test.ts src/commands/doctor-lint.test.ts test/scripts/ci-workflow-guards.test.ts`
- `node scripts/run-oxlint.mjs src/flows/doctor-lint-flow.ts src/flows/doctor-lint-flow.test.ts test/scripts/ci-workflow-guards.test.ts`
- `tmp_home="$(mktemp -d)"; OPENCLAW_HOME="$tmp_home" node scripts/run-node.mjs doctor --lint --json --severity-min warning --only core/doctor/final-config-validation; proof_rc=$?; rm -rf "$tmp_home"; exit "$proof_rc"`

## Real behavior proof
Behavior addressed: deterministic machine-readable doctor lint gating in existing doctor/workflow seams.
Real environment tested: local source checkout with an isolated temporary OPENCLAW_HOME and OPENCLAW_TEST_FAST unset.
Exact steps or command run after this patch: `tmp_home="$(mktemp -d)"; OPENCLAW_HOME="$tmp_home" node scripts/run-node.mjs doctor --lint --json --severity-min warning --only core/doctor/final-config-validation; proof_rc=$?; rm -rf "$tmp_home"; exit "$proof_rc"`
Evidence after fix: command emitted JSON output `{"ok":true,"checksRun":1,"checksSkipped":21,"findings":[]}`.
Observed result after fix: `doctor --lint --json` executed through the real node command path, selected the real final-config-validation check, emitted machine-readable JSON, and exited successfully.
What was not tested: full GitHub Actions run for this branch.

## Context
Refs: #90087 and #90127 (closed/superseded).
Conversation: https://app.warp.dev/conversation/ac14c3af-59df-48d6-961b-57f906c660ab

Co-Authored-By: Oz <oz-agent@warp.dev>
