### PR TITLE
fix: preserve user model on stale rollover

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1456,6 +1456,84 @@ describe("initSessionState reset policy", () => {
     expect(peekSystemEvents(existingSessionId)).toStrictEqual([]);
   });
 
+  it("preserves user model/auth overrides across implicit daily rollover (#90119)", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+    const root = await makeCaseDir("openclaw-reset-daily-user-overrides-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:user-model-rollover";
+    const existingSessionId = "daily-user-model-session";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+        providerOverride: "openai",
+        modelOverride: "gpt-4o",
+        modelOverrideSource: "user",
+        authProfileOverride: "openai:work",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 2,
+        verboseLevel: "on",
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.sessionEntry.providerOverride).toBe("openai");
+    expect(result.sessionEntry.modelOverride).toBe("gpt-4o");
+    expect(result.sessionEntry.modelOverrideSource).toBe("user");
+    expect(result.sessionEntry.authProfileOverride).toBe("openai:work");
+    expect(result.sessionEntry.authProfileOverrideSource).toBe("user");
+    expect(result.sessionEntry.authProfileOverrideCompactionCount).toBe(2);
+    expect(result.sessionEntry.verboseLevel).toBeUndefined();
+  });
+
+  it("clears auto model/auth overrides across implicit daily rollover (#90119)", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+    const root = await makeCaseDir("openclaw-reset-daily-auto-overrides-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:auto-model-rollover";
+    const existingSessionId = "daily-auto-model-session";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+        providerOverride: "openai",
+        modelOverride: "gpt-5.4",
+        modelOverrideSource: "auto",
+        authProfileOverride: "openai:fallback",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 1,
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+    expect(result.sessionEntry.authProfileOverride).toBeUndefined();
+    expect(result.sessionEntry.authProfileOverrideSource).toBeUndefined();
+    expect(result.sessionEntry.authProfileOverrideCompactionCount).toBeUndefined();
+  });
+
   it("treats sessions as stale before the daily reset when updated before yesterday's boundary", async () => {
     vi.setSystemTime(new Date(2026, 0, 18, 3, 0, 0));
     const root = await makeCaseDir("openclaw-reset-daily-edge-");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -519,11 +519,13 @@ export async function initSessionState(params: {
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      // Only carry over user-driven overrides on reset. Auto-created
-      // fallback overrides (e.g. rate-limit auth rotation, model auto-pin)
-      // must be cleared so /new and /reset actually return the session to
-      // the configured default instead of staying pinned to the auto pick
-      // (#69301).
+    }
+    if (entry) {
+      // Carry user-driven model/auth selections across both explicit resets and
+      // implicit stale rollovers. Auto-created fallback overrides (e.g.
+      // rate-limit auth rotation, model auto-pin) must be cleared so /new,
+      // /reset, and daily/idle rollover return to the configured default instead
+      // of staying pinned to the auto pick (#69301, #90119).
       const preservedSelection = resolveResetPreservedSelection({ entry });
       persistedModelOverride = preservedSelection.modelOverride;
       persistedProviderOverride = preservedSelection.providerOverride;
@@ -532,6 +534,8 @@ export async function initSessionState(params: {
       persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount =
         preservedSelection.authProfileOverrideCompactionCount;
+    }
+    if (resetTriggered && entry) {
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
       persistedLabel = entry.label;


### PR DESCRIPTION
## Summary
- preserve user-selected model/provider/auth overrides when stale daily or idle rollover creates a fresh session
- keep auto-sourced fallback overrides cleared on rollover, matching `/new` and `/reset` behavior
- add regression coverage for user vs auto model/auth rollover behavior

Fixes #90119

## Real behavior proof

- **Behavior or issue addressed:** Stale idle rollover should create a fresh OpenClaw session while preserving user-selected provider/model/auth overrides, and should clear auto-sourced fallback provider/model/auth overrides.
- **Real environment tested:** Local OpenClaw checkout on Linux, Node v24.15.0, branch `fix/90119-preserve-user-model-rollover` at head `c693ea877a8772303bda2e1469fc2ce372ea0c7e`, using an isolated temp OpenClaw state root and the production `initSessionState` path.
- **Exact steps or command run after this patch:** Ran a redacted `node_modules/.bin/tsx` harness that seeded `agents/main/sessions/sessions.json` with a one-hour-stale session (`updatedAt`, `sessionStartedAt`, and `lastInteractionAt` old enough for `reset: { mode: "idle", idleMinutes: 30 }`), invoked `initSessionState`, and then inspected the persisted store. Also ran `npm test -- --run src/auto-reply/reply/session.test.ts -t 'preserves user model/auth overrides across implicit daily rollover|clears auto model/auth overrides across implicit daily rollover'`.
- **Evidence after fix:** Redacted terminal output / runtime logs copied from the after-fix run:

```
BEGIN user override survives stale idle rollover
[session-init] store-load agent=main session=agent:main:slack:dm:u_redacted elapsedMs=2 path=/tmp/openclaw-90149-state-GFluwV/agents/main/sessions/sessions.json
TRACE freshness {
  sessionKey: 'agent:main:slack:dm:u_redacted',
  canReuseExistingEntry: true,
  skipImplicitExpiry: false,
  entryFreshness: {
    fresh: false,
    dailyResetAt: undefined,
    idleExpiresAt: 1780886143567,
    staleReason: 'idle'
  }
}
TRACE after new/reuse decision {
  isNewSession: true,
  sessionId: '645c2b54-24f2-4715-8be9-b8f2cd30f36c',
  persistedModelOverride: 'gpt-4o',
  persistedModelOverrideSource: 'user',
  persistedAuthProfileOverride: 'openai:work',
  persistedAuthProfileOverrideSource: 'user'
}

STORE <tmp-state>-GFluwV
{
  "key": "agent:main:slack:dm:<redacted-user>",
  "entry": {
    "sessionId": "<uuid>",
    "providerOverride": "openai",
    "modelOverride": "gpt-4o",
    "modelOverrideSource": "user",
    "authProfileOverride": "openai:<profile>",
    "authProfileOverrideSource": "user",
    "authProfileOverrideCompactionCount": 2,
    "sessionFile": "<tmp-state>"
  }
}

BEGIN auto fallback clears on stale idle rollover
[session-init] store-load agent=main session=agent:main:slack:dm:u_redacted elapsedMs=2 path=/tmp/openclaw-90149-state-8M6QhI/agents/main/sessions/sessions.json
TRACE freshness {
  sessionKey: 'agent:main:slack:dm:u_redacted',
  canReuseExistingEntry: true,
  skipImplicitExpiry: false,
  entryFreshness: {
    fresh: false,
    dailyResetAt: undefined,
    idleExpiresAt: 1780886205222,
    staleReason: 'idle'
  }
}
TRACE after new/reuse decision {
  isNewSession: true,
  sessionId: '9e4402bf-b816-4caf-954d-0348185fb978',
  persistedModelOverride: undefined,
  persistedModelOverrideSource: undefined,
  persistedAuthProfileOverride: undefined,
  persistedAuthProfileOverrideSource: undefined
}

STORE <tmp-state>-8M6QhI
{
  "key": "agent:main:slack:dm:<redacted-user>",
  "entry": {
    "sessionId": "<uuid>",
    "sessionFile": "<tmp-state>"
  }
}
```

- **Observed result after fix:** The stale idle rollover minted a new session ID in both cases. The user-sourced provider/model/auth override remained persisted with `modelOverrideSource: "user"` and `authProfileOverrideSource: "user"`; the auto-sourced fallback provider/model/auth fields were absent from the persisted entry after rollover.
- **What was not tested:** Browser UI and mobile channel screenshots were not tested; this proof uses redacted terminal/runtime output from the OpenClaw session-state path plus focused regression tests.

## Tests
- `npm test -- --run src/auto-reply/reply/session.test.ts -t "daily rollover"`
- `npm test -- --run src/auto-reply/reply/session.test.ts`
- `git diff --check`
- `PATH=/tmp/openclaw-bin:$PATH npm run check` (using a local wrapper that delegates `pnpm` to `corepack pnpm`, because `pnpm` is not directly on PATH in this environment)
- `npm test -- --run src/auto-reply/reply/session.test.ts -t 'preserves user model/auth overrides across implicit daily rollover|clears auto model/auth overrides across implicit daily rollover'`

Signed-off-by: Glenn-Agent <glenn_agent@163.com>
