### PR TITLE
test: make doctor state integrity symlink test robust on Windows

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -23,6 +23,21 @@ import {
   stateIntegrityIssueToRepairEffect,
 } from "./doctor-state-integrity.js";
 
+const canCreateDirectorySymlinks = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-symlink-probe-"));
+  const targetDir = path.join(probeDir, "target");
+  const linkDir = path.join(probeDir, "link");
+  try {
+    fs.mkdirSync(targetDir);
+    fs.symlinkSync(targetDir, linkDir, process.platform === "win32" ? "junction" : "dir");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 vi.mock("../channels/plugins/bundled-ids.js", () => ({
   listBundledChannelIds: () => ["matrix", "whatsapp"],
   listBundledChannelPluginIds: () => ["matrix", "whatsapp"],
@@ -557,7 +572,7 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(archivedOrphanTranscripts).toStrictEqual([]);
   });
 
-  it.skipIf(process.platform === "win32")(
+  it.skipIf(process.platform === "win32" ? !canCreateDirectorySymlinks : false)(
     "does not archive referenced transcripts when the state dir path resolves through a symlink",
     async () => {
       const cfg: OpenClawConfig = {};
@@ -566,7 +581,7 @@ describe("doctor state integrity oauth dir checks", () => {
         path.dirname(originalHome),
         `${path.basename(originalHome)}-link`,
       );
-      fs.symlinkSync(originalHome, symlinkHome, "dir");
+      fs.symlinkSync(originalHome, symlinkHome, process.platform === "win32" ? "junction" : "dir");
       try {
         const symlinkStateDir = path.join(symlinkHome, ".openclaw");
         setTestEnvValue("HOME", symlinkHome);

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -572,7 +572,7 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(archivedOrphanTranscripts).toStrictEqual([]);
   });
 
-  it.skipIf(process.platform === "win32" ? !canCreateDirectorySymlinks : false)(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "does not archive referenced transcripts when the state dir path resolves through a symlink",
     async () => {
       const cfg: OpenClawConfig = {};

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -23,7 +23,7 @@ import {
   stateIntegrityIssueToRepairEffect,
 } from "./doctor-state-integrity.js";
 
-const canCreateDirectorySymlinks = (() => {
+function canCreateDirectorySymlinks(): boolean {
   const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-symlink-probe-"));
   const targetDir = path.join(probeDir, "target");
   const linkDir = path.join(probeDir, "link");
@@ -36,7 +36,7 @@ const canCreateDirectorySymlinks = (() => {
   } finally {
     fs.rmSync(probeDir, { recursive: true, force: true });
   }
-})();
+}
 
 vi.mock("../channels/plugins/bundled-ids.js", () => ({
   listBundledChannelIds: () => ["matrix", "whatsapp"],
@@ -572,52 +572,52 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(archivedOrphanTranscripts).toStrictEqual([]);
   });
 
-  it.skipIf(!canCreateDirectorySymlinks)(
-    "does not archive referenced transcripts when the state dir path resolves through a symlink",
-    async () => {
-      const cfg: OpenClawConfig = {};
-      const originalHome = tempHome;
-      const symlinkHome = path.join(
-        path.dirname(originalHome),
-        `${path.basename(originalHome)}-link`,
+  it("does not archive referenced transcripts when the state dir path resolves through a symlink", async ({
+    skip,
+  }) => {
+    if (!canCreateDirectorySymlinks()) {
+      skip("directory symlinks or junctions are not available on this host");
+    }
+    const cfg: OpenClawConfig = {};
+    const originalHome = tempHome;
+    const symlinkHome = path.join(
+      path.dirname(originalHome),
+      `${path.basename(originalHome)}-link`,
+    );
+    fs.symlinkSync(originalHome, symlinkHome, process.platform === "win32" ? "junction" : "dir");
+    try {
+      const symlinkStateDir = path.join(symlinkHome, ".openclaw");
+      setTestEnvValue("HOME", symlinkHome);
+      setTestEnvValue("OPENCLAW_HOME", symlinkHome);
+      setTestEnvValue("OPENCLAW_STATE_DIR", symlinkStateDir);
+
+      setupSessionState(cfg, process.env, symlinkHome);
+      const sessionsDir = resolveSessionTranscriptsDirForAgent(
+        "main",
+        process.env,
+        () => symlinkHome,
       );
-      fs.symlinkSync(originalHome, symlinkHome, process.platform === "win32" ? "junction" : "dir");
-      try {
-        const symlinkStateDir = path.join(symlinkHome, ".openclaw");
-        setTestEnvValue("HOME", symlinkHome);
-        setTestEnvValue("OPENCLAW_HOME", symlinkHome);
-        setTestEnvValue("OPENCLAW_STATE_DIR", symlinkStateDir);
+      const transcriptPath = path.join(sessionsDir, "linked-session.jsonl");
+      fs.writeFileSync(transcriptPath, '{"type":"session"}\n');
+      writeSessionStore(cfg, {
+        "agent:main:main": {
+          sessionId: "linked-session",
+          updatedAt: Date.now(),
+        },
+      });
 
-        setupSessionState(cfg, process.env, symlinkHome);
-        const sessionsDir = resolveSessionTranscriptsDirForAgent(
-          "main",
-          process.env,
-          () => symlinkHome,
-        );
-        const transcriptPath = path.join(sessionsDir, "linked-session.jsonl");
-        fs.writeFileSync(transcriptPath, '{"type":"session"}\n');
-        writeSessionStore(cfg, {
-          "agent:main:main": {
-            sessionId: "linked-session",
-            updatedAt: Date.now(),
-          },
-        });
+      const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
+        params.message.includes("This only renames them to *.deleted.<timestamp>."),
+      );
+      await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-        const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
-          params.message.includes("This only renames them to *.deleted.<timestamp>."),
-        );
-        await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
-
-        expect(fs.existsSync(transcriptPath)).toBe(true);
-        expect(fs.readdirSync(sessionsDir).filter((name) => name.includes(".deleted."))).toEqual(
-          [],
-        );
-        expect(stateIntegrityText()).not.toContain("These .jsonl files are no longer referenced");
-      } finally {
-        fs.rmSync(symlinkHome, { force: true, recursive: true });
-      }
-    },
-  );
+      expect(fs.existsSync(transcriptPath)).toBe(true);
+      expect(fs.readdirSync(sessionsDir).filter((name) => name.includes(".deleted."))).toEqual([]);
+      expect(stateIntegrityText()).not.toContain("These .jsonl files are no longer referenced");
+    } finally {
+      fs.rmSync(symlinkHome, { force: true, recursive: true });
+    }
+  });
 
   it("suppresses orphan transcript warnings when QMD sessions are enabled", async () => {
     const confirmRuntimeRepair = await runOrphanTranscriptCheckWithQmdSessions(true, tempHome);


### PR DESCRIPTION
Replaces the hardcoded Windows skip with a dynamic directory symlink capability check. If directory symlinks are supported (either on POSIX or Windows with junctions), the test runs. This enables test execution on Windows when permissions are available.

### Verified Windows Proof

The following test execution log shows the test run on Windows. All 30 tests in the suite (including the dynamically skipped/run symlinked path test) passed successfully:

```
 RUN  v4.1.7 C:/Users/ANIRUDDHA/.gemini/antigravity/scratch/openclaw

 ✓  commands  ../../src/commands/doctor-state-integrity.test.ts (30 tests) 4354ms

 Test Files  1 passed (1)
      Tests  30 passed (30)
```
