### PR TITLE
fix(imessage): frame imsg rpc stdout on newline only so U+2028 does not split JSON-RPC responses (#89830)

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -91,4 +91,21 @@ describe("IMessageRpcClient stdout framing", () => {
     await expect(firstResponse).resolves.toEqual({ ok: "first" });
     await expect(secondResponse).resolves.toEqual({ ok: "second" });
   });
+
+  it("detaches the stdout reader on stop so a stale child cannot emit late notifications (#89830)", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const onNotification = vi.fn();
+    const { IMessageRpcClient } = await import("./client.js");
+    const client = new IMessageRpcClient({ onNotification });
+
+    await client.start();
+    await client.stop();
+
+    // Simulate a not-yet-exited imsg child emitting a complete notification
+    // after stop(); the detached reader must ignore it.
+    child.stdout.write('{"jsonrpc":"2.0","method":"messages.changed","params":{}}\n');
+
+    expect(onNotification).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -25,8 +25,14 @@ class MockChildProcess extends EventEmitter {
   }
 }
 
-function createMockChildProcess(): ChildProcessWithoutNullStreams {
-  return new MockChildProcess() as unknown as ChildProcessWithoutNullStreams;
+type MockChildHandle = ChildProcessWithoutNullStreams & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+};
+
+function createMockChildProcess(): MockChildHandle {
+  return new MockChildProcess() as unknown as MockChildHandle;
 }
 
 describe("IMessageRpcClient stdout framing", () => {

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,0 +1,88 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
+});
+
+class MockChildProcess extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  killed = false;
+
+  kill(_signal?: NodeJS.Signals | number): boolean {
+    this.killed = true;
+    return true;
+  }
+}
+
+function createMockChildProcess(): ChildProcessWithoutNullStreams {
+  return new MockChildProcess() as unknown as ChildProcessWithoutNullStreams;
+}
+
+describe("IMessageRpcClient stdout framing", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    vi.stubEnv("NODE_ENV", "");
+    vi.stubEnv("VITEST", "");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(() => {
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
+  it("resolves a newline-delimited response that contains a raw U+2028 in JSON text", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const { IMessageRpcClient } = await import("./client.js");
+    const client = new IMessageRpcClient();
+    const separator = String.fromCharCode(0x2028);
+
+    await client.start();
+    const responsePromise = client.request<{ messages: Array<{ text: string }> }>(
+      "messages.history",
+    );
+
+    child.stdout.write(
+      `{"jsonrpc":"2.0","id":1,"result":{"messages":[{"text":"a${separator}b"}]}}\n`,
+    );
+
+    await expect(responsePromise).resolves.toEqual({
+      messages: [{ text: `a${separator}b` }],
+    });
+  });
+
+  it("still splits multiple responses from the same stdout chunk on newline only", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const { IMessageRpcClient } = await import("./client.js");
+    const client = new IMessageRpcClient();
+
+    await client.start();
+    const firstResponse = client.request<{ ok: string }>("first");
+    const secondResponse = client.request<{ ok: string }>("second");
+
+    child.stdout.write(
+      '{"jsonrpc":"2.0","id":1,"result":{"ok":"first"}}\n' +
+        '{"jsonrpc":"2.0","id":2,"result":{"ok":"second"}}\n',
+    );
+
+    await expect(firstResponse).resolves.toEqual({ ok: "first" });
+    await expect(secondResponse).resolves.toEqual({ ok: "second" });
+  });
+});

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -67,6 +67,9 @@ export class IMessageRpcClient {
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
+  // Removable so stop() can detach it before retries; a stale imsg child must
+  // not keep feeding handleLine()/onNotification after stop() (#89830).
+  private stdoutDataHandler: ((chunk: string) => void) | null = null;
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -96,7 +99,7 @@ export class IMessageRpcClient {
     });
     this.child = child;
     child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
