### PR TITLE
fix(gateway): require pairing for shared-token backend clients

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -116,11 +116,13 @@ Treat Gateway and node as one operator trust domain, with different roles:
 - A caller authenticated to the Gateway is trusted at Gateway scope. After pairing, node actions are trusted operator actions on that node.
 - Operator scope levels and approval-time checks are summarized in
   [Operator scopes](/gateway/operator-scopes).
-- Direct loopback backend clients authenticated with the shared gateway
-  token/password can make internal control-plane RPCs without presenting a user
-  device identity. This is not a remote or browser pairing bypass: network
-  clients, node clients, device-token clients, and explicit device identities
-  still go through pairing and scope-upgrade enforcement.
+- Direct loopback backend clients authenticated with a dedicated device token
+  can make internal control-plane RPCs without presenting a separate user
+  device identity. Shared gateway token/password auth and bootstrap-token auth
+  stay on the normal pairing path because backend identity is client-declared.
+  This is not a remote or browser pairing bypass: network clients, node
+  clients, and explicit device identities still go through pairing and
+  scope-upgrade enforcement.
 - `sessionKey` is routing/context selection, not per-user auth.
 - Exec approvals (allowlist + ask) are guardrails for operator intent, not hostile multi-tenant isolation.
 - OpenClaw's product default for trusted single-operator setups is that host exec on `gateway`/`node` is allowed without approval prompts (`security="full"`, `ask="off"` unless you tighten it). That default is intentional UX, not a vulnerability by itself.
@@ -907,8 +909,9 @@ Local device pairing:
 
 - Device pairing is auto-approved for direct local loopback connects to keep
   same-host clients smooth.
-- OpenClaw also has a narrow backend/container-local self-connect path for
-  trusted shared-secret helper flows.
+- OpenClaw also has a narrow direct-local backend self-connect path for trusted
+  device-token helper flows. Shared token/password and bootstrap-token
+  handshakes stay on the normal pairing path.
 - Tailnet and LAN connects, including same-host tailnet binds, are treated as
   remote for pairing and still need approval.
 - Forwarded-header evidence on a loopback request disqualifies loopback

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -66,7 +66,7 @@ async function expectSharedOperatorScopesCleared(
   }
 }
 
-async function expectLocalBackendGatewayClientScopesPreserved(
+async function expectLocalBackendGatewayClientScopesCleared(
   port: number,
   auth: { token?: string; password?: string; skipDefaultAuth?: boolean },
 ) {
@@ -87,10 +87,11 @@ async function expectLocalBackendGatewayClientScopesPreserved(
           };
         }
       | undefined;
-    expect(helloOk?.auth?.scopes).toEqual(["operator.admin"]);
+    expect(helloOk?.auth?.scopes).toEqual([]);
 
     const adminRes = await rpcReq(ws, "set-heartbeats", { enabled: false });
-    expect(adminRes.ok).toBe(true);
+    expect(adminRes.ok).toBe(false);
+    expect(adminRes.error?.message ?? "").toContain("missing scope");
   } finally {
     ws.close();
   }
@@ -129,8 +130,8 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { token: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-token connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { token: "secret" });
+    test("clears scopes for direct-local backend shared-token connects without device identity", async () => {
+      await expectLocalBackendGatewayClientScopesCleared(port, { token: "secret" });
     });
 
     test("returns stable token-missing details for control ui without token", async () => {
@@ -303,8 +304,8 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { password: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-password connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { password: "secret" });
+    test("clears scopes for direct-local backend shared-password connects without device identity", async () => {
+      await expectLocalBackendGatewayClientScopesCleared(port, { password: "secret" });
     });
   });
 
