### PR TITLE
fix(gateway): restrict backend self-pairing shared auth

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -116,11 +116,11 @@ Treat Gateway and node as one operator trust domain, with different roles:
 - A caller authenticated to the Gateway is trusted at Gateway scope. After pairing, node actions are trusted operator actions on that node.
 - Operator scope levels and approval-time checks are summarized in
   [Operator scopes](/gateway/operator-scopes).
-- Direct loopback backend clients authenticated with the shared gateway
-  token/password can make internal control-plane RPCs without presenting a user
-  device identity. This is not a remote or browser pairing bypass: network
-  clients, node clients, device-token clients, and explicit device identities
-  still go through pairing and scope-upgrade enforcement.
+- Direct loopback backend clients can make internal control-plane RPCs without
+  presenting a user device identity only when the gateway is explicitly running
+  without auth or when the backend presents a device token. Shared gateway
+  token/password callers can connect as trusted operators, but they do not get
+  the backend self-pairing exception that preserves self-declared scopes.
 - `sessionKey` is routing/context selection, not per-user auth.
 - Exec approvals (allowlist + ask) are guardrails for operator intent, not hostile multi-tenant isolation.
 - OpenClaw's product default for trusted single-operator setups is that host exec on `gateway`/`node` is allowed without approval prompts (`security="full"`, `ask="off"` unless you tighten it). That default is intentional UX, not a vulnerability by itself.

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -440,6 +440,24 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.deviceIdentity).toBeNull();
   });
 
