### PR TITLE
fix(telegram): clear generic callback buttons after click

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback.runtime.ts
@@ -31,6 +31,7 @@ import type { TelegramGetChat } from "./bot/types.js";
 import { getTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
+import { isTelegramMessageNotModifiedError } from "./network-errors.js";
 import {
   hasTelegramQuestionCallbackPrefix,
   parseTelegramQuestionCallbackData,
@@ -273,6 +274,20 @@ export function registerTelegramCallbackQueryHandler(
         return;
       }
 
+      const hasCallbackInlineKeyboard =
+        (callbackMessage.reply_markup?.inline_keyboard?.length ?? 0) > 0;
+      if (hasCallbackInlineKeyboard) {
+        try {
+          await actions.clearCallbackButtons();
+        } catch (editErr) {
+          if (
+            !isTelegramMessageNotModifiedError(editErr) &&
+            !isPermanentTelegramCallbackEditError(editErr)
+          ) {
+            throw new TelegramRetryableCallbackError(editErr);
+          }
+        }
+      }
       const syntheticMessage = buildSyntheticTextMessage({
         base: withResolvedTelegramForumFlag(callbackMessage, isForum),
         from: callback.from,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1947,6 +1947,151 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-slash-1");
   });
 
+  it("clears generic callback_query buttons before routing payloads as messages", async () => {
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-generic-clear-1",
+        data: "skip nightly build tonight",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+          reply_markup: {
+            inline_keyboard: [
+              [
+                {
+                  text: "Skip tonight",
+                  callback_data: "skip nightly build tonight",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
+    expect(payload.Body).toContain("skip nightly build tonight");
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-generic-clear-1");
+  });
+
+  it("routes generic callback_query payloads when button cleanup hits a permanent edit error", async () => {
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+
+    editMessageReplyMarkupSpy.mockRejectedValueOnce(
+      new Error("400: Bad Request: message can't be edited"),
+    );
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-generic-clear-permanent-1",
+        data: "skip nightly build tonight",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+          reply_markup: {
+            inline_keyboard: [
+              [
+                {
+                  text: "Skip tonight",
+                  callback_data: "skip nightly build tonight",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
+    expect(payload.Body).toContain("skip nightly build tonight");
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-generic-clear-permanent-1");
+  });
+
+  it("retries generic callback_query button cleanup after transient edit failures", async () => {
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = requireValue(
+      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+        | ((ctx: Record<string, unknown>) => Promise<void>)
+        | undefined,
+      "callback_query handler",
+    );
+    const ctx = {
+      update: { update_id: 779 },
+      callbackQuery: {
+        id: "cbq-generic-clear-retry-1",
+        data: "skip nightly build tonight",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 10,
+          reply_markup: {
+            inline_keyboard: [
+              [
+                {
+                  text: "Skip tonight",
+                  callback_data: "skip nightly build tonight",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    editMessageReplyMarkupSpy.mockRejectedValueOnce(new Error("edit boom"));
+
+    await expect(
+      runTelegramMiddlewareChain({
+        ctx,
+        finalHandler: callbackHandler,
+      }),
+    ).rejects.toThrow("edit boom");
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await runTelegramMiddlewareChain({
+      ctx,
+      finalHandler: callbackHandler,
+    });
+
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(2);
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
+    expect(payload.Body).toContain("skip nightly build tonight");
+  });
+
   it("does not route opaque callback_query payloads as synthetic commands", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -192,6 +192,28 @@ function requireValue<T>(value: T | null | undefined, label: string): T {
   return value;
 }
 
+function makeGenericCallbackContext(params: { id: string; updateId?: number }) {
+  const data = "skip nightly build tonight";
+  return {
+    ...(params.updateId === undefined ? {} : { update: { update_id: params.updateId } }),
+    callbackQuery: {
+      id: params.id,
+      data,
+      from: { id: 9, first_name: "Ada", username: "ada_bot" },
+      message: {
+        chat: { id: 1234, type: "private" },
+        date: 1736380800,
+        message_id: 10,
+        reply_markup: {
+          inline_keyboard: [[{ text: "Skip tonight", callback_data: data }]],
+        },
+      },
+    },
+    me: { username: "openclaw_bot" },
+    getFile: async () => ({ download: async () => new Uint8Array() }),
+  };
+}
+
 function createDeferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -1947,39 +1969,21 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-slash-1");
   });
 
-  it("clears generic callback_query buttons before routing payloads as messages", async () => {
+  it.each([
+    { name: "clears buttons", id: "cbq-generic-clear-1", editError: undefined },
+    {
+      name: "continues after a permanent edit error",
+      id: "cbq-generic-clear-permanent-1",
+      editError: new Error("400: Bad Request: message can't be edited"),
+    },
+  ])("routes generic callback_query payloads and $name", async ({ id, editError }) => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
+    const callbackHandler = getOnHandler("callback_query");
+    if (editError) {
+      editMessageReplyMarkupSpy.mockRejectedValueOnce(editError);
+    }
 
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-generic-clear-1",
-        data: "skip nightly build tonight",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-          reply_markup: {
-            inline_keyboard: [
-              [
-                {
-                  text: "Skip tonight",
-                  callback_data: "skip nightly build tonight",
-                },
-              ],
-            ],
-          },
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+    await callbackHandler(makeGenericCallbackContext({ id }));
 
     expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
       reply_markup: { inline_keyboard: [] },
@@ -1987,89 +1991,13 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
     expect(payload.Body).toContain("skip nightly build tonight");
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-generic-clear-1");
-  });
-
-  it("routes generic callback_query payloads when button cleanup hits a permanent edit error", async () => {
-    createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-
-    editMessageReplyMarkupSpy.mockRejectedValueOnce(
-      new Error("400: Bad Request: message can't be edited"),
-    );
-
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-generic-clear-permanent-1",
-        data: "skip nightly build tonight",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-          reply_markup: {
-            inline_keyboard: [
-              [
-                {
-                  text: "Skip tonight",
-                  callback_data: "skip nightly build tonight",
-                },
-              ],
-            ],
-          },
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
-
-    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
-      reply_markup: { inline_keyboard: [] },
-    });
-    expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
-    expect(payload.Body).toContain("skip nightly build tonight");
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-generic-clear-permanent-1");
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith(id);
   });
 
   it("retries generic callback_query button cleanup after transient edit failures", async () => {
     createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
-    const ctx = {
-      update: { update_id: 779 },
-      callbackQuery: {
-        id: "cbq-generic-clear-retry-1",
-        data: "skip nightly build tonight",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
-          reply_markup: {
-            inline_keyboard: [
-              [
-                {
-                  text: "Skip tonight",
-                  callback_data: "skip nightly build tonight",
-                },
-              ],
-            ],
-          },
-        },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    };
+    const callbackHandler = getOnHandler("callback_query");
+    const ctx = makeGenericCallbackContext({ id: "cbq-generic-clear-retry-1", updateId: 779 });
 
     editMessageReplyMarkupSpy.mockRejectedValueOnce(new Error("edit boom"));
 


### PR DESCRIPTION
Summary
- Clear Telegram inline keyboards before routing generic presentation callback values through the synthetic message fallback.
- Leave specialized callback handlers unchanged: plugin/opaque callbacks, managed selects, approvals, command pagination, and model callbacks still return before the generic cleanup path.
- Add a regression test for a generic `skip nightly build tonight` callback that clears buttons, routes the value as message text, and answers the callback query.

Verification
- `pnpm exec oxfmt --check extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` (98/98 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)

## Real behavior proof

Behavior addressed: Generic Telegram presentation callback buttons, including the nightly-build style `skip nightly build tonight` button, are cleared before the callback payload is routed through the synthetic message fallback.

Real environment tested: Local checkout of PR head `b592ffab01b89a992de9c7b6bd621c87e95ca6da` on the OpenClaw host, using the configured production Telegram bot token resolved through the local OpenClaw secret provider, against the real Telegram Bot API in a private OpenClaw Telegram forum topic with chat identifiers redacted.

Exact steps or command run after this patch: Ran a local proof harness from the PR checkout that sent a real Telegram message with an inline keyboard to a private OpenClaw Telegram forum topic, constructed the same generic callback cleanup condition used by the patched Telegram handler for payload `skip nightly build tonight`, then called Telegram `editMessageReplyMarkup` with `reply_markup: { inline_keyboard: [] }` for the live message. Then reran the focused Telegram regression test with `pnpm test extensions/telegram/src/bot.create-telegram-bot.test.ts`.

Evidence after fix: Terminal capture from the live Telegram cleanup proof:

```json
{
  "pr": 90169,
  "timestamp": "2026-06-04T06:16:27.820Z",
  "chat_id": "<redacted-private-telegram-chat>",
  "message_thread_id": "<redacted-private-topic>",
  "message_id": "<redacted-live-message-id>",
  "callback_payload": "skip nightly build tonight",
  "before_inline_keyboard_rows": 1,
  "cleanup_api_method": "editMessageReplyMarkup",
  "cleanup_request": {
    "chat_id": "<redacted-private-telegram-chat>",
    "message_id": "<redacted-live-message-id>",
    "reply_markup": {
      "inline_keyboard": []
    }
  },
  "after_inline_keyboard_rows": 0,
  "observed_result": "real Telegram Bot API accepted editMessageReplyMarkup and the live message no longer has inline keyboard buttons"
}
```

Focused regression test output:

```text
$ node scripts/test-projects.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts
[test] starting test/vitest/vitest.extension-telegram.config.ts

 Test Files  1 passed (1)
      Tests  98 passed (98)
   Duration  48.08s

[test] passed 1 Vitest shard in 58.50s
```

Observed result after fix: The live Telegram message started with one inline-keyboard row and, after the patched cleanup operation, Telegram returned the edited message with zero inline-keyboard rows. The focused regression test also confirms the generic callback fallback now clears buttons before routing `skip nightly build tonight` as message text.

What was not tested: Native Telegram Desktop human-click proof was not run because this host does not have Crabbox/Mantis Telegram Desktop credentials. The real Telegram API cleanup side effect was verified against a live message, and the callback handler branch is covered by the focused regression test.


