### PR TITLE
fix(gateway): repair Ollama dense stream — preserve replacement stream deltas and rich tool call deltas

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-75896ec73db4dca59a9c1617059012fe85c2c82e1bb1260a47903c14b7ca2fbc  plugin-sdk-api-baseline.json
-51a9c6da283082854fa515c1e67b91c71ae8972b6fe01d404d31ac8ca34b583f  plugin-sdk-api-baseline.jsonl
+864fd6fc09b5e49f6c525cb449c68bbd1826dc480fcd78940975fa306f683563  plugin-sdk-api-baseline.json
+0d8e8baf61841c5514ec0df44bb1ac252a64f53ca97d5d4da9eeebd3cc89d273  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e4b9e86867fe7d3bcfefcf80b5bad3f02e41f00e390d6db4f9846ce6fdbc5db7  plugin-sdk-api-baseline.json
-d1e3e865a6b5c2ae776537f260690c0558bdbe04e727c4d60950cfc31ac826d9  plugin-sdk-api-baseline.jsonl
+75896ec73db4dca59a9c1617059012fe85c2c82e1bb1260a47903c14b7ca2fbc  plugin-sdk-api-baseline.json
+51a9c6da283082854fa515c1e67b91c71ae8972b6fe01d404d31ac8ca34b583f  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-2995e7aca9366a6482f2708d8596afd552ed7061e23a17e748d23799b5c1e319  plugin-sdk-api-baseline.json
-56aab8ffb5f34385c4746ddaab92b3ce701f84c0467acc53cd68049acd4aeb4e  plugin-sdk-api-baseline.jsonl
+e4b9e86867fe7d3bcfefcf80b5bad3f02e41f00e390d6db4f9846ce6fdbc5db7  plugin-sdk-api-baseline.json
+d1e3e865a6b5c2ae776537f260690c0558bdbe04e727c4d60950cfc31ac826d9  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -376,6 +376,14 @@ API key auth, and dynamic model resolution.
       - `openclaw/plugin-sdk/provider-stream` - `ProviderStreamFamily`, `buildProviderStreamFamilyHooks(...)`, `composeProviderStreamWrappers(...)`, plus the shared OpenAI/Codex wrappers (`createOpenAIAttributionHeadersWrapper`, `createOpenAIFastModeWrapper`, `createOpenAIServiceTierWrapper`, `createOpenAIResponsesContextManagementWrapper`, `createCodexNativeWebSearchWrapper`), DeepSeek V4 OpenAI-compatible wrapper (`createDeepSeekV4OpenAICompatibleThinkingWrapper`), Anthropic Messages thinking prefill cleanup (`createAnthropicThinkingPrefillPayloadWrapper`), plain-text tool-call compat (`createPlainTextToolCallCompatWrapper`), and shared proxy/provider wrappers (`createOpenRouterWrapper`, `createToolStreamWrapper`, `createMinimaxFastModeWrapper`).
       - `openclaw/plugin-sdk/provider-tools` - `ProviderToolCompatFamily`, `buildProviderToolCompatFamilyHooks("deepseek" | "gemini" | "openai")`, and underlying provider schema helpers.
 
+      Stream implementations can use `createAssistantStreamAccumulator(...)`
+      from `openclaw/plugin-sdk/provider-stream-shared` when they need to
+      convert upstream chunks into OpenClaw assistant stream events. Delta
+      events should be consumed through `delta`; `partial` on delta events may
+      be lightweight, while boundary events and terminal events carry the full
+      assistant message. A `text_delta` with `replace: true` carries corrected
+      full visible text instead of an append-only suffix.
+
       Some stream helpers stay provider-local on purpose. `@openclaw/anthropic-provider` keeps `wrapAnthropicProviderStream`, `resolveAnthropicBetas`, `resolveAnthropicFastMode`, `resolveAnthropicServiceTier`, and the lower-level Anthropic wrapper builders in its own public `api.ts` / `contract-api.ts` seam because they encode Claude OAuth beta handling and `context1m` gating. The xAI plugin similarly keeps native xAI Responses shaping in its own `wrapStreamFn` (`/fast` aliases, default `tool_stream`, unsupported strict-tool cleanup, xAI-specific reasoning-payload removal).
 
       The same package-root pattern also backs `@openclaw/openai-provider` (provider builders, default-model helpers, realtime provider builders) and `@openclaw/openrouter-provider` (provider builder plus onboarding/config helpers).

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -161,7 +161,7 @@ and pairing-path families.
     | `plugin-sdk/provider-tools` | `ProviderToolCompatFamily`, `buildProviderToolCompatFamilyHooks`, and DeepSeek/Gemini/OpenAI schema cleanup + diagnostics |
     | `plugin-sdk/provider-usage` | `fetchClaudeUsage` and similar |
     | `plugin-sdk/provider-stream` | `ProviderStreamFamily`, `buildProviderStreamFamilyHooks`, `composeProviderStreamWrappers`, stream wrapper types, plain-text tool-call compat, and shared Anthropic/Bedrock/DeepSeek V4/Google/Kilocode/Moonshot/OpenAI/OpenRouter/Z.A.I/MiniMax/Copilot wrapper helpers |
-    | `plugin-sdk/provider-stream-shared` | Public shared provider stream wrapper helpers including `composeProviderStreamWrappers`, `createPlainTextToolCallCompatWrapper`, `createPayloadPatchStreamWrapper`, `createToolStreamWrapper`, and Anthropic/DeepSeek/OpenAI-compatible stream utilities |
+    | `plugin-sdk/provider-stream-shared` | Public shared provider stream wrapper helpers including `composeProviderStreamWrappers`, `createAssistantStreamAccumulator`, `createPlainTextToolCallCompatWrapper`, `createPayloadPatchStreamWrapper`, `createToolStreamWrapper`, and Anthropic/DeepSeek/OpenAI-compatible stream utilities |
     | `plugin-sdk/provider-transport-runtime` | Native provider transport helpers such as guarded fetch, transport message transforms, and writable transport event streams |
     | `plugin-sdk/provider-onboard` | Onboarding config patch helpers |
     | `plugin-sdk/global-singleton` | Process-local singleton/map/cache helpers |

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1376,6 +1376,34 @@ describe("parseNdjsonStream", () => {
     expect(chunks[2].done).toBe(true);
   });
 
