### PR TITLE
fix(llm-core): guard tool argument schema validation

### DIFF
--- a/packages/llm-core/src/validation.test.ts
+++ b/packages/llm-core/src/validation.test.ts
@@ -38,4 +38,52 @@ describe("validateToolArguments", () => {
       }),
     ).toThrow(/Validation failed for tool "decimal-tool"/);
   });
+
+  it("reports unreadable tool parameter schemas as unsupported", () => {
+    const hostileTool = {
+      name: "hostile-tool",
+      description: "test tool",
+      get parameters() {
+        throw new Error("parameters getter exploded");
+      },
+    } as Tool;
+
+    expect(() =>
+      validateToolArguments(hostileTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "hostile-tool",
+        arguments: {},
+      }),
+    ).toThrow(/Unsupported tool schema for "hostile-tool": unreadable schema at parameters/);
+  });
+
+  it("reports unreadable nested JSON schemas as unsupported", () => {
+    const properties: Record<string, unknown> = {};
+    Object.defineProperty(properties, "amount", {
+      enumerable: true,
+      get() {
+        throw new Error("schema properties exploded");
+      },
+    });
+    const hostileTool = {
+      name: "hostile-tool",
+      description: "test tool",
+      parameters: {
+        type: "object",
+        properties,
+      },
+    } as Tool;
+
+    expect(() =>
+      validateToolArguments(hostileTool, {
+        type: "toolCall",
+        id: "call-1",
+        name: "hostile-tool",
+        arguments: { amount: "12" },
+      }),
+    ).toThrow(
+      /Unsupported tool schema for "hostile-tool": unreadable schema at parameters\.properties\.amount/,
+    );
+  });
 });

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -63,6 +63,73 @@ function isValidatorSchema(value: unknown): value is Tool["parameters"] {
   return isRecord(value);
 }
 
