### PR TITLE
test: make qqbot symlinked media helper test robust on Windows

### DIFF
--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -112,7 +112,7 @@ describe("qqbot file-utils downloadFile", () => {
     expect(adapterMocks.fetchMedia).not.toHaveBeenCalled();
   });
 
-  it.skipIf(process.platform === "win32" ? !canCreateFileSymlinks : false)("rejects symlinked local media helpers", async () => {
+  it.skipIf(!canCreateFileSymlinks)("rejects symlinked local media helpers", async () => {
     const targetPath = path.join(tempDir, "target.png");
     const linkPath = path.join(tempDir, "link.png");
     await fs.promises.writeFile(targetPath, "image-bytes");

--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -4,6 +4,21 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const canCreateFileSymlinks = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-qqbot-symlink-probe-"));
+  const targetFile = path.join(probeDir, "target.txt");
+  const linkFile = path.join(probeDir, "link.txt");
+  try {
+    fs.writeFileSync(targetFile, "content");
+    fs.symlinkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 const adapterMocks = vi.hoisted(() => ({
   fetchMedia: vi.fn(),
 }));
@@ -97,7 +112,7 @@ describe("qqbot file-utils downloadFile", () => {
     expect(adapterMocks.fetchMedia).not.toHaveBeenCalled();
   });
 
-  it.skipIf(process.platform === "win32")("rejects symlinked local media helpers", async () => {
+  it.skipIf(process.platform === "win32" ? !canCreateFileSymlinks : false)("rejects symlinked local media helpers", async () => {
     const targetPath = path.join(tempDir, "target.png");
     const linkPath = path.join(tempDir, "link.png");
     await fs.promises.writeFile(targetPath, "image-bytes");

--- a/extensions/qqbot/src/engine/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/engine/utils/file-utils.test.ts
@@ -4,20 +4,24 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const canCreateFileSymlinks = (() => {
-  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-qqbot-symlink-probe-"));
+async function probeFileSymlinkCapability(): Promise<boolean> {
+  const probeDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "openclaw-qqbot-symlink-probe-"),
+  );
   const targetFile = path.join(probeDir, "target.txt");
   const linkFile = path.join(probeDir, "link.txt");
   try {
-    fs.writeFileSync(targetFile, "content");
-    fs.symlinkSync(targetFile, linkFile);
+    await fs.promises.writeFile(targetFile, "content");
+    await fs.promises.symlink(targetFile, linkFile);
     return true;
   } catch {
     return false;
   } finally {
-    fs.rmSync(probeDir, { recursive: true, force: true });
+    await fs.promises.rm(probeDir, { recursive: true, force: true });
   }
-})();
+}
+
+const canCreateFileSymlinks = await probeFileSymlinkCapability();
 
 const adapterMocks = vi.hoisted(() => ({
   fetchMedia: vi.fn(),


### PR DESCRIPTION
Replaces the hardcoded Windows skip in the QQ Bot file-utils test with a dynamic file-symlink capability check. If file symlinks are supported by the environment, the test executes. Otherwise, it skips gracefully while keeping coverage active on capable hosts.

### What Problem This Solves

The symlinked local-media helper test should reject symlinked media paths when the runtime can create file symlinks, but it should not fail the suite on Windows or restricted environments where file symlink creation is unavailable. Gating the test on actual capability avoids false negatives while preserving the security regression coverage where the behavior can be exercised.

### Evidence

- Windows Vitest proof from the contributor: `extensions/qqbot/src/engine/utils/file-utils.test.ts` completed with `1 passed` test file, `4 passed` tests, and `1 skipped` symlink test when file symlink creation was unavailable.
- The follow-up repair commit `cb7d5a162e24f7ec5be6985e97b2b74ae45b20f9` changes the probe to async `fs.promises` APIs and skips solely on `!canCreateFileSymlinks`, which addresses the stale Copilot comments about non-Windows restricted environments and synchronous import-time filesystem work.
- Current PR CI is otherwise green; the remaining failed check was the external-PR body proof gate requiring these authored sections.
