### PR TITLE
fix(qqbot): sanitize outbound reasoning text

### DIFF
--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -42,6 +42,32 @@ const cfg = {
 } as OpenClawConfig;
 
 describe("qqbot message adapter", () => {
+  it("sanitizes hidden reasoning from outbound text before delivery", () => {
+    const raw = [
+      "<think>private reasoning</think>",
+      '<invoke name="exec">payload</invoke></minimax:tool_call>',
+      '<tool_result>{"output":"hidden"}</tool_result>',
+      "Visible <b>answer</b>",
+    ].join("\n");
+
+    expect(qqbotPlugin.outbound?.sanitizeText?.({ text: raw, payload: { text: raw } })).toBe(
+      "Visible *answer*",
+    );
+  });
+
+  it("preserves QQBot media tags while sanitizing surrounding text", () => {
+    const raw = [
+      "<think>private reasoning</think>",
+      "Visible <b>answer</b>",
+      '<qqmedia file="https://example.com/a.png" />',
+      "Done <i>now</i>",
+    ].join("\n");
+
+    expect(qqbotPlugin.outbound?.sanitizeText?.({ text: raw, payload: { text: raw } })).toBe(
+      ["Visible *answer*", "<qqmedia>https://example.com/a.png</qqmedia>", "Done _now_"].join("\n"),
+    );
+  });
+
   it("declares durable text, media, and reply target capabilities with receipt proofs", async () => {
     sendTextMock.mockResolvedValue({ messageId: "qq-text-1" });
     sendMediaMock.mockResolvedValue({ messageId: "qq-media-1" });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -2,11 +2,13 @@ import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/approval-runti
 import {
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
+  sanitizeForPlainText,
   type ChannelMessageSendResult,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 // Register the PlatformAdapter before any core/ module is used.
 import "./bridge/bootstrap.js";
 import { getQQBotApprovalCapability } from "./bridge/approval/capability.js";
@@ -27,6 +29,7 @@ import {
   normalizeTarget as coreNormalizeTarget,
   looksLikeQQBotTarget,
 } from "./engine/messaging/target-parser.js";
+import { normalizeMediaTags } from "./engine/utils/media-tags.js";
 import type { ResolvedQQBotAccount } from "./types.js";
 
 // Shared promise so concurrent multi-account startups serialize the dynamic
@@ -134,6 +137,24 @@ function toQQBotMessageSendResult(result: Awaited<ReturnType<typeof sendQQBotTex
     messageId: result.messageId,
     receipt: result.receipt,
   } satisfies ChannelMessageSendResult;
+}
+
+const QQBOT_MEDIA_TAG_RE =
+  /<(?:qqimg|qqvoice|qqvideo|qqfile|qqmedia)>[^<>]+<\/(?:qqimg|qqvoice|qqvideo|qqfile|qqmedia|img)>/gi;
+
+function sanitizeQQBotOutboundText(text: string): string {
+  const visibleText = normalizeMediaTags(sanitizeAssistantVisibleText(text));
+  let cursor = 0;
+  let sanitized = "";
+
+  for (const match of visibleText.matchAll(QQBOT_MEDIA_TAG_RE)) {
+    const tag = match[0];
+    sanitized += sanitizeForPlainText(visibleText.slice(cursor, match.index));
+    sanitized += tag;
+    cursor = match.index + tag.length;
+  }
+
+  return sanitized + sanitizeForPlainText(visibleText.slice(cursor));
 }
 
 const qqbotMessageAdapter = defineChannelMessageAdapter({
@@ -253,6 +274,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
     chunker: (text, limit) => getQQBotRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 5000,
+    sanitizeText: ({ text }) => sanitizeQQBotOutboundText(text),
     shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
       shouldSuppressLocalQQBotApprovalPrompt({
         cfg,


### PR DESCRIPTION
Fixes #89913.

## Summary

- Add QQBot-owned outbound text sanitization so hidden assistant reasoning and tool scaffolding are removed before user-visible delivery.
- Preserve QQBot private media tags while sanitizing surrounding text, so `<qqmedia>`, `<qqimg>`, `<qqvoice>`, `<qqvideo>`, and `<qqfile>` still reach the existing QQBot media sender.
- Add focused QQBot adapter regression coverage for both reasoning stripping and media-tag preservation.

## Root Cause

QQBot did not define an `outbound.sanitizeText` hook, while shared outbound delivery only applies channel sanitization when the channel opts in. That left QQBot replies exposed when providers emitted hidden reasoning/scaffolding as text. Applying generic plain-text sanitization directly would also strip QQBot media tags, so this patch partitions those tags and sanitizes only the surrounding visible text.

## Real behavior proof

Behavior addressed: QQBot outbound replies now strip hidden reasoning/tool scaffolding before delivery while preserving QQBot media tags for attachment routing.

Real environment tested: Local OpenClaw source worktree on macOS using the repository Vitest, oxfmt, oxlint, and tsgo wrappers. GitHub's `Real behavior proof` workflow also passed on this PR head.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts
node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts src/shared/text/assistant-visible-text.test.ts src/infra/outbound/deliver.test.ts
pnpm format:check -- extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts
pnpm tsgo:extensions
git diff --check
```

Evidence after fix: The new QQBot adapter test invokes the actual `qqbotPlugin.outbound.sanitizeText` hook. It proves `<think>`/tool scaffolding is removed from outbound text, regular visible formatting still becomes plain text, and `<qqmedia file="https://example.com/a.png" />` is preserved for QQBot media routing as `<qqmedia>https://example.com/a.png</qqmedia>`.

Observed result after fix: All listed local checks passed, and the PR `Real behavior proof` check passed.

What was not tested: Live QQBot/Tencent delivery and live MiniMax generation were not run.

## Verification

- `node scripts/run-vitest.mjs extensions/qqbot/src/channel.message-adapter.test.ts`
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts src/shared/text/assistant-visible-text.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm format:check -- extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/qqbot/src/channel.ts extensions/qqbot/src/channel.message-adapter.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check`
- GitHub Actions: `Real behavior proof` passed