### PR TITLE
[codex] fix(ui): proxy inbound media previews

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1582,6 +1582,57 @@ describe("grouped chat rendering", () => {
     vi.unstubAllGlobals();
   });
 
+  it("renders canonical inbound media refs through the Control UI media route", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const mediaUrl = new URL(url, "http://control.test");
+      expect(mediaUrl.pathname).toBe("/openclaw/__openclaw__/assistant-media");
+      expect([...mediaUrl.searchParams.keys()].toSorted()).toEqual(["meta", "source"]);
+      expect(mediaUrl.searchParams.get("meta")).toBe("1");
+      expect(mediaUrl.searchParams.get("source")).toBe("media://inbound/telegram-photo.png");
+      const headers = init?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer session-token");
+      return {
+        ok: true,
+        json: async () => mediaTicketPayload("ticket-inbound"),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const container = document.createElement("div");
+    const renderMessage = () =>
+      renderGroupedMessage(
+        container,
+        {
+          id: "user-inbound-media-ref",
+          role: "user",
+          content: "",
+          MediaPath: "media://inbound/telegram-photo.png",
+          MediaType: "image/png",
+          timestamp: Date.now(),
+        },
+        "user",
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          assistantAttachmentAuthToken: "session-token",
+          localMediaPreviewRoots: [],
+          onRequestUpdate: renderMessage,
+        },
+      );
+
+    renderMessage();
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+    ).toBe(
+      "/openclaw/__openclaw__/assistant-media?source=media%3A%2F%2Finbound%2Ftelegram-photo.png&mediaTicket=ticket-inbound",
+    );
+    vi.unstubAllGlobals();
+  });
+
   it("fetches managed chat images with auth and renders blob previews", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
     const managedChatImageUrl =

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1013,6 +1013,7 @@ function isLocalAssistantAttachmentSource(source: string): boolean {
     return false;
   }
   return (
+    isCanonicalInboundMediaRef(trimmed) ||
     trimmed.startsWith("file://") ||
     trimmed.startsWith("~") ||
     trimmed.startsWith("/") ||
@@ -1020,9 +1021,29 @@ function isLocalAssistantAttachmentSource(source: string): boolean {
   );
 }
 
+function isCanonicalInboundMediaRef(source: string): boolean {
+  try {
+    const parsed = new URL(source.trim());
+    const id = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+    return (
+      parsed.protocol === "media:" &&
+      parsed.hostname === "inbound" &&
+      Boolean(id) &&
+      !id.includes("/") &&
+      !id.includes("\\") &&
+      !id.includes("\0")
+    );
+  } catch {
+    return false;
+  }
+}
+
 function normalizeLocalAttachmentPath(source: string): string | null {
   const trimmed = source.trim();
   if (!isLocalAssistantAttachmentSource(trimmed)) {
+    return null;
+  }
+  if (isCanonicalInboundMediaRef(trimmed)) {
     return null;
   }
   if (trimmed.startsWith("file://")) {
@@ -1075,6 +1096,9 @@ function isLocalAttachmentPreviewAllowed(
   source: string,
   localMediaPreviewRoots: readonly string[],
 ): boolean {
+  if (isCanonicalInboundMediaRef(source)) {
+    return true;
+  }
   const normalizedSource = normalizeLocalAttachmentPath(source);
   const comparableSources = normalizedSource
     ? [canonicalizeLocalPathForComparison(normalizedSource)]


### PR DESCRIPTION
## Summary

- Route canonical inbound image refs like `media://inbound/photo.png` through the existing authenticated Control UI `__openclaw__/assistant-media` route.
- Keep proxying limited to single-file `media://inbound/<id>` refs so other `media://` locations do not bypass the existing gateway validation.
- Add a renderer regression test covering transcript `MediaPath` inbound image refs with empty local preview roots.

Fixes #89591

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts -t "renders canonical inbound media refs" --reporter=dot`
- `node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts src/gateway/control-ui.http.test.ts --reporter=dot`
- `npx oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts`
- `node scripts/run-oxlint.mjs ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts`
- `git diff --check`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`

## Real behavior proof

Behavior addressed: WebUI transcript images stored as `media://inbound/...` were detected as image `MediaPath` entries, but the renderer left the browser-facing `<img src>` as `media://...` instead of using the existing authenticated `__openclaw__/assistant-media` route. Browsers cannot load that scheme, so inbound Telegram/iMessage images showed as attachments without an inline preview.

Real environment tested: Local OpenClaw worktree at commit `98f8ec1fafcf2e32320e0a488a21462d84a3067f` on macOS with repo dependencies installed via `pnpm install --frozen-lockfile`. The proof used the actual Control UI grouped renderer in jsdom, the actual async media-ticket path, and the existing Gateway HTTP media route tests.

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts src/gateway/control-ui.http.test.ts --reporter=dot
node --import tsx - <<'NODE'
# jsdom render probe: render a user message with MediaPath="media://inbound/proof-photo.png",
# stub the authenticated meta response, flush the renderer update, and print fetchCalls + imageSrc.
NODE
node scripts/run-oxlint.mjs ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts
npx oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts
git diff --check
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
```

Evidence after fix:
```text
RED before fix:
FAIL grouped-render.test.ts > renders canonical inbound media refs through the Control UI media route
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times

After fix targeted suite:
Test Files  4 passed (4)
Tests  200 passed (200)
Test Files  1 passed (1)
Tests  57 passed (57)

Actual jsdom renderer output:
{"fetchCalls":[{"url":"/openclaw/__openclaw__/assistant-media?source=media%3A%2F%2Finbound%2Fproof-photo.png&meta=1","auth":"Bearer session-token"}],"imageSrc":"/openclaw/__openclaw__/assistant-media?source=media%3A%2F%2Finbound%2Fproof-photo.png&mediaTicket=proof-ticket"}
```

Observed result after fix: The renderer now treats `media://inbound/proof-photo.png` as a managed inbound media ref, requests authenticated metadata from `/openclaw/__openclaw__/assistant-media?...&meta=1`, receives a media ticket, and renders the final `<img>` with `/openclaw/__openclaw__/assistant-media?source=media%3A%2F%2Finbound%2Fproof-photo.png&mediaTicket=proof-ticket`.

What was not tested: I did not run a live Telegram or iMessage account through the full Gateway UI in a browser screenshot pass. The channel receive path was not changed; existing Gateway tests cover serving canonical inbound refs, and the new proof exercises the shared WebUI renderer path that was leaving `media://inbound` unloadable.
