### PR TITLE
fix(agents): guard tool definition schemas

### DIFF
--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -43,6 +43,24 @@ async function executeTool(tool: AgentTool, callId: string) {
 }
 
 describe("agent tool definition adapter", () => {
+  it("uses an empty object schema when an agent tool parameter getter throws", () => {
+    const tool = {
+      name: "hostile_schema",
+      label: "Hostile Schema",
+      description: "throws while reading parameters",
+      execute: async () => ({ content: [] }),
+    } as unknown as AgentTool;
+    Object.defineProperty(tool, "parameters", {
+      get() {
+        throw new Error("schema unavailable");
+      },
+    });
+
+    const [def] = toToolDefinitions([tool]);
+
+    expect(def?.parameters).toEqual({ type: "object", properties: {} });
+  });
+
   it("wraps tool errors into a tool result", async () => {
     const result = await executeThrowingTool("boom", "call1");
 
@@ -140,6 +158,22 @@ async function executeClientTool(params: unknown): Promise<{
 }
 
 describe("toClientToolDefinitions – param coercion", () => {
+  it("uses an empty object schema when a client tool parameter getter throws", () => {
+    const func = {
+      name: "client_schema",
+      description: "throws while reading parameters",
+    } as ClientToolDefinition["function"];
+    Object.defineProperty(func, "parameters", {
+      get() {
+        throw new Error("schema unavailable");
+      },
+    });
+
+    const [def] = toClientToolDefinitions([{ type: "function", function: func }]);
+
+    expect(def?.parameters).toEqual({ type: "object", properties: {} });
+  });
+
   it("returns terminal pending results for each client tool in a batch", async () => {
     const completed: Array<{ id: string; name: string; params: Record<string, unknown> }> = [];
     const defs = toClientToolDefinitions([makeClientTool("search"), makeClientTool("lookup")], {

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -53,6 +53,7 @@ const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
 const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
 const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
 const EXEC_COMMAND_PARAM_KEYS = new Set(["command", "cmd"]);
+const EMPTY_OBJECT_TOOL_PARAMETERS = { type: "object", properties: {} } as ToolDefinition["parameters"];
 
 export type ClientToolCallRecorder =
   | ((toolName: string, params: Record<string, unknown>) => void)
@@ -133,6 +134,32 @@ function kindForLog(value: unknown): string {
     return "null";
   }
   return typeof value;
+}
+
+function resolveAgentToolParameters(tool: AnyAgentTool): ToolDefinition["parameters"] {
+  try {
+    return tool.parameters;
+  } catch (err) {
+    const described = describeToolExecutionError(err);
+    logDebug(
+      `tools: ${tool.name || "tool"} has unreadable parameter schema; using empty object schema: ${described.message}`,
+    );
+    return EMPTY_OBJECT_TOOL_PARAMETERS;
+  }
+}
+
+function resolveClientToolParameters(
+  func: ClientToolDefinition["function"],
+): ToolDefinition["parameters"] {
+  try {
+    return func.parameters as ToolDefinition["parameters"];
+  } catch (err) {
+    const described = describeToolExecutionError(err);
+    logDebug(
+      `tools: ${func.name || "client_tool"} has unreadable client parameter schema; using empty object schema: ${described.message}`,
+    );
+    return EMPTY_OBJECT_TOOL_PARAMETERS;
+  }
 }
 
 function summarizeSensitiveValueForLog(params: {
@@ -358,7 +385,7 @@ export function toToolDefinitions(
       name,
       label: tool.label ?? name,
       description: tool.description ?? "",
-      parameters: tool.parameters,
+      parameters: resolveAgentToolParameters(tool),
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
@@ -490,7 +517,7 @@ export function toClientToolDefinitions(
       name: func.name,
       label: func.name,
       description: func.description ?? "",
-      parameters: func.parameters as ToolDefinition["parameters"],
+      parameters: resolveClientToolParameters(func),
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
         if (onClientToolCall && typeof onClientToolCall !== "function") {


### PR DESCRIPTION
## Summary

- guard agent tool definition adaptation against unreadable `parameters` getters
- guard client tool definition adaptation against unreadable `function.parameters` getters
- fall back to the minimal empty object schema instead of crashing the adapter before healthy tools can proceed

## Real behavior proof

Behavior addressed: Bad plugin/extension tool schema getters could crash `toToolDefinitions()` / `toClientToolDefinitions()` while materializing session tool definitions, before provider/runtime filtering or healthy sibling tools had a chance to continue.

Real environment tested: Local OpenClaw linked Codex worktree on Node/Vitest via repo wrapper; remote broad gate attempted through Blacksmith Testbox and AWS Crabbox.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts --testNamePattern="uses an empty object schema when"`
- `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts`
- `node scripts/run-oxlint.mjs src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next192-check-changed --shell -- "pnpm check:changed"`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next192-check-changed --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Evidence after fix: Focused adapter test file passed with 20 tests after rebase; oxlint passed; diff whitespace check passed; local and branch autoreview both returned no accepted/actionable findings.

Observed result after fix: Hostile schema getters no longer throw out of tool definition adaptation. The resulting tool definitions keep running with `{ "type": "object", "properties": {} }` as the safe fallback schema.

What was not tested: Full `pnpm check:changed` was not completed because Blacksmith Testbox auth is missing locally (`not authenticated`) and direct AWS Crabbox coordinator calls returned HTTP 401 for run/lease creation.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts --testNamePattern="uses an empty object schema when"` failed with `schema unavailable` from both the agent tool and client tool parameter getters.
- Post-fix focused proof: `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts --testNamePattern="uses an empty object schema when"` passed 2 tests.
- Post-fix full file proof: `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts` passed 20 tests.
- Post-rebase proof: `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.test.ts` passed 20 tests.
- Lint: `node scripts/run-oxlint.mjs src/agents/agent-tool-definition-adapter.ts src/agents/agent-tool-definition-adapter.test.ts` passed.
- Whitespace: `git diff --check origin/main...HEAD` passed.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local` clean, `overall: patch is correct (0.82)`.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.86)`.
- Broad proof attempted but blocked: `blacksmith testbox list --all` reported not authenticated; AWS Crabbox coordinator returned HTTP 401; delegated Blacksmith-through-Crabbox failed on the same missing Blacksmith auth.