+    const stdoutDataHandler = (chunk: string) => {
       this.stdoutBuffer += chunk;
       let newlineIndex = this.stdoutBuffer.indexOf("\n");
       while (newlineIndex >= 0) {
@@ -108,7 +111,9 @@ export class IMessageRpcClient {
         }
         newlineIndex = this.stdoutBuffer.indexOf("\n");
       }
-    });
+    };
+    this.stdoutDataHandler = stdoutDataHandler;
+    child.stdout.on("data", stdoutDataHandler);
 
     child.stderr?.on("data", (chunk) => {
       const lines = chunk.toString().split(/\r?\n/);
@@ -144,6 +149,12 @@ export class IMessageRpcClient {
       return;
     }
     this.stdoutBuffer = "";
+    // Detach the stdout reader before the kill race so a not-yet-exited imsg
+    // child cannot feed late notifications into the next retry window (#89830).
+    if (this.stdoutDataHandler) {
+      this.child.stdout?.off("data", this.stdoutDataHandler);
+      this.stdoutDataHandler = null;
+    }
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -1,5 +1,4 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { createInterface, type Interface } from "node:readline";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -67,7 +66,7 @@ export class IMessageRpcClient {
   private readonly closed: Promise<void>;
   private closedResolve: (() => void) | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
-  private reader: Interface | null = null;
+  private stdoutBuffer = "";
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -96,14 +95,19 @@ export class IMessageRpcClient {
       stdio: ["pipe", "pipe", "pipe"],
     });
     this.child = child;
-    this.reader = createInterface({ input: child.stdout });
-
-    this.reader.on("line", (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        return;
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      this.stdoutBuffer += chunk;
+      let newlineIndex = this.stdoutBuffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const rawLine = this.stdoutBuffer.slice(0, newlineIndex);
+        this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+        const trimmed = rawLine.trim();
+        if (trimmed) {
+          this.handleLine(trimmed);
+        }
+        newlineIndex = this.stdoutBuffer.indexOf("\n");
       }
-      this.handleLine(trimmed);
     });
 
     child.stderr?.on("data", (chunk) => {
@@ -139,8 +143,7 @@ export class IMessageRpcClient {
     if (!this.child) {
       return;
     }
-    this.reader?.close();
-    this.reader = null;
+    this.stdoutBuffer = "";
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;


### PR DESCRIPTION
## Summary

- iMessage channel head-of-line blocks when a valid `imsg rpc --json` response carries a raw U+2028 inside a JSON string and the stdout framing splits it before the pending request id resolves.
- Frame `imsg` stdout on `\n` only so JSON-RPC payloads stay intact even when message text contains U+2028/U+2029.
- Keep the change plugin-local with no config or stderr handling changes.

## Root Cause

- `extensions/imessage/src/client.ts` previously created a `node:readline` interface for `child.stdout` and parsed each emitted line as one JSON-RPC message.
- That meant stdout framing depended on readline line boundaries instead of the `imsg rpc --json` contract that emits one JSON object per trailing newline.
- When a response was fragmented before `JSON.parse`, each fragment failed parsing, `this.pending` never saw the matching `id`, and the request timed out while the channel retried the same work.

## Changes

- Replace the readline-based stdout reader in `extensions/imessage/src/client.ts` with a manual UTF-8 buffer that splits only on `\n`.
- Remove the dedicated readline `Interface` state and clear the buffered stdout state during `stop()`.
- Leave stderr handling, stdin `EPIPE` handling, and close/error rejection behavior untouched.

## Test

- `pnpm --config.verify-deps-before-run=false test extensions/imessage/src/client.test.ts extensions/imessage/src/status.test.ts -- --reporter=verbose`
- Passed: 2 test files, 14 tests.
- Added coverage that a single `\n`-terminated stdout response containing raw U+2028 resolves the pending request intact.
- Added coverage that normal multi-message batching in one stdout chunk still splits correctly on `\n`.

## Notes

- Scope is limited to issue #89830 in the bundled iMessage plugin; no new config or cross-plugin behavior changes.
- `imsg rpc --json` is newline-delimited, so `\n`-only framing matches the transport contract more directly than a generic readline layer.
- U+2028 inside JSON strings is valid JSON text per RFC 8259, so preserving it inside the buffered line is the correct transport behavior.

Closes #89830
