### PR TITLE
docs: clarify OpenClaw vs Codex code mode

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -31,7 +31,17 @@ entirely unless you opt into the experimental sandbox exec-server path.
 
 This Codex-native feature is separate from
 [OpenClaw code mode](/reference/code-mode), which is an opt-in QuickJS-WASI
-runtime for generic OpenClaw runs with a different `exec` input shape.
+runtime for generic OpenClaw runs with a different `exec` input shape. The
+shared name causes regular confusion:
+
+- Codex Code Mode is a Codex-owned native harness feature that is normally on
+  for Codex app-server threads.
+- OpenClaw code mode is an OpenClaw-owned experimental runtime feature that is
+  normally off until `tools.codeMode.enabled: true`.
+
+For a side-by-side comparison of defaults, runtimes, policy ownership, and
+`exec` contracts, see
+[OpenClaw code mode vs Codex Code Mode](/reference/code-mode#openclaw-code-mode-vs-codex-code-mode).
 
 For the broader model/provider/runtime split, start with
 [Agent runtimes](/concepts/agent-runtimes). The short version is:

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -167,8 +167,8 @@ operators validating high-risk deployments.
 
 - Runtime: [`quickjs-wasi`](https://github.com/vercel-labs/quickjs-wasi).
 - Default state: disabled.
-- Stability: experimental OpenClaw surface; Codex Code mode is a separate stable
-  Codex harness surface.
+- Stability: experimental OpenClaw surface; Codex Code mode is a separate
+  Codex-owned harness surface that upstream Codex marks as under development.
 - Target surface: generic OpenClaw agent runs.
 - Security posture: model code is hostile.
 - User-facing promise: enabling code mode never silently falls back to broad

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -20,7 +20,7 @@ different `exec` contracts:
 
 - Codex Code Mode is enabled for Codex app-server threads unless restricted
   tool policy disables native code mode. It runs in the Codex coding harness,
-  where the model writes raw JavaScript or TypeScript source through an `exec` contract.
+  where the model writes raw JavaScript source through an `exec` contract.
 - OpenClaw code mode is disabled unless `tools.codeMode.enabled: true` is
   configured. It runs in the OpenClaw generic agent runtime, where the model
   writes JavaScript or TypeScript programs through an `exec.code` contract.
@@ -37,7 +37,7 @@ tool catalog, and the normal OpenClaw tool executor.
 | Owner                      | OpenClaw generic agent runtime                                                          | Codex app-server runtime                                                                    |
 | Default state              | Off unless `tools.codeMode.enabled: true`                                               | On for Codex app-server threads unless native code mode is restricted or disabled           |
 | Guest runtime              | `quickjs-wasi`                                                                          | Codex native coding harness                                                                 |
-| Model-visible `exec` input | `exec.code` (and `exec.command` as an alias) with JavaScript or TypeScript              | `exec` with raw JavaScript or TypeScript source code                                        |
+| Model-visible `exec` input | `exec.code` (and `exec.command` as an alias) with JavaScript or TypeScript              | `exec` with raw JavaScript source code                                                      |
 | Visible tool surface       | `exec` and `wait`, plus the hidden OpenClaw tool catalog behind guest helpers           | Codex-native code mode plus Codex-native dynamic tool surfaces                              |
 | Policy path                | Nested calls still run through normal OpenClaw tools, hooks, approvals, auth, and audit | Native Codex thread/tool policy, with OpenClaw bridging selected app-server and hook events |
 | Stability                  | Experimental OpenClaw feature                                                           | Stable Codex harness surface                                                                |

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -25,10 +25,13 @@ different `exec` contracts:
   configured. It runs in the OpenClaw generic agent runtime, where the model
   writes JavaScript or TypeScript programs through an `exec.code` contract.
 
-Codex Code Mode and Codex-native dynamic tool search are stable Codex harness
-surfaces. OpenClaw code mode is an OpenClaw-owned experimental tool-surface
-adapter for generic OpenClaw runs. It uses `quickjs-wasi`, a hidden OpenClaw
-tool catalog, and the normal OpenClaw tool executor.
+Codex Code Mode and Codex-native dynamic tool search are Codex-owned harness
+surfaces that upstream Codex still marks as under development (`code_mode` and
+`code_mode_only` are `Stage::UnderDevelopment`). OpenClaw enables them for Codex
+app-server threads but does not own their stability. OpenClaw code mode is an
+OpenClaw-owned experimental tool-surface adapter for generic OpenClaw runs. It
+uses `quickjs-wasi`, a hidden OpenClaw tool catalog, and the normal OpenClaw tool
+executor.
 
 ## OpenClaw code mode vs Codex Code Mode
 
@@ -40,7 +43,7 @@ tool catalog, and the normal OpenClaw tool executor.
 | Model-visible `exec` input | `exec.code` (and `exec.command` as an alias) with JavaScript or TypeScript              | `exec` with raw JavaScript source code                                                      |
 | Visible tool surface       | `exec` and `wait`, plus the hidden OpenClaw tool catalog behind guest helpers           | Codex-native code mode plus Codex-native dynamic tool surfaces                              |
 | Policy path                | Nested calls still run through normal OpenClaw tools, hooks, approvals, auth, and audit | Native Codex thread/tool policy, with OpenClaw bridging selected app-server and hook events |
-| Stability                  | Experimental OpenClaw feature                                                           | Stable Codex harness surface                                                                |
+| Stability                  | Experimental OpenClaw feature                                                           | Codex-owned feature; upstream marks `code_mode`/`code_mode_only` as under development       |
 
 If you are using the bundled Codex harness, see
 [Codex harness](/plugins/codex-harness) for the Codex-native side of the split.

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -20,7 +20,7 @@ different `exec` contracts:
 
 - Codex Code Mode is enabled for Codex app-server threads unless restricted
   tool policy disables native code mode. It runs in the Codex coding harness,
-  where the model writes shell commands through an `exec.command` contract.
+  where the model writes raw JavaScript or TypeScript source through an `exec` contract.
 - OpenClaw code mode is disabled unless `tools.codeMode.enabled: true` is
   configured. It runs in the OpenClaw generic agent runtime, where the model
   writes JavaScript or TypeScript programs through an `exec.code` contract.
@@ -29,6 +29,21 @@ Codex Code Mode and Codex-native dynamic tool search are stable Codex harness
 surfaces. OpenClaw code mode is an OpenClaw-owned experimental tool-surface
 adapter for generic OpenClaw runs. It uses `quickjs-wasi`, a hidden OpenClaw
 tool catalog, and the normal OpenClaw tool executor.
+
+## OpenClaw code mode vs Codex Code Mode
+
+| Topic                      | OpenClaw code mode                                                                      | Codex Code Mode                                                                             |
+| -------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Owner                      | OpenClaw generic agent runtime                                                          | Codex app-server runtime                                                                    |
+| Default state              | Off unless `tools.codeMode.enabled: true`                                               | On for Codex app-server threads unless native code mode is restricted or disabled           |
+| Guest runtime              | `quickjs-wasi`                                                                          | Codex native coding harness                                                                 |
+| Model-visible `exec` input | `exec.code` (and `exec.command` as an alias) with JavaScript or TypeScript              | `exec` with raw JavaScript or TypeScript source code                                        |
+| Visible tool surface       | `exec` and `wait`, plus the hidden OpenClaw tool catalog behind guest helpers           | Codex-native code mode plus Codex-native dynamic tool surfaces                              |
+| Policy path                | Nested calls still run through normal OpenClaw tools, hooks, approvals, auth, and audit | Native Codex thread/tool policy, with OpenClaw bridging selected app-server and hook events |
+| Stability                  | Experimental OpenClaw feature                                                           | Stable Codex harness surface                                                                |
+
+If you are using the bundled Codex harness, see
+[Codex harness](/plugins/codex-harness) for the Codex-native side of the split.
 
 ## What is this?
 

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -12,10 +12,11 @@ compact way to discover and call large tool catalogs. It is useful when the run
 has many available tools but the model is likely to need only a few of them.
 
 This page documents OpenClaw Tool Search. It is not the Codex-native tool
-search or dynamic-tools surface. Codex-native code mode, tool search, deferred
-dynamic tools, and nested tool calls are Codex-owned harness surfaces that
-upstream Codex marks as under development, and they do not depend on
-`tools.toolSearch`.
+search or dynamic-tools surface. Codex-native code mode is a Codex-owned
+harness surface that upstream Codex marks as under development
+(`code_mode`/`code_mode_only`); Codex-native tool search, deferred dynamic
+tools, and nested tool calls are separate Codex-owned surfaces that do not
+depend on `tools.toolSearch`.
 
 When enabled for OpenClaw runs, the model receives one `tool_search_code` tool
 by default. That tool runs a short JavaScript body in an isolated Node

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -13,8 +13,9 @@ has many available tools but the model is likely to need only a few of them.
 
 This page documents OpenClaw Tool Search. It is not the Codex-native tool
 search or dynamic-tools surface. Codex-native code mode, tool search, deferred
-dynamic tools, and nested tool calls are stable Codex harness surfaces and do
-not depend on `tools.toolSearch`.
+dynamic tools, and nested tool calls are Codex-owned harness surfaces that
+upstream Codex marks as under development, and they do not depend on
+`tools.toolSearch`.
 
 When enabled for OpenClaw runs, the model receives one `tool_search_code` tool
 by default. That tool runs a short JavaScript body in an isolated Node
@@ -36,7 +37,7 @@ needs the exact schema, and calls that tool through OpenClaw.
 
 Codex harness runs do not receive these experimental OpenClaw Tool Search
 controls. OpenClaw passes product capabilities to Codex as dynamic tools, and
-Codex owns the stable native code mode, native tool search, deferred dynamic
+Codex owns the native code mode, native tool search, deferred dynamic
 tools, and nested tool calls.
 
 ## How a turn runs
@@ -79,7 +80,7 @@ compacted behind the directory catalog. A direct call to an exact hidden
 directory name is hydrated from that same authorized catalog before execution.
 
 All modes are experimental. Prefer direct tool exposure for small OpenClaw tool
-catalogs, and prefer the Codex-native stable surfaces for Codex harness runs.
+catalogs, and prefer the Codex-native surfaces for Codex harness runs.
 
 There is no separate source-selection config. When Tool Search is enabled, the
 catalog includes eligible OpenClaw, MCP, and client tools after normal policy


### PR DESCRIPTION
Closes #83390

## What Problem This Solves
Readers were unclear how OpenClaw native code mode differs from Codex Code Mode. The docs also claimed Codex Code Mode is a "stable Codex harness surface", contradicting upstream Codex `Stage::UnderDevelopment` for `code_mode`/`code_mode_only`.

## Why This Change Was Made
Add a side-by-side comparison table in `docs/reference/code-mode.md` and cross-link from `docs/plugins/codex-harness.md`. Correct all stability claims — drop "stable" and align with upstream under-development stage. Split the under-development claim into two separate sentences: Codex Code Mode (`code_mode`/`code_mode_only`) is `Stage::UnderDevelopment`, while Codex-native dynamic tool search (`tool_search`/`search_tool`) is a separate surface whose flags are `Stage::Removed` compatibility no-ops (tool search is always enabled upstream) — not an under-development stage. This matches the sibling `docs/tools/tool-search.md` page, which already separates the two surfaces.

## User Impact
Readers can now understand the difference between OpenClaw code mode and Codex Code Mode at a glance, with accurate upstream stability status.

## Evidence

**`docs:list` — all 3 changed pages render:**
```
$ node scripts/docs-list.js | grep -E "code-mode|codex-harness|tool-search"
plugins/codex-harness.md - Run OpenClaw embedded agent turns through Codex harness
reference/code-mode.md - OpenClaw code mode: opt-in exec/wait tool surface
  Read when: ... explain why code mode is different from Codex Code mode ...
tools/tool-search.md - Tool Search: compact large OpenClaw tool catalogs
```

**`docs-link-audit` — no broken links:**
```
$ node scripts/docs-link-audit.mjs
broken_links=0
```

**Codex source verification (per the AGENTS Codex gate — inspected `openai/codex`):**
```
codex-rs/features/src/lib.rs   code_mode / code_mode_host / code_mode_only -> Stage::UnderDevelopment
codex-rs/features/src/lib.rs   tool_search / search_tool                  -> Stage::Removed
codex-rs/features/src/lib.rs:161  "Removed compatibility flag retained as a no-op now that tool_search is always enabled"
codex-rs/features/src/tests.rs:203  assert_eq!(Feature::ToolSearch.stage(), Stage::Removed)
codex-rs/features/src/tests.rs:759  "Under-development features enabled: code_mode, ..."
```
This confirms the corrected page: Code Mode = under development; dynamic tool search = removed compat flags (always-on), not under development.
