### PR TITLE
fix(doctor): guard tool allowlist manifest metadata

### DIFF
--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -64,6 +64,74 @@ describe("collectPluginToolAllowlistWarnings", () => {
     ]);
   });
 
+  it("skips unreadable manifest ids before healthy tool owners", () => {
+    const poisonedPlugin = {
+      get id(): string {
+        throw new Error("doctor tool allowlist plugin id exploded");
+      },
+      channels: [],
+      cliBackends: [],
+      hooks: [],
+      manifestPath: "/virtual/poisoned/openclaw.plugin.json",
+      origin: "bundled",
+      providers: [],
+      rootDir: "/virtual/poisoned",
+      skills: [],
+      source: "/virtual/poisoned/index.ts",
+      contracts: {
+        tools: ["poisoned_tool"],
+      },
+    };
+
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        plugins: { allow: ["telegram"] },
+        tools: { allow: ["firecrawl_search"] },
+      },
+      manifestRegistry: {
+        diagnostics: [],
+        plugins: [poisonedPlugin, ...manifestRegistry.plugins],
+      } as unknown as PluginManifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- tools.allow references tool "firecrawl_search", owned by plugin "firecrawl", but plugins.allow does not include the owning plugin. Add "firecrawl" to plugins.allow or remove plugins.allow.',
+    ]);
+  });
+
+  it("skips unreadable manifest tool contracts before healthy tool owners", () => {
+    const poisonedPlugin = {
+      id: "poisoned-plugin",
+      channels: [],
+      cliBackends: [],
+      hooks: [],
+      manifestPath: "/virtual/poisoned/openclaw.plugin.json",
+      origin: "bundled",
+      providers: [],
+      rootDir: "/virtual/poisoned",
+      skills: [],
+      source: "/virtual/poisoned/index.ts",
+      get contracts(): { tools: string[] } {
+        throw new Error("doctor tool allowlist contracts exploded");
+      },
+    };
+
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        plugins: { allow: ["telegram"] },
+        tools: { allow: ["firecrawl_search"] },
+      },
+      manifestRegistry: {
+        diagnostics: [],
+        plugins: [poisonedPlugin, ...manifestRegistry.plugins],
+      } as unknown as PluginManifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- tools.allow references tool "firecrawl_search", owned by plugin "firecrawl", but plugins.allow does not include the owning plugin. Add "firecrawl" to plugins.allow or remove plugins.allow.',
+    ]);
+  });
+
   it("warns when a tool policy references a known plugin outside plugins.allow", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -125,8 +125,11 @@ function formatSourceLabelSubject(labels: Iterable<string>): { text: string; ver
 function collectToolOwners(registry: PluginManifestRegistry): Map<string, string[]> {
   const owners = new Map<string, string[]>();
   for (const plugin of registry.plugins) {
-    const pluginId = normalizePluginId(plugin.id);
-    for (const toolNameRaw of plugin.contracts?.tools ?? []) {
+    const pluginId = readManifestPluginId(plugin);
+    if (!pluginId) {
+      continue;
+    }
+    for (const toolNameRaw of readManifestToolContractNames(plugin)) {
       const toolName = normalizeToolName(toolNameRaw);
       if (!toolName) {
         continue;
@@ -138,7 +141,53 @@ function collectToolOwners(registry: PluginManifestRegistry): Map<string, string
 }
 
 function collectKnownPluginIds(registry: PluginManifestRegistry): Set<string> {
-  return new Set(registry.plugins.map((plugin) => normalizePluginId(plugin.id)));
+  return new Set(
+    registry.plugins
+      .map((plugin) => readManifestPluginId(plugin))
+      .filter((pluginId): pluginId is string => Boolean(pluginId)),
+  );
+}
+
+function readManifestPluginId(
+  plugin: PluginManifestRegistry["plugins"][number],
+): string | undefined {
+  try {
+    return normalizePluginId(plugin.id);
+  } catch {
+    return undefined;
+  }
+}
+
+function readManifestToolContractNames(
+  plugin: PluginManifestRegistry["plugins"][number],
+): string[] {
+  let tools: unknown;
+  try {
+    tools = plugin.contracts?.tools;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+  let length: number;
+  try {
+    length = tools.length;
+  } catch {
+    return [];
+  }
+  const entries: string[] = [];
+  for (let index = 0; index < length; index += 1) {
+    try {
+      const toolName = tools[index];
+      if (typeof toolName === "string") {
+        entries.push(toolName);
+      }
+    } catch {
+      // Doctor warnings should skip only the unreadable manifest tool row.
+    }
+  }
+  return entries;
 }
 
 function collectConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {


### PR DESCRIPTION
## Summary

- Guards doctor tool-allowlist manifest scans against unreadable plugin ids and tool-contract metadata.
- Keeps healthy manifest owners visible so doctor can still warn when a configured tool is owned by a plugin outside `plugins.allow`.
- Adds regressions for poisoned manifest `id` and `contracts` accessors ahead of a healthy tool owner.
- Out of scope: changing tool policy semantics, plugin allowlist semantics, or runtime tool loading.

## Linked context

No linked issue.

Related fuzzing PRs:
- https://github.com/openclaw/openclaw/pull/90130
- https://github.com/openclaw/openclaw/pull/90135
- https://github.com/openclaw/openclaw/pull/90136

Requested by maintainer fuzzing sweep for plugin/tool/schema/metadata crash paths.

## Real behavior proof (required for external PRs)

- Behavior addressed: doctor tool-allowlist warnings no longer throw when a manifest registry row exposes unreadable plugin ids or tool contracts before a healthy tool owner.
- Real environment tested: linked OpenClaw worktree on macOS using the repo Vitest wrapper, oxlint wrapper, and local autoreview helper.
- Exact steps or command run after this patch:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next173-rebased nodenv exec node scripts/run-vitest.mjs run src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts --reporter=verbose`
  - `node scripts/run-oxlint.mjs src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts`
  - `git diff --check origin/main...HEAD`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - `node scripts/crabbox-wrapper.mjs run -provider aws -label next173-check-changed -shell -- "pnpm check:changed"`
- Evidence after fix: the full `plugin-tool-allowlist-warnings.test.ts` file passed with 29 tests; oxlint passed; diff whitespace check passed; branch autoreview reported no accepted/actionable findings.
- Observed result after fix: poisoned manifest rows are skipped and doctor still emits the expected missing tool-owner warning for the healthy `firecrawl_search` owner.
- What was not tested: full remote `pnpm check:changed` did not run to completion because remote validation auth is unavailable in this environment.
- Proof limitations or environment constraints: Crabbox AWS failed before lease creation with coordinator `POST /v1/runs` and `POST /v1/leases` HTTP 401 unauthorized. Blacksmith Testbox failed with `not authenticated - run 'blacksmith auth login' first`.
- Before evidence (optional but encouraged): the focused red repro failed pre-fix with `doctor tool allowlist plugin id exploded` and `doctor tool allowlist contracts exploded`.

## Tests and validation

Commands run:
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next173-red nodenv exec node scripts/run-vitest.mjs run src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts --testNamePattern="skips unreadable" --reporter=verbose` failed before the fix with the poisoned accessor errors.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next173-rebased nodenv exec node scripts/run-vitest.mjs run src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts --reporter=verbose` passed after rebase.
- `node scripts/run-oxlint.mjs src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings.

Regression coverage added:
- unreadable manifest `id` before a healthy tool owner
- unreadable manifest `contracts` before a healthy tool owner

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Doctor warning collection now treats malformed manifest rows as absent metadata instead of crashing.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?
Losing a valid tool-owner warning while skipping malformed manifest metadata.

How is that risk mitigated?
The helpers only guard the manifest `id` and `contracts.tools` reads used by this warning path, and the full warning test file still passes across existing plugin allowlist and MCP sandbox warning cases.

## Current review state

What is the next action?
Run CI and maintainer remote changed gate when Crabbox/Testbox auth is available.

What is still waiting on author, maintainer, CI, or external proof?
Remote `pnpm check:changed` proof is blocked by Crabbox coordinator 401 and missing Blacksmith auth.

Which bot or reviewer comments were addressed?
Local and branch autoreview reported no accepted/actionable findings.
