### PR TITLE
fix(gateway): guard reload metadata descriptors

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -30,6 +30,11 @@ type ReloadRule = {
   actions?: ReloadAction[];
 };
 
+type ReloadPrefixKey = "configPrefixes" | "noopPrefixes" | "restartPrefixes" | "hotPrefixes";
+type ReloadDescriptor = Partial<Record<ReloadPrefixKey, unknown>>;
+type ReloadPrefixGroups = Partial<Record<ReloadPrefixKey, string[]>>;
+type ReadPropertyResult<T> = { ok: true; value: T | null } | { ok: false };
+
 export type ConfigReloadMetadata = {
   kind: ReloadRule["kind"];
 };
@@ -142,6 +147,49 @@ let cachedRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
 let cachedActiveRegistryVersion = -1;
 let cachedChannelRegistryVersion = -1;
 
+function readOptionalProperty<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+): ReadPropertyResult<NonNullable<T[K]>> {
+  try {
+    return { ok: true, value: target[key] ?? null };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function readReloadPrefixGroups(
+  reload: ReloadDescriptor | null,
+  keys: readonly ReloadPrefixKey[],
+): ReloadPrefixGroups | null {
+  if (!reload) {
+    return {};
+  }
+  const groups: ReloadPrefixGroups = {};
+  try {
+    for (const key of keys) {
+      const prefixes = reload[key];
+      groups[key] = Array.isArray(prefixes)
+        ? prefixes.filter(
+            (prefix): prefix is string => typeof prefix === "string" && prefix.length > 0,
+          )
+        : [];
+    }
+    return groups;
+  } catch {
+    return null;
+  }
+}
+
+function listPluginReloadFailureRules(pluginId: string): ReloadRule[] {
+  return ["plugins.enabled", "plugins.allow", "plugins.deny", `plugins.entries.${pluginId}`].map(
+    (prefix): ReloadRule => ({
+      prefix,
+      kind: "restart",
+    }),
+  );
+}
+
 function listReloadRules(): ReloadRule[] {
   const registry = getActivePluginRegistry();
   const activeRegistryVersion = getActivePluginRegistryVersion();
@@ -160,8 +208,16 @@ function listReloadRules(): ReloadRule[] {
     return cachedReloadRules;
   }
   // Channel docking: plugins contribute hot reload/no-op prefixes here.
-  const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) =>
-    (plugin.reload?.configPrefixes ?? [])
+  const channelReloadRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) => {
+    const reload = readOptionalProperty(plugin, "reload");
+    if (!reload.ok) {
+      return [];
+    }
+    const prefixes = readReloadPrefixGroups(reload.value, ["configPrefixes", "noopPrefixes"]);
+    if (!prefixes) {
+      return [];
+    }
+    return (prefixes.configPrefixes ?? [])
       .map(
         (prefix): ReloadRule => ({
           prefix,
@@ -170,14 +226,14 @@ function listReloadRules(): ReloadRule[] {
         }),
       )
       .concat(
-        (plugin.reload?.noopPrefixes ?? []).map(
+        (prefixes.noopPrefixes ?? []).map(
           (prefix): ReloadRule => ({
             prefix,
             kind: "none",
           }),
         ),
-      ),
-  );
+      );
+  });
   const channelPluginStateRules: ReloadRule[] = listChannelPlugins().flatMap((plugin) => [
     {
       prefix: `plugins.entries.${plugin.id}`,
@@ -189,8 +245,20 @@ function listReloadRules(): ReloadRule[] {
       ],
     },
   ]);
