### PR TITLE
fix(ui): accept short tweakcn theme ids

### DIFF
--- a/ui/src/ui/custom-theme.test.ts
+++ b/ui/src/ui/custom-theme.test.ts
@@ -82,6 +82,16 @@ describe("custom theme import helpers", () => {
       fetchUrl: "https://tweakcn.com/r/themes/cmlhfpjhw000004l4f4ax3m7z",
       themeId: "cmlhfpjhw000004l4f4ax3m7z",
     });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
+    expect(normalizeTweakcnThemeUrl("zinc")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/zinc",
+      fetchUrl: "https://tweakcn.com/r/themes/zinc",
+      themeId: "zinc",
+    });
   });
 
   it("extracts theme ids from copied tweakcn editor URLs and pasted text", () => {

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{3,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
Fixes #88987.

AI-assisted: yes, prepared with Codex.

## Summary

- Relax the tweakcn theme ID validator so built-in short names such as `claude` and `zinc` are accepted.
- Keep the existing tweakcn host/path normalization, registry fetch URL shape, first-character, character-set, and max-length guardrails.
- Add regression coverage for a short registry URL and a raw short theme ID.

## Root Cause

The custom theme importer required tweakcn theme IDs to be at least 8 characters long. tweakcn built-in theme names can be shorter, so valid links such as `https://tweakcn.com/r/themes/claude` and raw IDs such as `zinc` were rejected before import.

## Verification

- `./node_modules/.bin/vitest run --config test/vitest/vitest.ui.config.ts ui/src/ui/custom-theme.test.ts --reporter=verbose`
  - `Test Files  1 passed (1)`
  - `Tests  13 passed (13)`
- `git diff --check origin/main...HEAD`
  - exited 0

Note: I used the non-watch `vitest run` fallback because `node scripts/run-vitest.mjs ...` did not produce usable test evidence in this local Node setup, and the Node 26 path hit a native binding architecture mismatch.

## Real behavior proof

Behavior addressed: Short tweakcn built-in theme IDs such as `claude` and `zinc` now normalize successfully instead of throwing `Unsupported tweakcn link. Expected a theme share URL.`

Real environment tested: Local macOS Codex worktree on branch `fix/88987-tweakcn-short-theme-ids`, Node `v23.10.0`, Vitest `v4.1.7`.

Exact steps or command run after this patch: `./node_modules/.bin/vitest run --config test/vitest/vitest.ui.config.ts ui/src/ui/custom-theme.test.ts --reporter=verbose`

Evidence after fix: The focused test file passed with `Test Files  1 passed (1)` and `Tests  13 passed (13)`.

Observed result after fix: The regression cases normalize `https://tweakcn.com/r/themes/claude` to `https://tweakcn.com/r/themes/claude` for fetches and raw `zinc` to `https://tweakcn.com/r/themes/zinc`.

What was not tested: I did not run a full browser click-through import against the Control UI or the full `pnpm build && pnpm check && pnpm test` baseline.
