### PR TITLE
fix(acp): redact URL credentials in runtime errors

### DIFF
--- a/packages/acp-core/src/error-format.ts
+++ b/packages/acp-core/src/error-format.ts
@@ -10,6 +10,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /Authorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]+)/gi,
   /(?:X-OpenClaw-Token|x-pomerium-jwt-assertion|X-Api-Key|X-Auth-Token)\s*[:=]\s*([^\s"',;]+)/gi,
   /\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b/g,
+  /(?<=\b[a-z][a-z0-9+.-]*:\/\/)[^/@\s?#:]+(?::[^/@\s?#]*)?(?=@)/gi,
   /(^|[\s,;])(?:access_token|refresh_token|auth[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|token|secret|password|passwd|card[-_]?number|card[-_]?cvc|card[-_]?cvv|cvc|cvv|security[-_]?code|payment[-_]?credential|shared[-_]?payment[-_]?token)=([^\s&#]+)/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----/g,
   /\b(sk-[A-Za-z0-9_-]{8,})\b/g,

--- a/packages/acp-core/src/runtime/errors.test.ts
+++ b/packages/acp-core/src/runtime/errors.test.ts
@@ -164,8 +164,12 @@ describe("formatAcpErrorChain redaction", () => {
   it("redacts common HTTP, provider, and private-key credentials in ACP error text", () => {
     const secrets = [
       "Authorization: Basic dXNlcjpwYXNzd29yZGFiY2RlZg==",
-      "Bearer eyJabcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz",
-      "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+      `Bearer ${[
+        "eyJabcdefghijklmnopqrstuvwxyz",
+        "abcdefghijklmnopqrstuvwxyz",
+        "abcdefghijklmnopqrstuvwxyz",
+      ].join(".")}`,
+      ["github", "pat", "abcdefghijklmnopqrstuvwxyz123456"].join("_"),
       ["xoxb", "1234567890", "abcdefghijklmnop"].join("-"),
       "bot123456789:abcdefghijklmnopqrstuvwxyz123456",
       "-----BEGIN PRIVATE KEY-----\nabcdefghijklmnopqrstuvwxyz\n-----END PRIVATE KEY-----",
@@ -178,6 +182,23 @@ describe("formatAcpErrorChain redaction", () => {
       expect(out).not.toContain(secret);
     }
     expect(out).toContain("backend failed");
+  });
+
+  it("redacts URL userinfo in ACP runtime diagnostics", () => {
+    const proxyUrl = "https://user:super-secret@example.com/proxy";
+    const checkoutUrl = "git+https://deploy-token@git.example.test/org/repo.git";
+
+    const out = formatAcpErrorChain(
+      new AcpRuntimeError(
+        "ACP_TURN_FAILED",
+        `backend failed through ${proxyUrl}; retrying ${checkoutUrl}`,
+      ),
+    );
+
+    expect(out).toContain("https://[REDACTED]@example.com/proxy");
+    expect(out).toContain("git+https://[REDACTED]@git.example.test/org/repo.git");
+    expect(out).not.toContain("user:super-secret");
+    expect(out).not.toContain("deploy-token");
   });
 
   it("uses a configured host redactor before rendering ACP error text", () => {


### PR DESCRIPTION
## What changed

This tightens ACP runtime error redaction so URL userinfo never leaks into logs, tool results, lifecycle events, or chat-facing diagnostics.

Today the ACP error formatter already catches obvious provider tokens, auth headers, query-string secrets, bot tokens, and private keys. One common shape was still easy to miss: credentials embedded directly in a URL, for example:

- `https://user:password@example.com/proxy`
- `git+https://deploy-token@git.example.test/org/repo.git`

Those URLs are common in proxy configuration, temporary checkout URLs, CI diagnostics, and backend adapter failures. If one bubbles through an ACP error chain, it should be scrubbed before it reaches an operator-visible surface.

This PR adds a targeted URL-userinfo redaction pattern and a regression test around both password-bearing and token-only userinfo forms.

## Why this matters

ACP backends and hosted agent runtimes fail in messy ways. When they do, diagnostics often get forwarded further than we expect: local logs, gateway logs, Telegram/Slack replies, support bundles, CI artifacts, etc. Redacting URL credentials at the shared ACP formatter boundary gives every downstream surface the safer default.

Small patch, but it closes a real leak class.

## Real behavior proof

Behavior or issue addressed: ACP runtime diagnostics containing URL userinfo should keep useful host/path context but remove credentials before they can reach logs, tool results, lifecycle events, or chat-facing output.

Real environment tested: macOS 26.2, OpenClaw checkout at `2f9b50e5`, Node v26.0.0 from `/opt/homebrew/bin/node`.

Exact steps or command run after this patch: Ran the new URL-userinfo redaction pattern locally with real Node execution. Used two representative failure strings: a proxy URL with `user:password` userinfo and a git checkout URL with token-only userinfo. Checked that both credentials disappear while the host/path stays readable.

Evidence after fix:

```bash
PATH=/opt/homebrew/bin:$PATH node - <<'NODE'
const patterns = [
  /\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|CARD[_-]?NUMBER|CARD[_-]?CVC|CARD[_-]?CVV|CVC|CVV|SECURITY[_-]?CODE|PAYMENT[_-]?CREDENTIAL|SHARED[_-]?PAYMENT[_-]?TOKEN)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g,
  /(?<=\b[a-z][a-z0-9+.-]*:\/\/)[^\/@\s?#:]+(?::[^\/@\s?#]*)?(?=@)/gi,
];
function redact(value){
  let redacted=value;
  for(const pattern of patterns){
    redacted=redacted.replace(pattern,(match,...args)=>{
      const groups=args.slice(0,-2);
      const token=groups.findLast((g)=>typeof g==='string'&&g.length>0);
      return token?match.replace(token,'[REDACTED]'):'[REDACTED]';
    });
  }
  return redacted;
}
const input='backend failed through https://user:super-secret@example.com/proxy; retrying git+https://deploy-token@git.example.test/org/repo.git';
console.log(redact(input));
NODE
```

```text
backend failed through https://[REDACTED]@example.com/proxy; retrying git+https://[REDACTED]@git.example.test/org/repo.git
```

Observed result after fix: the redacted diagnostic keeps `example.com/proxy` and `git.example.test/org/repo.git`, while removing both `user:super-secret` and `deploy-token`.

What was not tested: full live ACP backend session with real provider credentials. The repo-wide dependency install was too slow on this machine, so I verified the changed formatter behavior directly and ran the focused Vitest file via `npx`.

## Verification

```bash
PATH=/opt/homebrew/bin:$PATH npx --yes -p vitest@4.0.11 vitest run packages/acp-core/src/runtime/errors.test.ts --config /dev/null --pool=forks --reporter=dot
```

Result:

```text
Test Files  1 passed (1)
Tests       11 passed (11)
```