+function unsupportedSchemaError(toolName: string, path: string): Error {
+  return new Error(`Unsupported tool schema for "${toolName}": unreadable schema at ${path}`);
+}
+
+function isUnsupportedSchemaError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("Unsupported tool schema for ");
+}
+
+function schemaPath(parent: string, key: string): string {
+  if (/^[A-Za-z_$][\w$]*$/u.test(key)) {
+    return `${parent}.${key}`;
+  }
+  return `${parent}[${JSON.stringify(key)}]`;
+}
+
+function assertReadableSchema(
+  schema: unknown,
+  toolName: string,
+  path: string,
+  seen = new WeakSet<object>(),
+): void {
+  if (!isRecord(schema)) {
+    return;
+  }
+  if (seen.has(schema)) {
+    return;
+  }
+  seen.add(schema);
+
+  let keys: string[];
+  try {
+    keys = Object.keys(schema);
+  } catch {
+    throw unsupportedSchemaError(toolName, path);
+  }
+
+  for (const key of keys) {
+    const childPath = Array.isArray(schema) ? `${path}[${key}]` : schemaPath(path, key);
+    let child: unknown;
+    try {
+      child = Reflect.get(schema, key);
+    } catch {
+      throw unsupportedSchemaError(toolName, childPath);
+    }
+    assertReadableSchema(child, toolName, childPath, seen);
+  }
+}
+
+function readToolParameters(tool: Tool): Tool["parameters"] {
+  try {
+    return Reflect.get(tool, "parameters") as Tool["parameters"];
+  } catch {
+    throw unsupportedSchemaError(tool.name, "parameters");
+  }
+}
+
+function guardSchemaOperation<T>(toolName: string, path: string, operation: () => T): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (isUnsupportedSchemaError(error)) {
+      throw error;
+    }
+    throw unsupportedSchemaError(toolName, path);
+  }
+}
+
 const JSON_NUMBER_TOKEN_RE = /^[+-]?(?:(?:\d+\.?\d*)|(?:\.\d+))(?:e[+-]?\d+)?$/iu;
 
 function parseJsonNumberString(value: string): number | undefined {
@@ -293,13 +360,20 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
 /** Validates tool arguments against TypeBox or plain JSON-schema parameters. */
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
   const args = structuredClone(toolCall.arguments);
-  Value.Convert(tool.parameters, args);
+  const parameters = readToolParameters(tool);
+  assertReadableSchema(parameters, tool.name, "parameters");
+  guardSchemaOperation(tool.name, "parameters", () => Value.Convert(parameters, args));
 
-  const validator = getValidator(tool.parameters);
-  if (!hasTypeBoxMetadata(tool.parameters) && isJsonSchemaObject(tool.parameters)) {
+  const validator = guardSchemaOperation(tool.name, "parameters", () => getValidator(parameters));
+  if (
+    guardSchemaOperation(tool.name, "parameters", () => !hasTypeBoxMetadata(parameters)) &&
+    isJsonSchemaObject(parameters)
+  ) {
     // TypeBox Value.Convert is intentionally conservative for plain JSON schemas;
     // mirror the provider-facing coercions so model-emitted string numbers validate.
-    const coerced = coerceWithJsonSchema(args, tool.parameters);
+    const coerced = guardSchemaOperation(tool.name, "parameters", () =>
+      coerceWithJsonSchema(args, parameters),
+    );
     if (coerced !== args) {
       if (isRecord(args) && isRecord(coerced)) {
         for (const key of Object.keys(args)) {
@@ -307,20 +381,26 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
         }
         Object.assign(args, coerced);
       } else {
-        return validator.Check(coerced) ? coerced : args;
+        return guardSchemaOperation(tool.name, "parameters", () => validator.Check(coerced))
+          ? coerced
+          : args;
       }
     }
   }
 
-  if (validator.Check(args)) {
+  if (guardSchemaOperation(tool.name, "parameters", () => validator.Check(args))) {
     return args;
   }
 
-  const errors =
-    validator
-      .Errors(args)
-      .map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)
-      .join("\n") || "Unknown validation error";
+  const errors = guardSchemaOperation(
+    tool.name,
+    "parameters",
+    () =>
+      validator
+        .Errors(args)
+        .map((error) => `  - ${formatValidationPath(error)}: ${error.message}`)
+        .join("\n") || "Unknown validation error",
+  );
 
   throw new Error(
     `Validation failed for tool "${toolCall.name}":\n${errors}\n\nReceived arguments:\n${JSON.stringify(toolCall.arguments, null, 2)}`,


### PR DESCRIPTION
## Summary
- Guard `validateToolArguments()` against unreadable plugin-provided tool parameter schemas.
- Convert top-level `parameters` getter failures, nested schema getter failures, and schema-owned TypeBox/coercion operation failures into a stable unsupported-schema error.
- Add regression coverage for hostile top-level and nested schema access while preserving plain JSON-schema numeric coercion.

## Context
Refreshed this existing draft branch from current `origin/main` instead of opening another duplicate fuzz PR for the same `packages/llm-core/src/validation.ts` surface.

## Verification
- Red proof before the fix: `node scripts/run-vitest.mjs run packages/llm-core/src/validation.test.ts -t "unreadable"` failed with raw `parameters getter exploded` and raw `schema properties exploded` errors.
- `node scripts/run-vitest.mjs run packages/llm-core/src/validation.test.ts`
- `./node_modules/.bin/oxfmt --check packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts`
- `./node_modules/.bin/oxlint packages/llm-core/src/validation.ts packages/llm-core/src/validation.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof
Behavior addressed: A bad plugin/tool schema can currently throw from the `parameters` getter or nested JSON-schema accessors and bubble a raw extension error through tool-call validation.

Real environment tested: Local gwt worktree using the repo Vitest wrapper for the touched `llm-core` unit surface.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run packages/llm-core/src/validation.test.ts`.

Evidence after fix: The focused test file passed 4 tests, including the two new hostile schema cases and the existing numeric-coercion cases.

Observed result after fix: `validateToolArguments()` now throws `Unsupported tool schema for "hostile-tool": unreadable schema at parameters` or the nested schema path instead of surfacing raw plugin getter errors.

What was not tested: Broad `pnpm check:changed` was not completed. `blacksmith testbox list --all` is blocked by missing Blacksmith auth, and both Crabbox wrapper attempts for `pnpm check:changed` failed local sparse-sync preflight because the Crabbox sync filesystem had 316.3 MiB free with 1.00 GiB required, then 312 MiB after safe cleanup.
