### PR TITLE
fix(disk-space): promote 1024 MiB to 1.0 GiB in disk warnings

### DIFF
--- a/src/infra/disk-space.test.ts
+++ b/src/infra/disk-space.test.ts
@@ -77,4 +77,13 @@ describe("disk-space helpers", () => {
     expect(formatDiskSpaceBytes(420 * 1024 * 1024)).toBe("420 MiB");
     expect(formatDiskSpaceBytes(1536 * 1024 * 1024)).toBe("1.5 GiB");
   });
+
+  it("promotes MiB values that round up to 1024 into GiB", () => {
+    // mib in [1023.5, 1024) rounds to 1024; must render as GiB, not "1024 MiB".
+    expect(formatDiskSpaceBytes(Math.round(1023.6 * 1024 * 1024))).toBe("1.0 GiB");
+    expect(formatDiskSpaceBytes(Math.round(1023.9 * 1024 * 1024))).toBe("1.0 GiB");
+    expect(formatDiskSpaceBytes(1024 * 1024 * 1024)).toBe("1.0 GiB");
+    // Just below the rounding boundary still reads as MiB.
+    expect(formatDiskSpaceBytes(Math.round(1023.4 * 1024 * 1024))).toBe("1023 MiB");
+  });
 });

--- a/src/infra/disk-space.ts
+++ b/src/infra/disk-space.ts
@@ -65,8 +65,11 @@ export function tryReadDiskSpace(targetPath: string): DiskSpaceSnapshot | null {
 /** Formats byte counts for compact operator-facing disk-space warnings. */
 export function formatDiskSpaceBytes(bytes: number): string {
   const mib = bytes / (1024 * 1024);
-  if (mib < 1024) {
-    return `${Math.max(0, Math.round(mib))} MiB`;
+  // Round before choosing the unit so a value that rounds up to 1024 MiB is
+  // promoted to "1.0 GiB" instead of printing the impossible "1024 MiB".
+  const roundedMib = Math.max(0, Math.round(mib));
+  if (roundedMib < 1024) {
+    return `${roundedMib} MiB`;
   }
   const gib = mib / 1024;
   return `${gib.toFixed(gib < 10 ? 1 : 0)} GiB`;


### PR DESCRIPTION
Fixes #90245

## Summary
- `formatDiskSpaceBytes` chose the unit on the **unrounded** `mib < 1024` but then `Math.round(mib)`'d the MiB branch, so any value with `mib ∈ [1023.5, 1024)` printed the impossible `"1024 MiB"` instead of `"1.0 GiB"`.
- Round MiB first and branch on the rounded value, so a value that rounds up to 1024 MiB is promoted to GiB.
- Added a regression test for the `[1023.5, 1024)` boundary.

This string is operator-facing: it appears in the low-disk warning from `createLowDiskSpaceWarning` during setup/update staging.

## Real behavior proof

**Behavior addressed:** the low-disk warning should never render `"1024 MiB"`; values that round up to 1 GiB must read `"1.0 GiB"`.

**Real environment tested:** local checkout on current `main` (`ec3aa5def4`), exercising the real exported `formatDiskSpaceBytes` and `createLowDiskSpaceWarning` via `node --import tsx` (the latter with `fs.statfsSync` stubbed to report boundary free space, which is the only external input that path reads).

**Exact steps or command run after this patch:**
```
node --import tsx -e 'import("./src/infra/disk-space.ts").then(m => {
  const b = Math.round(1023.7 * 1024 * 1024);
  console.log(m.formatDiskSpaceBytes(b));
})'
```
plus `node scripts/run-vitest.mjs src/infra/disk-space.test.ts`.

**Evidence after fix:**
```
formatDiskSpaceBytes(1023.7 MiB) => "1.0 GiB"
formatDiskSpaceBytes(1 GiB)      => "1.0 GiB"
low-disk warning => "Low disk space near <cwd>: 1.0 GiB available; the update may fail."
```
Before this patch the same input on `main` produced `"1024 MiB"` (warning: `"... 1024 MiB available; ..."`).

**Observed result after fix:** boundary values render `"1.0 GiB"`; `1023.4 MiB` still reads `"1023 MiB"`; existing `420 MiB` / `1.5 GiB` cases unchanged.

**What was not tested:** no real volume was driven to exactly the boundary free-space; the disk read (`fs.statfsSync`) is the single external dependency and was stubbed to the boundary value, while the formatting under test runs unmodified.

## Verification
- `node scripts/run-vitest.mjs src/infra/disk-space.test.ts` → 4 passed (incl. new boundary test)
- `oxfmt --check` clean; `oxlint` clean; `git diff --check` clean
