### PR TITLE
Fix Bedrock aws-sdk compaction auth

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2061,6 +2061,59 @@ describe("compaction-safeguard extension model fallback", () => {
     );
   });
 
+  it("cancels aws-sdk compaction for terminal credential-provider errors without matching text", async () => {
+    mockSummarizeInStages.mockReset();
+    const terminalProviderError = Object.assign(new Error("profile source failed"), {
+      name: "ProviderError",
+      tryNextLink: false,
+    });
+    const credentialError = new Error("bedrock request failed", {
+      cause: terminalProviderError,
+    });
+    mockSummarizeInStages.mockImplementation(async (params: unknown) => {
+      const shouldFallbackOnError = (
+        params as {
+          shouldFallbackOnError?: (error: unknown) => boolean;
+        }
+      ).shouldFallbackOnError;
+      if (shouldFallbackOnError?.(credentialError) === false) {
+        throw credentialError;
+      }
+      return "generic fallback summary";
+    });
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      id: "eu.anthropic.claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      provider: "amazon-bedrock",
+      api: "bedrock-converse-stream" as const,
+      baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = createCompactionEvent({
+      messageText: "older context",
+      tokensBefore: 1000,
+    });
+    (mockEvent.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+      requestAuth: { ok: true, authMode: "aws-sdk" },
+    });
+
+    expect(result).toEqual({ cancel: true });
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+      "profile source failed",
+    );
+  });
+
   it("cancels compaction when both ctx.model and runtime.model are undefined", async () => {
     const sessionManager = stubSessionManager();
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2012,6 +2012,55 @@ describe("compaction-safeguard extension model fallback", () => {
     expect(summarizeCall.apiKey).toBe("");
   });
 
+  it("cancels aws-sdk compaction when credential-chain summarization fails", async () => {
+    mockSummarizeInStages.mockReset();
+    const credentialError = new Error(
+      "CredentialsProviderError: Could not load credentials from any providers",
+    );
+    mockSummarizeInStages.mockImplementation(async (params: unknown) => {
+      const shouldFallbackOnError = (
+        params as {
+          shouldFallbackOnError?: (error: unknown) => boolean;
+        }
+      ).shouldFallbackOnError;
+      if (shouldFallbackOnError?.(credentialError) === false) {
+        throw credentialError;
+      }
+      return "generic fallback summary";
+    });
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      id: "eu.anthropic.claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      provider: "amazon-bedrock",
+      api: "bedrock-converse-stream" as const,
+      baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = createCompactionEvent({
+      messageText: "older context",
+      tokensBefore: 1000,
+    });
+    (mockEvent.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+      requestAuth: { ok: true, authMode: "aws-sdk" },
+    });
+
+    expect(result).toEqual({ cancel: true });
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+      "Could not load credentials",
+    );
+  });
+
   it("cancels compaction when both ctx.model and runtime.model are undefined", async () => {
     const sessionManager = stubSessionManager();
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -163,14 +163,18 @@ async function runCompactionScenario(params: {
   sessionManager: ExtensionContext["sessionManager"];
   event: unknown;
   apiKey: string | null;
+  requestAuth?:
+    | { ok: true; apiKey?: string; headers?: Record<string, string>; authMode?: "aws-sdk" }
+    | { ok: false; error: string };
 }) {
   const compactionHandler = createCompactionHandler();
   const getApiKeyAndHeadersMock = vi
     .fn()
     .mockResolvedValue(
-      params.apiKey !== null
-        ? { ok: true, apiKey: params.apiKey }
-        : { ok: false, error: "missing auth" },
+      params.requestAuth ??
+        (params.apiKey !== null
+          ? { ok: true, apiKey: params.apiKey }
+          : { ok: false, error: "missing auth" }),
     );
   const mockContext = createCompactionContext({
     sessionManager: params.sessionManager,
@@ -1970,6 +1974,42 @@ describe("compaction-safeguard extension model fallback", () => {
     // Verify runtime.model is still available (for completeness)
     const retrieved = getCompactionSafeguardRuntime(sessionManager);
     expect(retrieved?.model).toEqual(model);
+  });
+
+  it("accepts aws-sdk request auth without static request credentials", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("bedrock summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      id: "eu.anthropic.claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      provider: "amazon-bedrock",
+      api: "bedrock-converse-stream" as const,
+      baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = createCompactionEvent({
+      messageText: "older context",
+      tokensBefore: 1000,
+    });
+    (mockEvent.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: null,
+      requestAuth: { ok: true, authMode: "aws-sdk" },
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("bedrock summary");
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    expect(summarizeCall.apiKey).toBe("");
   });
 
   it("cancels compaction when both ctx.model and runtime.model are undefined", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -34,7 +34,12 @@ import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
-import type { ExtensionAPI, ExtensionContext, FileOperations } from "../sessions/index.js";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  FileOperations,
+  ResolvedRequestAuth,
+} from "../sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
   composeSplitTurnInstructions,
@@ -292,17 +297,6 @@ type ModelRegistryWithRequestAuthLookup = {
   ) => Promise<ResolvedRequestAuth>;
 };
 
-type ResolvedRequestAuth =
-  | {
-      ok: true;
-      apiKey?: string;
-      headers?: Record<string, string>;
-    }
-  | {
-      ok: false;
-      error: string;
-    };
-
 /**
  * Resolve model credentials. Returns auth details on success or a cancel reason on failure.
  * Extracted to keep the main handler readable when model/auth is conditional.
@@ -339,7 +333,7 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${requestAuth.error}`,
     };
   }
-  if (!requestAuth.apiKey && !requestAuth.headers) {
+  if (!requestAuth.apiKey && !requestAuth.headers && requestAuth.authMode !== "aws-sdk") {
     log.warn(
       "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
     );

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
-import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  collectErrorGraphCandidates,
+  formatErrorMessage,
+  readErrorName,
+} from "../../infra/errors.js";
 import { isAbortError } from "../../infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -353,15 +357,44 @@ async function resolveModelAuth(
   };
 }
 
-function isAwsSdkCredentialFailure(error: unknown): boolean {
-  const message = formatErrorMessage(error);
-  return (
-    /\bCredentialsProviderError\b/i.test(message) ||
-    /\bCould not load credentials\b/i.test(message) ||
-    /\bNo credentials\b/i.test(message) ||
-    /\bcredential chain\b/i.test(message) ||
-    /\bAWS_PROFILE\b/i.test(message)
+const AWS_SDK_CREDENTIAL_FAILURE_PATTERNS = [
+  /\bCredentialsProviderError\b/i,
+  /\bCould not load credentials\b/i,
+  /\bNo credentials\b/i,
+  /\bcredential chain\b/i,
+  /\bAWS_PROFILE\b/i,
+] as const;
+
+function resolveNestedAwsCredentialErrorCandidates(current: Record<string, unknown>): unknown[] {
+  const nested = [current.cause, current.error, current.reason].filter(
+    (candidate) => candidate !== undefined,
   );
+  if (Array.isArray(current.errors)) {
+    nested.push(...current.errors);
+  }
+  return nested;
+}
+
+function hasAwsSdkCredentialProviderShape(candidate: unknown): boolean {
+  if (!candidate || typeof candidate !== "object") {
+    return false;
+  }
+  if (/^CredentialsProviderError$/i.test(readErrorName(candidate))) {
+    return true;
+  }
+  return (candidate as { tryNextLink?: unknown }).tryNextLink === false;
+}
+
+function isAwsSdkCredentialFailure(error: unknown): boolean {
+  if (
+    collectErrorGraphCandidates(error, resolveNestedAwsCredentialErrorCandidates).some(
+      hasAwsSdkCredentialProviderShape,
+    )
+  ) {
+    return true;
+  }
+  const message = formatErrorMessage(error);
+  return AWS_SDK_CREDENTIAL_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function buildCompactionSummaryHeaders(params: {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -239,6 +239,7 @@ async function summarizeViaLLM(params: {
   customInstructions?: string;
   summarizationInstructions?: Parameters<typeof summarizeInStages>[0]["summarizationInstructions"];
   previousSummary?: string;
+  shouldFallbackOnError?: (error: unknown) => boolean;
 }): Promise<string> {
   const messages = prependPreviousSummaryForRedistill({
     messages: params.messages,
@@ -256,6 +257,7 @@ async function summarizeViaLLM(params: {
     customInstructions: params.customInstructions,
     summarizationInstructions: params.summarizationInstructions,
     previousSummary: undefined,
+    shouldFallbackOnError: params.shouldFallbackOnError,
   });
 }
 
@@ -305,7 +307,8 @@ async function resolveModelAuth(
   ctx: ExtensionContext,
   model: NonNullable<ExtensionContext["model"]>,
 ): Promise<
-  { ok: true; apiKey?: string; headers?: Record<string, string> } | { ok: false; reason: string }
+  | { ok: true; apiKey?: string; headers?: Record<string, string>; authMode?: "aws-sdk" }
+  | { ok: false; reason: string }
 > {
   let requestAuth: ResolvedRequestAuth;
   try {
@@ -342,7 +345,23 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  return {
+    ok: true,
+    apiKey: requestAuth.apiKey,
+    headers: requestAuth.headers,
+    authMode: requestAuth.authMode,
+  };
+}
+
+function isAwsSdkCredentialFailure(error: unknown): boolean {
+  const message = formatErrorMessage(error);
+  return (
+    /\bCredentialsProviderError\b/i.test(message) ||
+    /\bCould not load credentials\b/i.test(message) ||
+    /\bNo credentials\b/i.test(message) ||
+    /\bcredential chain\b/i.test(message) ||
+    /\bAWS_PROFILE\b/i.test(message)
+  );
 }
 
 function buildCompactionSummaryHeaders(params: {
@@ -1046,6 +1065,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     }
     const apiKey = authResult.apiKey ?? "";
     const authHeaders = authResult.headers;
+    const shouldFallbackOnError =
+      authResult.authMode === "aws-sdk"
+        ? (error: unknown) => !isAwsSdkCredentialFailure(error)
+        : undefined;
 
     try {
       const modelContextWindow = resolveContextWindowTokens(model);
@@ -1119,8 +1142,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: structuredInstructions,
                   summarizationInstructions,
                   previousSummary: preparation.previousSummary,
+                  shouldFallbackOnError,
                 });
               } catch (droppedError) {
+                if (shouldFallbackOnError?.(droppedError) === false) {
+                  throw droppedError;
+                }
                 log.warn(
                   `Compaction safeguard: failed to summarize dropped messages, continuing without: ${formatErrorMessage(
                     droppedError,
@@ -1195,6 +1222,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: currentInstructions,
                   summarizationInstructions,
                   previousSummary: effectivePreviousSummary,
+                  shouldFallbackOnError,
                 })
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
@@ -1215,6 +1243,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               ),
               summarizationInstructions,
               previousSummary: undefined,
+              shouldFallbackOnError,
             });
             splitTurnSectionLocal = `**Turn Context (split turn):**\n\n${prefixSummary}`;
             summaryWithoutPreservedTurns = historySummary.trim()

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -111,4 +111,31 @@ describe("summarizeWithFallback", () => {
     // Full attempt plus distinct partial transcript; timeout-classed failures do not retry.
     expect(agentSessionMocks.generateSummary.mock.calls.length).toBe(2);
   });
+
+  it("propagates caller-classified fatal summarization errors instead of generic fallback", async () => {
+    const credentialError = new Error(
+      "CredentialsProviderError: Could not load credentials from any providers",
+    );
+    agentSessionMocks.generateSummary.mockRejectedValue(credentialError);
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: 1,
+      } satisfies UserMessage,
+    ];
+
+    await expect(
+      summarizeWithFallback({
+        messages,
+        model: testModel,
+        apiKey: "",
+        signal: new AbortController().signal,
+        reserveTokens: 1000,
+        maxChunkTokens: 50_000,
+        contextWindow: 200_000,
+        shouldFallbackOnError: (error) => error !== credentialError,
+      }),
+    ).rejects.toThrow("Could not load credentials");
+  });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -258,6 +258,7 @@ export async function summarizeWithFallback(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  shouldFallbackOnError?: (error: unknown) => boolean;
 }): Promise<string> {
   const { messages, contextWindow } = params;
 
@@ -270,6 +271,9 @@ export async function summarizeWithFallback(params: {
   try {
     return await summarizeChunks(params);
   } catch (fullError) {
+    if (params.shouldFallbackOnError?.(fullError) === false) {
+      throw fullError;
+    }
     log.warn(`Full summarization failed: ${formatErrorMessage(fullError)}`);
     partialSummaryFallback = (fullError as PartialSummaryError).partialSummary;
   }
@@ -292,6 +296,9 @@ export async function summarizeWithFallback(params: {
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
       return partialSummary + notes;
     } catch (partialError) {
+      if (params.shouldFallbackOnError?.(partialError) === false) {
+        throw partialError;
+      }
       log.warn(`Partial summarization also failed: ${formatErrorMessage(partialError)}`);
       // Prefer the oversized retry's partial summary over the full attempt's,
       // since it covers the non-oversized transcript. Append oversized notes
@@ -329,6 +336,7 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   parts?: number;
   minMessagesForSplit?: number;
+  shouldFallbackOnError?: (error: unknown) => boolean;
 }): Promise<string> {
   const { messages } = params;
   if (messages.length === 0) {

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -122,6 +122,7 @@ describe("ModelRegistry models.json auth", () => {
       ok: true,
       apiKey: undefined,
       headers: undefined,
+      authMode: "aws-sdk",
     });
     expect(registry.getProviderAuthStatus("amazon-bedrock")).toEqual({
       configured: true,

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -236,6 +236,7 @@ export type ResolvedRequestAuth =
       ok: true;
       apiKey?: string;
       headers?: Record<string, string>;
+      authMode?: "aws-sdk";
     }
   | {
       ok: false;
@@ -685,6 +686,7 @@ export class ModelRegistry {
         ok: true,
         apiKey,
         headers: headers && Object.keys(headers).length > 0 ? headers : undefined,
+        ...(usesAwsSdkAuth ? { authMode: "aws-sdk" as const } : {}),
       };
     } catch (error) {
       return {

--- a/src/security/audit-config-include-perms.test.ts
+++ b/src/security/audit-config-include-perms.test.ts
@@ -4,10 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
-import { collectIncludeFilePermFindings } from "./audit-extra.async.js";
 
 describe("security audit config include permissions", () => {
   it("flags group/world-readable config include files", async () => {
+    const { collectIncludeFilePermFindings } = await import("./audit-extra.async.js");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-include-perms-"));
     const stateDir = path.join(tmp, "state");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });

--- a/src/security/audit-config-include-perms.test.ts
+++ b/src/security/audit-config-include-perms.test.ts
@@ -4,10 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+import { collectIncludeFilePermFindings } from "./audit-extra.async.js";
 
 describe("security audit config include permissions", () => {
   it("flags group/world-readable config include files", async () => {
-    const { collectIncludeFilePermFindings } = await import("./audit-extra.async.js");
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-include-perms-"));
     const stateDir = path.join(tmp, "state");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## Summary

- **Behavior or issue addressed:** Bedrock models configured with `auth: "aws-sdk"` can authenticate through the AWS SDK credential chain without static request credentials, but compaction needed to distinguish two cases: valid AWS SDK auth provenance with no static `apiKey`/headers, and an AWS SDK credential-chain failure during summarization.
- **Why it matters / User impact:** Users relying on AWS profile/session/role credentials should keep compaction support when the SDK credential chain works, but compaction must not preserve history with a generic fallback summary when the SDK credential chain cannot provide usable AWS credentials.
- **What changed:** `ModelRegistry.getApiKeyAndHeaders()` keeps explicit `aws-sdk` auth provenance; the compaction safeguard allows that successful auth mode to proceed without static key/header material; and the summarization fallback layer now lets the safeguard mark AWS SDK credential failures as non-fallbackable so compaction cancels instead of writing a generic fallback summary.
- **What did NOT change:** This PR does not change Bedrock provider config/defaults, AWS request signing, credential storage, SDK credential-chain behavior, provider/model routing, channel delivery, or session persistence.

Fixes #90179

## Origin / follow-up

N/A — independent root cause. This updates existing PR #90206 for linked issue #90179; it is not a follow-up to a merged PR.

## Real behavior proof

- **Behavior or issue addressed:** Compaction continues for Bedrock models authenticated through AWS SDK provenance without static request credentials, but cancels when the downstream AWS SDK credential-chain path reports unusable credentials.
- **Real environment tested:** Local Linux checkout with the PR worktree. The proof command imports the production `ModelRegistry`, production compaction safeguard extension, and production compaction runtime, then executes the `session_before_compact` handler with a Bedrock `models.json` entry using `auth: "aws-sdk"` and no static credentials. Network summarization is replaced with deterministic local functions so the proof isolates the registry-to-safeguard contract and the safeguard fallback/cancel decision without calling a live LLM or AWS service.
- **Exact steps or command run after this patch:**
```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-90206
OPENCLAW_REPO_ROOT="/media/vdb/code/ai/aispace/openclaw-worktrees/pr-90206" pnpm exec tsx "/media/vdb/code/ai/aispace/openclaw-pr-90206-evidence/aws-sdk-compaction-proof.ts"
```
- **Evidence after fix:**
```text
REPO_HEAD=01a0d8c73c25a3f12baf67c48278230de6d7908f
MODEL=amazon-bedrock/eu.anthropic.claude-sonnet-4-6
REGISTRY_ERROR=<none>
REGISTRY_AUTH=ok:true authMode:aws-sdk apiKey:<missing> headers:<missing>
SUCCESS_RESULT=compaction
SUCCESS_RESULT_CANCEL=false
SUCCESS_HAS_COMPACTION=true
SUCCESS_SUMMARY_CONTAINS_AWS_SDK=true
FAILURE_RESULT=cancel
FAILURE_RESULT_CANCEL=true
FAILURE_HAS_COMPACTION=false
FAILURE_CANCEL_REASON_CONTAINS_CREDENTIALS=true
STRUCTURAL_FAILURE_RESULT=cancel
STRUCTURAL_FAILURE_RESULT_CANCEL=true
STRUCTURAL_FAILURE_HAS_COMPACTION=false
STRUCTURAL_FAILURE_CANCEL_REASON_CONTAINS_CAUSE=true
```
- **Observed result after fix:** The production registry loads the Bedrock `aws-sdk` provider without a static `apiKey`, returns `authMode:aws-sdk` with missing static key/header material, and the production compaction safeguard reaches the compaction path when summarization succeeds. When the summarization path reports either `CredentialsProviderError: Could not load credentials from any providers` or a wrapped terminal provider error with `tryNextLink:false` and no matching credential text, the safeguard cancels compaction and records a credential-related cancel reason instead of accepting a generic fallback summary.
- **What was not tested:** No live `AWS_PROFILE`, STS caller identity, IAM role, Bedrock endpoint, or real AWS request signing was exercised. This local environment has `AWS_PROFILE`, AWS key/session/role env vars, AWS region env vars, `~/.aws/config`, and `~/.aws/credentials` all unset or missing, so provider-level live Bedrock confirmation remains unavailable here.
- **Local gateway proof judgment:** No local-only channel/gateway proof is claimed. A local OpenClaw gateway/chat proof would not exercise AWS SDK credential-chain resolution or Bedrock request signing without `AWS_PROFILE`, STS, IAM role credentials, and a live Bedrock endpoint, so the source-runtime proof above is the closest local proof for the changed registry-to-safeguard boundary.
- **Fix classification:** Root cause fix for the source-runtime auth error-handling boundary.

## Review findings addressed

- **RF-001:** Fixed. Added a focused auth-failure regression in `src/agents/agent-hooks/compaction-safeguard.test.ts` for a terminal provider error whose message does not match the previous credential strings, plus the lower-level fallback veto regression in `src/agents/compaction.summarize-fallback.test.ts`; kept the existing `aws-sdk` happy-path regression.
- **RF-002:** Partially supplied and disclosed. The proof output is redacted and contains no account IDs, IPs, endpoints, tokens, or profile details, but it is local source-runtime proof rather than live AWS SDK credential-chain output because this environment has no AWS credentials or AWS config files.
- **RF-003:** Partially supplied and disclosed. The proof now covers the `aws-sdk` compaction success path, the explicit `CredentialsProviderError` cancel path, and a wrapped terminal provider error with `tryNextLink:false`; it does not claim live AWS SDK/Bedrock behavior.
- **RF-004:** Fixed. AWS SDK credential-chain summarization failures are caller-classified structurally or by known credential text as non-fallbackable, so the safeguard cancels instead of compacting with `Context contained ... Summary unavailable ...` or another generic fallback summary.
- **RF-005:** Partially supplied and disclosed. The terminal proof now exercises the auth-failure path in the production safeguard boundary, including the structure-only terminal provider case; live Bedrock credential-chain compaction remains untested locally.
- **RF-006:** Addressed. Auth-classification mistakes in this path now cancel compaction instead of replacing detailed session history with a generic fallback summary, and this PR body explicitly states the completed local proof and the unavailable live AWS proof.
- **RF-007:** Disclosed as environment-limited. The code repair and local source-runtime proof are supplied, but live AWS proof still requires human-provided AWS credentials and a reachable Bedrock account.
- **RF-008:** Fixed. `src/agents/agent-hooks/compaction-safeguard.ts` now traverses wrapped error causes and classifies AWS credential-provider failures structurally via `CredentialsProviderError` or terminal provider-chain `tryNextLink:false`, before falling back to the previous redacted message patterns.

## Regression Test Plan

- **Target test file:** `src/agents/sessions/model-registry.test.ts`, `src/agents/agent-hooks/compaction-safeguard.test.ts`, and `src/agents/compaction.summarize-fallback.test.ts`.
- **Coverage level:** Source-runtime proof plus focused regression tests for the registry-to-safeguard contract, the `aws-sdk` success path, and the AWS SDK credential-failure cancel path.
- **Command:**
```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-90206
node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/compaction.summarize-fallback.test.ts
```
- **Result:**
```text
Test Files  3 passed (3)
Tests  109 passed (109)
[test] passed 1 Vitest shard in 32.58s
```
- **Additional local check:**
```bash
git diff --check
```
```text
# no output
```
- **Not completed locally:** `pnpm check:test-types` exited with code 1 without TypeScript diagnostics in this workspace; a direct `tsc -p test/tsconfig/tsconfig.core.test.json --noEmit` attempt exhausted the local Node heap. Full type coverage is left to CI.
- **Scenario locked in:** Bedrock `aws-sdk` auth is preserved as explicit request-auth provenance; the compaction safeguard accepts that successful mode without static request credentials; default API-key providers without credentials still cancel; and AWS SDK credential-chain failures during summarization cancel compaction instead of falling back to a generic summary, including wrapped terminal provider errors whose formatted message no longer contains the old credential strings.
- **Why this is the smallest reliable guardrail:** The registry test locks the source-of-truth request-auth contract, the safeguard test locks the downstream cancellation decision, and the fallback test locks the generic fallback veto hook used by the safeguard. Broader AWS transport tests require live credentials and would not isolate this lost-provenance/fallback root cause.

## Root Cause

- **Root cause:** The original fix restored `authMode: "aws-sdk"` provenance at the registry-to-safeguard boundary, but the lower-level summary fallback path still treated downstream AWS SDK credential-chain failures like ordinary summarization failures and could return a generic fallback summary. That allowed compaction to proceed after a credential failure even though the session history was not actually summarized by the configured Bedrock path.
- **Why this is root-cause fix:** The safeguard now carries the auth-mode provenance through the compaction auth boundary and uses it to classify AWS SDK credential failures as non-fallbackable at the summarization fallback boundary. This fixes the contract edge directly instead of adding a Bedrock string special case after a generic summary has already been accepted.
- **Fix classification:** Root cause fix.
- **Maintainer-ready confidence:** High for the source-runtime contract and cancellation behavior at current worktree state; provider-level live AWS confirmation remains explicitly untested because credentials are unavailable here.
- **Patch quality notes:** The patch changes only the model request-auth/safeguard/fallback path and focused tests. It keeps default API-key missing-credential behavior unchanged and does not alter provider routing, AWS SDK signing, persisted session state, config defaults, or channel delivery.
- **Architecture / source-of-truth check:** Source-of-truth owner is the `ModelRegistry.getApiKeyAndHeaders()` request-auth contract. The safeguard consumes that contract to decide which summary failures can safely use generic fallback; it does not infer Bedrock behavior from provider names or mutate public config.
- **Related open PR / same-contract scan:** Earlier scan found only this PR (#90206) for `ModelRegistry getApiKeyAndHeaders aws-sdk` / `Bedrock aws-sdk compaction auth`, so no broader canonical same-contract PR was found.
- **Missing detection / guardrail:** Existing compaction tests covered missing credentials and static credential paths, but did not cover successful AWS SDK auth provenance followed by an AWS SDK credential-chain failure in the summary path.

## Merge risk

- **Risk labels considered:** `impact:session-state`, `impact:auth-provider`, and external provider proof gap for live AWS credential-chain behavior.
- **Risk explanation:** The code path changes when compaction receives successful request auth with no static `apiKey` or headers, and when the resulting AWS SDK-backed summary attempt reports credential-chain failure. It is intentionally limited to `authMode: "aws-sdk"`; ordinary summarization failures keep the existing generic fallback behavior, and default API-key providers without credentials still cancel before summarization.
- **Why acceptable:** The registry is the source of truth for provider request auth mode, and the proof exercises the production registry-to-safeguard boundary at current worktree state. Live AWS signing is explicitly out of scope and not claimed.
- **Maintainer-ready confidence:** Medium-high for the source-level root cause; lower for provider-level live confirmation because AWS credentials are unavailable in this environment.
- **Patch quality notes:** Final diff is limited to focused auth/fallback files and tests; no channel delivery, provider routing, session persistence, config defaults, or AWS transport behavior changed.
