### PR TITLE
fix(outbound): keep Discord runtime adapters resolvable

### DIFF
--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -110,6 +110,39 @@ describe("bootstrapOutboundChannelPlugin", () => {
     expect(loaderMocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
   });
 
+  it("skips bootstrap when the active replacement registry has a message send surface", () => {
+    const setup = createEmptyPluginRegistry();
+    setup.channels = [
+      {
+        pluginId: "discord",
+        plugin: { id: "discord", meta: {} },
+        source: "setup",
+      },
+    ] as never;
+    const runtime = createEmptyPluginRegistry();
+    runtime.channels = [
+      {
+        pluginId: "discord",
+        plugin: {
+          id: "discord",
+          meta: {},
+          message: { send: { text: async () => ({ messageId: "1" }) } },
+        },
+        source: "runtime",
+      },
+    ] as never;
+    setActivePluginRegistry(setup);
+    pinActivePluginChannelRegistry(setup);
+    setActivePluginRegistry(runtime);
+
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: discordConfig,
+    });
+
+    expect(loaderMocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
+  });
+
   it("retries when bootstrap returns without making the channel send-capable", () => {
     const registry = createEmptyPluginRegistry();
     registry.channels = [

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -76,4 +76,61 @@ describe("bootstrapOutboundChannelPlugin", () => {
 
     expect(loaderMocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
   });
+
+  it("skips bootstrap when the active replacement registry can send for a pinned setup shell", () => {
+    const setup = createEmptyPluginRegistry();
+    setup.channels = [
+      {
+        pluginId: "discord",
+        plugin: { id: "discord", meta: {} },
+        source: "setup",
+      },
+    ] as never;
+    const runtime = createEmptyPluginRegistry();
+    runtime.channels = [
+      {
+        pluginId: "discord",
+        plugin: {
+          id: "discord",
+          meta: {},
+          outbound: { sendText: async () => ({ messageId: "1" }) },
+        },
+        source: "runtime",
+      },
+    ] as never;
+    setActivePluginRegistry(setup);
+    pinActivePluginChannelRegistry(setup);
+    setActivePluginRegistry(runtime);
+
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: discordConfig,
+    });
+
+    expect(loaderMocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
+  });
+
+  it("retries when bootstrap returns without making the channel send-capable", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.channels = [
+      {
+        pluginId: "discord",
+        plugin: { id: "discord", meta: {} },
+        source: "setup",
+      },
+    ] as never;
+    setActivePluginRegistry(registry);
+    pinActivePluginChannelRegistry(registry);
+
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: discordConfig,
+    });
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: discordConfig,
+    });
+
+    expect(loaderMocks.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -8,6 +8,8 @@ import type { PluginChannelRegistration } from "../../plugins/registry-types.js"
 import {
   getActivePluginChannelRegistry,
   getActivePluginChannelRegistryVersion,
+  getActivePluginRegistry,
+  getActivePluginRegistryVersion,
 } from "../../plugins/runtime.js";
 import type { DeliverableMessageChannel } from "../../utils/message-channel.js";
 
@@ -22,6 +24,27 @@ function channelEntryCanSend(entry: PluginChannelRegistration | undefined): bool
   return Boolean(entry?.plugin?.outbound?.sendText ?? entry?.plugin?.message?.send?.text);
 }
 
