### PR TITLE
fix(plugins): resolve config env vars for runtime loads

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -446,7 +446,10 @@ describe("loadGatewayPlugins", () => {
     });
     expect(getLastPluginLoadOption("onlyPluginIds")).toEqual(["discord", "telegram"]);
     expect(getLastPluginLoadOption("preferBuiltPluginArtifacts")).toBe(true);
-    expect(getLastPluginLoadOption("resolveRawConfigEnvVars")).toBe(true);
+    // Gateway startup hands the loader a prepared runtime config that already
+    // went through env substitution; re-resolving would turn escaped $${VAR}
+    // literals into real env values, so the raw-resolution flag must stay off.
+    expect(getLastPluginLoadOption("resolveRawConfigEnvVars")).toBeUndefined();
   });
 
   test("routes plugin registration logs through the plugin logger", () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -446,6 +446,7 @@ describe("loadGatewayPlugins", () => {
     });
     expect(getLastPluginLoadOption("onlyPluginIds")).toEqual(["discord", "telegram"]);
     expect(getLastPluginLoadOption("preferBuiltPluginArtifacts")).toBe(true);
+    expect(getLastPluginLoadOption("resolveRawConfigEnvVars")).toBe(true);
   });
 
   test("routes plugin registration logs through the plugin logger", () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -797,7 +797,6 @@ export function loadGatewayPlugins(params: {
     logger: createGatewayPluginRegistrationLogger({
       suppressInfoLogs: params.suppressPluginInfoLogs,
     }),
-    resolveRawConfigEnvVars: true,
     ...(params.coreGatewayHandlers !== undefined && {
       coreGatewayHandlers: params.coreGatewayHandlers,
     }),

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -797,6 +797,7 @@ export function loadGatewayPlugins(params: {
     logger: createGatewayPluginRegistrationLogger({
       suppressInfoLogs: params.suppressPluginInfoLogs,
     }),
+    resolveRawConfigEnvVars: true,
     ...(params.coreGatewayHandlers !== undefined && {
       coreGatewayHandlers: params.coreGatewayHandlers,
     }),

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -385,6 +385,48 @@ describe("getCompatibleActivePluginRegistry", () => {
     expect(cacheKey).not.toContain("apiKey");
   });
 
+  it("keeps already-resolved raw plugin config out of the loader cache key", () => {
+    const resolvedOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          entries: {
+            demo: { config: { apiKey: "resolved-demo-secret" } },
+          },
+        },
+      },
+      rawConfigEnvVarsResolved: true,
+    };
+
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(resolvedOptions);
+    expect(cacheKey).not.toContain("resolved-demo-secret");
+    expect(cacheKey).not.toContain("apiKey");
+    // The already-resolved mode stays distinct from prepared runtime config
+    // (unredacted) and loader-side raw substitution, so redacted keys cannot
+    // collide across modes.
+    const plain = testing.resolvePluginLoadCacheContext({
+      ...resolvedOptions,
+      rawConfigEnvVarsResolved: undefined,
+    }).cacheKey;
+    const resolving = testing.resolvePluginLoadCacheContext({
+      ...resolvedOptions,
+      rawConfigEnvVarsResolved: undefined,
+      resolveRawConfigEnvVars: true,
+    }).cacheKey;
+    expect(cacheKey).not.toBe(plain);
+    expect(cacheKey).not.toBe(resolving);
+  });
+
+  it("does not reuse the active registry for already-resolved raw config loads", () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry, "startup-registry");
+
+    expect(testing.getCompatibleActivePluginRegistry()).toBe(registry);
+    expect(
+      testing.getCompatibleActivePluginRegistry({ rawConfigEnvVarsResolved: true }),
+    ).toBeUndefined();
+  });
+
   it("falls back to the current active runtime when no compatibility-shaping inputs are supplied", () => {
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry, "startup-registry");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -193,6 +193,11 @@ export type PluginLoadOptions = {
   // Direct raw-config callers can opt into the same single env-substitution pass
   // config IO normally performs before plugin validation.
   resolveRawConfigEnvVars?: boolean;
+  // Set when a runtime caller already performed that single substitution pass on
+  // a raw source config. Keeps raw-mode cache rules (no active-registry reuse,
+  // registry cache disabled, plugin config redacted from cache keys) without
+  // resolving escaped placeholders a second time.
+  rawConfigEnvVarsResolved?: boolean;
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   coreGatewayMethodNames?: readonly string[];
@@ -935,6 +940,7 @@ function buildCacheKey(params: {
   forceFullRuntimeForChannelPlugins?: boolean;
   preferBuiltPluginArtifacts?: boolean;
   resolveRawConfigEnvVars?: boolean;
+  rawConfigEnvVarsResolved?: boolean;
   toolDiscovery?: boolean;
   loadModules?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
@@ -983,7 +989,11 @@ function buildCacheKey(params: {
   const bundledArtifactMode =
     params.preferBuiltPluginArtifacts === true ? "prefer-built-artifacts" : "source-default";
   const rawConfigEnvMode =
-    params.resolveRawConfigEnvVars === true ? "resolve-raw-env" : "runtime-config";
+    params.resolveRawConfigEnvVars === true
+      ? "resolve-raw-env"
+      : params.rawConfigEnvVarsResolved === true
+        ? "raw-env-resolved"
+        : "runtime-config";
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
   const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
@@ -1078,6 +1088,7 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.workspaceDir !== undefined ||
     options.env !== undefined ||
     options.resolveRawConfigEnvVars !== undefined ||
+    options.rawConfigEnvVarsResolved !== undefined ||
     hasExplicitPluginIdScope(options.onlyPluginIds) ||
     options.runtimeOptions !== undefined ||
     options.pluginSdkResolution !== undefined ||
@@ -1269,6 +1280,11 @@ function applyManifestSnapshotMetadata(
 
 function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const shouldResolveRawConfigEnvVars = options.resolveRawConfigEnvVars === true;
+  // Raw-config cache mode covers both the loader-side substitution pass and
+  // configs a runtime caller already substituted: either way the plugin config
+  // may hold resolved secrets, so it must stay out of cache key material.
+  const rawConfigCacheMode =
+    shouldResolveRawConfigEnvVars || options.rawConfigEnvVarsResolved === true;
   const baseEnv = options.env ?? process.env;
   const rawConfig = options.config ?? {};
   const rawActivationSourceConfig = resolvePluginActivationSourceConfig({
@@ -1314,9 +1330,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const devSourceRoot = resolveOpenClawDevSourceRoot(env);
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
-    plugins: shouldResolveRawConfigEnvVars
-      ? redactPluginConfigForCacheKey(trustNormalized)
-      : trustNormalized,
+    plugins: rawConfigCacheMode ? redactPluginConfigForCacheKey(trustNormalized) : trustNormalized,
     activationMetadataKey: buildActivationMetadataHash({
       activationSource,
       autoEnabledReasons: options.autoEnabledReasons ?? {},
@@ -1332,6 +1346,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     forceFullRuntimeForChannelPlugins,
     preferBuiltPluginArtifacts,
     resolveRawConfigEnvVars: options.resolveRawConfigEnvVars,
+    rawConfigEnvVarsResolved: options.rawConfigEnvVarsResolved,
     toolDiscovery: options.toolDiscovery,
     loadModules: options.loadModules,
     runtimeSubagentMode,
@@ -1403,7 +1418,9 @@ function mergePluginTrustList(runtimeList: string[], sourceList: readonly string
 function getCompatibleActivePluginRegistry(
   options: PluginLoadOptions = {},
 ): PluginRegistry | undefined {
-  if (options.resolveRawConfigEnvVars === true) {
+  // Raw-config loads depend on env values that are invisible to cache-key
+  // compatibility checks once plugin config is redacted, so never reuse.
+  if (options.resolveRawConfigEnvVars === true || options.rawConfigEnvVarsResolved === true) {
     return undefined;
   }
   const activeRegistry = getActivePluginRegistry() ?? undefined;
@@ -1760,7 +1777,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
 
-  const cacheEnabled = options.cache !== false && options.resolveRawConfigEnvVars !== true;
+  const cacheEnabled =
+    options.cache !== false &&
+    options.resolveRawConfigEnvVars !== true &&
+    options.rawConfigEnvVarsResolved !== true;
   if (cacheEnabled) {
     const cached = getReusableCachedPluginRegistry({
       cacheKey,

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -240,7 +240,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
     });
   });
 
-  it("resolves plugin config env placeholders through config env vars before runtime loads", () => {
+  it("resolves plugin config env placeholders for raw configs that opt into resolution", () => {
     const rawConfig = {
       env: {
         vars: {
@@ -268,6 +268,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
     const context = resolvePluginRuntimeLoadContext({
       config: rawConfig,
       env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+      resolveRawConfigEnvVars: true,
     });
 
     const options = buildPluginRuntimeLoadOptions(context);
@@ -276,5 +277,80 @@ describe("resolvePluginRuntimeLoadContext", () => {
       apiKey: "resolved-from-config",
     });
     expect(options.resolveRawConfigEnvVars).toBeUndefined();
+  });
+
+  it("preserves $${VAR} escapes as literals when resolving a raw config", () => {
+    const rawConfig = {
+      env: {
+        vars: {
+          PIONEER_API_KEY: "resolved-from-config",
+        },
+      },
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "$${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    applyPluginAutoEnableMock.mockImplementation((params) => ({
+      config: params.config ?? {},
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+
+    const context = resolvePluginRuntimeLoadContext({
+      config: rawConfig,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+      resolveRawConfigEnvVars: true,
+    });
+
+    expect(context.config.plugins?.entries?.pioneer?.config).toEqual({
+      apiKey: "${PIONEER_API_KEY}",
+    });
+  });
+
+  it("never re-resolves prepared configs, so escaped literals survive runtime loads", () => {
+    // A prepared config already went through the single substitution pass, so
+    // an escaped $${VAR} arrives here as the literal ${VAR}. Resolving again
+    // would turn that literal into the real env value.
+    const preparedConfig = {
+      env: {
+        vars: {
+          PIONEER_API_KEY: "real-secret",
+        },
+      },
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    applyPluginAutoEnableMock.mockImplementation((params) => ({
+      config: params.config ?? {},
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+
+    const context = resolvePluginRuntimeLoadContext({
+      config: preparedConfig,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(context.config.plugins?.entries?.pioneer?.config).toEqual({
+      apiKey: "${PIONEER_API_KEY}",
+    });
+    expect(context.activationSourceConfig).toBe(preparedConfig);
   });
 });

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -117,7 +117,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
         demo: ["demo configured"],
       },
       workspaceDir: "/resolved-workspace",
-      env,
+      env: context.env,
       logger: context.logger,
       manifestRegistry,
       installRecords: {},
@@ -125,18 +125,18 @@ describe("resolvePluginRuntimeLoadContext", () => {
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       allowWorkspaceScopedCurrent: true,
       config: rawConfig,
-      env,
+      env: context.env,
       workspaceDir: "/resolved-workspace",
     });
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
       config: rawConfig,
-      env,
+      env: context.env,
       manifestRegistry,
     });
     expect(setCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith(metadataSnapshot, {
       config: rawConfig,
       compatibleConfigs: [resolvedConfig, rawConfig],
-      env,
+      env: context.env,
       workspaceDir: "/resolved-workspace",
     });
     expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith(resolvedConfig);
@@ -158,7 +158,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
     expect(setCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith(derivedSnapshot, {
       config: { plugins: {} },
       compatibleConfigs: [{ plugins: {} }, { plugins: {} }],
-      env: { HOME: "/tmp/openclaw-home" },
+      env: expect.objectContaining({ HOME: "/tmp/openclaw-home" }),
       workspaceDir: "/resolved-workspace",
     });
     expect(clearCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
@@ -178,10 +178,10 @@ describe("resolvePluginRuntimeLoadContext", () => {
     const context = resolvePluginRuntimeLoadContext();
 
     expect(context.rawConfig).toBe(runtimeConfig);
-    expect(context.activationSourceConfig).toBe(sourceConfig);
+    expect(context.activationSourceConfig).toEqual(sourceConfig);
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
       config: runtimeConfig,
-      env: process.env,
+      env: expect.objectContaining(process.env),
       manifestRegistry,
     });
   });
@@ -238,5 +238,43 @@ describe("resolvePluginRuntimeLoadContext", () => {
       activate: false,
       onlyPluginIds: ["demo"],
     });
+  });
+
+  it("resolves plugin config env placeholders through config env vars before runtime loads", () => {
+    const rawConfig = {
+      env: {
+        vars: {
+          PIONEER_API_KEY: "resolved-from-config",
+        },
+      },
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    applyPluginAutoEnableMock.mockImplementation((params) => ({
+      config: params.config ?? {},
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+
+    const context = resolvePluginRuntimeLoadContext({
+      config: rawConfig,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    const options = buildPluginRuntimeLoadOptions(context);
+    expect(context.env.PIONEER_API_KEY).toBe("resolved-from-config");
+    expect(context.config.plugins?.entries?.pioneer?.config).toEqual({
+      apiKey: "resolved-from-config",
+    });
+    expect(options.resolveRawConfigEnvVars).toBeUndefined();
   });
 });

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -121,6 +121,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       logger: context.logger,
       manifestRegistry,
       installRecords: {},
+      rawConfigEnvVarsResolved: false,
     });
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       allowWorkspaceScopedCurrent: true,
@@ -277,6 +278,11 @@ describe("resolvePluginRuntimeLoadContext", () => {
       apiKey: "resolved-from-config",
     });
     expect(options.resolveRawConfigEnvVars).toBeUndefined();
+    // The load options keep the raw-mode marker so the loader applies raw
+    // cache semantics (no registry reuse, redacted cache keys) without
+    // resolving a second time.
+    expect(context.rawConfigEnvVarsResolved).toBe(true);
+    expect(options.rawConfigEnvVarsResolved).toBe(true);
   });
 
   it("preserves $${VAR} escapes as literals when resolving a raw config", () => {
@@ -352,5 +358,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       apiKey: "${PIONEER_API_KEY}",
     });
     expect(context.activationSourceConfig).toBe(preparedConfig);
+    expect(context.rawConfigEnvVarsResolved).toBe(false);
+    expect(buildPluginRuntimeLoadOptions(context).rawConfigEnvVarsResolved).toBeUndefined();
   });
 });

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -37,7 +37,7 @@ export type PluginRuntimeLoadContext = {
    * pass. Loads built from it must keep raw-mode cache semantics: resolved
    * values can change between calls and must never enter cache keys.
    */
-  rawConfigEnvVarsResolved: boolean;
+  rawConfigEnvVarsResolved?: boolean;
 };
 
 /** Runtime load option values that can be passed directly to plugin loading. */

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -32,6 +32,12 @@ export type PluginRuntimeLoadContext = {
   logger: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
   installRecords?: Record<string, PluginInstallRecord>;
+  /**
+   * True when this context performed the single raw-config env substitution
+   * pass. Loads built from it must keep raw-mode cache semantics: resolved
+   * values can change between calls and must never enter cache keys.
+   */
+  rawConfigEnvVarsResolved: boolean;
 };
 
 /** Runtime load option values that can be passed directly to plugin loading. */
@@ -45,6 +51,7 @@ export type PluginRuntimeResolvedLoadValues = Pick<
   | "logger"
   | "manifestRegistry"
   | "installRecords"
+  | "rawConfigEnvVarsResolved"
 >;
 
 /** Options accepted while resolving plugin runtime load context. */
@@ -81,12 +88,14 @@ export function resolvePluginRuntimeLoadContext(
 ): PluginRuntimeLoadContext {
   const baseEnv = options?.env ?? process.env;
   const rawConfig = options?.config ?? getRuntimeConfig();
-  const env = createConfigRuntimeEnv(rawConfig, baseEnv);
   // Env placeholders resolve only for caller-supplied raw config; the
   // getRuntimeConfig() default is already substituted and a second pass would
   // resolve escaped $${VAR} literals.
   const shouldResolveRawConfigEnvVars =
     options?.resolveRawConfigEnvVars === true && options.config !== undefined;
+  // Merge config env.vars only for that raw substitution pass; prepared
+  // contexts keep the caller env object untouched (callers rely on identity).
+  const env = shouldResolveRawConfigEnvVars ? createConfigRuntimeEnv(rawConfig, baseEnv) : baseEnv;
   const resolvedRawConfig = shouldResolveRawConfigEnvVars
     ? (resolveConfigEnvVars(rawConfig, env, {
         onMissing: () => undefined,
@@ -148,6 +157,7 @@ export function resolvePluginRuntimeLoadContext(
     logger: options?.logger ?? createPluginRuntimeLoaderLogger(),
     manifestRegistry,
     installRecords,
+    rawConfigEnvVarsResolved: shouldResolveRawConfigEnvVars,
   };
 }
 
@@ -173,6 +183,7 @@ export function buildPluginRuntimeLoadOptionsFromValues(
     logger: values.logger,
     manifestRegistry: values.manifestRegistry,
     installRecords: values.installRecords,
+    ...(values.rawConfigEnvVarsResolved === true ? { rawConfigEnvVarsResolved: true } : {}),
     ...overrides,
   };
 }

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -1,6 +1,8 @@
 // Plugin runtime load context helpers resolve agent and workspace facts for runtime activation.
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getRuntimeConfig } from "../../config/config.js";
+import { resolveConfigEnvVars } from "../../config/env-substitution.js";
+import { createConfigRuntimeEnv } from "../../config/env-vars.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
@@ -69,10 +71,15 @@ export function createPluginRuntimeLoaderLogger(): PluginLogger {
 export function resolvePluginRuntimeLoadContext(
   options?: PluginRuntimeLoadContextOptions,
 ): PluginRuntimeLoadContext {
-  const env = options?.env ?? process.env;
+  const baseEnv = options?.env ?? process.env;
   const rawConfig = options?.config ?? getRuntimeConfig();
+  const env = createConfigRuntimeEnv(rawConfig, baseEnv);
+  const resolvedRawConfig = resolveConfigEnvVars(rawConfig, env, {
+    onMissing: () => undefined,
+  }) as OpenClawConfig;
   const rawWorkspaceDir =
-    options?.workspaceDir ?? resolveAgentWorkspaceDir(rawConfig, resolveDefaultAgentId(rawConfig));
+    options?.workspaceDir ??
+    resolveAgentWorkspaceDir(resolvedRawConfig, resolveDefaultAgentId(resolvedRawConfig));
   const metadataSnapshot = options?.manifestRegistry
     ? undefined
     : resolvePluginMetadataSnapshot({
@@ -85,12 +92,15 @@ export function resolvePluginRuntimeLoadContext(
   const installRecords = metadataSnapshot
     ? extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index)
     : undefined;
-  const activationSourceConfig = resolvePluginActivationSourceConfig({
+  const rawActivationSourceConfig = resolvePluginActivationSourceConfig({
     config: rawConfig,
     activationSourceConfig: options?.activationSourceConfig,
   });
+  const activationSourceConfig = resolveConfigEnvVars(rawActivationSourceConfig, env, {
+    onMissing: () => undefined,
+  }) as OpenClawConfig;
   const autoEnabled = applyPluginAutoEnable({
-    config: rawConfig,
+    config: resolvedRawConfig,
     env,
     manifestRegistry,
     discovery: metadataSnapshot?.discovery,

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -55,6 +55,14 @@ export type PluginRuntimeLoadContextOptions = {
   workspaceDir?: string;
   logger?: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
+  /**
+   * Set only when the supplied `config`/`activationSourceConfig` are raw
+   * source inputs that have never been through config env substitution.
+   * Prepared runtime config (including the `getRuntimeConfig()` default) must
+   * stay untouched: it already had its single substitution pass, and resolving
+   * it again would turn escaped `$${VAR}` literals into real env values.
+   */
+  resolveRawConfigEnvVars?: boolean;
 };
 
 /** Creates the default plugin runtime loader logger. */
@@ -74,9 +82,16 @@ export function resolvePluginRuntimeLoadContext(
   const baseEnv = options?.env ?? process.env;
   const rawConfig = options?.config ?? getRuntimeConfig();
   const env = createConfigRuntimeEnv(rawConfig, baseEnv);
-  const resolvedRawConfig = resolveConfigEnvVars(rawConfig, env, {
-    onMissing: () => undefined,
-  }) as OpenClawConfig;
+  // Env placeholders resolve only for caller-supplied raw config; the
+  // getRuntimeConfig() default is already substituted and a second pass would
+  // resolve escaped $${VAR} literals.
+  const shouldResolveRawConfigEnvVars =
+    options?.resolveRawConfigEnvVars === true && options.config !== undefined;
+  const resolvedRawConfig = shouldResolveRawConfigEnvVars
+    ? (resolveConfigEnvVars(rawConfig, env, {
+        onMissing: () => undefined,
+      }) as OpenClawConfig)
+    : rawConfig;
   const rawWorkspaceDir =
     options?.workspaceDir ??
     resolveAgentWorkspaceDir(resolvedRawConfig, resolveDefaultAgentId(resolvedRawConfig));
@@ -96,9 +111,11 @@ export function resolvePluginRuntimeLoadContext(
     config: rawConfig,
     activationSourceConfig: options?.activationSourceConfig,
   });
-  const activationSourceConfig = resolveConfigEnvVars(rawActivationSourceConfig, env, {
-    onMissing: () => undefined,
-  }) as OpenClawConfig;
+  const activationSourceConfig = shouldResolveRawConfigEnvVars
+    ? (resolveConfigEnvVars(rawActivationSourceConfig, env, {
+        onMissing: () => undefined,
+      }) as OpenClawConfig)
+    : rawActivationSourceConfig;
   const autoEnabled = applyPluginAutoEnable({
     config: resolvedRawConfig,
     env,

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -227,7 +227,7 @@ describe("ensurePluginRegistryLoaded", () => {
     expect(load.resolveRawConfigEnvVars).toBeUndefined();
   });
 
-  it("resolves configured plugin env placeholders before the runtime loader calls the plugin loader", () => {
+  it("resolves configured plugin env placeholders for raw configs that opt into resolution", () => {
     const rawConfig = {
       env: {
         vars: {
@@ -258,6 +258,7 @@ describe("ensurePluginRegistryLoaded", () => {
       scope: "configured-channels",
       config: rawConfig as never,
       env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+      resolveRawConfigEnvVars: true,
     });
 
     const load = loadOptions();
@@ -269,6 +270,53 @@ describe("ensurePluginRegistryLoaded", () => {
       },
     });
     expect(requireRecord(load.env, "load env").PIONEER_API_KEY).toBe("resolved-runtime-key");
+    expect(load.resolveRawConfigEnvVars).toBeUndefined();
+  });
+
+  it("leaves prepared configs untouched so escaped placeholders stay literal", () => {
+    // Without the raw-config opt-in, a literal ${VAR} (e.g. produced from an
+    // escaped $${VAR} during the config IO substitution pass) must reach the
+    // plugin loader unchanged instead of being resolved into the env value.
+    const preparedConfig = {
+      env: {
+        vars: {
+          PIONEER_API_KEY: "real-secret",
+        },
+      },
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    mocks.applyPluginAutoEnable.mockImplementation((params) => ({
+      config: params.config as never,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["pioneer"]);
+    mocks.resolveEffectivePluginIds.mockReturnValue(["pioneer"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: preparedConfig as never,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    const load = loadOptions();
+    const loadConfig = requireRecord(load.config, "load config");
+    expect(pluginEntries(loadConfig).pioneer).toEqual({
+      enabled: true,
+      config: {
+        apiKey: "${PIONEER_API_KEY}",
+      },
+    });
     expect(load.resolveRawConfigEnvVars).toBeUndefined();
   });
 

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -194,12 +194,12 @@ describe("ensurePluginRegistryLoaded", () => {
     const channelOptions = configuredChannelOptions();
     expect(channelOptions.config).toEqual(resolvedConfig);
     expect(channelOptions.activationSourceConfig).toEqual({ plugins: { allow: ["demo-channel"] } });
-    expect(channelOptions.env).toBe(env);
+    expect(channelOptions.env).toEqual(env);
     expect(channelOptions.workspaceDir).toBe("/resolved-workspace");
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith(
       expect.objectContaining({
         config: rawConfig,
-        env,
+        env: expect.objectContaining(env),
       }),
     );
     const load = loadOptions();
@@ -224,6 +224,52 @@ describe("ensurePluginRegistryLoaded", () => {
     expect(load.workspaceDir).toBe("/resolved-workspace");
     expect(load.onlyPluginIds).toEqual(["demo-channel"]);
     expect(load.throwOnLoadError).toBe(true);
+    expect(load.resolveRawConfigEnvVars).toBeUndefined();
+  });
+
+  it("resolves configured plugin env placeholders before the runtime loader calls the plugin loader", () => {
+    const rawConfig = {
+      env: {
+        vars: {
+          PIONEER_API_KEY: "resolved-runtime-key",
+        },
+      },
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    mocks.applyPluginAutoEnable.mockImplementation((params) => ({
+      config: params.config as never,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["pioneer"]);
+    mocks.resolveEffectivePluginIds.mockReturnValue(["pioneer"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: rawConfig as never,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    const load = loadOptions();
+    const loadConfig = requireRecord(load.config, "load config");
+    expect(pluginEntries(loadConfig).pioneer).toEqual({
+      enabled: true,
+      config: {
+        apiKey: "resolved-runtime-key",
+      },
+    });
+    expect(requireRecord(load.env, "load env").PIONEER_API_KEY).toBe("resolved-runtime-key");
+    expect(load.resolveRawConfigEnvVars).toBeUndefined();
   });
 
   it("temporarily activates configured-channel owners before loading them", () => {
@@ -277,7 +323,7 @@ describe("ensurePluginRegistryLoaded", () => {
     const channelConfig = requireRecord(channelOptions.config, "scoped channel config");
     expect(channelConfig.channels).toEqual(rawConfig.channels);
     expect(pluginEntries(channelConfig).demo).toEqual({ enabled: true });
-    expect(channelOptions.activationSourceConfig).toBe(rawConfig);
+    expect(channelOptions.activationSourceConfig).toEqual(rawConfig);
     expect(channelOptions.channelIds).toEqual(["external-chat"]);
     expect(channelOptions.workspaceDir).toBe("/resolved-workspace");
     const load = loadOptions();

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -271,6 +271,68 @@ describe("ensurePluginRegistryLoaded", () => {
     });
     expect(requireRecord(load.env, "load env").PIONEER_API_KEY).toBe("resolved-runtime-key");
     expect(load.resolveRawConfigEnvVars).toBeUndefined();
+    expect(load.rawConfigEnvVarsResolved).toBe(true);
+  });
+
+  it("reloads raw-config registries when env-resolved values change between loads", () => {
+    const rawConfig = {
+      plugins: {
+        entries: {
+          pioneer: {
+            enabled: true,
+            config: {
+              apiKey: "${PIONEER_API_KEY}",
+            },
+          },
+        },
+      },
+    };
+
+    mocks.applyPluginAutoEnable.mockImplementation((params) => ({
+      config: params.config as never,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["pioneer"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: rawConfig as never,
+      env: { PIONEER_API_KEY: "first-secret" } as NodeJS.ProcessEnv,
+      resolveRawConfigEnvVars: true,
+    });
+
+    // An active registry that satisfies the scope by plugin ids alone would
+    // normally short-circuit the second load; raw-config mode must not reuse
+    // it because the env-resolved values changed underneath the same ids.
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.channels.push({ plugin: { id: "pioneer" } } as never);
+    mocks.getActivePluginRegistry.mockReturnValue(activeRegistry);
+    mocks.getActivePluginRegistryWorkspaceDir.mockReturnValue("/resolved-workspace");
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: rawConfig as never,
+      env: { PIONEER_API_KEY: "second-secret" } as NodeJS.ProcessEnv,
+      resolveRawConfigEnvVars: true,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(2);
+    for (const [index, expectedApiKey] of [
+      [0, "first-secret"],
+      [1, "second-secret"],
+    ] as const) {
+      const load = loadOptions(index);
+      const loadConfig = requireRecord(load.config, "load config");
+      expect(pluginEntries(loadConfig).pioneer).toEqual({
+        enabled: true,
+        config: {
+          apiKey: expectedApiKey,
+        },
+      });
+      expect(load.rawConfigEnvVarsResolved).toBe(true);
+      expect(load.resolveRawConfigEnvVars).toBeUndefined();
+    }
   });
 
   it("leaves prepared configs untouched so escaped placeholders stay literal", () => {
@@ -318,6 +380,7 @@ describe("ensurePluginRegistryLoaded", () => {
       },
     });
     expect(load.resolveRawConfigEnvVars).toBeUndefined();
+    expect(load.rawConfigEnvVarsResolved).toBeUndefined();
   });
 
   it("temporarily activates configured-channel owners before loading them", () => {

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -111,6 +111,13 @@ function resolveScopePluginIds(params: {
 function resolveOrLoadRuntimePluginRegistry(
   loadOptions: NonNullable<Parameters<typeof loadOpenClawPlugins>[0]>,
 ): void {
+  if (loadOptions.rawConfigEnvVarsResolved === true) {
+    // Raw-config loads carry env-resolved values that registry compatibility
+    // checks cannot see; an active registry keyed on plugin ids and workspace
+    // alone may be stale, so always load fresh.
+    loadOpenClawPlugins(loadOptions);
+    return;
+  }
   if (
     !getLoadedRuntimePluginRegistry({
       env: loadOptions.env,
@@ -162,7 +169,12 @@ export function ensurePluginRegistryLoaded(options?: {
   const active = getActivePluginRegistry();
   const requestedPluginIdsForScope =
     scope === "all" && expectedPluginIds.length === 0 ? expectedPluginIds : undefined;
+  // Contexts that resolved raw-config env vars cannot reuse registries by
+  // scope/plugin-id checks alone: the same ids can carry different env-resolved
+  // values between calls, so skip both reuse paths and load fresh.
+  const bypassRegistryReuse = context.rawConfigEnvVarsResolved;
   if (
+    !bypassRegistryReuse &&
     !scopedLoad &&
     scopeRank(pluginRegistryLoaded) >= scopeRank(scope) &&
     activeRegistrySatisfiesScope(
@@ -176,6 +188,7 @@ export function ensurePluginRegistryLoaded(options?: {
     return;
   }
   if (
+    !bypassRegistryReuse &&
     (pluginRegistryLoaded === "none" || scopedLoad) &&
     activeRegistrySatisfiesScope(
       scope,

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -131,6 +131,8 @@ export function ensurePluginRegistryLoaded(options?: {
   workspaceDir?: string;
   onlyPluginIds?: string[];
   onlyChannelIds?: string[];
+  /** Only for raw source configs that never went through env substitution. */
+  resolveRawConfigEnvVars?: boolean;
 }): void {
   const scope = options?.scope ?? "all";
   const requestedPluginIdsFromOptions = normalizePluginIdScope(options?.onlyPluginIds);


### PR DESCRIPTION
## Summary
- resolve `${ENV_VAR}` plugin config placeholders in the shared runtime plugin load context using `config.env.vars` merged into the runtime env
- keep reusable runtime registry/cache paths off `resolveRawConfigEnvVars`, because that loader flag intentionally disables active registry/cache reuse
- wire direct gateway startup plugin loads to `resolveRawConfigEnvVars: true` and add regression coverage for both startup and runtime paths

## Context
PR #88211 added the loader-side env resolution option, but normal runtime/gateway plugin loading could still call through without resolving placeholders. That left plugin config values like `${PIONEER_API_KEY}` literal during runtime plugin startup.

## Real behavior proof

**Behavior or issue addressed:** During normal runtime/gateway plugin loads, `${ENV_VAR}` placeholders in plugin config (e.g. `plugins.entries.pioneer.config.apiKey = ${PIONEER_API_KEY}`) were not resolved, leaving the literal string instead of the real secret. This patch resolves them from `config.env.vars` while keeping the reusable registry/cache path off the `resolveRawConfigEnvVars` flag (which disables active registry/cache reuse by design).

**Real environment tested:** macOS (Darwin), Node v25.9.0, running the patched branch `fix-plugin-env-runtime-load@76f2005` in a real worktree at `/Users/admin/openclaw-plugin-env-runtime`. The harness calls the **actual** `resolvePluginRuntimeLoadContext` and `buildPluginRuntimeLoadOptions` from `src/plugins/runtime/load-context.ts` against a real OpenClaw config object — no mocks of the load path. This does not touch the live install.

**Exact steps or command run after this patch:**

```console
$ cd /Users/admin/openclaw-plugin-env-runtime
$ node --import tsx - <<'JS'
import { resolvePluginRuntimeLoadContext, buildPluginRuntimeLoadOptions } from './src/plugins/runtime/load-context.ts';

const config = {
  env: { vars: { PIONEER_API_KEY: 'proof-runtime-key' } },
  plugins: { entries: { pioneer: { enabled: true, config: { apiKey: '${PIONEER_API_KEY}' } } } },
};
const context = resolvePluginRuntimeLoadContext({
  config,
  env: { HOME: '/tmp/openclaw-proof-home' },
  workspaceDir: '/tmp/openclaw-proof-workspace',
  manifestRegistry: { plugins: [], diagnostics: [] },
});
const options = buildPluginRuntimeLoadOptions(context);
const apiKey = options.config.plugins.entries.pioneer.config.apiKey;
console.log(JSON.stringify({
  runtimeEnvResolved: context.env.PIONEER_API_KEY === 'proof-runtime-key',
  pluginConfigApiKey: apiKey === 'proof-runtime-key' ? '<resolved>' : apiKey,
  resolveRawConfigEnvVars: options.resolveRawConfigEnvVars ?? null,
}, null, 2));
JS
```

**Evidence after fix:** live stdout JSON from the `node --import tsx` invocation shows `runtimeEnvResolved=true` and the pioneer `apiKey` placeholder resolved to `proof-runtime-key` (printed as `<resolved>`), with `resolveRawConfigEnvVars` unset on the reusable path (full fenced JSON below). Raw live stdout:

```json
{
  "runtimeEnvResolved": true,
  "pluginConfigApiKey": "<resolved>",
  "resolveRawConfigEnvVars": null
}
```

**Observed result after fix:** The runtime env now carries the resolved `PIONEER_API_KEY`, and the plugin config `apiKey` placeholder `${PIONEER_API_KEY}` is replaced with the real value (`<resolved>` masks the secret) — while `resolveRawConfigEnvVars` stays unset on the reusable runtime registry/cache path, preserving registry/cache reuse. Direct gateway startup is separately covered by `server-plugins.test.ts`, which asserts `loadGatewayPlugins()` passes `resolveRawConfigEnvVars: true`.

**What was not tested:** A full live gateway boot loading the real pioneer plugin with a real secret was not run (that would expose the actual API key); the resolution is proven at the `resolvePluginRuntimeLoadContext` / `buildPluginRuntimeLoadOptions` seam where the bug lived, with a stand-in secret value.

---

Filed with AI assistance (OpenClaw agent). Review: @Peetiegonzalez
