### PR TITLE
fix(cron): sweep isolated-target base cron sessions under sessionRetention

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -517,7 +517,7 @@ Disable cron: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
 
   </Accordion>
   <Accordion title="Maintenance">
-    `cron.sessionRetention` (default `24h`) prunes isolated run-session entries. `cron.runLog.keepLines` limits retained SQLite run-history rows per job; `maxBytes` is retained for config compatibility with older file-backed run logs.
+    `cron.sessionRetention` (default `24h`) prunes isolated run-session entries and orphaned base cron sessions left by deleted jobs; active jobs' sessions are kept. `cron.runLog.keepLines` limits retained SQLite run-history rows per job; `maxBytes` is retained for config compatibility with older file-backed run logs.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -225,7 +225,7 @@ Cron does not classify final-output prose or approval-looking refusal phrases as
 
 Retention and pruning are controlled in config:
 
-- `cron.sessionRetention` (default `24h`) prunes completed isolated run sessions.
+- `cron.sessionRetention` (default `24h`) prunes completed isolated run sessions and orphaned base cron sessions from deleted jobs; active jobs' sessions are kept.
 - `cron.runLog.keepLines` prunes retained SQLite run-history rows per job. `cron.runLog.maxBytes` remains accepted for compatibility with older file-backed run logs.
 
 ## Migrating older jobs

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1308,7 +1308,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 }
 ```
 
-- `sessionRetention`: how long to keep completed isolated cron run sessions before pruning from `sessions.json`. Also controls cleanup of archived deleted cron transcripts. Default: `24h`; set `false` to disable.
+- `sessionRetention`: how long to keep completed isolated cron run sessions, plus orphaned base cron sessions left by deleted jobs, before pruning from `sessions.json`. Active jobs' base sessions are always preserved. Also controls cleanup of archived deleted cron transcripts. Default: `24h`; set `false` to disable.
 - `runLog.maxBytes`: accepted for compatibility with older file-backed cron run logs. Default: `2_000_000` bytes.
 - `runLog.keepLines`: newest SQLite run-history rows retained per job. Default: `2000`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -430,7 +430,7 @@ candidate contains redacted secret placeholders such as `***`.
     }
     ```
 
-    - `sessionRetention`: prune completed isolated run sessions from `sessions.json` (default `24h`; set `false` to disable).
+    - `sessionRetention`: prune completed isolated run sessions, plus orphaned base cron sessions from deleted jobs, from `sessions.json`; active jobs' sessions are kept (default `24h`; set `false` to disable).
     - `runLog`: prune retained cron run-history rows per job. `maxBytes` remains accepted for older file-backed run logs.
     - See [Cron jobs](/automation/cron-jobs) for feature overview and CLI examples.
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -124,7 +124,7 @@ openclaw sessions cleanup --enforce
 
 Isolated cron runs also create session entries/transcripts, and they have dedicated retention controls:
 
