### PR TITLE
fix(thinking): filter empty text blocks in dropThinkingBlocks and dropReasoningFromHistory

### DIFF
--- a/scripts/repro/issue-90139-empty-text-block-proof.mts
+++ b/scripts/repro/issue-90139-empty-text-block-proof.mts
@@ -1,0 +1,100 @@
+import { dropReasoningFromHistory, dropThinkingBlocks } from "../../src/agents/embedded-agent-runner/thinking.js";
+
+const OMITTED = "[assistant reasoning omitted]";
+
+function makeMessages() {
+  return {
+    thinkingOnly: [
+      { role: "user", content: "first" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "old" }] },
+      { role: "user", content: "second" },
+      { role: "assistant", content: [{ type: "text", text: "latest" }] },
+    ],
+    thinkingAndEmptyText: [
+      { role: "user", content: "first" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "" }] },
+      { role: "user", content: "second" },
+      { role: "assistant", content: [{ type: "text", text: "latest" }] },
+    ],
+    thinkingAndWhitespaceText: [
+      { role: "user", content: "first" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "   " }] },
+      { role: "user", content: "second" },
+      { role: "assistant", content: [{ type: "text", text: "latest" }] },
+    ],
+    thinkingAndRealText: [
+      { role: "user", content: "first" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "" }, { type: "text", text: "real answer" }] },
+      { role: "user", content: "second" },
+      { role: "assistant", content: [{ type: "text", text: "latest" }] },
+    ],
+  } as Record<string, Array<{ role: string; content: unknown }>>;
+}
+
+function textOf(msg: { content: unknown }) {
+  const c = msg.content as Array<{ type: string; text?: string }>;
+  return c.map((b) => (b.type === "text" ? b.text : `[${b.type}]`)).join(", ");
+}
+
+let failures = 0;
+
+function check(name: string, actual: string, expected: string) {
+  if (actual === expected) {
+    console.log(`  PASS: ${name}`);
+  } else {
+    console.log(`  FAIL: ${name}`);
+    console.log(`    expected: ${expected}`);
+    console.log(`    actual:   ${actual}`);
+    failures++;
+  }
+}
+
+console.log("=== Reproduction for issue #90139 ===\n");
+
+const cases = makeMessages();
+
+// --- dropThinkingBlocks ---
+console.log("-- dropThinkingBlocks --");
+{
+  const result = dropThinkingBlocks(cases.thinkingOnly as any);
+  check("thinking-only -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropThinkingBlocks(cases.thinkingAndEmptyText as any);
+  check("thinking + empty text -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropThinkingBlocks(cases.thinkingAndWhitespaceText as any);
+  check("thinking + whitespace text -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropThinkingBlocks(cases.thinkingAndRealText as any);
+  check("thinking + empty + real text -> real answer", textOf(result[1]), "real answer");
+}
+
+// --- dropReasoningFromHistory ---
+console.log("\n-- dropReasoningFromHistory --");
+{
+  const result = dropReasoningFromHistory(cases.thinkingOnly as any);
+  check("thinking-only -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropReasoningFromHistory(cases.thinkingAndEmptyText as any);
+  check("thinking + empty text -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropReasoningFromHistory(cases.thinkingAndWhitespaceText as any);
+  check("thinking + whitespace text -> omitted", textOf(result[1]), OMITTED);
+}
+{
+  const result = dropReasoningFromHistory(cases.thinkingAndRealText as any);
+  check("thinking + empty + real text -> real answer", textOf(result[1]), "real answer");
+}
+
+console.log("\n=========================");
+if (failures === 0) {
+  console.log("All checks passed.");
+} else {
+  console.log(`${failures} check(s) failed.`);
+  process.exitCode = 1;
+}

--- a/scripts/repro/issue-90139-empty-text-block-proof.mts
+++ b/scripts/repro/issue-90139-empty-text-block-proof.mts
@@ -1,34 +1,39 @@
 import { dropReasoningFromHistory, dropThinkingBlocks } from "../../src/agents/embedded-agent-runner/thinking.js";
+import type { AgentMessage } from "../../src/agents/runtime/index.js";
 
 const OMITTED = "[assistant reasoning omitted]";
 
-function makeMessages() {
+function toAgentMessages(msgs: Array<{ role: string; content: unknown }>): AgentMessage[] {
+  return msgs as unknown as AgentMessage[];
+}
+
+function makeMessages(): Record<string, AgentMessage[]> {
   return {
-    thinkingOnly: [
+    thinkingOnly: toAgentMessages([
       { role: "user", content: "first" },
       { role: "assistant", content: [{ type: "thinking", thinking: "old" }] },
       { role: "user", content: "second" },
       { role: "assistant", content: [{ type: "text", text: "latest" }] },
-    ],
-    thinkingAndEmptyText: [
+    ]),
+    thinkingAndEmptyText: toAgentMessages([
       { role: "user", content: "first" },
       { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "" }] },
       { role: "user", content: "second" },
       { role: "assistant", content: [{ type: "text", text: "latest" }] },
-    ],
-    thinkingAndWhitespaceText: [
+    ]),
+    thinkingAndWhitespaceText: toAgentMessages([
       { role: "user", content: "first" },
       { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "   " }] },
       { role: "user", content: "second" },
       { role: "assistant", content: [{ type: "text", text: "latest" }] },
-    ],
-    thinkingAndRealText: [
+    ]),
+    thinkingAndRealText: toAgentMessages([
       { role: "user", content: "first" },
       { role: "assistant", content: [{ type: "thinking", thinking: "old" }, { type: "text", text: "" }, { type: "text", text: "real answer" }] },
       { role: "user", content: "second" },
       { role: "assistant", content: [{ type: "text", text: "latest" }] },
-    ],
-  } as Record<string, Array<{ role: string; content: unknown }>>;
+    ]),
+  };
 }
 
 function textOf(msg: { content: unknown }) {
@@ -56,38 +61,38 @@ const cases = makeMessages();
 // --- dropThinkingBlocks ---
 console.log("-- dropThinkingBlocks --");
 {
-  const result = dropThinkingBlocks(cases.thinkingOnly as any);
+  const result = dropThinkingBlocks(cases.thinkingOnly);
   check("thinking-only -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropThinkingBlocks(cases.thinkingAndEmptyText as any);
+  const result = dropThinkingBlocks(cases.thinkingAndEmptyText);
   check("thinking + empty text -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropThinkingBlocks(cases.thinkingAndWhitespaceText as any);
+  const result = dropThinkingBlocks(cases.thinkingAndWhitespaceText);
   check("thinking + whitespace text -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropThinkingBlocks(cases.thinkingAndRealText as any);
+  const result = dropThinkingBlocks(cases.thinkingAndRealText);
   check("thinking + empty + real text -> real answer", textOf(result[1]), "real answer");
 }
 
 // --- dropReasoningFromHistory ---
 console.log("\n-- dropReasoningFromHistory --");
 {
-  const result = dropReasoningFromHistory(cases.thinkingOnly as any);
+  const result = dropReasoningFromHistory(cases.thinkingOnly);
   check("thinking-only -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropReasoningFromHistory(cases.thinkingAndEmptyText as any);
+  const result = dropReasoningFromHistory(cases.thinkingAndEmptyText);
   check("thinking + empty text -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropReasoningFromHistory(cases.thinkingAndWhitespaceText as any);
+  const result = dropReasoningFromHistory(cases.thinkingAndWhitespaceText);
   check("thinking + whitespace text -> omitted", textOf(result[1]), OMITTED);
 }
 {
-  const result = dropReasoningFromHistory(cases.thinkingAndRealText as any);
+  const result = dropReasoningFromHistory(cases.thinkingAndRealText);
   check("thinking + empty + real text -> real answer", textOf(result[1]), "real answer");
 }
 

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -60,6 +60,32 @@ describe("thinking-free history contract", () => {
       expect(result).toBe(messages);
     },
   );
+
+  it.each(noThinkingReferenceCases)(
+    "$name preserves blank no-thinking assistant turns unchanged",
+    ({ drop }) => {
+      const messages: AgentMessage[] = [
+        castAgentMessage({ role: "user", content: "hello" }),
+        castAgentMessage({ role: "assistant", content: [{ type: "text", text: "" }] }),
+      ];
+
+      const result = drop(messages);
+      expect(result).toBe(messages);
+    },
+  );
+
+  it.each(noThinkingReferenceCases)(
+    "$name preserves whitespace-only no-thinking assistant turns unchanged",
+    ({ drop }) => {
+      const messages: AgentMessage[] = [
+        castAgentMessage({ role: "user", content: "hello" }),
+        castAgentMessage({ role: "assistant", content: [{ type: "text", text: "   " }] }),
+      ];
+
+      const result = drop(messages);
+      expect(result).toBe(messages);
+    },
+  );
 });
 
 describe("isAssistantMessageWithContent", () => {

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -177,6 +177,55 @@ describe("dropThinkingBlocks", () => {
       { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
     ]);
   });
+
+  it("uses omitted-reasoning text when an older assistant turn contains only thinking and empty text", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old" },
+          { type: "text", text: "" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "latest text" }],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const oldAssistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+
+    expect(oldAssistant.content).toEqual([
+      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+    ]);
+  });
+
+  it("preserves meaningful text when an older assistant turn has thinking and whitespace-only text alongside real text", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old" },
+          { type: "text", text: "   " },
+          { type: "text", text: "real answer" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "latest text" }],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const oldAssistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+
+    expect(oldAssistant.content).toEqual([{ type: "text", text: "real answer" }]);
+  });
 });
 
 describe("dropReasoningFromHistory", () => {
@@ -267,6 +316,45 @@ describe("dropReasoningFromHistory", () => {
     expect(assistant.content).toEqual([
       { type: "toolCall", id: "call123456", name: "lookup", arguments: {} },
     ]);
+  });
+
+  it("uses omitted-reasoning text when a completed assistant turn contains only thinking and empty text", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "private" },
+          { type: "text", text: "" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+    ];
+
+    const result = dropReasoningFromHistory(messages);
+    const assistant = result[1] as AssistantMessage;
+
+    expect(assistant.content).toEqual([{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }]);
+  });
+
+  it("preserves meaningful text when a completed assistant turn has thinking and whitespace-only text alongside real text", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "private" },
+          { type: "text", text: "   " },
+          { type: "text", text: "visible" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+    ];
+
+    const result = dropReasoningFromHistory(messages);
+    const assistant = result[1] as AssistantMessage;
+
+    expect(assistant.content).toEqual([{ type: "text", text: "visible" }]);
   });
 });
 

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -229,6 +229,31 @@ describe("dropThinkingBlocks", () => {
     ]);
   });
 
