### PR TITLE
fix(anthropic): add claude-haiku-4-5 to static model catalog

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -104,6 +104,17 @@
             },
             "contextWindow": 200000,
             "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
           }
         ]
       }
@@ -123,7 +134,9 @@
           "opus-4.8": "claude-opus-4-8",
           "opus": "claude-opus-4-8",
           "opus-4.6": "claude-opus-4-6",
-          "sonnet-4.6": "claude-sonnet-4-6"
+          "sonnet-4.6": "claude-sonnet-4-6",
+          "haiku-4.5": "claude-haiku-4-5",
+          "haiku": "claude-haiku-4-5"
         }
       }
     }


### PR DESCRIPTION
## Fixes #90088

### Problem

On the  (api_key) provider, no Claude Haiku 4.5 model ID resolves. Both  and  fail at model resolution with:



The static model catalog in  only lists , , , and . Since , there is no runtime discovery to fill the gap.

### Fix

Added  to , mirroring the existing Sonnet entry:



Also added  and  aliases to  for convenience.

### Testing

- [x] JSON schema valid ( passes)
- [x] Diff is minimal and focused (1 file, 14 insertions)