### PR TITLE
fix(providers): skip unreadable Google tool schemas

### DIFF
--- a/extensions/google/function-declarations.ts
+++ b/extensions/google/function-declarations.ts
@@ -1,0 +1,87 @@
+const MAX_GOOGLE_EXTENSION_TOOL_SCHEMA_NODES = 1_000;
+
+type GoogleExtensionToolSchemaReadState = {
+  stack: WeakSet<object>;
+  nodes: number;
+};
+
+export type GoogleExtensionToolDeclarationInput = {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+};
+
+export type GoogleExtensionFunctionDeclaration = {
+  name: string;
+  description?: string;
+  parametersJsonSchema?: unknown;
+};
+
+export function buildGoogleExtensionFunctionDeclarations<
+  TTool extends GoogleExtensionToolDeclarationInput,
+  TExtra extends Record<string, unknown> = Record<string, never>,
+>(
+  tools: readonly TTool[] | undefined,
+  decorate?: (tool: TTool, name: string) => TExtra,
+): Array<GoogleExtensionFunctionDeclaration & Partial<TExtra>> {
+  return (tools ?? []).flatMap((tool) => {
+    try {
+      const name = tool.name.trim();
+      if (!name) {
+        return [];
+      }
+      const parametersJsonSchema = snapshotGoogleExtensionToolSchema(tool.parameters);
+      return [
+        {
+          name,
+          ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+          parametersJsonSchema,
+          ...decorate?.(tool, name),
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function snapshotGoogleExtensionToolSchema(
+  schema: unknown,
+  state: GoogleExtensionToolSchemaReadState = { stack: new WeakSet(), nodes: 0 },
+): unknown {
+  state.nodes += 1;
+  if (state.nodes > MAX_GOOGLE_EXTENSION_TOOL_SCHEMA_NODES) {
+    throw new Error("Google extension tool schema exceeds traversal budget");
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (state.stack.has(schema)) {
+    throw new Error("Google extension tool schema contains cyclic object references");
+  }
+  state.stack.add(schema);
+
+  try {
+    if (Array.isArray(schema)) {
+      try {
+        return Array.from(schema, (value) => snapshotGoogleExtensionToolSchema(value, state));
+      } catch {
+        throw new Error("Google extension tool schema array is unreadable");
+      }
+    }
+    const snapshot: Record<string, unknown> = {};
+    try {
+      for (const key of Object.keys(schema)) {
+        snapshot[key] = snapshotGoogleExtensionToolSchema(
+          (schema as Record<string, unknown>)[key],
+          state,
+        );
+      }
+    } catch {
+      throw new Error("Google extension tool schema object is unreadable");
+    }
+    return snapshot;
+  } finally {
+    state.stack.delete(schema);
+  }
+}

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -301,6 +301,63 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(declarations[1]?.behavior).toBe("NON_BLOCKING");
   });
 
+  it("skips unreadable Google Live tool schemas while preserving healthy declarations", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const hostileParameters: Record<string, unknown> = {
+      type: "object",
+      properties: {},
+    };
+    Object.defineProperty(hostileParameters.properties, "query", {
+      enumerable: true,
+      get() {
+        throw new Error("nested schema getter exploded");
+      },
+    });
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "gemini-key",
+      },
+      instructions: "Speak briefly.",
+      tools: [
+        {
+          type: "function",
+          name: "broken_lookup",
+          description: "Broken lookup",
+          parameters: hostileParameters,
+        },
+        {
+          type: "function",
+          name: "message",
+          description: "Send a message",
+          parameters: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+            },
+          },
+        },
+      ],
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    const declarations = lastConnectParams().config.tools?.[0]?.functionDeclarations ?? [];
+    expect(declarations).toEqual([
+      {
+        name: "message",
+        description: "Send a message",
+        parametersJsonSchema: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+        },
+      },
+    ]);
+  });
+
   it("omits zero temperature for native audio responses", async () => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -46,6 +46,7 @@ import {
   asFiniteNumber,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { buildGoogleExtensionFunctionDeclarations } from "./function-declarations.js";
 import { createGoogleGenAI } from "./google-genai-runtime.js";
 
 const GOOGLE_REALTIME_DEFAULT_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025";
@@ -338,17 +339,9 @@ function buildRealtimeInputConfig(
 }
 
 function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): FunctionDeclaration[] {
-  return (tools ?? []).map((tool) => {
-    const declaration: FunctionDeclaration = {
-      name: tool.name,
-      description: tool.description,
-      parametersJsonSchema: tool.parameters,
-    };
-    if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      declaration.behavior = "NON_BLOCKING" as Behavior;
-    }
-    return declaration;
-  });
+  return buildGoogleExtensionFunctionDeclarations(tools, (_tool, name) =>
+    name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME ? { behavior: "NON_BLOCKING" as Behavior } : {},
+  );
 }
 
 function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveConnectConfig {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1093,6 +1093,186 @@ describe("google transport stream", () => {
     });
   });
 
