### PR TITLE
fix(agents): bound runtime tool list projection

### DIFF
--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -134,6 +134,32 @@ describe("runtime tool input schema projection", () => {
     });
   });
 
+  it("reports invalid runtime tool list lengths", () => {
+    const healthy = {
+      name: "healthy",
+      parameters: { type: "object", properties: {} },
+    };
+    const proxy = new Proxy([healthy] as Array<typeof healthy>, {
+      get(target, property, receiver) {
+        if (property === "length") {
+          return -1;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(filterRuntimeCompatibleTools(proxy)).toEqual({
+      tools: [],
+      diagnostics: [
+        {
+          toolName: "tool[0]",
+          toolIndex: 0,
+          violations: ["runtime tool list length is invalid"],
+        },
+      ],
+    });
+  });
+
   it("quarantines unreadable runtime tool fields without dropping healthy siblings", () => {
     const unreadable = {
       name: "fuzzplugin_unreadable",

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -41,15 +41,18 @@ type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters"
 
 type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
 
+const MAX_RUNTIME_TOOL_ENTRY_READS = 10_000;
+
 function unreadableRuntimeToolEntry(
   toolIndex: number,
+  violation = `tool[${toolIndex}] is unreadable`,
 ): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
   return {
     ok: false,
     diagnostic: {
       toolName: `tool[${toolIndex}]`,
       toolIndex,
-      violations: [`tool[${toolIndex}] is unreadable`],
+      violations: [violation],
     },
   };
 }
@@ -62,6 +65,24 @@ function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "param
     length = tools.length;
   } catch {
     return [unreadableRuntimeToolEntry(0) as RuntimeToolEntryRead<TTool>];
+  }
+  if (!Number.isSafeInteger(length) || length < 0) {
+    return [
+      unreadableRuntimeToolEntry(
+        0,
+        "runtime tool list length is invalid",
+      ) as RuntimeToolEntryRead<TTool>,
+    ];
+  }
+  // Projection is a safety check for plugin-controlled tool lists. Reject
+  // hostile array-like lengths before diagnostics become an unbounded loop.
+  if (length > MAX_RUNTIME_TOOL_ENTRY_READS) {
+    return [
+      unreadableRuntimeToolEntry(
+        MAX_RUNTIME_TOOL_ENTRY_READS,
+        `runtime tool list length exceeds ${MAX_RUNTIME_TOOL_ENTRY_READS}`,
+      ) as RuntimeToolEntryRead<TTool>,
+    ];
   }
   const entries: RuntimeToolEntryRead<TTool>[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {


### PR DESCRIPTION
## Summary

- Reject invalid or excessive runtime tool-list lengths before schema projection iterates plugin-controlled array-likes.
- Preserve the existing per-entry diagnostics path for normal lists, while reporting malformed list metadata as a bounded `tool[0]` diagnostic.
- Add a regression for a proxy that lies about `length` and previously caused `filterRuntimeCompatibleTools()` to silently drop the whole tool set with no diagnostic.

## Verification

Behavior addressed: hostile runtime tool-list metadata can no longer make schema projection silently treat the active tool surface as empty, or turn projection into an unbounded loop.

Real environment tested: local linked OpenClaw worktree on current `origin/main`; broad remote gates attempted but blocked by missing operator auth.

Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next182-red nodenv exec node scripts/run-vitest.mjs run src/agents/tool-schema-projection.test.ts --testNamePattern="reports invalid runtime tool list lengths" --reporter=verbose
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next182-rebased nodenv exec node scripts/run-vitest.mjs run src/agents/tool-schema-projection.test.ts --reporter=verbose
nodenv exec node scripts/run-oxlint.mjs src/agents/tool-schema-projection.ts src/agents/tool-schema-projection.test.ts
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
blacksmith testbox list --all
node scripts/crabbox-wrapper.mjs run --provider aws --label next182-check-changed --shell -- "pnpm check:changed"
```

Evidence after fix: the targeted red test failed pre-fix with `expected { tools: [], diagnostics: [] } to deeply equal ...`; after the patch, `src/agents/tool-schema-projection.test.ts` passed 11/11, oxlint exited cleanly, `git diff --check` exited cleanly, and branch autoreview was clean with `overall: patch is correct (0.83)`.

Observed result after fix: malformed `length` now produces a diagnostic with `runtime tool list length is invalid` instead of dropping all tools silently; normal compatible tools still pass the existing projection tests.

What was not tested: `pnpm check:changed` could not run remotely because `blacksmith testbox list --all` reported `not authenticated`, and direct AWS Crabbox failed with coordinator 401 on run and lease creation.