+function findChannelEntry(
+  registry: ReturnType<typeof getActivePluginRegistry>,
+  channel: DeliverableMessageChannel,
+): PluginChannelRegistration | undefined {
+  return registry?.channels?.find((entry) => entry?.plugin?.id === channel);
+}
+
+function canResolveSendCapableChannel(channel: DeliverableMessageChannel): boolean {
+  const activeChannelRegistry = getActivePluginChannelRegistry();
+  const channelEntry = findChannelEntry(activeChannelRegistry, channel);
+  if (channelEntryCanSend(channelEntry)) {
+    return true;
+  }
+
+  const activeRegistry = getActivePluginRegistry();
+  if (activeRegistry && activeRegistry !== activeChannelRegistry) {
+    return channelEntryCanSend(findChannelEntry(activeRegistry, channel));
+  }
+  return false;
+}
+
 /** Loads runtime plugins on demand when a selected outbound channel has only a setup shell. */
 export function bootstrapOutboundChannelPlugin(params: {
   channel: DeliverableMessageChannel;
@@ -32,15 +55,11 @@ export function bootstrapOutboundChannelPlugin(params: {
     return;
   }
 
-  const activeChannelRegistry = getActivePluginChannelRegistry();
-  const activeChannelEntry = activeChannelRegistry?.channels?.find(
-    (entry) => entry?.plugin?.id === params.channel,
-  );
-  if (channelEntryCanSend(activeChannelEntry)) {
+  if (canResolveSendCapableChannel(params.channel)) {
     return;
   }
 
-  const attemptKey = `${getActivePluginChannelRegistryVersion()}:${params.channel}`;
+  const attemptKey = `${getActivePluginChannelRegistryVersion()}:${getActivePluginRegistryVersion()}:${params.channel}`;
   if (bootstrapAttempts.has(attemptKey)) {
     return;
   }
@@ -61,6 +80,9 @@ export function bootstrapOutboundChannelPlugin(params: {
         allowGatewaySubagentBinding: true,
       },
     });
+    if (!canResolveSendCapableChannel(params.channel)) {
+      bootstrapAttempts.delete(attemptKey);
+    }
   } catch {
     bootstrapAttempts.delete(attemptKey);
   }

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -9,6 +9,7 @@ const getChannelPluginMock = vi.hoisted(() => vi.fn());
 const applyPluginAutoEnableMock = vi.hoisted(() => vi.fn());
 const resolveRuntimePluginRegistryMock = vi.hoisted(() => vi.fn());
 const getActivePluginRegistryMock = vi.hoisted(() => vi.fn());
+const getActivePluginRegistryVersionMock = vi.hoisted(() => vi.fn());
 const getActivePluginChannelRegistryMock = vi.hoisted(() => vi.fn());
 const getActivePluginChannelRegistryVersionMock = vi.hoisted(() => vi.fn());
 const normalizeMessageChannelMock = vi.hoisted(() => vi.fn());
@@ -34,6 +35,8 @@ vi.mock("../../plugins/loader.js", () => ({
 
 vi.mock("../../plugins/runtime.js", () => ({
   getActivePluginRegistry: (...args: unknown[]) => getActivePluginRegistryMock(...args),
+  getActivePluginRegistryVersion: (...args: unknown[]) =>
+    getActivePluginRegistryVersionMock(...args),
   getActivePluginChannelRegistry: (...args: unknown[]) =>
     getActivePluginChannelRegistryMock(...args),
   getActivePluginChannelRegistryVersion: (...args: unknown[]) =>
@@ -75,6 +78,7 @@ describe("outbound channel resolution", () => {
     applyPluginAutoEnableMock.mockReset();
     resolveRuntimePluginRegistryMock.mockReset();
     getActivePluginRegistryMock.mockReset();
+    getActivePluginRegistryVersionMock.mockReset();
     getActivePluginChannelRegistryMock.mockReset();
     getActivePluginChannelRegistryVersionMock.mockReset();
     normalizeMessageChannelMock.mockReset();
@@ -87,6 +91,7 @@ describe("outbound channel resolution", () => {
       ["alpha", "beta", "gamma"].includes(String(value)),
     );
     getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    getActivePluginRegistryVersionMock.mockReturnValue(1);
     getActivePluginChannelRegistryMock.mockReturnValue({ channels: [] });
     getActivePluginChannelRegistryVersionMock.mockReturnValue(1);
     applyPluginAutoEnableMock.mockReturnValue({
@@ -110,7 +115,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("returns the already-registered plugin without bootstrapping", async () => {
-    const plugin = { id: "alpha" };
+    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
     getLoadedChannelPluginMock.mockReturnValueOnce(plugin);
     const channelResolution = await importChannelResolution("existing-plugin");
 
@@ -124,7 +129,7 @@ describe("outbound channel resolution", () => {
   });
 
   it("returns a bundled plugin without bootstrapping", async () => {
-    const plugin = { id: "alpha" };
+    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(plugin);
     const channelResolution = await importChannelResolution("bundled-plugin");
@@ -158,8 +163,27 @@ describe("outbound channel resolution", () => {
     ).toBe(plugin);
   });
 
+  it("resolves message adapters from the pinned channel registry after active registry replacement", async () => {
+    const message = { send: { text: vi.fn() } };
+    const plugin = { id: "alpha", message };
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin }],
+    });
+    getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    const channelResolution = await importChannelResolution("pinned-message-registry");
+
+    expect(
+      channelResolution.resolveOutboundChannelMessageAdapter({
+        channel: "alpha",
+        cfg: {} as never,
+      }),
+    ).toBe(message);
+  });
+
   it("bootstraps configured channel plugins when the active registry is missing the target", async () => {
-    const plugin = { id: "alpha" };
+    const plugin = { id: "alpha", outbound: { sendText: vi.fn() } };
     getLoadedChannelPluginMock.mockReturnValueOnce(undefined).mockReturnValueOnce(plugin);
     const channelResolution = await importChannelResolution("bootstrap-missing-target");
 
@@ -180,6 +204,94 @@ describe("outbound channel resolution", () => {
     expect(registryOptions.runtimeOptions).toEqual({
       allowGatewaySubagentBinding: true,
     });
+  });
+
+  it("bootstraps instead of returning a pinned setup shell as the outbound plugin", async () => {
+    const setupPlugin = { id: "alpha" };
+    const runtimePlugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValueOnce(setupPlugin).mockReturnValueOnce(runtimePlugin);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginRegistryMock.mockReturnValue({ channels: [] });
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: setupPlugin }],
+    });
+    const channelResolution = await importChannelResolution("bootstrap-setup-shell");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(runtimePlugin);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not return a setup shell when bootstrap does not produce a runtime plugin", async () => {
+    const setupPlugin = { id: "alpha" };
+    getLoadedChannelPluginMock.mockReturnValue(setupPlugin);
+    getChannelPluginMock.mockReturnValue(setupPlugin);
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin: setupPlugin }],
+    });
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: setupPlugin }],
+    });
+    const channelResolution = await importChannelResolution("bootstrap-still-setup-shell");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBeUndefined();
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat an actions-only plugin as send-capable after bootstrap", async () => {
+    const actionsOnlyPlugin = { id: "alpha", actions: { handleAction: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(actionsOnlyPlugin);
+    getChannelPluginMock.mockReturnValue(actionsOnlyPlugin);
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin: actionsOnlyPlugin }],
+    });
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: actionsOnlyPlugin }],
+    });
+    const channelResolution = await importChannelResolution("actions-only-plugin");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBeUndefined();
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers an active runtime plugin over a loaded setup shell", async () => {
+    const setupPlugin = { id: "alpha" };
+    const runtimePlugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(setupPlugin);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin: runtimePlugin }],
+    });
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: setupPlugin }],
+    });
+    const channelResolution = await importChannelResolution("active-runtime-over-setup");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: { channels: {} } as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(runtimePlugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
   it("attempts activation when the active registry has other channels but not the requested one", async () => {
@@ -203,7 +315,7 @@ describe("outbound channel resolution", () => {
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry registry loads after a missing outbound plugin", async () => {
+  it("retries registry loads after bootstrap does not make the channel send-capable", async () => {
     getChannelPluginMock.mockReturnValue(undefined);
     const channelResolution = await importChannelResolution("bootstrap-retry");
 
@@ -220,7 +332,7 @@ describe("outbound channel resolution", () => {
       cfg: { channels: {} } as never,
       allowBootstrap: true,
     });
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(1);
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledTimes(2);
   });
 
   it("allows another activation attempt when the pinned channel registry version changes", async () => {

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -294,6 +294,27 @@ describe("outbound channel resolution", () => {
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
+  it("keeps setup shells visible for read-only channel lookup", async () => {
+    const setupPlugin = { id: "alpha" };
+    const runtimePlugin = { id: "alpha", outbound: { sendText: vi.fn() } };
+    getLoadedChannelPluginMock.mockReturnValue(setupPlugin);
+    getChannelPluginMock.mockReturnValue(undefined);
+    getActivePluginRegistryMock.mockReturnValue({
+      channels: [{ plugin: runtimePlugin }],
+    });
+    getActivePluginChannelRegistryMock.mockReturnValue({
+      channels: [{ plugin: setupPlugin }],
+    });
+    const channelResolution = await importChannelResolution("read-setup-shell");
+
+    expect(
+      channelResolution.resolveOutboundChannelPluginForRead({
+        channel: "alpha",
+      }),
+    ).toBe(setupPlugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
   it("attempts activation when the active registry has other channels but not the requested one", async () => {
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(undefined);

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -21,7 +21,7 @@ import type {
   ChannelThreadingAdapter,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { getActivePluginChannelRegistry, getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -111,18 +111,75 @@ function maybeBootstrapChannelPlugin(params: {
   bootstrapOutboundChannelPlugin(params);
 }
 
-function resolveDirectFromActiveRegistry(channel: string): ChannelPlugin | undefined {
-  const activeRegistry = getActivePluginRegistry();
-  if (!activeRegistry) {
+function resolveDirectFromRegistry(
+  registry: ReturnType<typeof getActivePluginRegistry>,
+  channel: string,
+): ChannelPlugin | undefined {
+  if (!registry) {
     return undefined;
   }
-  for (const entry of activeRegistry.channels) {
+  for (const entry of registry.channels) {
     const plugin = entry?.plugin;
     if (plugin?.id === channel) {
       return plugin;
     }
   }
   return undefined;
+}
+
+function resolveDirectFromActiveRegistry(channel: string): ChannelPlugin | undefined {
+  return resolveDirectFromRegistry(getActivePluginRegistry(), channel);
+}
+
+function channelPluginHasRuntimeOutboundSurface(plugin: ChannelPlugin | undefined): boolean {
+  return Boolean(plugin?.outbound ?? plugin?.message);
+}
+
+function resolveRuntimeOutboundPluginCandidate(params: {
+  loaded?: ChannelPlugin;
+  active?: ChannelPlugin;
+  bundled?: ChannelPlugin;
+  allowSetupShell?: boolean;
+}): ChannelPlugin | undefined {
+  if (channelPluginHasRuntimeOutboundSurface(params.loaded)) {
+    return params.loaded;
+  }
+  if (channelPluginHasRuntimeOutboundSurface(params.active)) {
+    return params.active;
+  }
+  if (channelPluginHasRuntimeOutboundSurface(params.bundled)) {
+    return params.bundled;
+  }
+  if (params.allowSetupShell) {
+    return params.loaded ?? params.active ?? params.bundled;
+  }
+  return undefined;
+}
+
+function resolveValueFromRuntimeRegistries<TValue>(
+  channel: string,
+  resolveValue: (plugin: ChannelPlugin) => TValue | undefined,
+): TValue | undefined {
+  const channelRegistry = getActivePluginChannelRegistry();
+  const channelPlugin = resolveDirectFromRegistry(channelRegistry, channel);
+  if (channelPlugin) {
+    const value = resolveValue(channelPlugin);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  const activeRegistry = getActivePluginRegistry();
+  if (activeRegistry && activeRegistry !== channelRegistry) {
+    const activePlugin = resolveDirectFromRegistry(activeRegistry, channel);
+    if (activePlugin) {
+      return resolveValue(activePlugin);
+    }
+  }
+  return undefined;
+}
+
+function resolveDirectFromRuntimeRegistries(channel: string): ChannelPlugin | undefined {
+  return resolveValueFromRuntimeRegistries(channel, (plugin) => plugin);
 }
 
 function toOutboundChannelRuntime(plugin: ChannelPlugin): OutboundChannelRuntime {
@@ -191,17 +248,16 @@ export function resolveOutboundChannelPlugin(params: {
   const resolveLoaded = () => getLoadedChannelPlugin(normalized);
   const resolve = () => getChannelPlugin(normalized);
   const current = resolveLoaded();
-  if (current) {
-    return current;
-  }
   const directCurrent = resolveDirectFromActiveRegistry(normalized);
-  if (directCurrent) {
-    return directCurrent;
-  }
-
   const bundledCurrent = resolve();
-  if (bundledCurrent) {
-    return bundledCurrent;
+  const candidate = resolveRuntimeOutboundPluginCandidate({
+    loaded: current,
+    active: directCurrent,
+    bundled: bundledCurrent,
+    allowSetupShell: params.allowBootstrap !== true,
+  });
+  if (candidate) {
+    return candidate;
   }
 
   if (params.allowBootstrap !== true) {
@@ -209,7 +265,11 @@ export function resolveOutboundChannelPlugin(params: {
   }
 
   maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
-  return resolveLoaded() ?? resolveDirectFromActiveRegistry(normalized) ?? resolve();
+  return resolveRuntimeOutboundPluginCandidate({
+    loaded: resolveLoaded(),
+    active: resolveDirectFromActiveRegistry(normalized),
+    bundled: resolve(),
+  });
 }
 
 /** Resolves the message adapter for a deliverable outbound channel. */
@@ -218,7 +278,23 @@ export function resolveOutboundChannelMessageAdapter(params: {
   cfg?: OpenClawConfig;
   allowBootstrap?: boolean;
 }): ChannelMessageAdapterShape | undefined {
-  return resolveOutboundChannelPlugin(params)?.message;
+  const normalized = normalizeDeliverableOutboundChannel(params.channel);
+  if (!normalized) {
+    return undefined;
+  }
+  const current =
+    getLoadedChannelPlugin(normalized)?.message ??
+    resolveValueFromRuntimeRegistries(normalized, (plugin) => plugin.message) ??
+    getChannelPlugin(normalized)?.message;
+  if (current || params.allowBootstrap !== true) {
+    return current;
+  }
+  maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+  return (
+    getLoadedChannelPlugin(normalized)?.message ??
+    resolveValueFromRuntimeRegistries(normalized, (plugin) => plugin.message) ??
+    getChannelPlugin(normalized)?.message
+  );
 }
 
 /** Resolves a channel plugin for read-only metadata paths. */
@@ -235,7 +311,7 @@ export function resolveOutboundChannelPluginForRead(params: {
   if (current) {
     return current;
   }
-  const directCurrent = resolveDirectFromActiveRegistry(normalized);
+  const directCurrent = resolveDirectFromRuntimeRegistries(normalized);
   if (directCurrent) {
     return directCurrent;
   }
@@ -244,7 +320,7 @@ export function resolveOutboundChannelPluginForRead(params: {
     maybeBootstrapChannelPlugin({ channel: deliverable, cfg: params.cfg });
     return (
       getLoadedChannelPlugin(deliverable) ??
-      resolveDirectFromActiveRegistry(deliverable) ??
+      resolveDirectFromRuntimeRegistries(deliverable) ??
       getChannelPlugin(deliverable)
     );
   }
@@ -270,6 +346,6 @@ export function resolveLoadedOutboundChannelPluginForRead(params: {
   }
   return (
     getLoadedChannelPlugin(normalized as Parameters<typeof getLoadedChannelPlugin>[0]) ??
-    resolveDirectFromActiveRegistry(normalized)
+    resolveDirectFromRuntimeRegistries(normalized)
   );
 }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Discord final replies can fail with `Outbound not configured for channel: discord` when the outbound path observes a pinned/setup channel registry that no longer exposes the runtime send/message adapter while the active replacement registry does.
- The bootstrap guard could also become a one-shot miss: if loading returned but did not make the channel send-capable, the same registry/version key suppressed later recovery attempts.

Why does this matter now?

- Issue #90162 reports the final reply delivery failure on v2026.6.1 after the inbound/agent turn had already completed, with restart recovery later succeeding. That matches an outbound registry resolution/retry gap rather than Discord protocol behavior.

What is the intended outcome?

- Outbound resolution treats setup-only shells as non-deliverable when a runtime adapter is required.
- Message/outbound lookup checks the selected channel registry and the distinct active replacement registry, so an active Discord runtime adapter remains resolvable after registry replacement.
- Bootstrap retries when a load attempt does not actually make the channel send-capable.

What is intentionally out of scope?

- Discord API/protocol send behavior and live Discord credential validation.
- Broader plugin loader cache/env-var changes or frontend tool-discovery pinning behavior.

What does success look like?

- Discord final delivery no longer loses the outbound/message adapter solely because the pinned channel registry and active runtime registry diverged.

What should reviewers focus on?

- Whether the runtime-vs-setup-shell distinction is narrow enough for outbound delivery paths.
- Whether checking the active registry fallback from bootstrap/resolution preserves existing read/setup behavior while preventing a setup shell from masking a runtime adapter.

## Linked context

Which issue does this close?

Closes #90162

Which issues, PRs, or discussions are related?

Related #87333 (adjacent channel-registry pinning issue; different files and failure path).

Was this requested by a maintainer or owner?

No maintainer request seen; ClawSweeper marked the issue source-repro/fix-shape-clear.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  Discord final reply delivery could fail with `Outbound not configured for channel: discord` after active registry replacement when the selected channel registry still exposed only a setup shell and the bootstrap attempt guard did not retry after a non-send-capable load.
- Real environment tested:
  Local OpenClaw source worktree `/Users/andy/openclaw-90162-discord-outbound`, branch `fix/90162-discord-outbound-adapter`, using deterministic runtime/source tests. Live Discord proof was also captured on a PR-head temp gateway running OpenClaw 2026.6.2 (`f62c3e0`) with build-info commit `f62c3e0912ee0a7aebe5db4910f7ec2ecd57781b`; the temp PR-head gateway was stopped afterward and production gateway health was verified OK.
- Exact steps or command run after this patch:
  `node scripts/run-vitest.mjs run src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-bootstrap.runtime.test.ts src/plugins/runtime.channel-pin.test.ts`

  `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/channel-selection.test.ts src/infra/outbound/targets.test.ts`

  `node scripts/run-vitest.mjs src/infra/outbound/message.test.ts src/cron/isolated-agent/delivery-target.test.ts src/gateway/server-methods/send.test.ts src/channels/turn/durable-delivery.test.ts`

  `pnpm exec oxfmt --check src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-bootstrap.runtime.ts src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-resolution.ts`

  `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-bootstrap.runtime.ts src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-resolution.ts`

  `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`

  `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`

  `git diff --check`

  `codex review --base upstream/main`

  Live Discord proof commands/checks:

  `git -C <pr-worktree> rev-parse HEAD`

  `node <pr-worktree>/dist/index.js --version`

  `jq . <pr-worktree>/dist/build-info.json`

  Started PR-head gateway on temp port `18790` with temp config and Discord tech account enabled.

  `gateway health --json` against temp port.

  Sent a real Discord trigger message in `#agent-chat` from another bot account.

  Read recent Discord messages through the Discord API.

  `rg "Outbound not configured for channel: discord" <pr-head-log>`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Live Discord proof environment:
PR: https://github.com/openclaw/openclaw/pull/90198
Issue: #90162
Head SHA: f62c3e0912ee0a7aebe5db4910f7ec2ecd57781b
Build: OpenClaw 2026.6.2 (f62c3e0)
build-info: version=2026.6.2 commit=f62c3e0912ee0a7aebe5db4910f7ec2ecd57781b builtAt=2026-06-04T07:27:06.943Z

Redacted live Discord proof log:
2026-06-04T00:48:14.163-07:00 [gateway] loading configuration...
2026-06-04T00:48:16.594-07:00 [gateway] http server listening (... discord ...)
2026-06-04T00:48:16.609-07:00 [discord] [tech] starting provider
2026-06-04T00:48:17.360-07:00 [gateway] ready
2026-06-04T00:48:18.174-07:00 [discord] [tech] Discord bot probe resolved @CTO
2026-06-04T00:48:18.778-07:00 discord gateway: Gateway websocket opened

2026-06-04T00:51:53.947-07:00 discord: inbound id=<message-id> guild=<guild-id> channel=<channel-id> mention=yes type=guild content=yes
2026-06-04T00:51:53.956-07:00 [discord-preflight] success: route=tech sessionKey=<session-key>
2026-06-04T00:51:54.064-07:00 [diagnostic] message received: channel=discord chatId=channel:<channel-id> messageId=<message-id> sessionKey=<session-key>
2026-06-04T00:51:54.810-07:00 [diagnostic] session turn created: runId=<run-id> sessionId=<session-id> sessionKey=<session-key> agentId=tech channel=discord trigger=user
2026-06-04T00:51:58.702-07:00 [diagnostic] session state: sessionId=<session-id> sessionKey=<session-key> prev=processing new=idle reason="run_completed"
2026-06-04T00:51:59.101-07:00 [diagnostic] message dispatch completed: channel=discord sessionKey=<session-key> outcome=completed duration=4558ms
2026-06-04T00:51:59.101-07:00 [diagnostic] message processed: channel=discord chatId=channel:<channel-id> messageId=<message-id> outcome=completed duration=5036ms
2026-06-04T00:52:01.058-07:00 discord: delivered 1 reply to channel:<channel-id>

Discord API readback:
2026-06-04T07:51:53.747000+00:00 author=ATLAS id=<message-id> content="<@CTO> PR90198_PROOF_TRIGGER_20260604T0055Z ..."
2026-06-04T07:51:59.006000+00:00 author=CTO id=<message-id> content="PR90198_PROOF_OK_20260604T0055Z"

Error check:
no Outbound-not-configured error found in PR-head log

[test] passed 2 Vitest shards in 8.37s
# channel-resolution + channel-bootstrap + runtime.channel-pin: 21 infra tests, 14 plugin tests

[test] passed 1 Vitest shard in 6.50s
# nearby outbound sweep: 6 files, 252 tests

[test] passed 4 Vitest shards in 17.07s
# gateway/infra/cron/channels consumer sweep: 2 gateway files/112 tests, 1 infra file/11 tests, 1 cron file/53 tests, 1 channels file/6 tests

All matched files use the correct format.

codex review --base upstream/main:
No actionable regressions were identified in the changed outbound channel bootstrap/resolution paths. The added behavior is covered by targeted tests, and nearby outbound/gateway tests passed.
```

- Observed result after fix:
  Source-backed runtime tests prove that setup-only and actions-only shells do not satisfy runtime outbound resolution, active replacement registries remain visible to message/outbound resolution, and bootstrap retries after a load that still does not make the channel send-capable. Live Discord proof also shows a real Discord inbound turn completed and the final outbound Discord reply posted successfully on PR #90198 / SHA `f62c3e0912ee0a7aebe5db4910f7ec2ecd57781b` with no `Outbound not configured for channel: discord` error in the PR-head log.
- What was not tested:
  A live before/after reproduction on the exact pre-patch SHA was not run; the before behavior is covered by the linked stable-release issue logs and source-level regression tests.
- Proof limitations or environment constraints:
  Live proof used a temporary PR-head gateway on port `18790` with a Discord tech account. Message, guild, channel, session, and run identifiers are redacted. The temp PR-head gateway was stopped after proof capture and production gateway health was verified OK.
- Before evidence (optional but encouraged):
  The added regression tests model the source-level failure shape from #90162: pinned setup/channel registry plus active runtime replacement and a non-send-capable bootstrap result. These cases would have returned/kept a setup shell or suppressed retry before the resolver/bootstrap changes.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs run src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-bootstrap.runtime.test.ts src/plugins/runtime.channel-pin.test.ts` — passed
- `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/channel-selection.test.ts src/infra/outbound/targets.test.ts` — passed
- `node scripts/run-vitest.mjs src/infra/outbound/message.test.ts src/cron/isolated-agent/delivery-target.test.ts src/gateway/server-methods/send.test.ts src/channels/turn/durable-delivery.test.ts` — passed
- `pnpm exec oxfmt --check src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-bootstrap.runtime.ts src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-resolution.ts` — passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/outbound/channel-bootstrap.runtime.test.ts src/infra/outbound/channel-bootstrap.runtime.ts src/infra/outbound/channel-resolution.test.ts src/infra/outbound/channel-resolution.ts` — passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed
- `git diff --check` — passed
- `codex review --base upstream/main` — no actionable regressions

What regression coverage was added or updated?

- `src/infra/outbound/channel-bootstrap.runtime.test.ts` covers active replacement registry send-capability visibility and retry after a bootstrap attempt that leaves the channel non-send-capable.
- `src/infra/outbound/channel-resolution.test.ts` covers pinned message adapter lookup after active registry replacement, setup shell and actions-only avoidance during bootstrap, active runtime preference over loaded setup shells, and non-return of setup shells after unsuccessful bootstrap.

What failed before this fix, if known?

- A setup-only channel shell could be returned as the outbound plugin for a runtime delivery path, masking a send-capable active runtime plugin or leaving delivery to fail as unsupported.
- Bootstrap could record an attempt even when the channel still could not send, suppressing a later retry in the same registry-version window.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Final outbound delivery should now recover through a runtime adapter instead of failing when registry replacement leaves a setup shell in the selected channel registry.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Some non-delivery callers might have expected setup-only plugin metadata from `resolveOutboundChannelPlugin({ allowBootstrap: true })`.

How is that risk mitigated?

- The stricter runtime-surface filtering applies to outbound/runtime resolution. Read-only resolver paths still preserve setup/metadata visibility, and targeted plus nearby consumer tests passed.

## Current review state

What is the next action?

- Ready for maintainer/ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

- CI is green on the current SHA. ClawSweeper requested live Discord proof; redacted live proof has now been added to the PR body showing inbound Discord processing and final reply delivery on `f62c3e0912ee0a7aebe5db4910f7ec2ecd57781b`.

Which bot or reviewer comments were addressed?

- No PR comments yet. The implementation follows the issue hint to prioritize registry/outbound adapter resolution over Discord protocol code.


