### PR TITLE
fix(channels): guard legacy config rule metadata

### DIFF
--- a/src/channels/plugins/legacy-config.test.ts
+++ b/src/channels/plugins/legacy-config.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { findLegacyConfigIssues } from "../../config/legacy.js";
 import type { LegacyConfigRule } from "../../config/legacy.shared.js";
 
 const {
@@ -217,5 +218,118 @@ describe("collectChannelLegacyConfigRules", () => {
     ]);
     expect(loadBundledChannelDoctorContractApiMock).toHaveBeenCalledTimes(1);
     expect(loadBundledChannelDoctorContractApiMock).toHaveBeenCalledWith("discord");
+  });
+
+  it("skips unreadable bundled doctor contract rule rows", () => {
+    loadBundledChannelDoctorContractApiMock.mockImplementation((channelId: string) => {
+      if (channelId !== "discord") {
+        return undefined;
+      }
+      return {
+        legacyConfigRules: [
+          {
+            get path() {
+              throw new Error("bundled legacy rule path exploded");
+            },
+            message: "bad bundled rule",
+          },
+          {
+            path: ["channels", "discord", "healthy"],
+            message: "healthy bundled rule",
+          },
+        ],
+      };
+    });
+
+    const rules = collectChannelLegacyConfigRules({
+      channels: {
+        discord: {},
+      },
+    });
+
+    expect(rules).toEqual([
+      {
+        path: ["channels", "discord", "healthy"],
+        message: "healthy bundled rule",
+      },
+    ]);
+  });
+
+  it("skips unreadable bootstrap doctor rule metadata before healthy rules", () => {
+    getBootstrapChannelPluginMock.mockImplementation((channelId: string) =>
+      channelId === "matrix"
+        ? {
+            doctor: {
+              get legacyConfigRules() {
+                throw new Error("bootstrap legacy rules exploded");
+              },
+            },
+          }
+        : channelId === "slack"
+          ? {
+              doctor: {
+                legacyConfigRules: [
+                  {
+                    path: ["channels", "slack", "legacy"],
+                    message: "healthy slack rule",
+                  },
+                ],
+              },
+            }
+          : undefined,
+    );
+
+    const rules = collectChannelLegacyConfigRules({
+      channels: {
+        matrix: {},
+        slack: {},
+      },
+    });
+
+    expect(rules).toEqual([
+      {
+        path: ["channels", "slack", "legacy"],
+        message: "healthy slack rule",
+      },
+    ]);
+  });
+
+  it("treats throwing plugin rule matchers as non-matches", () => {
+    loadBundledChannelDoctorContractApiMock.mockImplementation((channelId: string) =>
+      channelId === "discord"
+        ? {
+            legacyConfigRules: [
+              {
+                path: ["channels", "discord", "legacy"],
+                message: "bad match rule",
+                match: () => {
+                  throw new Error("legacy rule match exploded");
+                },
+              },
+              {
+                path: ["channels", "discord", "healthy"],
+                message: "healthy match rule",
+              },
+            ],
+          }
+        : undefined,
+    );
+
+    const cfg = {
+      channels: {
+        discord: {
+          healthy: true,
+          legacy: true,
+        },
+      },
+    };
+    const rules = collectChannelLegacyConfigRules(cfg);
+
+    expect(findLegacyConfigIssues(cfg, undefined, rules)).toEqual([
+      {
+        path: "channels.discord.healthy",
+        message: "healthy match rule",
+      },
+    ]);
   });
 });

--- a/src/channels/plugins/legacy-config.ts
+++ b/src/channels/plugins/legacy-config.ts
@@ -40,6 +40,118 @@ function shouldIncludeLegacyRuleForTouchedPaths(
   });
 }
 
