### PR TITLE
fix(agents): stabilize a2a prompt cache context

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -188,6 +188,8 @@ type AgentCallParams = {
   inputProvenance?: {
     kind?: string;
     sourceSessionKey?: string;
+    sourceChannel?: string;
+    sourceTool?: string;
   };
 };
 
@@ -1145,6 +1147,24 @@ describe("sessions tools", () => {
           ),
       ),
     ).toBe(true);
+    const initialAgentCall = agentCalls.find((call) =>
+      agentParams(call).extraSystemPrompt?.includes("Agent-to-agent message context"),
+    );
+    const initialAgentParams = agentParams(initialAgentCall ?? {});
+    expect(initialAgentParams.extraSystemPrompt).toContain(
+      "Agent 1 (requester) session: <REQUESTER_SESSION>.",
+    );
+    expect(initialAgentParams.extraSystemPrompt).toContain("Agent 1 (requester) channel: discord.");
+    expect(initialAgentParams.extraSystemPrompt).toContain(
+      "Agent 2 (target) session: <TARGET_SESSION>.",
+    );
+    expect(initialAgentParams.extraSystemPrompt).not.toContain(requesterKey);
+    expect(initialAgentParams.inputProvenance).toMatchObject({
+      kind: "inter_session",
+      sourceSessionKey: requesterKey,
+      sourceChannel: "discord",
+      sourceTool: "sessions_send",
+    });
     expect(
       agentCalls.some(
         (call) =>

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -3,7 +3,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
-import { resolveAnnounceTargetFromKey, resolvePingPongTurns } from "./sessions-send-helpers.js";
+import {
+  buildAgentToAgentMessageContext,
+  buildAgentToAgentReplyContext,
+  resolveAnnounceTargetFromKey,
+  resolvePingPongTurns,
+} from "./sessions-send-helpers.js";
 
 describe("resolveAnnounceTargetFromKey", () => {
   beforeEach(() => {
@@ -90,5 +95,40 @@ describe("resolvePingPongTurns", () => {
     expect(
       resolvePingPongTurns({ session: { agentToAgent: { maxPingPongTurns: 50 } } } as never),
     ).toBe(20);
+  });
+});
+
+describe("agent-to-agent prompt context", () => {
+  it("keeps volatile routing identifiers out of system prompt context", () => {
+    const context = buildAgentToAgentMessageContext({
+      requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      requesterChannel: "slack",
+      targetSessionKey: "agent:worker:discord:channel:ops:run:run-123",
+    });
+
+    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
+    expect(context).toContain("Agent 1 (requester) channel: slack.");
+    expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
+    expect(context).not.toContain("agent:main:slack:channel:C123:thread:171.222");
+    expect(context).not.toContain("agent:worker:discord:channel:ops:run:run-123");
+  });
+
+  it("preserves optional session line shape with concrete channel values", () => {
+    const context = buildAgentToAgentReplyContext({
+      requesterSessionKey: "agent:requester:main",
+      targetSessionKey: "agent:target:main",
+      targetChannel: "telegram",
+      currentRole: "target",
+      turn: 2,
+      maxTurns: 5,
+    });
+
+    expect(context).toContain("Current agent: Agent 2 (target).");
+    expect(context).toContain("Agent 1 (requester) session: <REQUESTER_SESSION>.");
+    expect(context).not.toContain("Agent 1 (requester) channel:");
+    expect(context).toContain("Agent 2 (target) session: <TARGET_SESSION>.");
+    expect(context).toContain("Agent 2 (target) channel: telegram.");
+    expect(context).not.toContain("agent:requester:main");
+    expect(context).not.toContain("agent:target:main");
   });
 });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -59,13 +59,14 @@ function buildAgentSessionLines(params: {
   targetChannel?: string;
 }): string[] {
   return [
-    params.requesterSessionKey
-      ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
-      : undefined,
+    // Session keys are high-cardinality (thread/run ids), so concrete values churn the
+    // system prompt and break provider prompt-cache reuse across A2A turns. Channels are
+    // low-cardinality and inform reply formatting, so they stay concrete.
+    params.requesterSessionKey ? "Agent 1 (requester) session: <REQUESTER_SESSION>." : undefined,
     params.requesterChannel
       ? `Agent 1 (requester) channel: ${params.requesterChannel}.`
       : undefined,
-    `Agent 2 (target) session: ${params.targetSessionKey}.`,
+    "Agent 2 (target) session: <TARGET_SESSION>.",
     params.targetChannel ? `Agent 2 (target) channel: ${params.targetChannel}.` : undefined,
   ].filter((line): line is string => Boolean(line));
 }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- `sessions_send` agent-to-agent prompt context currently embeds concrete requester/target session keys in `extraSystemPrompt`.
- Session keys are high-cardinality (they embed thread/run identifiers), so otherwise identical A2A handoffs produce different system prompt bytes on the target session, and provider prompt-cache prefix reuse breaks for everything ordered after the system prompt — including the target session's conversation history.

Why does this matter now?

- A2A/subagent traffic can repeat large stable prompt prefixes while only routing identifiers change.
- Keeping volatile routing IDs in the system prompt makes prompt cache behavior depend on session key churn rather than stable prompt content.

What is the intended outcome?

- Keep the A2A context line shape stable in `extraSystemPrompt` by using placeholders for the high-cardinality requester/target **session keys** only.
- Keep **channel labels concrete** (revised after review feedback): channels are a small closed set (discord/slack/webchat/...), so they barely fragment the cache, and they carry real formatting/routing context for the receiving agent.
- Preserve concrete routing metadata in non-prompt provenance fields (`inputProvenance`) where tools and runtime code still need it.

What is intentionally out of scope?

- No change to message routing, session lookup, delivery behavior, or provenance storage.
- No provider-specific cache tuning and no cache-control parameter changes.
- The A2A announce step still embeds the model-generated reply text (`Latest reply: ...`), which varies per run by design; this PR only stabilizes routing identifiers.

What does success look like?

- A2A prompts keep the same bytes across changed requester session identifiers.
- Concrete requester/target values remain available outside the prompt.
- Live provider cache usage improves for the changed-requester A2A scenario on the same target session.

What should reviewers focus on?

- Whether the placeholder-session / concrete-channel split preserves enough model-visible context for the receiving agent.
- Whether the regression tests cover both helper output and the caller-level `sessions_send` agent call.

## Linked context

Which issue does this close?

None.

Which issues, PRs, or discussions are related?

None.

Was this requested by a maintainer or owner?

No formal linked issue. This came from investigating A2A/subagent prompt-cache stability. The session-placeholder/concrete-channel split follows reviewer feedback in this PR's comments.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: concrete A2A requester session keys in `extraSystemPrompt` change the target session's system prompt bytes on every handoff from a different requester session, breaking provider prompt-cache prefix reuse for the target session.
- Real environment tested: local OpenClaw gateway built from this branch (and from its merge-base for the before run), isolated state dir with two synthetic agents (`alpha` -> `beta`), `anthropic/claude-haiku-4-5` via direct Anthropic API, `OPENCLAW_CACHE_TRACE=1` and `OPENCLAW_ANTHROPIC_PAYLOAD_LOG=1` enabled on the gateway process.
- Exact steps or command run after this patch: started `openclaw gateway run`, then issued two real `sessions_send` handoffs into the same target session from two different requester sessions:

  ```
  openclaw agent --agent alpha --session-key agent:alpha:req-c -m 'Call the sessions_send tool now with sessionKey "agent:beta:main2" and message "ping". Do nothing else, then reply "done".' --json
  openclaw agent --agent alpha --session-key agent:alpha:req-d -m '...same instruction...' --json
  ```

  The identical procedure was run on the merge-base build first (requesters `req-a`/`req-b`, fresh target session) to capture the before baseline.
- Evidence after fix: copied live output / trace excerpt from the target-session runtime cache trace (`cache:state` system prompt digests) and provider-attested usage from the Anthropic payload log, same-position turns across the two handoffs:

  | build | handoff #1 digest | handoff #2 digest | digest equal? | handoff #2 cacheRead | handoff #2 cacheWrite |
  |---|---|---|---|---|---|
  | before (merge-base) | `b30e2ea341251bc2` | `627b2420e36dcdb9` | no — `systemPrompt digest changed` flagged | 22400 | 247 |
  | after (this patch) | `521ad38c6ce64431` | `521ad38c6ce64431` | **yes — byte-identical** | **22005 (= full prefix written by handoff #1)** | **204** |

  Target-session system prompt excerpt after the patch (from the gateway cache trace):

  ```
  Agent-to-agent message context:
  Agent 1 (requester) session: <REQUESTER_SESSION>.
  Agent 1 (requester) channel: webchat.
  Agent 2 (target) session: <TARGET_SESSION>.
  ```

  Before the patch the same excerpt contained the concrete keys (`Agent 1 (requester) session: agent:alpha:req-a.`), and the runner's prompt-cache observability flagged `systemPrompt(system prompt digest changed)` on every handoff turn of the target session.
- Observed result after fix: handoffs from different requester sessions now produce byte-identical target-session system prompts (same digest), and the second handoff reads back exactly the full cached prefix written by the first (cacheRead 22005 vs cacheWrite 204). Before the patch, every handoff from a new requester changed the system prompt digest, so the cached prefix written by prior handoffs could not be fully reused; with longer target-session histories the re-written span grows with the history.
- What was not tested: real Discord/Telegram/Slack channel delivery; OAuth-based auth profiles (API key only); long target-session histories (the repro uses short sessions, so absolute token deltas are small — the structural signal is the digest equality); the announce-step turns still differ across runs because they embed the model-generated reply text, which is out of scope here.
- Proof limitations or environment constraints: trace artifacts contain local paths/hostnames and stay local; only the excerpts, digests, and token counts above are published. Credentials were supplied via the local environment and are not included.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/tools/sessions-send-helpers.test.ts src/agents/openclaw-tools.sessions.test.ts` (40 passed)
- `corepack pnpm exec oxfmt --check src/agents/tools/sessions-send-helpers.ts src/agents/tools/sessions-send-helpers.test.ts src/agents/openclaw-tools.sessions.test.ts`
- `node scripts/run-oxlint.mjs src/agents/tools/sessions-send-helpers.ts src/agents/tools/sessions-send-helpers.test.ts src/agents/openclaw-tools.sessions.test.ts`
- `git diff --check`
- live before/after gateway cache-trace comparison summarized above

What regression coverage was added or updated?

- Added direct helper tests proving A2A initial and reply contexts use placeholders for session keys while keeping concrete channel values.
- Added caller-level `sessions_send` coverage proving concrete requester metadata remains in `inputProvenance` while `extraSystemPrompt` carries placeholder session lines and the concrete channel.

What failed before this fix, if known?

- Previous A2A prompt-context output varied by concrete requester/target session IDs; the runner's cache observability flagged `systemPrompt digest changed` on every A2A handoff turn of the target session (live trace above).

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, narrowly. Receiving agents now see placeholder labels instead of concrete **session keys** in the A2A prompt context. Channel labels remain concrete (unchanged from shipped behavior), which preserves formatting/routing context.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

An agent could have been relying on prompt-visible concrete session key strings for reasoning instead of using structured provenance/runtime metadata.

How is that risk mitigated?

The prompt still communicates the requester/target roles, whether session fields exist, and the concrete channel; concrete session values remain available in `inputProvenance` and session routing state. The change is limited to A2A prompt-context formatting.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI re-run on the revised commit; maintainer review.

Which bot or reviewer comments were addressed?

- @byungskers's middle-ground suggestion (keep a stable channel hint, placeholder only the volatile identifiers) is adopted in the revised commit: channel lines are concrete again; only session keys are placeholders.
