### PR TITLE
fix: protect global agent config defaults [AI]

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -512,9 +512,10 @@ The agent-facing `gateway` runtime tool still refuses to rewrite
 `tools.exec.ask` or `tools.exec.security`; legacy `tools.bash.*` aliases are
 normalized to the same protected exec paths before the write.
 Agent-driven `gateway config.apply` and `gateway config.patch` edits are
-fail-closed by default: only a narrow set of prompt, model, and mention-gating
-paths are agent-tunable. New sensitive config trees are therefore protected
-unless they are deliberately added to the allowlist.
+fail-closed by default: only a narrow set of low-risk runtime tuning,
+mention-gating, and visible-reply paths are agent-tunable. Global model defaults
+and prompt overlays stay operator-controlled. New sensitive config trees are
+therefore protected unless they are deliberately added to the allowlist.
 
 For any agent/surface that handles untrusted content, deny these by default:
 

--- a/src/agents/tools/gateway-tool-guard-coverage.test.ts
+++ b/src/agents/tools/gateway-tool-guard-coverage.test.ts
@@ -58,8 +58,8 @@ function expectAllowedApply(
 
 describe("gateway config mutation guard coverage", () => {
   it("keeps a narrow allowlist of agent-tunable config paths", () => {
-    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.defaults.promptOverlays");
-    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.defaults.model");
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.promptOverlays");
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.model");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.defaults.subagents.thinking");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.list[].id");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.list[].model");
@@ -69,6 +69,20 @@ describe("gateway config mutation guard coverage", () => {
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("messages.groupChat.visibleReplies");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain(
       "messages.groupChat.unmentionedInbound",
+    );
+  });
+
+  it("blocks global prompt overlay edits via config.patch", () => {
+    expectBlocked(
+      { agents: { defaults: { promptOverlays: { gpt5: { personality: "off" } } } } },
+      { agents: { defaults: { promptOverlays: { gpt5: { personality: "best" } } } } },
+    );
+  });
+
+  it("blocks global default model edits via config.patch", () => {
+    expectBlocked(
+      { agents: { defaults: { model: { primary: "openai/gpt-5.4" } } } },
+      { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } },
     );
   });
 
@@ -539,6 +553,29 @@ describe("gateway config mutation guard coverage", () => {
         agents: {
           defaults: {
             sandbox: { mode: "off" },
+            reasoningDefault: "medium",
+          },
+        },
+      },
+    );
+  });
+
+  it("blocks config.apply replacing global prompt and model defaults", () => {
+    expectBlockedApply(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4" },
+            promptOverlays: { gpt5: { personality: "off" } },
+            reasoningDefault: "low",
+          },
+        },
+      },
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            promptOverlays: { gpt5: { personality: "best" } },
             reasoningDefault: "medium",
           },
         },

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -40,9 +40,7 @@ const CONFIG_SCHEMA_PATH_NOT_FOUND_MESSAGE = "config schema path not found";
 // trust-boundary control on `config.apply`/`config.patch`, so the runtime tool
 // must fail closed and allow only a narrow set of agent-tunable paths.
 const ALLOWED_GATEWAY_CONFIG_PATHS = [
-  // Agent prompt/model tuning.
-  "agents.defaults.promptOverlays",
-  "agents.defaults.model",
+  // Low-risk agent runtime tuning.
   "agents.defaults.thinkingDefault",
   "agents.defaults.subagents.thinking",
   "agents.defaults.reasoningDefault",


### PR DESCRIPTION
## Summary

- Removes global agent prompt overlays and global default model selection from the agent-facing gateway config mutation allowlist.
- Keeps bounded agent runtime tuning, per-agent model selection, mention gating, and visible-reply settings available through the existing guard.
- Updates the gateway security docs so the public trust-boundary description matches the runtime guard.
- Adds regression coverage for both `config.patch` and `config.apply` attempts to rewrite global prompt/model defaults.

## Linked context

Which issue does this close?

No public issue linked.

Which issues, PRs, or discussions are related?

Related: maintainer security hardening request

Was this requested by a maintainer or owner?

Yes, via maintainer-directed security hardening intake.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Agent-facing gateway config writes can no longer persistently rewrite global prompt overlays or the global default model.
- Real environment tested: Local source checkout plus a real temporary `openclaw gateway run` process with isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`.
- Exact steps or command run after this patch: `OPENCLAW_HOME="$tmp_root/home" OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" pnpm openclaw gateway run --dev --reset --port 18879 --auth none --allow-unconfigured --ws-log compact`
- Exact steps or command run after this patch: `OPENCLAW_HOME="$tmp_root/home" OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" OPENCLAW_GATEWAY_PORT=18879 pnpm tsx --eval '<createGatewayTool proof script>'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `global_prompt_overlays: REJECTED gateway config.patch cannot change protected config paths: agents.defaults.promptOverlays.gpt5.personality`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `global_default_model: REJECTED gateway config.patch cannot change protected config paths: agents.defaults.model.primary`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `allowed_reasoning_default: ALLOWED ok`
- Observed result after fix: The real gateway tool path rejects global prompt/model default mutations before forwarding the write, while a valid bounded tuning path still succeeds.
- What was not tested: No external chat/channel UI was used; the proof invoked the agent-facing gateway tool directly against a real local gateway process.
- Proof limitations or environment constraints: The gateway used auth-none in an isolated temp state dir with a dummy explicit gatewayToken only to satisfy the agent tool's explicit URL override contract; no real credentials were used.
- Before evidence (optional but encouraged): Existing guard coverage asserted these global paths were present in the allowlist.

## Tests and validation

Which commands did you run?

`node scripts/run-vitest.mjs src/agents/tools/gateway-tool-guard-coverage.test.ts`

`OPENCLAW_HOME="$tmp_root/home" OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" pnpm openclaw gateway run --dev --reset --port 18879 --auth none --allow-unconfigured --ws-log compact`

`OPENCLAW_HOME="$tmp_root/home" OPENCLAW_STATE_DIR="$tmp_root/state" OPENCLAW_CONFIG_PATH="$tmp_root/state/openclaw.json" OPENCLAW_GATEWAY_PORT=18879 pnpm tsx --eval '<createGatewayTool proof script>'`

What regression coverage was added or updated?

Updated gateway mutation guard coverage to assert global prompt overlays and global default model paths are not allowlisted, plus new blocked `config.patch` and `config.apply` cases.

What failed before this fix, if known?

Before this change, the allowlist coverage expected `agents.defaults.promptOverlays` and `agents.defaults.model` to be agent-tunable.

If no test was added, why not?

Not applicable; focused regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Agent-driven `gateway config.patch` and `gateway config.apply` calls that target global prompt overlays or global default model settings now fail as protected config changes.

Did config, environment, or migration behavior change? (`Yes/No`)

No config shape, environment variable, or migration behavior changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. The agent-facing gateway tool boundary is stricter for persistent global prompt/model config writes; auth, secrets, network, sandbox, plugin, channel, provider, and tool execution behavior are otherwise unchanged.

What is the highest-risk area?

Compatibility for workflows that asked the model to persist global default model or prompt overlay changes through the gateway tool.

How is that risk mitigated?

The stricter behavior is limited to the model-facing gateway mutation guard; trusted operators can still edit those settings through operator-controlled config surfaces.

## Current review state

What is the next action?

Await ClawSweeper re-review and GitHub CI completion.

What is still waiting on author, maintainer, CI, or external proof?

GitHub CI and maintainer review are still pending.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper proof feedback by adding real temporary gateway proof for blocked global prompt/model writes and one allowed bounded tuning write.
