### PR TITLE
fix(agents): defer bootstrap context-engine maintenance to background

### DIFF
--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -674,6 +674,67 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("defers bootstrap maintenance to a background debt consumer for background-mode engines", async () => {
+    await withStateDirEnv("openclaw-bootstrap-maintenance-", async () => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const sessionKey = "agent:main:bootstrap-1";
+      const maintain = vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      }));
+      const backgroundEngine = {
+        info: {
+          id: "test",
+          name: "Test Engine",
+          turnMaintenanceMode: "background" as const,
+        },
+        ingest: async () => ({ ingested: true }),
+        assemble: async ({ messages }: { messages: unknown[] }) => ({
+          messages,
+          estimatedTokens: 0,
+        }),
+        compact: async () => ({ ok: true, compacted: false }),
+        maintain,
+      } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+      let deferred: Promise<void> | undefined;
+      const result = await runContextEngineMaintenance({
+        contextEngine: backgroundEngine,
+        sessionId: "bootstrap-1",
+        sessionKey,
+        sessionFile: "/tmp/session.jsonl",
+        reason: "bootstrap",
+        runtimeContext: {
+          workspaceDir: "/tmp/workspace",
+          tokenBudget: 2048,
+          currentTokenCount: 1536,
+        },
+        onDeferredMaintenance: (promise) => {
+          deferred = promise;
+        },
+      });
+
+      // Foreground bootstrap maintenance cannot pay deferred compaction debt, so
+      // a background consumer must be scheduled instead of running inline.
+      expect(result).toBeUndefined();
+      const queuedTasks = listTasksForOwnerKey(sessionKey).filter(
+        (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+      );
+      expect(queuedTasks).toHaveLength(1);
+
+      await deferred;
+      expect(maintain).toHaveBeenCalledTimes(1);
+      const maintainParams = firstMaintainParams(maintain);
+      expectRecordFields(requireRecord(maintainParams.runtimeContext, "runtime context"), {
+        allowDeferredCompactionExecution: true,
+      });
+    });
+  });
+
   it("coalesces repeated requests into one active run plus one follow-up run for the same session", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -711,8 +711,12 @@ export async function runContextEngineMaintenance(params: {
   }
 
   const executionMode = params.executionMode ?? "foreground";
+  // Bootstrap/reconcile runs foreground, where deferred compaction debt cannot
+  // execute (allowDeferredCompactionExecution is background-only). For engines
+  // that opt into background maintenance, schedule the same background debt
+  // consumer as turns so bootstrap-created debt is not stranded (issue #67716).
   const shouldDefer =
-    params.reason === "turn" &&
+    (params.reason === "turn" || params.reason === "bootstrap") &&
     executionMode !== "background" &&
     params.contextEngine.info.turnMaintenanceMode === "background";
 


### PR DESCRIPTION
## Summary

- Bootstrap/reconcile context-engine maintenance runs in **foreground**, where deferred compaction debt cannot execute (`allowDeferredCompactionExecution` is background-only) and no background follow-up is scheduled (only turns defer). So debt created when bootstrap imports tail messages past the leaf trigger is **stranded**, leaving sessions repeating `deferred compaction still needed` (issue #67716, Case 1).
- Lets `reason="bootstrap"` schedule the **same background debt consumer** turns already use, for engines that opt into background maintenance (`turnMaintenanceMode === "background"`).
- Foreground bootstrap is unchanged for engines without background maintenance; the plugin-owned (Lossless-Claw) hot-cache sticky-debt path (Case 2) is intentionally **out of scope**.
- Reviewers should focus on: deferring bootstrap is safe because turns already defer for these engines, the deferred run dedups/coalesces per session, and it runs in background mode (so it can actually pay the debt).

## Linked context

Closes #67716

Related #66820 — deferred-maintenance token budget (a different aspect of the same subsystem; not this scheduling gap).

Not maintainer-requested; selected from the `clawsweeper:queueable-fix` backlog. ClawSweeper's review of #67716 recommended exactly this OpenClaw-scoped fix: "extend the existing deferred-maintenance lifecycle so bootstrap/reconcile can schedule a valid background debt consumer," keeping plugin hot-cache/dedup policy out.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: bootstrap/reconcile created deferred compaction debt that could not execute because bootstrap maintenance runs foreground (issue #67716 Case 1).
- Real environment tested: Linux / Node 24, exercising the real production `runContextEngineMaintenance` lifecycle — the deferred background worker, the task registry/queue, and the session lane — not mocked.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output. The added regression fails on unfixed `main` (bootstrap ran foreground and returned a maintenance result) and passes after the fix (bootstrap defers and the background worker runs):

```
unfixed main: × defers bootstrap maintenance to a background debt consumer for background-mode engines
              AssertionError: expected { Object (changed, bytesFreed, ...) } to be undefined

with the fix: Test Files  1 passed (1)
              Tests       23 passed (23)
```

- Observed result after fix: for a background-mode engine, bootstrap maintenance schedules a background `context_engine_turn_maintenance` task instead of running inline, and the deferred worker runs `maintain()` with `allowDeferredCompactionExecution: true` (the debt can now be paid).
- What was not tested: a live gateway bootstrap/reconcile overflow on a running OpenClaw deployment.
- Proof limitations or environment constraints: this is unit/integration-level proof against the real lifecycle functions, which CONTRIBUTING.md treats as supplemental rather than a live-setup capture. I could not drive a live gateway into a bootstrap overflow in this environment (needs a full running OpenClaw + provider + forced overflow; the sandbox network also blocked a clean install and the `crabbox check:changed` gate). A maintainer with a live setup can confirm end-to-end, or apply `proof: override` for this logic-scoped scheduling fix.
- Before evidence (optional but encouraged): the failing assertion above (`expected { ... } to be undefined`) is the before-state from unfixed `main`, where bootstrap ran foreground.

<details>
<summary>How to capture live behavior proof on a real setup (for a maintainer or the reporter)</summary>

This needs the background-maintenance context engine (the Lossless-Claw / "LCM" engine from the issue, which sets `turnMaintenanceMode: "background"` and emits the `LCM compaction leaf pass` lines) plus a real provider — neither of which I can run in CI/sandbox. Steps:

1. Build this branch: `pnpm install && pnpm build`; run the gateway with the LCM-configured agent and tail logs (`./scripts/clawlog.sh`).
2. Restart the gateway on a session whose reconcile tail-import pushes `rawTokensOutsideTail` past the leaf trigger (issue #67716 Case 1).
3. Grep the bootstrap window (redact session keys/content):

```
grep -E "reconcileSessionTail|deferred turn maintenance (queued|resuming)|deferred compaction (debt pending|skipped|completed)|allowDeferredCompactionExecution|reason=compacted|compactLeafAsync" <gateway-log>
```

Before this fix the bootstrap window shows `deferred compaction debt pending ... allowDeferredCompactionExecution is disabled` → `deferred compaction skipped ... reason=deferred compaction still needed` (stranded). After this fix it shows the core line `[context-engine] deferred turn maintenance queued ... lane=context-engine-turn-maintenance:<key>` **during bootstrap** (emitted at `context-engine-maintenance.ts:619`; previously only on turns) followed by `compactLeafAsync start` → `LCM compaction leaf pass` → `deferred compaction completed ... reason=compacted` (paid). I will paste the redacted excerpt here once it is captured.

</details>

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/context-engine-maintenance.test.ts` -> 23 passed (1 new).
- Acceptance set (from the issue review, paths updated for the `embedded-agent-runner` rename): `attempt.spawn-workspace.context-engine.test.ts` -> 56 passed; `extensions/codex/src/app-server/run-attempt.context-engine.test.ts` -> 24 passed; `src/agents/harness/context-engine-lifecycle.test.ts` -> 9 passed.
- `tsgo -p tsconfig.core.json` and core test types: no errors in the changed files (two unrelated pre-existing errors in `src/config/io.ts` and `src/secrets/config-io.ts` are present on `main`).
- Regression coverage added: "defers bootstrap maintenance to a background debt consumer for background-mode engines" (fails first, passes after).

## Risk checklist

- Did user-visible behavior change? No — internal startup maintenance scheduling.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: deferring bootstrap maintenance to background (session-state).
- How is that risk mitigated? It only defers for engines that already opt into background turn maintenance (foreground is unchanged for all others); it reuses the existing per-session, dedup/coalesced deferred-maintenance lane that turns use; and it is covered by the new regression plus the existing 22 maintenance tests and the spawn-workspace / codex / lifecycle suites.

## Current review state

- Next action: maintainer / ClawSweeper review. The code itself is accepted by ClawSweeper ("no narrow code repair is needed"); the only open item is the real-behavior-proof gate (`status: 📣 needs proof`).
- Scope: this addresses the OpenClaw-owned Case 1 only. Case 2 (hot-cache sticky debt / duplicate ledger) is plugin-owned (Lossless-Claw) per ClawSweeper's review and is intentionally excluded; the broader duplicate-transcript umbrella can stay open if maintainers prefer.
- On proof: the change is verified at the unit/integration level against the real lifecycle functions, but the live-overflow capture requires the external Lossless-Claw engine + a provider, which I can't run here. The exact live-capture steps are in the "How to capture live behavior proof" block above; I will add the redacted excerpt as soon as anyone with a live LCM setup runs it. **Requesting a maintainer `proof: override`** for this logic-scoped core scheduling fix in the meantime — ClawSweeper offered that path for exactly this case.

