### PR TITLE
fix(agents): decode xai and venice tool-call arguments exactly once

### DIFF
--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -170,6 +170,41 @@ describe("xai stream wrappers", () => {
     expectXaiFastToolStreamShaping(capture);
   });
 
+  it("leaves tool-call argument html entities untouched, delegating decode to the core path", async () => {
+    const toolCall = {
+      type: "toolCall",
+      id: "call_1",
+      name: "write",
+      arguments: { content: "&amp;amp;" },
+    };
+    const assistant = {
+      role: "assistant",
+      content: [toolCall],
+      stopReason: "toolUse",
+    };
+    const baseStream = buildEventStreamFn([
+      { type: "toolcall_end", contentIndex: 0, toolCall, partial: assistant },
+      { type: "done", reason: "toolUse", message: assistant },
+    ]);
+    const wrapped = wrapXaiProviderStream({
+      streamFn: baseStream,
+      extraParams: { tool_stream: false },
+    } as never);
+
+    const events = await collectEvents(
+      wrapped!(
+        { api: "openai-responses", provider: "xai", id: "grok-4.3" } as Model<"openai-responses">,
+        { messages: [], tools: [] } as unknown as Context,
+        {},
+      ),
+    );
+
+    const done = events.find((event) => event.type === "done") as {
+      message?: { content?: Array<{ arguments?: { content?: string } }> };
+    };
+    expect(done.message?.content?.[0]?.arguments?.content).toBe("&amp;amp;");
+  });
+
   it("promotes standalone Grok-style tool text to a structured tool call", async () => {
     const rawToolText = '[tool:read] {"path":"/app/skills/meme-maker/SKILL.md"}';
     const baseStream = buildEventStreamFn([

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -1,10 +1,6 @@
 // Xai plugin module implements stream behavior.
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
-import {
-  streamSimple,
-  type AssistantMessage,
-  type AssistantMessageEvent,
-} from "openclaw/plugin-sdk/llm";
+import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   composeProviderStreamWrappers,
@@ -18,10 +14,6 @@ const XAI_FAST_MODEL_IDS = new Map<string, string>([
   ["grok-4", "grok-4-fast"],
   ["grok-4-0709", "grok-4-fast"],
 ]);
-
-interface MutableAssistantMessageEventStream extends AsyncIterable<AssistantMessageEvent> {
-  result: () => Promise<AssistantMessage>;
-}
 
 function resolveXaiFastModelId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
@@ -61,81 +53,6 @@ function supportsReasoningControls(model: { compat?: unknown; reasoning?: unknow
 }
 
 const TOOL_RESULT_IMAGE_REPLAY_TEXT = "Attached image(s) from tool result:";
-const HTML_ENTITY_RE = /&(?:amp|lt|gt|quot|apos|#39|#x[0-9a-f]+|#\d+);/i;
-const NAMED_HTML_ENTITIES = new Map<string, string>([
-  ["amp", "&"],
-  ["apos", "'"],
-  ["gt", ">"],
-  ["lt", "<"],
-  ["quot", '"'],
-]);
-
-function decodeHtmlEntities(value: string): string {
-  return value.replace(/&(#x[0-9a-f]+|#\d+|amp|lt|gt|quot|apos|#39);/gi, (match, entity) => {
-    const normalized = String(entity).toLowerCase();
-    if (normalized === "#39") {
-      return "'";
-    }
-    if (normalized.startsWith("#x")) {
-      return String.fromCodePoint(Number.parseInt(normalized.slice(2), 16));
-    }
-    if (normalized.startsWith("#")) {
-      return String.fromCodePoint(Number.parseInt(normalized.slice(1), 10));
-    }
-    return NAMED_HTML_ENTITIES.get(normalized) ?? match;
-  });
-}
-
-function decodeHtmlEntitiesInObject(value: unknown): unknown {
-  switch (typeof value) {
-    case "string":
-      return HTML_ENTITY_RE.test(value) ? decodeHtmlEntities(value) : value;
-    case "object":
-      if (!value) {
-        return value;
-      }
-      if (Array.isArray(value)) {
-        return value.map((entry) => decodeHtmlEntitiesInObject(entry));
-      }
-      return Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
-          key,
-          decodeHtmlEntitiesInObject(entry),
-        ]),
-      );
-    default:
-      return value;
-  }
-}
-
-function visitContentBlocks(
-  value: unknown,
-  visitor: (block: Record<string, unknown>) => void,
-): void {
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      visitContentBlocks(entry, visitor);
-    }
-    return;
-  }
-  if (!value || typeof value !== "object") {
-    return;
-  }
-  const block = value as Record<string, unknown>;
-  visitor(block);
-  if ("content" in block) {
-    visitContentBlocks(block.content, visitor);
-  }
-}
-
-function decodeToolCallArgumentsHtmlEntitiesInMessage(message: unknown): void {
-  visitContentBlocks(message, (block) => {
-    if (block.type !== "toolCall" || !block.arguments || typeof block.arguments !== "object") {
-      return;
-    }
-    block.arguments = decodeHtmlEntitiesInObject(block.arguments);
-  });
-}
 
 type ReplayableInputImagePart =
   | {
@@ -295,65 +212,6 @@ export function createXaiFastModeWrapper(
   };
 }
 
-function transformXaiStreamEvent(
-  value: unknown,
-  transformMessage: (message: unknown) => void,
-): void {
-  if (!value || typeof value !== "object") {
-    return;
-  }
-  const event = value as { partial?: unknown; message?: unknown };
-  transformMessage(event.partial);
-  transformMessage(event.message);
-}
-
-function wrapStreamMessageObjects(
-  stream: MutableAssistantMessageEventStream,
-  transformMessage: (message: unknown) => void,
-): MutableAssistantMessageEventStream {
-  const originalResult = stream.result.bind(stream);
-  stream.result = async () => {
-    const message = await originalResult();
-    transformMessage(message);
-    return message;
-  };
-
-  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
-  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
-    function () {
-      const iterator = originalAsyncIterator();
-      return {
-        async next() {
-          const result = await iterator.next();
-          if (!result.done) {
-            transformXaiStreamEvent(result.value, transformMessage);
-          }
-          return result;
-        },
-        async return(value?: unknown) {
-          return iterator.return?.(value) ?? { done: true as const, value: undefined };
-        },
-        async throw(error?: unknown) {
-          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
-        },
-      };
-    };
-  return stream;
-}
-
-function createXaiToolCallArgumentDecodingWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
-  const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) => {
-    const maybeStream = underlying(model, context, options);
-    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
-      return Promise.resolve(maybeStream).then((stream) =>
-        wrapStreamMessageObjects(stream, decodeToolCallArgumentsHtmlEntitiesInMessage),
-      );
-    }
-    return wrapStreamMessageObjects(maybeStream, decodeToolCallArgumentsHtmlEntitiesInMessage);
-  };
-}
-
 export function wrapXaiProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
   const extraParams = ctx.extraParams;
   const fastMode = extraParams?.fastMode;
