### PR TITLE
test: detect file symlink support dynamically in json-file tests

### DIFF
--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,9 +1,25 @@
 // Covers JSON file load/save behavior.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+const canCreateFileSymlinks = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-json-symlink-probe-"));
+  const targetFile = path.join(probeDir, "target.json");
+  const linkFile = path.join(probeDir, "link.json");
+  try {
+    fs.writeFileSync(targetFile, "{}", "utf8");
+    fs.symlinkSync(targetFile, linkFile, "file");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
 
 const SAVED_PAYLOAD = { enabled: true, count: 2 };
 const PREVIOUS_JSON = '{"enabled":false}\n';
@@ -129,7 +145,7 @@ describe("json-file helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateFileSymlinks)(
     "preserves symlink destinations when replacing existing JSON files",
     async () => {
       await withJsonSymlink(({ targetDir, targetPath, linkPath }) => {
@@ -144,7 +160,7 @@ describe("json-file helpers", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateFileSymlinks)(
     "creates a missing target file through an existing symlink",
     async () => {
       await withJsonSymlink(({ targetDir, targetPath, linkPath }) => {
@@ -158,7 +174,7 @@ describe("json-file helpers", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateFileSymlinks)(
     "does not create missing target directories through an existing symlink",
     async () => {
       await withTempDir({ prefix: "openclaw-json-file-" }, async (root) => {


### PR DESCRIPTION
Replaces the hardcoded Windows skip in JSON file helper tests with a dynamic file symlink capability check. If file symlinks are supported by the environment, the tests execute. Otherwise, they skip gracefully, allowing correct platform-specific testing.

### Verified Windows Proof

The following test execution log shows the test run on Windows. Since file symlink creation is not permitted on this host, the symlink tests were skipped gracefully as expected (3 skipped, 8 passed), rather than failing the whole suite:

```
 RUN  v4.1.7 C:/Users/ANIRUDDHA/.gemini/antigravity/scratch/openclaw

 ✓  infra  ../../src/infra/json-file.test.ts (11 tests | 3 skipped) 417ms

 Test Files  1 passed (1)
      Tests  8 passed | 3 skipped (11)
```