-  const pluginReloadRules: ReloadRule[] = (registry?.reloads ?? []).flatMap((entry) =>
-    (entry.registration.restartPrefixes ?? [])
+  const pluginReloadRules: ReloadRule[] = (registry?.reloads ?? []).flatMap((entry) => {
+    const registration = readOptionalProperty(entry, "registration");
+    if (!registration.ok || !registration.value) {
+      return listPluginReloadFailureRules(entry.pluginId);
+    }
+    const prefixes = readReloadPrefixGroups(registration.value, [
+      "restartPrefixes",
+      "hotPrefixes",
+      "noopPrefixes",
+    ]);
+    if (!prefixes) {
+      return listPluginReloadFailureRules(entry.pluginId);
+    }
+    return (prefixes.restartPrefixes ?? [])
       .map(
         (prefix): ReloadRule => ({
           prefix,
@@ -198,20 +266,20 @@ function listReloadRules(): ReloadRule[] {
         }),
       )
       .concat(
-        (entry.registration.hotPrefixes ?? []).map(
+        (prefixes.hotPrefixes ?? []).map(
           (prefix): ReloadRule => ({
             prefix,
             kind: "hot",
           }),
         ),
-        (entry.registration.noopPrefixes ?? []).map(
+        (prefixes.noopPrefixes ?? []).map(
           (prefix): ReloadRule => ({
             prefix,
             kind: "none",
           }),
         ),
-      ),
-  );
+      );
+  });
   const rules = [
     ...BASE_RELOAD_RULES,
     ...pluginReloadRules,

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -258,6 +258,180 @@ describe("buildGatewayReloadPlan", () => {
     expect(afterPinPlan.restartChannels).toEqual(new Set(["telegram"]));
   });
 
+  it("skips channels with unreadable reload descriptors", () => {
+    const brokenPlugin = Object.defineProperty(
+      {
+        id: "broken",
+        meta: {
+          id: "broken",
+          label: "Broken",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({}),
+        },
+      },
+      "reload",
+      {
+        get() {
+          throw new Error("channel reload descriptor exploded");
+        },
+      },
+    ) as ChannelPlugin;
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "broken", plugin: brokenPlugin, source: "test" },
+        { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+      ]),
+    );
+
+    const plan = buildGatewayReloadPlan(["channels.telegram.botToken"]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+  });
+
+  it("skips unreadable channel reload prefix lists", () => {
+    const brokenReload = Object.defineProperty({}, "configPrefixes", {
+      get() {
+        throw new Error("channel reload config prefixes exploded");
+      },
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "broken",
+          plugin: {
+            id: "broken",
+            meta: {
+              id: "broken",
+              label: "Broken",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => [],
+              resolveAccount: () => ({}),
+            },
+            reload: brokenReload,
+          } as ChannelPlugin,
+          source: "test",
+        },
+        { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+      ]),
+    );
+
+    const plan = buildGatewayReloadPlan(["channels.telegram.botToken"]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["telegram"]));
+  });
+
+  it("does not keep lower-priority channel reload rules after an unreadable prefix list", () => {
+    const brokenReload = Object.defineProperty(
+      { noopPrefixes: ["channels.broken"] },
+      "configPrefixes",
+      {
+        get() {
+          throw new Error("channel reload config prefixes exploded");
+        },
+      },
+    );
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "broken",
+          plugin: {
+            id: "broken",
+            meta: {
+              id: "broken",
+              label: "Broken",
+            },
+            capabilities: { chatTypes: ["direct"] },
+            config: {
+              listAccountIds: () => [],
+              resolveAccount: () => ({}),
+            },
+            reload: brokenReload,
+          } as ChannelPlugin,
+          source: "test",
+        },
+      ]),
+    );
+
+    const plan = buildGatewayReloadPlan(["channels.broken.replyToMode"]);
+
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("channels.broken.replyToMode");
+    expect(plan.noopPaths).toStrictEqual([]);
+  });
+
+  it("skips unreadable plugin reload registrations", () => {
+    const registryWithBrokenReload = createTestRegistry([]);
+    const brokenReloadEntry = Object.defineProperty(
+      {
+        pluginId: "broken",
+        pluginName: "Broken",
+        source: "test",
+      },
+      "registration",
+      {
+        get() {
+          throw new Error("plugin reload registration exploded");
+        },
+      },
+    );
+    registryWithBrokenReload.reloads = [
+      brokenReloadEntry as never,
+      {
+        pluginId: "healthy",
+        pluginName: "Healthy",
+        registration: { hotPrefixes: ["healthy"] },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registryWithBrokenReload);
+
+    const plan = buildGatewayReloadPlan(["healthy.enabled"]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.hotReasons).toEqual(["healthy.enabled"]);
+
+    const brokenPluginPlan = buildGatewayReloadPlan(["plugins.entries.broken.enabled"]);
+
+    expect(brokenPluginPlan.restartGateway).toBe(true);
+    expect(brokenPluginPlan.restartReasons).toContain("plugins.entries.broken.enabled");
+  });
+
+  it("fails closed when an unreadable plugin reload prefix list would expose lower-priority rules", () => {
+    const registryWithBrokenReload = createTestRegistry([]);
+    const brokenRegistration = Object.defineProperty(
+      { noopPrefixes: ["plugins.entries.broken"] },
+      "restartPrefixes",
+      {
+        get() {
+          throw new Error("plugin reload restart prefixes exploded");
+        },
+      },
+    );
+    registryWithBrokenReload.reloads = [
+      {
+        pluginId: "broken",
+        pluginName: "Broken",
+        registration: brokenRegistration,
+        source: "test",
+      },
+    ] as never;
+    setActivePluginRegistry(registryWithBrokenReload);
+
+    const plan = buildGatewayReloadPlan(["plugins.entries.broken.enabled"]);
+
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("plugins.entries.broken.enabled");
+    expect(plan.hotReasons).toStrictEqual([]);
+    expect(plan.noopPaths).toStrictEqual([]);
+  });
+
   it("restarts loaded channel plugins when plugin entry state changes", () => {
     const plan = buildGatewayReloadPlan(["plugins.entries.telegram.enabled"]);
 


### PR DESCRIPTION
## Summary

- Hardens gateway config reload planning against malformed channel/plugin reload metadata.
- Keeps healthy channel/plugin reload rules usable when one descriptor is unreadable.
- Fails closed for unreadable plugin reload registrations on plugin control-plane config, so a bad descriptor cannot downgrade restart-required plugin state changes to generic hot reload.
- Out of scope: broad runtime/tool-schema doctor validation and full changed-gate proof, which is currently blocked by remote runner auth.

## Linked context

Related to the ongoing tool-schema/runtime fuzzing hardening sweep.

No linked issue.

## Real behavior proof

Behavior addressed: A malformed channel/plugin reload descriptor can throw during gateway reload-plan construction and crash planning, or under-classify higher-priority restart/hot reload paths as no-op/hot when only part of the descriptor is readable.

Real environment tested: macOS gwt worktree, Node v24.15.0, pnpm 11.2.2.

Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next179-finalrebase nodenv exec node scripts/run-vitest.mjs run src/gateway/config-reload.test.ts --reporter=verbose`; `nodenv exec node scripts/run-oxlint.mjs src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: The focused gateway config reload shard passed with `Test Files 4 passed (4)` and `Tests 340 passed (340)`. Oxlint and diff-check exited cleanly. Branch autoreview reported `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: `buildGatewayReloadPlan()` skips unreadable channel descriptors without crashing, preserves unrelated healthy reload rules, rejects lower-priority no-op rules when a higher-priority list cannot be read, and forces restart handling for affected plugin entry/control-plane paths when plugin reload registration metadata is unreadable.

What was not tested: Full `pnpm check:changed` did not run.

Proof limitations or environment constraints: `blacksmith testbox list --all` is blocked by missing Blacksmith auth. Direct AWS Crabbox proof is blocked by coordinator 401 on run history and lease creation.

Before evidence: Narrow red tests reproduced throws from `channel reload descriptor exploded`, `channel reload config prefixes exploded`, and `plugin reload registration exploded` before the guard/fail-closed changes.

## Tests and validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next179-finalrebase nodenv exec node scripts/run-vitest.mjs run src/gateway/config-reload.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated.
- `node scripts/crabbox-wrapper.mjs run -provider aws -label next179-check-changed -shell -- "pnpm check:changed"` blocked: coordinator 401.

Regression coverage added:

- Unreadable channel `reload` descriptor getter.
- Unreadable channel reload prefix getter.
- Unreadable channel high-priority prefix getter with readable lower-priority no-op prefixes.
- Unreadable plugin reload registration getter.
- Unreadable plugin high-priority prefix getter with readable lower-priority no-op prefixes.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Reload classification could over- or under-restart gateway/plugin state.

How is that risk mitigated? Valid descriptors keep the existing ordering and behavior; malformed channel descriptors are skipped so unknown channel config falls back to restart; malformed plugin reload registrations add conservative restart rules for plugin control-plane paths instead of allowing the generic `plugins` hot rule to win.

## Current review state

What is the next action? Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof? Full changed-gate proof is waiting on Testbox or Crabbox auth.

Which bot or reviewer comments were addressed? Local autoreview findings about union-index type safety, lower-priority no-op leakage, and plugin restart-to-hot downgrade were fixed before push.