+  it("cooperatively yields while parsing dense buffered chunks", async () => {
+    const reader = mockNdjsonReader(
+      Array.from(
+        { length: 25 },
+        (_value, index) =>
+          `{"model":"m","created_at":"t","message":{"role":"assistant","content":"${String(
+            index,
+          )}"},"done":false}`,
+      ),
+    );
+    let timerFired = false;
+    setTimeout(() => {
+      timerFired = true;
+    }, 0);
+
+    let count = 0;
+    for await (const chunk of parseNdjsonStream(reader, { yieldEveryLines: 10 })) {
+      void chunk;
+      count += 1;
+      if (count > 10) {
+        break;
+      }
+    }
+
+    expect(count).toBe(11);
+    expect(timerFired).toBe(true);
+  });
+
   it("parses tool_calls from intermediate chunk (not final)", async () => {
     // Ollama sends tool_calls in done:false chunk, final done:true has no tool_calls
     const reader = mockNdjsonReader([

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1628,15 +1628,15 @@ describe("createOllamaStreamFn streaming events", () => {
         expect(textEnd?.contentIndex).toBe(0);
         expect(textEnd?.content).toBe("Hello world");
 
-        // start/text_start carry empty partials (before any content accumulates)
+        // start is empty; text_start opens the text block before any text accumulates.
         const startEvent = events.find((e) => e.type === "start");
         expect(startEvent?.partial.content).toStrictEqual([]);
         const textStartEvent = events.find((e) => e.type === "text_start");
-        expect(textStartEvent?.partial.content).toStrictEqual([]);
+        expect(textStartEvent?.partial.content).toStrictEqual([{ type: "text", text: "" }]);
 
-        // text_delta partials accumulate content progressively
-        expect(deltas[0].partial.content).toEqual([{ type: "text", text: "Hello" }]);
-        expect(deltas[1].partial.content).toEqual([{ type: "text", text: "Hello world" }]);
+        // text_delta events carry lightweight partials; text_end/done carry full content.
+        expect(deltas[0].partial.content).toEqual([]);
+        expect(deltas[1].partial.content).toEqual([]);
 
         // done event contains the final message
         const doneEvent = events.at(-1);
@@ -2101,14 +2101,14 @@ describe("createOllamaStreamFn streaming events", () => {
         expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
 
         const textStart = events.find((e) => e.type === "text_start");
-        expect(textStart?.partial.content).toEqual([]);
+        expect(textStart?.partial.content).toEqual([{ type: "text", text: "" }]);
         const delta = events.find((e) => e.type === "text_delta");
         expect(delta?.delta).toBe("one shot");
       },
     );
   });
 
-  it("sanitizes Kimi inline reasoning in text_delta, text_end, partial, and done output", async () => {
+  it("sanitizes Kimi inline reasoning in text_delta, text_end, and done output", async () => {
     await withMockNdjsonFetch(
       [
         JSON.stringify({
@@ -2146,13 +2146,13 @@ describe("createOllamaStreamFn streaming events", () => {
         ]);
 
         const textStart = events.find((e) => e.type === "text_start");
-        expect(textStart?.partial.content).toEqual([]);
+        expect(textStart?.partial.content).toEqual([{ type: "text", text: "" }]);
         const deltas = events.filter((e) => e.type === "text_delta");
         expect(deltas).toHaveLength(2);
         expect(deltas[0]?.delta).toBe("Final answer");
         expect(deltas[1]?.delta).toBe(" only.");
-        expect(deltas[0]?.partial.content).toEqual([{ type: "text", text: "Final answer" }]);
-        expect(deltas[1]?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
+        expect(deltas[0]?.partial.content).toEqual([]);
+        expect(deltas[1]?.partial.content).toEqual([]);
 
         const textEnd = events.find((e) => e.type === "text_end");
         expect(textEnd?.content).toBe("Final answer only.");

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -480,6 +480,7 @@ type OllamaUsageFallback = {
 };
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
+const NDJSON_PARSE_YIELD_INTERVAL = 100;
 
 function buildUsageWithNoCost(params: {
   input?: number;
@@ -1018,11 +1019,28 @@ export function buildAssistantMessage(
   });
 }
 
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 export async function* parseNdjsonStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  options: { yieldEveryLines?: number } = {},
 ): AsyncGenerator<OllamaChatResponse> {
   const decoder = new TextDecoder();
   let buffer = "";
+  let parsedLines = 0;
+  const yieldEveryLines = Math.max(
+    1,
+    Math.floor(options.yieldEveryLines ?? NDJSON_PARSE_YIELD_INTERVAL),
+  );
+
+  const yieldAfterParsedLine = async () => {
+    parsedLines += 1;
+    if (parsedLines % yieldEveryLines === 0) {
+      await yieldToEventLoop();
+    }
+  };
 
   while (true) {
     const { done, value } = await reader.read();
@@ -1040,6 +1058,7 @@ export async function* parseNdjsonStream(
       }
       try {
         yield parseJsonPreservingUnsafeIntegers(trimmed) as OllamaChatResponse;
+        await yieldAfterParsedLine();
       } catch {
         log.warn(`Skipping malformed NDJSON line: ${trimmed.slice(0, 120)}`);
       }
@@ -1049,6 +1068,7 @@ export async function* parseNdjsonStream(
   if (buffer.trim()) {
     try {
       yield parseJsonPreservingUnsafeIntegers(buffer.trim()) as OllamaChatResponse;
+      await yieldAfterParsedLine();
     } catch {
       log.warn(`Skipping malformed trailing data: ${buffer.trim().slice(0, 120)}`);
     }

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -376,19 +376,22 @@ function resolveOllamaTopLevelParams(
   return Object.keys(requestParams).length > 0 ? requestParams : undefined;
 }
 
-function resolveStreamingTextDelta(previousText: string, nextText: string): string {
+function resolveStreamingTextDelta(
+  previousText: string,
+  nextText: string,
+): { delta: string; replace: boolean } {
   if (!nextText) {
-    return "";
+    return { delta: "", replace: false };
   }
   if (!previousText) {
-    return nextText;
+    return { delta: nextText, replace: false };
   }
   if (nextText.startsWith(previousText)) {
-    return nextText.slice(previousText.length);
+    return { delta: nextText.slice(previousText.length), replace: false };
   }
   // Sanitizers may rewrite previously accumulated content. Fall back to
   // re-emitting the latest complete text so downstream partial state converges.
-  return nextText;
+  return { delta: nextText, replace: true };
 }
 
 export function createConfiguredOllamaCompatStreamWrapper(
@@ -1227,7 +1230,10 @@ function createRawOllamaStreamFn(
               return;
             }
             const previousVisibleContent = accumulatedVisibleContent;
-            const delta = resolveStreamingTextDelta(previousVisibleContent, nextVisibleContent);
+            const { delta, replace } = resolveStreamingTextDelta(
+              previousVisibleContent,
+              nextVisibleContent,
+            );
             if (!delta) {
               return;
             }
@@ -1245,7 +1251,7 @@ function createRawOllamaStreamFn(
             }
 
             accumulatedVisibleContent = nextVisibleContent;
-            stream.push(streamAccumulator.appendTextDelta(textContentIndex(), delta));
+            stream.push(streamAccumulator.appendTextDelta(textContentIndex(), delta, { replace }));
           };
 
           const resolveVisibleContent = (final: boolean): string | undefined => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -22,6 +22,7 @@ import {
   normalizeProviderId,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  createAssistantStreamAccumulator,
   createMoonshotThinkingWrapper,
   createPlainTextToolCallCompatWrapper,
   resolveMoonshotThinkingType,
@@ -1189,6 +1190,15 @@ function createRawOllamaStreamFn(
           let pendingFinalVisibleContent: string | undefined;
           const modelInfo = { api: model.api, provider: model.provider, id: model.id };
           const visibleContentSanitizer = createOllamaVisibleContentSanitizer(model.id);
+          const streamAccumulator = createAssistantStreamAccumulator({
+            model: {
+              api: modelInfo.api,
+              provider: modelInfo.provider,
+              model: modelInfo.id,
+            },
+            usage: buildUsageWithNoCost({}),
+            deltaPartialMode: "empty",
+          });
           let streamStarted = false;
           let thinkingStarted = false;
           let thinkingEnded = false;
@@ -1196,37 +1206,12 @@ function createRawOllamaStreamFn(
           let textBlockClosed = false;
           const textContentIndex = () => (thinkingStarted ? 1 : 0);
 
-          const buildCurrentContent = (): (TextContent | ThinkingContent | ToolCall)[] => {
-            const parts: (TextContent | ThinkingContent | ToolCall)[] = [];
-            if (accumulatedThinking) {
-              parts.push({
-                type: "thinking",
-                thinking: accumulatedThinking,
-              });
-            }
-            if (accumulatedVisibleContent) {
-              parts.push({ type: "text", text: accumulatedVisibleContent });
-            }
-            return parts;
-          };
-
           const closeThinkingBlock = () => {
             if (!thinkingStarted || thinkingEnded) {
               return;
             }
             thinkingEnded = true;
-            const partial = buildStreamAssistantMessage({
-              model: modelInfo,
-              content: buildCurrentContent(),
-              stopReason: "stop",
-              usage: buildUsageWithNoCost({}),
-            });
-            stream.push({
-              type: "thinking_end",
-              contentIndex: 0,
-              content: accumulatedThinking,
-              partial,
-            });
+            stream.push(streamAccumulator.endThinking(0));
           };
 
           const closeTextBlock = () => {
@@ -1234,18 +1219,7 @@ function createRawOllamaStreamFn(
               return;
             }
             textBlockClosed = true;
-            const partial = buildStreamAssistantMessage({
-              model: modelInfo,
-              content: buildCurrentContent(),
-              stopReason: "stop",
-              usage: buildUsageWithNoCost({}),
-            });
-            stream.push({
-              type: "text_end",
-              contentIndex: textContentIndex(),
-              content: accumulatedVisibleContent,
-              partial,
-            });
+            stream.push(streamAccumulator.endText(textContentIndex()));
           };
 
           const flushVisibleText = (nextVisibleContent: string | undefined) => {
@@ -1263,38 +1237,15 @@ function createRawOllamaStreamFn(
 
             if (!streamStarted) {
               streamStarted = true;
-              const emptyPartial = buildStreamAssistantMessage({
-                model: modelInfo,
-                content: [],
-                stopReason: "stop",
-                usage: buildUsageWithNoCost({}),
-              });
-              stream.push({ type: "start", partial: emptyPartial });
+              stream.push(streamAccumulator.start());
             }
             if (!textBlockStarted) {
               textBlockStarted = true;
-              const partial = buildStreamAssistantMessage({
-                model: modelInfo,
-                content: buildCurrentContent(),
-                stopReason: "stop",
-                usage: buildUsageWithNoCost({}),
-              });
-              stream.push({ type: "text_start", contentIndex: textContentIndex(), partial });
+              stream.push(streamAccumulator.startText(textContentIndex()));
             }
 
             accumulatedVisibleContent = nextVisibleContent;
-            const partial = buildStreamAssistantMessage({
-              model: modelInfo,
-              content: buildCurrentContent(),
-              stopReason: "stop",
-              usage: buildUsageWithNoCost({}),
-            });
-            stream.push({
-              type: "text_delta",
-              contentIndex: textContentIndex(),
-              delta,
-              partial,
-            });
+            stream.push(streamAccumulator.appendTextDelta(textContentIndex(), delta));
           };
 
           const resolveVisibleContent = (final: boolean): string | undefined => {
@@ -1313,37 +1264,14 @@ function createRawOllamaStreamFn(
             if (thinkingDelta) {
               if (!streamStarted) {
                 streamStarted = true;
-                const emptyPartial = buildStreamAssistantMessage({
-                  model: modelInfo,
-                  content: [],
-                  stopReason: "stop",
-                  usage: buildUsageWithNoCost({}),
-                });
-                stream.push({ type: "start", partial: emptyPartial });
+                stream.push(streamAccumulator.start());
               }
               if (!thinkingStarted) {
                 thinkingStarted = true;
-                const partial = buildStreamAssistantMessage({
-                  model: modelInfo,
-                  content: buildCurrentContent(),
-                  stopReason: "stop",
-                  usage: buildUsageWithNoCost({}),
-                });
-                stream.push({ type: "thinking_start", contentIndex: 0, partial });
+                stream.push(streamAccumulator.startThinking(0));
               }
               accumulatedThinking += thinkingDelta;
-              const partial = buildStreamAssistantMessage({
-                model: modelInfo,
-                content: buildCurrentContent(),
-                stopReason: "stop",
-                usage: buildUsageWithNoCost({}),
-              });
-              stream.push({
-                type: "thinking_delta",
-                contentIndex: 0,
-                delta: thinkingDelta,
-                partial,
-              });
+              stream.push(streamAccumulator.appendThinkingDelta(0, thinkingDelta));
             }
 
             if (chunk.message?.content) {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -82,6 +82,13 @@ function assistantToolName(message: AgentMessage | undefined): string {
   return message.content.find((part) => part.type === "toolCall")?.name ?? "";
 }
 
+function assistantToolArguments(message: AgentMessage | undefined): Record<string, unknown> {
+  if (!message || message.role !== "assistant") {
+    return {};
+  }
+  return message.content.find((part) => part.type === "toolCall")?.arguments ?? {};
+}
+
 async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const event of stream) {
@@ -190,6 +197,47 @@ describe("agentLoop EventStream failures", () => {
       "search",
       "search",
       "search",
+    ]);
+  });
+
+  it("uses updated tool-call partials when providers include them on deltas", async () => {
+    const startToolCall = {
+      type: "toolCall" as const,
+      id: "call-1",
+      name: "search",
+      arguments: {},
+    };
+    const updatedToolCall = {
+      type: "toolCall" as const,
+      id: "call-1",
+      name: "search",
+      arguments: { q: "openclaw" },
+    };
+    const finalMessage = assistantMessage([]);
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamEvents([
+        { type: "start", partial: assistantMessage([]) },
+        { type: "toolcall_start", contentIndex: 0, partial: assistantMessage([startToolCall]) },
+        {
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"q":"openclaw"}',
+          partial: assistantMessage([updatedToolCall]),
+        },
+        { type: "done", reason: "stop", message: finalMessage },
+      ]),
+    );
+
+    const events = await collectEvents(stream);
+    const updates = events.filter((event) => event.type === "message_update");
+
+    expect(updates.map((event) => assistantToolArguments(event.message))).toEqual([
+      {},
+      { q: "openclaw" },
     ]);
   });
 });

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -75,6 +75,13 @@ function assistantText(message: AgentMessage | undefined): string {
   return message.content.map((part) => (part.type === "text" ? part.text : "")).join("");
 }
 
+function assistantToolName(message: AgentMessage | undefined): string {
+  if (!message || message.role !== "assistant") {
+    return "";
+  }
+  return message.content.find((part) => part.type === "toolCall")?.name ?? "";
+}
+
 async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const event of stream) {
@@ -151,6 +158,38 @@ describe("agentLoop EventStream failures", () => {
       "Hel",
       "Hello",
       "Hello",
+    ]);
+  });
+
+  it("preserves tool-call state across lightweight tool-call deltas", async () => {
+    const toolCall = { type: "toolCall" as const, id: "call-1", name: "search", arguments: {} };
+    const finalMessage = assistantMessage([]);
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamEvents([
+        { type: "start", partial: assistantMessage([]) },
+        { type: "toolcall_start", contentIndex: 0, partial: assistantMessage([toolCall]) },
+        { type: "toolcall_delta", contentIndex: 0, delta: '{"q"', partial: assistantMessage([]) },
+        {
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: ':"openclaw"}',
+          partial: assistantMessage([]),
+        },
+        { type: "done", reason: "stop", message: finalMessage },
+      ]),
+    );
+
+    const events = await collectEvents(stream);
+    const updates = events.filter((event) => event.type === "message_update");
+
+    expect(updates.map((event) => assistantToolName(event.message))).toEqual([
+      "search",
+      "search",
+      "search",
     ]);
   });
 });

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -57,7 +57,15 @@ function streamEvents(events: AssistantMessageEvent[]): StreamFn {
   return async () => {
     const stream = new EventStream<AssistantMessageEvent, AssistantMessage>(
       (event) => event.type === "done" || event.type === "error",
-      (event) => (event.type === "done" ? event.message : event.error),
+      (event) => {
+        if (event.type === "done") {
+          return event.message;
+        }
+        if (event.type === "error") {
+          return event.error;
+        }
+        throw new Error(`Unexpected terminal event: ${event.type}`);
+      },
     );
     queueMicrotask(() => {
       for (const event of events) {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { agentLoop, agentLoopContinue } from "./agent-loop.js";
-import type { Message, Model } from "./llm.js";
+import {
+  EventStream,
+  type AssistantMessage,
+  type AssistantMessageEvent,
+  type Message,
+  type Model,
+} from "./llm.js";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.js";
 
 const model: Model = {
@@ -21,9 +27,53 @@ const config: AgentLoopConfig = {
   convertToLlm: (messages) => messages as Message[],
 };
 
+const emptyUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
 const failingStreamFn: StreamFn = async () => {
   throw new Error("provider exploded");
 };
+
+function assistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "test-api",
+    provider: "test-provider",
+    model: "test-model",
+    stopReason: "stop",
+    timestamp: 2,
+    usage: emptyUsage,
+  };
+}
+
+function streamEvents(events: AssistantMessageEvent[]): StreamFn {
+  return async () => {
+    const stream = new EventStream<AssistantMessageEvent, AssistantMessage>(
+      (event) => event.type === "done" || event.type === "error",
+      (event) => (event.type === "done" ? event.message : event.error),
+    );
+    queueMicrotask(() => {
+      for (const event of events) {
+        stream.push(event);
+      }
+    });
+    return stream;
+  };
+}
+
+function assistantText(message: AgentMessage | undefined): string {
+  if (!message || message.role !== "assistant") {
+    return "";
+  }
+  return message.content.map((part) => (part.type === "text" ? part.text : "")).join("");
+}
 
 async function collectEvents(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
@@ -70,5 +120,37 @@ describe("agentLoop EventStream failures", () => {
     const result = await stream.result();
 
     expectTerminalFailure(events, result);
+  });
+
+  it("accumulates lightweight text delta partials for message updates", async () => {
+    const finalMessage = assistantMessage([{ type: "text", text: "Hello" }]);
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamEvents([
+        { type: "start", partial: assistantMessage([]) },
+        {
+          type: "text_start",
+          contentIndex: 0,
+          partial: assistantMessage([{ type: "text", text: "" }]),
+        },
+        { type: "text_delta", contentIndex: 0, delta: "Hel", partial: assistantMessage([]) },
+        { type: "text_delta", contentIndex: 0, delta: "lo", partial: assistantMessage([]) },
+        { type: "text_end", contentIndex: 0, content: "Hello", partial: finalMessage },
+        { type: "done", reason: "stop", message: finalMessage },
+      ]),
+    );
+
+    const events = await collectEvents(stream);
+    const updates = events.filter((event) => event.type === "message_update");
+
+    expect(updates.map((event) => assistantText(event.message))).toEqual([
+      "",
+      "Hel",
+      "Hello",
+      "Hello",
+    ]);
   });
 });

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -73,6 +73,10 @@ function applyToolCallDelta(
   message: AssistantMessage,
   event: Extract<AssistantMessageEvent, { type: "toolcall_delta" }>,
 ): AssistantMessage {
+  const partialToolCall = event.partial.content[event.contentIndex];
+  if (partialToolCall?.type === "toolCall") {
+    return event.partial;
+  }
   const existing = message.content[event.contentIndex];
   return existing?.type === "toolCall" ? cloneAssistantMessage(message) : event.partial;
 }

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -69,6 +69,14 @@ function applyThinkingDelta(
   return next;
 }
 
+function applyToolCallDelta(
+  message: AssistantMessage,
+  event: Extract<AssistantMessageEvent, { type: "toolcall_delta" }>,
+): AssistantMessage {
+  const existing = message.content[event.contentIndex];
+  return existing?.type === "toolCall" ? cloneAssistantMessage(message) : event.partial;
+}
+
 function resolvePartialAssistantMessage(
   current: AssistantMessage | null,
   event: AssistantMessageEvent,
@@ -78,13 +86,14 @@ function resolvePartialAssistantMessage(
       return applyTextDelta(current ?? event.partial, event);
     case "thinking_delta":
       return applyThinkingDelta(current ?? event.partial, event);
+    case "toolcall_delta":
+      return applyToolCallDelta(current ?? event.partial, event);
     case "start":
     case "text_start":
     case "text_end":
     case "thinking_start":
     case "thinking_end":
     case "toolcall_start":
-    case "toolcall_delta":
     case "toolcall_end":
       return event.partial;
     case "done":

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -3,7 +3,13 @@
  * Transforms to Message[] only at the LLM call boundary.
  */
 
-import { type AssistantMessage, type Context, EventStream, type ToolResultMessage } from "./llm.js";
+import {
+  type AssistantMessage,
+  type AssistantMessageEvent,
+  type Context,
+  EventStream,
+  type ToolResultMessage,
+} from "./llm.js";
 import { type AgentCoreStreamRuntimeDeps, resolveAgentCoreStreamFn } from "./runtime-deps.js";
 import type {
   AgentContext,
@@ -27,6 +33,67 @@ const EMPTY_USAGE = {
   totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+function cloneAssistantMessage(message: AssistantMessage): AssistantMessage {
+  return {
+    ...message,
+    content: message.content.map((part) => ({ ...part })),
+  };
+}
+
+function applyTextDelta(
+  message: AssistantMessage,
+  event: Extract<AssistantMessageEvent, { type: "text_delta" }>,
+): AssistantMessage {
+  const next = cloneAssistantMessage(message);
+  const existing = next.content[event.contentIndex];
+  const currentText = existing?.type === "text" ? existing.text : "";
+  next.content[event.contentIndex] = {
+    ...(existing?.type === "text" ? existing : { type: "text" as const }),
+    text: event.replace ? event.delta : `${currentText}${event.delta}`,
+  };
+  return next;
+}
+
+function applyThinkingDelta(
+  message: AssistantMessage,
+  event: Extract<AssistantMessageEvent, { type: "thinking_delta" }>,
+): AssistantMessage {
+  const next = cloneAssistantMessage(message);
+  const existing = next.content[event.contentIndex];
+  const currentThinking = existing?.type === "thinking" ? existing.thinking : "";
+  next.content[event.contentIndex] = {
+    ...(existing?.type === "thinking" ? existing : { type: "thinking" as const }),
+    thinking: `${currentThinking}${event.delta}`,
+  };
+  return next;
+}
+
+function resolvePartialAssistantMessage(
+  current: AssistantMessage | null,
+  event: AssistantMessageEvent,
+): AssistantMessage | null {
+  switch (event.type) {
+    case "text_delta":
+      return applyTextDelta(current ?? event.partial, event);
+    case "thinking_delta":
+      return applyThinkingDelta(current ?? event.partial, event);
+    case "start":
+    case "text_start":
+    case "text_end":
+    case "thinking_start":
+    case "thinking_end":
+    case "toolcall_start":
+    case "toolcall_delta":
+    case "toolcall_end":
+      return event.partial;
+    case "done":
+      return event.message;
+    case "error":
+      return event.error;
+  }
+  return null;
+}
 
 /**
  * Start an agent loop with a new prompt message.
@@ -52,11 +119,13 @@ export function agentLoop(
     signal,
     streamFn,
     runtime,
-  ).then((messages) => {
-    stream.end(messages);
-  }).catch((error) => {
-    pushLoopFailure(stream, config, error, signal?.aborted === true);
-  });
+  )
+    .then((messages) => {
+      stream.end(messages);
+    })
+    .catch((error) => {
+      pushLoopFailure(stream, config, error, signal?.aborted === true);
+    });
 
   return stream;
 }
@@ -95,11 +164,13 @@ export function agentLoopContinue(
     signal,
     streamFn,
     runtime,
-  ).then((messages) => {
-    stream.end(messages);
-  }).catch((error) => {
-    pushLoopFailure(stream, config, error, signal?.aborted === true);
-  });
+  )
+    .then((messages) => {
+      stream.end(messages);
+    })
+    .catch((error) => {
+      pushLoopFailure(stream, config, error, signal?.aborted === true);
+    });
 
   return stream;
 }
@@ -390,7 +461,10 @@ async function streamAssistantResponse(
       case "toolcall_delta":
       case "toolcall_end":
         if (partialMessage) {
-          const message = event.partial;
+          const message = resolvePartialAssistantMessage(partialMessage, event);
+          if (!message) {
+            break;
+          }
           partialMessage = message;
           context.messages[context.messages.length - 1] = message;
           await emit({

--- a/packages/agent-core/src/llm.ts
+++ b/packages/agent-core/src/llm.ts
@@ -167,12 +167,19 @@ export interface Tool<TParameters extends TSchema = TSchema> {
 }
 
 // Delta fields are the source of truth for incremental text, thinking, and tool
-// argument fragments. `partial` may be lightweight on delta events; boundary
-// events and `done`/`error` carry full assistant-message content.
+// argument fragments. `replace` marks text deltas that carry corrected full
+// visible text. `partial` may be lightweight on delta events; boundary events
+// and `done`/`error` carry full assistant-message content.
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }
   | { type: "text_start"; contentIndex: number; partial: AssistantMessage }
-  | { type: "text_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
+  | {
+      type: "text_delta";
+      contentIndex: number;
+      delta: string;
+      replace?: boolean;
+      partial: AssistantMessage;
+    }
   | { type: "text_end"; contentIndex: number; content: string; partial: AssistantMessage }
   | { type: "thinking_start"; contentIndex: number; partial: AssistantMessage }
   | { type: "thinking_delta"; contentIndex: number; delta: string; partial: AssistantMessage }

--- a/packages/agent-core/src/llm.ts
+++ b/packages/agent-core/src/llm.ts
@@ -166,6 +166,9 @@ export interface Tool<TParameters extends TSchema = TSchema> {
   parameters: TParameters;
 }
 
+// Delta fields are the source of truth for incremental text, thinking, and tool
+// argument fragments. `partial` may be lightweight on delta events; boundary
+// events and `done`/`error` carry full assistant-message content.
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }
   | { type: "text_start"; contentIndex: number; partial: AssistantMessage }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -225,6 +225,9 @@ function readChatProjection(event: OpenClawEvent): ChatProjection | undefined {
 }
 
 function readChatProjectionText(payload: Record<string, unknown>): string | undefined {
+  if (payload.replace === true && typeof payload.deltaText === "string") {
+    return payload.deltaText;
+  }
   const message = asRecord(payload.message);
   const content = message.content;
   if (typeof content === "string") {

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -747,20 +747,36 @@ describe("OpenClaw SDK", () => {
           payload: {
             runId: "run_chat_only",
             sessionKey: "chat-only",
-            state: "final",
+            state: "delta",
+            deltaText: "",
+            replace: true,
             message: {
               role: "assistant",
-              content: [{ type: "text", text: "reset" }],
+              content: [{ type: "text", text: "" }],
               timestamp: ts + 3,
             },
           },
         });
         fake.emit({
-          event: "custom.debug",
+          event: "chat",
           seq: 5,
           payload: {
             runId: "run_chat_only",
-            ts: ts + 4,
+            sessionKey: "chat-only",
+            state: "final",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "reset" }],
+              timestamp: ts + 4,
+            },
+          },
+        });
+        fake.emit({
+          event: "custom.debug",
+          seq: 6,
+          payload: {
+            runId: "run_chat_only",
+            ts: ts + 5,
             data: { ok: true },
           },
         });
@@ -807,11 +823,20 @@ describe("OpenClaw SDK", () => {
       const fourth = await iterator.next();
       expect(fourth.done).toBe(false);
       if (fourth.done !== false) {
+        throw new Error("expected empty replacement chat projection event");
+      }
+      expect(fourth.value.type).toBe("assistant.delta");
+      expect(fourth.value.data).toEqual({ text: "", delta: "", replace: true });
+      expect(fourth.value.raw?.event).toBe("chat");
+
+      const fifth = await iterator.next();
+      expect(fifth.done).toBe(false);
+      if (fifth.done !== false) {
         throw new Error("expected chat projection completion event");
       }
-      expect(fourth.value.type).toBe("run.completed");
-      expect(fourth.value.data).toEqual({ phase: "end", outputText: "reset" });
-      expect(fourth.value.raw?.event).toBe("chat");
+      expect(fifth.value.type).toBe("run.completed");
+      expect(fifth.value.data).toEqual({ phase: "end", outputText: "reset" });
+      expect(fifth.value.raw?.event).toBe("chat");
     } finally {
       await iterator.return?.();
     }

--- a/scripts/repro-gateway-dense-stream-latency.ts
+++ b/scripts/repro-gateway-dense-stream-latency.ts
@@ -7,11 +7,14 @@ import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/te
 import { createOpenClawTestState } from "../src/test-utils/openclaw-test-state.js";
 
 type Options = {
+  assertResponsive: boolean;
   assertStall: boolean;
   chunkSize: number;
   chunks: number;
   healthTimeoutMs: number;
   pingIntervalMs: number;
+  responsiveThresholdMs: number;
+  serverBatchSize: number;
   stallThresholdMs: number;
 };
 
@@ -48,11 +51,14 @@ type EventLike = {
 };
 
 const DEFAULT_OPTIONS: Options = {
+  assertResponsive: false,
   assertStall: false,
   chunks: 10_000,
   chunkSize: 64,
   pingIntervalMs: 20,
   healthTimeoutMs: 10_000,
+  responsiveThresholdMs: 1_000,
+  serverBatchSize: 100,
   stallThresholdMs: 1_000,
 };
 
@@ -90,6 +96,9 @@ function parseOptions(argv: string[]): Options {
     };
 
     switch (arg) {
+      case "--assert-responsive":
+        options.assertResponsive = true;
+        break;
       case "--assert-stall":
         options.assertStall = true;
         break;
@@ -105,6 +114,12 @@ function parseOptions(argv: string[]): Options {
       case "--ping-interval-ms":
         options.pingIntervalMs = readNumber("--ping-interval-ms");
         break;
+      case "--responsive-threshold-ms":
+        options.responsiveThresholdMs = readNumber("--responsive-threshold-ms");
+        break;
+      case "--server-batch-size":
+        options.serverBatchSize = readNumber("--server-batch-size");
+        break;
       case "--stall-threshold-ms":
         options.stallThresholdMs = readNumber("--stall-threshold-ms");
         break;
@@ -114,6 +129,9 @@ function parseOptions(argv: string[]): Options {
       default:
         throw new Error(`unknown argument: ${arg}`);
     }
+  }
+  if (options.assertResponsive && options.assertStall) {
+    throw new Error("--assert-responsive and --assert-stall cannot be used together");
   }
 
   return options;
@@ -131,8 +149,11 @@ Options:
   --chunk-size <n>          Text bytes per chunk (default: 64)
   --ping-interval-ms <n>    Health ping cadence during the run (default: 20)
   --health-timeout-ms <n>   Per-health RPC timeout (default: 10000)
+  --server-batch-size <n>   Provider chunks to write before yielding (default: 100)
   --assert-stall            Exit nonzero unless max health latency exceeds threshold
   --stall-threshold-ms <n>  Assertion threshold for --assert-stall (default: 1000)
+  --assert-responsive       Exit nonzero unless p99 health latency stays below threshold
+  --responsive-threshold-ms <n> Assertion threshold for --assert-responsive (default: 1000)
 `);
 }
 
@@ -164,6 +185,38 @@ async function closeServer(server: Server): Promise<void> {
 function writeJson(res: ServerResponse, value: unknown): void {
   res.setHeader("content-type", "application/json");
   res.end(`${JSON.stringify(value)}\n`);
+}
+
+async function writeDenseChatResponse(
+  res: ServerResponse,
+  options: Options,
+  chunkText: string,
+): Promise<void> {
+  for (let index = 0; index < options.chunks; index += 1) {
+    const canContinue = res.write(
+      `${JSON.stringify({
+        model: "qwen2.5:0.5b",
+        created_at: new Date().toISOString(),
+        message: { role: "assistant", content: chunkText },
+        done: false,
+      })}\n`,
+    );
+    if (!canContinue) {
+      await new Promise<void>((resolve) => res.once("drain", resolve));
+    }
+    if ((index + 1) % options.serverBatchSize === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  res.end(
+    `${JSON.stringify({
+      model: "qwen2.5:0.5b",
+      created_at: new Date().toISOString(),
+      message: { role: "assistant", content: "" },
+      done: true,
+      done_reason: "stop",
+    })}\n`,
+  );
 }
 
 async function createDenseStreamServer(options: Options): Promise<DenseStreamServer> {
@@ -199,25 +252,9 @@ async function createDenseStreamServer(options: Options): Promise<DenseStreamSer
       chatRequests += 1;
       req.resume();
       res.writeHead(200, { "content-type": "application/x-ndjson" });
-      for (let index = 0; index < options.chunks; index += 1) {
-        res.write(
-          `${JSON.stringify({
-            model: "qwen2.5:0.5b",
-            created_at: new Date().toISOString(),
-            message: { role: "assistant", content: chunkText },
-            done: false,
-          })}\n`,
-        );
-      }
-      res.end(
-        `${JSON.stringify({
-          model: "qwen2.5:0.5b",
-          created_at: new Date().toISOString(),
-          message: { role: "assistant", content: "" },
-          done: true,
-          done_reason: "stop",
-        })}\n`,
-      );
+      void writeDenseChatResponse(res, options, chunkText).catch((error: unknown) => {
+        res.destroy(error instanceof Error ? error : new Error(String(error)));
+      });
       return;
     }
 
@@ -499,6 +536,7 @@ async function main(): Promise<void> {
         realProviderDaemon: false,
         chunks: options.chunks,
         chunkBytes: options.chunkSize,
+        serverBatchSize: options.serverBatchSize,
         finalExpectedChars: options.chunks * options.chunkSize,
         chatRequests: denseStreamServer.chatRequests(),
         sendStatus:
@@ -522,6 +560,13 @@ async function main(): Promise<void> {
         throw new Error(
           `expected max health latency >= ${String(options.stallThresholdMs)}ms, observed ${String(
             during.max,
+          )}ms`,
+        );
+      }
+      if (options.assertResponsive && during.p99 >= options.responsiveThresholdMs) {
+        throw new Error(
+          `expected p99 health latency < ${String(options.responsiveThresholdMs)}ms, observed ${String(
+            during.p99,
           )}ms`,
         );
       }

--- a/scripts/repro-gateway-dense-stream-latency.ts
+++ b/scripts/repro-gateway-dense-stream-latency.ts
@@ -511,23 +511,35 @@ async function main(): Promise<void> {
       const pingResultPromise = pingHealthLoop(pingClient, stopFlag, options);
       const runId = `dense-${randomUUID()}`;
       const startedAt = performance.now();
-      const sendResult = await runClient.request(
-        "chat.send",
-        {
-          sessionKey: "agent:main:gateway-dense-stream-repro",
-          idempotencyKey: runId,
-          message: "Reply normally.",
-        },
-        { timeoutMs: 30_000 },
-      );
-      const ackMs = performance.now() - startedAt;
-      const waitResult = await runClient.request(
-        "agent.wait",
-        { runId, timeoutMs: 120_000 },
-        { timeoutMs: 125_000 },
-      );
-      stopFlag.done = true;
+      let sendResult: unknown;
+      let waitResult: unknown;
+      let ackMs = 0;
+      let runError: unknown;
+      try {
+        sendResult = await runClient.request(
+          "chat.send",
+          {
+            sessionKey: "agent:main:gateway-dense-stream-repro",
+            idempotencyKey: runId,
+            message: "Reply normally.",
+          },
+          { timeoutMs: 30_000 },
+        );
+        ackMs = performance.now() - startedAt;
+        waitResult = await runClient.request(
+          "agent.wait",
+          { runId, timeoutMs: 120_000 },
+          { timeoutMs: 125_000 },
+        );
+      } catch (err) {
+        runError = err;
+      } finally {
+        stopFlag.done = true;
+      }
       const pingResult = await pingResultPromise;
+      if (runError) {
+        throw runError;
+      }
       const totalMs = performance.now() - startedAt;
       const during = summarizeLatency(pingResult.samples);
       const result = {

--- a/scripts/repro-gateway-dense-stream-latency.ts
+++ b/scripts/repro-gateway-dense-stream-latency.ts
@@ -27,7 +27,7 @@ type LatencySummary = {
   p99: number;
 };
 
-type DenseOllamaServer = {
+type DenseStreamServer = {
   chatRequests: () => number;
   close: () => Promise<void>;
   port: number;
@@ -71,10 +71,10 @@ function parseOptions(argv: string[]): Options {
   const options: Options = {
     ...DEFAULT_OPTIONS,
     chunks:
-      parsePositiveInteger(process.env.OPENCLAW_REPRO_OLLAMA_DENSE_CHUNKS, "chunks") ??
+      parsePositiveInteger(process.env.OPENCLAW_REPRO_DENSE_STREAM_CHUNKS, "chunks") ??
       DEFAULT_OPTIONS.chunks,
     chunkSize:
-      parsePositiveInteger(process.env.OPENCLAW_REPRO_OLLAMA_DENSE_CHUNK_SIZE, "chunk-size") ??
+      parsePositiveInteger(process.env.OPENCLAW_REPRO_DENSE_STREAM_CHUNK_SIZE, "chunk-size") ??
       DEFAULT_OPTIONS.chunkSize,
   };
 
@@ -120,7 +120,7 @@ function parseOptions(argv: string[]): Options {
 }
 
 function printHelp(): void {
-  console.log(`Usage: node --import tsx scripts/repro-ollama-dense-gateway-latency.ts [options]
+  console.log(`Usage: node --import tsx scripts/repro-gateway-dense-stream-latency.ts [options]
 
 Starts a real OpenClaw gateway and points the Ollama provider at a local
 Ollama-compatible endpoint that emits dense native /api/chat NDJSON.
@@ -166,7 +166,7 @@ function writeJson(res: ServerResponse, value: unknown): void {
   res.end(`${JSON.stringify(value)}\n`);
 }
 
-async function createDenseOllamaServer(options: Options): Promise<DenseOllamaServer> {
+async function createDenseStreamServer(options: Options): Promise<DenseStreamServer> {
   const port = await getFreePort();
   let chatRequests = 0;
   const chunkText = "x".repeat(options.chunkSize);
@@ -375,11 +375,11 @@ function finalTextLength(events: EventLike[], runId: string): number {
 
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
-  const denseOllama = await createDenseOllamaServer(options);
+  const denseStreamServer = await createDenseStreamServer(options);
   const gatewayPort = await getFreePort();
   const gatewayToken = `gateway-token-${randomUUID()}`;
   const state = await createOpenClawTestState({
-    label: `ollama-dense-gateway-repro-${Date.now()}`,
+    label: `gateway-dense-stream-repro-${Date.now()}`,
     layout: "home",
     applyEnv: false,
   });
@@ -393,7 +393,7 @@ async function main(): Promise<void> {
       providers: {
         ollama: {
           api: "ollama",
-          baseUrl: `http://127.0.0.1:${String(denseOllama.port)}`,
+          baseUrl: `http://127.0.0.1:${String(denseStreamServer.port)}`,
           apiKey: "ollama-local",
           models: [
             {
@@ -450,7 +450,7 @@ async function main(): Promise<void> {
       url: `ws://127.0.0.1:${String(gatewayPort)}`,
       token: gatewayToken,
       role: "operator",
-      clientDisplayName: "ollama-dense-repro-run",
+      clientDisplayName: "dense-stream-repro-run",
       timeoutMs: 30_000,
       onEvent: (event) => events.push(event),
     });
@@ -458,7 +458,7 @@ async function main(): Promise<void> {
       url: `ws://127.0.0.1:${String(gatewayPort)}`,
       token: gatewayToken,
       role: "operator",
-      clientDisplayName: "ollama-dense-repro-ping",
+      clientDisplayName: "dense-stream-repro-ping",
       timeoutMs: 30_000,
     });
 
@@ -477,7 +477,7 @@ async function main(): Promise<void> {
       const sendResult = await runClient.request(
         "chat.send",
         {
-          sessionKey: "agent:main:ollama-dense-gateway-repro",
+          sessionKey: "agent:main:gateway-dense-stream-repro",
           idempotencyKey: runId,
           message: "Reply normally.",
         },
@@ -495,12 +495,12 @@ async function main(): Promise<void> {
       const during = summarizeLatency(pingResult.samples);
       const result = {
         liveGateway: true,
-        nativeOllamaHttpPath: true,
-        realOllamaDaemon: false,
+        providerProtocol: "ollama-native-compatible",
+        realProviderDaemon: false,
         chunks: options.chunks,
         chunkBytes: options.chunkSize,
         finalExpectedChars: options.chunks * options.chunkSize,
-        chatRequests: denseOllama.chatRequests(),
+        chatRequests: denseStreamServer.chatRequests(),
         sendStatus:
           sendResult && typeof sendResult === "object"
             ? (sendResult as { status?: unknown }).status
@@ -535,7 +535,7 @@ async function main(): Promise<void> {
       proc.kill("SIGKILL");
     }
     await state.cleanup();
-    await denseOllama.close();
+    await denseStreamServer.close();
   }
 }
 

--- a/scripts/repro-ollama-dense-gateway-latency.ts
+++ b/scripts/repro-ollama-dense-gateway-latency.ts
@@ -1,0 +1,545 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import net from "node:net";
+import { performance } from "node:perf_hooks";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { createOpenClawTestState } from "../src/test-utils/openclaw-test-state.js";
+
+type Options = {
+  assertStall: boolean;
+  chunkSize: number;
+  chunks: number;
+  healthTimeoutMs: number;
+  pingIntervalMs: number;
+  stallThresholdMs: number;
+};
+
+type LatencySummary = {
+  count: number;
+  max: number;
+  min: number;
+  over1000ms: number;
+  over100ms: number;
+  over500ms: number;
+  p50: number;
+  p95: number;
+  p99: number;
+};
+
+type DenseOllamaServer = {
+  chatRequests: () => number;
+  close: () => Promise<void>;
+  port: number;
+};
+
+type StopFlag = {
+  done: boolean;
+};
+
+type PingResult = {
+  errors: number;
+  samples: number[];
+};
+
+type EventLike = {
+  event?: unknown;
+  payload?: unknown;
+};
+
+const DEFAULT_OPTIONS: Options = {
+  assertStall: false,
+  chunks: 10_000,
+  chunkSize: 64,
+  pingIntervalMs: 20,
+  healthTimeoutMs: 10_000,
+  stallThresholdMs: 1_000,
+};
+
+function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || String(parsed) !== value.trim()) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseOptions(argv: string[]): Options {
+  const options: Options = {
+    ...DEFAULT_OPTIONS,
+    chunks:
+      parsePositiveInteger(process.env.OPENCLAW_REPRO_OLLAMA_DENSE_CHUNKS, "chunks") ??
+      DEFAULT_OPTIONS.chunks,
+    chunkSize:
+      parsePositiveInteger(process.env.OPENCLAW_REPRO_OLLAMA_DENSE_CHUNK_SIZE, "chunk-size") ??
+      DEFAULT_OPTIONS.chunkSize,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readNumber = (name: string): number => {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return parsePositiveInteger(value, name) ?? 0;
+    };
+
+    switch (arg) {
+      case "--assert-stall":
+        options.assertStall = true;
+        break;
+      case "--chunks":
+        options.chunks = readNumber("--chunks");
+        break;
+      case "--chunk-size":
+        options.chunkSize = readNumber("--chunk-size");
+        break;
+      case "--health-timeout-ms":
+        options.healthTimeoutMs = readNumber("--health-timeout-ms");
+        break;
+      case "--ping-interval-ms":
+        options.pingIntervalMs = readNumber("--ping-interval-ms");
+        break;
+      case "--stall-threshold-ms":
+        options.stallThresholdMs = readNumber("--stall-threshold-ms");
+        break;
+      case "--help":
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  console.log(`Usage: node --import tsx scripts/repro-ollama-dense-gateway-latency.ts [options]
+
+Starts a real OpenClaw gateway and points the Ollama provider at a local
+Ollama-compatible endpoint that emits dense native /api/chat NDJSON.
+While the agent stream is processed, a second gateway client measures health RPC latency.
+
+Options:
+  --chunks <n>              Dense stream chunk count (default: 10000)
+  --chunk-size <n>          Text bytes per chunk (default: 64)
+  --ping-interval-ms <n>    Health ping cadence during the run (default: 20)
+  --health-timeout-ms <n>   Per-health RPC timeout (default: 10000)
+  --assert-stall            Exit nonzero unless max health latency exceeds threshold
+  --stall-threshold-ms <n>  Assertion threshold for --assert-stall (default: 1000)
+`);
+}
+
+async function getFreePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (!address || typeof address === "string") {
+    throw new Error("failed to allocate a free port");
+  }
+  return address.port;
+}
+
+async function listen(server: Server, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function writeJson(res: ServerResponse, value: unknown): void {
+  res.setHeader("content-type", "application/json");
+  res.end(`${JSON.stringify(value)}\n`);
+}
+
+async function createDenseOllamaServer(options: Options): Promise<DenseOllamaServer> {
+  const port = await getFreePort();
+  let chatRequests = 0;
+  const chunkText = "x".repeat(options.chunkSize);
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.url === "/api/tags") {
+      writeJson(res, {
+        models: [
+          {
+            name: "qwen2.5:0.5b",
+            model: "qwen2.5:0.5b",
+            modified_at: new Date().toISOString(),
+            size: 1,
+            digest: "dense-repro",
+          },
+        ],
+      });
+      return;
+    }
+
+    if (req.url === "/api/show") {
+      writeJson(res, {
+        model_info: { "qwen2.context_length": 32768 },
+        parameters: "num_ctx 32768",
+        capabilities: ["completion"],
+      });
+      return;
+    }
+
+    if (req.url === "/api/chat") {
+      chatRequests += 1;
+      req.resume();
+      res.writeHead(200, { "content-type": "application/x-ndjson" });
+      for (let index = 0; index < options.chunks; index += 1) {
+        res.write(
+          `${JSON.stringify({
+            model: "qwen2.5:0.5b",
+            created_at: new Date().toISOString(),
+            message: { role: "assistant", content: chunkText },
+            done: false,
+          })}\n`,
+        );
+      }
+      res.end(
+        `${JSON.stringify({
+          model: "qwen2.5:0.5b",
+          created_at: new Date().toISOString(),
+          message: { role: "assistant", content: "" },
+          done: true,
+          done_reason: "stop",
+        })}\n`,
+      );
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end("not found\n");
+  });
+
+  await listen(server, port);
+  return {
+    port,
+    chatRequests: () => chatRequests,
+    close: () => closeServer(server),
+  };
+}
+
+async function waitForGatewayPort(
+  proc: ChildProcessWithoutNullStreams,
+  port: number,
+  logs: string[],
+  timeoutMs = 120_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (proc.exitCode !== null) {
+      throw new Error(
+        `gateway exited code=${String(proc.exitCode)}\n${logs.join("").slice(-4000)}`,
+      );
+    }
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.connect({ host: "127.0.0.1", port });
+        socket.once("connect", () => {
+          socket.destroy();
+          resolve();
+        });
+        socket.once("error", (error) => {
+          socket.destroy();
+          reject(error);
+        });
+      });
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw new Error(
+    `timeout waiting for gateway port ${String(port)}\n${logs.join("").slice(-4000)}`,
+  );
+}
+
+async function waitForExit(
+  proc: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<boolean> {
+  return await Promise.race([
+    new Promise<boolean>((resolve) => proc.once("exit", () => resolve(true))),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+  ]);
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.toSorted((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p))] ?? 0;
+}
+
+function summarizeLatency(values: number[]): LatencySummary {
+  if (values.length === 0) {
+    return {
+      count: 0,
+      min: 0,
+      p50: 0,
+      p95: 0,
+      p99: 0,
+      max: 0,
+      over100ms: 0,
+      over500ms: 0,
+      over1000ms: 0,
+    };
+  }
+  return {
+    count: values.length,
+    min: Math.round(Math.min(...values)),
+    p50: Math.round(percentile(values, 0.5)),
+    p95: Math.round(percentile(values, 0.95)),
+    p99: Math.round(percentile(values, 0.99)),
+    max: Math.round(Math.max(...values)),
+    over100ms: values.filter((value) => value > 100).length,
+    over500ms: values.filter((value) => value > 500).length,
+    over1000ms: values.filter((value) => value > 1000).length,
+  };
+}
+
+async function pingHealthLoop(
+  client: Awaited<ReturnType<typeof connectGatewayClient>>,
+  stopFlag: StopFlag,
+  options: Options,
+): Promise<PingResult> {
+  const samples: number[] = [];
+  let errors = 0;
+  while (!stopFlag.done) {
+    const startedAt = performance.now();
+    try {
+      await client.request("health", {}, { timeoutMs: options.healthTimeoutMs });
+    } catch {
+      errors += 1;
+    }
+    const elapsedMs = performance.now() - startedAt;
+    samples.push(elapsedMs);
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.max(0, options.pingIntervalMs - elapsedMs)),
+    );
+  }
+  return { samples, errors };
+}
+
+function finalTextLength(events: EventLike[], runId: string): number {
+  for (const event of events) {
+    if (event.event !== "chat") {
+      continue;
+    }
+    const payload = event.payload;
+    if (
+      !payload ||
+      typeof payload !== "object" ||
+      (payload as { runId?: unknown }).runId !== runId ||
+      (payload as { state?: unknown }).state !== "final"
+    ) {
+      continue;
+    }
+    const message = (payload as { message?: unknown }).message;
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const directText = (message as { text?: unknown }).text;
+    if (typeof directText === "string") {
+      return directText.length;
+    }
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) {
+      return 0;
+    }
+    return content
+      .map((entry) =>
+        entry && typeof entry === "object" && typeof (entry as { text?: unknown }).text === "string"
+          ? (entry as { text: string }).text
+          : "",
+      )
+      .join("\n").length;
+  }
+  return 0;
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const denseOllama = await createDenseOllamaServer(options);
+  const gatewayPort = await getFreePort();
+  const gatewayToken = `gateway-token-${randomUUID()}`;
+  const state = await createOpenClawTestState({
+    label: `ollama-dense-gateway-repro-${Date.now()}`,
+    layout: "home",
+    applyEnv: false,
+  });
+  await state.writeConfig({
+    gateway: {
+      port: gatewayPort,
+      auth: { mode: "token", token: gatewayToken },
+      controlUi: { enabled: false },
+    },
+    models: {
+      providers: {
+        ollama: {
+          api: "ollama",
+          baseUrl: `http://127.0.0.1:${String(denseOllama.port)}`,
+          apiKey: "ollama-local",
+          models: [
+            {
+              id: "qwen2.5:0.5b",
+              name: "qwen2.5:0.5b",
+              contextWindow: 32768,
+              maxTokens: 8192,
+              compat: { supportsTools: false, supportsUsageInStreaming: true },
+            },
+          ],
+        },
+      },
+    },
+    agents: { defaults: { model: { primary: "ollama/qwen2.5:0.5b" } } },
+  });
+
+  const logs: string[] = [];
+  const proc = spawn(
+    "node",
+    [
+      "scripts/run-node.mjs",
+      "gateway",
+      "--port",
+      String(gatewayPort),
+      "--bind",
+      "loopback",
+      "--allow-unconfigured",
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...state.env,
+        OPENCLAW_GATEWAY_TOKEN: "",
+        OPENCLAW_GATEWAY_PASSWORD: "",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OLLAMA_API_KEY: "ollama-local",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  proc.stdout.setEncoding("utf8");
+  proc.stderr.setEncoding("utf8");
+  proc.stdout.on("data", (chunk) => logs.push(String(chunk)));
+  proc.stderr.on("data", (chunk) => logs.push(String(chunk)));
+
+  try {
+    await waitForGatewayPort(proc, gatewayPort, logs);
+    const events: EventLike[] = [];
+    const runClient = await connectGatewayClient({
+      url: `ws://127.0.0.1:${String(gatewayPort)}`,
+      token: gatewayToken,
+      role: "operator",
+      clientDisplayName: "ollama-dense-repro-run",
+      timeoutMs: 30_000,
+      onEvent: (event) => events.push(event),
+    });
+    const pingClient = await connectGatewayClient({
+      url: `ws://127.0.0.1:${String(gatewayPort)}`,
+      token: gatewayToken,
+      role: "operator",
+      clientDisplayName: "ollama-dense-repro-ping",
+      timeoutMs: 30_000,
+    });
+
+    try {
+      const baseline: number[] = [];
+      for (let index = 0; index < 20; index += 1) {
+        const startedAt = performance.now();
+        await pingClient.request("health", {}, { timeoutMs: options.healthTimeoutMs });
+        baseline.push(performance.now() - startedAt);
+      }
+
+      const stopFlag: StopFlag = { done: false };
+      const pingResultPromise = pingHealthLoop(pingClient, stopFlag, options);
+      const runId = `dense-${randomUUID()}`;
+      const startedAt = performance.now();
+      const sendResult = await runClient.request(
+        "chat.send",
+        {
+          sessionKey: "agent:main:ollama-dense-gateway-repro",
+          idempotencyKey: runId,
+          message: "Reply normally.",
+        },
+        { timeoutMs: 30_000 },
+      );
+      const ackMs = performance.now() - startedAt;
+      const waitResult = await runClient.request(
+        "agent.wait",
+        { runId, timeoutMs: 120_000 },
+        { timeoutMs: 125_000 },
+      );
+      stopFlag.done = true;
+      const pingResult = await pingResultPromise;
+      const totalMs = performance.now() - startedAt;
+      const during = summarizeLatency(pingResult.samples);
+      const result = {
+        liveGateway: true,
+        nativeOllamaHttpPath: true,
+        realOllamaDaemon: false,
+        chunks: options.chunks,
+        chunkBytes: options.chunkSize,
+        finalExpectedChars: options.chunks * options.chunkSize,
+        chatRequests: denseOllama.chatRequests(),
+        sendStatus:
+          sendResult && typeof sendResult === "object"
+            ? (sendResult as { status?: unknown }).status
+            : undefined,
+        runStatus:
+          waitResult && typeof waitResult === "object"
+            ? (waitResult as { status?: unknown }).status
+            : undefined,
+        ackMs: Math.round(ackMs),
+        totalMs: Math.round(totalMs),
+        baseline: summarizeLatency(baseline),
+        during: { ...during, errors: pingResult.errors },
+        chatEvents: events.filter((event) => event.event === "chat").length,
+        finalChars: finalTextLength(events, runId),
+      };
+      console.log(JSON.stringify(result, null, 2));
+
+      if (options.assertStall && during.max < options.stallThresholdMs) {
+        throw new Error(
+          `expected max health latency >= ${String(options.stallThresholdMs)}ms, observed ${String(
+            during.max,
+          )}ms`,
+        );
+      }
+    } finally {
+      await disconnectGatewayClient(runClient).catch(() => {});
+      await disconnectGatewayClient(pingClient).catch(() => {});
+    }
+  } finally {
+    proc.kill("SIGTERM");
+    if (!(await waitForExit(proc, 1_500))) {
+      proc.kill("SIGKILL");
+    }
+    await state.cleanup();
+    await denseOllama.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+  process.exitCode = 1;
+});

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -552,6 +552,31 @@ describe("runBtwSideQuestion", () => {
     });
   });
 
+  it("uses replacement text deltas as the current BTW answer", async () => {
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Draft answer",
+          partial: { role: "assistant", content: [] },
+        },
+        {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Corrected answer",
+          replace: true,
+          partial: { role: "assistant", content: [] },
+        },
+        createDoneEvent("Corrected answer"),
+      ]),
+    );
+
+    const result = await runSideQuestion();
+
+    expect(result).toEqual({ text: "Corrected answer" });
+  });
+
   it("routes Codex-selected BTW questions through the harness side-question hook", async () => {
     const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
     registerAgentHarness({

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -586,7 +586,10 @@ export async function runBtwSideQuestion(
 
     if (event.type === "text_delta") {
       sawTextEvent = true;
-      answerText += event.delta;
+      answerText = event.replace ? event.delta : answerText + event.delta;
+      if (event.replace) {
+        chunker?.reset();
+      }
       chunker?.append(event.delta);
       if (chunker && params.resolvedBlockStreamingBreak === "text_end") {
         chunker.drain({ force: false, emit: (chunk) => void emitBlockChunk(chunk) });

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -263,6 +263,58 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     }
   });
 
+  it("counts text deltas without repeatedly serializing growing partial snapshots", async () => {
+    const hugeFirstPartial = "a".repeat(200_000);
+    const hugeSecondPartial = `${hugeFirstPartial}${"b".repeat(200_000)}`;
+    async function* stream() {
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "a",
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text: hugeFirstPartial }],
+        },
+      };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "b",
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text: hugeSecondPartial }],
+        },
+      };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-1",
+        provider: "vllm",
+        model: "qwen/qwen3.5-9b",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-delta-bytes",
+      },
+    );
+
+    const events = await collectModelCallEvents(async () => {
+      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+
+    const completedEvent = getEvent(events, 1);
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.responseStreamBytes).toBe(
+      Buffer.byteLength(
+        JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "a" }),
+        "utf8",
+      ) +
+        Buffer.byteLength(
+          JSON.stringify({ type: "text_delta", contentIndex: 0, delta: "b" }),
+          "utf8",
+        ),
+    );
+  });
+
   it("does not retain stream progress activity when diagnostics are disabled", async () => {
     setDiagnosticsEnabledForProcess(false);
     const runProgressEvents: DiagnosticEventPayload[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -106,6 +106,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function responseStreamChunkByteLength(chunk: unknown): number | undefined {
+  if (!isRecord(chunk)) {
+    return utf8JsonByteLength(chunk);
+  }
+  if (
+    (chunk.type === "text_delta" ||
+      chunk.type === "thinking_delta" ||
+      chunk.type === "toolcall_delta") &&
+    typeof chunk.delta === "string"
+  ) {
+    return utf8JsonByteLength({
+      type: chunk.type,
+      ...(typeof chunk.contentIndex === "number" ? { contentIndex: chunk.contentIndex } : {}),
+      delta: chunk.delta,
+    });
+  }
+  return utf8JsonByteLength(chunk);
+}
+
 function cloneDiagnosticContentValue(value: unknown): unknown {
   try {
     return structuredClone(value);
@@ -157,7 +176,7 @@ function observeResponseChunk(
 ): void {
   state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
   observeOutputMessageContent(state, chunk);
-  const bytes = utf8JsonByteLength(chunk);
+  const bytes = responseStreamChunkByteLength(chunk);
   if (bytes !== undefined) {
     state.responseStreamBytes += bytes;
   }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -25,7 +25,7 @@ function createMessageUpdateContext(
     onAgentEvent?: ReturnType<typeof vi.fn>;
     onPartialReply?: ReturnType<typeof vi.fn>;
     flushBlockReplyBuffer?: ReturnType<typeof vi.fn>;
-    resetAssistantTextStreamState?: ReturnType<typeof vi.fn>;
+    resetAssistantTextStreamState?: () => void;
     resetAssistantMessageState?: ReturnType<typeof vi.fn>;
     debug?: ReturnType<typeof vi.fn>;
     shouldEmitPartialReplies?: boolean;

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -330,6 +330,50 @@ describe("handleMessageUpdate text signatures", () => {
     ]);
   });
 
+  it("keeps unphased text deltas independent from large partial snapshots", () => {
+    const onAgentEvent = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      stripBlockTags,
+      consumePartialReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: { deltaBuffer: "x".repeat(20_000) },
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "a",
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text: "x".repeat(20_000) }],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(context.state.deltaBuffer).toBe(`${"x".repeat(20_000)}a`);
+    expect(stripBlockTags.mock.calls.map(([text]) => text.length)).toEqual([1]);
+    expect(firstMockArg(onAgentEvent, "agent event")).toEqual({
+      stream: "assistant",
+      data: {
+        text: "a",
+        delta: "a",
+        replace: undefined,
+        mediaUrls: undefined,
+        phase: undefined,
+      },
+    });
+  });
+
   it("uses full partial text for suffix deltas after a suppressed commentary item", () => {
     const onAgentEvent = vi.fn();
     const context = createMessageUpdateContext({ onAgentEvent });

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -480,6 +480,163 @@ describe("handleMessageUpdate text signatures", () => {
     expect(context.state.blockBuffer).toBe("Corrected answer");
   });
 
+  it("resets block parsers before replacement text deltas", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        deltaBuffer: "<think>stale",
+        blockBuffer: "stale",
+        blockState: {
+          thinking: true,
+          final: true,
+          inlineCode: createInlineCodeState(),
+          pendingTagFragment: "<thi",
+        },
+        partialBlockState: {
+          thinking: true,
+          final: true,
+          inlineCode: createInlineCodeState(),
+          pendingTagFragment: "<fin",
+        },
+        lastStreamedAssistantCleaned: "stale",
+        emittedAssistantUpdate: true,
+      },
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Corrected answer",
+        replace: true,
+        partial: {
+          role: "assistant",
+          content: [],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(context.state.blockState).toMatchObject({
+      thinking: false,
+      final: false,
+      pendingTagFragment: undefined,
+    });
+    expect(context.state.partialBlockState).toMatchObject({
+      thinking: false,
+      final: false,
+      pendingTagFragment: undefined,
+    });
+    expect(context.state.deltaBuffer).toBe("Corrected answer");
+    expect(context.state.blockBuffer).toBe("Corrected answer");
+  });
+
+  it("emits empty replacement text deltas to clear stale streamed text", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        deltaBuffer: "stale",
+        blockBuffer: "stale",
+        lastStreamedAssistantCleaned: "stale",
+        emittedAssistantUpdate: true,
+      },
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "",
+        replace: true,
+        partial: {
+          role: "assistant",
+          content: [],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(firstMockArg(onAgentEvent, "agent event")).toEqual({
+      stream: "assistant",
+      data: {
+        text: "",
+        delta: "",
+        replace: true,
+        mediaUrls: undefined,
+        phase: undefined,
+      },
+    });
+    expect(context.state.lastStreamedAssistantCleaned).toBe("");
+    expect(context.state.deltaBuffer).toBe("");
+    expect(context.state.blockBuffer).toBe("");
+  });
+
+  it("resets assistant text stream state before replacement text deltas", () => {
+    const onAgentEvent = vi.fn();
+    const accumulator = createStreamingDirectiveAccumulator();
+    const resetAssistantTextStreamState = vi.fn(() => accumulator.reset());
+    accumulator.consume("\nMEDIA");
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string, options?: { final?: boolean }) =>
+        accumulator.consume(text, options),
+      ),
+      resetAssistantTextStreamState,
+      state: {
+        lastStreamedAssistantCleaned: "stale",
+        emittedAssistantUpdate: true,
+      },
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Corrected answer",
+        replace: true,
+        partial: {
+          role: "assistant",
+          content: [],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(resetAssistantTextStreamState).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(onAgentEvent, "agent event")).toMatchObject({
+      data: {
+        text: "Corrected answer",
+        mediaUrls: undefined,
+        replace: true,
+      },
+    });
+  });
+
   it("emits media-only unphased streaming directives", () => {
     const onAgentEvent = vi.fn();
     const context = createMessageUpdateContext({
@@ -1055,6 +1212,39 @@ describe("handleMessageEnd", () => {
     expect(onAgentEvent).not.toHaveBeenCalled();
     expect(emitBlockReply).not.toHaveBeenCalled();
     expect(finalizeAssistantTexts).not.toHaveBeenCalled();
+  });
+
+  it("emits final text after an empty replacement cleared the stream", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createMessageEndContext({
+      onAgentEvent,
+      state: {
+        emittedAssistantUpdate: true,
+        lastStreamedAssistantCleaned: "",
+        deltaBuffer: "",
+        blockBuffer: "",
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    expect(firstMockArg(onAgentEvent, "agent event")).toEqual({
+      stream: "assistant",
+      data: {
+        text: "Final answer",
+        delta: "Final answer",
+        replace: undefined,
+        mediaUrls: undefined,
+        phase: undefined,
+      },
+    });
   });
 
   it("does not duplicate block reply for text_end channels when text was already delivered", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -409,6 +409,90 @@ describe("handleMessageUpdate text signatures", () => {
     ]);
   });
 
+  it("uses replacement text deltas as full streamed text", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: { lastStreamedAssistantCleaned: "Final answer", emittedAssistantUpdate: true },
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Corrected answer",
+        replace: true,
+        partial: {
+          role: "assistant",
+          content: [],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(firstMockArg(onAgentEvent, "agent event")).toEqual({
+      stream: "assistant",
+      data: {
+        text: "Corrected answer",
+        delta: "",
+        replace: true,
+        mediaUrls: undefined,
+        phase: undefined,
+      },
+    });
+    expect(context.state.lastStreamedAssistantCleaned).toBe("Corrected answer");
+  });
+
+  it("emits media-only unphased streaming directives", () => {
+    const onAgentEvent = vi.fn();
+    const context = createMessageUpdateContext({
+      onAgentEvent,
+      consumePartialReplyDirectives: vi.fn(() => ({
+        text: "",
+        mediaUrls: ["/tmp/reply.png"],
+      })),
+    });
+
+    handleMessageUpdate(context, {
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "<media>",
+        partial: {
+          role: "assistant",
+          content: [],
+          stopReason: "stop",
+          api: "ollama",
+          provider: "ollama",
+          model: "qwen3:32b",
+          usage: {},
+          timestamp: 0,
+        },
+      },
+    } as never);
+
+    expect(firstMockArg(onAgentEvent, "agent event")).toEqual({
+      stream: "assistant",
+      data: {
+        text: "",
+        delta: "",
+        replace: undefined,
+        mediaUrls: ["/tmp/reply.png"],
+        phase: undefined,
+      },
+    });
+  });
+
   it("treats phased textSignature item changes as assistant-message boundaries", () => {
     const flushBlockReplyBuffer = vi.fn();
     const resetAssistantMessageState = vi.fn();

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -414,7 +414,12 @@ describe("handleMessageUpdate text signatures", () => {
     const context = createMessageUpdateContext({
       onAgentEvent,
       consumePartialReplyDirectives: vi.fn((text: string) => ({ text })),
-      state: { lastStreamedAssistantCleaned: "Final answer", emittedAssistantUpdate: true },
+      state: {
+        deltaBuffer: "Final answer",
+        blockBuffer: "Final answer",
+        lastStreamedAssistantCleaned: "Final answer",
+        emittedAssistantUpdate: true,
+      },
     });
 
     handleMessageUpdate(context, {
@@ -449,6 +454,8 @@ describe("handleMessageUpdate text signatures", () => {
       },
     });
     expect(context.state.lastStreamedAssistantCleaned).toBe("Corrected answer");
+    expect(context.state.deltaBuffer).toBe("Corrected answer");
+    expect(context.state.blockBuffer).toBe("Corrected answer");
   });
 
   it("emits media-only unphased streaming directives", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -25,6 +25,7 @@ function createMessageUpdateContext(
     onAgentEvent?: ReturnType<typeof vi.fn>;
     onPartialReply?: ReturnType<typeof vi.fn>;
     flushBlockReplyBuffer?: ReturnType<typeof vi.fn>;
+    resetAssistantTextStreamState?: ReturnType<typeof vi.fn>;
     resetAssistantMessageState?: ReturnType<typeof vi.fn>;
     debug?: ReturnType<typeof vi.fn>;
     shouldEmitPartialReplies?: boolean;
@@ -33,7 +34,7 @@ function createMessageUpdateContext(
     state?: Record<string, unknown>;
   } = {},
 ) {
-  return {
+  const context = {
     params: {
       runId: "run-1",
       session: { id: "session-1" },
@@ -47,6 +48,11 @@ function createMessageUpdateContext(
       streamReasoning: false,
       deltaBuffer: "",
       blockBuffer: "",
+      blockState: {
+        thinking: false,
+        final: false,
+        inlineCode: createInlineCodeState(),
+      },
       partialBlockState: {
         thinking: false,
         final: false,
@@ -73,6 +79,22 @@ function createMessageUpdateContext(
     recordAssistantUsage: vi.fn(),
     commitAssistantUsage: vi.fn(),
   } as unknown as EmbeddedAgentSubscribeContext;
+  context.resetAssistantTextStreamState =
+    params.resetAssistantTextStreamState ??
+    vi.fn(() => {
+      context.state.deltaBuffer = "";
+      context.state.blockBuffer = "";
+      context.blockChunker?.reset();
+      context.state.blockState.thinking = false;
+      context.state.blockState.final = false;
+      context.state.blockState.inlineCode = createInlineCodeState();
+      context.state.blockState.pendingTagFragment = undefined;
+      context.state.partialBlockState.thinking = false;
+      context.state.partialBlockState.final = false;
+      context.state.partialBlockState.inlineCode = createInlineCodeState();
+      context.state.partialBlockState.pendingTagFragment = undefined;
+    });
+  return context;
 }
 
 function createMessageEndContext(

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -500,6 +500,40 @@ describe("handleMessageUpdate text signatures", () => {
     });
   });
 
+  it("accumulates lightweight thinking deltas before emitting reasoning streams", () => {
+    const emitReasoningStream = vi.fn((text: string) => {
+      context.state.lastStreamedReasoning = text;
+    });
+    const context = createMessageUpdateContext({
+      state: { streamReasoning: true },
+    });
+    context.emitReasoningStream = emitReasoningStream;
+
+    for (const delta of ["first", " second"]) {
+      handleMessageUpdate(context, {
+        type: "message_update",
+        message: { role: "assistant", content: [] },
+        assistantMessageEvent: {
+          type: "thinking_delta",
+          contentIndex: 0,
+          delta,
+          partial: {
+            role: "assistant",
+            content: [],
+            stopReason: "stop",
+            api: "ollama",
+            provider: "ollama",
+            model: "qwen3:32b",
+            usage: {},
+            timestamp: 0,
+          },
+        },
+      } as never);
+    }
+
+    expect(emitReasoningStream.mock.calls.map(([text]) => text)).toEqual(["first", "first second"]);
+  });
+
   it("treats phased textSignature item changes as assistant-message boundaries", () => {
     const flushBlockReplyBuffer = vi.fn();
     const resetAssistantMessageState = vi.fn();

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -562,6 +562,7 @@ export function handleMessageUpdate(
     content,
     accumulatedText: ctx.state.deltaBuffer,
   });
+  const isReplacementDelta = evtType === "text_delta" && assistantRecord?.replace === true;
 
   const partialAssistant =
     assistantRecord?.partial && typeof assistantRecord.partial === "object"
@@ -597,8 +598,18 @@ export function handleMessageUpdate(
   const phaseAwareVisibleText = shouldUsePhaseAwareBlockReply
     ? coerceChatContentText(extractAssistantVisibleText(partialAssistant)).trim()
     : "";
+  const isUnphasedReplacementDelta = isReplacementDelta && !shouldUsePhaseAwareBlockReply;
 
   if (chunk) {
+    if (isUnphasedReplacementDelta) {
+      ctx.state.deltaBuffer = "";
+      ctx.state.blockBuffer = "";
+      ctx.blockChunker?.reset();
+      ctx.state.partialBlockState.thinking = false;
+      ctx.state.partialBlockState.final = false;
+      ctx.state.partialBlockState.inlineCode = createInlineCodeState();
+      ctx.state.partialBlockState.pendingTagFragment = undefined;
+    }
     ctx.state.deltaBuffer += chunk;
     if (!shouldUsePhaseAwareBlockReply) {
       appendBlockReplyChunk(ctx, chunk);
@@ -611,9 +622,7 @@ export function handleMessageUpdate(
   }
   const wasThinking = ctx.state.partialBlockState.thinking;
   let visibleDelta = "";
-  let next = shouldUsePhaseAwareBlockReply
-    ? coerceChatContentText(extractAssistantVisibleText(partialAssistant)).trim()
-    : "";
+  let next = phaseAwareVisibleText;
   let nextRawStreamText = next;
   if (!next && deliveryPhase !== "final_answer") {
     const pendingTagFragment = ctx.state.partialBlockState.pendingTagFragment;
@@ -660,9 +669,7 @@ export function handleMessageUpdate(
       final: evtType === "text_end",
     });
   }
-  const isReplacementDelta =
-    !shouldUsePhaseAwareBlockReply && evtType === "text_delta" && assistantRecord?.replace === true;
-  if (isReplacementDelta) {
+  if (isUnphasedReplacementDelta) {
     next = visibleDelta.trim();
     nextRawStreamText = visibleDelta;
   }
@@ -694,7 +701,8 @@ export function handleMessageUpdate(
       shouldEmit = false;
     } else {
       replace =
-        isReplacementDelta || Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
+        isUnphasedReplacementDelta ||
+        Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
       deltaText = replace ? "" : cleanedText.slice(previousCleaned.length);
       shouldEmit = replace
         ? cleanedText !== previousCleaned || hasMedia || hasAudio

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -161,6 +161,22 @@ function appendBlockReplyChunk(ctx: EmbeddedAgentSubscribeContext, chunk: string
   ctx.state.blockBuffer += chunk;
 }
 
+function resetBlockTagState(
+  state: EmbeddedAgentSubscribeState["blockState"] | EmbeddedAgentSubscribeState["partialBlockState"],
+) {
+  state.thinking = false;
+  state.final = false;
+  state.inlineCode = createInlineCodeState();
+  state.fence = undefined;
+  state.reasoningInlineCode = undefined;
+  state.reasoningFence = undefined;
+  state.reasoningPendingFenceFragment = undefined;
+  state.finalInlineCode = undefined;
+  state.finalFence = undefined;
+  state.pendingFenceFragment = undefined;
+  state.pendingTagFragment = undefined;
+}
+
 function replaceBlockReplyBuffer(ctx: EmbeddedAgentSubscribeContext, text: string) {
   if (ctx.blockChunker) {
     ctx.blockChunker.reset();
@@ -604,10 +620,10 @@ export function handleMessageUpdate(
     : "";
   const isUnphasedReplacementDelta = isReplacementDelta && !shouldUsePhaseAwareBlockReply;
 
+  if (isUnphasedReplacementDelta) {
+    ctx.resetAssistantTextStreamState();
+  }
   if (chunk) {
-    if (isUnphasedReplacementDelta) {
-      ctx.resetAssistantTextStreamState();
-    }
     ctx.state.deltaBuffer += chunk;
     if (!shouldUsePhaseAwareBlockReply) {
       appendBlockReplyChunk(ctx, chunk);
@@ -687,7 +703,7 @@ export function handleMessageUpdate(
   const cleanedText = parsedFull.text;
   const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
   const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
-  if (next || hasMedia || hasAudio) {
+  if (next || hasMedia || hasAudio || isUnphasedReplacementDelta) {
     if (shouldUsePhaseAwareBlockReply) {
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
     }
@@ -695,7 +711,10 @@ export function handleMessageUpdate(
     let shouldEmit = false;
     let deltaText = "";
     let replace = false;
-    if (!hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice: hasAudio })) {
+    if (
+      !isUnphasedReplacementDelta &&
+      !hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice: hasAudio })
+    ) {
       shouldEmit = false;
     } else {
       replace =
@@ -703,7 +722,7 @@ export function handleMessageUpdate(
         Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
       deltaText = replace ? "" : cleanedText.slice(previousCleaned.length);
       shouldEmit = replace
-        ? cleanedText !== previousCleaned || hasMedia || hasAudio
+        ? cleanedText !== previousCleaned || hasMedia || hasAudio || isUnphasedReplacementDelta
         : Boolean(deltaText || hasMedia || hasAudio);
     }
 
@@ -838,25 +857,8 @@ export function handleMessageEnd(
     ctx.state.deltaBuffer = "";
     ctx.state.blockBuffer = "";
     ctx.blockChunker?.reset();
-    ctx.state.blockState.thinking = false;
-    ctx.state.blockState.final = false;
-    ctx.state.blockState.inlineCode = createInlineCodeState();
-    ctx.state.blockState.fence = undefined;
-    ctx.state.blockState.reasoningInlineCode = undefined;
-    ctx.state.blockState.reasoningFence = undefined;
-    ctx.state.blockState.reasoningPendingFenceFragment = undefined;
-    ctx.state.blockState.finalInlineCode = undefined;
-    ctx.state.blockState.finalFence = undefined;
-    ctx.state.blockState.pendingFenceFragment = undefined;
-    ctx.state.blockState.pendingTagFragment = undefined;
-    ctx.state.partialBlockState.fence = undefined;
-    ctx.state.partialBlockState.reasoningInlineCode = undefined;
-    ctx.state.partialBlockState.reasoningFence = undefined;
-    ctx.state.partialBlockState.reasoningPendingFenceFragment = undefined;
-    ctx.state.partialBlockState.finalInlineCode = undefined;
-    ctx.state.partialBlockState.finalFence = undefined;
-    ctx.state.partialBlockState.pendingFenceFragment = undefined;
-    ctx.state.partialBlockState.pendingTagFragment = undefined;
+    resetBlockTagState(ctx.state.blockState);
+    resetBlockTagState(ctx.state.partialBlockState);
     ctx.state.lastStreamedAssistant = undefined;
     ctx.state.lastStreamedAssistantCleaned = undefined;
     ctx.state.reasoningStreamOpen = false;
@@ -872,6 +874,9 @@ export function handleMessageEnd(
   const finalStreamDelta = shouldReplaceFinalStream
     ? ""
     : cleanedText.slice(previousStreamedText.length);
+  const shouldEmitFinalDeltaAfterEmptyStream = Boolean(
+    ctx.state.emittedAssistantUpdate && !previousStreamedText && finalStreamDelta,
+  );
 
   if (
     !ctx.params.silentExpected &&
@@ -880,6 +885,7 @@ export function handleMessageEnd(
     (!ctx.state.emittedAssistantUpdate ||
       shouldReplaceFinalStream ||
       didTextChangeWithinCurrentMessage ||
+      shouldEmitFinalDeltaAfterEmptyStream ||
       hasMedia)
   ) {
     const data = buildAssistantStreamData({

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -528,7 +528,11 @@ export function handleMessageUpdate(
     if (ctx.state.streamReasoning) {
       // Prefer full partial-message thinking when available; fall back to event payloads.
       const partialThinking = extractAssistantThinking(msg);
-      ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
+      const fallbackThinking =
+        evtType === "thinking_delta" && thinkingDelta
+          ? `${ctx.state.lastStreamedReasoning ?? ""}${thinkingDelta}`
+          : thinkingDelta;
+      ctx.emitReasoningStream(partialThinking || thinkingContent || fallbackThinking);
     }
     if (evtType === "thinking_end") {
       if (!ctx.state.reasoningStreamOpen) {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -162,7 +162,9 @@ function appendBlockReplyChunk(ctx: EmbeddedAgentSubscribeContext, chunk: string
 }
 
 function resetBlockTagState(
-  state: EmbeddedAgentSubscribeState["blockState"] | EmbeddedAgentSubscribeState["partialBlockState"],
+  state:
+    | EmbeddedAgentSubscribeState["blockState"]
+    | EmbeddedAgentSubscribeState["partialBlockState"],
 ) {
   state.thinking = false;
   state.final = false;
@@ -698,11 +700,17 @@ export function handleMessageUpdate(
   const finalParsedDelta =
     evtType === "text_end" ? ctx.consumePartialReplyDirectives("", { final: true }) : null;
   const parsedStreamDirectives = mergeReplyDirectiveResults(parsedDelta, finalParsedDelta);
-  const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
   const parsedFull = parseReplyDirectives(splitTrailingDirective(next).text);
-  const cleanedText = parsedFull.text;
+  const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
   const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
   const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
+  const streamDirectiveOnly = Boolean(
+    parsedStreamDirectives &&
+    (hasMedia || hasAudio) &&
+    !parsedStreamDirectives.text?.trim() &&
+    !previousCleaned,
+  );
+  const cleanedText = streamDirectiveOnly ? "" : parsedFull.text;
   if (next || hasMedia || hasAudio || isUnphasedReplacementDelta) {
     if (shouldUsePhaseAwareBlockReply) {
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
@@ -859,8 +867,6 @@ export function handleMessageEnd(
     ctx.blockChunker?.reset();
     resetBlockTagState(ctx.state.blockState);
     resetBlockTagState(ctx.state.partialBlockState);
-    ctx.state.lastStreamedAssistant = undefined;
-    ctx.state.lastStreamedAssistantCleaned = undefined;
     ctx.state.reasoningStreamOpen = false;
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -660,26 +660,32 @@ export function handleMessageUpdate(
       final: evtType === "text_end",
     });
   }
-  if (next) {
-    if (!wasThinking && ctx.state.partialBlockState.thinking) {
-      openReasoningStream(ctx);
-    }
-    // Detect when thinking block ends (</think> tag processed)
-    if (wasThinking && !ctx.state.partialBlockState.thinking) {
-      emitReasoningEnd(ctx);
-    }
-    const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
-    const finalParsedDelta =
-      evtType === "text_end" ? ctx.consumePartialReplyDirectives("", { final: true }) : null;
-    const parsedStreamDirectives = mergeReplyDirectiveResults(parsedDelta, finalParsedDelta);
+  const isReplacementDelta =
+    !shouldUsePhaseAwareBlockReply && evtType === "text_delta" && assistantRecord?.replace === true;
+  if (isReplacementDelta) {
+    next = visibleDelta.trim();
+    nextRawStreamText = visibleDelta;
+  }
+  if (!wasThinking && ctx.state.partialBlockState.thinking) {
+    openReasoningStream(ctx);
+  }
+  // Detect when thinking block ends (</think> tag processed)
+  if (wasThinking && !ctx.state.partialBlockState.thinking) {
+    emitReasoningEnd(ctx);
+  }
+  const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
+  const finalParsedDelta =
+    evtType === "text_end" ? ctx.consumePartialReplyDirectives("", { final: true }) : null;
+  const parsedStreamDirectives = mergeReplyDirectiveResults(parsedDelta, finalParsedDelta);
+  const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+  const parsedFull = parseReplyDirectives(splitTrailingDirective(next).text);
+  const cleanedText = parsedFull.text;
+  const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
+  const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
+  if (next || hasMedia || hasAudio) {
     if (shouldUsePhaseAwareBlockReply) {
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
     }
-    const parsedFull = parseReplyDirectives(splitTrailingDirective(next).text);
-    const cleanedText = parsedFull.text;
-    const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
-    const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
-    const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
 
     let shouldEmit = false;
     let deltaText = "";
@@ -687,7 +693,8 @@ export function handleMessageUpdate(
     if (!hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice: hasAudio })) {
       shouldEmit = false;
     } else {
-      replace = Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
+      replace =
+        isReplacementDelta || Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
       deltaText = replace ? "" : cleanedText.slice(previousCleaned.length);
       shouldEmit = replace
         ? cleanedText !== previousCleaned || hasMedia || hasAudio

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -568,15 +568,16 @@ export function handleMessageUpdate(
       ? (assistantRecord.partial as AssistantMessage)
       : msg;
   const deliveryPhase = resolveAssistantMessagePhase(partialAssistant);
-  const streamItemId = resolveAssistantStreamItemId({
-    contentIndex: assistantRecord?.contentIndex,
-    message: partialAssistant,
-  });
+  const isOpenAiResponsesPartial = isOpenAiResponsesAssistantMessage(partialAssistant);
+  const streamItemId =
+    deliveryPhase || isOpenAiResponsesPartial
+      ? resolveAssistantStreamItemId({
+          contentIndex: assistantRecord?.contentIndex,
+          message: partialAssistant,
+        })
+      : undefined;
   const isPhasePendingOpenAiResponsesTextItem =
-    evtType !== "text_end" &&
-    !deliveryPhase &&
-    Boolean(streamItemId) &&
-    isOpenAiResponsesAssistantMessage(partialAssistant);
+    evtType !== "text_end" && !deliveryPhase && Boolean(streamItemId) && isOpenAiResponsesPartial;
   if ((deliveryPhase || isPhasePendingOpenAiResponsesTextItem) && streamItemId) {
     const previousStreamItemId = ctx.state.lastAssistantStreamItemId;
     if (previousStreamItemId && previousStreamItemId !== streamItemId) {
@@ -593,6 +594,9 @@ export function handleMessageUpdate(
     return;
   }
   const shouldUsePhaseAwareBlockReply = Boolean(deliveryPhase);
+  const phaseAwareVisibleText = shouldUsePhaseAwareBlockReply
+    ? coerceChatContentText(extractAssistantVisibleText(partialAssistant)).trim()
+    : "";
 
   if (chunk) {
     ctx.state.deltaBuffer += chunk;

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -606,13 +606,7 @@ export function handleMessageUpdate(
 
   if (chunk) {
     if (isUnphasedReplacementDelta) {
-      ctx.state.deltaBuffer = "";
-      ctx.state.blockBuffer = "";
-      ctx.blockChunker?.reset();
-      ctx.state.partialBlockState.thinking = false;
-      ctx.state.partialBlockState.final = false;
-      ctx.state.partialBlockState.inlineCode = createInlineCodeState();
-      ctx.state.partialBlockState.pendingTagFragment = undefined;
+      ctx.resetAssistantTextStreamState();
     }
     ctx.state.deltaBuffer += chunk;
     if (!shouldUsePhaseAwareBlockReply) {

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -193,6 +193,7 @@ export type EmbeddedAgentSubscribeContext = {
     text: string,
     options?: { final?: boolean },
   ) => ReplyDirectiveParseResult | null;
+  resetAssistantTextStreamState: () => void;
   resetAssistantMessageState: (nextAssistantTextBaseline: number) => void;
   resetForCompactionRetry: () => void;
   finalizeAssistantTexts: (args: {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -351,6 +351,47 @@ describe("subscribeEmbeddedAgentSession", () => {
     },
   );
 
+  it("resets block parsing before consuming replacement text deltas", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run",
+      onAgentEvent,
+      onBlockReply,
+      blockReplyBreak: "text_end",
+    });
+
+    emitAssistantTextDelta(emit, "<think>\nDraft reasoning");
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Corrected answer",
+        replace: true,
+      },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_end",
+        content: "Corrected answer",
+      },
+    });
+    await flushBlockReplyCallbacks();
+
+    expectBlockReplyPayload(onBlockReply, { text: "Corrected answer" });
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toContainEqual({
+      text: "Corrected answer",
+      delta: "",
+      replace: true,
+      mediaUrls: undefined,
+      phase: undefined,
+    });
+  });
+
   it("blocks local MEDIA urls from case-variant tool names in verbose output", async () => {
     const onToolResult = vi.fn();
     const { emit } = createSubscribedHarness({

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -296,7 +296,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     }
   };
 
-  const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
+  const resetAssistantTextStreamState = () => {
     state.deltaBuffer = "";
     state.blockBuffer = "";
     blockChunker?.reset();
@@ -324,6 +324,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.partialBlockState.finalFence = undefined;
     state.partialBlockState.pendingFenceFragment = undefined;
     state.partialBlockState.pendingTagFragment = undefined;
+  };
+
+  const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
+    resetAssistantTextStreamState();
     state.lastStreamedAssistant = undefined;
     state.lastStreamedAssistantCleaned = undefined;
     state.emittedAssistantUpdate = false;
@@ -752,10 +756,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           const after = scanText.slice(afterIndex);
           if (hasOrphanReasoningCloseBoundary({ before, after })) {
             processed = "";
+            lastIndex = afterIndex + after.length - after.trimStart().length;
           } else {
             processed += before;
+            lastIndex = afterIndex;
           }
-          lastIndex = afterIndex;
           continue;
         }
         processed += scanText.slice(lastIndex, idx);
@@ -1156,6 +1161,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     emitReasoningStream,
     consumeReplyDirectives,
     consumePartialReplyDirectives,
+    resetAssistantTextStreamState,
     resetAssistantMessageState,
     resetForCompactionRetry,
     finalizeAssistantTexts,

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -153,6 +153,41 @@ describe("streamProxy", () => {
     });
   });
 
+  it("preserves proxy replacement text deltas", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFromText(
+          [
+            { type: "start" },
+            { type: "text_start", contentIndex: 0 },
+            { type: "text_delta", contentIndex: 0, delta: "Draft" },
+            { type: "text_delta", contentIndex: 0, delta: "Corrected", replace: true },
+            { type: "text_end", contentIndex: 0 },
+            { type: "done", reason: "stop", usage },
+          ]
+            .map((event) => `data: ${JSON.stringify(event)}`)
+            .join("\n"),
+        ),
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const replacement = events.find((event) => event.type === "text_delta" && event.replace);
+    expect(replacement?.partial.content).toEqual([{ type: "text", text: "Corrected" }]);
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ type: "text", text: "Corrected" }],
+    });
+  });
+
   it("returns an error result when EOF arrives without a terminal event", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -182,7 +182,9 @@ describe("streamProxy", () => {
     }
 
     const replacement = events.find((event) => event.type === "text_delta" && event.replace);
-    expect(replacement?.partial.content).toEqual([{ type: "text", text: "Corrected" }]);
+    expect(replacement).toMatchObject({
+      partial: { content: [{ type: "text", text: "Corrected" }] },
+    });
     await expect(stream.result()).resolves.toMatchObject({
       content: [{ type: "text", text: "Corrected" }],
     });

--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -115,6 +115,44 @@ describe("streamProxy", () => {
     });
   });
 
+  it("reconstructs proxy text deltas with compatibility partial snapshots", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFromText(
+          [
+            { type: "start" },
+            { type: "text_start", contentIndex: 0 },
+            { type: "text_delta", contentIndex: 0, delta: "Hel" },
+            { type: "text_delta", contentIndex: 0, delta: "lo" },
+            { type: "text_end", contentIndex: 0 },
+            { type: "done", reason: "stop", usage },
+          ]
+            .map((event) => `data: ${JSON.stringify(event)}`)
+            .join("\n"),
+        ),
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const deltas = events.filter((event) => event.type === "text_delta");
+    expect(deltas[0]?.partial.content).toEqual([{ type: "text", text: "Hel" }]);
+    expect(deltas[1]?.partial.content).toEqual([{ type: "text", text: "Hello" }]);
+
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ type: "text", text: "Hello" }],
+      stopReason: "stop",
+    });
+  });
+
   it("returns an error result when EOF arrives without a terminal event", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -43,7 +43,7 @@ class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, Assista
 export type ProxyAssistantMessageEvent =
   | { type: "start" }
   | { type: "text_start"; contentIndex: number }
-  | { type: "text_delta"; contentIndex: number; delta: string }
+  | { type: "text_delta"; contentIndex: number; delta: string; replace?: boolean }
   | { type: "text_end"; contentIndex: number; contentSignature?: string }
   | { type: "thinking_start"; contentIndex: number }
   | { type: "thinking_delta"; contentIndex: number; delta: string }
@@ -261,7 +261,9 @@ function processProxyEvent(
       return accumulator.startText(proxyEvent.contentIndex);
 
     case "text_delta":
-      return accumulator.appendTextDelta(proxyEvent.contentIndex, proxyEvent.delta);
+      return accumulator.appendTextDelta(proxyEvent.contentIndex, proxyEvent.delta, {
+        replace: proxyEvent.replace === true,
+      });
 
     case "text_end":
       return accumulator.endText(proxyEvent.contentIndex, {

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -3,6 +3,7 @@
  * The server manages auth and proxies requests to LLM providers.
  */
 
+import { createAssistantStreamAccumulator } from "../../llm/assistant-stream-accumulator.js";
 // Internal import for JSON parsing utility
 import {
   type AssistantMessage,
@@ -132,24 +133,10 @@ export function streamProxy(
   const stream = new ProxyMessageEventStream();
 
   void (async () => {
-    // Initialize the partial message that we'll build up from events
-    const partial: AssistantMessage = {
-      role: "assistant",
-      stopReason: "stop",
-      content: [],
-      api: model.api,
-      provider: model.provider,
-      model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      timestamp: Date.now(),
-    };
+    const accumulator = createAssistantStreamAccumulator({
+      model: { api: model.api, provider: model.provider, model: model.id },
+      deltaPartialMode: "snapshot",
+    });
 
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
@@ -205,7 +192,7 @@ export function streamProxy(
           return;
         }
         const proxyEvent = JSON.parse(data) as ProxyAssistantMessageEvent;
-        const event = processProxyEvent(proxyEvent, partial);
+        const event = processProxyEvent(proxyEvent, accumulator);
         if (!event) {
           return;
         }
@@ -247,13 +234,7 @@ export function streamProxy(
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const reason = options.signal?.aborted ? "aborted" : "error";
-      partial.stopReason = reason;
-      partial.errorMessage = errorMessage;
-      stream.push({
-        type: "error",
-        reason,
-        error: partial,
-      });
+      stream.push(accumulator.error(reason, { errorMessage }));
       stream.end();
     } finally {
       if (options.signal) {
@@ -266,131 +247,71 @@ export function streamProxy(
 }
 
 /**
- * Process a proxy event and update the partial message.
+ * Process a proxy event and update the local assistant stream accumulator.
  */
 function processProxyEvent(
   proxyEvent: ProxyAssistantMessageEvent,
-  partial: AssistantMessage,
+  accumulator: ReturnType<typeof createAssistantStreamAccumulator>,
 ): AssistantMessageEvent | undefined {
   switch (proxyEvent.type) {
     case "start":
-      return { type: "start", partial };
+      return accumulator.start();
 
     case "text_start":
-      partial.content[proxyEvent.contentIndex] = { type: "text", text: "" };
-      return { type: "text_start", contentIndex: proxyEvent.contentIndex, partial };
+      return accumulator.startText(proxyEvent.contentIndex);
 
-    case "text_delta": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "text") {
-        content.text += proxyEvent.delta;
-        return {
-          type: "text_delta",
-          contentIndex: proxyEvent.contentIndex,
-          delta: proxyEvent.delta,
-          partial,
-        };
-      }
-      throw new Error("Received text_delta for non-text content");
-    }
+    case "text_delta":
+      return accumulator.appendTextDelta(proxyEvent.contentIndex, proxyEvent.delta);
 
-    case "text_end": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "text") {
-        content.textSignature = proxyEvent.contentSignature;
-        return {
-          type: "text_end",
-          contentIndex: proxyEvent.contentIndex,
-          content: content.text,
-          partial,
-        };
-      }
-      throw new Error("Received text_end for non-text content");
-    }
+    case "text_end":
+      return accumulator.endText(proxyEvent.contentIndex, {
+        textSignature: proxyEvent.contentSignature,
+      });
 
     case "thinking_start":
-      partial.content[proxyEvent.contentIndex] = { type: "thinking", thinking: "" };
-      return { type: "thinking_start", contentIndex: proxyEvent.contentIndex, partial };
+      return accumulator.startThinking(proxyEvent.contentIndex);
 
-    case "thinking_delta": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "thinking") {
-        content.thinking += proxyEvent.delta;
-        return {
-          type: "thinking_delta",
-          contentIndex: proxyEvent.contentIndex,
-          delta: proxyEvent.delta,
-          partial,
-        };
-      }
-      throw new Error("Received thinking_delta for non-thinking content");
-    }
+    case "thinking_delta":
+      return accumulator.appendThinkingDelta(proxyEvent.contentIndex, proxyEvent.delta);
 
-    case "thinking_end": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "thinking") {
-        content.thinkingSignature = proxyEvent.contentSignature;
-        return {
-          type: "thinking_end",
-          contentIndex: proxyEvent.contentIndex,
-          content: content.thinking,
-          partial,
-        };
-      }
-      throw new Error("Received thinking_end for non-thinking content");
-    }
+    case "thinking_end":
+      return accumulator.endThinking(proxyEvent.contentIndex, {
+        thinkingSignature: proxyEvent.contentSignature,
+      });
 
     case "toolcall_start":
-      partial.content[proxyEvent.contentIndex] = {
+      return accumulator.startToolCall(proxyEvent.contentIndex, {
         type: "toolCall",
         id: proxyEvent.id,
         name: proxyEvent.toolName,
         arguments: {},
         partialJson: "",
-      } satisfies ToolCall & { partialJson: string } as ToolCall;
-      return { type: "toolcall_start", contentIndex: proxyEvent.contentIndex, partial };
+      } satisfies ToolCall & { partialJson: string } as ToolCall);
 
-    case "toolcall_delta": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "toolCall") {
-        const streamingContent = content as StreamingToolCall;
-        streamingContent.partialJson = `${streamingContent.partialJson ?? ""}${proxyEvent.delta}`;
-        content.arguments = parseStreamingJson(streamingContent.partialJson) || {};
-        partial.content[proxyEvent.contentIndex] = { ...content }; // Trigger reactivity
-        return {
-          type: "toolcall_delta",
-          contentIndex: proxyEvent.contentIndex,
-          delta: proxyEvent.delta,
-          partial,
-        };
-      }
-      throw new Error("Received toolcall_delta for non-toolCall content");
-    }
+    case "toolcall_delta":
+      return accumulator.appendToolCallDelta(
+        proxyEvent.contentIndex,
+        proxyEvent.delta,
+        (toolCall) => {
+          const streamingContent = toolCall as StreamingToolCall;
+          streamingContent.partialJson = `${streamingContent.partialJson ?? ""}${proxyEvent.delta}`;
+          toolCall.arguments = parseStreamingJson(streamingContent.partialJson) || {};
+        },
+      );
 
-    case "toolcall_end": {
-      const content = partial.content[proxyEvent.contentIndex];
-      if (content?.type === "toolCall") {
-        delete (content as StreamingToolCall).partialJson;
-        return {
-          type: "toolcall_end",
-          contentIndex: proxyEvent.contentIndex,
-          toolCall: content,
-          partial,
-        };
-      }
-      return undefined;
-    }
+    case "toolcall_end":
+      return accumulator.endToolCall(proxyEvent.contentIndex, (toolCall) => {
+        delete (toolCall as StreamingToolCall).partialJson;
+      });
 
     case "done":
-      partial.stopReason = proxyEvent.reason;
-      partial.usage = proxyEvent.usage;
-      return { type: "done", reason: proxyEvent.reason, message: partial };
+      return accumulator.done(proxyEvent.reason, { usage: proxyEvent.usage });
 
     case "error":
-      partial.stopReason = proxyEvent.reason;
-      partial.errorMessage = proxyEvent.errorMessage;
-      partial.usage = proxyEvent.usage;
-      return { type: "error", reason: proxyEvent.reason, error: partial };
+      return accumulator.error(proxyEvent.reason, {
+        errorMessage: proxyEvent.errorMessage,
+        usage: proxyEvent.usage,
+      });
 
     default: {
       proxyEvent satisfies never;

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -24,10 +24,10 @@ export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
   nextDelta: string;
-  replace?: boolean;
+  nextReplace?: boolean;
 }): string {
-  const { previousText, nextText, nextDelta } = params;
-  if (params.replace) {
+  const { previousText, nextText, nextDelta, nextReplace } = params;
+  if (nextReplace) {
     return capLiveAssistantBuffer(nextText);
   }
   if (nextText && previousText) {

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -24,8 +24,12 @@ export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
   nextDelta: string;
+  replace?: boolean;
 }): string {
   const { previousText, nextText, nextDelta } = params;
+  if (params.replace) {
+    return capLiveAssistantBuffer(nextText);
+  }
   if (nextText && previousText) {
     if (nextText.startsWith(previousText) && nextText.length > previousText.length) {
       return capLiveAssistantBuffer(nextText);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1239,6 +1239,117 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("honors explicit replacement deltas that shorten to a prefix", () => {
+    let now = 12_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-prefix-replacement", {
+      sessionKey: "session-prefix-replacement",
+      clientRunId: "client-prefix-replacement",
+    });
+
+    handler({
+      runId: "run-prefix-replacement",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    now = 12_200;
+    handler({
+      runId: "run-prefix-replacement",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello", delta: "", replace: true },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    const replacementPayload = chatCalls[1]?.[1] as {
+      deltaText?: string;
+      replace?: boolean;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(replacementPayload.deltaText).toBe("Hello");
+    expect(replacementPayload.replace).toBe(true);
+    expect(replacementPayload.message?.content?.[0]?.text).toBe("Hello");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
+    nowSpy.mockRestore();
+  });
+
+  it("honors explicit empty replacement deltas", () => {
+    let now = 12_400;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-empty-replacement", {
+      sessionKey: "session-empty-replacement",
+      clientRunId: "client-empty-replacement",
+    });
+
+    handler({
+      runId: "run-empty-replacement",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    now = 12_450;
+    handler({
+      runId: "run-empty-replacement",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "", delta: "", replace: true },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    const replacementPayload = chatCalls[1]?.[1] as {
+      deltaText?: string;
+      replace?: boolean;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(replacementPayload.deltaText).toBe("");
+    expect(replacementPayload.replace).toBe(true);
+    expect(replacementPayload.message?.content?.[0]?.text).toBe("");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
+    nowSpy.mockRestore();
+  });
+
+  it("suppresses non-empty control lead fragment replacements", () => {
+    let now = 12_500;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-control-replacement", {
+      sessionKey: "session-control-replacement",
+      clientRunId: "client-control-replacement",
+    });
+
+    handler({
+      runId: "run-control-replacement",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world" },
+    });
+
+    now = 12_550;
+    handler({
+      runId: "run-control-replacement",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "NO_", delta: "", replace: true },
+    });
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy.mockRestore();
+  });
+
   it("cleans up agent run sequence tracking when lifecycle completes", () => {
     const { agentRunSeq, chatRunState, handler, nowSpy } = createHarness({ now: 2_500 });
     chatRunState.registry.add("run-cleanup", {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -440,6 +440,39 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("coalesces dense assistant agent deltas without per-chunk broadcasts", () => {
+    let now = 11_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-agent-dense", {
+      sessionKey: "session-agent-dense",
+      clientRunId: "client-agent-dense",
+    });
+
+    let text = "";
+    for (let i = 0; i < 100; i += 1) {
+      text += "x";
+      now = 11_000 + i;
+      handler({
+        runId: "run-agent-dense",
+        seq: i + 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { text, delta: "x" },
+      });
+    }
+
+    const agentCalls = agentBroadcastCalls(broadcast);
+    expect(agentCalls).toHaveLength(1);
+    expect(sessionAgentCalls(nodeSendToSession)).toHaveLength(1);
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    expect((agentCalls[0]?.[1] as { data?: { delta?: string; text?: string } }).data).toMatchObject(
+      { delta: "x", text: "x" },
+    );
+    nowSpy.mockRestore();
+  });
+
   it("flushes coalesced assistant agent text before lifecycle end", () => {
     let now = 20_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -47,15 +47,26 @@ describe("server chat stream text merge", () => {
     ).toBe("Hello world");
   });
 
-  it("honors replacement snapshots even when they are shorter prefixes", () => {
+  it("honors explicit replacements even when the new text is a shorter prefix", () => {
     expect(
       resolveMergedAssistantText({
         previousText: "Hello world",
         nextText: "Hello",
         nextDelta: "",
-        replace: true,
+        nextReplace: true,
       }),
     ).toBe("Hello");
+  });
+
+  it("honors explicit empty replacements", () => {
+    expect(
+      resolveMergedAssistantText({
+        previousText: "Hello world",
+        nextText: "",
+        nextDelta: "",
+        nextReplace: true,
+      }),
+    ).toBe("");
   });
 
   it("keeps non-prefix incremental segments after tool calls", () => {

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  MAX_LIVE_CHAT_BUFFER_CHARS,
-  resolveMergedAssistantText,
-} from "./live-chat-projector.js";
+import { MAX_LIVE_CHAT_BUFFER_CHARS, resolveMergedAssistantText } from "./live-chat-projector.js";
 
 describe("server chat stream text merge", () => {
   it.each([
@@ -48,6 +45,17 @@ describe("server chat stream text merge", () => {
         nextDelta: " world",
       }),
     ).toBe("Hello world");
+  });
+
+  it("honors replacement snapshots even when they are shorter prefixes", () => {
+    expect(
+      resolveMergedAssistantText({
+        previousText: "Hello world",
+        nextText: "Hello",
+        nextDelta: "",
+        replace: true,
+      }),
+    ).toBe("Hello");
   });
 
   it("keeps non-prefix incremental segments after tool calls", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -197,7 +197,11 @@ type BroadcastDelta = { deltaText: string; replace?: true };
 function resolveBroadcastDelta(params: {
   text: string;
   previousBroadcastText: string | undefined;
+  replace?: boolean;
 }): BroadcastDelta | undefined {
+  if (params.replace) {
+    return { deltaText: params.text, replace: true };
+  }
   if (!params.text) {
     return undefined;
   }
@@ -521,16 +525,18 @@ export function createAgentEventHandler({
       previousText: previousRawText,
       nextText: cleaned.text,
       nextDelta: cleaned.delta,
-      replace: opts?.replace === true,
+      nextReplace: opts?.replace === true,
     });
-    if (!mergedRawText) {
+    if (!mergedRawText && opts?.replace !== true) {
       return;
     }
     chatRunState.rawBuffers.set(clientRunId, mergedRawText);
     const projected = projectLiveAssistantBufferedText(mergedRawText);
     const mergedText = projected.text;
     chatRunState.buffers.set(clientRunId, mergedText);
-    if (projected.suppress) {
+    const shouldEmitSuppressedReplacementClear =
+      opts?.replace === true && mergedText === "" && !projected.pendingLeadFragment;
+    if (projected.suppress && !shouldEmitSuppressedReplacementClear) {
       return;
     }
     if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
@@ -538,12 +544,13 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
-    if (now - last < 150) {
+    if (now - last < 150 && opts?.replace !== true) {
       return;
     }
     const broadcastDelta = resolveBroadcastDelta({
       text: mergedText,
       previousBroadcastText: chatRunState.deltaLastBroadcastText.get(clientRunId),
+      replace: opts?.replace === true,
     });
     if (!broadcastDelta) {
       return;

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -513,7 +513,7 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; replace?: boolean },
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
     const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
@@ -521,6 +521,7 @@ export function createAgentEventHandler({
       previousText: previousRawText,
       nextText: cleaned.text,
       nextDelta: cleaned.delta,
+      replace: opts?.replace === true,
     });
     if (!mergedRawText) {
       return;
@@ -1067,6 +1068,7 @@ export function createAgentEventHandler({
       ) {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta, {
           controlUiVisible: isControlUiVisible,
+          replace: evt.data.replace === true,
         });
       }
     }

--- a/src/llm/assistant-stream-accumulator.test.ts
+++ b/src/llm/assistant-stream-accumulator.test.ts
@@ -50,6 +50,19 @@ describe("createAssistantStreamAccumulator", () => {
     expectTextContent(delta.partial, "Hello");
   });
 
+  it("marks replacement text deltas and keeps the final message converged", () => {
+    const accumulator = createAssistantStreamAccumulator({ model, timestamp: 123 });
+
+    accumulator.start();
+    accumulator.startText(0);
+    accumulator.appendTextDelta(0, "Final answer");
+    const replacement = accumulator.appendTextDelta(0, "Final answer only.", { replace: true });
+
+    expect(replacement.replace).toBe(true);
+    expect(replacement.delta).toBe("Final answer only.");
+    expect(accumulator.endText(0).content).toBe("Final answer only.");
+  });
+
   it("accumulates thinking and tool-call boundaries without provider policy", () => {
     const accumulator = createAssistantStreamAccumulator({ model, timestamp: 123 });
 

--- a/src/llm/assistant-stream-accumulator.test.ts
+++ b/src/llm/assistant-stream-accumulator.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { createAssistantStreamAccumulator } from "./assistant-stream-accumulator.js";
+import type { AssistantMessage } from "./types.js";
+
+const model = {
+  api: "test-api",
+  provider: "test-provider",
+  model: "test-model",
+};
+
+function expectTextContent(message: AssistantMessage, text: string): void {
+  expect(message.content).toEqual([{ type: "text", text }]);
+}
+
+describe("createAssistantStreamAccumulator", () => {
+  it("emits lightweight partials for dense text deltas and a full final message", () => {
+    const accumulator = createAssistantStreamAccumulator({ model, timestamp: 123 });
+
+    expect(accumulator.start().partial.content).toEqual([]);
+    expect(accumulator.startText(0).partial.content).toEqual([{ type: "text", text: "" }]);
+
+    const firstDelta = accumulator.appendTextDelta(0, "Hel");
+    const secondDelta = accumulator.appendTextDelta(0, "lo");
+
+    expect(firstDelta.delta).toBe("Hel");
+    expect(firstDelta.partial.content).toEqual([]);
+    expect(secondDelta.delta).toBe("lo");
+    expect(secondDelta.partial.content).toEqual([]);
+
+    const textEnd = accumulator.endText(0);
+    expect(textEnd.content).toBe("Hello");
+    expectTextContent(textEnd.partial, "Hello");
+
+    const done = accumulator.done("stop");
+    expectTextContent(done.message, "Hello");
+    expect(done.message.timestamp).toBe(123);
+  });
+
+  it("can preserve full delta partial snapshots for compatibility streams", () => {
+    const accumulator = createAssistantStreamAccumulator({
+      model,
+      deltaPartialMode: "snapshot",
+      timestamp: 123,
+    });
+
+    accumulator.start();
+    accumulator.startText(0);
+    const delta = accumulator.appendTextDelta(0, "Hello");
+
+    expectTextContent(delta.partial, "Hello");
+  });
+
+  it("accumulates thinking and tool-call boundaries without provider policy", () => {
+    const accumulator = createAssistantStreamAccumulator({ model, timestamp: 123 });
+
+    accumulator.start();
+    accumulator.startThinking(0);
+    const thinkingDelta = accumulator.appendThinkingDelta(0, "because");
+    expect(thinkingDelta.partial.content).toEqual([]);
+    expect(accumulator.endThinking(0).partial.content).toEqual([
+      { type: "thinking", thinking: "because" },
+    ]);
+
+    accumulator.startToolCall(1, {
+      type: "toolCall",
+      id: "call-1",
+      name: "lookup",
+      arguments: {},
+    });
+    accumulator.appendToolCallDelta(1, '{"q":"hi"}', (toolCall) => {
+      toolCall.arguments = { q: "hi" };
+    });
+
+    const toolEnd = accumulator.endToolCall(1);
+    expect(toolEnd.toolCall).toEqual({
+      type: "toolCall",
+      id: "call-1",
+      name: "lookup",
+      arguments: { q: "hi" },
+    });
+    expect(toolEnd.partial.content).toEqual([
+      { type: "thinking", thinking: "because" },
+      {
+        type: "toolCall",
+        id: "call-1",
+        name: "lookup",
+        arguments: { q: "hi" },
+      },
+    ]);
+  });
+});

--- a/src/llm/assistant-stream-accumulator.ts
+++ b/src/llm/assistant-stream-accumulator.ts
@@ -117,13 +117,15 @@ export function createAssistantStreamAccumulator(options: AssistantStreamAccumul
     appendTextDelta(
       contentIndex: number,
       delta: string,
+      options: { replace?: boolean } = {},
     ): Extract<AssistantMessageEvent, { type: "text_delta" }> {
       const block = ensureTextContent(content, contentIndex, "text_delta");
-      block.text += delta;
+      block.text = options.replace ? delta : block.text + delta;
       return {
         type: "text_delta",
         contentIndex,
         delta,
+        ...(options.replace ? { replace: true } : {}),
         partial: deltaPartial(),
       };
     },

--- a/src/llm/assistant-stream-accumulator.ts
+++ b/src/llm/assistant-stream-accumulator.ts
@@ -1,0 +1,253 @@
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  StopReason,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  Usage,
+} from "./types.js";
+
+export type AssistantStreamAccumulatorModel = Pick<AssistantMessage, "api" | "provider" | "model">;
+
+export type AssistantStreamDeltaPartialMode = "empty" | "snapshot";
+
+export interface AssistantStreamAccumulatorOptions {
+  model: AssistantStreamAccumulatorModel;
+  usage?: Usage;
+  timestamp?: number;
+  deltaPartialMode?: AssistantStreamDeltaPartialMode;
+}
+
+type AssistantContent = AssistantMessage["content"][number];
+
+const ZERO_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function cloneContentBlock(block: AssistantContent): AssistantContent {
+  return { ...block };
+}
+
+function cloneContent(content: AssistantContent[]): AssistantMessage["content"] {
+  return content.map(cloneContentBlock);
+}
+
+function ensureTextContent(
+  content: AssistantContent[],
+  contentIndex: number,
+  eventType: string,
+): TextContent {
+  const block = content[contentIndex];
+  if (block?.type !== "text") {
+    throw new Error(`Received ${eventType} for non-text content`);
+  }
+  return block;
+}
+
+function ensureThinkingContent(
+  content: AssistantContent[],
+  contentIndex: number,
+  eventType: string,
+): ThinkingContent {
+  const block = content[contentIndex];
+  if (block?.type !== "thinking") {
+    throw new Error(`Received ${eventType} for non-thinking content`);
+  }
+  return block;
+}
+
+function ensureToolCallContent(
+  content: AssistantContent[],
+  contentIndex: number,
+  eventType: string,
+): ToolCall {
+  const block = content[contentIndex];
+  if (block?.type !== "toolCall") {
+    throw new Error(`Received ${eventType} for non-toolCall content`);
+  }
+  return block;
+}
+
+export function createAssistantStreamAccumulator(options: AssistantStreamAccumulatorOptions) {
+  const content: AssistantContent[] = [];
+  const usage = options.usage ?? ZERO_USAGE;
+  const timestamp = options.timestamp ?? Date.now();
+  const deltaPartialMode = options.deltaPartialMode ?? "empty";
+
+  const buildMessage = (
+    nextContent: AssistantContent[],
+    overrides: {
+      stopReason?: StopReason;
+      usage?: Usage;
+      errorMessage?: string;
+      timestamp?: number;
+    } = {},
+  ): AssistantMessage => ({
+    role: "assistant",
+    content: cloneContent(nextContent),
+    api: options.model.api,
+    provider: options.model.provider,
+    model: options.model.model,
+    stopReason: overrides.stopReason ?? "stop",
+    ...(overrides.errorMessage ? { errorMessage: overrides.errorMessage } : {}),
+    usage: overrides.usage ?? usage,
+    timestamp: overrides.timestamp ?? timestamp,
+  });
+
+  const boundaryPartial = (): AssistantMessage => buildMessage(content);
+  const deltaPartial = (): AssistantMessage =>
+    deltaPartialMode === "snapshot" ? boundaryPartial() : buildMessage([]);
+
+  const accumulator = {
+    start(): Extract<AssistantMessageEvent, { type: "start" }> {
+      return { type: "start", partial: boundaryPartial() };
+    },
+
+    startText(contentIndex: number): Extract<AssistantMessageEvent, { type: "text_start" }> {
+      content[contentIndex] = { type: "text", text: "" };
+      return { type: "text_start", contentIndex, partial: boundaryPartial() };
+    },
+
+    appendTextDelta(
+      contentIndex: number,
+      delta: string,
+    ): Extract<AssistantMessageEvent, { type: "text_delta" }> {
+      const block = ensureTextContent(content, contentIndex, "text_delta");
+      block.text += delta;
+      return {
+        type: "text_delta",
+        contentIndex,
+        delta,
+        partial: deltaPartial(),
+      };
+    },
+
+    endText(
+      contentIndex: number,
+      options: { textSignature?: string } = {},
+    ): Extract<AssistantMessageEvent, { type: "text_end" }> {
+      const block = ensureTextContent(content, contentIndex, "text_end");
+      if (options.textSignature !== undefined) {
+        block.textSignature = options.textSignature;
+      }
+      return {
+        type: "text_end",
+        contentIndex,
+        content: block.text,
+        partial: boundaryPartial(),
+      };
+    },
+
+    startThinking(
+      contentIndex: number,
+    ): Extract<AssistantMessageEvent, { type: "thinking_start" }> {
+      content[contentIndex] = { type: "thinking", thinking: "" };
+      return { type: "thinking_start", contentIndex, partial: boundaryPartial() };
+    },
+
+    appendThinkingDelta(
+      contentIndex: number,
+      delta: string,
+    ): Extract<AssistantMessageEvent, { type: "thinking_delta" }> {
+      const block = ensureThinkingContent(content, contentIndex, "thinking_delta");
+      block.thinking += delta;
+      return {
+        type: "thinking_delta",
+        contentIndex,
+        delta,
+        partial: deltaPartial(),
+      };
+    },
+
+    endThinking(
+      contentIndex: number,
+      options: { thinkingSignature?: string } = {},
+    ): Extract<AssistantMessageEvent, { type: "thinking_end" }> {
+      const block = ensureThinkingContent(content, contentIndex, "thinking_end");
+      if (options.thinkingSignature !== undefined) {
+        block.thinkingSignature = options.thinkingSignature;
+      }
+      return {
+        type: "thinking_end",
+        contentIndex,
+        content: block.thinking,
+        partial: boundaryPartial(),
+      };
+    },
+
+    startToolCall(
+      contentIndex: number,
+      toolCall: ToolCall,
+    ): Extract<AssistantMessageEvent, { type: "toolcall_start" }> {
+      content[contentIndex] = { ...toolCall };
+      return { type: "toolcall_start", contentIndex, partial: boundaryPartial() };
+    },
+
+    appendToolCallDelta(
+      contentIndex: number,
+      delta: string,
+      update?: (toolCall: ToolCall) => void,
+    ): Extract<AssistantMessageEvent, { type: "toolcall_delta" }> {
+      const block = ensureToolCallContent(content, contentIndex, "toolcall_delta");
+      update?.(block);
+      return {
+        type: "toolcall_delta",
+        contentIndex,
+        delta,
+        partial: deltaPartial(),
+      };
+    },
+
+    endToolCall(
+      contentIndex: number,
+      update?: (toolCall: ToolCall) => void,
+    ): Extract<AssistantMessageEvent, { type: "toolcall_end" }> {
+      const block = ensureToolCallContent(content, contentIndex, "toolcall_end");
+      update?.(block);
+      return {
+        type: "toolcall_end",
+        contentIndex,
+        toolCall: { ...block },
+        partial: boundaryPartial(),
+      };
+    },
+
+    message(overrides: { stopReason?: StopReason; usage?: Usage; errorMessage?: string } = {}) {
+      return buildMessage(content, overrides);
+    },
+
+    done(
+      reason: Extract<StopReason, "stop" | "length" | "toolUse">,
+      options: { usage?: Usage } = {},
+    ): Extract<AssistantMessageEvent, { type: "done" }> {
+      return {
+        type: "done",
+        reason,
+        message: buildMessage(content, { stopReason: reason, usage: options.usage }),
+      };
+    },
+
+    error(
+      reason: Extract<StopReason, "aborted" | "error">,
+      options: { errorMessage?: string; usage?: Usage } = {},
+    ): Extract<AssistantMessageEvent, { type: "error" }> {
+      return {
+        type: "error",
+        reason,
+        error: buildMessage(content, {
+          stopReason: reason,
+          errorMessage: options.errorMessage,
+          usage: options.usage,
+        }),
+      };
+    },
+  };
+
+  return accumulator;
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -323,13 +323,21 @@ export interface Context {
  *   and errorMessage.
  *
  * Delta fields are the source of truth for incremental text, thinking, and tool
- * argument fragments. `partial` may be a lightweight compatibility snapshot on
- * delta events; only boundary events and `done`/`error` guarantee full content.
+ * argument fragments. `replace` marks text deltas that carry a corrected full
+ * visible text instead of a suffix. `partial` may be a lightweight
+ * compatibility snapshot on delta events; only boundary events and `done`/`error`
+ * guarantee full content.
  */
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }
   | { type: "text_start"; contentIndex: number; partial: AssistantMessage }
-  | { type: "text_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
+  | {
+      type: "text_delta";
+      contentIndex: number;
+      delta: string;
+      replace?: boolean;
+      partial: AssistantMessage;
+    }
   | { type: "text_end"; contentIndex: number; content: string; partial: AssistantMessage }
   | { type: "thinking_start"; contentIndex: number; partial: AssistantMessage }
   | { type: "thinking_delta"; contentIndex: number; delta: string; partial: AssistantMessage }

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -321,6 +321,10 @@ export interface Context {
  * - `done` carrying the final successful AssistantMessage, or
  * - `error` carrying the final AssistantMessage with stopReason "error" or "aborted"
  *   and errorMessage.
+ *
+ * Delta fields are the source of truth for incremental text, thinking, and tool
+ * argument fragments. `partial` may be a lightweight compatibility snapshot on
+ * delta events; only boundary events and `done`/`error` guarantee full content.
  */
 export type AssistantMessageEvent =
   | { type: "start"; partial: AssistantMessage }

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  createAssistantStreamAccumulator,
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createAnthropicThinkingPrefillPayloadWrapper,
   createPayloadPatchStreamWrapper,
@@ -61,6 +62,27 @@ describe("isOpenAICompatibleThinkingEnabled", () => {
         options: { reasoning: { effort: "off" } } as never,
       }),
     ).toBe(true);
+  });
+});
+
+describe("createAssistantStreamAccumulator", () => {
+  it("is available from the provider stream shared SDK subpath", () => {
+    const accumulator = createAssistantStreamAccumulator({
+      model: {
+        api: "openai-compatible",
+        provider: "example-provider",
+        model: "example-model",
+      },
+      timestamp: 123,
+    });
+
+    accumulator.start();
+    accumulator.startText(0);
+    const delta = accumulator.appendTextDelta(0, "hi");
+    const end = accumulator.endText(0);
+
+    expect(delta.partial.content).toEqual([]);
+    expect(end.partial.content).toEqual([{ type: "text", text: "hi" }]);
   });
 });
 

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -7,6 +7,13 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type { ProviderWrapStreamFnContext } from "./plugin-entry.js";
 import { parseStandalonePlainTextToolCallBlocks } from "./tool-payload.js";
 
+export {
+  createAssistantStreamAccumulator,
+  type AssistantStreamAccumulatorModel,
+  type AssistantStreamAccumulatorOptions,
+  type AssistantStreamDeltaPartialMode,
+} from "../llm/assistant-stream-accumulator.js";
+
 export type ProviderStreamWrapperFactory =
   | ((streamFn: StreamFn | undefined) => StreamFn | undefined)
   | null

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -441,6 +441,28 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Alpha");
   });
 
+  it("clears the stream for empty replacement deltas", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Alpha beta",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      deltaText: "",
+      replace: true,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("");
+  });
+
   it("returns final for another run when payload has no message", () => {
     const state = createActiveStreamingState();
     const payload: ChatEventPayload = {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -286,9 +286,18 @@ export type ChatEventPayload = {
   runId?: string;
   sessionKey: string;
   state: "delta" | "final" | "aborted" | "error";
+  deltaText?: string;
+  replace?: boolean;
   message?: unknown;
   errorMessage?: string;
 };
+
+function readChatDeltaText(payload: ChatEventPayload): string | null {
+  if (payload.replace === true && typeof payload.deltaText === "string") {
+    return payload.deltaText;
+  }
+  return extractText(payload.message);
+}
 
 function maybeResetToolStream(state: ChatState) {
   const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
@@ -752,11 +761,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     });
 
   if (payload.state === "delta") {
-    const next = extractText(payload.message);
+    const next = readChatDeltaText(payload);
+    const isEmptyReplacementDelta = payload.replace === true && payload.deltaText === "";
     if (
       typeof next === "string" &&
       !isSilentReplyStream(next) &&
-      !isAssistantHeartbeatAckForDisplay(payload.message)
+      (isEmptyReplacementDelta || !isAssistantHeartbeatAckForDisplay(payload.message))
     ) {
       state.chatStream = next;
     }


### PR DESCRIPTION
Fixes internal reports of Ollama dense stream truncation during replacement turns.

## Changes
- Centralize assistant stream accumulation in gateway
- Preserve replacement stream deltas across all delta types
- Accumulate lightweight reasoning deltas incrementally
- Preserve rich tool call deltas (function name, args, ID)
- Add stream accumulator contract documentation
- Reset parser state cleanly for replacement deltas
- Add Ollama dense stream repro test