### PR TITLE
fix(agents): deliver native /compact replies through source suppression

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1019,6 +1019,54 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("routes /compact through the standard reply dispatch path (#90185)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: {
+          sender_id: {
+            open_id: "ou-command-user",
+          },
+        },
+        message: {
+          message_id: "msg-compact-command",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "/compact" }),
+        },
+      },
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const dispatchParams = mockCallArg<{
+      ctx: {
+        CommandAuthorized?: boolean;
+        CommandBody?: string;
+        BodyForCommands?: string;
+        RawBody?: string;
+        MessageSid?: string;
+      };
+    }>(mockDispatchReplyFromConfig, 0, 0);
+    expect(dispatchParams.ctx).toMatchObject({
+      CommandAuthorized: true,
+      CommandBody: "/compact",
+      BodyForCommands: "/compact",
+      RawBody: "/compact",
+      MessageSid: "msg-compact-command",
+    });
+  });
+
   it("does not enqueue inbound preview text as system events", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4589,7 +4589,7 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("delivers compaction hook messages without duplicating notifyUser notices", async () => {
+  it("delivers compaction hook messages alongside notifyUser notices (#90185)", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
       await params.onAgentEvent?.({
@@ -4639,7 +4639,7 @@ describe("runAgentTurnWithFallback", () => {
     });
 
     expect(result.kind).toBe("success");
-    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect(onBlockReply).toHaveBeenCalledTimes(4);
     expectBlockReplyCall(onBlockReply, 0, {
       text: "Hook before",
       replyToId: "msg",
@@ -4647,7 +4647,19 @@ describe("runAgentTurnWithFallback", () => {
       isCompactionNotice: true,
     });
     expectBlockReplyCall(onBlockReply, 1, {
+      text: "🧹 Compacting context...",
+      replyToId: "msg",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+    expectBlockReplyCall(onBlockReply, 2, {
       text: "Hook after",
+      replyToId: "msg",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+    expectBlockReplyCall(onBlockReply, 3, {
+      text: "🧹 Compaction complete",
       replyToId: "msg",
       replyToCurrent: true,
       isCompactionNotice: true,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2550,28 +2550,24 @@ export async function runAgentTurnWithFallback(params: {
                           summary: readStringValue(evt.data.summary),
                         });
                       }
-                      // Track auto-compaction and notify higher layers.
                       if (evt.stream === "compaction") {
                         const phase = readStringValue(evt.data.phase) ?? "";
                         const hookMessages = readCompactionHookMessages(evt.data.messages);
+                        const sendCompactionUserNotices = async (
+                          noticePhase: "start" | "end" | "incomplete",
+                        ) => {
+                          if (hookMessages.length > 0) {
+                            await sendCompactionHookMessages(hookMessages);
+                          }
+                          if (notifyUserAboutCompaction) {
+                            await sendCompactionNotice(noticePhase);
+                          }
+                        };
                         if (phase === "start") {
-                          // Three independent audiences: internal callbacks
-                          // (Control UI) fire regardless; hookMessages deliver
-                          // plugin-authored user-channel text (overlap with the
-                          // default notice, so they suppress it); notifyUser is
-                          // the opt-in user-channel notice. Internal callbacks
-                          // must not suppress the user notice — see #87107.
                           if (params.opts?.onCompactionStart) {
                             await params.opts.onCompactionStart();
                           }
-                          if (hookMessages.length > 0) {
-                            await sendCompactionHookMessages(hookMessages);
-                          } else if (notifyUserAboutCompaction) {
-                            // Send directly via opts.onBlockReply (bypassing the
-                            // pipeline) so the notice does not cause final payloads
-                            // to be discarded on non-streaming model paths.
-                            await sendCompactionNotice("start");
-                          }
+                          await sendCompactionUserNotices("start");
                         }
                         if (phase === "end") {
                           const completed = evt.data?.completed === true;
@@ -2580,15 +2576,9 @@ export async function runAgentTurnWithFallback(params: {
                             if (params.opts?.onCompactionEnd) {
                               await params.opts.onCompactionEnd();
                             }
-                            if (hookMessages.length > 0) {
-                              await sendCompactionHookMessages(hookMessages);
-                            } else if (notifyUserAboutCompaction) {
-                              await sendCompactionNotice("end");
-                            }
-                          } else if (hookMessages.length > 0) {
-                            await sendCompactionHookMessages(hookMessages);
-                          } else if (notifyUserAboutCompaction) {
-                            await sendCompactionNotice("incomplete");
+                            await sendCompactionUserNotices("end");
+                          } else {
+                            await sendCompactionUserNotices("incomplete");
                           }
                         }
                       }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -3565,6 +3565,76 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
     });
   });
 
+  it("routes queued compaction hook messages alongside notifyUser notices (#90185)", async () => {
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        await args.onAgentEvent?.({
+          stream: "compaction",
+          data: { phase: "start", messages: ["Hook before"] },
+        });
+        await args.onAgentEvent?.({
+          stream: "compaction",
+          data: { phase: "end", completed: true, messages: ["Hook after"] },
+        });
+        return { payloads: [], meta: {} };
+      },
+    );
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.5",
+    });
+
+    await runner(
+      createQueuedRun({
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        messageId: "current-msg-1",
+        run: {
+          config: {
+            channels: { discord: { replyToMode: "all" } },
+            agents: { defaults: { compaction: { notifyUser: true } } },
+          },
+          messageProvider: "discord",
+        },
+      }),
+    );
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(4);
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "hook start"),
+    ).toMatchObject({
+      text: "Hook before",
+      replyToId: "current-msg-1",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 1).payload, "notice start"),
+    ).toMatchObject({
+      text: "🧹 Compacting context...",
+      replyToId: "current-msg-1",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+    expect(requireRecord(requireMockCallArg(routeReplyMock, 2).payload, "hook end")).toMatchObject({
+      text: "Hook after",
+      replyToId: "current-msg-1",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 3).payload, "notice end"),
+    ).toMatchObject({
+      text: "🧹 Compaction complete",
+      replyToId: "current-msg-1",
+      replyToCurrent: true,
+      isCompactionNotice: true,
+    });
+  });
+
   it("applies reply-to mode filtering to queued compaction notices", async () => {
     runPreflightCompactionIfNeededMock.mockImplementationOnce(
       async (params: {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -231,24 +231,28 @@ async function forwardFollowupProgressEvent(params: {
   if (evt.stream === "compaction") {
     const phase = readStringValue(evt.data.phase) ?? "";
     const hookMessages = readCompactionHookMessages(evt.data.messages);
-    if (phase === "start" && emitChannelProgress) {
-      await opts?.onCompactionStart?.();
-    }
-    if (phase === "start") {
+    const sendCompactionUserNotices = async (noticePhase: "start" | "end" | "incomplete") => {
       const hookPayload = createCompactionHookNoticePayload({
         messages: hookMessages,
         currentMessageId: params.currentMessageId,
       });
       if (hookPayload) {
         await params.onCompactionNoticePayload?.(hookPayload);
-      } else if (params.notifyUserAboutCompaction === true) {
+      }
+      if (params.notifyUserAboutCompaction === true) {
         await params.onCompactionNoticePayload?.(
           createCompactionNoticePayload({
-            phase: "start",
+            phase: noticePhase,
             currentMessageId: params.currentMessageId,
           }),
         );
       }
+    };
+    if (phase === "start" && emitChannelProgress) {
+      await opts?.onCompactionStart?.();
+    }
+    if (phase === "start") {
+      await sendCompactionUserNotices("start");
     }
     if (phase === "end" && evt.data?.completed === true) {
       params.onCompactionComplete?.();
@@ -258,35 +262,9 @@ async function forwardFollowupProgressEvent(params: {
       if (evt.data?.willRetry === true) {
         return;
       }
-      const hookPayload = createCompactionHookNoticePayload({
-        messages: hookMessages,
-        currentMessageId: params.currentMessageId,
-      });
-      if (hookPayload) {
-        await params.onCompactionNoticePayload?.(hookPayload);
-      } else if (params.notifyUserAboutCompaction === true) {
-        await params.onCompactionNoticePayload?.(
-          createCompactionNoticePayload({
-            phase: "end",
-            currentMessageId: params.currentMessageId,
-          }),
-        );
-      }
+      await sendCompactionUserNotices("end");
     } else if (phase === "end") {
-      const hookPayload = createCompactionHookNoticePayload({
-        messages: hookMessages,
-        currentMessageId: params.currentMessageId,
-      });
-      if (hookPayload) {
-        await params.onCompactionNoticePayload?.(hookPayload);
-      } else if (params.notifyUserAboutCompaction === true) {
-        await params.onCompactionNoticePayload?.(
-          createCompactionNoticePayload({
-            phase: "incomplete",
-            currentMessageId: params.currentMessageId,
-          }),
-        );
-      }
+      await sendCompactionUserNotices("incomplete");
     }
   }
 }

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -32,7 +32,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     handleCommandsMock.mockReset();
   });
 
-  it("marks native /compact terminal replies for delivery under message_tool_only (#87107)", async () => {
+  it("marks native /compact terminal replies for delivery under message_tool_only (#90185)", async () => {
     handleCommandsMock.mockResolvedValueOnce({
       shouldContinue: false,
       reply: { text: "⚙️ Compaction skipped: no real conversation messages yet • Context 12.1k" },
@@ -50,6 +50,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         kind: "native",
         source: "native",
         authorized: true,
+        commandName: "compact",
         body: "/compact",
       },
     });
@@ -82,9 +83,10 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     if (!result.handled) {
       throw new Error("expected handled");
     }
-    expect(
-      getReplyPayloadMetadata(result.reply as object)?.deliverDespiteSourceReplySuppression,
-    ).toBe(true);
+    if (!result.reply || Array.isArray(result.reply)) {
+      throw new Error("expected single reply payload");
+    }
+    expect(getReplyPayloadMetadata(result.reply)?.deliverDespiteSourceReplySuppression).toBe(true);
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -296,7 +296,10 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     skillFilter: params.skillFilter,
   });
   if (inlineActionResult.kind === "reply") {
-    return { handled: true, reply: inlineActionResult.reply };
+    return {
+      handled: true,
+      reply: markCommandReplyForDelivery(inlineActionResult.reply),
+    };
   }
   return { handled: false };
 }

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -10,6 +10,7 @@ import {
   readSessionStoreForTest,
   writeSessionStoreForTestAsync,
 } from "../../config/sessions/test-helpers.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import {
   buildFastReplyCommandContext,
   initFastReplySessionState,
@@ -480,6 +481,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       throw new Error("expected single reply payload");
     }
     expect(reply.text).toContain("Think: xhigh");
+    expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
     expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();
@@ -504,22 +506,26 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       reply: { text: "model status" },
     });
 
-    await expect(
-      getReplyFromConfig(
-        buildGetReplyCtx({
-          Body: "/model status",
-          BodyForAgent: "/model status",
-          RawBody: "/model status",
-          CommandBody: "/model status",
-          CommandSource: "native",
-          CommandAuthorized: true,
-          SessionKey: "telegram:slash:123",
-          CommandTargetSessionKey: targetSessionKey,
-        }),
-        undefined,
-        cfg,
-      ),
-    ).resolves.toEqual({ text: "model status" });
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Body: "/model status",
+        BodyForAgent: "/model status",
+        RawBody: "/model status",
+        CommandBody: "/model status",
+        CommandSource: "native",
+        CommandAuthorized: true,
+        SessionKey: "telegram:slash:123",
+        CommandTargetSessionKey: targetSessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    expect(reply).toMatchObject({ text: "model status" });
+    if (!reply || Array.isArray(reply)) {
+      throw new Error("expected single reply payload");
+    }
+    expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
 
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Addresses the native `/compact` reply-loss path from #90185 and the related compaction notification lane where configured hook messages must not suppress the built-in `notifyUser` notices.

This PR covers these two confirmed paths:

1. Native `/compact` fast-path replies could return before the full inline-action command marker was applied. Channels using `message_tool_only` source-reply delivery then treated the terminal command reply as ordinary source content and suppressed it, producing `queuedFinal=false, replies=0` even though compaction ran.
2. Configured compaction hook messages could suppress the built-in `notifyUser` compaction notice because the notice lived behind an `else if` branch.

This PR intentionally does **not** claim to fix the separate CardKit streaming/rendering corruption mentioned around the issue; that remains separate scope if maintainers want it handled in another patch.

## Root cause

Native slash commands can be handled before workspace bootstrap and before the normal inline command path. The full inline command path already marks terminal command replies with `deliverDespiteSourceReplySuppression`; the native slash fast path did not. That meant an explicit `/compact` result could be generated but later dropped by source-reply delivery policy in message-tool-only channels.

The compaction notice path had a separate branch-ordering issue: hook messages and the built-in `notifyUser` notice were mutually exclusive even though they are independent user-visible lanes.

## Changes

- Mark native slash fast-path replies with the same source-suppression bypass metadata used by the full inline command path.
- Apply the marker to native slash status replies, direct command-handler replies such as `/compact`, directive replies, and inline replies returned from the fast path.
- Keep compaction hook messages and built-in `notifyUser` notices independent.
- Update the stale compaction notice comment so it matches the new behavior.
- Add a regression test proving native `/compact` command-handler replies are marked for message-tool-only delivery.
- Extend fast-path tests to assert native slash status/directive replies carry the delivery marker.
- Keep bundled Feishu `/compact` routing coverage from the earlier patch.
- Resolve the latest upstream merge conflict in `src/commands/migrate/skill-selection-prompt.ts` by keeping the compatibility alias explanation and latest-main deprecation wording. That merge-only follow-up does not alter the `/compact` delivery path.
- Stabilize `src/commands/agent-via-gateway.test.ts` SIGTERM local-run waits after the latest main merge exposed a shard-order timing flake; production `/compact` delivery logic is unchanged.
- Merge latest upstream `main` again and combine both SIGTERM test-stability fixes in `src/commands/agent-via-gateway.test.ts`: the PR keeps the per-test `initialCalls` baseline and the upstream `abortListenerAttached.promise` readiness wait. Production `/compact` delivery logic remains unchanged.

## Real behavior proof

Behavior or issue addressed: visible reply loss for native `/compact`, plus the related compaction notice lane where hook messages and built-in `notifyUser` notices must both remain deliverable.

Real environment tested: Linux local OpenClaw checkout running the current PR head `881ce6d64c8f4a5ca4edd160a652f39688553abd` as an isolated local gateway, connected by a WebChat WebSocket client. The model backend was a local mock OpenAI Responses provider so the proof did not depend on external model credentials. Gateway token, device identity material, loopback URL, and local filesystem paths are redacted/omitted.

Exact steps or command run after this patch: Started the PR-head gateway in isolated local mode, connected a WebChat WebSocket client, approved the local WebChat device, sent `/compact` through `chat.send`, waited for the final `chat` event, then read WebChat history. The captured command was `node --import tsx .artifacts/proof-90185-live-webchat.ts` against the current PR checkout.

Evidence after fix: Redacted live WebChat terminal output from the current PR head:

```json
{
  "head": "881ce6d64c8f4a5ca4edd160a652f39688553abd",
  "mode": "isolated local WebChat websocket live run",
  "request": {
    "sessionKey": "main",
    "message": "/compact",
    "idempotencyKey": "proof-90185-1780629173685"
  },
  "connect": {
    "ok": true,
    "payloadType": "hello-ok",
    "auth": "<redacted>"
  },
  "send": {
    "ok": true,
    "payload": {
      "runId": "proof-90185-1780629173685",
      "status": "started"
    }
  },
  "finalEvent": {
    "event": "chat",
    "payload": {
      "runId": "proof-90185-1780629173685",
      "sessionKey": "agent:main:main",
      "state": "final",
      "message": {
        "role": "assistant",
        "content": [
          {
            "type": "text",
            "text": "⚙️ Compaction skipped: no real conversation messages yet • Context ?/128k"
          }
        ]
      }
    }
  },
  "historySummary": {
    "ok": true,
    "messageCount": 2,
    "compactMessageCount": 2
  }
}
```

Observed result after fix: The current head delivered a visible WebChat assistant reply for `/compact` after dispatch: `⚙️ Compaction skipped: no real conversation messages yet • Context ?/128k`. WebChat history contained both `user: /compact` and the assistant compaction reply, so the old `message_tool_only` silent-drop path is no longer reproduced.

What was not tested: A live Feishu tenant screenshot/video was not attached. WebChat was used as the live transport-visible proof path requested by ClawSweeper, with sensitive runtime details redacted.

### Before-fix reproduction / root-cause proof

A source-level reproduction compared the current base (`upstream/main`) with this PR head:

```json
{
  "baseRef": "81eee470451d6039f899e52397111eea19926d80",
  "headRef": "881ce6d64c8f4a5ca4edd160a652f39688553abd",
  "reproduction": {
    "baseNativeSlashFastPathHasDeliveryMarker": false,
    "headNativeSlashFastPathHasDeliveryMarker": true,
    "dispatchRequiresMarkerForSuppressedDelivery": true
  }
}
```

Relevant base excerpt from `src/auto-reply/reply/get-reply-native-slash-fast-path.ts`:

```text
return { handled: true, reply: commandResult.reply };
return { handled: true, reply: directiveResult.reply };
return { handled: true, reply: inlineActionResult.reply };
```

That is the broken path: the native slash fast-path produced a terminal `/compact` reply, but returned it without the explicit-command delivery marker. Dispatch already requires `deliverDespiteSourceReplySuppression` to bypass `message_tool_only` source suppression, so an unmarked native slash reply can be generated and then dropped.

Relevant PR-head excerpt:

```text
function markNativeSlashCommandReplyForDelivery(...)
reply: markNativeSlashCommandReplyForDelivery(...)
return { handled: true, reply: markNativeSlashCommandReplyForDelivery(commandResult.reply) };
return { handled: true, reply: markNativeSlashCommandReplyForDelivery(directiveResult.reply) };
reply: markNativeSlashCommandReplyForDelivery(inlineActionResult.reply)
```

### Hook messages + built-in notifyUser notices

The second path is covered by the focused regression test added in this PR:

```text
src/auto-reply/reply/agent-runner-execution.test.ts
- delivers compaction hook messages alongside notifyUser notices (#90185)
```

Expected visible sequence under `compaction.notifyUser: true` and hook-provided messages:

```text
Hook before
🧹 Compacting context...
Hook after
🧹 Compaction complete
```

This verifies hook messages are additive and no longer suppress the built-in `notifyUser` compaction notices.

## Validation after fix

Current-head local focused validation after merging latest upstream `main`:

```text
CI=true node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.auto-reply-reply.config.ts \
  src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts \
  src/auto-reply/reply/get-reply.fast-path.test.ts \
  src/auto-reply/reply/agent-runner-execution.test.ts
# 3 files passed, 200 tests passed

CI=true node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-feishu.config.ts \
  extensions/feishu/src/bot.test.ts
# 1 file passed, 74 tests passed

CI=true node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.unit-fast.config.ts \
  src/security/audit-config-include-perms.test.ts
# 1 file passed, 1 test passed

CI=true node scripts/run-tsgo.mjs \
  -p test/tsconfig/tsconfig.core.test.json \
  --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/core-test-pr90212-merge.tsbuildinfo
# passed

CI=true ./node_modules/.bin/oxfmt --check --threads=1 \
  extensions/feishu/src/bot.test.ts \
  src/auto-reply/reply/agent-runner-execution.test.ts \
  src/auto-reply/reply/agent-runner-execution.ts \
  src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts \
  src/auto-reply/reply/get-reply-native-slash-fast-path.ts \
  src/auto-reply/reply/get-reply.fast-path.test.ts \
  src/commands/migrate.ts \
  src/commands/migrate/skill-selection-prompt.ts \
  src/infra/json-file.ts \
  src/plugin-sdk/json-store.ts \
  src/security/audit-config-include-perms.test.ts \
  test/scripts/lint-suppressions.test.ts
# All matched files use the correct format.

git diff --check openclaw-main..HEAD
# passed
```

Current GitHub PR status for `881ce6d64c8f4a5ca4edd160a652f39688553abd` immediately after the latest-main merge-resolution push:

```text
mergeable: MERGEABLE
conflicts: resolved
cloud checks: running on current head
```

Additional validation for the shard exposed by CI after the latest main merge:

```text
OPENCLAW_VITEST_INCLUDE_FILE=/tmp/pr90212-agentic-commands-agent-channel-includes.json \
OPENCLAW_VITEST_SHARD_NAME=agentic-commands-agent-channel \
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 \
OPENCLAW_TEST_PROJECTS_PARALLEL=2 \
NODE_OPTIONS=--max-old-space-size=8192 \
CI=true pnpm exec node scripts/test-projects.mjs test/vitest/vitest.commands.config.ts
# 32 files passed, 313 tests passed
```

## Risk / safety

- Narrow scope: only explicit native slash command replies returned by the fast path get the same delivery marker already used by the normal inline command path.
- Does not broaden ambient message delivery; the marker is applied only inside the native slash command fast path.
- Maintains existing `sendPolicy: deny` behavior because final dispatch still enforces send policy.
- Keeps room-event safeguards: dispatch still requires an explicit command turn for marked replies in room events.

## Notes

The issue references separate CardKit streaming rendering problems via related issues. This PR fixes the `/compact` reply-loss path and the compaction notice suppression path tracked here; it does not modify unrelated streaming card rendering code.