+function readLegacyConfigRule(rule: unknown): LegacyConfigRule | undefined {
+  if (!rule || typeof rule !== "object") {
+    return undefined;
+  }
+  let path: unknown;
+  let message: unknown;
+  let match: unknown;
+  let requireSourceLiteral: unknown;
+  try {
+    const candidate = rule as LegacyConfigRule;
+    path = candidate.path;
+    message = candidate.message;
+    match = candidate.match;
+    requireSourceLiteral = candidate.requireSourceLiteral;
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(path) || !path.every((entry) => typeof entry === "string")) {
+    return undefined;
+  }
+  if (typeof message !== "string") {
+    return undefined;
+  }
+  const safeRule: LegacyConfigRule = {
+    path: [...path],
+    message,
+  };
+  if (typeof match === "function") {
+    safeRule.match = (value, root) => {
+      try {
+        return match(value, root) === true;
+      } catch {
+        return false;
+      }
+    };
+  }
+  if (requireSourceLiteral === true) {
+    safeRule.requireSourceLiteral = true;
+  }
+  return safeRule;
+}
+
+function collectReadableLegacyConfigRules(rules: unknown): LegacyConfigRule[] {
+  if (!Array.isArray(rules)) {
+    return [];
+  }
+  const readableRules: LegacyConfigRule[] = [];
+  let ruleCount: number;
+  try {
+    ruleCount = rules.length;
+  } catch {
+    return readableRules;
+  }
+  for (let index = 0; index < ruleCount; index += 1) {
+    let rule: unknown;
+    try {
+      rule = rules[index];
+    } catch {
+      continue;
+    }
+    const readableRule = readLegacyConfigRule(rule);
+    if (readableRule) {
+      readableRules.push(readableRule);
+    }
+  }
+  return readableRules;
+}
+
+function readBootstrapLegacyConfigRules(channelId: ChannelId): {
+  pluginFound: boolean;
+  rules: LegacyConfigRule[];
+} {
+  const plugin = getBootstrapChannelPlugin(channelId);
+  if (!plugin) {
+    return { pluginFound: false, rules: [] };
+  }
+  let rules: unknown;
+  try {
+    rules = plugin.doctor?.legacyConfigRules;
+  } catch {
+    return { pluginFound: true, rules: [] };
+  }
+  return {
+    pluginFound: true,
+    rules: collectReadableLegacyConfigRules(rules),
+  };
+}
+
+function readBundledLegacyConfigRules(
+  contractApi: ReturnType<typeof loadBundledChannelDoctorContractApi>,
+): {
+  contractFound: boolean;
+  rules: LegacyConfigRule[];
+} {
+  if (!contractApi) {
+    return { contractFound: false, rules: [] };
+  }
+  let rules: unknown;
+  try {
+    rules = contractApi.legacyConfigRules;
+  } catch {
+    return { contractFound: true, rules: [] };
+  }
+  if (!Array.isArray(rules)) {
+    return { contractFound: false, rules: [] };
+  }
+  return {
+    contractFound: true,
+    rules: collectReadableLegacyConfigRules(rules),
+  };
+}
+
 function collectRelevantChannelIdsForTouchedPaths(params: {
   raw?: unknown;
   touchedPaths?: ReadonlyArray<ReadonlyArray<string>>;
@@ -89,19 +201,18 @@ export function collectChannelLegacyConfigRules(
   const rules: LegacyConfigRule[] = [];
   const unresolvedChannelIds: ChannelId[] = [];
   for (const channelId of channelIds) {
-    const contractApi = loadBundledChannelDoctorContractApi(channelId);
-    const contractRules = contractApi?.legacyConfigRules;
-    if (Array.isArray(contractRules)) {
-      rules.push(...contractRules);
+    const bundled = readBundledLegacyConfigRules(loadBundledChannelDoctorContractApi(channelId));
+    if (bundled.contractFound) {
+      rules.push(...bundled.rules);
       continue;
     }
 
-    const plugin = getBootstrapChannelPlugin(channelId);
-    if (plugin?.doctor?.legacyConfigRules?.length) {
-      rules.push(...plugin.doctor.legacyConfigRules);
+    const bootstrap = readBootstrapLegacyConfigRules(channelId);
+    if (bootstrap.rules.length > 0) {
+      rules.push(...bootstrap.rules);
       continue;
     }
-    if (plugin) {
+    if (bootstrap.pluginFound) {
       continue;
     }
 
@@ -111,10 +222,12 @@ export function collectChannelLegacyConfigRules(
   }
   if (unresolvedChannelIds.length > 0) {
     rules.push(
-      ...listPluginDoctorLegacyConfigRules({
-        config: raw as OpenClawConfig,
-        pluginIds: unresolvedChannelIds,
-      }),
+      ...collectReadableLegacyConfigRules(
+        listPluginDoctorLegacyConfigRules({
+          config: raw as OpenClawConfig,
+          pluginIds: unresolvedChannelIds,
+        }),
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary

- Harden channel legacy config rule collection against malformed plugin-provided doctor metadata.
- Skip unreadable rule rows, unreadable rule arrays, and throwing rule matchers instead of crashing config diagnostics.
- Preserve healthy sibling rules and existing fallback ordering between bundled doctor contracts, bootstrap plugin metadata, and registry-provided doctor output.
- Out of scope: changing the legacy config rule contract or adding compatibility for malformed config keys.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Ongoing tool/schema fuzzing hardening work.

## Real behavior proof (required for external PRs)

- Behavior addressed: channel plugin doctor metadata can no longer crash legacy config issue collection when a rule row, rule list, or matcher is malformed.
- Real environment tested: local OpenClaw source worktree on Node via nodenv, branch `fuzz-tool-schema-next175-20260604`, commit `232c3c5d027dc1b79d4fc1ad20522e2ec121e204`.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next175-full nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/legacy-config.test.ts --reporter=verbose`
- Evidence after fix: `src/channels/plugins/legacy-config.test.ts` passed 1 file / 9 tests after the patch.
- Observed result after fix: unreadable bundled/bootstrap/registry legacy rule metadata is skipped or treated as non-matching, and healthy legacy config rules are still reported.
- What was not tested: broad `pnpm check:changed` did not run because Blacksmith Testbox is not authenticated and AWS Crabbox returned coordinator 401 before lease creation.
- Proof limitations or environment constraints: broad remote validation is blocked by maintainer-runner auth in this environment.
- Before evidence: with the source fix temporarily reverted, the new repros failed with `bundled legacy rule path exploded`, `bootstrap legacy rules exploded`, and `legacy rule match exploded`.

## Tests and validation

Which commands did you run?

- `./node_modules/.bin/oxfmt --write --threads=1 src/channels/plugins/legacy-config.ts src/channels/plugins/legacy-config.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next175-full nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/legacy-config.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/legacy-config.ts src/channels/plugins/legacy-config.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git fetch origin main --prune && git rebase origin/main`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next175-rebased nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/legacy-config.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/legacy-config.ts src/channels/plugins/legacy-config.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Added coverage for unreadable bundled doctor contract rule rows.
- Added coverage for unreadable bootstrap doctor rule metadata before healthy sibling rules.
- Added coverage for plugin rule matchers that throw during issue discovery.

What failed before this fix, if known?

- `bundled legacy rule path exploded`
- `bootstrap legacy rules exploded`
- `legacy rule match exploded`

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Doctor/config diagnostics now continue past malformed plugin legacy config rule metadata.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Legacy config issue collection is more fault-tolerant, but the config contract is unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Over-skipping malformed rule metadata could hide a plugin-owned diagnostic.

How is that risk mitigated?

The patch only skips rules whose own descriptor access or matcher throws, while preserving readable sibling rules and existing bundled/bootstrap/registry precedence.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Broad `pnpm check:changed` proof still needs authenticated Blacksmith Testbox or Crabbox access.

Which bot or reviewer comments were addressed?

Local and branch autoreview both passed with no accepted findings.