-- `cron.sessionRetention` (default `24h`) prunes old isolated cron run sessions from the session store (`false` disables).
+- `cron.sessionRetention` (default `24h`) prunes old isolated cron run sessions, plus orphaned base cron sessions left by deleted jobs, from the session store; active jobs' sessions are preserved (`false` disables).
 - `cron.runLog.keepLines` prunes retained SQLite run-history rows per cron job (default: `2000`). `cron.runLog.maxBytes` remains accepted for older file-backed run logs.
 
 When cron force-creates a new isolated run session, it sanitizes the previous

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -71,6 +71,16 @@ export type CronServiceDeps = {
   defaultAgentId?: string;
   /** Resolve session store path for a given agent id. */
   resolveSessionStorePath?: (agentId?: string) => string;
+  /**
+   * Resolve a job's agent id the way the runtime does when writing the cron base
+   * row (a configured agent wins, else the default), so reaper keys match storage.
+   */
+  resolveCronAgentId?: (requested?: string | null) => string;
+  /**
+   * Configured agent ids, so the reaper also sweeps stores of agents that have
+   * no live cron job but may hold a deleted job's orphan base session.
+   */
+  listConfiguredAgentIds?: () => readonly string[];
   /** Path to the session store (sessions.json) for reaper use. */
   sessionStorePath?: string;
   /**

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -34,7 +34,11 @@ import {
   summarizeCronRunDiagnostics,
 } from "../run-diagnostics.js";
 import { computeNextRunAtMs } from "../schedule.js";
-import { sweepCronRunSessions } from "../session-reaper.js";
+import {
+  buildCronSweepStorePaths,
+  buildKnownCronJobSessionKeys,
+  sweepCronRunSessions,
+} from "../session-reaper.js";
 import type {
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
@@ -1413,37 +1417,48 @@ export async function onTimer(state: CronServiceState) {
     // Piggyback session reaper on timer tick (self-throttled to every 5 min).
     // Placed in `finally` so the reaper runs even when a long-running job keeps
     // `state.running` true across multiple timer ticks — the early return at the
-    // top of onTimer would otherwise skip the reaper indefinitely.
-    const storePaths = new Set<string>();
-    if (state.deps.resolveSessionStorePath) {
-      const defaultAgentId = state.deps.defaultAgentId ?? DEFAULT_AGENT_ID;
-      if (state.store?.jobs?.length) {
-        for (const job of state.store.jobs) {
-          const agentId =
-            typeof job.agentId === "string" && job.agentId.trim() ? job.agentId : defaultAgentId;
-          storePaths.add(state.deps.resolveSessionStorePath(agentId));
-        }
-      } else {
-        storePaths.add(state.deps.resolveSessionStorePath(defaultAgentId));
-      }
-    } else if (state.deps.sessionStorePath) {
-      storePaths.add(state.deps.sessionStorePath);
-    }
+    // top of onTimer would otherwise skip the reaper indefinitely. Wrapped so a
+    // throw here (e.g. a config read) can never skip armTimer and wedge the timer.
+    try {
+      const agentResolution = {
+        defaultAgentId: state.deps.defaultAgentId ?? DEFAULT_AGENT_ID,
+        resolveCronAgentId: state.deps.resolveCronAgentId,
+      };
+      const storePaths = buildCronSweepStorePaths({
+        jobs: state.store?.jobs ?? [],
+        configuredAgentIds: state.deps.listConfiguredAgentIds?.() ?? [],
+        agentResolution,
+        resolveSessionStorePath: state.deps.resolveSessionStorePath,
+        sessionStorePath: state.deps.sessionStorePath,
+      });
 
-    if (storePaths.size > 0) {
-      const nowMs = state.deps.nowMs();
-      for (const storePath of storePaths) {
-        try {
-          await sweepCronRunSessions({
-            cronConfig: state.deps.cronConfig,
-            sessionStorePath: storePath,
-            nowMs,
-            log: state.deps.log,
-          });
-        } catch (err) {
-          state.deps.log.warn({ err: String(err), storePath }, "cron: session reaper sweep failed");
+      if (storePaths.size > 0) {
+        const nowMs = state.deps.nowMs();
+        // Live jobs' base rows carry model/auth/label into their next run, so the
+        // reaper preserves them; only orphans from deleted jobs are swept. A null
+        // store (load failed) is unknown ownership → undefined preserves all base keys.
+        const knownCronJobSessionKeys = state.store
+          ? buildKnownCronJobSessionKeys(state.store.jobs, agentResolution)
+          : undefined;
+        for (const storePath of storePaths) {
+          try {
+            await sweepCronRunSessions({
+              cronConfig: state.deps.cronConfig,
+              sessionStorePath: storePath,
+              nowMs,
+              log: state.deps.log,
+              knownCronJobSessionKeys,
+            });
+          } catch (err) {
+            state.deps.log.warn(
+              { err: String(err), storePath },
+              "cron: session reaper sweep failed",
+            );
+          }
         }
       }
+    } catch (err) {
+      state.deps.log.warn({ err: String(err) }, "cron: session reaper setup failed");
     }
 
     state.running = false;

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -5,7 +5,14 @@ import path from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
-import { sweepCronRunSessions, resolveRetentionMs, resetReaperThrottle } from "./session-reaper.js";
+import {
+  buildCronSweepStorePaths,
+  buildKnownCronJobSessionKeys,
+  resolveCronJobAgentId,
+  sweepCronRunSessions,
+  resolveRetentionMs,
+  resetReaperThrottle,
+} from "./session-reaper.js";
 
 function createTestLogger(): Logger {
   return {
@@ -62,6 +69,94 @@ describe("isCronRunSessionKey", () => {
   it("does not match non-canonical cron-like keys", () => {
     expect(isCronRunSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
     expect(isCronRunSessionKey("cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("resolveCronJobAgentId", () => {
+  // Mirrors resolveCronAgent: only a configured id wins; anything else → default.
+  const resolveCronAgentId = (requested?: string | null) =>
+    requested === "configured" ? "configured" : "main";
+
+  it("uses the runtime resolver result when present", () => {
+    expect(
+      resolveCronJobAgentId(
+        { agentId: "configured" },
+        { defaultAgentId: "main", resolveCronAgentId },
+      ),
+    ).toBe("configured");
+  });
+
+  it("falls back to the default for a dangling/non-configured agent id", () => {
+    expect(
+      resolveCronJobAgentId({ agentId: "ghost" }, { defaultAgentId: "main", resolveCronAgentId }),
+    ).toBe("main");
+  });
+
+  it("uses the raw agent id when no resolver is provided", () => {
+    expect(resolveCronJobAgentId({ agentId: "custom" }, { defaultAgentId: "main" })).toBe("custom");
+  });
+
+  it("falls back to the default when the job has no agent id", () => {
+    expect(resolveCronJobAgentId({ agentId: undefined }, { defaultAgentId: "main" })).toBe("main");
+  });
+});
+
+describe("buildKnownCronJobSessionKeys", () => {
+  it("reconstructs each live job's base key under its runtime-resolved agent", () => {
+    // A dangling agent id must resolve to the default — matching where the runtime
+    // stored the row — so the live job is protected, not misread as an orphan.
+    const resolveCronAgentId = (requested?: string | null) =>
+      requested === "real" ? "real" : "main";
+    const keys = buildKnownCronJobSessionKeys(
+      [
+        { id: "iso", sessionTarget: "isolated" },
+        { id: "ghosted", sessionTarget: "isolated", agentId: "ghost" },
+        { id: "scoped", sessionTarget: "isolated", agentId: "real" },
+        { id: "named", sessionTarget: "session:cron:weekly" },
+      ],
+      { defaultAgentId: "main", resolveCronAgentId },
+    );
+    expect(keys).toEqual(
+      new Set([
+        "agent:main:cron:iso",
+        "agent:main:cron:ghosted",
+        "agent:real:cron:scoped",
+        "agent:main:cron:weekly",
+      ]),
+    );
+    // The dangling job resolves under the default agent, never agent:ghost:*.
+    expect(keys.has("agent:ghost:cron:ghosted")).toBe(false);
+  });
+
+  it("skips jobs whose sessionTarget cannot resolve to a key", () => {
+    const keys = buildKnownCronJobSessionKeys([{ id: "bad", sessionTarget: "session:" }], {
+      defaultAgentId: "main",
+    });
+    expect(keys.size).toBe(0);
+  });
+});
+
+describe("buildCronSweepStorePaths", () => {
+  it("sweeps live-job agents, configured agents, and the default store", () => {
+    // "beta" is configured but has no live cron job — its store must still be
+    // swept so a deleted job's orphan there is reaped (the P2 coverage gap).
+    const paths = buildCronSweepStorePaths({
+      jobs: [{ id: "j1", sessionTarget: "isolated", agentId: "alpha" }],
+      configuredAgentIds: ["alpha", "beta"],
+      agentResolution: { defaultAgentId: "main" },
+      resolveSessionStorePath: (agentId) => `/store/${agentId}.json`,
+    });
+    expect(paths).toEqual(new Set(["/store/alpha.json", "/store/beta.json", "/store/main.json"]));
+  });
+
+  it("falls back to the single sessionStorePath when no per-agent resolver", () => {
+    const paths = buildCronSweepStorePaths({
+      jobs: [],
+      configuredAgentIds: [],
+      agentResolution: { defaultAgentId: "main" },
+      sessionStorePath: "/shared/sessions.json",
+    });
+    expect(paths).toEqual(new Set(["/shared/sessions.json"]));
   });
 });
 
@@ -285,5 +380,176 @@ describe("sweepCronRunSessions", () => {
       log,
     });
     expect(r3.swept).toBe(false);
+  });
+
+  it("prunes stale base sessions orphaned by deleted jobs", async () => {
+    // Base keys absent from the live-job ownership set are orphans left by
+    // deleted jobs; prune them when stale, keep fresh ones until they age out.
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:orphan-stale": { sessionId: "stale-base", updatedAt: now - 25 * 3_600_000 },
+      "agent:main:cron:orphan-fresh": { sessionId: "fresh-base", updatedAt: now - 1 * 3_600_000 },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+      knownCronJobSessionKeys: new Set(),
+    });
+
+    expect(result.pruned).toBe(1);
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      "agent:main:cron:orphan-fresh": { sessionId: "fresh-base", updatedAt: now - 1 * 3_600_000 },
+    });
+  });
+
+  it("preserves a live isolated job's stale base session, keeping carried model/auth/label (#89666)", async () => {
+    // Regression guard for the ClawSweeper P1: an isolated job that runs less
+    // often than the retention window goes stale between runs, but its base row
+    // carries the user's model/auth/label overrides into the next run (see
+    // resolveCronSession). A live job's row must survive; only the deleted job's
+    // orphan is pruned.
+    const now = Date.now();
+    const liveKey = "agent:main:cron:weekly-isolated";
+    const store: Record<string, { sessionId: string; modelOverride?: string; updatedAt: number }> =
+      {
+        [liveKey]: {
+          sessionId: "iso-live",
+          modelOverride: "gpt-5.5",
+          updatedAt: now - 25 * 3_600_000,
+        },
+        "agent:main:cron:deleted-isolated": {
+          sessionId: "iso-orphan",
+          updatedAt: now - 25 * 3_600_000,
+        },
+      };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+      knownCronJobSessionKeys: new Set([liveKey]),
+    });
+
+    expect(result.pruned).toBe(1); // only the deleted job's orphan is pruned
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      [liveKey]: {
+        sessionId: "iso-live",
+        modelOverride: "gpt-5.5",
+        updatedAt: now - 25 * 3_600_000,
+      },
+    });
+  });
+
+  it("preserves a live job's stale base session while pruning its expired :run: rows", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:main-job": { sessionId: "main-base", updatedAt: now - 25 * 3_600_000 },
+      "agent:main:cron:main-job:run:run1": { sessionId: "run1", updatedAt: now - 25 * 3_600_000 },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+      knownCronJobSessionKeys: new Set(["agent:main:cron:main-job"]),
+    });
+
+    expect(result.pruned).toBe(1); // expired :run: pruned, owned base preserved
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      "agent:main:cron:main-job": { sessionId: "main-base", updatedAt: now - 25 * 3_600_000 },
+    });
+  });
+
+  it("preserves a persistent named cron session via knownCronJobSessionKeys", async () => {
+    // A job with sessionTarget="session:cron:weekly" produces base key
+    // agent:main:cron:weekly. A live job owns it, so it is never pruned even
+    // when stale; the orphan from a deleted job is.
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:weekly": { sessionId: "weekly-base", updatedAt: now - 25 * 3_600_000 },
+      "agent:main:cron:orphaned": { sessionId: "orphaned-base", updatedAt: now - 25 * 3_600_000 },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+      knownCronJobSessionKeys: new Set(["agent:main:cron:weekly"]),
+    });
+
+    expect(result.pruned).toBe(1); // orphaned pruned; weekly preserved
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      "agent:main:cron:weekly": { sessionId: "weekly-base", updatedAt: now - 25 * 3_600_000 },
+    });
+  });
+
+  it("preserves base cron keys when no ownership set is provided", async () => {
+    // Without the live-job set, orphans cannot be told from live jobs, so base
+    // keys are never pruned — only :run: rows are. This is the fail-safe default.
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number }> = {
+      "agent:main:cron:isolated-stale": { sessionId: "iso-stale", updatedAt: now - 25 * 3_600_000 },
+      "agent:main:cron:isolated-stale:run:r1": {
+        sessionId: "run1",
+        updatedAt: now - 25 * 3_600_000,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(1); // :run: pruned, base preserved (no ownership set)
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated).toEqual({
+      "agent:main:cron:isolated-stale": { sessionId: "iso-stale", updatedAt: now - 25 * 3_600_000 },
+    });
+  });
+
+  it("archives transcript for a pruned orphaned isolated cron base session", async () => {
+    const now = Date.now();
+    const isoSessionId = "iso-old-session";
+    const isoTranscript = path.join(tmpDir, `${isoSessionId}.jsonl`);
+    fs.writeFileSync(isoTranscript, '{"type":"session"}\n');
+    const store: Record<string, { sessionId: string; sessionFile?: string; updatedAt: number }> = {
+      "agent:main:cron:isolated-job": {
+        sessionId: isoSessionId,
+        sessionFile: isoTranscript,
+        updatedAt: now - 25 * 3_600_000,
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+      knownCronJobSessionKeys: new Set(),
+    });
+
+    expect(result.pruned).toBe(1);
+    expect(fs.existsSync(isoTranscript)).toBe(false);
+    const files = fs.readdirSync(tmpDir);
+    const archived = files.filter((name) => name.startsWith(`${isoSessionId}.jsonl.deleted.`));
+    expect(archived.length).toBeGreaterThan(0);
   });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -7,10 +7,83 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isCronSessionKey } from "../sessions/session-key-utils.js";
+import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
 import type { Logger } from "./service/state.js";
+import { resolveCronSessionTargetSessionKey } from "./session-target.js";
+import type { CronJob } from "./types.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
+
+type CronAgentResolution = {
+  defaultAgentId: string;
+  resolveCronAgentId?: (requested?: string | null) => string;
+};
+
+/**
+ * Resolves a cron job's agent id the way the runtime does when writing its base
+ * row (a configured agent wins, else the default), so reaper keys match storage.
+ */
+export function resolveCronJobAgentId(
+  job: Pick<CronJob, "agentId">,
+  opts: CronAgentResolution,
+): string {
+  const resolved = opts.resolveCronAgentId?.(job.agentId);
+  if (resolved && resolved.trim()) {
+    return resolved;
+  }
+  return typeof job.agentId === "string" && job.agentId.trim() ? job.agentId : opts.defaultAgentId;
+}
+
+/** Base session keys owned by live cron jobs; these are preserved from retention pruning. */
+export function buildKnownCronJobSessionKeys(
+  jobs: readonly Pick<CronJob, "id" | "sessionTarget" | "agentId">[],
+  opts: CronAgentResolution,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const job of jobs) {
+    try {
+      const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
+      keys.add(
+        resolveCronAgentSessionKey({ sessionKey, agentId: resolveCronJobAgentId(job, opts) }),
+      );
+    } catch {
+      // Skip malformed sessionTarget (e.g. "session:" empty id) so a single bad
+      // job cannot throw the whole set construction out of the timer tick.
+    }
+  }
+  return keys;
+}
+
+/**
+ * Session-store paths the reaper sweeps: live jobs' agents, every configured
+ * agent, and the default. Configured agents are included so a deleted job's
+ * orphan is reaped even when no live job references that agent anymore.
+ */
+export function buildCronSweepStorePaths(opts: {
+  jobs: readonly Pick<CronJob, "id" | "sessionTarget" | "agentId">[];
+  configuredAgentIds: readonly string[];
+  agentResolution: CronAgentResolution;
+  resolveSessionStorePath?: (agentId?: string) => string;
+  sessionStorePath?: string;
+}): Set<string> {
+  const paths = new Set<string>();
+  const resolve = opts.resolveSessionStorePath;
+  if (!resolve) {
+    if (opts.sessionStorePath) {
+      paths.add(opts.sessionStorePath);
+    }
+    return paths;
+  }
+  for (const job of opts.jobs) {
+    paths.add(resolve(resolveCronJobAgentId(job, opts.agentResolution)));
+  }
+  for (const agentId of opts.configuredAgentIds) {
+    paths.add(resolve(agentId));
+  }
+  paths.add(resolve(opts.agentResolution.defaultAgentId));
+  return paths;
+}
 
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
@@ -39,7 +112,7 @@ type ReaperResult = {
 };
 
 /**
- * Sweeps completed isolated cron run sessions while preserving base cron sessions.
+ * Sweeps expired isolated cron run sessions and orphaned base cron sessions.
  *
  * Must run outside the cron service `locked()` section because this acquires
  * the session-store file lock; reversing that order can deadlock timer ticks.
@@ -52,6 +125,13 @@ export async function sweepCronRunSessions(params: {
   log: Logger;
   /** Override for testing — skips the min-interval throttle. */
   force?: boolean;
