### PR TITLE
fix(providers): skip unreadable Mistral tool schemas

### DIFF
--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -121,6 +121,27 @@ describe("Mistral provider", () => {
     ]);
   });
 
+  it("omits tools and automatic tool choice when every schema is unreadable", async () => {
+    const stream = streamMistral(
+      makeMistralModel(),
+      {
+        ...context,
+        tools: [makeUnreadableParameterTool()] as never,
+      },
+      {
+        apiKey: "sk-mistral-provider",
+        toolChoice: "auto",
+      },
+    );
+
+    const result = await stream.result();
+    const payload = mistralMockState.payloads[0] as Record<string, unknown>;
+
+    expect(result.stopReason).toBe("error");
+    expect(payload).not.toHaveProperty("tools");
+    expect(payload).not.toHaveProperty("toolChoice");
+  });
+
   it("fails locally when a pinned Mistral tool choice is skipped", async () => {
     const stream = streamMistral(
       makeMistralModel(),
@@ -147,7 +168,9 @@ describe("Mistral provider", () => {
     const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toContain('Mistral tool_choice requested unavailable tool "broken_tool"');
+    expect(result.errorMessage).toContain(
+      'Mistral tool_choice requested unavailable tool "broken_tool"',
+    );
     expect(mistralMockState.payloads).toHaveLength(0);
   });
 });

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -173,4 +173,45 @@ describe("Mistral provider", () => {
     );
     expect(mistralMockState.payloads).toHaveLength(0);
   });
+
+  it("validates and emits one snapshot of a pinned Mistral tool name", async () => {
+    let nameReads = 0;
+    const stream = streamMistral(
+      makeMistralModel(),
+      {
+        ...context,
+        tools: [
+          {
+            name: "healthy_tool",
+            description: "healthy tool",
+            parameters: { type: "object", properties: {} },
+            async execute() {
+              return { content: [{ type: "text", text: "ok" }] };
+            },
+          },
+        ] as never,
+      },
+      {
+        apiKey: "sk-mistral-provider",
+        toolChoice: {
+          type: "function",
+          function: {
+            get name() {
+              nameReads += 1;
+              return nameReads === 1 ? "healthy_tool" : "broken_tool";
+            },
+          },
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(nameReads).toBe(1);
+    expect((mistralMockState.payloads[0] as { toolChoice?: unknown }).toolChoice).toEqual({
+      type: "function",
+      function: { name: "healthy_tool" },
+    });
+  });
 });

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -17,7 +17,7 @@ vi.mock("@mistralai/mistralai", () => ({
   },
 }));
 
