### PR TITLE
fix(qr): stabilize terminal colors

### DIFF
--- a/packages/plugin-sdk/src/testing.ts
+++ b/packages/plugin-sdk/src/testing.ts
@@ -1,3 +1,1 @@
-// Public package facade for plugin SDK testing helpers.
-
 export * from "../../../src/plugin-sdk/testing.js";

--- a/src/media/qr-terminal.render.test.ts
+++ b/src/media/qr-terminal.render.test.ts
@@ -68,6 +68,16 @@ describe("renderQrTerminal (real qrcode runtime)", () => {
     expect(max).toBeLessThanOrEqual(median * 6);
   });
 
+  it("keeps full QR rows on a controlled white background", async () => {
+    const sample = "https://accounts.feishu.cn/oauth/qr-demo";
+    const rendered = await renderQrTerminal(sample);
+    for (const line of rendered.split(/\r?\n/).filter(Boolean)) {
+      expect(line.startsWith("\x1b[48;2;255;255;255m\x1b[38;2;0;0;0m")).toBe(true);
+      expect(line.endsWith("\x1b[0m")).toBe(true);
+      expect((line.match(ansiSgr) ?? []).length).toBe(3);
+    }
+  });
+
   it("renders compact output from the same QR matrix", async () => {
     const sample = "https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF";
     const qr = QRCode.create(sample);

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -25,12 +25,12 @@ describe("renderQrTerminal", () => {
     toString.mockClear();
   });
 
-  it("delegates terminal rendering to qrcode", async () => {
-    await expect(renderQrTerminal("openclaw")).resolves.toBe("ASCII-QR");
-    expect(toString).toHaveBeenCalledWith("openclaw", {
-      small: false,
-      type: "terminal",
-    });
+  it("renders full QR output without qrcode terminal mode", async () => {
+    const rendered = await renderQrTerminal("openclaw");
+    expect(rendered).toContain("██");
+    expect(rendered).toContain("\x1b[48;2;255;255;255m\x1b[38;2;0;0;0m");
+    expect(create).toHaveBeenCalledWith("openclaw");
+    expect(toString).not.toHaveBeenCalled();
   });
 
   it("renders compact QR output without qrcode terminal small mode", async () => {

--- a/src/media/qr-terminal.ts
+++ b/src/media/qr-terminal.ts
@@ -6,11 +6,13 @@ type QrTerminalModules = {
 };
 
 const COMPACT_MARGIN_MODULES = 1;
-const TERMINAL_BLACK_ON_WHITE = "\x1b[47m\x1b[30m";
+const TERMINAL_BLACK_ON_WHITE = "\x1b[48;2;255;255;255m\x1b[38;2;0;0;0m";
 const TERMINAL_RESET = "\x1b[0m";
 const FULL_BLOCK = "█";
 const UPPER_HALF_BLOCK = "▀";
 const LOWER_HALF_BLOCK = "▄";
+const FULL_MODULE = "██";
+const EMPTY_MODULE = "  ";
 
 function readModule(modules: QrTerminalModules, x: number, y: number): boolean {
   if (x < 0 || y < 0 || x >= modules.size || y >= modules.size) {
@@ -44,6 +46,18 @@ function renderCompactTerminalQr(modules: QrTerminalModules): string {
   return lines.join("\n");
 }
 
+function renderFullTerminalQr(modules: QrTerminalModules): string {
+  const lines: string[] = [];
+  for (let y = -COMPACT_MARGIN_MODULES; y < modules.size + COMPACT_MARGIN_MODULES; y += 1) {
+    let line = TERMINAL_BLACK_ON_WHITE;
+    for (let x = -COMPACT_MARGIN_MODULES; x < modules.size + COMPACT_MARGIN_MODULES; x += 1) {
+      line += readModule(modules, x, y) ? FULL_MODULE : EMPTY_MODULE;
+    }
+    lines.push(`${line}${TERMINAL_RESET}`);
+  }
+  return lines.join("\n");
+}
+
 /** Renders QR text for terminal display, with an optional compact half-block mode. */
 export async function renderQrTerminal(
   input: string,
@@ -55,8 +69,5 @@ export async function renderQrTerminal(
     // Avoid qrcode's small terminal mode so we control quiet-zone size and ANSI reset placement.
     return renderCompactTerminalQr(qrCode.create(text).modules);
   }
-  return await qrCode.toString(text, {
-    small: false,
-    type: "terminal",
-  });
+  return renderFullTerminalQr(qrCode.create(text).modules);
 }


### PR DESCRIPTION
## Summary

  - Fixes terminal QR rendering so large QR codes keep a stable white background and black foreground even in terminals with dark
    or remapped ANSI themes.
  - Replaces the default qrcode terminal renderer for full-size QR output with OpenClaw’s own matrix renderer, matching the
    controlled rendering approach already used by compact QR output.
  - Intended outcome: Feishu scan-to-create/login QR codes, and any other default terminal QR users, remain readable without
    requiring users to change terminal themes.
  - Out of scope: changing Feishu OAuth/device-code flow, QR payload generation, plugin setup behavior, or image/PNG QR rendering.
  - Reviewers should focus on terminal ANSI behavior, QR matrix fidelity, and whether the shared renderer change is appropriate
    for all callers.

  ## Linked context

  Closes #

  Related #

  Requested during maintainer testing of Feishu scan-to-create/login QR display, where the large terminal QR appeared dark because
  terminal theme colors affected ANSI white/black rendering.

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: Large terminal QR codes could render with dark “white” areas in some terminal themes, making
    Feishu scan QR codes difficult to scan.
  - Real environment tested: Local OpenClaw checkout on branch fix/terminal-qr-theme-stable.
  - Exact steps or command run after this patch:

  node scripts/run-vitest.mjs src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts --reporter=verbose
  .agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/media/qr-
  terminal.test.ts src/media/qr-terminal.render.test.ts --reporter=verbose"

  - Evidence after fix: Local manual Feishu QR display was reported readable after switching from ANSI palette colors to 24-bit
    truecolor white background and black foreground.
  - Observed result after fix: QR white areas render as true RGB white instead of terminal-theme ANSI white, and large QR rows
    keep a controlled background until the end-of-line reset.
  - What was not tested: No automated screenshot or phone-camera scan test was added.
  - Proof limitations or environment constraints: Validation is local terminal behavior plus focused renderer tests; terminal
    rendering can still vary in terminals that do not support ANSI truecolor.
  - Before evidence: Large QR output was visually dark in the maintainer’s terminal before this change.

  ## Tests and validation

  Commands run:

  node scripts/run-vitest.mjs src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts --reporter=verbose
  .agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/media/qr-
  terminal.test.ts src/media/qr-terminal.render.test.ts --reporter=verbose"

  Regression coverage added or updated:

  - Updated unit coverage so full-size terminal QR rendering no longer delegates to qrcode terminal mode.
  - Added real-runtime coverage that full QR rows start with controlled truecolor white-background/black-foreground ANSI and reset
    only at row end.
  - Existing compact QR matrix fidelity test remains green.

  What failed before this fix:

  - The default large QR renderer depended on terminal ANSI palette colors and per-cell reset behavior, which could make white QR
    regions appear dark in some themes.

  If no test was added, why not?

  - Tests were added.

  ## Risk checklist

  Did user-visible behavior change? (Yes)

  Did config, environment, or migration behavior change? (No)

  Did security, auth, secrets, network, or tool execution behavior change? (No)

  What is the highest-risk area?

  Shared terminal QR rendering affects all callers of renderQrTerminal() that use default full-size output.

  How is that risk mitigated?

  The renderer still uses the same qrcode.create(text).modules matrix source, and focused tests verify both full-size row color
  control and compact QR matrix fidelity.

  ## Current review state

  What is the next action?

  Open PR and request maintainer review.

  What is still waiting on author, maintainer, CI, or external proof?

  CI and maintainer review.

  Which bot or reviewer comments were addressed?

  Local autoreview completed cleanly with no accepted/actionable findings.

Before:

<img width="1638" height="1328" alt="Clipboard_Screenshot_1780563028" src="https://github.com/user-attachments/assets/d408252a-033b-4020-a59c-19a41a3649c6" />

 Now:
 
<img width="1364" height="1216" alt="Clipboard_Screenshot_1780563017" src="https://github.com/user-attachments/assets/673f5f3d-373d-4624-b2ab-0d335059b9c7" />