+  /**
+   * Base session keys of every live cron job; these are preserved regardless of
+   * age (they carry model/auth/label into the next run). Base keys absent from
+   * it are deleted-job orphans, pruned when stale. Omit to disable base-key
+   * pruning — orphans cannot be told from live jobs without it.
+   */
+  knownCronJobSessionKeys?: ReadonlySet<string>;
 }): Promise<ReaperResult> {
   const now = params.nowMs ?? Date.now();
   const storePath = params.sessionStorePath;
@@ -73,10 +153,21 @@ export async function sweepCronRunSessions(params: {
   let transcriptCleanupError: unknown;
   try {
     const cutoff = now - retentionMs;
+    const allEntries = [...listSessionEntries({ storePath, clone: false })];
+
     const removals: SessionEntryLifecycleRemoval[] = [];
-    for (const { sessionKey, entry } of listSessionEntries({ storePath, clone: false })) {
-      if (!isCronRunSessionKey(sessionKey)) {
+    for (const { sessionKey, entry } of allEntries) {
+      if (!isCronSessionKey(sessionKey)) {
         continue;
+      }
+      if (!isCronRunSessionKey(sessionKey)) {
+        // Base cron key carries a live job's model/auth/label into its next run;
+        // prune only when the ownership set proves no live job owns it (an orphan
+        // from a deleted job). No set means we cannot tell orphan from live.
+        const owned = params.knownCronJobSessionKeys;
+        if (!owned || owned.has(sessionKey)) {
+          continue;
+        }
       }
       const updatedAt = entry.updatedAt ?? 0;
       if (updatedAt < cutoff) {
@@ -120,7 +211,7 @@ export async function sweepCronRunSessions(params: {
   if (pruned > 0) {
     params.log.info(
       { pruned, retentionMs },
-      `cron-reaper: pruned ${pruned} expired cron run session(s)`,
+      `cron-reaper: pruned ${pruned} expired cron session(s)`,
     );
   }
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,7 +1,7 @@
 // Gateway cron runtime service runs scheduled agent turns, heartbeat wakeups,
 // plugin hooks, notifications, and cron lifecycle cleanup.
 import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
@@ -321,6 +321,8 @@ export function buildGatewayCronService(params: {
     cronConfig: params.cfg.cron,
     defaultAgentId,
     resolveSessionStorePath,
+    resolveCronAgentId: (requested) => resolveCronAgent(requested).agentId,
+    listConfiguredAgentIds: () => listAgentIds(getRuntimeConfig()),
     sessionStorePath,
     enqueueSystemEvent: (text, opts) => {
       const { sessionKey } = resolveCronTarget(opts);


### PR DESCRIPTION
### Summary

- **Problem**: Issue #89666 — `cron.sessionRetention` (default 24h) never prunes isolated-target cron sessions. The reaper gates every key with `isCronRunSessionKey`, which only matches `:run:` keys, but isolated jobs persist a single base key `agent:<agentId>:cron:<jobId>` (overwritten each run via `forceNew`, no `:run:` entry). Base sessions therefore skip the cutoff and accumulate forever — including orphans left behind by deleted jobs — regardless of the configured retention (the reporter confirmed 47 base sessions, oldest 25 days, plus 2 orphans from deleted jobs).
- **Root cause**: `sweepCronRunSessions` only ever reaches the `updatedAt < cutoff` check for `:run:` keys. Isolated-job base keys and deleted-job remnants are never eligible, so retention is inert for all-isolated deployments.
- **Fix (ownership-based)**: The reaper now also considers base cron keys, but prunes one only when it is an orphan — a base key no live job owns. `timer.ts` builds `knownCronJobSessionKeys` from every currently-configured job (isolated **and** non-isolated) before each sweep; keys in that set are preserved regardless of age, and base keys absent from it (deleted-job orphans) are pruned once stale. Without the set the reaper preserves all base keys (fail-safe). This is required because a live job's base row carries the user's model/auth/label overrides forward into its next run (`resolveCronSession` → `sanitizeFreshCronSessionEntry`, `src/cron/isolated-agent/session.ts:91`); deleting it would silently drop those choices for jobs that run less often than the retention window — the regression raised in review and corroborated by the issue's own field-union analysis (`authProfileOverride`, `modelOverride`, `label` are persisted on these rows). This matches the reporter's Option A ("only prune if the job was deleted") and the issue's "Secondary gap — orphaned sessions from deleted jobs". `:run:` pruning is unchanged.
- **Agent-id correctness**: ownership keys are reconstructed with the same agent-id resolution the runtime uses when it writes the base row — a configured agent wins, an unset or dangling/non-configured id falls back to the default agent (`resolveCronAgent`, `src/gateway/server-cron.ts:175`). Using the raw `job.agentId` instead would mis-key a job that references a removed/typo'd agent (a state job creation never validates), so its live base row — written under the default agent — would be misread as an orphan and pruned. The cron service receives a `resolveCronAgentId` dependency for this; the reconstruction lives in small, directly tested pure helpers (`resolveCronJobAgentId`, `buildKnownCronJobSessionKeys`).
- **Orphan-store coverage**: the reaper sweeps the stores of all configured agents (via a `listConfiguredAgentIds` dependency), not only agents that currently have a live cron job. Without this, a deleted job's orphan in a non-default agent's store would linger until a new job for that agent appeared. The default store is always swept. Path selection lives in the tested helper `buildCronSweepStorePaths`. (This is config-driven — no per-tick directory scan.)
- **What changed**:
  - `src/cron/session-reaper.ts` — base cron keys become prunable only as orphans (absent from the ownership set and stale); preserved when owned or when no set is provided. Adds the pure helpers `resolveCronJobAgentId`, `buildKnownCronJobSessionKeys`, and `buildCronSweepStorePaths`.
  - `src/cron/service/timer.ts` — builds the sweep store-paths and the ownership set from live jobs + configured agents via the helpers, resolving each job's agent id through `resolveCronAgentId`.
  - `src/cron/service/state.ts` — adds the optional `resolveCronAgentId` and `listConfiguredAgentIds` cron-service dependencies (internal dependency injection).
  - `src/gateway/server-cron.ts` — wires `resolveCronAgentId` to the existing `resolveCronAgent` and `listConfiguredAgentIds` to `listAgentIds`.
  - `src/cron/session-reaper.test.ts` — ownership-based reaper cases plus pure unit tests for the three helpers (agent-id resolution incl. dangling → default; ownership-key reconstruction; sweep-path selection incl. configured-but-no-live-job agents).
  - `docs/{gateway/configuration-reference,gateway/configuration,cli/cron,automation/cron-jobs,reference/session-management-compaction}.md` — clarify that `cron.sessionRetention` now also reaps orphaned base cron sessions left by deleted jobs while preserving active jobs' sessions (behavior-description only; the config key, schema, and default are unchanged).
- **What did NOT change (scope boundary)**:
  - Cutoff arithmetic, throttle, archiving, and transcript-cleanup paths are unchanged.
  - `:run:` pruning (main-target accumulation cleanup) is unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader). `CronServiceDeps` is internal cron-service dependency injection, not a public contract.
  - No dependency changes.

### Reproduction

1. Configure one or more cron jobs with `sessionTarget: isolated` that run less often than `cron.sessionRetention` (e.g. weekly with the default 24h), and leave behind a base session belonging to a since-deleted job.
2. Let the gateway run so the session reaper sweeps (every 5 minutes).
3. Inspect `~/.openclaw/agents/main/sessions/sessions.json` for `agent:main:cron:<jobId>` base keys older than the cutoff.
4. **Before this PR**: no base key is ever pruned; isolated and orphaned base sessions accumulate indefinitely regardless of `cron.sessionRetention`.
5. **After this PR**: base sessions for deleted jobs older than the cutoff are pruned on the next sweep, while a live job's base session (isolated or not, including under a dangling agent id) is preserved with its carried model/auth/label overrides intact.

### Real behavior proof

**Behavior addressed (#89666)**: orphaned base cron sessions (`agent:<agentId>:cron:<jobId>` for jobs no longer present in `state.store.jobs`) are pruned when `updatedAt < cutoff`; a live job's base session is preserved regardless of staleness so its persisted model/auth/label overrides survive; `:run:` rows continue to be pruned when stale.

**Real environment tested (Linux, Node 22 — Vitest against the production session-store helpers, real `listSessionEntries` / `applySessionEntryLifecycleMutation` I/O on actual temp-dir files; plus the production cron timer via `onTimer`)**: `sweepCronRunSessions` is exercised with on-disk session stores and real JSONL transcript files under `os.tmpdir()`; the ownership-set reconstruction is tested directly through the pure helpers.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/session-reaper.test.ts src/cron/service.session-reaper-in-finally.test.ts` and `pnpm tsgo:core`.

**Evidence after fix (Vitest + typecheck)**:

```
Test Files  2 passed (2)
      Tests  32 passed (32)
tsgo:core   exit 0 (no type errors)
```

**Observed result after fix**: `buildKnownCronJobSessionKeys` test seeds jobs `iso` (isolated, no agentId), `ghosted` (agentId `ghost`, not configured), `scoped` (agentId `real`, configured), and a `session:cron:weekly` target; with a resolver that mirrors `resolveCronAgent`, it yields `{agent:main:cron:iso, agent:main:cron:ghosted, agent:real:cron:scoped, agent:main:cron:weekly}` — the dangling-agent job resolves under the default agent, never `agent:ghost:*`. The reaper test `preserves a live isolated job's stale base session` confirms a stale owned key (with `modelOverride`) survives while the orphan is pruned.

**What was not tested**: a live gateway run with real isolated cron jobs past the retention window; `resolveCronAgentSessionKey` with a non-default `mainKey` config (canonicalization is omitted when building the set — safe for `cron:*` keys, which never trigger the `main` alias path).

**Repro confirmation**: the orphan-prune behavior fails on `main` (`isCronRunSessionKey` returns false for base keys, `result.pruned === 0`) and passes with the patch; the live-isolated-job guard and the `buildKnownCronJobSessionKeys` dangling-agent assertion are pure regression tests that fail if a live job's base row is swept or mis-keyed.

### Risk / Mitigation

- **Risk**: A live isolated job's base session pruned, dropping its carried model/auth/label overrides. **Mitigation**: every currently-configured job (isolated and non-isolated) is added to `knownCronJobSessionKeys`, so a live job's base row is preserved regardless of age; only base keys with no owning job are eligible.
- **Risk**: A job under a dangling/non-configured agent id is mis-keyed and its live row pruned. **Mitigation**: the ownership key is reconstructed with the same `resolveCronAgent` fallback the runtime uses to store the row, so the keys match; covered by a dedicated helper unit test.
- **Risk**: The reaper prunes base keys it cannot prove are orphans. **Mitigation**: pruning a base key requires the ownership set to be present and to exclude that key; when no set is provided the reaper preserves all base keys (fail-safe), reproducing the prior behavior.
- **Risk**: Sweeping all configured agents' stores widens the reaper's footprint. **Mitigation**: the agent list is read from in-memory config (no per-tick directory scan); each store sweep is still throttled to once per 5 min per path, and non-cron keys are never touched.

### Change Type (select all)

- [x] Bug fix (non-breaking)

### Scope (select all touched areas)

- [x] Core runtime
- [x] Cron
- [x] Documentation

### Linked Issue/PR

Fixes #89666
