### PR TITLE
test: detect file symlink support dynamically in canvas tool test

### DIFF
--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -1,8 +1,24 @@
+import fs from "node:fs";
 import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCanvasTool } from "./tool.js";
+
+const canCreateFileSymlinks = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-canvas-symlink-probe-"));
+  const targetFile = path.join(probeDir, "target.txt");
+  const linkFile = path.join(probeDir, "link.txt");
+  try {
+    fs.writeFileSync(targetFile, "content");
+    fs.symlinkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
 
 const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
@@ -41,7 +57,7 @@ describe("Canvas tool", () => {
     }
   });
 
-  it.skipIf(process.platform === "win32")(
+  it.skipIf(!canCreateFileSymlinks)(
     "rejects jsonlPath symlinks that resolve outside the workspace",
     async () => {
       tempRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-tool-"));


### PR DESCRIPTION
Replaces the hardcoded Windows skip with a dynamic file symlink capability check, allowing the test to run on Windows systems when Developer Mode or symlink privileges are available.

### Verified Windows Proof

The following test execution log shows the test run on Windows. Since symlink privileges are not present on this host, the symlink test was skipped gracefully as expected (1 skipped, 2 passed), rather than failing the whole suite:

```
 RUN  v4.1.7 C:/Users/ANIRUDDHA/.gemini/antigravity/scratch/openclaw

 ✓  extensions  ../../extensions/canvas/src/tool.test.ts (3 tests | 1 skipped) 211ms

 Test Files  1 passed (1)
      Tests  2 passed | 1 skipped (3)
```
