### PR TITLE
fix(auto-reply): clear delivered pending final before abort

### DIFF
--- a/scripts/proof-89115-pending-final-delivery-abort.ts
+++ b/scripts/proof-89115-pending-final-delivery-abort.ts
@@ -1,0 +1,220 @@
+/**
+ * Real-runtime behavior proof for #89115.
+ *
+ * This script does NOT use Vitest mocks. It wires the production
+ * `dispatchReplyFromConfig` path to a real temporary sessions.json store and a
+ * concrete dispatcher. The dispatcher accepts final delivery, then aborts the
+ * turn in the post-send window that regressed in #89115.
+ *
+ * Run with:
+ *   pnpm tsx scripts/proof-89115-pending-final-delivery-abort.ts
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { dispatchReplyFromConfig } from "../src/auto-reply/reply/dispatch-from-config.js";
+import { finalizeInboundContext } from "../src/auto-reply/reply/inbound-context.js";
+import { resetInboundDedupe } from "../src/auto-reply/reply/inbound-dedupe.js";
+import type {
+  ReplyDispatchKind,
+  ReplyDispatcher,
+} from "../src/auto-reply/reply/reply-dispatcher.types.js";
+import type { ReplyPayload } from "../src/auto-reply/types.js";
+import { loadSessionStore } from "../src/config/sessions/store.js";
+import type { SessionEntry } from "../src/config/sessions/types.js";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import {
+  resetGlobalHookRunner,
+  initializeGlobalHookRunner,
+} from "../src/plugins/hook-runner-global.js";
+import { createEmptyPluginRegistry } from "../src/plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../src/plugins/runtime.js";
+
+const SESSION_KEY = "agent:proof89115:direct:post-send-abort";
+const FINAL_TEXT = "proof final delivered before abort";
+const PENDING_FINAL_KEYS = [
+  "pendingFinalDelivery",
+  "pendingFinalDeliveryText",
+  "pendingFinalDeliveryCreatedAt",
+  "pendingFinalDeliveryLastAttemptAt",
+  "pendingFinalDeliveryAttemptCount",
+  "pendingFinalDeliveryLastError",
+  "pendingFinalDeliveryContext",
+  "pendingFinalDeliveryIntentId",
+] as const satisfies readonly (keyof SessionEntry)[];
+
+type PendingFinalKey = (typeof PENDING_FINAL_KEYS)[number];
+type PendingFinalSnapshot = Partial<Record<PendingFinalKey, unknown>>;
+
+function assertProof(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`[proof-89115] ${message}`);
+  }
+}
+
+function projectPendingFields(entry: Partial<SessionEntry> | undefined): PendingFinalSnapshot {
+  const projected: PendingFinalSnapshot = {};
+  if (!entry) {
+    return projected;
+  }
+  for (const key of PENDING_FINAL_KEYS) {
+    if (Object.hasOwn(entry, key)) {
+      projected[key] = entry[key];
+    }
+  }
+  return projected;
+}
+
+function createAbortAfterFinalDispatcher(params: {
+  abortController: AbortController;
+  deliveredFinalPayloads: ReplyPayload[];
+}): ReplyDispatcher {
+  const counts: Record<ReplyDispatchKind, number> = { tool: 0, block: 0, final: 0 };
+  const failedCounts: Record<ReplyDispatchKind, number> = { tool: 0, block: 0, final: 0 };
+  const copyCounts = () => ({ ...counts });
+  return {
+    sendToolResult: () => {
+      counts.tool += 1;
+      return true;
+    },
+    sendBlockReply: () => {
+      counts.block += 1;
+      return true;
+    },
+    sendFinalReply: (payload) => {
+      counts.final += 1;
+      params.deliveredFinalPayloads.push(payload);
+      params.abortController.abort(new Error("proof abort after accepted final delivery"));
+      return true;
+    },
+    waitForIdle: async () => {},
+    getQueuedCounts: copyCounts,
+    getFailedCounts: () => ({ ...failedCounts }),
+    markComplete: () => {},
+  };
+}
+
+async function readRawStoreEntry(storePath: string): Promise<Partial<SessionEntry> | undefined> {
+  const raw = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+    string,
+    Partial<SessionEntry>
+  >;
+  return raw[SESSION_KEY];
+}
+
+async function main() {
+  resetInboundDedupe();
+  resetGlobalHookRunner();
+  resetPluginRuntimeStateForTest();
+  const emptyRegistry = createEmptyPluginRegistry();
+  setActivePluginRegistry(emptyRegistry, "proof-89115");
+  initializeGlobalHookRunner(emptyRegistry);
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-89115-"));
+  const storePath = path.join(tempDir, "sessions.json");
+  const beforeEntry: SessionEntry = {
+    sessionId: "proof-session",
+    updatedAt: 1,
+    chatType: "direct",
+    pendingFinalDelivery: true,
+    pendingFinalDeliveryText: FINAL_TEXT,
+    pendingFinalDeliveryCreatedAt: 2,
+    pendingFinalDeliveryLastAttemptAt: 3,
+    pendingFinalDeliveryAttemptCount: 4,
+    pendingFinalDeliveryLastError: "previous transient send failure",
+    pendingFinalDeliveryContext: {
+      channel: "proof",
+      to: "proof-user",
+      accountId: "default",
+    },
+    pendingFinalDeliveryIntentId: "intent-proof-89115",
+  };
+  await fs.writeFile(storePath, JSON.stringify({ [SESSION_KEY]: beforeEntry }, null, 2));
+
+  const cfg: OpenClawConfig = {
+    plugins: { enabled: false },
+    messages: { visibleReplies: "automatic" },
+    session: { store: storePath },
+  };
+  const ctx = finalizeInboundContext({
+    Body: "run proof",
+    BodyForAgent: "run proof",
+    BodyForCommands: "run proof",
+    ChatType: "direct",
+    CommandAuthorized: false,
+    From: "proof-user",
+    MessageSid: "proof-89115-message",
+    Provider: "proof",
+    SessionKey: SESSION_KEY,
+    Surface: "proof",
+  });
+  const abortController = new AbortController();
+  const deliveredFinalPayloads: ReplyPayload[] = [];
+  const dispatcher = createAbortAfterFinalDispatcher({
+    abortController,
+    deliveredFinalPayloads,
+  });
+
+  console.log("[proof-89115] Real-runtime dispatch proof for post-send abort cleanup.");
+  console.log(`[proof-89115] session store: ${storePath}`);
+  console.log(
+    `[proof-89115] before pending fields: ${JSON.stringify(projectPendingFields(beforeEntry))}`,
+  );
+
+  const result = await dispatchReplyFromConfig({
+    cfg,
+    ctx,
+    dispatcher,
+    replyOptions: {
+      abortSignal: abortController.signal,
+      runId: "proof-89115-run",
+    },
+    fastAbortResolver: async () => ({ handled: false, aborted: false }),
+    formatAbortReplyTextResolver: () => "abort",
+    replyResolver: async () => ({ text: FINAL_TEXT }),
+  });
+
+  const loadedAfterEntry = loadSessionStore(storePath, { skipCache: true })[SESSION_KEY];
+  const rawAfterEntry = await readRawStoreEntry(storePath);
+  const afterPending = projectPendingFields(loadedAfterEntry);
+  const rawAfterPending = projectPendingFields(rawAfterEntry);
+
+  console.log(`[proof-89115] delivered final payloads: ${JSON.stringify(deliveredFinalPayloads)}`);
+  console.log(`[proof-89115] abort signal after dispatch: ${abortController.signal.aborted}`);
+  console.log(`[proof-89115] dispatch result: ${JSON.stringify(result)}`);
+  console.log(
+    `[proof-89115] after pending fields (loadSessionStore): ${JSON.stringify(afterPending)}`,
+  );
+  console.log(`[proof-89115] after pending fields (raw JSON): ${JSON.stringify(rawAfterPending)}`);
+
+  assertProof(deliveredFinalPayloads.length === 1, "expected exactly one final delivery");
+  assertProof(
+    deliveredFinalPayloads[0]?.text === FINAL_TEXT,
+    "expected dispatcher to receive the final reply text",
+  );
+  assertProof(
+    abortController.signal.aborted,
+    "expected dispatcher to abort after accepting final delivery",
+  );
+  assertProof(
+    !result.queuedFinal,
+    "expected dispatch to surface the post-send abort as queuedFinal=false",
+  );
+  assertProof(result.counts.final === 1, "expected final dispatcher count to record delivery");
+  assertProof(
+    Object.keys(afterPending).length === 0,
+    "expected loaded session entry to have no pending final delivery fields",
+  );
+  assertProof(
+    Object.keys(rawAfterPending).length === 0,
+    "expected persisted sessions.json to have no pending final delivery fields",
+  );
+
+  console.log("[proof-89115] All runtime assertions passed.");
+}
+
+main().catch((err: unknown) => {
+  console.error("[proof-89115] FAILED:", err);
+  process.exitCode = 1;
+});

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -285,63 +285,95 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
   });
 
-  it.each([
-    ["cancelled", { cancelled: 1, failed: 0 }],
-    ["failed", { cancelled: 0, failed: 1 }],
-  ] as const)(
-    "preserves pending final delivery when accepted final dispatch is later %s",
-    async (_outcome, finalOutcome) => {
-      hookMocks.runner.hasHooks.mockReturnValue(false);
-      sessionStoreMocks.currentEntry = {
-        sessionKey: "agent:test:session",
-        pendingFinalDelivery: true,
-        pendingFinalDeliveryText: "durable reply",
-        pendingFinalDeliveryCreatedAt: 1,
-      };
-      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
-        existing: sessionStoreMocks.currentEntry,
-      });
-      const dispatcher = createDispatcher();
-      let cancelledFinal = 0;
-      let failedFinal = 0;
-      let sentFinal = false;
-      dispatcher.getCancelledCounts = vi.fn(() => ({
-        tool: 0,
-        block: 0,
-        final: cancelledFinal,
-      }));
-      vi.mocked(dispatcher.getFailedCounts).mockImplementation(() => ({
-        tool: 0,
-        block: 0,
-        final: failedFinal,
-      }));
-      vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
-        sentFinal = true;
-        return true;
-      });
-      vi.mocked(dispatcher.waitForIdle).mockImplementation(async () => {
-        if (sentFinal) {
-          cancelledFinal = finalOutcome.cancelled;
-          failedFinal = finalOutcome.failed;
-        }
-      });
+  it("preserves pending final delivery when accepted final dispatch later fails", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+    let failedFinal = 0;
+    let sentFinal = false;
+    vi.mocked(dispatcher.getFailedCounts).mockImplementation(() => ({
+      tool: 0,
+      block: 0,
+      final: failedFinal,
+    }));
+    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+      sentFinal = true;
+      return true;
+    });
+    vi.mocked(dispatcher.waitForIdle).mockImplementation(async () => {
+      if (sentFinal) {
+        failedFinal = 1;
+      }
+    });
 
-      const result = await dispatchReplyFromConfig({
-        ctx: createHookCtx(),
-        cfg: emptyConfig,
-        dispatcher,
-        replyResolver: async () => ({ text: "durable reply" }),
-      });
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
 
-      expect(result.queuedFinal).toBe(true);
-      expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
-      expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
-      expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
-      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
-      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
-      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
-    },
-  );
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
+    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+  });
+
+  it("clears pending final delivery when accepted final dispatch is intentionally cancelled", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+    let cancelledFinal = 0;
+    let sentFinal = false;
+    dispatcher.getCancelledCounts = vi.fn(() => ({
+      tool: 0,
+      block: 0,
+      final: cancelledFinal,
+    }));
+    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+      sentFinal = true;
+      return true;
+    });
+    vi.mocked(dispatcher.waitForIdle).mockImplementation(async () => {
+      if (sentFinal) {
+        cancelledFinal = 1;
+      }
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+  });
 
   it("clears pending final delivery when only earlier queued final dispatch failed", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(false);

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -187,6 +187,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       pendingFinalDeliveryAttemptCount: 3,
       pendingFinalDeliveryLastError: "previous failure",
       pendingFinalDeliveryContext: { source: "heartbeat" },
+      pendingFinalDeliveryIntentId: "intent-1",
     };
     sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
       existing: sessionStoreMocks.currentEntry,
@@ -209,6 +210,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
   });
 
   it("clears pending final delivery when abort arrives after final dispatch succeeds", async () => {
@@ -222,6 +224,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       pendingFinalDeliveryAttemptCount: 3,
       pendingFinalDeliveryLastError: "previous failure",
       pendingFinalDeliveryContext: { source: "heartbeat" },
+      pendingFinalDeliveryIntentId: "intent-1",
     };
     sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
       existing: sessionStoreMocks.currentEntry,
@@ -251,6 +254,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
   });
 
   it("preserves pending final delivery when final dispatch fails", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -284,4 +284,107 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
   });
+
+  it.each([
+    ["cancelled", { cancelled: 1, failed: 0 }],
+    ["failed", { cancelled: 0, failed: 1 }],
+  ] as const)(
+    "preserves pending final delivery when accepted final dispatch is later %s",
+    async (_outcome, finalOutcome) => {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "durable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const dispatcher = createDispatcher();
+      let cancelledFinal = 0;
+      let failedFinal = 0;
+      let sentFinal = false;
+      dispatcher.getCancelledCounts = vi.fn(() => ({
+        tool: 0,
+        block: 0,
+        final: cancelledFinal,
+      }));
+      vi.mocked(dispatcher.getFailedCounts).mockImplementation(() => ({
+        tool: 0,
+        block: 0,
+        final: failedFinal,
+      }));
+      vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+        sentFinal = true;
+        return true;
+      });
+      vi.mocked(dispatcher.waitForIdle).mockImplementation(async () => {
+        if (sentFinal) {
+          cancelledFinal = finalOutcome.cancelled;
+          failedFinal = finalOutcome.failed;
+        }
+      });
+
+      const result = await dispatchReplyFromConfig({
+        ctx: createHookCtx(),
+        cfg: emptyConfig,
+        dispatcher,
+        replyResolver: async () => ({ text: "durable reply" }),
+      });
+
+      expect(result.queuedFinal).toBe(true);
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+      expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
+      expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+    },
+  );
+
+  it("clears pending final delivery when only earlier queued final dispatch failed", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+    let sentFinal = false;
+    let failedFinal = 0;
+    vi.mocked(dispatcher.getFailedCounts).mockImplementation(() => ({
+      tool: 0,
+      block: 0,
+      final: failedFinal,
+    }));
+    vi.mocked(dispatcher.waitForIdle).mockImplementation(async () => {
+      if (!sentFinal) {
+        failedFinal = 1;
+      }
+    });
+    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+      sentFinal = true;
+      return true;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -211,6 +211,48 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
   });
 
+  it("clears pending final delivery when abort arrives after final dispatch succeeds", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryLastAttemptAt: 2,
+      pendingFinalDeliveryAttemptCount: 3,
+      pendingFinalDeliveryLastError: "previous failure",
+      pendingFinalDeliveryContext: { source: "heartbeat" },
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const abortController = new AbortController();
+    const dispatcher = createDispatcher();
+    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+      abortController.abort();
+      return true;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { abortSignal: abortController.signal },
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+  });
+
   it("preserves pending final delivery when final dispatch fails", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(false);
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -8426,7 +8426,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     expect(result.queuedFinal).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(sourceReply);
-    expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(1);
+    expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(2);
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -718,6 +718,7 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
         pendingFinalDeliveryAttemptCount: undefined,
         pendingFinalDeliveryLastError: undefined,
         pendingFinalDeliveryContext: undefined,
+        pendingFinalDeliveryIntentId: undefined,
         updatedAt: Date.now(),
       };
     },

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2868,11 +2868,13 @@ export async function dispatchReplyFromConfig(
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
-      throwIfDispatchOperationAborted();
+      // Final delivery already succeeded; clear durable pending state before
+      // surfacing a later abort so successful replies cannot strand sessions.
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
       });
+      throwIfDispatchOperationAborted();
     }
 
     if (!suppressDelivery) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2008,7 +2008,11 @@ export async function dispatchReplyFromConfig(
     const sendFinalPayload = async (
       payload: ReplyPayload,
       options: { abortSignal?: AbortSignal } = {},
-    ): Promise<{ queuedFinal: boolean; deliveredFinal: boolean; routedFinalCount: number }> => {
+    ): Promise<{
+      queuedFinal: boolean;
+      completedFinalDeliveryAttempt: boolean;
+      routedFinalCount: number;
+    }> => {
       const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
       const throwIfFinalDeliveryAborted = () => {
         if (abortSignal?.aborted) {
@@ -2054,7 +2058,7 @@ export async function dispatchReplyFromConfig(
         }
         return {
           queuedFinal: result.ok,
-          deliveredFinal: isRoutedReplyDelivered(result),
+          completedFinalDeliveryAttempt: result.ok,
           routedFinalCount: isRoutedReplyDelivered(result) ? 1 : 0,
         };
       }
@@ -2068,7 +2072,7 @@ export async function dispatchReplyFromConfig(
         metadata: sourceReplyTranscriptMirror,
       });
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
-      let deliveredFinal = queuedFinal;
+      let completedFinalDeliveryAttempt = queuedFinal;
       if (queuedFinal) {
         await mirrorInternalSourceReplyAfterDispatcherDelivery({
           dispatcher,
@@ -2077,13 +2081,11 @@ export async function dispatchReplyFromConfig(
           cfg,
         });
         const finalOutcomeAfter = getDispatcherFinalOutcomeCounts(dispatcher);
-        deliveredFinal =
-          finalOutcomeAfter.cancelled <= finalOutcomeBefore.cancelled &&
-          finalOutcomeAfter.failed <= finalOutcomeBefore.failed;
+        completedFinalDeliveryAttempt = finalOutcomeAfter.failed <= finalOutcomeBefore.failed;
       }
       return {
         queuedFinal,
-        deliveredFinal,
+        completedFinalDeliveryAttempt,
         routedFinalCount: 0,
       };
     };
@@ -2872,7 +2874,7 @@ export async function dispatchReplyFromConfig(
       const finalReply = await sendFinalPayload(reply);
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
-      if (!finalReply.deliveredFinal) {
+      if (!finalReply.completedFinalDeliveryAttempt) {
         finalDeliveryFailed = true;
       }
     }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2008,7 +2008,7 @@ export async function dispatchReplyFromConfig(
     const sendFinalPayload = async (
       payload: ReplyPayload,
       options: { abortSignal?: AbortSignal } = {},
-    ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
+    ): Promise<{ queuedFinal: boolean; deliveredFinal: boolean; routedFinalCount: number }> => {
       const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
       const throwIfFinalDeliveryAborted = () => {
         if (abortSignal?.aborted) {
@@ -2054,17 +2054,21 @@ export async function dispatchReplyFromConfig(
         }
         return {
           queuedFinal: result.ok,
+          deliveredFinal: isRoutedReplyDelivered(result),
           routedFinalCount: isRoutedReplyDelivered(result) ? 1 : 0,
         };
       }
       throwIfFinalDeliveryAborted();
       markInboundDedupeReplayUnsafe();
+      await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+      throwIfFinalDeliveryAborted();
       const finalOutcomeBefore = getDispatcherFinalOutcomeCounts(dispatcher);
       const deliveredSourceReplyTranscriptMirror = captureDeliveredSourceReplyTranscriptMirror({
         dispatcher,
         metadata: sourceReplyTranscriptMirror,
       });
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
+      let deliveredFinal = queuedFinal;
       if (queuedFinal) {
         await mirrorInternalSourceReplyAfterDispatcherDelivery({
           dispatcher,
@@ -2072,9 +2076,14 @@ export async function dispatchReplyFromConfig(
           metadata: deliveredSourceReplyTranscriptMirror,
           cfg,
         });
+        const finalOutcomeAfter = getDispatcherFinalOutcomeCounts(dispatcher);
+        deliveredFinal =
+          finalOutcomeAfter.cancelled <= finalOutcomeBefore.cancelled &&
+          finalOutcomeAfter.failed <= finalOutcomeBefore.failed;
       }
       return {
         queuedFinal,
+        deliveredFinal,
         routedFinalCount: 0,
       };
     };
@@ -2863,7 +2872,7 @@ export async function dispatchReplyFromConfig(
       const finalReply = await sendFinalPayload(reply);
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
-      if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {
+      if (!finalReply.deliveredFinal) {
         finalDeliveryFailed = true;
       }
     }


### PR DESCRIPTION
## Summary

- Clear durable `pendingFinalDelivery` state immediately after a final reply is successfully delivered.
- Also clear `pendingFinalDeliveryIntentId` with the rest of the pending-final retry fields, matching the existing agent-command cleanup shape.
- Surface a post-delivery dispatch abort only after cleanup completes, so cancellation reporting is preserved without stranding session state.
- Preserve durable pending-final retry state when an accepted final dispatch later reports a failed final outcome.
- Add focused regression coverage plus a real-runtime proof script for the post-send abort window.

Fixes #89115.
Related: #89344.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/check-no-conflict-markers.mjs scripts/proof-89115-pending-final-delivery-abort.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 scripts/proof-89115-pending-final-delivery-abort.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.test.ts`
- `./node_modules/.bin/tsx scripts/proof-89115-pending-final-delivery-abort.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/proof-89115-pending-final-delivery-abort.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: In the final-dispatch success path, an abort that arrived after a successful final send but before `clearPendingFinalDeliveryAfterSuccess()` could leave `pendingFinalDelivery` and its durable retry fields set. That made the reply visible to the user while later inbound work could still be blocked by stale pending-final state. This update proves the post-send abort window, clears `pendingFinalDeliveryIntentId` with the rest of the durable pending-final fields, and preserves retry state when an accepted final dispatch later reports a failed final outcome.

Real environment tested: Local OpenClaw source checkout on macOS arm64 (`Darwin arm64`) with Node `v24.8.0`, at head `19703eb62ee3563907ee1039a867b3d60034e715`. The proof script uses production `dispatchReplyFromConfig()`, real `updateSessionStoreEntry()`/`loadSessionStore()` against an actual temporary `sessions.json`, a real empty plugin registry/hook runner, and a concrete dispatcher; it does not use Vitest mocks.

Exact steps or command run after this patch:

```sh
git diff --check origin/main...HEAD
node scripts/check-no-conflict-markers.mjs scripts/proof-89115-pending-final-delivery-abort.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
./node_modules/.bin/oxfmt --check --threads=1 scripts/proof-89115-pending-final-delivery-abort.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.test.ts
./node_modules/.bin/tsx scripts/proof-89115-pending-final-delivery-abort.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/proof-89115-pending-final-delivery-abort.ts
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix:

```text
[proof-89115] Real-runtime dispatch proof for post-send abort cleanup.
[proof-89115] session store: [tmp]/openclaw-proof-89115-lx1lgs/sessions.json
[proof-89115] before pending fields: {"pendingFinalDelivery":true,"pendingFinalDeliveryText":"proof final delivered before abort","pendingFinalDeliveryCreatedAt":2,"pendingFinalDeliveryLastAttemptAt":3,"pendingFinalDeliveryAttemptCount":4,"pendingFinalDeliveryLastError":"previous transient send failure","pendingFinalDeliveryContext":{"channel":"proof","to":"proof-user","accountId":"default"},"pendingFinalDeliveryIntentId":"intent-proof-89115"}
[proof-89115] delivered final payloads: [{"text":"proof final delivered before abort"}]
[proof-89115] abort signal after dispatch: true
[proof-89115] dispatch result: {"queuedFinal":false,"counts":{"tool":0,"block":0,"final":1}}
[proof-89115] after pending fields (loadSessionStore): {}
[proof-89115] after pending fields (raw JSON): {}
[proof-89115] All runtime assertions passed.

node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts:
Test Files  1 passed (1)
Tests  8 passed (8)

node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts:
Test Files  1 passed (1)
Tests  191 passed (191)

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/proof-89115-pending-final-delivery-abort.ts: passed

git diff --check origin/main...HEAD: no output
node scripts/check-no-conflict-markers.mjs ...: no output

All matched files use the correct format.
Finished in 33ms on 3 files using 1 threads.
All matched files use the correct format.
Finished in 28ms on 1 files using 1 threads.

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

Observed result after fix: The proof script seeds a real `sessions.json` entry with `pendingFinalDelivery`, pending text, timestamps, attempt count, last error, delivery context, and `pendingFinalDeliveryIntentId`. The dispatcher accepts the final payload once, then aborts immediately in the post-send window. `dispatchReplyFromConfig()` returns through the existing aborted-dispatch path (`queuedFinal:false`) while preserving the accepted final count (`final:1`), and both `loadSessionStore()` and raw persisted JSON show no pending-final fields left afterward. The focused regression tests also cover the failed-final retry path, the intentional-cancellation cleanup path, and the existing internal source-reply cancellation path from the wider auto-reply dispatch shard.

What was not tested: A live external channel transport under production load. The deterministic proof targets the exact race window at the dispatch boundary with production dispatch/session-store code and a concrete dispatcher that models an accepted channel final delivery followed by post-send abort.

