### PR TITLE
fix(channels): guard pairing adapter metadata

### DIFF
--- a/src/channels/plugins/pairing.test.ts
+++ b/src/channels/plugins/pairing.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { getPairingAdapter, listPairingChannels } from "./pairing.js";
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
+
+describe("channel pairing adapters", () => {
+  it("skips plugins with unreadable pairing metadata", () => {
+    const registry = createEmptyPluginRegistry();
+    const brokenPlugin = Object.defineProperties(
+      {
+        id: "broken",
+        meta: { label: "Broken" },
+      },
+      {
+        pairing: {
+          get() {
+            throw new Error("channel pairing getter exploded");
+          },
+        },
+      },
+    );
+    registry.channels = [
+      {
+        pluginId: "broken",
+        plugin: brokenPlugin as never,
+        source: "test",
+      },
+      {
+        pluginId: "healthy",
+        plugin: {
+          id: "healthy",
+          meta: { label: "Healthy" },
+          pairing: { idLabel: "healthyUserId" },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listPairingChannels()).toEqual(["healthy"]);
+    expect(getPairingAdapter("broken")).toBeNull();
+    expect(getPairingAdapter("healthy")?.idLabel).toBe("healthyUserId");
+  });
+});

--- a/src/channels/plugins/pairing.ts
+++ b/src/channels/plugins/pairing.ts
@@ -4,16 +4,26 @@ import type { ChannelId } from "./channel-id.types.js";
 import type { ChannelPairingAdapter } from "./pairing.types.js";
 import { getChannelPlugin, listChannelPlugins } from "./registry.js";
 
+function readPairingAdapter(plugin: {
+  pairing?: ChannelPairingAdapter;
+}): ChannelPairingAdapter | null {
+  try {
+    return plugin.pairing ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function listPairingChannels(): ChannelId[] {
   // Channel docking: pairing support is declared via plugin.pairing.
   return listChannelPlugins()
-    .filter((plugin) => plugin.pairing)
+    .filter((plugin) => readPairingAdapter(plugin))
     .map((plugin) => plugin.id);
 }
 
 export function getPairingAdapter(channelId: ChannelId): ChannelPairingAdapter | null {
   const plugin = getChannelPlugin(channelId);
-  return plugin?.pairing ?? null;
+  return plugin ? readPairingAdapter(plugin) : null;
 }
 
 export function requirePairingAdapter(channelId: ChannelId): ChannelPairingAdapter {


### PR DESCRIPTION
## Summary

- Harden channel pairing adapter lookup against malformed plugin metadata.
- Treat a throwing `plugin.pairing` descriptor as unsupported for that plugin instead of crashing pairing channel listing or direct adapter lookup.
- Preserve healthy pairing-enabled channels and the existing `requirePairingAdapter()` behavior for unsupported channels.
- Out of scope: changing pairing store behavior, approval flows, or channel plugin registry ordering.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Ongoing tool/schema fuzzing hardening work.

## Real behavior proof (required for external PRs)

- Behavior addressed: pairing channel enumeration and adapter lookup can no longer crash when one loaded channel plugin exposes an unreadable `pairing` descriptor.
- Real environment tested: local OpenClaw source worktree on Node via nodenv, branch `fuzz-tool-schema-next177-20260604`, commit `6f416ef9e2ab4dce11ea2bd3f732bac45305ec09`.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next177-rebased nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/pairing.test.ts --reporter=verbose`
- Evidence after fix: `src/channels/plugins/pairing.test.ts` passed 1 file / 1 test after the patch.
- Observed result after fix: the broken plugin is skipped, the healthy pairing channel is still listed, `getPairingAdapter("broken")` returns `null`, and the healthy adapter still resolves.
- What was not tested: broad `pnpm check:changed` did not run because Blacksmith Testbox is not authenticated and AWS Crabbox returned coordinator 401 before lease creation.
- Proof limitations or environment constraints: broad remote validation is blocked by maintainer-runner auth in this environment.
- Before evidence: the new focused repro failed pre-fix with `channel pairing getter exploded`.

## Tests and validation

Which commands did you run?

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next177-red nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/pairing.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next177-green nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/pairing.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --write --threads=1 src/channels/plugins/pairing.ts src/channels/plugins/pairing.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next177-full nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/pairing.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/pairing.ts src/channels/plugins/pairing.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git fetch origin main --prune && git rebase origin/main`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next177-rebased nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/pairing.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/pairing.ts src/channels/plugins/pairing.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Added coverage for a broken channel plugin whose `pairing` getter throws while a healthy pairing channel remains available.

What failed before this fix, if known?

- `channel pairing getter exploded`

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Pairing listing and adapter lookup now continue past a malformed plugin pairing descriptor.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

A plugin with a broken pairing descriptor is treated as not supporting pairing.

How is that risk mitigated?

Only descriptor-read failures are swallowed; valid adapters still resolve, and `requirePairingAdapter()` still throws for channels without readable pairing support.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Broad `pnpm check:changed` proof still needs authenticated Blacksmith Testbox or Crabbox access.

Which bot or reviewer comments were addressed?

Local and branch autoreview both passed with no accepted findings.
