### PR TITLE
fix(agents): guard OpenAI strict tool diagnostics

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearOpenAIToolSchemaCacheForTest,
+  findOpenAIStrictToolSchemaDiagnostics,
   isStrictOpenAIJsonSchemaCompatible,
   normalizeStrictOpenAIJsonSchema,
   resolveOpenAIStrictToolFlagForInventory,
@@ -90,5 +91,27 @@ describe("OpenAI strict tool schema normalization", () => {
         unsupportedToolSchemaKeywords: ["minimum"],
       }),
     ).toBe(third);
+  });
+
+  it("reports unreadable strict tool parameters without throwing", () => {
+    const unreadable = {
+      name: "fuzzplugin_unreadable",
+      parameters: { type: "object", properties: {} },
+    };
+    Object.defineProperty(unreadable, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+
+    expect(resolveOpenAIStrictToolFlagForInventory([unreadable], true)).toBe(false);
+    expect(findOpenAIStrictToolSchemaDiagnostics([unreadable])).toEqual([
+      {
+        toolIndex: 0,
+        toolName: "fuzzplugin_unreadable",
+        violations: ["fuzzplugin_unreadable.parameters is unreadable"],
+      },
+    ]);
   });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -18,8 +18,49 @@ type ToolWithParameters = {
   parameters: unknown;
 };
 
+type ToolFieldRead<TField extends keyof ToolWithParameters> =
+  | { readable: true; value: ToolWithParameters[TField] }
+  | { readable: false };
+
 const MAX_STRICT_SCHEMA_CACHE_ENTRIES_PER_SCHEMA = 8;
 let strictOpenAISchemaCache = new WeakMap<object, Array<{ key: string; value: unknown }>>();
+
+function readToolField<TField extends keyof ToolWithParameters>(
+  tool: ToolWithParameters,
+  field: TField,
+): ToolFieldRead<TField> {
+  try {
+    return { readable: true, value: tool[field] };
+  } catch {
+    return { readable: false };
+  }
+}
+
+function readToolName(tool: ToolWithParameters, toolIndex: number): {
+  toolName: string;
+  diagnosticToolName?: string;
+  violations: string[];
+} {
+  const nameRead = readToolField(tool, "name");
+  if (!nameRead.readable) {
+    const toolName = `tool[${toolIndex}]`;
+    return {
+      toolName,
+      violations: [`${toolName}.name is unreadable`],
+    };
+  }
+  if (typeof nameRead.value === "string" && nameRead.value) {
+    return {
+      toolName: nameRead.value,
+      diagnosticToolName: nameRead.value,
+      violations: [],
+    };
+  }
+  return {
+    toolName: `tool[${toolIndex}]`,
+    violations: [],
+  };
+}
 
 function resolveToolSchemaModelCompat(
   compat: ToolSchemaCompatInput | null | undefined,
@@ -179,18 +220,33 @@ export function findOpenAIStrictToolSchemaDiagnostics(
   tools: readonly ToolWithParameters[],
 ): OpenAIStrictToolSchemaDiagnostic[] {
   return tools.flatMap((tool, toolIndex) => {
+    const nameRead = readToolName(tool, toolIndex);
+    const parametersRead = readToolField(tool, "parameters");
+    if (!parametersRead.readable) {
+      return [
+        {
+          toolIndex,
+          ...(nameRead.diagnosticToolName ? { toolName: nameRead.diagnosticToolName } : {}),
+          violations: [
+            ...nameRead.violations,
+            `${nameRead.toolName}.parameters is unreadable`,
+          ],
+        },
+      ];
+    }
     const violations = findStrictOpenAIJsonSchemaViolations(
-      normalizeStrictOpenAIJsonSchema(tool.parameters),
-      `${typeof tool.name === "string" && tool.name ? tool.name : `tool[${toolIndex}]`}.parameters`,
+      normalizeStrictOpenAIJsonSchema(parametersRead.value),
+      `${nameRead.toolName}.parameters`,
     );
-    if (violations.length === 0) {
+    const allViolations = [...nameRead.violations, ...violations];
+    if (allViolations.length === 0) {
       return [];
     }
     return [
       {
         toolIndex,
-        ...(typeof tool.name === "string" && tool.name ? { toolName: tool.name } : {}),
-        violations,
+        ...(nameRead.diagnosticToolName ? { toolName: nameRead.diagnosticToolName } : {}),
+        violations: allViolations,
       },
     ];
   });
@@ -317,5 +373,8 @@ export function resolveOpenAIStrictToolFlagForInventory(
   if (strict !== true) {
     return strict === false ? false : undefined;
   }
-  return tools.every((tool) => isStrictOpenAIJsonSchemaCompatible(tool.parameters));
+  return tools.every((tool) => {
+    const parametersRead = readToolField(tool, "parameters");
+    return parametersRead.readable && isStrictOpenAIJsonSchemaCompatible(parametersRead.value);
+  });
 }


### PR DESCRIPTION
## Summary

- Guard OpenAI strict-tool inventory and diagnostic reads for plugin-controlled `name` and `parameters` descriptors.
- Downgrade strict mode cleanly when a tool's `parameters` getter is unreadable instead of throwing during request setup.
- Add a focused regression for unreadable strict tool parameters.

## Verification

Behavior addressed: unreadable tool descriptors can no longer crash OpenAI strict-tool flag resolution or strict downgrade diagnostics before the request path can continue with `strict=false`.

Real environment tested: local linked OpenClaw worktree on current `origin/main`; broad remote gates attempted but blocked by missing operator auth.

Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next183-red nodenv exec node scripts/run-vitest.mjs run src/agents/openai-tool-schema.test.ts --testNamePattern="reports unreadable strict tool parameters" --reporter=verbose
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next183-rebased nodenv exec node scripts/run-vitest.mjs run src/agents/openai-tool-schema.test.ts --reporter=verbose
nodenv exec node scripts/run-oxlint.mjs src/agents/openai-tool-schema.ts src/agents/openai-tool-schema.test.ts
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
blacksmith testbox list --all
node scripts/crabbox-wrapper.mjs run --provider aws --label next183-check-changed --shell -- "pnpm check:changed"
```

Evidence after fix: the targeted red test failed pre-fix with `fuzzplugin parameters getter exploded`; after the patch, `src/agents/openai-tool-schema.test.ts` passed 5/5, oxlint exited cleanly, `git diff --check` exited cleanly, and branch autoreview was clean with `overall: patch is correct (0.82)`.

Observed result after fix: unreadable strict tool parameters now make `resolveOpenAIStrictToolFlagForInventory(..., true)` return `false`, and `findOpenAIStrictToolSchemaDiagnostics()` reports `fuzzplugin_unreadable.parameters is unreadable`.

What was not tested: `pnpm check:changed` could not run remotely because `blacksmith testbox list --all` reported `not authenticated`, and direct AWS Crabbox failed with coordinator 401 on run and lease creation.