@@ -337,7 +338,30 @@ describe("gateway auth compatibility baseline", () => {
     });
 
     test("allows auth-none local backend connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { skipDefaultAuth: true });
+      const ws = await openWs(port);
+      try {
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          client: { ...BACKEND_GATEWAY_CLIENT },
+          scopes: ["operator.admin"],
+          device: null,
+        });
+        expect(res.ok, JSON.stringify(res)).toBe(true);
+
+        const helloOk = res.payload as
+          | {
+              auth?: {
+                scopes?: unknown;
+              };
+            }
+          | undefined;
+        expect(helloOk?.auth?.scopes).toEqual(["operator.admin"]);
+
+        const adminRes = await rpcReq(ws, "set-heartbeats", { enabled: false });
+        expect(adminRes.ok).toBe(true);
+      } finally {
+        ws.close();
+      }
     });
 
     test("rejects auth-none browser-origin backend connects without device identity", async () => {

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -375,13 +375,30 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients", () => {
-    expect(skipBackendSelfPairing()).toBe(true);
+  it("requires pairing for backend clients using shared token or password auth", () => {
+    expect(
+      skipBackendSelfPairing({
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+    expect(
+      skipBackendSelfPairing({
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "password",
+      }),
+    ).toBe(false);
     expect(
       skipBackendSelfPairing({
         locality: "shared_secret_loopback_local",
+        sharedAuthOk: true,
+        authMethod: "token",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       skipBackendSelfPairing({
         locality: "remote",
@@ -409,6 +426,25 @@ describe("handshake auth helpers", () => {
     expect(
       skipBackendSelfPairing({
         locality: "cli_container_local",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let bootstrap tokens skip backend self-pairing", () => {
+    expect(
+      skipBackendSelfPairing({
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(false);
+    expect(
+      skipBackendSelfPairing({
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "bootstrap-token",
       }),
     ).toBe(false);
   });
@@ -441,7 +477,7 @@ describe("handshake auth helpers", () => {
         locality: "shared_secret_loopback_local",
         authMethod: "none",
       }),
-    ).toBe(true);
+    ).toBe(false);
     // sharedAuthOk=false is fine for auth:none on local backend
     expect(
       skipBackendSelfPairing({

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -266,9 +266,7 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (!isBackendClient) {
     return false;
   }
-  const isLocal =
-    params.locality === "direct_local" || params.locality === "shared_secret_loopback_local";
-  if (!isLocal || params.hasBrowserOriginHeader) {
+  if (params.locality !== "direct_local" || params.hasBrowserOriginHeader) {
     return false;
   }
   // No-auth local backend: scoped bypass — not shared secret, but local-only
@@ -276,9 +274,7 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (params.authMethod === "none") {
     return true;
   }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
-  const usesDeviceTokenAuth = params.authMethod === "device-token";
-  return (params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth;
+  return params.authMethod === "device-token";
 }
 
 function resolveSignatureToken(connectParams: ConnectParams): string | null {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -887,10 +887,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             hasSharedAuth,
             isLocalClient,
           });
-          // Shared token/password auth can bypass pairing for trusted operators.
           // Device-less clients still clear self-declared scopes by default, with
-          // one narrow exception: the direct-local backend gateway-client shared-
-          // auth handoff used for in-process control-plane coordination.
+          // narrow exceptions for explicit local backend/device-token or open-auth
+          // paths. Shared token/password auth stays on the pairing path because
+          // backend identity is client-declared.
           if (
             !device &&
             !skipLocalBackendSelfPairing &&


### PR DESCRIPTION
## Summary

- Remove the backend self-pairing bypass for direct-local backend clients authenticated only with the shared gateway `token` or `password`.
- Keep the dedicated direct-local backend `device-token` path and existing `auth.mode: "none"` local backend behavior.
- Keep `bootstrap-token` on the normal pairing path; it does not skip backend self-pairing.
- Update gateway security docs and regression coverage for the new shared-auth boundary.

Closes #72418

## Behavior Delta

Before this change, a loopback/no-Origin client could self-declare the backend gateway client identity and use shared gateway token/password auth to preserve requested privileged scopes without a paired device identity.

After this change, shared token/password auth no longer satisfies `shouldSkipLocalBackendSelfPairing`. Those connections can still authenticate according to the normal shared-auth rules, but self-declared scopes are cleared and privileged operations still require the normal pairing/device guardrails. The direct-local backend `device-token` path remains allowed, and `bootstrap-token` remains on the pairing path.

## Root Cause

`shouldSkipLocalBackendSelfPairing()` treated attacker-controlled `connectParams.client.id` and `connectParams.client.mode`, plus local/no-Origin metadata and successful shared auth, as enough proof to skip backend self-pairing. Shared token/password credentials are not a dedicated backend identity proof.

## Tests

- `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- `pnpm test src/gateway/server.auth.compat-baseline.test.ts`
- `pnpm test src/gateway/server.auth.control-ui.suite.ts`
- `pnpm format:check src/gateway/server/ws-connection/handshake-auth-helpers.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server.auth.compat-baseline.test.ts docs/gateway/security/index.md`
- `pnpm docs:check-mdx docs/gateway/security/index.md`

Attempted `pnpm check:changed`; the local Testbox delegate failed before running checks because `crabbox` did not pass its version/help sanity check.

## Review Notes

This is a new branch from current `upstream/main` and does not revive the closed PR #72419 branch. The old bootstrap-token bypass idea is intentionally not included.
