### PR TITLE
[codex] fix(gateway): open config on Windows

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -74,14 +74,14 @@ describe("resolveConfigOpenCommand", () => {
     });
   });
 
-  it("uses a quoted PowerShell literal on Windows", () => {
+  it("uses Start-Process FilePath with a quoted PowerShell literal on Windows", () => {
     expect(resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32")).toEqual({
       command: "powershell.exe",
       args: [
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        String.raw`Start-Process -LiteralPath 'C:\tmp\o''hai & calc.json'`,
+        String.raw`Start-Process -FilePath 'C:\tmp\o''hai & calc.json'`,
       ],
     });
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -181,7 +181,7 @@ export function resolveConfigOpenCommand(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        `Start-Process -LiteralPath '${escapePowerShellSingleQuotedString(configPath)}'`,
+        `Start-Process -FilePath '${escapePowerShellSingleQuotedString(configPath)}'`,
       ],
     };
   }


### PR DESCRIPTION
## Summary

- Replace the Windows dashboard config opener command from `Start-Process -LiteralPath` to `Start-Process -FilePath`.
- Preserve the existing single-quoted PowerShell escaping so config paths stay data, not executable shell text.
- Update the focused Gateway command-shape regression test.

Fixes #90157

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts -t "uses Start-Process FilePath" --reporter=dot`
- `node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts ui/src/ui/controllers/config.test.ts --reporter=dot`
- `npx oxfmt --check src/gateway/server-methods/config.ts src/gateway/server-methods/config.test.ts`
- `node scripts/run-oxlint.mjs src/gateway/server-methods/config.ts src/gateway/server-methods/config.test.ts`
- `git diff --check`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`

## Real behavior proof

Behavior addressed: Dashboard `Open config` on Windows used the Gateway `config.openFile` method, which built a PowerShell command containing `Start-Process -LiteralPath '<openclaw.json path>'`. `Start-Process` supports `-FilePath` for files/documents, not `-LiteralPath`, so Windows users saw the dashboard request fail instead of opening `openclaw.json`.

Real environment tested: Local OpenClaw worktree at commit `3fcc6e50ab` on macOS with dependencies installed via `pnpm install --frozen-lockfile`. The proof exercised the actual Gateway `resolveConfigOpenCommand()` implementation, the `config.openFile` Gateway test file, and the UI controller test that calls `config.openFile`. Microsoft Learn `Start-Process` docs for PowerShell 7.6 and 5.1 list `[-FilePath] <string>` as the file/program parameter.

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts -t "uses Start-Process FilePath" --reporter=dot
node scripts/run-vitest.mjs src/gateway/server-methods/config.test.ts ui/src/ui/controllers/config.test.ts --reporter=dot
node --import tsx - <<'NODE'
import { resolveConfigOpenCommand } from "./src/gateway/server-methods/config.ts";
console.log(JSON.stringify(resolveConfigOpenCommand(String.raw`C:\tmp\o'hai & calc.json`, "win32"), null, 2));
NODE
node scripts/run-oxlint.mjs src/gateway/server-methods/config.ts src/gateway/server-methods/config.test.ts
npx oxfmt --check src/gateway/server-methods/config.ts src/gateway/server-methods/config.test.ts
git diff --check
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json
```

Evidence after fix:
```text
RED before fix:
FAIL resolveConfigOpenCommand > uses Start-Process FilePath with a quoted PowerShell literal on Windows
Expected: "Start-Process -FilePath 'C:\\tmp\\o''hai & calc.json'"
Received: "Start-Process -LiteralPath 'C:\\tmp\\o''hai & calc.json'"

Focused Gateway + UI tests after fix:
Test Files  2 passed (2)
Tests  18 passed (18)
Test Files  1 passed (1)
Tests  43 passed (43)

Actual resolver output after fix:
{
  "command": "powershell.exe",
  "args": [
    "-NoProfile",
    "-NonInteractive",
    "-Command",
    "Start-Process -FilePath 'C:\\tmp\\o''hai & calc.json'"
  ]
}
```

Observed result after fix: The Windows opener now emits `powershell.exe -NoProfile -NonInteractive -Command "Start-Process -FilePath '<escaped config path>'"`, preserving the existing quote escaping while using the supported `Start-Process` parameter.

What was not tested: I did not run a live Windows dashboard click-through or execute PowerShell locally because this macOS environment does not have `pwsh`, `powershell`, or `powershell.exe` installed. The changed command contract was validated against the actual Gateway command builder, existing UI `config.openFile` request tests, and Microsoft Learn parameter documentation.
