### PR TITLE
fix(plugins): skip unreadable tool descriptor cache entries

### DIFF
--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -16,9 +16,37 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 
 import {
   buildPluginToolDescriptorCacheKey,
+  capturePluginToolDescriptor,
   createPluginToolDescriptorConfigCacheKeyMemo,
   resetPluginToolDescriptorCache,
 } from "./tool-descriptor-cache.js";
+
+describe("plugin tool descriptor capture", () => {
+  it("skips unreadable plugin tool descriptor fields", () => {
+    const tool = {
+      name: "unstable_tool",
+      description: "unstable tool",
+      parameters: { type: "object", properties: {} },
+      async execute() {
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    Object.defineProperty(tool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("fuzzplugin parameters getter exploded");
+      },
+    });
+
+    expect(
+      capturePluginToolDescriptor({
+        pluginId: "fuzzplugin",
+        tool: tool as never,
+        optional: false,
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe("plugin tool descriptor cache keys", () => {
   afterEach(() => {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -145,21 +145,27 @@ export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
-}): CachedPluginToolDescriptor {
-  const label = (params.tool as { label?: unknown }).label;
-  const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
-  return {
-    ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
-    optional: params.optional,
-    descriptor: {
-      name: params.tool.name,
-      ...(title ? { title } : {}),
-      description: params.tool.description,
-      inputSchema: asJsonObject(params.tool.parameters),
-      owner: { kind: "plugin", pluginId: params.pluginId },
-      executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
-    },
-  };
+}): CachedPluginToolDescriptor | undefined {
+  try {
+    const label = (params.tool as { label?: unknown }).label;
+    const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+    const displaySummary = params.tool.displaySummary;
+    const name = params.tool.name;
+    return {
+      ...(displaySummary ? { displaySummary } : {}),
+      optional: params.optional,
+      descriptor: {
+        name,
+        ...(title ? { title } : {}),
+        description: params.tool.description,
+        inputSchema: asJsonObject(params.tool.parameters),
+        owner: { kind: "plugin", pluginId: params.pluginId },
+        executor: { kind: "plugin", pluginId: params.pluginId, toolName: name },
+      },
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 export function readCachedPluginToolDescriptors(

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -163,6 +163,22 @@ function createMalformedTool(name: string) {
   };
 }
 
+function createToolWithUnstableDescriptorSchema(name: string) {
+  let parameterReads = 0;
+  const tool = makeTool(name);
+  Object.defineProperty(tool, "parameters", {
+    enumerable: true,
+    get() {
+      parameterReads += 1;
+      if (parameterReads > 1) {
+        throw new Error("fuzzplugin parameters getter exploded");
+      }
+      return { type: "object", properties: {} };
+    },
+  });
+  return tool;
+}
+
 function installConsoleMethodSpy(method: "log" | "warn") {
   const spy = vi.fn();
   loggingState.rawConsole = {
@@ -2058,6 +2074,28 @@ describe("resolvePluginTools optional tools", () => {
     await expect(second[0]?.execute("call", {}, undefined)).resolves.toEqual({
       content: [{ type: "text", text: "same" }],
     });
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps live tools when descriptor cache capture hits an unstable schema getter", () => {
+    const factory = vi.fn(() =>
+      createToolWithUnstableDescriptorSchema("unstable_descriptor_tool"),
+    );
+    setRegistry([
+      {
+        pluginId: "cache-fuzz",
+        optional: false,
+        source: "/tmp/cache-fuzz.js",
+        names: ["unstable_descriptor_tool"],
+        factory,
+      },
+    ]);
+
+    const first = resolvePluginTools(createResolveToolsParams());
+    const second = resolvePluginTools(createResolveToolsParams());
+
+    expectResolvedToolNames(first, ["unstable_descriptor_tool"]);
+    expectResolvedToolNames(second, ["unstable_descriptor_tool"]);
     expect(factory).toHaveBeenCalledTimes(2);
   });
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1333,14 +1333,15 @@ export function resolvePluginTools(params: {
       });
       if (manifestPlugin) {
         const capturedDescriptors = capturedDescriptorsByPluginId.get(entry.pluginId) ?? [];
-        capturedDescriptors.push(
-          capturePluginToolDescriptor({
-            pluginId: entry.pluginId,
-            tool,
-            optional,
-          }),
-        );
-        capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        const capturedDescriptor = capturePluginToolDescriptor({
+          pluginId: entry.pluginId,
+          tool,
+          optional,
+        });
+        if (capturedDescriptor) {
+          capturedDescriptors.push(capturedDescriptor);
+          capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);
+        }
       }
       tools.push(tool);
     }


### PR DESCRIPTION
## Summary

- make plugin tool descriptor-cache capture best-effort when plugin-controlled descriptor fields throw
- keep live plugin tools available even when their cache descriptor cannot be captured safely
- add regression coverage for direct descriptor capture and repeated runtime resolution with an unstable schema getter

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next188-red nodenv exec node scripts/run-vitest.mjs run src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts --testNamePattern="unreadable plugin tool descriptor|unstable schema getter" --reporter=verbose` failed before the fix with `fuzzplugin parameters getter exploded`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-next188-rebase1 nodenv exec node scripts/run-vitest.mjs run src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts --reporter=verbose`
- `nodenv exec node scripts/run-oxlint.mjs src/plugins/tool-descriptor-cache.ts src/plugins/tools.ts src/plugins/tool-descriptor-cache.test.ts src/plugins/tools.optional.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: a plugin tool whose schema descriptor becomes unreadable during descriptor-cache capture can no longer crash plugin tool resolution after the live tool already passed validation.

Real environment tested: local focused plugin Vitest shard in the linked gwt worktree, plus oxlint, diff-check, and branch autoreview.

Exact steps or command run after this patch: reproduced the pre-fix crash with the new regression tests, restored the fix, rebased on current `origin/main`, then ran the full affected plugin test files, oxlint, `git diff --check`, and branch autoreview.

Evidence after fix: `src/plugins/tool-descriptor-cache.test.ts` and `src/plugins/tools.optional.test.ts` passed 73/73 after the rebase; branch autoreview reported no accepted/actionable findings and `overall: patch is correct (0.82)`.

Observed result after fix: unreadable descriptor-cache entries are skipped, incomplete descriptor sets are not cached, and live plugin tools continue to resolve.

What was not tested: broad `pnpm check:changed` was not run because Blacksmith Testbox is not authenticated in this environment and AWS Crabbox coordinator calls returned 401 on run history and lease creation.
