### PR TITLE
fix(compaction): allow compaction with aws-sdk auth without apiKey or headers

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -141,6 +141,7 @@ const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
   getApiKeyAndHeadersMock?: ReturnType<typeof vi.fn>;
   getApiKeyMock?: ReturnType<typeof vi.fn>;
+  getProviderAuthStatusMock?: ReturnType<typeof vi.fn>;
 }) =>
   ({
     model: undefined,
@@ -155,6 +156,8 @@ const createCompactionContext = (params: {
           const apiKey = await legacyGetApiKey?.(model);
           return apiKey !== undefined ? { ok: true, apiKey } : { ok: false, error: "missing auth" };
         }),
+      getProviderAuthStatus:
+        params.getProviderAuthStatusMock ?? vi.fn(() => ({ configured: false })),
     },
   }) as unknown as Partial<ExtensionContext>;
 
@@ -162,6 +165,7 @@ async function runCompactionScenario(params: {
   sessionManager: ExtensionContext["sessionManager"];
   event: unknown;
   apiKey: string | null;
+  providerAuthLabel?: string;
 }) {
   const compactionHandler = createCompactionHandler();
   const getApiKeyAndHeadersMock = vi
@@ -169,11 +173,17 @@ async function runCompactionScenario(params: {
     .mockResolvedValue(
       params.apiKey !== null
         ? { ok: true, apiKey: params.apiKey }
-        : { ok: false, error: "missing auth" },
+        : { ok: true, apiKey: undefined, headers: undefined },
     );
+  const getProviderAuthStatusMock = vi.fn(() =>
+    params.providerAuthLabel
+      ? { configured: true, source: "models_json_key" as const, label: params.providerAuthLabel }
+      : { configured: false },
+  );
   const mockContext = createCompactionContext({
     sessionManager: params.sessionManager,
     getApiKeyAndHeadersMock,
+    getProviderAuthStatusMock,
   });
   const result = (await compactionHandler(params.event, mockContext)) as {
     cancel?: boolean;
@@ -183,7 +193,7 @@ async function runCompactionScenario(params: {
       tokensBefore: number;
     };
   };
-  return { result, getApiKeyAndHeadersMock };
+  return { result, getApiKeyAndHeadersMock, getProviderAuthStatusMock };
 }
 
 function expectCompactionResult(result: {
@@ -1990,6 +2000,35 @@ describe("compaction-safeguard extension model fallback", () => {
 
     // Verify early return: request auth should NOT have been resolved when both models are missing.
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("allows compaction for aws-sdk auth without apiKey or headers", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("aws-sdk compaction summary");
+
+    const mockEvent = createCompactionEvent({
+      messageText: "test message",
+      tokensBefore: 1000,
+    });
+    (mockEvent.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+    const { result, getApiKeyAndHeadersMock, getProviderAuthStatusMock } =
+      await runCompactionScenario({
+        sessionManager,
+        event: mockEvent,
+        apiKey: null,
+        providerAuthLabel: "aws-sdk",
+      });
+
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction).toBeDefined();
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
+    expect(getProviderAuthStatusMock).toHaveBeenCalledWith(model.provider);
   });
 });
 

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -339,6 +339,15 @@ async function resolveModelAuth(
     };
   }
   if (!requestAuth.apiKey && !requestAuth.headers) {
+    const providerAuthStatus = (
+      ctx.modelRegistry as unknown as {
+        getProviderAuthStatus?: (provider: string) => { configured: boolean; label?: string };
+      }
+    ).getProviderAuthStatus?.(model.provider);
+    if (providerAuthStatus?.label === "aws-sdk") {
+      return { ok: true };
+    }
+
     log.warn(
       "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
     );


### PR DESCRIPTION
## Summary

Fixes #90179.

When using AWS session-based credentials (e.g. `aws-sdk` auth mode), the compaction safeguard incorrectly cancelled compaction because `resolveModelAuth` found no `apiKey` or `headers`. AWS SDK auth uses the SDK credential chain rather than explicit API keys, so the absence of `apiKey`/`headers` is expected.

## Changes

- `src/agents/agent-hooks/compaction-safeguard.ts`: In `resolveModelAuth`, check `getProviderAuthStatus(model.provider)?.label === "aws-sdk"` before cancelling compaction when both `apiKey` and `headers` are absent.
- `src/agents/agent-hooks/compaction-safeguard.test.ts`: Added regression test verifying compaction proceeds for aws-sdk auth without apiKey or headers.

## Verification

- `npx vitest run src/agents/agent-hooks/compaction-safeguard.test.ts` — 192 passed

## Behavior addressed

Compaction fails with session-based AWS credentials (#90179).

## Real environment tested

Local vitest run.

## Exact steps or command run after this patch

```bash
npx vitest run src/agents/agent-hooks/compaction-safeguard.test.ts
```

## Evidence after fix

New regression test `allows compaction for aws-sdk auth without apiKey or headers` passes.

## Observed result after fix

Compaction no longer cancels for aws-sdk auth mode when `apiKey` and `headers` are missing.

## What was not tested

Live AWS credential chain integration; this fix is a runtime auth-check relaxation only.