+  it("skips unreadable Google transport tool schemas while preserving healthy tools", () => {
+    const hostileParameters: Record<string, unknown> = {
+      type: "object",
+      properties: {},
+    };
+    Object.defineProperty(hostileParameters.properties, "q", {
+      enumerable: true,
+      get() {
+        throw new Error("nested schema getter exploded");
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(buildGeminiModel(), {
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      tools: [
+        {
+          name: "broken_lookup",
+          description: "Broken lookup",
+          parameters: hostileParameters,
+        },
+        {
+          name: "lookup",
+          description: "Look up a value",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } },
+            required: ["q"],
+          },
+        },
+      ],
+    } as never);
+
+    expect(params.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { q: { type: "string" } },
+              required: ["q"],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("omits Google transport tool config when every tool schema is skipped", () => {
+    const hostileParameters: Record<string, unknown> = {
+      type: "object",
+      properties: {},
+    };
+    Object.defineProperty(hostileParameters.properties, "q", {
+      enumerable: true,
+      get() {
+        throw new Error("nested schema getter exploded");
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "broken_lookup",
+            description: "Broken lookup",
+            parameters: hostileParameters,
+          },
+        ],
+      } as never,
+      { toolChoice: "required" },
+    );
+
+    expect(params.tools).toBeUndefined();
+    expect(params.toolConfig).toBeUndefined();
+  });
+
+  it("drops function-specific Google tool choice when that tool schema is skipped", () => {
+    const hostileParameters: Record<string, unknown> = {
+      type: "object",
+      properties: {},
+    };
+    Object.defineProperty(hostileParameters.properties, "q", {
+      enumerable: true,
+      get() {
+        throw new Error("nested schema getter exploded");
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "broken_lookup",
+            description: "Broken lookup",
+            parameters: hostileParameters,
+          },
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parameters: {
+              type: "object",
+              properties: { q: { type: "string" } },
+            },
+          },
+        ],
+      } as never,
+      {
+        toolChoice: {
+          type: "function",
+          function: { name: "broken_lookup" },
+        },
+      },
+    );
+
+    expect(params.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { q: { type: "string" } },
+            },
+          },
+        ],
+      },
+    ]);
+    expect(params.toolConfig).toBeUndefined();
+  });
+
+  it("snapshots Google transport schemas before returning request params", () => {
+    let propertiesReads = 0;
+    const parameters: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(parameters, "properties", {
+      enumerable: true,
+      get() {
+        propertiesReads += 1;
+        if (propertiesReads > 1) {
+          throw new Error("properties getter changed after snapshot");
+        }
+        return { q: { type: "string" } };
+      },
+    });
+
+    const params = buildGoogleGenerativeAiParams(buildGeminiModel(), {
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      tools: [
+        {
+          name: "lookup",
+          description: "Look up a value",
+          parameters,
+        },
+      ],
+    } as never);
+
+    expect(propertiesReads).toBe(1);
+    expect(() => JSON.stringify(params.tools)).not.toThrow();
+    expect(params.tools).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { q: { type: "string" } },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it("replays Gemini tool call thought signatures for same-model history", () => {
     const model = buildGeminiModel({
       id: "gemini-3-flash-preview",

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -26,6 +26,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { buildGoogleExtensionFunctionDeclarations } from "./function-declarations.js";
 import { parseGeminiAuth } from "./gemini-auth.js";
 import { normalizeGoogleApiBaseUrl } from "./provider-policy.js";
 import {
@@ -285,12 +286,15 @@ function toolCallThoughtSignatureReplayKey(block: {
 
 function mapToolChoice(
   choice: GoogleTransportOptions["toolChoice"],
+  declaredToolNames?: ReadonlySet<string>,
 ): { mode: "AUTO" | "NONE" | "ANY"; allowedFunctionNames?: string[] } | undefined {
   if (!choice) {
     return undefined;
   }
   if (typeof choice === "object" && choice.type === "function") {
-    return { mode: "ANY", allowedFunctionNames: [choice.function.name] };
+    return declaredToolNames?.has(choice.function.name)
+      ? { mode: "ANY", allowedFunctionNames: [choice.function.name] }
+      : undefined;
   }
   switch (choice) {
     case "none":
@@ -680,13 +684,13 @@ function convertGoogleTools(tools: NonNullable<Context["tools"]>) {
   if (tools.length === 0) {
     return undefined;
   }
+  const functionDeclarations = buildGoogleExtensionFunctionDeclarations(tools);
+  if (functionDeclarations.length === 0) {
+    return undefined;
+  }
   return [
     {
-      functionDeclarations: tools.map((tool) => ({
-        name: tool.name,
-        description: tool.description,
-        parametersJsonSchema: tool.parameters,
-      })),
+      functionDeclarations,
     },
   ];
 }
@@ -732,9 +736,18 @@ export function buildGoogleGenerativeAiParams(
     };
   }
   if (!cachedContent && context.tools?.length) {
-    params.tools = convertGoogleTools(context.tools);
-    const toolChoice = mapToolChoice(options?.toolChoice);
-    if (toolChoice) {
+    const tools = convertGoogleTools(context.tools);
+    params.tools = tools;
+    const declaredToolNames = new Set(
+      tools?.flatMap(
+        (tool) =>
+          (tool.functionDeclarations as Array<{ name?: unknown }> | undefined)?.flatMap(
+            (declaration) => (typeof declaration.name === "string" ? [declaration.name] : []),
+          ) ?? [],
+      ),
+    );
+    const toolChoice = tools ? mapToolChoice(options?.toolChoice, declaredToolNames) : undefined;
+    if (tools && toolChoice) {
       params.toolConfig = {
         functionCallingConfig: toolChoice,
       };

--- a/src/llm/providers/google-shared.convert.test.ts
+++ b/src/llm/providers/google-shared.convert.test.ts
@@ -17,6 +17,77 @@ const convertMessagesForTest = convertMessages as unknown as (
   context: Context,
 ) => ReturnType<typeof convertMessages>;
 
+function makeUnreadableParameterTool(): Tool {
+  const tool = {
+    name: "broken_tool",
+    description: "Broken tool",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "broken" }] };
+    },
+  };
+  Object.defineProperty(tool, "parameters", {
+    enumerable: true,
+    get() {
+      throw new Error("fuzzplugin parameters getter exploded");
+    },
+  });
+  return tool as unknown as Tool;
+}
+
+function makeHostileNestedParameterTool(): Tool {
+  const parameters: Record<string, unknown> = {
+    type: "object",
+    properties: {},
+  };
+  Object.defineProperty(parameters.properties, "query", {
+    enumerable: true,
+    get() {
+      throw new Error("nested parameter getter exploded");
+    },
+  });
+  return {
+    name: "hostile_nested_tool",
+    description: "Hostile nested tool",
+    parameters,
+    async execute() {
+      return { content: [{ type: "text", text: "hostile" }] };
+    },
+  } as unknown as Tool;
+}
+
+function makeCyclicParameterTool(): Tool {
+  const parameters: Record<string, unknown> = {
+    type: "object",
+    properties: {},
+  };
+  parameters.self = parameters;
+  return {
+    name: "cyclic_tool",
+    description: "Cyclic tool",
+    parameters,
+    async execute() {
+      return { content: [{ type: "text", text: "cycle" }] };
+    },
+  } as unknown as Tool;
+}
+
+function makeHealthyTool(): Tool {
+  return {
+    name: "healthy_tool",
+    description: "Healthy tool",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    },
+    async execute() {
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  } as unknown as Tool;
+}
+
 function requireRecordProperty(
   record: Record<string, unknown>,
   key: string,
@@ -29,6 +100,153 @@ function requireRecordProperty(
 }
 
 describe("google-shared convertTools", () => {
+  it("skips unreadable tool schemas while preserving healthy Gemini declarations", () => {
+    const converted = convertTools([makeUnreadableParameterTool(), makeHealthyTool()]);
+
+    expect(converted).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "healthy_tool",
+            description: "Healthy tool",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("omits Google tool declarations when every schema is unreadable", () => {
+    expect(convertTools([makeUnreadableParameterTool()])).toBeUndefined();
+  });
+
+  it("skips nested hostile and cyclic schemas before Google payload creation", () => {
+    const converted = convertTools([
+      makeHostileNestedParameterTool(),
+      makeCyclicParameterTool(),
+      makeHealthyTool(),
+    ]);
+
+    expect(converted).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "healthy_tool",
+            description: "Healthy tool",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps valid schemas that reuse a shared subschema object", () => {
+    const sharedString = { type: "string" };
+    const tools = [
+      {
+        name: "shared_schema_tool",
+        description: "Shared schema tool",
+        parameters: {
+          type: "object",
+          properties: {
+            first: sharedString,
+            second: sharedString,
+          },
+        },
+        async execute() {
+          return { content: [{ type: "text", text: "ok" }] };
+        },
+      },
+    ] as unknown as Tool[];
+
+    expect(convertTools(tools)).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "shared_schema_tool",
+            description: "Shared schema tool",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                first: { type: "string" },
+                second: { type: "string" },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("snapshots schemas before returning Google declarations", () => {
+    let propertiesReads = 0;
+    const parameters: Record<string, unknown> = { type: "object" };
+    Object.defineProperty(parameters, "properties", {
+      enumerable: true,
+      get() {
+        propertiesReads += 1;
+        if (propertiesReads > 1) {
+          throw new Error("properties getter changed after snapshot");
+        }
+        return { q: { type: "string" } };
+      },
+    });
+
+    const converted = convertTools([
+      {
+        name: "snapshot_tool",
+        description: "Snapshot tool",
+        parameters,
+        async execute() {
+          return { content: [{ type: "text", text: "ok" }] };
+        },
+      },
+    ] as unknown as Tool[]);
+
+    expect(propertiesReads).toBe(1);
+    expect(() => JSON.stringify(converted)).not.toThrow();
+    expect(converted).toEqual([
+      {
+        functionDeclarations: [
+          {
+            name: "snapshot_tool",
+            description: "Snapshot tool",
+            parametersJsonSchema: {
+              type: "object",
+              properties: { q: { type: "string" } },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("skips unreadable legacy OpenAPI parameter declarations", () => {
+    const converted = convertTools([makeUnreadableParameterTool(), makeHealthyTool()], true);
+
+    const declaration = converted?.[0]?.functionDeclarations[0];
+    expect(declaration).toEqual({
+      name: "healthy_tool",
+      description: "Healthy tool",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+      },
+    });
+  });
+
   it("preserves parameters when type is missing", () => {
     const tools = [
       {

--- a/src/llm/providers/google-shared.test.ts
+++ b/src/llm/providers/google-shared.test.ts
@@ -1,6 +1,6 @@
 import { FinishReason, type GenerateContentResponse } from "@google/genai";
 import { describe, expect, it } from "vitest";
-import type { AssistantMessage, Model } from "../types.js";
+import type { AssistantMessage, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import {
   buildGoogleGenerateContentParams,
@@ -49,6 +49,24 @@ function createOutput(): AssistantMessage {
     stopReason: "stop",
     timestamp: 0,
   };
+}
+
+function makeUnreadableParameterTool(): Tool {
+  const tool = {
+    name: "broken_tool",
+    description: "Broken tool",
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text", text: "broken" }] };
+    },
+  };
+  Object.defineProperty(tool, "parameters", {
+    enumerable: true,
+    get() {
+      throw new Error("fuzzplugin parameters getter exploded");
+    },
+  });
+  return tool as unknown as Tool;
 }
 
 async function* chunks(items: GenerateContentResponse[]) {
@@ -144,5 +162,19 @@ describe("buildGoogleGenerateContentParams", () => {
     );
 
     expect(params.config?.stopSequences).toEqual(["STOP"]);
+  });
+
+  it("omits tool config when every Google tool schema is skipped", () => {
+    const params = buildGoogleGenerateContentParams(
+      model,
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [makeUnreadableParameterTool()],
+      },
+      { toolChoice: "any" },
+    );
+
+    expect(params.config?.tools).toBeUndefined();
+    expect(params.config?.toolConfig).toBeUndefined();
   });
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -337,6 +337,12 @@ const JSON_SCHEMA_META_DECLARATIONS = new Set([
   "$defs",
   "definitions", // pre-draft-2019-09 equivalent of $defs
 ]);
+const MAX_GOOGLE_TOOL_SCHEMA_NODES = 1_000;
+
+type GoogleToolSchemaReadState = {
+  stack: WeakSet<object>;
+  nodes: number;
+};
 
 /**
  * Strip meta-declarations from a schema obj
@@ -356,6 +362,44 @@ function sanitizeForOpenApi(schema: unknown): unknown {
   return result;
 }
 
+function snapshotGoogleToolSchema(
+  schema: unknown,
+  state: GoogleToolSchemaReadState = { stack: new WeakSet(), nodes: 0 },
+): unknown {
+  state.nodes += 1;
+  if (state.nodes > MAX_GOOGLE_TOOL_SCHEMA_NODES) {
+    throw new Error("Google tool schema exceeds traversal budget");
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (state.stack.has(schema)) {
+    throw new Error("Google tool schema contains cyclic object references");
+  }
+  state.stack.add(schema);
+
+  try {
+    if (Array.isArray(schema)) {
+      try {
+        return Array.from(schema, (value) => snapshotGoogleToolSchema(value, state));
+      } catch {
+        throw new Error("Google tool schema array is unreadable");
+      }
+    }
+    const snapshot: Record<string, unknown> = {};
+    try {
+      for (const key of Object.keys(schema)) {
+        snapshot[key] = snapshotGoogleToolSchema((schema as Record<string, unknown>)[key], state);
+      }
+    } catch {
+      throw new Error("Google tool schema object is unreadable");
+    }
+    return snapshot;
+  } finally {
+    state.stack.delete(schema);
+  }
+}
+
 /**
  * Convert tools to Gemini function declarations format.
  *
@@ -371,15 +415,26 @@ export function convertTools(
   if (tools.length === 0) {
     return undefined;
   }
-  return [
-    {
-      functionDeclarations: tools.map((tool) => ({
+  const functionDeclarations = tools.flatMap((tool) => {
+    try {
+      const parameters = snapshotGoogleToolSchema(tool.parameters);
+      return {
         name: tool.name,
         description: tool.description,
         ...(useParameters
-          ? { parameters: sanitizeForOpenApi(tool.parameters as unknown) }
-          : { parametersJsonSchema: tool.parameters }),
-      })),
+          ? { parameters: sanitizeForOpenApi(parameters) }
+          : { parametersJsonSchema: parameters }),
+      };
+    } catch {
+      return [];
+    }
+  });
+  if (functionDeclarations.length === 0) {
+    return undefined;
+  }
+  return [
+    {
+      functionDeclarations,
     },
   ];
 }
@@ -484,14 +539,15 @@ export function buildGoogleGenerateContentParams<T extends GoogleApiType>(
   if (options.stop !== undefined && options.stop.length > 0) {
     generationConfig.stopSequences = options.stop;
   }
+  const convertedTools = context.tools?.length ? convertTools(context.tools) : undefined;
 
   const config: GenerateContentConfig = {
     ...(Object.keys(generationConfig).length > 0 && generationConfig),
     ...(context.systemPrompt && { systemInstruction: sanitizeSurrogates(context.systemPrompt) }),
-    ...(context.tools && context.tools.length > 0 && { tools: convertTools(context.tools) }),
+    ...(convertedTools && { tools: convertedTools }),
   };
 
-  if (context.tools && context.tools.length > 0 && options.toolChoice) {
+  if (convertedTools && options.toolChoice) {
     config.toolConfig = {
       functionCallingConfig: {
         mode: mapToolChoice(options.toolChoice),


### PR DESCRIPTION
## Summary

- Skip unreadable, cyclic, or traversal-budget-exceeding Google tool schemas before building Google function declarations.
- Snapshot readable schemas before returning declarations so accessor/proxy-backed schemas cannot mutate or throw later during SDK/request serialization.
- Apply the same fail-closed behavior to shared Google LLM providers plus bundled Google extension transport and realtime voice paths, including empty-tool and function-specific `toolChoice` reconciliation.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-google-tool-schemas node scripts/run-vitest.mjs run src/llm/providers/google-shared.convert.test.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/google-shared.ts src/llm/providers/google-shared.convert.test.ts extensions/google/function-declarations.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/google-shared.ts src/llm/providers/google-shared.convert.test.ts extensions/google/function-declarations.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: local Blacksmith CLI is not authenticated.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"` blocked before lease allocation: coordinator `POST /v1/runs` and `POST /v1/leases` returned HTTP 401.

## Real behavior proof

Behavior addressed: Google provider request construction no longer lets one hostile or unreadable active tool schema poison the whole request before the assistant can reply.

Real environment tested: local focused Google shared-provider and bundled Google extension tests in an OpenClaw linked Codex worktree. Broad remote proof was attempted through Testbox and AWS Crabbox, but both authenticated remote paths are unavailable from this shell.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/llm/providers/google-shared.convert.test.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/google-shared.ts src/llm/providers/google-shared.convert.test.ts extensions/google/function-declarations.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`; `node scripts/run-oxlint.mjs src/llm/providers/google-shared.ts src/llm/providers/google-shared.convert.test.ts extensions/google/function-declarations.ts extensions/google/realtime-voice-provider.ts extensions/google/realtime-voice-provider.test.ts extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `blacksmith testbox list --all`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: focused Vitest passed `src/llm/providers/google-shared.convert.test.ts` with 17 tests and the Google extension provider shard with 92 tests; targeted formatter/lint/diff checks passed; autoreview found and drove fixes for SDK declaration typing, empty declaration blocks, repeated-fragment handling, schema snapshotting, and function-specific tool choice reconciliation; final autoreview reported no accepted/actionable findings with `overall: patch is correct (0.82)`; final head is `f81098581d470042c5a96f011a1f2518f278bb82`.

Observed result after fix: unreadable or cyclic Google schemas are skipped, valid shared subschema objects are preserved, emitted declarations contain plain snapshots instead of hostile schema objects, all-skipped tool sets omit `tools`/`toolConfig`, and function-specific `toolChoice` is dropped when the selected tool was skipped while healthy sibling tools remain available.

What was not tested: a full live Google/Gemini model turn and broad `pnpm check:changed` proof. Testbox is blocked by missing Blacksmith auth; AWS Crabbox is blocked by coordinator HTTP 401 before a lease id is issued.
