### PR TITLE
fix(agents): guard system prompt tool schema stats

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -216,4 +216,83 @@ describe("buildSystemPromptReport", () => {
     });
     expect(report.tools.entries[0]?.schemaHash).toMatch(/^[a-f0-9]{64}$/u);
   });
+
+  it("keeps reporting when a tool schema getter throws", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const brokenTool = {
+      name: "broken",
+      description: "Broken schema",
+    };
+    Object.defineProperty(brokenTool, "parameters", {
+      get() {
+        throw new Error("schema getter exploded");
+      },
+    });
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        brokenTool,
+        {
+          name: "healthy",
+          description: "Healthy schema",
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries).toHaveLength(2);
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "broken",
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+    expect(report.tools.entries[1]).toMatchObject({
+      name: "healthy",
+      propertiesCount: 1,
+    });
+  });
+
+  it("keeps reporting when a tool schema properties getter throws", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const schema = { type: "object" };
+    Object.defineProperty(schema, "properties", {
+      get() {
+        throw new Error("properties getter exploded");
+      },
+      enumerable: true,
+    });
+
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [],
+      skillsPrompt: "",
+      tools: [
+        {
+          name: "broken",
+          description: "Broken schema",
+          parameters: schema,
+        },
+      ] as never,
+    });
+
+    expect(report.tools.entries[0]).toMatchObject({
+      name: "broken",
+      schemaChars: 0,
+      propertiesCount: null,
+    });
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -49,7 +49,7 @@ function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChar
 }
 
 function buildToolSchemaStats(
-  parameters: AgentTool["parameters"],
+  parameters: AgentTool["parameters"] | undefined,
 ): Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> {
   if (!parameters || typeof parameters !== "object") {
     return { schemaChars: 0, schemaHash: sha256(""), propertiesCount: null };
@@ -67,19 +67,33 @@ function buildToolSchemaStats(
   const stats = {
     schemaChars: schemaJson.length,
     schemaHash: sha256(schemaJson),
-    propertiesCount: (() => {
-      const schema = parameters as Record<string, unknown>;
-      const props = typeof schema.properties === "object" ? schema.properties : null;
-      if (!props || typeof props !== "object") {
-        return null;
-      }
-      return Object.keys(props as Record<string, unknown>).length;
-    })(),
+    propertiesCount: countToolSchemaProperties(parameters),
   };
   // Tool parameter objects are reused across runs; cache their stable size/hash
   // so report generation stays cheap during frequent prompt rebuilds.
   toolSchemaStatsCache.set(parameters, stats);
   return stats;
+}
+
+function countToolSchemaProperties(parameters: object): number | null {
+  try {
+    const schema = parameters as Record<string, unknown>;
+    const props = typeof schema.properties === "object" ? schema.properties : null;
+    if (!props || typeof props !== "object") {
+      return null;
+    }
+    return Object.keys(props as Record<string, unknown>).length;
+  } catch {
+    return null;
+  }
+}
+
+function readToolParameters(tool: AgentTool): AgentTool["parameters"] | undefined {
+  try {
+    return tool.parameters;
+  } catch {
+    return undefined;
+  }
 }
 
 function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools"]["entries"] {
@@ -91,7 +105,7 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
     const name = tool.name;
     const summary = tool.description?.trim() || tool.label?.trim() || "";
     const summaryChars = summary.length;
-    const schemaStats = buildToolSchemaStats(tool.parameters);
+    const schemaStats = buildToolSchemaStats(readToolParameters(tool));
     const entry = { name, summaryChars, summaryHash: sha256(summary), ...schemaStats };
     toolReportEntryCache.set(tool, entry);
     return entry;


### PR DESCRIPTION
## Summary

- guard system prompt report generation against throwing tool `parameters` getters
- guard tool schema property counting against throwing `properties` getters
- preserve the existing zero-size/hash fallback for schemas that cannot be measured

## Real behavior proof

Behavior addressed: A bad plugin/extension tool schema could crash system prompt report generation while session metadata accounted for tool schema footprint, even though the report path already intended to tolerate unstringifiable schemas.

Real environment tested: Local OpenClaw linked Codex worktree on Node/Vitest via repo wrapper; remote broad gate attempted through Blacksmith Testbox and AWS Crabbox.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts --testNamePattern="keeps reporting when a tool schema .*getter throws"`
- `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts`
- `node scripts/run-oxlint.mjs src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next193-check-changed --shell -- "pnpm check:changed"`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next193-check-changed --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Evidence after fix: Focused system prompt report tests passed with 12 tests after rebase; oxlint passed; diff whitespace check passed; local and branch autoreview both returned no accepted/actionable findings.

Observed result after fix: Throwing schema accessors no longer abort report generation. The affected tool entry reports zero schema chars, the empty-schema hash, and `propertiesCount: null`, while healthy sibling tools remain represented.

What was not tested: Full `pnpm check:changed` was not completed because Blacksmith Testbox auth is missing locally (`not authenticated`), direct AWS Crabbox coordinator calls returned HTTP 401 for run/lease creation, and the delegated Crabbox/Testbox wrapper also hit the sparse-sync free-disk preflight.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts --testNamePattern="keeps reporting when a tool schema .*getter throws"` failed with `schema getter exploded` and `properties getter exploded`.
- Post-fix focused proof: `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts --testNamePattern="keeps reporting when a tool schema .*getter throws"` passed 2 tests.
- Post-fix full file proof: `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts` passed 12 tests.
- Post-rebase proof: `node scripts/run-vitest.mjs run src/agents/system-prompt-report.test.ts` passed 12 tests.
- Lint: `node scripts/run-oxlint.mjs src/agents/system-prompt-report.ts src/agents/system-prompt-report.test.ts` passed.
- Whitespace: `git diff --check origin/main...HEAD` passed.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local` clean, `overall: patch is correct (0.84)`.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.86)`.
- Broad proof attempted but blocked: `blacksmith testbox list --all` reported not authenticated; AWS Crabbox coordinator returned HTTP 401; delegated Blacksmith-through-Crabbox failed the sparse-sync free-disk preflight at `free=1022.1 MiB; required=1.00 GiB`.
