### PR TITLE
fix(channels): guard loaded channel registry metadata

### DIFF
--- a/src/channels/plugins/registry-loaded-read.ts
+++ b/src/channels/plugins/registry-loaded-read.ts
@@ -11,16 +11,27 @@ import type { ChannelId } from "./types.public.js";
 function coerceLoadedChannelPlugin(
   plugin: ActiveChannelPluginRuntimeShape | null | undefined,
 ): ChannelPlugin | undefined {
-  const id = normalizeOptionalString(plugin?.id) ?? "";
-  if (!plugin || !id) {
+  if (!plugin || typeof plugin !== "object" || !readLoadedChannelId(plugin)) {
     return undefined;
   }
-  if (!plugin.meta || typeof plugin.meta !== "object") {
-    // Normalize optional metadata for callers that inspect labels/capabilities
-    // without requiring a full registry view materialization.
-    plugin.meta = {};
+  try {
+    if (!plugin.meta || typeof plugin.meta !== "object") {
+      // Normalize optional metadata for callers that inspect labels/capabilities
+      // without requiring a full registry view materialization.
+      plugin.meta = {};
+    }
+  } catch {
+    return undefined;
   }
   return plugin as ChannelPlugin;
+}
+
+function readLoadedChannelId(plugin: ActiveChannelPluginRuntimeShape): string {
+  try {
+    return normalizeOptionalString(plugin.id) ?? "";
+  } catch {
+    return "";
+  }
 }
 
 /**
@@ -37,7 +48,7 @@ export function getLoadedChannelPluginForRead(id: ChannelId): ChannelPlugin | un
   }
   for (const entry of registry.channels) {
     const plugin = coerceLoadedChannelPlugin(entry?.plugin);
-    if (plugin && plugin.id === resolvedId) {
+    if (plugin && readLoadedChannelId(plugin) === resolvedId) {
       return plugin;
     }
   }

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -34,23 +34,51 @@ type ChannelPluginView = {
 function coerceLoadedChannelPlugin(
   plugin: ActiveChannelPluginRuntimeShape | null | undefined,
 ): LoadedChannelPlugin | null {
-  const id = normalizeOptionalString(plugin?.id) ?? "";
-  if (!plugin || !id) {
+  if (!plugin || typeof plugin !== "object") {
     return null;
   }
-  if (!plugin.meta || typeof plugin.meta !== "object") {
-    // Loaded plugin metadata is optional at the runtime-state boundary, but
-    // channel sorting expects an object so normalize it once at read time.
-    plugin.meta = {};
+  const id = readLoadedChannelId(plugin);
+  if (!id) {
+    return null;
   }
-  return plugin as LoadedChannelPlugin;
+  return normalizeLoadedChannelMeta(plugin) ? (plugin as LoadedChannelPlugin) : null;
+}
+
+function readLoadedChannelId(plugin: ActiveChannelPluginRuntimeShape): string {
+  try {
+    return normalizeOptionalString(plugin.id) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function normalizeLoadedChannelMeta(plugin: ActiveChannelPluginRuntimeShape): boolean {
+  try {
+    if (!plugin.meta || typeof plugin.meta !== "object") {
+      // Loaded plugin metadata is optional at the runtime-state boundary, but
+      // channel sorting expects an object so normalize it once at read time.
+      plugin.meta = {};
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readLoadedChannelOrder(plugin: LoadedChannelPlugin): number | undefined {
+  try {
+    const order = plugin.meta.order;
+    return typeof order === "number" && Number.isFinite(order) ? order : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function dedupeChannels(channels: LoadedChannelPlugin[]): LoadedChannelPlugin[] {
   const seen = new Set<string>();
   const resolved: LoadedChannelPlugin[] = [];
   for (const plugin of channels) {
-    const id = normalizeOptionalString(plugin.id) ?? "";
+    const id = readLoadedChannelId(plugin);
     if (!id || seen.has(id)) {
       continue;
     }
@@ -76,25 +104,37 @@ function resolveChannelPlugins(): ChannelPluginView {
   }
 
   const sorted = dedupeChannels(channelPlugins).toSorted((a, b) => {
-    const indexA = CHAT_CHANNEL_ORDER.indexOf(a.id);
-    const indexB = CHAT_CHANNEL_ORDER.indexOf(b.id);
+    const idA = readLoadedChannelId(a);
+    const idB = readLoadedChannelId(b);
+    const indexA = CHAT_CHANNEL_ORDER.indexOf(idA);
+    const indexB = CHAT_CHANNEL_ORDER.indexOf(idB);
     // Explicit plugin order wins; known built-ins keep their product order;
     // unknown extension channels sort after them by id for deterministic lists.
-    const orderA = a.meta.order ?? (indexA === -1 ? 999 : indexA);
-    const orderB = b.meta.order ?? (indexB === -1 ? 999 : indexB);
+    const orderA = readLoadedChannelOrder(a) ?? (indexA === -1 ? 999 : indexA);
+    const orderB = readLoadedChannelOrder(b) ?? (indexB === -1 ? 999 : indexB);
     if (orderA !== orderB) {
       return orderA - orderB;
     }
-    return a.id.localeCompare(b.id);
+    return idA.localeCompare(idB);
   });
   const byId = new Map<string, LoadedChannelPlugin>();
   const entriesById = new Map<string, LoadedChannelPluginEntry>();
-  const unsortedEntriesById = new Map(pluginEntries.map((entry) => [entry.plugin.id, entry]));
+  const unsortedEntriesById = new Map<string, LoadedChannelPluginEntry>();
+  for (const entry of pluginEntries) {
+    const id = readLoadedChannelId(entry.plugin);
+    if (id) {
+      unsortedEntriesById.set(id, entry);
+    }
+  }
   for (const plugin of sorted) {
-    byId.set(plugin.id, plugin);
-    const entry = unsortedEntriesById.get(plugin.id);
+    const id = readLoadedChannelId(plugin);
+    if (!id) {
+      continue;
+    }
+    byId.set(id, plugin);
+    const entry = unsortedEntriesById.get(id);
     if (entry) {
-      entriesById.set(plugin.id, entry);
+      entriesById.set(id, entry);
     }
   }
 

--- a/src/channels/plugins/registry.test.ts
+++ b/src/channels/plugins/registry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { getLoadedChannelPluginForRead } from "./registry-loaded-read.js";
 import { getChannelPlugin, listChannelPlugins } from "./registry.js";
 
 vi.mock("./bundled.js", () => ({
@@ -71,5 +72,130 @@ describe("listChannelPlugins", () => {
     expect(getChannelPlugin("alpha")).toBeUndefined();
     expect(getChannelPlugin("beta")?.meta.label).toBe("beta");
     expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["beta"]);
+  });
+
+  it("keeps loaded channel plugin identities stable across registry reads", () => {
+    const registry = createEmptyPluginRegistry();
+    const plugin = {
+      id: "alpha",
+      meta: { label: "alpha" },
+    };
+    registry.channels = [
+      {
+        pluginId: "alpha",
+        plugin: plugin as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    const first = listChannelPlugins()[0];
+    expect(first).toBe(plugin);
+    expect(listChannelPlugins()[0]).toBe(first);
+    expect(getChannelPlugin("alpha")).toBe(first);
+  });
+
+  it("skips loaded channel plugins with unreadable ids", () => {
+    const registry = createEmptyPluginRegistry();
+    const brokenPlugin = Object.defineProperty(
+      {
+        meta: { label: "broken" },
+      },
+      "id",
+      {
+        get() {
+          throw new Error("channel id getter exploded");
+        },
+      },
+    );
+    registry.channels = [
+      {
+        pluginId: "broken",
+        plugin: brokenPlugin as never,
+        source: "test",
+      },
+      {
+        pluginId: "healthy",
+        plugin: {
+          id: "healthy",
+          meta: { label: "healthy" },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["healthy"]);
+  });
+
+  it("skips unreadable loaded channel ids in the direct read path", () => {
+    const registry = createEmptyPluginRegistry();
+    const brokenPlugin = Object.defineProperty(
+      {
+        meta: { label: "broken" },
+      },
+      "id",
+      {
+        get() {
+          throw new Error("direct read channel id getter exploded");
+        },
+      },
+    );
+    registry.channels = [
+      {
+        pluginId: "broken",
+        plugin: brokenPlugin as never,
+        source: "test",
+      },
+      {
+        pluginId: "healthy",
+        plugin: {
+          id: "healthy",
+          meta: { label: "healthy" },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(getLoadedChannelPluginForRead("healthy")?.id).toBe("healthy");
+    expect(getLoadedChannelPluginForRead("broken")).toBeUndefined();
+  });
+
+  it("falls back when loaded channel order metadata is unreadable", () => {
+    const registry = createEmptyPluginRegistry();
+    const brokenOrderMeta = Object.defineProperty(
+      {
+        label: "broken-order",
+      },
+      "order",
+      {
+        get() {
+          throw new Error("channel order getter exploded");
+        },
+      },
+    );
+    registry.channels = [
+      {
+        pluginId: "broken-order",
+        plugin: {
+          id: "broken-order",
+          meta: brokenOrderMeta,
+        } as never,
+        source: "test",
+      },
+      {
+        pluginId: "healthy",
+        plugin: {
+          id: "healthy",
+          meta: { label: "healthy", order: 1 },
+        } as never,
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(listChannelPlugins().map((plugin) => plugin.id)).toEqual(["healthy", "broken-order"]);
+    expect(getChannelPlugin("broken-order")?.meta.label).toBe("broken-order");
   });
 });


### PR DESCRIPTION
## Summary

- Harden loaded channel registry projection against malformed plugin metadata.
- Skip loaded channel plugins with unreadable ids, fall back when `meta.order` is unreadable, and apply the same guarded id/meta reads to the hot direct-read path.
- Preserve exact registered plugin object identity for valid plugins, including repeated `listChannelPlugins()` and `getChannelPlugin()` reads.
- Out of scope: changing plugin registry lifecycle, bundled fallback behavior, or channel plugin ordering policy beyond malformed order fallback.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Ongoing tool/schema fuzzing hardening work.

## Real behavior proof (required for external PRs)

- Behavior addressed: channel registry listing and direct loaded-channel reads can no longer crash when a loaded plugin exposes an unreadable `id` descriptor or unreadable `meta.order` descriptor.
- Real environment tested: local OpenClaw source worktree on Node via nodenv, branch `fuzz-tool-schema-next178-20260604`, commit `64d8b7d214a6781bc4825e21ba41e1c3ae116c4e`.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next178-rebased nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/registry.test.ts --reporter=verbose`
- Evidence after fix: `src/channels/plugins/registry.test.ts` passed 1 file / 7 tests after the patch.
- Observed result after fix: unreadable channel ids are skipped, unreadable order metadata falls back to default ordering, the direct read path skips malformed entries, and valid loaded plugin object identity is preserved.
- What was not tested: broad `pnpm check:changed` did not run because Blacksmith Testbox is not authenticated and AWS Crabbox returned coordinator 401 before lease creation.
- Proof limitations or environment constraints: broad remote validation is blocked by maintainer-runner auth in this environment.
- Before evidence: the new focused repros failed pre-fix with `channel id getter exploded` and `channel order getter exploded`; autoreview also identified the sibling direct-read path before it was folded into this patch.

## Tests and validation

Which commands did you run?

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next178-red nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/registry.test.ts --testNamePattern="unreadable ids|order metadata" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next178-green-target nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/registry.test.ts --testNamePattern="unreadable ids|order metadata" --reporter=verbose`
- `./node_modules/.bin/oxfmt --write --threads=1 src/channels/plugins/registry-loaded.ts src/channels/plugins/registry-loaded-read.ts src/channels/plugins/registry.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next178-full4 nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/registry.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/registry-loaded.ts src/channels/plugins/registry-loaded-read.ts src/channels/plugins/registry.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git fetch origin main --prune && git rebase origin/main`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next178-rebased nodenv exec node scripts/run-vitest.mjs run src/channels/plugins/registry.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/channels/plugins/registry-loaded.ts src/channels/plugins/registry-loaded-read.ts src/channels/plugins/registry.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

What regression coverage was added or updated?

- Added coverage for unreadable loaded channel ids in the full registry listing.
- Added coverage for unreadable loaded channel ids in the direct read path.
- Added coverage for unreadable loaded channel order metadata.
- Added coverage that valid loaded plugin object identity remains exact and stable.

What failed before this fix, if known?

- `channel id getter exploded`
- `channel order getter exploded`

If no test was added, why not?

Not applicable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Channel enumeration and read paths now continue past malformed loaded channel plugin metadata.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Loaded channel plugin identity and ordering.

How is that risk mitigated?

The final patch returns the exact registered plugin object for valid plugins, keeps bundled fallback behavior unchanged, and only skips or falls back when id/meta/order descriptors cannot be read.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Broad `pnpm check:changed` proof still needs authenticated Blacksmith Testbox or Crabbox access.

Which bot or reviewer comments were addressed?

Local autoreview first caught wrapper identity regressions; the patch was changed to preserve exact plugin identity. Branch autoreview then passed with no accepted findings.
