### PR TITLE
fix(agent-runtime): guard prompt cache tool names

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.test.ts
@@ -17,6 +17,23 @@ describe("prompt cache observability", () => {
     ).toEqual(["read", "write"]);
   });
 
+  it("skips unreadable prompt cache tool names", () => {
+    const unreadableTool = Object.defineProperty({}, "name", {
+      get() {
+        throw new Error("prompt cache tool name exploded");
+      },
+    });
+
+    expect(
+      collectPromptCacheToolNames([
+        { name: "read" },
+        unreadableTool as { name?: string },
+        { name: 42 } as { name?: string },
+        { name: " write " },
+      ]),
+    ).toEqual(["read", "write"]);
+  });
+
   it("tracks cache-relevant changes and reports a real cache-read drop", () => {
     const first = beginPromptCacheObservation({
       sessionId: "session-1",

--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -137,8 +137,22 @@ function diffSnapshots(
   return changes.length > 0 ? changes : null;
 }
 
+function readPromptCacheToolName(tool: { name?: unknown }): string | undefined {
+  try {
+    const name = tool.name;
+    if (typeof name !== "string") {
+      return undefined;
+    }
+    return name.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function collectPromptCacheToolNames(tools: Array<{ name?: string }>): string[] {
-  return tools.map((tool) => tool.name?.trim()).filter((name): name is string => Boolean(name));
+  return tools
+    .map((tool) => readPromptCacheToolName(tool))
+    .filter((name): name is string => Boolean(name));
 }
 
 export function beginPromptCacheObservation(params: {


### PR DESCRIPTION
## Summary

- Harden prompt-cache observability against hostile tool-name descriptors.
- Treat unreadable and non-string tool names as absent while preserving the existing trim/filter behavior for healthy tools.
- Keep the change scoped to diagnostics metadata; runtime tool behavior is unchanged.
- Out of scope: changing prompt-cache affinity keys, cache-break thresholds, or tool projection rules.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Ongoing tool/schema fuzzing hardening work.

## Real behavior proof (required for external PRs)

- Behavior addressed: prompt-cache diagnostics can no longer crash when an active tool exposes an unreadable `name` descriptor.
- Real environment tested: local OpenClaw source worktree on Node via nodenv, branch `fuzz-tool-schema-next176-20260604`, commit `b7294fa9214c705340688020b9e30ddaa2740d20`.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next176-rebased nodenv exec node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=verbose`
- Evidence after fix: `src/agents/embedded-agent-runner/prompt-cache-observability.test.ts` passed 1 file / 8 tests after the patch.
- Observed result after fix: unreadable and non-string prompt-cache tool names are skipped, while readable names are still trimmed and included.
- What was not tested: broad `pnpm check:changed` did not run because Blacksmith Testbox is not authenticated and AWS Crabbox returned coordinator 401 before lease creation.
- Proof limitations or environment constraints: broad remote validation is blocked by maintainer-runner auth in this environment.
- Before evidence: the new focused repro failed pre-fix with `prompt cache tool name exploded`.

## Tests and validation

Which commands did you run?

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next176-red nodenv exec node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --testNamePattern="skips unreadable" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next176-green-target nodenv exec node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --testNamePattern="skips unreadable" --reporter=verbose`
- `./node_modules/.bin/oxfmt --write --threads=1 src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next176-full nodenv exec node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git fetch origin main --prune && git rebase origin/main`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next176-rebased nodenv exec node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/prompt-cache-observability.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/prompt-cache-observability.ts src/agents/embedded-agent-runner/prompt-cache-observability.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Added coverage that `collectPromptCacheToolNames()` skips unreadable and non-string tool-name metadata while preserving healthy names.

What failed before this fix, if known?

- `prompt cache tool name exploded`

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No. This only changes diagnostic metadata collection.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Prompt-cache diagnostics could omit a tool name if its descriptor is malformed.

How is that risk mitigated?

Only unreadable or non-string names are skipped, and this path only feeds observability snapshots, not runtime tool availability.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Broad `pnpm check:changed` proof still needs authenticated Blacksmith Testbox or Crabbox access.

Which bot or reviewer comments were addressed?

Local and branch autoreview both passed with no accepted findings.
