### PR TITLE
feat(memory-wiki): add managed local source imports

### DIFF
--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -38,6 +38,10 @@
       "label": "Allow Private Memory Access",
       "help": "Experimental same-repo escape hatch for reading memory-core private paths."
     },
+    "localImports.enabled": {
+      "label": "Enable Local Imports",
+      "help": "Import explicitly configured local files and directories into wiki source pages."
+    },
     "context.includeCompiledDigestPrompt": {
       "label": "Include Compiled Digest In Prompt",
       "help": "Append a compact compiled wiki digest snapshot to memory prompt sections for context engines and legacy prompt assembly."
@@ -111,6 +115,21 @@
         "additionalProperties": false,
         "properties": {
           "allowPrivateMemoryCoreAccess": {
+            "type": "boolean"
+          },
+          "paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "localImports": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
             "type": "boolean"
           },
           "paths": {

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -550,6 +550,33 @@ cli note
     expect(callGatewayFromCliMock).not.toHaveBeenCalled();
   });
 
+  it("registers local-import import and syncs configured local files locally", async () => {
+    const sourcePath = path.join(suiteRoot, `local-import-${caseIndex}.md`);
+    await fs.writeFile(sourcePath, "# local import\n", "utf8");
+    const { rootDir, config } = await createCliVault({
+      config: {
+        localImports: {
+          enabled: true,
+          paths: [sourcePath],
+        },
+      },
+    });
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, config);
+
+    await program.parseAsync(["wiki", "local-import", "import", "--json"], { from: "user" });
+
+    const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
+      (entry) => entry !== "index.md",
+    );
+    expect(sourceFiles).toHaveLength(1);
+    await expect(
+      fs.readFile(path.join(rootDir, "sources", sourceFiles[0] ?? ""), "utf8"),
+    ).resolves.toContain("sourceType: local-import");
+    expect(callGatewayFromCliMock).not.toHaveBeenCalled();
+  });
+
   it("imports ChatGPT exports with dry-run, apply, and rollback", async () => {
     const { rootDir, config } = await createCliVault({ initialize: true });
     const exportDir = await createChatGptExport(rootDir);

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -15,7 +15,7 @@ import {
   type ChatGptImportResult,
   type ChatGptRollbackResult,
 } from "./chatgpt-import.js";
-import { compileMemoryWikiVault } from "./compile.js";
+import { compileMemoryWikiVault, refreshMemoryWikiIndexesAfterImport } from "./compile.js";
 import {
   resolveMemoryWikiConfig,
   WIKI_SEARCH_BACKENDS,
@@ -25,6 +25,7 @@ import {
 } from "./config.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
 import { lintMemoryWikiVault } from "./lint.js";
+import { syncMemoryWikiLocalImportSources } from "./local-import.js";
 import {
   probeObsidianCli,
   runObsidianCommand,
@@ -132,6 +133,10 @@ type WikiUnsafeLocalImportCommandOptions = {
   json?: boolean;
 };
 
+type WikiLocalImportCommandOptions = {
+  json?: boolean;
+};
+
 type WikiChatGptImportCommandOptions = {
   json?: boolean;
   dryRun?: boolean;
@@ -167,7 +172,8 @@ function isResolvedMemoryWikiConfig(
     "vault" in config &&
     "bridge" in config &&
     "obsidian" in config &&
-    "unsafeLocal" in config,
+    "unsafeLocal" in config &&
+    "localImports" in config,
   );
 }
 
@@ -780,6 +786,33 @@ export async function runWikiUnsafeLocalImport(params: {
   });
 }
 
+export async function runWikiLocalImport(params: {
+  config: ResolvedMemoryWikiConfig;
+  appConfig?: OpenClawConfig;
+  json?: boolean;
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+}) {
+  return runWikiCommandWithSummary({
+    json: params.json,
+    stdout: params.stdout,
+    run: async () => {
+      const syncResult = await syncMemoryWikiLocalImportSources(params.config);
+      const refreshResult = await refreshMemoryWikiIndexesAfterImport({
+        config: params.config,
+        syncResult,
+      });
+      return {
+        ...syncResult,
+        indexesRefreshed: refreshResult.refreshed,
+        indexUpdatedFiles: refreshResult.compile?.updatedFiles ?? [],
+        indexRefreshReason: refreshResult.reason,
+      };
+    },
+    render: (value) =>
+      `Local import synced ${value.artifactCount} artifacts (${value.importedCount} new, ${value.updatedCount} updated, ${value.skippedCount} unchanged, ${value.removedCount} removed). Indexes ${value.indexesRefreshed ? `refreshed (${value.indexUpdatedFiles.length} files)` : `not refreshed (${value.indexRefreshReason})`}.`,
+  });
+}
+
 export async function runWikiObsidianStatus(params: {
   config: ResolvedMemoryWikiConfig;
   json?: boolean;
@@ -1082,6 +1115,17 @@ export function registerWikiCli(
     .option("--json", "Print JSON")
     .action(async (opts: WikiUnsafeLocalImportCommandOptions) => {
       await runWikiUnsafeLocalImport({ config, appConfig, json: opts.json });
+    });
+
+  const localImport = wiki
+    .command("local-import")
+    .description("Import explicitly configured local files into wiki source pages");
+  localImport
+    .command("import")
+    .description("Sync configured local import paths into wiki source pages")
+    .option("--json", "Print JSON")
+    .action(async (opts: WikiLocalImportCommandOptions) => {
+      await runWikiLocalImport({ config, appConfig, json: opts.json });
     });
 
   const chatgpt = wiki

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -37,6 +37,10 @@ describe("resolveMemoryWikiConfig", () => {
     expect(config.search.backend).toBe(DEFAULT_WIKI_SEARCH_BACKEND);
     expect(config.search.corpus).toBe(DEFAULT_WIKI_SEARCH_CORPUS);
     expect(config.context.includeCompiledDigestPrompt).toBe(false);
+    expect(config.localImports).toEqual({
+      enabled: false,
+      paths: [],
+    });
   });
 
   it("expands ~/ paths and preserves explicit modes", () => {
@@ -88,6 +92,10 @@ describe("memory-wiki manifest config schema", () => {
       unsafeLocal: {
         allowPrivateMemoryCoreAccess: true,
         paths: ["extensions/memory-core/src"],
+      },
+      localImports: {
+        enabled: true,
+        paths: ["~/notes", "./docs"],
       },
       search: {
         backend: "shared",

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -37,6 +37,10 @@ export type MemoryWikiPluginConfig = {
     allowPrivateMemoryCoreAccess?: boolean;
     paths?: string[];
   };
+  localImports?: {
+    enabled?: boolean;
+    paths?: string[];
+  };
   ingest?: {
     autoCompile?: boolean;
     maxConcurrentJobs?: number;
@@ -78,6 +82,10 @@ export type ResolvedMemoryWikiConfig = {
   };
   unsafeLocal: {
     allowPrivateMemoryCoreAccess: boolean;
+    paths: string[];
+  };
+  localImports: {
+    enabled: boolean;
     paths: string[];
   };
   ingest: {
@@ -133,6 +141,12 @@ const MemoryWikiConfigSource = z.strictObject({
   unsafeLocal: z
     .strictObject({
       allowPrivateMemoryCoreAccess: z.boolean().optional(),
+      paths: z.array(z.string()).optional(),
+    })
+    .optional(),
+  localImports: z
+    .strictObject({
+      enabled: z.boolean().optional(),
       paths: z.array(z.string()).optional(),
     })
     .optional(),
@@ -231,6 +245,10 @@ export function resolveMemoryWikiConfig(
     unsafeLocal: {
       allowPrivateMemoryCoreAccess: safeConfig.unsafeLocal?.allowPrivateMemoryCoreAccess ?? false,
       paths: safeConfig.unsafeLocal?.paths ?? [],
+    },
+    localImports: {
+      enabled: safeConfig.localImports?.enabled ?? false,
+      paths: safeConfig.localImports?.paths ?? [],
     },
     ingest: {
       autoCompile: safeConfig.ingest?.autoCompile ?? true,

--- a/extensions/memory-wiki/src/local-import.test.ts
+++ b/extensions/memory-wiki/src/local-import.test.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { syncMemoryWikiLocalImportSources } from "./local-import.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createVault } = createMemoryWikiTestHarness();
+
+describe("syncMemoryWikiLocalImportSources", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-wiki-local-import-suite-"));
+  });
+
+  afterAll(async () => {
+    if (!fixtureRoot) {
+      return;
+    }
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  function nextCaseRoot(name: string): string {
+    return path.join(fixtureRoot, `case-${caseId++}-${name}`);
+  }
+
+  async function createSourceDir(name: string): Promise<string> {
+    const sourceDir = nextCaseRoot(name);
+    await fs.mkdir(sourceDir, { recursive: true });
+    return sourceDir;
+  }
+
+  it("imports configured local files and directories with local-import provenance", async () => {
+    const sourceDir = await createSourceDir("sources");
+    await fs.mkdir(path.join(sourceDir, "notes"), { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "notes", "memory.md"), "# agent memory\n", "utf8");
+    await fs.writeFile(path.join(sourceDir, "notes", "facts.json"), '{"ok":true}\n', "utf8");
+    await fs.writeFile(path.join(sourceDir, "notes", "blob.bin"), "\u0000\u0001", "utf8");
+    const directPath = path.join(sourceDir, "daily.txt");
+    await fs.writeFile(directPath, "daily note\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("vault"),
+      config: {
+        localImports: {
+          enabled: true,
+          paths: [path.join(sourceDir, "notes"), directPath],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiLocalImportSources(config);
+
+    expect(first.artifactCount).toBe(3);
+    expect(first.importedCount).toBe(3);
+    expect(first.updatedCount).toBe(0);
+    expect(first.skippedCount).toBe(0);
+    expect(first.removedCount).toBe(0);
+
+    const page = await fs.readFile(path.join(vaultDir, first.pagePaths[0] ?? ""), "utf8");
+    expect(page).toContain("sourceType: local-import");
+    expect(page).toContain("localImportConfiguredPath:");
+    expect(page).toContain("## Local Import Source");
+
+    const second = await syncMemoryWikiLocalImportSources(config);
+
+    expect(second.importedCount).toBe(0);
+    expect(second.updatedCount).toBe(0);
+    expect(second.skippedCount).toBe(3);
+    expect(second.removedCount).toBe(0);
+  });
+
+  it("updates changed local import pages and prunes disappeared configured files", async () => {
+    const sourceDir = await createSourceDir("update-prune");
+    const sourcePath = path.join(sourceDir, "memory.md");
+    await fs.writeFile(sourcePath, "# first\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("update-vault"),
+      config: {
+        localImports: {
+          enabled: true,
+          paths: [sourcePath],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiLocalImportSources(config);
+    const pagePath = first.pagePaths[0] ?? "";
+    await expect(fs.readFile(path.join(vaultDir, pagePath), "utf8")).resolves.toContain("# first");
+
+    await fs.writeFile(sourcePath, "# second\n", "utf8");
+    const updatedTime = new Date(Date.now() + 2_000);
+    await fs.utimes(sourcePath, updatedTime, updatedTime);
+    const second = await syncMemoryWikiLocalImportSources(config);
+
+    expect(second.updatedCount).toBe(1);
+    await expect(fs.readFile(path.join(vaultDir, pagePath), "utf8")).resolves.toContain("# second");
+
+    await fs.rm(sourcePath);
+    const third = await syncMemoryWikiLocalImportSources(config);
+
+    expect(third.artifactCount).toBe(0);
+    expect(third.removedCount).toBe(1);
+    await expect(fs.stat(path.join(vaultDir, pagePath))).rejects.toHaveProperty("code", "ENOENT");
+  });
+
+  it("returns zero artifacts when local imports are disabled or pathless", async () => {
+    const { config: disabledConfig } = await createVault({
+      rootDir: nextCaseRoot("disabled-vault"),
+      config: {
+        localImports: {
+          enabled: false,
+          paths: [nextCaseRoot("unused")],
+        },
+      },
+    });
+    const disabled = await syncMemoryWikiLocalImportSources(disabledConfig);
+    expect(disabled.artifactCount).toBe(0);
+
+    const { config: pathlessConfig } = await createVault({
+      rootDir: nextCaseRoot("pathless-vault"),
+      config: {
+        localImports: {
+          enabled: true,
+          paths: [],
+        },
+      },
+    });
+    const pathless = await syncMemoryWikiLocalImportSources(pathlessConfig);
+    expect(pathless.artifactCount).toBe(0);
+  });
+
+  it("caps composed local-import filenames to the filesystem component limit", async () => {
+    const sourceDir = await createSourceDir(`${"漢".repeat(50)}-sources`);
+    const nestedDir = path.join(sourceDir, `${"語".repeat(50)}-nested`);
+    const sourcePath = path.join(nestedDir, `${"録".repeat(50)}.md`);
+    await fs.mkdir(nestedDir, { recursive: true });
+    await fs.writeFile(sourcePath, "# long path\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("long-vault"),
+      config: {
+        localImports: {
+          enabled: true,
+          paths: [sourceDir],
+        },
+      },
+    });
+
+    const result = await syncMemoryWikiLocalImportSources(config);
+    const pagePath = result.pagePaths[0] ?? "";
+
+    expect(result.importedCount).toBe(1);
+    expect(Buffer.byteLength(path.basename(pagePath))).toBeLessThanOrEqual(255);
+    await expect(fs.readFile(path.join(vaultDir, pagePath), "utf8")).resolves.toContain(
+      "# long path",
+    );
+  });
+});

--- a/extensions/memory-wiki/src/local-import.ts
+++ b/extensions/memory-wiki/src/local-import.ts
@@ -1,0 +1,266 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { BridgeMemoryWikiResult } from "./bridge.js";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+import { appendMemoryWikiLog } from "./log.js";
+import {
+  createWikiPageFilename,
+  renderMarkdownFence,
+  renderWikiMarkdown,
+  slugifyWikiSegment,
+} from "./markdown.js";
+import { writeImportedSourcePage } from "./source-page-shared.js";
+import { resolveArtifactKey } from "./source-path-shared.js";
+import {
+  pruneImportedSourceEntries,
+  readMemoryWikiSourceSyncState,
+  writeMemoryWikiSourceSyncState,
+} from "./source-sync-state.js";
+import { initializeMemoryWikiVault } from "./vault.js";
+
+type LocalImportArtifact = {
+  syncKey: string;
+  configuredPath: string;
+  absolutePath: string;
+  relativePath: string;
+};
+
+const DIRECTORY_TEXT_EXTENSIONS = new Set([".json", ".jsonl", ".md", ".txt", ".yaml", ".yml"]);
+
+function detectFenceLanguage(filePath: string): string {
+  const ext = normalizeLowercaseStringOrEmpty(path.extname(filePath));
+  if (ext === ".json" || ext === ".jsonl") {
+    return "json";
+  }
+  if (ext === ".yaml" || ext === ".yml") {
+    return "yaml";
+  }
+  if (ext === ".txt") {
+    return "text";
+  }
+  return "markdown";
+}
+
+async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listAllowedFilesRecursive(fullPath)));
+      continue;
+    }
+    if (
+      entry.isFile() &&
+      DIRECTORY_TEXT_EXTENSIONS.has(normalizeLowercaseStringOrEmpty(path.extname(entry.name)))
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files.toSorted((left, right) => left.localeCompare(right));
+}
+
+async function collectLocalImportArtifacts(
+  configuredPaths: string[],
+): Promise<LocalImportArtifact[]> {
+  const artifacts: LocalImportArtifact[] = [];
+  for (const configuredPath of configuredPaths) {
+    const absoluteConfiguredPath = path.resolve(configuredPath);
+    const stat = await fs.stat(absoluteConfiguredPath).catch(() => null);
+    if (!stat) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      const files = await listAllowedFilesRecursive(absoluteConfiguredPath);
+      for (const absolutePath of files) {
+        artifacts.push({
+          syncKey: await resolveArtifactKey(absolutePath),
+          configuredPath: absoluteConfiguredPath,
+          absolutePath,
+          relativePath: path.relative(absoluteConfiguredPath, absolutePath).replace(/\\/g, "/"),
+        });
+      }
+      continue;
+    }
+    if (stat.isFile()) {
+      artifacts.push({
+        syncKey: await resolveArtifactKey(absoluteConfiguredPath),
+        configuredPath: absoluteConfiguredPath,
+        absolutePath: absoluteConfiguredPath,
+        relativePath: path.basename(absoluteConfiguredPath),
+      });
+    }
+  }
+
+  const deduped = new Map<string, LocalImportArtifact>();
+  for (const artifact of artifacts) {
+    deduped.set(artifact.syncKey, artifact);
+  }
+  return [...deduped.values()];
+}
+
+function resolveLocalImportPagePath(params: { configuredPath: string; absolutePath: string }): {
+  pageId: string;
+  pagePath: string;
+} {
+  const configuredBaseSlug = slugifyWikiSegment(path.basename(params.configuredPath));
+  const configuredHash = createHash("sha1")
+    .update(path.resolve(params.configuredPath))
+    .digest("hex")
+    .slice(0, 8);
+  const artifactBaseSlug = slugifyWikiSegment(path.basename(params.absolutePath));
+  const artifactHash = createHash("sha1")
+    .update(path.resolve(params.absolutePath))
+    .digest("hex")
+    .slice(0, 8);
+  const pageSlug = `${configuredBaseSlug}-${configuredHash}-${artifactBaseSlug}-${artifactHash}`;
+  return {
+    pageId: `source.local-import.${pageSlug}`,
+    pagePath: path
+      .join("sources", createWikiPageFilename(`local-import-${pageSlug}`))
+      .replace(/\\/g, "/"),
+  };
+}
+
+function resolveLocalImportTitle(artifact: LocalImportArtifact): string {
+  return `Local Import: ${artifact.relativePath}`;
+}
+
+async function writeLocalImportSourcePage(params: {
+  config: ResolvedMemoryWikiConfig;
+  artifact: LocalImportArtifact;
+  sourceUpdatedAtMs: number;
+  sourceSize: number;
+  state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
+}): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
+  const { pageId, pagePath } = resolveLocalImportPagePath({
+    configuredPath: params.artifact.configuredPath,
+    absolutePath: params.artifact.absolutePath,
+  });
+  const title = resolveLocalImportTitle(params.artifact);
+  const renderFingerprint = createHash("sha1")
+    .update(
+      JSON.stringify({
+        configuredPath: params.artifact.configuredPath,
+        relativePath: params.artifact.relativePath,
+      }),
+    )
+    .digest("hex");
+  return writeImportedSourcePage({
+    vaultRoot: params.config.vault.path,
+    syncKey: params.artifact.syncKey,
+    sourcePath: params.artifact.absolutePath,
+    sourceUpdatedAtMs: params.sourceUpdatedAtMs,
+    sourceSize: params.sourceSize,
+    renderFingerprint,
+    pagePath,
+    group: "local-import",
+    state: params.state,
+    buildRendered: (raw, updatedAt) =>
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: pageId,
+          title,
+          sourceType: "local-import",
+          sourcePath: params.artifact.absolutePath,
+          localImportConfiguredPath: params.artifact.configuredPath,
+          localImportRelativePath: params.artifact.relativePath,
+          status: "active",
+          updatedAt,
+        },
+        body: [
+          `# ${title}`,
+          "",
+          "## Local Import Source",
+          `- Configured path: \`${params.artifact.configuredPath}\``,
+          `- Relative path: \`${params.artifact.relativePath}\``,
+          `- Updated: ${updatedAt}`,
+          "",
+          "## Content",
+          renderMarkdownFence(raw, detectFenceLanguage(params.artifact.absolutePath)),
+          "",
+          "## Notes",
+          "<!-- openclaw:human:start -->",
+          "<!-- openclaw:human:end -->",
+          "",
+        ].join("\n"),
+      }),
+  });
+}
+
+export async function syncMemoryWikiLocalImportSources(
+  config: ResolvedMemoryWikiConfig,
+): Promise<BridgeMemoryWikiResult> {
+  await initializeMemoryWikiVault(config);
+  if (!config.localImports.enabled || config.localImports.paths.length === 0) {
+    return {
+      importedCount: 0,
+      updatedCount: 0,
+      skippedCount: 0,
+      removedCount: 0,
+      artifactCount: 0,
+      workspaces: 0,
+      pagePaths: [],
+    };
+  }
+
+  const artifacts = await collectLocalImportArtifacts(config.localImports.paths);
+  const state = await readMemoryWikiSourceSyncState(config.vault.path);
+  const activeKeys = new Set<string>();
+  const results = await Promise.all(
+    artifacts.map(async (artifact) => {
+      const stats = await fs.stat(artifact.absolutePath);
+      activeKeys.add(artifact.syncKey);
+      return await writeLocalImportSourcePage({
+        config,
+        artifact,
+        sourceUpdatedAtMs: stats.mtimeMs,
+        sourceSize: stats.size,
+        state,
+      });
+    }),
+  );
+
+  const removedCount = await pruneImportedSourceEntries({
+    vaultRoot: config.vault.path,
+    group: "local-import",
+    activeKeys,
+    state,
+  });
+  await writeMemoryWikiSourceSyncState(config.vault.path, state);
+  const importedCount = results.filter((result) => result.changed && result.created).length;
+  const updatedCount = results.filter((result) => result.changed && !result.created).length;
+  const skippedCount = results.filter((result) => !result.changed).length;
+  const pagePaths = results
+    .map((result) => result.pagePath)
+    .toSorted((left, right) => left.localeCompare(right));
+
+  if (importedCount > 0 || updatedCount > 0 || removedCount > 0) {
+    await appendMemoryWikiLog(config.vault.path, {
+      type: "ingest",
+      timestamp: new Date().toISOString(),
+      details: {
+        sourceType: "local-import",
+        configuredPathCount: config.localImports.paths.length,
+        artifactCount: artifacts.length,
+        importedCount,
+        updatedCount,
+        skippedCount,
+        removedCount,
+      },
+    });
+  }
+
+  return {
+    importedCount,
+    updatedCount,
+    skippedCount,
+    removedCount,
+    artifactCount: artifacts.length,
+    workspaces: 0,
+    pagePaths,
+  };
+}

--- a/extensions/memory-wiki/src/source-sync-state.ts
+++ b/extensions/memory-wiki/src/source-sync-state.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 
-export type MemoryWikiImportedSourceGroup = "bridge" | "unsafe-local";
+export type MemoryWikiImportedSourceGroup = "bridge" | "unsafe-local" | "local-import";
 
 type MemoryWikiImportedSourceStateEntry = {
   group: MemoryWikiImportedSourceGroup;

--- a/extensions/memory-wiki/src/source-sync.test.ts
+++ b/extensions/memory-wiki/src/source-sync.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { syncMemoryWikiImportedSources } from "./source-sync.js";
 
-const { syncBridgeMock, syncUnsafeLocalMock, refreshIndexesMock } = vi.hoisted(() => ({
-  syncBridgeMock: vi.fn(),
-  syncUnsafeLocalMock: vi.fn(),
-  refreshIndexesMock: vi.fn(),
-}));
+const { syncBridgeMock, syncUnsafeLocalMock, syncLocalImportMock, refreshIndexesMock } = vi.hoisted(
+  () => ({
+    syncBridgeMock: vi.fn(),
+    syncUnsafeLocalMock: vi.fn(),
+    syncLocalImportMock: vi.fn(),
+    refreshIndexesMock: vi.fn(),
+  }),
+);
 
 vi.mock("./bridge.js", () => ({
   syncMemoryWikiBridgeSources: syncBridgeMock,
@@ -13,6 +16,10 @@ vi.mock("./bridge.js", () => ({
 
 vi.mock("./unsafe-local.js", () => ({
   syncMemoryWikiUnsafeLocalSources: syncUnsafeLocalMock,
+}));
+
+vi.mock("./local-import.js", () => ({
+  syncMemoryWikiLocalImportSources: syncLocalImportMock,
 }));
 
 vi.mock("./compile.js", () => ({
@@ -33,11 +40,22 @@ describe("syncMemoryWikiImportedSources", () => {
   beforeEach(() => {
     syncBridgeMock.mockReset();
     syncUnsafeLocalMock.mockReset();
+    syncLocalImportMock.mockReset();
     refreshIndexesMock.mockReset();
     syncBridgeMock.mockResolvedValue(bridgeResult);
     syncUnsafeLocalMock.mockResolvedValue({
       ...bridgeResult,
       workspaces: 0,
+    });
+    syncLocalImportMock.mockResolvedValue({
+      ...bridgeResult,
+      artifactCount: 0,
+      importedCount: 0,
+      updatedCount: 0,
+      skippedCount: 0,
+      removedCount: 0,
+      workspaces: 0,
+      pagePaths: [],
     });
     refreshIndexesMock.mockResolvedValue({
       refreshed: true,
@@ -58,6 +76,7 @@ describe("syncMemoryWikiImportedSources", () => {
 
     expect(syncBridgeMock).toHaveBeenCalledWith({ config, appConfig });
     expect(syncUnsafeLocalMock).not.toHaveBeenCalled();
+    expect(syncLocalImportMock).not.toHaveBeenCalled();
     expect(refreshIndexesMock).toHaveBeenCalledWith({
       config,
       syncResult: bridgeResult,
@@ -90,6 +109,7 @@ describe("syncMemoryWikiImportedSources", () => {
 
     expect(syncUnsafeLocalMock).toHaveBeenCalledWith(config);
     expect(syncBridgeMock).not.toHaveBeenCalled();
+    expect(syncLocalImportMock).not.toHaveBeenCalled();
     expect(refreshIndexesMock).toHaveBeenCalledWith({
       config,
       syncResult: unsafeLocalResult,
@@ -111,6 +131,7 @@ describe("syncMemoryWikiImportedSources", () => {
 
     expect(syncBridgeMock).not.toHaveBeenCalled();
     expect(syncUnsafeLocalMock).not.toHaveBeenCalled();
+    expect(syncLocalImportMock).not.toHaveBeenCalled();
     expect(refreshIndexesMock).toHaveBeenCalledWith({
       config,
       syncResult: {
@@ -131,6 +152,80 @@ describe("syncMemoryWikiImportedSources", () => {
       artifactCount: 0,
       workspaces: 0,
       pagePaths: [],
+      indexesRefreshed: true,
+      indexRefreshReason: "import-changed",
+      indexUpdatedFiles: ["index.md", "sources/index.md"],
+    });
+  });
+
+  it("syncs enabled local imports outside imported-source vault modes", async () => {
+    const localImportResult = {
+      ...bridgeResult,
+      importedCount: 1,
+      artifactCount: 1,
+      workspaces: 0,
+      pagePaths: ["sources/local.md"],
+    };
+    syncLocalImportMock.mockResolvedValueOnce(localImportResult);
+    const config = {
+      vaultMode: "isolated",
+      localImports: { enabled: true },
+    } as Parameters<typeof syncMemoryWikiImportedSources>[0]["config"];
+
+    const result = await syncMemoryWikiImportedSources({ config });
+
+    expect(syncBridgeMock).not.toHaveBeenCalled();
+    expect(syncUnsafeLocalMock).not.toHaveBeenCalled();
+    expect(syncLocalImportMock).toHaveBeenCalledWith(config);
+    expect(refreshIndexesMock).toHaveBeenCalledWith({
+      config,
+      syncResult: localImportResult,
+    });
+    expect(result).toEqual({
+      ...localImportResult,
+      indexesRefreshed: true,
+      indexRefreshReason: "import-changed",
+      indexUpdatedFiles: ["index.md", "sources/index.md"],
+    });
+  });
+
+  it("merges bridge and enabled local import sync results before index refresh", async () => {
+    const localImportResult = {
+      ...bridgeResult,
+      importedCount: 5,
+      updatedCount: 0,
+      skippedCount: 1,
+      removedCount: 0,
+      artifactCount: 6,
+      workspaces: 0,
+      pagePaths: ["sources/local.md"],
+    };
+    syncLocalImportMock.mockResolvedValueOnce(localImportResult);
+    const config = {
+      vaultMode: "bridge",
+      localImports: { enabled: true },
+    } as Parameters<typeof syncMemoryWikiImportedSources>[0]["config"];
+    const appConfig = { agents: { list: [{ id: "main", default: true }] } } as Parameters<
+      typeof syncMemoryWikiImportedSources
+    >[0]["appConfig"];
+
+    const result = await syncMemoryWikiImportedSources({ config, appConfig });
+
+    const expectedMerged = {
+      importedCount: 6,
+      updatedCount: 2,
+      skippedCount: 4,
+      removedCount: 4,
+      artifactCount: 16,
+      workspaces: 2,
+      pagePaths: ["sources/alpha.md", "sources/local.md"],
+    };
+    expect(refreshIndexesMock).toHaveBeenCalledWith({
+      config,
+      syncResult: expectedMerged,
+    });
+    expect(result).toEqual({
+      ...expectedMerged,
       indexesRefreshed: true,
       indexRefreshReason: "import-changed",
       indexUpdatedFiles: ["index.md", "sources/index.md"],

--- a/extensions/memory-wiki/src/source-sync.ts
+++ b/extensions/memory-wiki/src/source-sync.ts
@@ -5,6 +5,7 @@ import {
   type RefreshMemoryWikiIndexesResult,
 } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import { syncMemoryWikiLocalImportSources } from "./local-import.js";
 import { syncMemoryWikiUnsafeLocalSources } from "./unsafe-local.js";
 
 export type MemoryWikiImportedSourceSyncResult = BridgeMemoryWikiResult & {
@@ -17,13 +18,28 @@ export async function syncMemoryWikiImportedSources(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
 }): Promise<MemoryWikiImportedSourceSyncResult> {
-  let syncResult: BridgeMemoryWikiResult;
+  const syncResults: BridgeMemoryWikiResult[] = [];
   if (params.config.vaultMode === "bridge") {
-    syncResult = await syncMemoryWikiBridgeSources(params);
+    syncResults.push(await syncMemoryWikiBridgeSources(params));
   } else if (params.config.vaultMode === "unsafe-local") {
-    syncResult = await syncMemoryWikiUnsafeLocalSources(params.config);
-  } else {
-    syncResult = {
+    syncResults.push(await syncMemoryWikiUnsafeLocalSources(params.config));
+  }
+  if (params.config.localImports?.enabled) {
+    syncResults.push(await syncMemoryWikiLocalImportSources(params.config));
+  }
+  const syncResult = syncResults.reduce<BridgeMemoryWikiResult>(
+    (acc, result) => ({
+      importedCount: acc.importedCount + result.importedCount,
+      updatedCount: acc.updatedCount + result.updatedCount,
+      skippedCount: acc.skippedCount + result.skippedCount,
+      removedCount: acc.removedCount + result.removedCount,
+      artifactCount: acc.artifactCount + result.artifactCount,
+      workspaces: acc.workspaces + result.workspaces,
+      pagePaths: [...acc.pagePaths, ...result.pagePaths].toSorted((left, right) =>
+        left.localeCompare(right),
+      ),
+    }),
+    {
       importedCount: 0,
       updatedCount: 0,
       skippedCount: 0,
@@ -31,8 +47,8 @@ export async function syncMemoryWikiImportedSources(params: {
       artifactCount: 0,
       workspaces: 0,
       pagePaths: [],
-    };
-  }
+    },
+  );
   const refreshResult = await refreshMemoryWikiIndexesAfterImport({
     config: params.config,
     syncResult,


### PR DESCRIPTION
## Summary

- Adds a managed `localImports` config path for memory-wiki.
- Adds `openclaw wiki local-import import` to sync explicitly configured local text files/directories into source pages.
- Integrates local imports with imported-source sync state so enabled local imports refresh alongside existing imported source sync paths.

Related to #69700 and complements #89409 by creating managed source pages for local files. This does not implement the per-agent/per-org vault isolation work tracked in #63829/#67584.

AI-assisted: yes. I reviewed the changed code, scoped the diff to memory-wiki importer/config/CLI/source-sync, and ran the checks below from this branch.

## Real behavior proof

Behavior addressed: `wiki ingest <path>` supports one-shot local ingestion, and bridge/unsafe-local cover different import modes. This adds a repeatable, explicitly configured local source import path that writes normal source pages with `sourceType: local-import` without enabling unsafe private memory-core access.

Real environment tested: Local OpenClaw checkout on this branch with a temporary memory-wiki vault and a temporary markdown source file.

Exact steps or command run after this patch: Ran a local Node/tsx proof from this checkout that resolved memory-wiki config with `localImports.enabled=true`, called `runWikiLocalImport`, read the generated source page from the temporary vault, confirmed the source page metadata/content, and deleted the temporary directory after the proof run.

Evidence after fix: Terminal output from the local OpenClaw proof run:

```json
{
  "importedCount": 1,
  "artifactCount": 1,
  "indexesRefreshed": true,
  "pagePath": "sources/local-import-memory-note-md-544daf05-memory-note-md-544daf05.md",
  "pageHasLocalImportSourceType": true,
  "pageHasProofContent": true,
  "tempRootCreated": true
}
```

Observed result after fix: The configured local markdown source was imported as a managed memory-wiki source page, the page included `sourceType: local-import`, the source content was present, and indexes refreshed after import.

What was not tested: Full `pnpm build && pnpm check && pnpm test`; live installed OpenClaw gateway.

## Validation

- `corepack pnpm exec oxfmt --check --threads=1 extensions/memory-wiki/src/cli.ts extensions/memory-wiki/src/config.ts extensions/memory-wiki/src/local-import.ts extensions/memory-wiki/src/source-sync.ts extensions/memory-wiki/src/source-sync-state.ts extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/config.test.ts extensions/memory-wiki/src/local-import.test.ts extensions/memory-wiki/src/source-sync.test.ts extensions/memory-wiki/openclaw.plugin.json`
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/config.test.ts extensions/memory-wiki/src/local-import.test.ts extensions/memory-wiki/src/source-sync.test.ts extensions/memory-wiki/src/cli.test.ts`
- `corepack pnpm test:extension memory-wiki`
- `node scripts/run-oxlint.mjs extensions/memory-wiki/src/cli.ts extensions/memory-wiki/src/config.ts extensions/memory-wiki/src/local-import.ts extensions/memory-wiki/src/source-sync.ts extensions/memory-wiki/src/source-sync-state.ts extensions/memory-wiki/src/cli.test.ts extensions/memory-wiki/src/config.test.ts extensions/memory-wiki/src/local-import.test.ts extensions/memory-wiki/src/source-sync.test.ts`
- `corepack pnpm tsgo:extensions:test`
- `git diff --check origin/main`
