### PR TITLE
Fix Feishu quoted media attachments

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1324,6 +1324,72 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.SupplementalContext?.quote?.body).toBe("quoted content");
   });
 
+  it("attaches media from quoted image messages", async () => {
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_parent_image",
+      chatId: "oc-dm",
+      content: "[image message]",
+      rawContent: JSON.stringify({ image_key: "img_parent_payload" }),
+      contentType: "image",
+    });
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      buffer: Buffer.from("quoted-image"),
+      contentType: "image/jpeg",
+      fileName: "quoted-image.jpg",
+    });
+    mockSaveMediaBuffer.mockResolvedValueOnce({
+      id: "quoted-image.jpg",
+      path: "/tmp/quoted-image.jpg",
+      size: Buffer.byteLength("quoted-image"),
+      contentType: "image/jpeg",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-replier",
+        },
+      },
+      message: {
+        message_id: "om_reply_image",
+        parent_id: "om_parent_image",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "describe the quoted image" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const downloadRequest = mockCallArg<{
+      fileKey?: string;
+      messageId?: string;
+      type?: string;
+    }>(mockDownloadMessageResourceFeishu, 0, 0);
+    expect(downloadRequest.messageId).toBe("om_parent_image");
+    expect(downloadRequest.fileKey).toBe("img_parent_payload");
+    expect(downloadRequest.type).toBe("image");
+
+    const finalized = mockCallArg<{
+      MediaPaths?: string[];
+      MediaTypes?: string[];
+      SupplementalContext?: { quote?: { body?: string } };
+    }>(mockFinalizeInboundContext, 0, 0);
+    expect(finalized.MediaPaths).toEqual(["/tmp/quoted-image.jpg"]);
+    expect(finalized.MediaTypes).toEqual(["image/jpeg"]);
+    expect(finalized.SupplementalContext?.quote?.body).toBe("[image message]");
+  });
+
   it("uses message create_time as Timestamp instead of Date.now()", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -942,7 +942,7 @@ export async function handleFeishuMessage(params: {
 
     // Resolve media from message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default
-    const mediaList = await resolveFeishuMediaList({
+    let mediaList = await resolveFeishuMediaList({
       cfg,
       messageId: ctx.messageId,
       messageType: event.message.message_type,
@@ -951,15 +951,71 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
+
+    // Fetch quoted/replied message content if parentId exists
+    let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
+    let quotedContent: string | undefined;
+    if (ctx.parentId) {
+      try {
+        quotedMessageInfo = await getMessageFeishu({
+          cfg,
+          messageId: ctx.parentId,
+          accountId: account.accountId,
+        });
+        if (
+          quotedMessageInfo &&
+          (await shouldIncludeFetchedGroupContextMessage({
+            cfg,
+            accountId: account.accountId,
+            chatId: ctx.chatId,
+            isGroup,
+            allowFrom: effectiveGroupSenderAllowFrom,
+            mode: contextVisibilityMode,
+            kind: "quote",
+            senderId: quotedMessageInfo.senderId,
+            senderType: quotedMessageInfo.senderType,
+          }))
+        ) {
+          quotedContent = quotedMessageInfo.content;
+          log(
+            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+          );
+          if (quotedMessageInfo.rawContent) {
+            const quotedMediaList = await resolveFeishuMediaList({
+              cfg,
+              messageId: quotedMessageInfo.messageId || ctx.parentId,
+              messageType: quotedMessageInfo.contentType,
+              content: quotedMessageInfo.rawContent,
+              maxBytes: mediaMaxBytes,
+              log,
+              accountId: account.accountId,
+            });
+            if (quotedMediaList.length > 0) {
+              mediaList = [...mediaList, ...quotedMediaList];
+              log(
+                `feishu[${account.accountId}]: attached ${quotedMediaList.length} media item(s) from quoted message`,
+              );
+            }
+          }
+        } else if (quotedMessageInfo) {
+          log(
+            `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
+          );
+        }
+      } catch (err) {
+        log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
+      }
+    }
+
     // Skip messages with no text content and no media attachments. Feishu can
     // deliver empty-text events (e.g. `{"text":""}`) when a user sends a blank
     // message or when media parsing produces an empty string. Writing a blank
     // user turn to the session causes downstream LLM providers (e.g. MiniMax)
     // to reject the request with "messages must not be empty" errors. Logging
     // the skip avoids silent loss without polluting the agent session.
-    if (!ctx.content.trim() && mediaList.length === 0) {
+    if (!ctx.content.trim() && mediaList.length === 0 && !quotedContent?.trim()) {
       log(
-        `feishu[${account.accountId}]: skipping empty message (no text, no media) from ${ctx.senderOpenId}`,
+        `feishu[${account.accountId}]: skipping empty message (no text, no media, no quoted content) from ${ctx.senderOpenId}`,
       );
       return;
     }
@@ -1028,44 +1084,6 @@ export async function handleFeishuMessage(params: {
               })
             ).commandAccess.authorized
       : undefined;
-
-    // Fetch quoted/replied message content if parentId exists
-    let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
-    let quotedContent: string | undefined;
-    if (ctx.parentId) {
-      try {
-        quotedMessageInfo = await getMessageFeishu({
-          cfg,
-          messageId: ctx.parentId,
-          accountId: account.accountId,
-        });
-        if (
-          quotedMessageInfo &&
-          (await shouldIncludeFetchedGroupContextMessage({
-            cfg,
-            accountId: account.accountId,
-            chatId: ctx.chatId,
-            isGroup,
-            allowFrom: effectiveGroupSenderAllowFrom,
-            mode: contextVisibilityMode,
-            kind: "quote",
-            senderId: quotedMessageInfo.senderId,
-            senderType: quotedMessageInfo.senderType,
-          }))
-        ) {
-          quotedContent = quotedMessageInfo.content;
-          log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
-          );
-        } else if (quotedMessageInfo) {
-          log(
-            `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
-          );
-        }
-      } catch (err) {
-        log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
-      }
-    }
 
     const isTopicSessionForThread =
       isGroup &&

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -378,6 +378,7 @@ function parseFeishuMessageItem(
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
+    rawContent,
     contentType: msgType,
     createTime: parseStrictNonNegativeInteger(item.create_time),
     threadId: item.thread_id || undefined,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -71,6 +71,7 @@ export type FeishuMessageInfo = {
   senderOpenId?: string;
   senderType?: string;
   content: string;
+  rawContent?: string;
   contentType: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */


### PR DESCRIPTION
## Summary

Fix Feishu/Lark replies that quote an image or media message and mention the bot. The quoted message now preserves its raw Feishu content payload, so the bot can parse media keys from the quoted message and attach the downloaded resource to the current agent turn.

Fixes #90220

## Changes

- Preserve `rawContent` on `FeishuMessageInfo` returned by `getMessageFeishu()`.
- When a quoted message passes context visibility checks, resolve media from the quoted message id and raw content.
- Merge quoted media into the inbound media list before audio preflight and context finalization.
- Keep empty-message skipping aware of quoted text/media.
- Add regression coverage for `quoted image + @bot`.

## Validation

- `npx pnpm@11.2.2 exec vitest run extensions/feishu/src/bot.test.ts`
- `npx pnpm@11.2.2 exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/send.ts extensions/feishu/src/types.ts`
- `npx pnpm@11.2.2 tsgo:test:extensions`