-import { streamSimpleMistral } from "./mistral.js";
+import { streamMistral, streamSimpleMistral } from "./mistral.js";
 
 function makeMistralModel(): Model<"mistral-conversations"> {
   return {
@@ -38,6 +38,24 @@ const context = {
   messages: [{ role: "user", content: "hello", timestamp: 0 }],
 } satisfies Context;
 
+function makeUnreadableParameterTool() {
+  const tool = {
+    name: "broken_tool",
+    description: "broken tool",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "broken" }] };
+    },
+  };
+  Object.defineProperty(tool, "parameters", {
+    enumerable: true,
+    get() {
+      throw new Error("fuzzplugin parameters getter exploded");
+    },
+  });
+  return tool;
+}
+
 describe("Mistral provider", () => {
   beforeEach(() => {
     mistralMockState.payloads = [];
@@ -53,5 +71,83 @@ describe("Mistral provider", () => {
 
     expect(result.stopReason).toBe("error");
     expect((mistralMockState.payloads[0] as { stop?: unknown }).stop).toEqual(["STOP"]);
+  });
+
+  it("skips unreadable tool schemas while preserving healthy Mistral tools", async () => {
+    const stream = streamMistral(
+      makeMistralModel(),
+      {
+        ...context,
+        tools: [
+          makeUnreadableParameterTool(),
+          {
+            name: "healthy_tool",
+            description: "healthy tool",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+            },
+            async execute() {
+              return { content: [{ type: "text", text: "ok" }] };
+            },
+          },
+        ] as never,
+      },
+      {
+        apiKey: "sk-mistral-provider",
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect((mistralMockState.payloads[0] as { tools?: unknown[] }).tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "healthy_tool",
+          description: "healthy tool",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+          },
+          strict: false,
+        },
+      },
+    ]);
+  });
+
+  it("fails locally when a pinned Mistral tool choice is skipped", async () => {
+    const stream = streamMistral(
+      makeMistralModel(),
+      {
+        ...context,
+        tools: [
+          makeUnreadableParameterTool(),
+          {
+            name: "healthy_tool",
+            description: "healthy tool",
+            parameters: { type: "object", properties: {} },
+            async execute() {
+              return { content: [{ type: "text", text: "ok" }] };
+            },
+          },
+        ] as never,
+      },
+      {
+        apiKey: "sk-mistral-provider",
+        toolChoice: { type: "function", function: { name: "broken_tool" } },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain('Mistral tool_choice requested unavailable tool "broken_tool"');
+    expect(mistralMockState.payloads).toHaveLength(0);
   });
 });

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -722,14 +722,15 @@ function mapToolChoice(
   if (choice === "auto" || choice === "none" || choice === "any" || choice === "required") {
     return choice;
   }
-  if (convertedToolNames && !convertedToolNames.has(choice.function.name)) {
+  const toolName = choice.function.name;
+  if (convertedToolNames && !convertedToolNames.has(toolName)) {
     throw new Error(
-      `Mistral tool_choice requested unavailable tool "${choice.function.name}" after schema conversion`,
+      `Mistral tool_choice requested unavailable tool "${toolName}" after schema conversion`,
     );
   }
   return {
     type: "function",
-    function: { name: choice.function.name },
+    function: { name: toolName },
   };
 }
 

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -275,9 +275,14 @@ function buildChatPayload(
     stream: true,
     messages: toChatMessages(messages, model.input.includes("image")),
   };
+  let convertedToolNames: Set<string> | undefined;
 
   if (context.tools?.length) {
-    payload.tools = toFunctionTools(context.tools);
+    const tools = toFunctionTools(context.tools);
+    convertedToolNames = new Set(tools.map((tool) => tool.function.name));
+    if (tools.length > 0) {
+      payload.tools = tools;
+    }
   }
   if (options?.temperature !== undefined) {
     payload.temperature = options.temperature;
@@ -289,7 +294,10 @@ function buildChatPayload(
     payload.stop = options.stop;
   }
   if (options?.toolChoice) {
-    payload.toolChoice = mapToolChoice(options.toolChoice);
+    const toolChoice = mapToolChoice(options.toolChoice, convertedToolNames);
+    if (toolChoice) {
+      payload.toolChoice = toolChoice;
+    }
   }
   if (options?.promptMode) {
     payload.promptMode = options.promptMode;
@@ -507,15 +515,21 @@ async function consumeChatStream(
 }
 
 function toFunctionTools(tools: Tool[]): Array<FunctionTool & { type: "function" }> {
-  return tools.map((tool) => ({
-    type: "function",
-    function: {
-      name: tool.name,
-      description: tool.description,
-      parameters: stripSymbolKeys(tool.parameters) as Record<string, unknown>,
-      strict: false,
-    },
-  }));
+  return tools.flatMap((tool) => {
+    try {
+      return {
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: stripSymbolKeys(tool.parameters) as Record<string, unknown>,
+          strict: false,
+        },
+      };
+    } catch {
+      return [];
+    }
+  });
 }
 
 function stripSymbolKeys(value: unknown): unknown {
@@ -688,6 +702,7 @@ function mapReasoningEffort(
 
 function mapToolChoice(
   choice: MistralOptions["toolChoice"],
+  convertedToolNames?: ReadonlySet<string>,
 ):
   | "auto"
   | "none"
@@ -698,8 +713,19 @@ function mapToolChoice(
   if (!choice) {
     return undefined;
   }
+  if (convertedToolNames && convertedToolNames.size === 0) {
+    if (choice === "none" || choice === "auto") {
+      return choice === "none" ? "none" : undefined;
+    }
+    throw new Error("Mistral tool_choice requires a tool, but no tools survived schema conversion");
+  }
   if (choice === "auto" || choice === "none" || choice === "any" || choice === "required") {
     return choice;
+  }
+  if (convertedToolNames && !convertedToolNames.has(choice.function.name)) {
+    throw new Error(
+      `Mistral tool_choice requested unavailable tool "${choice.function.name}" after schema conversion`,
+    );
   }
   return {
     type: "function",


### PR DESCRIPTION
## Summary

- skip only unreadable Mistral tool schemas while preserving healthy sibling tools
- omit empty Mistral tool payloads after schema filtering
- fail locally when a forced Mistral `toolChoice` references a tool that was skipped during conversion
- snapshot forced tool names so validation and emission use the same value

## Verification

- `node scripts/run-vitest.mjs src/llm/providers/mistral.test.ts` (5 passed)
- `pnpm exec oxfmt --check src/llm/providers/mistral.ts src/llm/providers/mistral.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/mistral.ts src/llm/providers/mistral.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` (`patch is correct`, 0.93 confidence)
- Live Mistral E2E: https://crabbox.openclaw.ai/portal/runs/run_9b34d30e9f5b

## Real behavior proof

Behavior addressed: an unreadable plugin/extension tool schema can no longer crash Mistral request payload construction before healthy sibling tools are sent.

Real environment tested: a fresh GCP Crabbox Linux host calling the public Mistral API with `mistral-small-latest`.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider gcp --type e2-standard-4 --full-resync --env-from-profile /tmp/pr90242-mistral.env --allow-env MISTRAL_API_KEY --script /tmp/pr90242-live.sh --timing-json`

Evidence after fix: Crabbox run `run_9b34d30e9f5b` sent only `healthy_tool`, omitted the unreadable `broken_tool`, and returned `MISTRAL_SCHEMA_OK` with stop reason `stop`.

Observed result after fix: the real Mistral request succeeded while preserving the healthy sibling tool; focused tests also prove empty tool omission, rejected pinned choices for skipped tools, and single-read forced tool names.

What was not tested: broad local `pnpm check:changed`; the pushed PR CI is the broad validation gate.