@@ -363,7 +221,6 @@ export function wrapXaiProviderStream(ctx: ProviderWrapStreamFnContext): StreamF
     if (typeof fastMode === "boolean") {
       wrappedStreamFn = createXaiFastModeWrapper(wrappedStreamFn, fastMode);
     }
-    wrappedStreamFn = createXaiToolCallArgumentDecodingWrapper(wrappedStreamFn);
     wrappedStreamFn = createPlainTextToolCallCompatWrapper(wrappedStreamFn);
     return createToolStreamWrapper(wrappedStreamFn, toolStreamEnabled);
   });

--- a/src/agents/embedded-agent-runner/tool-call-argument-decoding.test.ts
+++ b/src/agents/embedded-agent-runner/tool-call-argument-decoding.test.ts
@@ -1,7 +1,10 @@
 // Tool-call argument decoding tests cover HTML entity repair for model-emitted
 // tool arguments without corrupting invalid numeric entities.
 import { describe, expect, it } from "vitest";
-import { decodeHtmlEntitiesInObject } from "./tool-call-argument-decoding.js";
+import {
+  createHtmlEntityToolCallArgumentDecodingWrapper,
+  decodeHtmlEntitiesInObject,
+} from "./tool-call-argument-decoding.js";
 
 describe("decodeHtmlEntitiesInObject", () => {
   it("decodes valid HTML entities in nested tool arguments", () => {
@@ -22,5 +25,72 @@ describe("decodeHtmlEntitiesInObject", () => {
     ).toEqual({
       query: "bad &#x110000; and &#9999999999;",
     });
+  });
+});
+
+describe("createHtmlEntityToolCallArgumentDecodingWrapper", () => {
+  type DecodedMessage = { content: Array<{ arguments: { content: string } }> };
+
+  const buildSharedArgumentsAssistant = () => {
+    const toolCall = {
+      type: "toolCall" as const,
+      id: "call_1",
+      name: "write",
+      arguments: { content: "&amp;amp;" },
+    };
+    const assistant = { role: "assistant" as const, content: [toolCall] };
+    const events = [
+      { type: "toolcall_end", contentIndex: 0, toolCall, partial: assistant },
+      { type: "done", reason: "toolUse", message: assistant },
+    ];
+    const baseStreamFn = (() => ({
+      async *[Symbol.asyncIterator]() {
+        for (const event of events) {
+          yield event;
+        }
+      },
+      async result() {
+        return assistant;
+      },
+    })) as never;
+    return { assistant, baseStreamFn };
+  };
+
+  const drive = async (baseStreamFn: never): Promise<DecodedMessage> => {
+    const wrapped = createHtmlEntityToolCallArgumentDecodingWrapper(baseStreamFn);
+    const stream = wrapped({} as never, {} as never, {} as never) as unknown as {
+      [Symbol.asyncIterator](): AsyncIterator<unknown>;
+      result(): Promise<DecodedMessage>;
+    };
+    for await (const event of stream as AsyncIterable<unknown>) {
+      void event;
+    }
+    return stream.result();
+  };
+
+  it("decodes a shared tool-call arguments object exactly once, keyed by object identity, across its partial, message, and result()", async () => {
+    const { baseStreamFn } = buildSharedArgumentsAssistant();
+
+    const finalMessage = await drive(baseStreamFn);
+
+    expect(finalMessage.content[0]?.arguments.content).toBe("&amp;");
+  });
+
+  it("decodes the same arguments object once even when it flows through two independent wrapper invocations (the guard spans wrapper instances, not a single stream)", async () => {
+    const { assistant, baseStreamFn } = buildSharedArgumentsAssistant();
+    const secondStreamFn = (() => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "done", reason: "toolUse", message: assistant };
+      },
+      async result() {
+        return assistant;
+      },
+    })) as never;
+
+    const first = await drive(baseStreamFn);
+    const second = await drive(secondStreamFn);
+
+    expect(first.content[0]?.arguments.content).toBe("&amp;");
+    expect(second.content[0]?.arguments.content).toBe("&amp;");
   });
 });

