### PR TITLE
fix(telegram): stop duplicate fallback when dispatch fails after final reply

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2766,6 +2766,59 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).toHaveBeenCalledTimes(1);
   });
 
+  it("sends an error fallback when dispatch fails after only partial output", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "partial answer" }, { kind: "block" });
+      throw new Error("dispatch failed after partial output");
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectDeliveredReply(0, { text: "partial answer" });
+    expectDeliveredReply(
+      0,
+      {
+        text: "Something went wrong while processing your request. Please try again.",
+      },
+      1,
+    );
+  });
+
+  it("returns retryable when dispatch fails after partial output and the fallback is not delivered", async () => {
+    deliverReplies.mockResolvedValueOnce({ delivered: true });
+    deliverReplies.mockResolvedValueOnce({ delivered: false });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "partial answer" }, { kind: "block" });
+      throw new Error("dispatch failed after partial output");
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      retryDispatchErrors: true,
+      streamMode: "off",
+    });
+
+    expect(result).toMatchObject({ kind: "failed-retryable" });
+    expect((result as { error?: unknown }).error).toBeInstanceOf(Error);
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectDeliveredReply(0, { text: "partial answer" });
+    expectDeliveredReply(
+      0,
+      {
+        text: "Something went wrong while processing your request. Please try again.",
+      },
+      1,
+    );
+  });
+
   it("returns retryable when spooled replay suppresses fallback after non-silent delivery skip", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       dispatcherOptions.onSkip?.({ text: "final answer" }, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -109,10 +109,6 @@ import {
   retainTelegramGroupHistoryPromptContext,
   selectTelegramGroupHistoryAfterLastSelf,
 } from "./group-history-window.js";
-import {
-  createTelegramProgressSummaryTracker,
-  formatTelegramProgressSummaryLine,
-} from "./progress-summary.js";
 import { beginTelegramInboundEventDeliveryCorrelation } from "./inbound-event-delivery.js";
 import {
   createLaneDeliveryStateTracker,
@@ -126,6 +122,10 @@ import {
   recordOutboundMessageForPromptContext,
   withTelegramPromptContextTimestampMs,
 } from "./outbound-message-context.js";
+import {
+  createTelegramProgressSummaryTracker,
+  formatTelegramProgressSummaryLine,
+} from "./progress-summary.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -2949,9 +2949,8 @@ export const dispatchTelegramMessage = async ({
   const shouldSendFailureFallback =
     !isRoomEvent &&
     !suppressFailureFallback &&
-    (dispatchError ||
-      (!deliverySummary.delivered &&
-        (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
+    !finalAnswerDelivered &&
+    (dispatchError || deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
   if (shouldSendFailureFallback) {
     const fallbackText = dispatchError
       ? "Something went wrong while processing your request. Please try again."
@@ -3002,9 +3001,11 @@ export const dispatchTelegramMessage = async ({
   }
 
   const hasFinalResponse =
+    finalAnswerDelivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
+  const hasVisibleResponse =
     deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
   const deliveryFailureWithoutFinalResponse =
-    !deliverySummary.delivered &&
+    !finalAnswerDelivered &&
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
   const retryableDispatchFailure =
     dispatchError ??
@@ -3014,7 +3015,7 @@ export const dispatchTelegramMessage = async ({
         )
       : null);
 
-  if (statusReactionController && !hasFinalResponse) {
+  if (statusReactionController && !hasVisibleResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(
       (err: unknown) => {
         logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
@@ -3022,11 +3023,16 @@ export const dispatchTelegramMessage = async ({
     );
   }
 
-  if (retryableDispatchFailure && retryDispatchErrors && !hasFinalResponse) {
+  const shouldReturnRetryableDispatchFailure =
+    retryDispatchErrors &&
+    ((dispatchError != null && !hasFinalResponse) ||
+      (dispatchError == null && deliveryFailureWithoutFinalResponse && !hasVisibleResponse));
+
+  if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
 
-  if (!hasFinalResponse) {
+  if (!hasVisibleResponse) {
     return { kind: "completed" };
   }
 
@@ -3071,7 +3077,8 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (statusReactionController) {
-    const statusReactionOutcome = dispatchError || sentFallback ? "error" : "done";
+    const statusReactionOutcome =
+      !finalAnswerDelivered && (dispatchError != null || sentFallback) ? "error" : "done";
     void finalizeTelegramStatusReaction({
       outcome: statusReactionOutcome,
       hasFinalResponse: true,

--- a/extensions/telegram/src/reasoning-lane-coordinator.test.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.test.ts
@@ -19,7 +19,7 @@ describe("splitTelegramReasoningText", () => {
 
   it("formats tagged text when the payload is explicitly reasoning", () => {
     expect(splitTelegramReasoningText("<think>example</think>Done", true)).toEqual({
-      reasoningText: "Thinking\n\n_example_",
+      reasoningText: "🧠 _example_",
     });
   });
 


### PR DESCRIPTION
Related: #87299
Related: #89930

## What Problem This Solves

Resolves a Telegram late-dispatch boundary where a visible final reply could be followed by a generic error fallback if dispatch cleanup failed afterward.

The branch had also become unmergeable after upstream Telegram dispatch changes. This update rebases the proof harness onto current `origin/main`, resolves the conflicts, and keeps the fallback suppression tied to final-answer delivery rather than any partial/progress delivery.

## Why This Change Was Made

This adds a trusted private-QA proof scenario, `--proof-scenario late-dispatch-after-final`, and passes it into the local Telegram gateway as `OPENCLAW_TELEGRAM_QA_DISPATCH_FAULT=late-dispatch-after-final`. The Telegram hook remains gated by `OPENCLAW_BUILD_PRIVATE_QA=1`, `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1`, and the exact scenario value.

The proof runner also rejects candidate SUT checkouts that do not contain the matching Telegram QA fault hook, and the Mantis Telegram Desktop prompt tells agents to rebase onto the harness or test a merge result instead of treating an unsupported candidate run as proof. The SUT support guard now checks for the hook in the exported `dispatchTelegramMessage` dispatch path rather than accepting loose stale strings or fake dispatcher snippets (RF-003). The runtime fallback guard now suppresses duplicate generic fallback only after a final answer has been delivered, while preserving the error fallback after partial-only output failures. Spooled replay completion still treats already visible output as delivered so draft/progress output is not retried unnecessarily.

Maintainers should still decide whether carrying this private-QA runtime hook and trusted proof-runner behavior in bundled Telegram source is acceptable (RF-004, RF-005).

## User Impact

Developers and maintainers can now run a deterministic Telegram proof scenario for the late-dispatch-after-final boundary, and proof agents get a clear failure instead of misleading exact-path evidence when a candidate checkout lacks the hook.

Telegram users no longer receive a second generic error reply after a visible final answer is already delivered. If dispatch fails after only partial/block output, the existing terminal error fallback is still sent.

## Evidence

Before this update, `check-main-drift` reported `has_conflicts: true` and `sync-main` reproduced conflicts in:

- `extensions/telegram/src/bot-message-dispatch.ts`
- `extensions/telegram/src/bot-message-dispatch.test.ts`
- `scripts/e2e/telegram-user-crabbox-proof.ts`
- `test/scripts/telegram-user-crabbox-proof.test.ts`

After resolving the conflicts, `check-main-drift` reports `has_conflicts: false` against current `origin/main`; the updated branch is squashed to a single commit on top of `origin/main` (RF-002). Validation included the rebased full-file suites before the final focused guard hardening:

```text
$ pnpm exec vitest run extensions/telegram/src/bot-message-dispatch.test.ts
Test Files  1 passed (1)
     Tests  147 passed (147)
  Duration  18.83s

$ pnpm exec vitest run test/scripts/telegram-user-crabbox-proof.test.ts
Test Files  1 passed (1)
     Tests  32 passed (32)
  Duration  4.98s

$ pnpm run check:no-conflict-markers
$ node scripts/check-no-conflict-markers.mjs
```

Additional focused validation on the current head:

```text
$ pnpm exec vitest run test/scripts/telegram-user-crabbox-proof.test.ts -t "fake dispatcher option block|cleans local SUT children"
Test Files  1 passed (1)
     Tests  2 passed | 31 skipped (33)
  Duration  2.10s

$ pnpm exec vitest run extensions/telegram/src/bot-message-dispatch.test.ts -t "does not return retryable after spooled replay already showed visible output|returns retryable when dispatch fails after partial output and the fallback is not delivered|returns retryable when spooled replay suppresses fallback after non-silent delivery skip"
Test Files  1 passed (1)
     Tests  3 passed | 145 skipped (148)
  Duration  17.68s

$ git diff --check
```

Current limitations: this PR still does not include a fresh live Telegram Desktop forced late-dispatch capture (RF-001). The intended exact-path consumer remains the downstream Telegram behavior-fix proof after this harness lands or is tested as a merge result.