+  it("prefers paired backend device auth over implicit local shared-token auth", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "paired-device-token",
+      role: "operator",
+      scopes: ["operator.read"],
+      updatedAtMs: 123,
+    });
+
+    await callGateway({ method: "sessions.list" });
+
+    expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18789");
+    expect(lastClientOptions?.token).toBeUndefined();
+    expect(lastClientOptions?.password).toBeUndefined();
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+  });
+
   it("fails before opening a websocket when backend token auth has no shared or paired credential", async () => {
     getRuntimeConfig.mockReturnValue({
       gateway: { mode: "local", bind: "loopback", auth: { mode: "token" } },

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -415,11 +415,11 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
 }): boolean {
   const mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;
   const clientName = params.opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
-  const hasSharedAuth = Boolean(params.token || params.password);
+  const hasExplicitSharedAuth = Boolean(params.opts.token || params.opts.password);
   return (
     mode === GATEWAY_CLIENT_MODES.BACKEND &&
     clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
-    hasSharedAuth &&
+    hasExplicitSharedAuth &&
     isLoopbackGatewayUrl(params.url)
   );
 }
@@ -457,6 +457,29 @@ function hasStoredOperatorDeviceAuthToken(deviceIdentity: DeviceIdentity | null)
   } catch {
     return false;
   }
+}
+
+function shouldPreferStoredDeviceAuthForGatewayCall(params: {
+  opts: CallGatewayBaseOptions;
+  url: string;
+  token?: string;
+  password?: string;
+  deviceIdentity: DeviceIdentity | null;
+}): boolean {
+  const mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;
+  const clientName = params.opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
+  const hasExplicitSharedAuth = Boolean(params.opts.token || params.opts.password);
+  const envGatewayToken = trimToUndefined(process.env.OPENCLAW_GATEWAY_TOKEN);
+  const hasImplicitEnvGatewayToken =
+    Boolean(envGatewayToken) && params.token === envGatewayToken && !params.password;
+  return (
+    mode === GATEWAY_CLIENT_MODES.BACKEND &&
+    clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
+    !hasExplicitSharedAuth &&
+    hasImplicitEnvGatewayToken &&
+    isLoopbackGatewayUrl(params.url) &&
+    hasStoredOperatorDeviceAuthToken(params.deviceIdentity)
+  );
 }
 
 function resolveGatewayCallAuth(config: OpenClawConfig) {
@@ -1029,19 +1052,28 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     opts.deviceIdentity === undefined
       ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
       : opts.deviceIdentity;
+  const preferStoredDeviceAuth = shouldPreferStoredDeviceAuthForGatewayCall({
+    opts,
+    url,
+    token,
+    password,
+    deviceIdentity,
+  });
+  const clientToken = preferStoredDeviceAuth ? undefined : token;
+  const clientPassword = preferStoredDeviceAuth ? undefined : password;
   ensureGatewayCallCanAuthenticate({
     opts,
     context,
-    token,
-    password,
+    token: clientToken,
+    password: clientPassword,
     deviceIdentity,
   });
   return await executeGatewayRequestWithScopes<T>({
     opts,
     scopes,
     url,
-    token,
-    password,
+    token: clientToken,
+    password: clientPassword,
     tlsFingerprint,
     preauthHandshakeTimeoutMs: context.config.gateway?.handshakeTimeoutMs,
     timeoutMs,

--- a/src/gateway/probe.auth.integration.test.ts
+++ b/src/gateway/probe.auth.integration.test.ts
@@ -80,17 +80,17 @@ async function seedCachedOperatorToken(scopes: string[]): Promise<void> {
 }
 
 describe("probeGateway auth integration", () => {
-  it("keeps direct local authenticated status RPCs device-bound", async () => {
+  it("does not grant direct local authenticated status RPCs without cached device auth", async () => {
     const token = requireGatewayToken();
 
-    const status = await callGateway({
-      url: `ws://127.0.0.1:${gatewayHarness.port}`,
-      token,
-      method: "status",
-      timeoutMs: 5_000,
-    });
-
-    expectRecord(status, "status response");
+    await expect(
+      callGateway({
+        url: `ws://127.0.0.1:${gatewayHarness.port}`,
+        token,
+        method: "status",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("missing scope: operator.read");
   });
 
   it("keeps first-time local authenticated probes non-mutating", async () => {

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -96,6 +96,37 @@ async function expectLocalBackendGatewayClientScopesPreserved(
   }
 }
 
+async function expectLocalBackendGatewayClientScopesCleared(
+  port: number,
+  auth: { token?: string; password?: string },
+) {
+  const ws = await openWs(port);
+  try {
+    const res = await connectReq(ws, {
+      ...auth,
+      client: { ...BACKEND_GATEWAY_CLIENT },
+      scopes: ["operator.admin"],
+      device: null,
+    });
+    expect(res.ok, JSON.stringify(res)).toBe(true);
+
+    const helloOk = res.payload as
+      | {
+          auth?: {
+            scopes?: unknown;
+          };
+        }
+      | undefined;
+    expect(helloOk?.auth?.scopes).toEqual([]);
+
+    const adminRes = await rpcReq(ws, "set-heartbeats", { enabled: false });
+    expect(adminRes.ok).toBe(false);
+    expect(adminRes.error?.message ?? "").toContain("missing scope");
+  } finally {
+    ws.close();
+  }
+}
+
 describe("gateway auth compatibility baseline", () => {
   describe("token mode", () => {
     let server: Awaited<ReturnType<typeof startGatewayServer>>;
@@ -129,8 +160,8 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { token: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-token connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { token: "secret" });
+    test("clears scopes for direct-local backend shared-token connects without device identity", async () => {
+      await expectLocalBackendGatewayClientScopesCleared(port, { token: "secret" });
     });
 
     test("returns stable token-missing details for control ui without token", async () => {
@@ -303,8 +334,8 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { password: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-password connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { password: "secret" });
+    test("clears scopes for direct-local backend shared-password connects without device identity", async () => {
+      await expectLocalBackendGatewayClientScopesCleared(port, { password: "secret" });
     });
   });
 

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -202,45 +202,6 @@ type ChatApprovalContext = {
   turnSourceThreadId?: string | number;
 };
 
-async function requestChatAllowOnceApproval(params: {
-  ws: WebSocket;
-  command: string;
-  nodeId: string;
-  context: ChatApprovalContext;
-}): Promise<string> {
-  const approvalId = crypto.randomUUID();
-  const commandArgv = params.command.split(/\s+/).filter((part) => part.length > 0);
-  const requestP = rpcReq(params.ws, "exec.approval.request", {
-    id: approvalId,
-    command: params.command,
-    commandArgv,
-    systemRunPlan: {
-      argv: commandArgv,
-      cwd: null,
-      commandText: params.command,
-      agentId: params.context.agentId,
-      sessionKey: params.context.sessionKey,
-    },
-    nodeId: params.nodeId,
-    cwd: null,
-    host: "node",
-    agentId: params.context.agentId,
-    sessionKey: params.context.sessionKey,
-    turnSourceChannel: params.context.turnSourceChannel,
-    turnSourceTo: params.context.turnSourceTo,
-    turnSourceAccountId: params.context.turnSourceAccountId,
-    turnSourceThreadId: params.context.turnSourceThreadId,
-    timeoutMs: 30_000,
-  });
-  await rpcReq(params.ws, "exec.approval.resolve", {
-    id: approvalId,
-    decision: "allow-once",
-  });
-  const requested = await requestP;
-  expect(requested.ok).toBe(true);
-  return approvalId;
-}
-
 describe("node.invoke approval bypass", () => {
   let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
   let port: number;
@@ -592,7 +553,7 @@ describe("node.invoke approval bypass", () => {
     }
   });
 
-  test("bridges no-device chat approvals across backend reconnects only for the same turn source", async () => {
+  test("blocks no-device shared-token backend chat approvals from retaining operator scopes", async () => {
     const invokeCapture = createInvokeParamCapture();
     const node = await connectLinuxNode(invokeCapture.onInvoke);
 
@@ -600,7 +561,6 @@ describe("node.invoke approval bypass", () => {
     const wsReplay = await connectTrustedBackend(["operator.write", "operator.approvals"]);
 
     try {
-      const nodeId = await getConnectedNodeIdForTest(wsRequest);
       const context: ChatApprovalContext = {
         agentId: "main",
         sessionKey: "agent:main:telegram:direct:12345",
@@ -610,39 +570,45 @@ describe("node.invoke approval bypass", () => {
         turnSourceThreadId: "42",
       };
 
-      const approvalId = await requestChatAllowOnceApproval({
-        ws: wsRequest,
+      const nodes = await rpcReq(wsRequest, "node.list", {});
+      expect(nodes.ok).toBe(false);
+      expect(nodes.error?.message ?? "").toContain("missing scope: operator.read");
+
+      const approvalId = crypto.randomUUID();
+      const request = await rpcReq(wsRequest, "exec.approval.request", {
+        id: approvalId,
         command: "echo chat",
-        nodeId,
-        context,
+        commandArgv: ["echo", "chat"],
+        systemRunPlan: {
+          argv: ["echo", "chat"],
+          cwd: null,
+          commandText: "echo chat",
+          agentId: context.agentId,
+          sessionKey: context.sessionKey,
+        },
+        nodeId: "node-without-scope",
+        cwd: null,
+        host: "node",
+        agentId: context.agentId,
+        sessionKey: context.sessionKey,
+        turnSourceChannel: context.turnSourceChannel,
+        turnSourceTo: context.turnSourceTo,
+        turnSourceAccountId: context.turnSourceAccountId,
+        turnSourceThreadId: context.turnSourceThreadId,
+        timeoutMs: 30_000,
       });
+      expect(request.ok).toBe(false);
+      expect(request.error?.message ?? "").toContain("missing scope: operator.approvals");
+
       const invoke = await rpcReq(wsReplay, "node.invoke", {
-        nodeId,
+        nodeId: "node-without-scope",
         command: "system.run",
         params: approvedChatSystemRunParams(context, approvalId),
         idempotencyKey: crypto.randomUUID(),
       });
-      expect(invoke.ok).toBe(true);
-      await expectForwardedApprovedParams({ invokeCapture, absentKey: "turnSourceTo" });
-
-      const mismatchApprovalId = await requestChatAllowOnceApproval({
-        ws: wsRequest,
-        command: "echo chat",
-        nodeId,
-        context,
-      });
-      const invokeCountBeforeMismatch = invokeCapture.count();
-      const mismatch = await rpcReq(wsReplay, "node.invoke", {
-        nodeId,
-        command: "system.run",
-        params: approvedChatSystemRunParams(context, mismatchApprovalId, {
-          turnSourceTo: "telegram:67890",
-        }),
-        idempotencyKey: crypto.randomUUID(),
-      });
-      expect(mismatch.ok).toBe(false);
-      expect(mismatch.error?.message ?? "").toContain("not valid for this client");
-      await expectNoForwardedInvoke(() => invokeCapture.count() > invokeCountBeforeMismatch);
+      expect(invoke.ok).toBe(false);
+      expect(invoke.error?.message ?? "").toContain("missing scope: operator.write");
+      await expectNoForwardedInvoke(() => invokeCapture.count() > 0);
     } finally {
       wsRequest.close();
       wsReplay.close();

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -126,7 +126,7 @@ function skipBackendSelfPairing(overrides: Partial<BackendSelfPairingParams> = {
     locality: "direct_local",
     hasBrowserOriginHeader: false,
     sharedAuthOk: true,
-    authMethod: "token",
+    authMethod: "device-token",
     ...overrides,
   });
 }
@@ -375,13 +375,35 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients", () => {
+  it("skips backend self-pairing only for dedicated local backend credentials", () => {
     expect(skipBackendSelfPairing()).toBe(true);
     expect(
       skipBackendSelfPairing({
         locality: "shared_secret_loopback_local",
       }),
     ).toBe(true);
+    expect(
+      skipBackendSelfPairing({
+        authMethod: "none",
+        sharedAuthOk: false,
+      }),
+    ).toBe(true);
+    expect(
+      skipBackendSelfPairing({
+        authMethod: "token",
+      }),
+    ).toBe(false);
+    expect(
+      skipBackendSelfPairing({
+        authMethod: "password",
+      }),
+    ).toBe(false);
+    expect(
+      skipBackendSelfPairing({
+        authMethod: "bootstrap-token",
+        sharedAuthOk: false,
+      }),
+    ).toBe(false);
     expect(
       skipBackendSelfPairing({
         locality: "remote",

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -276,9 +276,8 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (params.authMethod === "none") {
     return true;
   }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
-  return (params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth;
+  return usesDeviceTokenAuth;
 }
 
 function resolveSignatureToken(connectParams: ConnectParams): string | null {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -854,10 +854,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             hasSharedAuth,
             isLocalClient,
           });
-          // Shared token/password auth can bypass pairing for trusted operators.
-          // Device-less clients still clear self-declared scopes by default, with
-          // one narrow exception: the direct-local backend gateway-client shared-
-          // auth handoff used for in-process control-plane coordination.
+          // Shared token/password auth can connect as trusted operators, but
+          // device-less clients still clear self-declared scopes by default. The
+          // backend self-pairing exception is limited to dedicated local backend
+          // credentials so general shared secrets cannot preserve claimed scopes.
           if (
             !device &&
             !skipLocalBackendSelfPairing &&


### PR DESCRIPTION
## Summary

- Fixes #72418 by removing shared gateway `token` / `password` auth from the direct-local backend self-pairing exception.
- Keeps the existing dedicated backend paths intact: `device-token` and explicit `auth.mode = "none"` local backend connects can still skip backend self-pairing.
- Leaves `bootstrap-token` on the existing guarded pairing path instead of adding it to the backend bypass, avoiding the concern from closed PR #72419.
- Updates the gateway security docs and compatibility baseline so shared-token/password backend connects prove their self-declared scopes are cleared.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/handshake-auth-helpers.test.ts` - passed, 124 tests
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/connect-policy.test.ts` - passed, 28 tests
- `node scripts/run-vitest.mjs src/gateway/server.auth.compat-baseline.test.ts` - passed, 32 tests
- `node scripts/run-vitest.mjs src/gateway/server.node-invoke-approval-bypass.test.ts src/gateway/probe.auth.integration.test.ts src/gateway/server.sessions-send.test.ts src/gateway/call.test.ts src/gateway/server.auth.compat-baseline.test.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/connect-policy.test.ts` - passed, 21 files / 591 tests
- `pnpm exec oxfmt --check src/gateway/call.ts src/gateway/call.test.ts src/gateway/server.node-invoke-approval-bypass.test.ts src/gateway/probe.auth.integration.test.ts src/gateway/server/ws-connection/handshake-auth-helpers.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.compat-baseline.test.ts docs/gateway/security/index.md && git diff --check` - passed
- `pnpm exec oxlint src/gateway/call.ts src/gateway/call.test.ts src/gateway/server.node-invoke-approval-bypass.test.ts src/gateway/probe.auth.integration.test.ts src/gateway/server/ws-connection/handshake-auth-helpers.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.compat-baseline.test.ts` - passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` - passed
- `~/.codex/skills/codex-review/scripts/codex-review --mode local` - found one stale compatibility-baseline finding; accepted and fixed by updating `src/gateway/server.auth.compat-baseline.test.ts`, then reran affected verification successfully

## Real behavior proof

Behavior addressed: a no-Origin loopback backend client that self-declares `gateway-client` / `backend` and authenticates with the shared gateway token no longer gets the backend self-pairing exception that preserves claimed `operator.admin` scopes.

Real environment tested: local OpenClaw gateway process started from this branch with `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_PROFILE=dev pnpm openclaw gateway run --allow-unconfigured --auth token --token secret --port 19418 --bind loopback --force --ws-log compact`, then a standalone WebSocket client connected to `ws://127.0.0.1:19418` as `gateway-client` / `backend` with `auth.token = "secret"` and requested `operator.admin`.

Exact steps or command run after this patch: start the gateway command above, then run a standalone `node --input-type=module` WebSocket probe that sends a `connect` frame followed by `set-heartbeats` on the same live socket.

Evidence after fix: copied live terminal output from the standalone WebSocket probe:

```text
openclaw-72418-live-ws-proof
url=ws://127.0.0.1:19418
connect.ok=true
connect.auth.scopes=[]
set-heartbeats.ok=false
set-heartbeats.error=missing scope: operator.admin
```

Observed result after fix: the live shared-token backend connection succeeded, but the server returned empty authenticated scopes and rejected the privileged `set-heartbeats` RPC with `missing scope: operator.admin`, proving the self-declared backend identity no longer preserves the requested admin scope.

What was not tested: full cross-platform CI/Testbox execution. `pnpm check:changed` normally delegates to Testbox, but the local `crabbox` binary failed its basic help/version sanity check in this environment, so I used the supported `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1` local child mode instead.

## Notes

This intentionally does not close the broader trusted-operator model. Shared token/password operator connects can still authenticate as trusted gateway operators, but device-less shared-secret backend clients no longer preserve self-declared scopes through the backend self-pairing exception.