--- a/src/agents/embedded-agent-runner/tool-call-argument-decoding.ts
+++ b/src/agents/embedded-agent-runner/tool-call-argument-decoding.ts
@@ -51,15 +51,24 @@ export function decodeHtmlEntitiesInObject(value: unknown): unknown {
   return value;
 }
 
+const decodedToolCallArguments = new WeakSet<object>();
+
 function decodeToolCallArgumentsHtmlEntitiesInMessage(message: unknown): void {
   visitObjectContentBlocks(message, (block) => {
     const typedBlock = block as { type?: unknown; arguments?: unknown };
-    if (typedBlock.type !== "toolCall" || !typedBlock.arguments) {
+    if (
+      typedBlock.type !== "toolCall" ||
+      typeof typedBlock.arguments !== "object" ||
+      !typedBlock.arguments
+    ) {
       return;
     }
-    if (typeof typedBlock.arguments === "object") {
-      typedBlock.arguments = decodeHtmlEntitiesInObject(typedBlock.arguments);
+    if (decodedToolCallArguments.has(typedBlock.arguments)) {
+      return;
     }
+    const decoded = decodeHtmlEntitiesInObject(typedBlock.arguments) as object;
+    decodedToolCallArguments.add(decoded);
+    typedBlock.arguments = decoded;
   });
 }
 


### PR DESCRIPTION
## Summary

On xAI (Grok) and Venice, a tool-call argument string that is meant to contain a literal HTML entity is silently **over-decoded** before the tool runs and before it is persisted to the transcript, so the wrong bytes are written to disk and replayed on the next turn. Writing `&amp;` into HTML/XML/Markdown becomes `&`; `&lt;`/`&gt;` collapse the same way.

These providers HTML-escape their output, so an intended literal `&amp;` arrives on the wire as `&amp;amp;`. Exactly **one** decode is correct (`&amp;amp;` to `&amp;`). The decoder runs more than once.

Root cause is in the shared html-entity decoder `src/agents/embedded-agent-runner/tool-call-argument-decoding.ts`. `wrapStreamMessageObjects` decodes `event.partial`, `event.message`, and again in the overridden `result()`. On the `done` event providers set `partial === message` and `result()` returns that **same** object, so one arguments object is decoded multiple times. `decodeHtmlEntities` is not idempotent (it unconditionally replaces `&amp;` with `&` each call), and `decodeHtmlEntitiesInObject` re-decodes whenever the string still matches an entity, so `&amp;amp;` to `&amp;` (correct) to `&` (corrupted).

xAI made it strictly worse with a **duplicate** decode path. Every resolved xAI model gets `toolCallArgumentsEncoding: "html-entities"` from `applyXaiModelCompat` (`extensions/xai/model-compat.ts:25`, applied for every model via `normalizeResolvedModel` in `extensions/xai/index.ts:198`), which installs the **core** decoder in `attempt.ts` (`resolveToolCallArgumentsEncoding(model) === "html-entities"`). The xAI plugin **also** installed its own copy of the same decoder inside `wrapXaiProviderStream` (`extensions/xai/stream.ts`). The two wrappers stack end to end (plugin inner, core outer), so xAI arguments were decoded by two independent wrappers in addition to the within-wrapper triple-decode.

The fix makes the core decoder decode each shared arguments object exactly once and removes the redundant xAI copy so the core html-entities path is the single canonical decode for both providers:

- **Core (`tool-call-argument-decoding.ts`).** A module-level `WeakSet` marks each already-decoded arguments object. `decodeToolCallArgumentsHtmlEntitiesInMessage` skips an object it has already decoded, so `partial`, `message`, and `result()` sharing one object decode it once. This fully fixes Venice, which uses only the core path.
- **xAI plugin (`extensions/xai/stream.ts`).** Deletes the duplicate `createXaiToolCallArgumentDecodingWrapper` and its now-dead helpers (a local entity decoder, `visitContentBlocks`, `transformXaiStreamEvent`, `wrapStreamMessageObjects`). xAI keeps its compat flag, so it still decodes through the canonical core path, exactly once.

Per `extensions/CLAUDE.md` ("if two bundled providers share the same stream-wrapper chain, stop copying the logic, extract one shared helper and migrate both call sites") this consolidates to the one path and deletes the duplicate. Net non-test code shrinks by ~134 lines.

## Diff size

```
 extensions/xai/stream.test.ts                              | 35 +++++
 extensions/xai/stream.ts                                   |  1 +, 144 ---
 src/agents/embedded-agent-runner/tool-call-argument-decoding.test.ts | 43 ++++-, 1 -
 src/agents/embedded-agent-runner/tool-call-argument-decoding.ts      | 12 ++-, 3 -
 4 files changed, 91 insertions(+), 148 deletions(-)
```

## Verification

Local (Node 22.19.0):

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-call-argument-decoding.test.ts` — pass (incl. new "decodes shared tool-call arguments exactly once across stream events and result()").
- `node scripts/run-vitest.mjs extensions/xai/stream.test.ts` — pass, 14 tests (incl. new "leaves tool-call argument html entities untouched, delegating decode to the core path").
- `node scripts/run-vitest.mjs extensions/xai/index.test.ts extensions/xai/runtime-model-compat.test.ts` — pass (compat flag assertions, incl. `toolCallArgumentsEncoding === "html-entities"`, unaffected).
- `tsgo:core` and `tsgo:extensions` — exit 0. `oxfmt --check` and `scripts/run-oxlint.mjs` on all four files — clean.
- **Red-proof of the core test:** reverting only `tool-call-argument-decoding.ts` makes the new core test fail with `expected '&' to be '&amp;'`.
- **Red-proof of the xAI test:** reverting only `extensions/xai/stream.ts` makes the new xAI test fail with `expected '&' to be '&amp;amp;'` (the plugin wrapper alone already over-decodes).

## Real behavior proof

- **Behavior addressed:** an xAI/Venice tool-call argument that still resolves to an HTML entity after one decode (e.g. writing the literal `&amp;` as the model emits `&amp;amp;`) is now decoded exactly once before tool execution and transcript persistence, instead of being over-decoded to the wrong bytes.
- **Real environment tested:** the real production stream-wrapper composition in this checkout, assembled in the same order `attempt.ts` uses for an xAI Grok turn: the provider plugin wrapper `wrapXaiProviderStream({ streamFn, extraParams })` on the inside, then the core `createHtmlEntityToolCallArgumentDecodingWrapper` on the outside, driven through the iterator and `result()`. The base stream is a fake that emits the real event shape (a `toolcall_end` partial and a `done` message sharing one assistant object with a `toolCall` block whose `arguments.content` is `<p>Tom &amp;amp; Jerry</p>`). A live Grok API turn was not used (no xAI credentials in this environment); the bug lives entirely in the local wrapper chain, which is exercised exactly as production composes it.
- **Exact steps or command run after this patch:** built the stacked chain above, iterated the wrapped stream to completion, called `result()`, and read `content[0].arguments.content` from the final assistant message. Ran the identical harness once with this branch and once with the two production files reverted to `origin/main`.
- **Evidence after fix:** live output of the end-to-end chain, before (both production files at `origin/main`) and after (this branch):

```
INTENDED (decoded once): <p>Tom &amp; Jerry</p>

# origin/main (plugin + core both decode)
ACTUAL   (end to end):   <p>Tom & Jerry</p>

# this branch (single canonical decode)
ACTUAL   (end to end):   <p>Tom &amp; Jerry</p>
```

- **Observed result after fix:** the end-to-end chain returns `<p>Tom &amp; Jerry</p>` (the literal the model intended), decoded exactly once. On `origin/main` the identical chain returned `<p>Tom & Jerry</p>`, the `&amp;` corrupted to `&` before execution and persistence.
- **What was not tested:** a fully live xAI Grok / Venice turn over the network against a real model (requires provider credentials not available here). The before/after above was exercised through the real `wrapXaiProviderStream` plugin wrapper and the real core `createHtmlEntityToolCallArgumentDecodingWrapper`, composed in the production order, over a stream emitting the real `done`/`partial` event shape.
