### PR TITLE
Fix Mission Control docs markdown links

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -13,7 +13,16 @@ import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
 const markdownRenderMock = vi.hoisted(() =>
-  vi.fn((value: string, _options?: { codeBlockChrome?: "copy" | "none" }) => value),
+  vi.fn(
+    (
+      value: string,
+      _options?: {
+        codeBlockChrome?: "copy" | "none";
+        preserveControlUiRoutes?: boolean;
+        rootRelativeLinkBaseUrl?: string;
+      },
+    ) => value,
+  ),
 );
 const streamingTextRenderMock = vi.hoisted(() =>
   vi.fn((value: string) => `<div class="markdown-plain-text-fallback">${value}</div>`),
@@ -31,6 +40,13 @@ vi.mock("../../local-storage.ts", () => ({
 }));
 
 vi.mock("../markdown.ts", () => ({
+  OPENCLAW_DOCS_MARKDOWN_OPTIONS: {
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
+  OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS: {
+    preserveControlUiRoutes: true,
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
   toSanitizedMarkdownHtml: markdownRenderMock,
   toStreamingMarkdownHtml: streamingMarkdownRenderMock,
   toStreamingPlainTextHtml: streamingTextRenderMock,
@@ -605,7 +621,10 @@ describe("grouped chat rendering", () => {
       timestamp: 1000,
     });
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, undefined);
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, {
+      preserveControlUiRoutes: true,
+      rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+    });
   });
 
   it("positions delete confirm by message side", () => {
@@ -905,7 +924,10 @@ describe("grouped chat rendering", () => {
 
     expect(markdownRenderMock).not.toHaveBeenCalled();
     expect(streamingTextRenderMock).not.toHaveBeenCalled();
-    expect(streamingMarkdownRenderMock).toHaveBeenCalledWith("**live**\nreply", undefined);
+    expect(streamingMarkdownRenderMock).toHaveBeenCalledWith("**live**\nreply", {
+      preserveControlUiRoutes: true,
+      rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+    });
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");
   });
@@ -2467,6 +2489,7 @@ describe("grouped chat rendering", () => {
 
     const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
     expect(sidebar.kind).toBe("markdown");
+    expect(sidebar.rewriteOpenClawDocsLinks).toBe(true);
     expect(sidebar.fullMessageRequest).toEqual({
       sessionKey: "global",
       agentId: "work",

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -6,7 +6,12 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "../markdown.ts";
+import {
+  OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+  toSanitizedMarkdownHtml,
+  toStreamingMarkdownHtml,
+  type MarkdownRenderOptions,
+} from "../markdown.ts";
 import { openExternalUrlSafe } from "../open-external-url.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 import { detectTextDirection } from "../text-direction.ts";
@@ -1587,6 +1592,7 @@ function renderExpandButton(
         onOpenSidebar({
           kind: "markdown",
           content: markdown,
+          rewriteOpenClawDocsLinks: true,
           ...(options?.sessionKey && options?.messageId
             ? {
                 fullMessageRequest: {
@@ -1672,7 +1678,8 @@ function renderGroupedMessage(
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
-  const markdownRenderOptions = role === "user" ? { codeBlockChrome: "none" as const } : undefined;
+  const markdownRenderOptions: MarkdownRenderOptions =
+    role === "user" ? { codeBlockChrome: "none" } : OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS;
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
   const hasActions = canCopyMarkdown || canExpand;
@@ -1824,7 +1831,12 @@ function renderGroupedMessage(
                       )}
                       ${reasoningMarkdown
                         ? html`<div class="chat-thinking">
-                            ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                            ${unsafeHTML(
+                              toSanitizedMarkdownHtml(
+                                reasoningMarkdown,
+                                OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+                              ),
+                            )}
                           </div>`
                         : nothing}
                       ${jsonResult
@@ -1881,7 +1893,12 @@ function renderGroupedMessage(
             )}
             ${reasoningMarkdown
               ? html`<div class="chat-thinking">
-                  ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
+                  ${unsafeHTML(
+                    toSanitizedMarkdownHtml(
+                      reasoningMarkdown,
+                      OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+                    ),
+                  )}
                 </div>`
               : nothing}
             ${normalizedRole === "assistant" && assistantViewBlocks.length > 0
@@ -1936,7 +1953,7 @@ function renderGroupedMessage(
 function renderMarkdownText(
   markdown: string,
   isStreaming: boolean,
-  markdownRenderOptions?: { codeBlockChrome: "copy" | "none" },
+  markdownRenderOptions: MarkdownRenderOptions,
 ) {
   if (isStreaming) {
     return html`

--- a/ui/src/ui/chat/run-controls.test.ts
+++ b/ui/src/ui/chat/run-controls.test.ts
@@ -22,6 +22,13 @@ vi.mock("../icons.ts", () => ({
 }));
 
 vi.mock("../markdown.ts", () => ({
+  OPENCLAW_DOCS_MARKDOWN_OPTIONS: {
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
+  OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS: {
+    preserveControlUiRoutes: true,
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
   toSanitizedMarkdownHtml: (value: string) => value,
 }));
 

--- a/ui/src/ui/chat/side-result-render.ts
+++ b/ui/src/ui/chat/side-result-render.ts
@@ -2,7 +2,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../icons.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS, toSanitizedMarkdownHtml } from "../markdown.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { ChatSideResult } from "./side-result.ts";
 
@@ -37,7 +37,9 @@ export function renderSideResult(
       </div>
       <div class="chat-side-result__question">${sideResult.question}</div>
       <div class="chat-side-result__body" dir=${detectTextDirection(sideResult.text)}>
-        ${unsafeHTML(toSanitizedMarkdownHtml(sideResult.text))}
+        ${unsafeHTML(
+          toSanitizedMarkdownHtml(sideResult.text, OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS),
+        )}
       </div>
     </section>
   `;

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import {
   md,
+  OPENCLAW_DOCS_MARKDOWN_OPTIONS,
+  OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
   toSanitizedMarkdownHtml,
   toStreamingMarkdownHtml,
   toStreamingPlainTextHtml,
@@ -603,23 +605,71 @@ PY
       );
     });
 
-    it("rewrites docs-root links to the public docs host", () => {
+    it("keeps docs-root links local by default", () => {
+      const html = toSanitizedMarkdownHtml("[workspace](/concepts/agent-workspace)");
+      expect(html).toBe(
+        '<p><a href="/concepts/agent-workspace" rel="noreferrer noopener" target="_blank">workspace</a></p>\n',
+      );
+    });
+
+    it("rewrites docs-root links to the public docs host in docs-link mode", () => {
       const html = toSanitizedMarkdownHtml(
         "[workspace](/concepts/agent-workspace) [hooks](/automation/hooks#session-memory) [telegram](/channels/telegram?tab=setup) [shortlink](/telegram) [openai](/openai) [images](/images) [groups](/groups) [camera](/nodes/camera) [macOS](/platforms/macos) [cliSessions](/cli/sessions) [toolSkills](/tools/skills) [pluginDocs](/plugins/reference/diffs) [prose](/prose) [refactor](/refactor/ingress-core)",
+        OPENCLAW_DOCS_MARKDOWN_OPTIONS,
       );
       expect(html).toBe(
         '<p><a href="https://docs.openclaw.ai/concepts/agent-workspace" rel="noreferrer noopener" target="_blank">workspace</a> <a href="https://docs.openclaw.ai/automation/hooks#session-memory" rel="noreferrer noopener" target="_blank">hooks</a> <a href="https://docs.openclaw.ai/channels/telegram?tab=setup" rel="noreferrer noopener" target="_blank">telegram</a> <a href="https://docs.openclaw.ai/telegram" rel="noreferrer noopener" target="_blank">shortlink</a> <a href="https://docs.openclaw.ai/openai" rel="noreferrer noopener" target="_blank">openai</a> <a href="https://docs.openclaw.ai/images" rel="noreferrer noopener" target="_blank">images</a> <a href="https://docs.openclaw.ai/groups" rel="noreferrer noopener" target="_blank">groups</a> <a href="https://docs.openclaw.ai/nodes/camera" rel="noreferrer noopener" target="_blank">camera</a> <a href="https://docs.openclaw.ai/platforms/macos" rel="noreferrer noopener" target="_blank">macOS</a> <a href="https://docs.openclaw.ai/cli/sessions" rel="noreferrer noopener" target="_blank">cliSessions</a> <a href="https://docs.openclaw.ai/tools/skills" rel="noreferrer noopener" target="_blank">toolSkills</a> <a href="https://docs.openclaw.ai/plugins/reference/diffs" rel="noreferrer noopener" target="_blank">pluginDocs</a> <a href="https://docs.openclaw.ai/prose" rel="noreferrer noopener" target="_blank">prose</a> <a href="https://docs.openclaw.ai/refactor/ingress-core" rel="noreferrer noopener" target="_blank">refactor</a></p>\n',
       );
     });
 
-    it("keeps app and resource routes instead of treating them as docs roots", () => {
+    it("keeps app and resource routes in Mission Control docs-link mode", () => {
       const html = withControlUiBasePath("/control", () =>
         toSanitizedMarkdownHtml(
           "[channels](/channels) [automation](/automation) [workshop](/skills/workshop) [chat](/chat) [baseChat](/control/chat?session=abc) [baseSessions](/control/sessions) [health](/healthz) [pluginDynamic](/googlechat) [asset](/api/files/1) [baseApi](/control/api/files/1) [baseAvatar](/control/avatar/main) [plugin](/plugins/diffs/view/id/token) [basePlugin](/control/plugins/diffs/view/id/token) [artifact](/__openclaw__/canvas/documents/x/index.html) [baseArtifact](/control/__openclaw__/canvas/x)",
+          OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
         ),
       );
       expect(html).toBe(
         '<p><a href="/channels" rel="noreferrer noopener" target="_blank">channels</a> <a href="/automation" rel="noreferrer noopener" target="_blank">automation</a> <a href="/skills/workshop" rel="noreferrer noopener" target="_blank">workshop</a> <a href="/chat" rel="noreferrer noopener" target="_blank">chat</a> <a href="/control/chat?session=abc" rel="noreferrer noopener" target="_blank">baseChat</a> <a href="/control/sessions" rel="noreferrer noopener" target="_blank">baseSessions</a> <a href="/healthz" rel="noreferrer noopener" target="_blank">health</a> <a href="/googlechat" rel="noreferrer noopener" target="_blank">pluginDynamic</a> <a href="/api/files/1" rel="noreferrer noopener" target="_blank">asset</a> <a href="/control/api/files/1" rel="noreferrer noopener" target="_blank">baseApi</a> <a href="/control/avatar/main" rel="noreferrer noopener" target="_blank">baseAvatar</a> <a href="/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">plugin</a> <a href="/control/plugins/diffs/view/id/token" rel="noreferrer noopener" target="_blank">basePlugin</a> <a href="/__openclaw__/canvas/documents/x/index.html" rel="noreferrer noopener" target="_blank">artifact</a> <a href="/control/__openclaw__/canvas/x" rel="noreferrer noopener" target="_blank">baseArtifact</a></p>\n',
+      );
+    });
+
+    it("rewrites docs subpaths that share a segment with Control UI routes", () => {
+      const html = toSanitizedMarkdownHtml(
+        "[Channel pairing](/channels/pairing) [Cron jobs](/automation/cron-jobs)",
+        OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+      );
+      expect(html).toBe(
+        '<p><a href="https://docs.openclaw.ai/channels/pairing" rel="noreferrer noopener" target="_blank">Channel pairing</a> <a href="https://docs.openclaw.ai/automation/cron-jobs" rel="noreferrer noopener" target="_blank">Cron jobs</a></p>\n',
+      );
+    });
+
+    it("caches default and docs-link rendering separately", () => {
+      const markdown = "[Nodes](/nodes)";
+      const local = toSanitizedMarkdownHtml(markdown);
+      const docs = toSanitizedMarkdownHtml(markdown, OPENCLAW_DOCS_MARKDOWN_OPTIONS);
+      const missionControl = toSanitizedMarkdownHtml(
+        markdown,
+        OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+      );
+      expect(local).toBe(
+        '<p><a href="/nodes" rel="noreferrer noopener" target="_blank">Nodes</a></p>\n',
+      );
+      expect(docs).toBe(
+        '<p><a href="https://docs.openclaw.ai/nodes" rel="noreferrer noopener" target="_blank">Nodes</a></p>\n',
+      );
+      expect(missionControl).toBe(
+        '<p><a href="/nodes" rel="noreferrer noopener" target="_blank">Nodes</a></p>\n',
+      );
+    });
+
+    it("preserves docs path query strings and hashes when rewriting", () => {
+      const html = toSanitizedMarkdownHtml(
+        "[Control UI](/web/control-ui?from=dashboard#device-pairing-first-connection)",
+        OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS,
+      );
+      expect(html).toBe(
+        '<p><a href="https://docs.openclaw.ai/web/control-ui?from=dashboard#device-pairing-first-connection" rel="noreferrer noopener" target="_blank">Control UI</a></p>\n',
       );
     });
   });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -89,6 +89,13 @@ const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const HOST_LOCAL_FILE_HREF_RE =
   /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
 const DOCS_ORIGIN = "https://docs.openclaw.ai";
+export const OPENCLAW_DOCS_MARKDOWN_OPTIONS = {
+  rootRelativeLinkBaseUrl: DOCS_ORIGIN,
+} as const satisfies MarkdownRenderOptions;
+export const OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS = {
+  preserveControlUiRoutes: true,
+  rootRelativeLinkBaseUrl: DOCS_ORIGIN,
+} as const satisfies MarkdownRenderOptions;
 const DOCS_ROOT_SEGMENTS = new Set([
   "agent-runtime-architecture",
   "announcements",
@@ -317,6 +324,8 @@ type WindowWithControlUiBasePath = Window &
     [key: string]: unknown;
   };
 const markdownCache = new Map<string, string>();
+let activeRootRelativeLinkBaseUrl: string | null = null;
+let activePreserveControlUiRoutes = false;
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
@@ -325,10 +334,14 @@ export type MarkdownCodeBlockChrome = "copy" | "none";
 
 export type MarkdownRenderOptions = {
   codeBlockChrome?: MarkdownCodeBlockChrome;
+  preserveControlUiRoutes?: boolean;
+  rootRelativeLinkBaseUrl?: string | null;
 };
 
 type MarkdownRenderEnv = {
   codeBlockChrome: MarkdownCodeBlockChrome;
+  preserveControlUiRoutes: boolean;
+  rootRelativeLinkBaseUrl: string | null;
 };
 
 // CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
@@ -362,6 +375,8 @@ function setCachedMarkdown(key: string, value: string) {
 function normalizeMarkdownRenderOptions(options: MarkdownRenderOptions = {}): MarkdownRenderEnv {
   return {
     codeBlockChrome: options.codeBlockChrome ?? "copy",
+    preserveControlUiRoutes: options.preserveControlUiRoutes === true,
+    rootRelativeLinkBaseUrl: normalizeRootRelativeLinkBaseUrl(options.rootRelativeLinkBaseUrl),
   };
 }
 
@@ -371,6 +386,22 @@ function shouldRenderCodeBlockCopy(env: unknown): boolean {
 
 function isHostLocalFileHref(href: string): boolean {
   return HOST_LOCAL_FILE_HREF_RE.test(href.trim());
+}
+
+function normalizeRootRelativeLinkBaseUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
 }
 
 function isControlUiRoutePath(pathname: string): boolean {
@@ -437,18 +468,25 @@ function isDocsRootPath(normalizedPath: string, segments: string[]): boolean {
   return segment ? DOCS_ROOT_SEGMENTS.has(segment) : false;
 }
 
-function normalizeDocsRootHref(href: string): string {
+function normalizeDocsRootHref(
+  href: string,
+  baseUrl: string | null,
+  preserveControlUiRoutes: boolean,
+): string {
+  if (!baseUrl) {
+    return href;
+  }
   const trimmed = href.trim();
   if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
     return href;
   }
   try {
-    const url = new URL(trimmed, DOCS_ORIGIN);
-    if (url.origin !== DOCS_ORIGIN) {
+    const url = new URL(trimmed, baseUrl);
+    if (url.origin !== baseUrl) {
       return href;
     }
     const normalizedPath = url.pathname.replace(/\/+$/, "") || "/";
-    if (isControlUiRoutePath(normalizedPath)) {
+    if (preserveControlUiRoutes && isControlUiRoutePath(normalizedPath)) {
       return href;
     }
     const segments = pathSegments(normalizedPath);
@@ -462,6 +500,23 @@ function normalizeDocsRootHref(href: string): string {
     return href;
   } catch {
     return href;
+  }
+}
+
+function sanitizeMarkdownHtml(
+  html: string,
+  rootRelativeLinkBaseUrl: string | null,
+  preserveControlUiRoutes: boolean,
+): string {
+  const previousRootRelativeLinkBaseUrl = activeRootRelativeLinkBaseUrl;
+  const previousPreserveControlUiRoutes = activePreserveControlUiRoutes;
+  activeRootRelativeLinkBaseUrl = rootRelativeLinkBaseUrl;
+  activePreserveControlUiRoutes = preserveControlUiRoutes;
+  try {
+    return DOMPurify.sanitize(html, sanitizeOptions);
+  } finally {
+    activeRootRelativeLinkBaseUrl = previousRootRelativeLinkBaseUrl;
+    activePreserveControlUiRoutes = previousPreserveControlUiRoutes;
   }
 }
 
@@ -485,7 +540,11 @@ function installHooks() {
       return;
     }
 
-    const normalizedHref = normalizeDocsRootHref(href);
+    const normalizedHref = normalizeDocsRootHref(
+      href,
+      activeRootRelativeLinkBaseUrl,
+      activePreserveControlUiRoutes,
+    );
     if (normalizedHref !== href) {
       node.setAttribute("href", normalizedHref);
     }
@@ -1030,7 +1089,7 @@ export function toSanitizedMarkdownHtml(
     return "";
   }
   installHooks();
-  const cacheKey = `${i18n.getLocale()}\0${renderOptions.codeBlockChrome}\0${input}`;
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.codeBlockChrome}\0${renderOptions.rootRelativeLinkBaseUrl ?? ""}\0${renderOptions.preserveControlUiRoutes ? "preserve-control-ui" : ""}\0${input}`;
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {
@@ -1046,7 +1105,11 @@ export function toSanitizedMarkdownHtml(
     // capped code-block chrome, while still preserving whitespace for logs
     // and other structured text that commonly trips the parse guard.
     const html = toEscapedPlainTextHtml(`${truncated.text}${suffix}`);
-    const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
+    const sanitized = sanitizeMarkdownHtml(
+      html,
+      renderOptions.rootRelativeLinkBaseUrl,
+      renderOptions.preserveControlUiRoutes,
+    );
     if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
       setCachedMarkdown(cacheKey, sanitized);
     }
@@ -1061,7 +1124,11 @@ export function toSanitizedMarkdownHtml(
     const escaped = escapeHtml(`${truncated.text}${suffix}`);
     rendered = `<pre class="code-block">${escaped}</pre>`;
   }
-  const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
+  const sanitized = sanitizeMarkdownHtml(
+    rendered,
+    renderOptions.rootRelativeLinkBaseUrl,
+    renderOptions.preserveControlUiRoutes,
+  );
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     setCachedMarkdown(cacheKey, sanitized);
   }

--- a/ui/src/ui/sidebar-content.ts
+++ b/ui/src/ui/sidebar-content.ts
@@ -10,6 +10,7 @@ export type MarkdownSidebarContent = {
   kind: "markdown";
   content: string;
   rawText?: string | null;
+  rewriteOpenClawDocsLinks?: boolean;
   fullMessageRequest?: SidebarFullMessageRequest;
   unavailableReason?: "not_found" | "oversized" | "not_visible" | null;
 };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -160,6 +160,13 @@ vi.mock("../chat/grouped-render.ts", () => ({
 }));
 
 vi.mock("../markdown.ts", () => ({
+  OPENCLAW_DOCS_MARKDOWN_OPTIONS: {
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
+  OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS: {
+    preserveControlUiRoutes: true,
+    rootRelativeLinkBaseUrl: "https://docs.openclaw.ai",
+  },
   toSanitizedMarkdownHtml: (value: string) => value,
 }));
 

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -469,7 +469,8 @@ describe("cron view", () => {
       sessionTarget: "isolated" as const,
       payload: {
         kind: "agentTurn" as const,
-        message: "## Plan\n\n- **Ship** [docs](https://example.com)\n\n<script>alert(1)</script>",
+        message:
+          "## Plan\n\n- **Ship** [docs](/concepts/agent-workspace)\n- Keep [Cron](/cron)\n\n<script>alert(1)</script>",
       },
       delivery: { mode: "announce" as const, channel: "telegram", to: "123" },
     };
@@ -494,7 +495,10 @@ describe("cron view", () => {
 
     const prompt = getElement(container, ".cron-job-detail-value.chat-text", HTMLElement);
     expect(prompt.querySelector("strong")?.textContent).toBe("Ship");
-    expect(prompt.querySelector("a")?.getAttribute("href")).toBe("https://example.com");
+    const promptLinks = Array.from(prompt.querySelectorAll("a")).map((link) =>
+      link.getAttribute("href"),
+    );
+    expect(promptLinks).toEqual(["https://docs.openclaw.ai/concepts/agent-workspace", "/cron"]);
     expect(prompt.querySelector("script")).toBeNull();
 
     const promptLink = getElement(prompt, "a", HTMLAnchorElement);

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -12,7 +12,7 @@ import type {
 import { getCronJobPayload } from "../cron-payload.ts";
 import { resolveCronJobLastRunStatus } from "../cron-status.ts";
 import { formatRelativeTimestamp, formatMs } from "../format.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS, toSanitizedMarkdownHtml } from "../markdown.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatCronSchedule, formatNextRun } from "../presenter.ts";
 import { normalizeStringEntries, uniqueStrings } from "../string-coerce.ts";
@@ -1757,7 +1757,9 @@ function renderJobPayload(job: CronJob) {
       <div class="cron-job-detail-section">
         <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
         <div class="muted cron-job-detail-value chat-text" @click=${stopPropagationForInteractive}>
-          ${unsafeHTML(toSanitizedMarkdownHtml(payload.message))}
+          ${unsafeHTML(
+            toSanitizedMarkdownHtml(payload.message, OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS),
+          )}
         </div>
       </div>
       ${delivery
@@ -1934,7 +1936,9 @@ function renderRun(
         </div>
       </div>
       <div class="cron-run-entry__body chat-text">
-        ${unsafeHTML(toSanitizedMarkdownHtml(bodySource))}
+        ${unsafeHTML(
+          toSanitizedMarkdownHtml(bodySource, OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS),
+        )}
       </div>
     </div>
   `;

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -8,7 +8,7 @@ import type {
   WikiImportInsights,
   WikiMemoryPalace,
 } from "../controllers/dreaming.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS, toSanitizedMarkdownHtml } from "../markdown.ts";
 
 // ── Diary entry parser ─────────────────────────────────────────────────
 
@@ -1435,7 +1435,9 @@ function renderDreamDiaryEntries(props: DreamingProps) {
         ${flattenDiaryBody(entry.body).map(
           (para, i) =>
             html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
-              ${unsafeHTML(toSanitizedMarkdownHtml(para))}
+              ${unsafeHTML(
+                toSanitizedMarkdownHtml(para, OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS),
+              )}
             </p>`,
         )}
       </div>

--- a/ui/src/ui/views/markdown-sidebar.ts
+++ b/ui/src/ui/views/markdown-sidebar.ts
@@ -5,7 +5,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { resolveCanvasIframeUrl } from "../canvas-url.ts";
 import { resolveEmbedSandbox, type EmbedSandboxMode } from "../embed-sandbox.ts";
 import { icons } from "../icons.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS, toSanitizedMarkdownHtml } from "../markdown.ts";
 import type { SidebarContent } from "../sidebar-content.ts";
 
 function resolveSidebarCanvasSandbox(
@@ -29,7 +29,10 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
   const content = props.content;
   const markdownHtml =
     content?.kind === "markdown" && content.content.trim()
-      ? toSanitizedMarkdownHtml(content.content)
+      ? toSanitizedMarkdownHtml(
+          content.content,
+          content.rewriteOpenClawDocsLinks ? OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS : undefined,
+        )
       : "";
   const canvasSandbox =
     content?.kind === "canvas"

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -12,7 +12,7 @@ import type {
 } from "../controllers/skills.ts";
 import { clawhubVerdictKey } from "../controllers/skills.ts";
 import { clampText } from "../format.ts";
-import { toSanitizedMarkdownHtml } from "../markdown.ts";
+import { OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS, toSanitizedMarkdownHtml } from "../markdown.ts";
 import { resolveSafeExternalUrl } from "../open-external-url.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
@@ -738,7 +738,7 @@ function renderInstalledSkillCard(skill: SkillStatusEntry, props: SkillsProps) {
   }
   return html`
     <article class="sidebar-markdown" style="max-width: 100%; overflow-wrap: anywhere;">
-      ${unsafeHTML(toSanitizedMarkdownHtml(content))}
+      ${unsafeHTML(toSanitizedMarkdownHtml(content, OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS))}
     </article>
   `;
 }


### PR DESCRIPTION
Fixes #89465.

## Summary
- Rewrite root-relative OpenClaw docs markdown links to `https://docs.openclaw.ai` in Mission Control markdown surfaces.
- Preserve Control UI routes such as `/cron`, `/channels`, `/nodes`, and `/skills/workshop` when rendering arbitrary Mission Control markdown.
- Gate sidebar docs-link rewriting with explicit markdown provenance so generic workspace markdown previews keep project-local links.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Mission Control markdown that contains root-relative OpenClaw docs links now renders those links against `https://docs.openclaw.ai`, while Control UI routes such as `/cron` stay in-app.
- Real environment tested: Local checkout of this PR head (`e0e79523e73d282bc622284a6284e4f76c1aeca1`) on macOS, Node.js v24.13.1, using the repository's actual UI markdown renderer with a jsdom DOM at `http://127.0.0.1:4317/`.
- Exact steps or command run after this patch: Ran a local Node command that imports `ui/src/ui/markdown.ts`, calls `toSanitizedMarkdownHtml` with `OPENCLAW_MISSION_CONTROL_MARKDOWN_OPTIONS` and `OPENCLAW_DOCS_MARKDOWN_OPTIONS`, and prints the rendered anchor `href` values.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture / console output from the command above:

```text
real behavior proof: markdown renderer link targets
Mission Control docs link: https://docs.openclaw.ai/concepts/agent-workspace
Mission Control internal route: /cron
Docs-only guide link: https://docs.openclaw.ai/cli/setup
Generic markdown preview link: /cli/setup
```

- Observed result after fix: Mission Control docs links are rewritten to the public docs host, Mission Control internal routes remain root-relative in the app, docs-only rendering still rewrites OpenClaw docs paths to `https://docs.openclaw.ai`, and generic markdown previews keep project-local root-relative links unchanged.
- What was not tested: I did not attach a browser screenshot or screen recording of the full Mission Control app. Browser-level coverage is supported by the focused UI regression tests listed below.
- Proof limitations or environment constraints: This proof exercises the real markdown sanitizer/link-rewrite code path from the PR checkout in a local DOM environment rather than a full running Control UI session.
- Before evidence (optional but encouraged): Before this patch, the same root-relative docs links rendered as host-local app paths such as `/concepts/agent-workspace`, which is the behavior reported in #89465.

## Validation
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/views/cron.test.ts ui/src/ui/markdown.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/views/cron.test.ts ui/src/ui/views/skills.test.ts ui/src/ui/views/dreaming.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/chat/side-result-render.ts ui/src/ui/chat/run-controls.test.ts ui/src/ui/views/markdown-sidebar.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts ui/src/ui/views/dreaming.ts ui/src/ui/views/skills.ts ui/src/ui/views/chat.test.ts ui/src/ui/sidebar-content.ts`
- `node scripts/run-oxlint.mjs ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/chat/side-result-render.ts ui/src/ui/chat/run-controls.test.ts ui/src/ui/views/markdown-sidebar.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts ui/src/ui/views/dreaming.ts ui/src/ui/views/skills.ts ui/src/ui/views/chat.test.ts ui/src/ui/sidebar-content.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
