### PR TITLE
fix(agents): guard Anthropic tool schema conversion

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1258,6 +1258,69 @@ describe("anthropic transport stream", () => {
     });
   });
 
+  it("skips tools with unreadable schemas when building Anthropic payloads", async () => {
+    const unreadableTool = {
+      name: "bad_plugin_tool",
+      description: "unreadable schema",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+    };
+    Object.defineProperty(unreadableTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+    const unreadablePropertiesTool = {
+      name: "bad_nested_plugin_tool",
+      description: "unreadable nested schema",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      execute: async () => ({ content: [{ type: "text", text: "bad" }] }),
+    };
+    Object.defineProperty(unreadablePropertiesTool.parameters, "properties", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin properties getter exploded");
+      },
+    });
+
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          unreadableTool,
+          unreadablePropertiesTool,
+          {
+            name: "good_plugin_tool",
+            description: "valid schema",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+              required: ["query"],
+            },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const tools = requireArray(latestAnthropicRequest().payload.tools, "tools");
+    expect(tools).toHaveLength(1);
+    const tool = requireRecord(tools[0], "tool");
+    expect(tool.name).toBe("good_plugin_tool");
+  });
+
   it("coerces replayed malformed tool-call args to an object for Anthropic payloads", async () => {
     const model = makeAnthropicTransportModel({
       requestTransport: {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -490,24 +490,56 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   for (const tool of tools) {
     // Main quarantine happens when plugin tools materialize; this keeps Anthropic
     // safe for direct/custom tool arrays that bypass the plugin registry.
-    const parameters =
-      tool.parameters && typeof tool.parameters === "object" && !Array.isArray(tool.parameters)
-        ? (tool.parameters as Record<string, unknown>)
-        : undefined;
-    if (!parameters) {
+    const snapshot = readAnthropicToolSnapshot(tool);
+    if (!snapshot) {
       continue;
     }
     converted.push({
-      name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
-      description: tool.description,
+      name: isOAuthToken ? toClaudeCodeName(snapshot.name) : snapshot.name,
+      ...(snapshot.description !== undefined ? { description: snapshot.description } : {}),
       input_schema: {
         type: "object",
-        properties: parameters.properties || {},
-        required: parameters.required || [],
+        properties: snapshot.properties,
+        required: snapshot.required,
       },
     });
   }
   return converted;
+}
+
+type AnthropicToolSnapshot = {
+  name: string;
+  description?: string;
+  properties: unknown;
+  required: unknown;
+};
+
+function readAnthropicToolSnapshot(
+  tool: NonNullable<Context["tools"]>[number],
+): AnthropicToolSnapshot | undefined {
+  try {
+    const name = tool.name;
+    const parameters = tool.parameters;
+    if (
+      typeof name !== "string" ||
+      !name.trim() ||
+      !parameters ||
+      typeof parameters !== "object" ||
+      Array.isArray(parameters)
+    ) {
+      return undefined;
+    }
+    const description = typeof tool.description === "string" ? tool.description : undefined;
+    const record = parameters as Record<string, unknown>;
+    return {
+      name,
+      ...(description !== undefined ? { description } : {}),
+      properties: record.properties || {},
+      required: record.required || [],
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function parseAnthropicToolCallArguments(inputJson: string): unknown {


### PR DESCRIPTION
## Summary

- Guard Anthropic tool payload conversion with a single safely-read tool snapshot.
- Skip direct/custom tools whose top-level `parameters` descriptor or nested schema fields throw, while preserving valid sibling tools.
- Cover unreadable top-level and nested schema getters in the Anthropic transport tests.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next186-final1 nodenv exec node scripts/run-vitest.mjs run src/agents/anthropic-transport-stream.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Behavior addressed: Anthropic request construction could fail the whole payload build when one direct/custom tool exposed an unreadable schema descriptor or nested schema field.

Real environment tested: local linked OpenClaw worktree on Node via `nodenv`, rebased on current `origin/main`.

Exact steps or command run after this patch: full Anthropic transport Vitest file, targeted oxlint, diff whitespace check, and branch autoreview commands listed above.

Evidence after fix: Vitest passed 52 tests in `src/agents/anthropic-transport-stream.test.ts`; oxlint exited 0; `git diff --check` exited 0; autoreview reported no accepted/actionable findings and `overall: patch is correct (0.87)`.

Observed result after fix: bad Anthropic direct/custom tools are skipped when schema descriptors throw, and the valid sibling tool remains in the request payload.

What was not tested: broad `pnpm check:changed` could not run because `blacksmith testbox list --all` reported unauthenticated and AWS Crabbox returned coordinator 401 for `/v1/runs` and `/v1/leases`.
