### PR TITLE
fix(plugins): isolate definition metadata failures

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2789,6 +2789,61 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
+  it("isolates unreadable definition reload metadata without dropping healthy plugins", () => {
+    useNoBundledPlugins();
+    const badPlugin = writePlugin({
+      id: "bad-definition-reload",
+      filename: "bad-definition-reload.cjs",
+      body: `module.exports = {
+        id: "bad-definition-reload",
+        reload: Object.defineProperty({}, "restartPrefixes", {
+          get() {
+            throw new Error("definition reload restart prefixes exploded");
+          },
+        }),
+        register() {
+          globalThis.badDefinitionReloadRegistered = true;
+        },
+      };`,
+    });
+    const healthyPlugin = writePlugin({
+      id: "healthy-after-bad-reload",
+      filename: "healthy-after-bad-reload.cjs",
+      body: `module.exports = {
+        id: "healthy-after-bad-reload",
+        register() {
+          globalThis.healthyAfterBadReloadRegistered = true;
+        },
+      };`,
+    });
+    const globals = globalThis as Record<string, unknown>;
+    delete globals.badDefinitionReloadRegistered;
+    delete globals.healthyAfterBadReloadRegistered;
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [badPlugin.file, healthyPlugin.file] },
+          allow: [badPlugin.id, healthyPlugin.id],
+        },
+      },
+      onlyPluginIds: [badPlugin.id, healthyPlugin.id],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === badPlugin.id)?.status).toBe("error");
+    expect(registry.plugins.find((entry) => entry.id === healthyPlugin.id)?.status).toBe("loaded");
+    expect(globals.badDefinitionReloadRegistered).toBeUndefined();
+    expect(globals.healthyAfterBadReloadRegistered).toBe(true);
+    expect(registry.reloads).toStrictEqual([]);
+    expectDiagnosticContaining({
+      registry,
+      level: "error",
+      pluginId: badPlugin.id,
+      message: "definition reload restart prefixes exploded",
+    });
+  });
+
   it("rolls back global side effects when registration fails", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2642,14 +2642,32 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (registrationPlan.runFullActivationOnlyRegistrations) {
-        if (definition?.reload) {
-          registerReload(record, definition.reload);
-        }
-        for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
-          registerNodeHostCommand(record, nodeHostCommand);
-        }
-        for (const collector of definition?.securityAuditCollectors ?? []) {
-          registerSecurityAuditCollector(record, collector);
+        const registrySnapshot = snapshotPluginRegistry(registry);
+        try {
+          if (definition?.reload) {
+            registerReload(record, definition.reload);
+          }
+          for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
+            registerNodeHostCommand(record, nodeHostCommand);
+          }
+          for (const collector of definition?.securityAuditCollectors ?? []) {
+            registerSecurityAuditCollector(record, collector);
+          }
+        } catch (err) {
+          restorePluginRegistry(registry, registrySnapshot);
+          recordPluginError({
+            logger,
+            registry,
+            record,
+            seenIds,
+            pluginId,
+            origin: candidate.origin,
+            phase: "load",
+            error: err,
+            logPrefix: `[plugins] ${record.id} failed to register plugin definition metadata from ${record.source}: `,
+            diagnosticMessagePrefix: "failed to register plugin definition metadata: ",
+          });
+          continue;
         }
       }
 


### PR DESCRIPTION
## Summary

- isolate failures while registering plugin definition metadata during full activation
- roll back reload/node-host/security-audit metadata mutations before marking the offending plugin as errored
- keep healthy sibling plugins loadable when a malformed definition reload descriptor throws before `register()` runs

## Real behavior proof

Behavior addressed: malformed plugin definition metadata no longer aborts `loadOpenClawPlugins()` before healthy sibling plugins load.

Real environment tested: linked OpenClaw worktree on Node via the repo Vitest wrapper, rebased once onto `origin/main` commit `5b98f03c64d`.

Exact steps or command run after this patch:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next180-final-pair nodenv exec node scripts/run-vitest.mjs run src/plugins/loader.test.ts --testNamePattern="isolates unreadable definition reload metadata|supports legacy plugins subscribing to diagnostic events" --reporter=verbose
nodenv exec node scripts/run-oxlint.mjs src/plugins/loader.ts src/plugins/loader.test.ts
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
blacksmith testbox list --all
node scripts/crabbox-wrapper.mjs run --provider aws --label next180-check-changed --shell -- "pnpm check:changed"
```

Evidence after fix: the focused regression pair passed (`2 passed | 151 skipped`), oxlint passed, diff-check passed, and branch autoreview returned `autoreview clean: no accepted/actionable findings reported` with `overall: patch is correct (0.82)`.

Observed result after fix: a plugin whose `reload.restartPrefixes` getter throws is recorded as `error`; its `register()` is not called; registry metadata is rolled back; the healthy sibling plugin still reaches `loaded` and its `register()` runs.

What was not tested: broad `pnpm check:changed` was blocked by maintainer runner auth. `blacksmith testbox list --all` failed with `not authenticated -- run 'blacksmith auth login' first`; AWS Crabbox failed before lease creation with coordinator `POST /v1/runs` and `POST /v1/leases` returning HTTP 401. The full `src/plugins/loader.test.ts` file was attempted twice before the final rebase; every test passed except the existing/order-dependent `supports legacy plugins subscribing to diagnostic events from the root sdk`, which passed alone and passed paired with this new regression test.

## Red proof

Before the fix, the new regression crashed the load pass with:

```text
definition reload restart prefixes exploded
```

That happened while registering definition-level reload metadata before the per-plugin registration try/catch, so healthy sibling plugins were not reached.