+  it("filters empty text regardless of block order (empty before thinking)", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "thinking", thinking: "old" },
+        ],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "latest text" }],
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const oldAssistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+
+    expect(oldAssistant.content).toEqual([
+      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+    ]);
+  });
+
   it("preserves meaningful text when an older assistant turn has thinking and whitespace-only text alongside real text", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({ role: "user", content: "first" }),

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -336,13 +336,19 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
     }
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
+    let hadThinkingRemoved = false;
     for (const block of msg.content) {
       if (isThinkingBlock(block)) {
         touched = true;
         changed = true;
+        hadThinkingRemoved = true;
         continue;
       }
-      if ((block as { type?: unknown }).type === "text" && !hasMeaningfulText(block)) {
+      if (
+        hadThinkingRemoved &&
+        (block as { type?: unknown }).type === "text" &&
+        !hasMeaningfulText(block)
+      ) {
         changed = true;
         continue;
       }
@@ -430,10 +436,11 @@ function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
       continue;
     }
 
+    const hadThinking = message.content.some((block) => isThinkingBlock(block));
     const nextContent = message.content.filter(
       (block) =>
         !isThinkingBlock(block) &&
-        ((block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
+        (!hadThinking || (block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
     );
     if (nextContent.length === message.content.length) {
       out.push(message);
@@ -471,10 +478,11 @@ export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage
       continue;
     }
 
+    const hadThinking = message.content.some((block) => isThinkingBlock(block));
     const nextContent = message.content.filter(
       (block) =>
         !isThinkingBlock(block) &&
-        ((block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
+        (!hadThinking || (block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
     );
     if (nextContent.length === message.content.length) {
       out.push(message);

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -342,6 +342,10 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
         changed = true;
         continue;
       }
+      if ((block as { type?: unknown }).type === "text" && !hasMeaningfulText(block)) {
+        changed = true;
+        continue;
+      }
       nextContent.push(block);
     }
     if (!changed) {
@@ -426,7 +430,11 @@ function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
       continue;
     }
 
-    const nextContent = message.content.filter((block) => !isThinkingBlock(block));
+    const nextContent = message.content.filter(
+      (block) =>
+        !isThinkingBlock(block) &&
+        ((block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
+    );
     if (nextContent.length === message.content.length) {
       out.push(message);
       continue;
@@ -463,7 +471,11 @@ export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage
       continue;
     }
 
-    const nextContent = message.content.filter((block) => !isThinkingBlock(block));
+    const nextContent = message.content.filter(
+      (block) =>
+        !isThinkingBlock(block) &&
+        ((block as { type?: unknown }).type !== "text" || hasMeaningfulText(block)),
+    );
     if (nextContent.length === message.content.length) {
       out.push(message);
       continue;

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -334,18 +334,17 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
       out.push(msg);
       continue;
     }
+    const hadThinking = msg.content.some((block) => isThinkingBlock(block));
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
-    let hadThinkingRemoved = false;
     for (const block of msg.content) {
       if (isThinkingBlock(block)) {
         touched = true;
         changed = true;
-        hadThinkingRemoved = true;
         continue;
       }
       if (
-        hadThinkingRemoved &&
+        hadThinking &&
         (block as { type?: unknown }).type === "text" &&
         !hasMeaningfulText(block)
       ) {


### PR DESCRIPTION
## Summary

Fixes #90139.

`dropThinkingBlocks` and `dropReasoningFromHistory` in `src/agents/embedded-agent-runner/thinking.ts` stripped thinking blocks but kept empty/whitespace-only text blocks in the remaining content array. This caused `nextContent.length > 0` to evaluate to true even when no meaningful visible text remained, preventing the omitted-reasoning placeholder from being emitted. In channel paths that use the sanitizer (WeChat, some webchat paths), a valid short text reply alongside a thinking block could be silently replaced with `[assistant reasoning omitted]` because an empty text block occupied the content slot.

The fix reuses the existing `hasMeaningfulText(block)` helper (already defined in the same file) to also discard empty text blocks when filtering, so the fallback placeholder is only emitted when no meaningful visible content actually remains.

## Changes

- `src/agents/embedded-agent-runner/thinking.ts`:
  - `dropThinkingBlocks`: skip empty/whitespace-only text blocks during the per-block loop
  - `stripAllThinkingBlocks` (internal helper): same filter in `.filter()` call
  - `dropReasoningFromHistory`: same filter in `.filter()` call
- `src/agents/embedded-agent-runner/thinking.test.ts`: add 4 regression tests covering empty-text and whitespace-only text alongside thinking blocks for both sanitizers
- `scripts/repro/issue-90139-empty-text-block-proof.mts`: standalone reproduction script

## Real behavior proof

- **Behavior addressed**: `dropThinkingBlocks` and `dropReasoningFromHistory` now correctly filter empty/whitespace-only text blocks before deciding whether to emit the `[assistant reasoning omitted]` placeholder
- **Real environment tested**: Linux 4.19.112, Node 22.19, local source checkout
- **Exact steps or command run after this patch**:
  - `node --import tsx scripts/repro/issue-90139-empty-text-block-proof.mts`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts --reporter=dot`
- **Evidence after fix**:

```text
=== Reproduction for issue #90139 ===

-- dropThinkingBlocks --
  PASS: thinking-only -> omitted
  PASS: thinking + empty text -> omitted
  PASS: thinking + whitespace text -> omitted
  PASS: thinking + empty + real text -> real answer

-- dropReasoningFromHistory --
  PASS: thinking-only -> omitted
  PASS: thinking + empty text -> omitted
  PASS: thinking + whitespace text -> omitted
  PASS: thinking + empty + real text -> real answer

=========================
All checks passed.
```

- **Observed result after fix**: Empty and whitespace-only text blocks are discarded alongside thinking blocks. When no meaningful text remains, the sanitizer correctly falls back to `[assistant reasoning omitted]`. When meaningful text exists alongside empty text, only the meaningful text is preserved.
- **What was not tested**: No end-to-end TUI/webchat/WeChat channel reproduction was executed; the fix addresses the shared sanitizer layer and relies on existing channel test coverage for integration.

## Verification

```bash
# Tests
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts --reporter=dot
# 38 passed

node scripts/run-vitest.mjs src/agents/embedded-agent-runner.sanitize-session-history.test.ts --reporter=dot
# 71 passed

# Lint (modified files only)
npx oxlint --import-plugin --config .oxlintrc.json   src/agents/embedded-agent-runner/thinking.ts   src/agents/embedded-agent-runner/thinking.test.ts
# clean
```