### PR TITLE
fix(trajectory): guard tool schema capture

### DIFF
--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -105,6 +105,116 @@ describe("trajectory runtime", () => {
     expect(JSON.stringify(parsed.data)).not.toContain("abcd-efgh-ijkl-mnop");
   });
 
+  it("keeps trajectory tool definitions when schema accessors throw", () => {
+    let nameReads = 0;
+    const unreadableTool = {
+      name: "unreadable",
+      description: "bad getter",
+    };
+    Object.defineProperty(unreadableTool, "parameters", {
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+    const nestedSchema = { type: "object" };
+    Object.defineProperty(nestedSchema, "properties", {
+      get() {
+        throw new Error("properties getter exploded");
+      },
+      enumerable: true,
+    });
+    const unreadableNameTool = {
+      description: "bad name",
+      parameters: { type: "object" },
+      get name() {
+        throw new Error("name getter exploded");
+      },
+    };
+    const unreadableDescriptionTool = {
+      name: "descriptionless",
+      parameters: { type: "object" },
+      get description() {
+        throw new Error("description getter exploded");
+      },
+    };
+    const singleReadTool = {
+      description: "single read",
+      parameters: { type: "object" },
+      get name() {
+        nameReads += 1;
+        if (nameReads > 1) {
+          throw new Error("name getter read twice");
+        }
+        return " single_read ";
+      },
+    };
+    const proxySchema = new Proxy(
+      { type: "object" },
+      {
+        ownKeys() {
+          throw new Error("schema keys exploded");
+        },
+      },
+    );
+    const proxyArray = new Proxy([{ ok: true }], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("schema array item exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(
+      toTrajectoryToolDefinitions([
+        unreadableTool,
+        unreadableNameTool,
+        unreadableDescriptionTool,
+        singleReadTool,
+        { name: "nested", description: "nested getter", parameters: nestedSchema },
+        { name: "proxy", parameters: proxySchema },
+        { name: "array", parameters: proxyArray },
+        { name: "healthy", parameters: { type: "object", properties: { value: {} } } },
+      ] as never),
+    ).toEqual([
+      {
+        name: "array",
+        parameters: [{ truncated: true, reason: "trajectory-array-item-unreadable" }],
+      },
+      {
+        name: "descriptionless",
+        parameters: { type: "object" },
+      },
+      {
+        name: "healthy",
+        parameters: { type: "object", properties: { value: {} } },
+      },
+      {
+        name: "nested",
+        description: "nested getter",
+        parameters: {
+          type: "object",
+          properties: { truncated: true, reason: "trajectory-field-unreadable" },
+        },
+      },
+      {
+        name: "proxy",
+        parameters: { truncated: true, reason: "trajectory-object-keys-unreadable" },
+      },
+      {
+        name: "single_read",
+        description: "single read",
+        parameters: { type: "object" },
+      },
+      {
+        name: "unreadable",
+        description: "bad getter",
+        parameters: { truncated: true, reason: "trajectory-tool-parameters-unreadable" },
+      },
+    ]);
+    expect(nameReads).toBe(1);
+  });
+
   it("bounds large runtime event fields before serialization", () => {
     const writes: string[] = [];
     const recorder = createTrajectoryRuntimeRecorder({

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -187,13 +187,32 @@ function limitTrajectoryPayloadValue(
   }
   seen.add(value);
   if (Array.isArray(value)) {
-    const limited = value
-      .slice(0, TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS)
-      .map((item) => limitTrajectoryPayloadValue(item, depth + 1, seen));
-    if (value.length > TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS) {
+    let arrayLength: number;
+    try {
+      arrayLength = value.length;
+    } catch {
+      seen.delete(value);
+      return truncatedTrajectoryValue("trajectory-array-unreadable");
+    }
+    const limited: unknown[] = [];
+    for (
+      let index = 0;
+      index < Math.min(arrayLength, TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS);
+      index += 1
+    ) {
+      let item: unknown;
+      try {
+        item = value[index];
+      } catch {
+        limited.push(truncatedTrajectoryValue("trajectory-array-item-unreadable"));
+        continue;
+      }
+      limited.push(limitTrajectoryPayloadValue(item, depth + 1, seen));
+    }
+    if (arrayLength > TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS) {
       limited.push(
         truncatedTrajectoryValue("trajectory-array-size-limit", {
-          originalLength: value.length,
+          originalLength: arrayLength,
           limitItems: TRAJECTORY_RUNTIME_DATA_ARRAY_MAX_ITEMS,
         }),
       );
@@ -202,10 +221,23 @@ function limitTrajectoryPayloadValue(
     return limited;
   }
   const record = value as Record<string, unknown>;
-  const keys = Object.keys(record);
+  let keys: string[];
+  try {
+    keys = Object.keys(record);
+  } catch {
+    seen.delete(value);
+    return truncatedTrajectoryValue("trajectory-object-keys-unreadable");
+  }
   const limited: Record<string, unknown> = {};
   for (const key of keys.slice(0, TRAJECTORY_RUNTIME_DATA_OBJECT_MAX_KEYS)) {
-    limited[key] = limitTrajectoryPayloadValue(record[key], depth + 1, seen);
+    let childValue: unknown;
+    try {
+      childValue = record[key];
+    } catch {
+      limited[key] = truncatedTrajectoryValue("trajectory-field-unreadable");
+      continue;
+    }
+    limited[key] = limitTrajectoryPayloadValue(childValue, depth + 1, seen);
   }
   if (keys.length > TRAJECTORY_RUNTIME_DATA_OBJECT_MAX_KEYS) {
     limited["_truncated"] = truncatedTrajectoryValue("trajectory-object-size-limit", {
@@ -222,6 +254,35 @@ function sanitizeTrajectoryPayload(data: Record<string, unknown>): Record<string
     string,
     unknown
   >;
+}
+
+function readTrajectoryToolParameters(tool: { parameters?: unknown }): unknown {
+  try {
+    return tool.parameters;
+  } catch {
+    return truncatedTrajectoryValue("trajectory-tool-parameters-unreadable");
+  }
+}
+
+function readTrajectoryToolName(tool: { name?: string }): string | undefined {
+  try {
+    const rawName = tool.name;
+    if (typeof rawName !== "string") {
+      return undefined;
+    }
+    return rawName.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTrajectoryToolDescription(tool: { description?: string }): string | undefined {
+  try {
+    const description = tool.description;
+    return typeof description === "string" ? description : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function describeTrajectoryWriterFlushState(writer: TrajectoryRuntimeWriter): string | undefined {
@@ -459,15 +520,18 @@ export function toTrajectoryToolDefinitions(
 ): TrajectoryToolDefinition[] {
   return tools
     .flatMap((tool) => {
-      const name = tool.name?.trim();
+      const name = readTrajectoryToolName(tool);
       if (!name) {
         return [];
       }
+      const description = readTrajectoryToolDescription(tool);
       return [
         {
           name,
-          description: tool.description,
-          parameters: sanitizeDiagnosticPayload(limitTrajectoryPayloadValue(tool.parameters)),
+          ...(description ? { description } : {}),
+          parameters: sanitizeDiagnosticPayload(
+            limitTrajectoryPayloadValue(readTrajectoryToolParameters(tool)),
+          ),
         },
       ];
     })


### PR DESCRIPTION
## Summary
- Guard trajectory tool-definition capture against throwing tool `name`, `description`, and `parameters` getters.
- Guard trajectory payload limiting against throwing nested object field getters, proxy object-key traps, and proxy array item traps.
- Record bounded truncation markers instead of crashing diagnostic capture, while skipping tools whose names cannot be read safely.

## Real behavior proof
Behavior addressed: A bad plugin/extension tool schema or hostile diagnostic object could crash trajectory diagnostic capture while projecting provider-visible tool definitions, preventing runtime support data from being written for the rest of the turn.

Real environment tested: Local OpenClaw linked Codex worktree on Node/Vitest via repo wrapper. Remote broad gate remained blocked because this environment lacks Blacksmith auth.

Exact steps or command run after this patch:
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-trajectory-90268 node scripts/run-vitest.mjs run src/trajectory/runtime.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/runtime.ts src/trajectory/runtime.test.ts`
- `node scripts/run-oxlint.mjs src/trajectory/runtime.ts src/trajectory/runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`

Evidence after fix: Focused trajectory runtime tests passed 1 file / 13 tests; oxfmt passed; oxlint passed; diff whitespace check passed; branch autoreview returned no accepted/actionable findings with `overall: patch is correct (0.84)`; final head is `4c396bf7fc480b32c5b74fde6fa3b12f5eaa6aff`.

Observed result after fix: Throwing tool-name accessors no longer abort trajectory capture and are skipped; throwing description accessors become omitted optional descriptions; throwing schema accessors and hostile nested proxies become bounded `{ "truncated": true, "reason": ... }` markers; healthy sibling tools remain captured and sorted.

What was not tested: Full `pnpm check:changed`/Testbox proof was not completed because `blacksmith testbox list --all` reported `not authenticated` in this environment.

## Verification
- Red repro before the original fix: `node scripts/run-vitest.mjs run src/trajectory/runtime.test.ts --testNamePattern="keeps trajectory tool definitions when schema accessors throw"` failed with `parameters getter exploded`.
- Post-refresh focused proof: `node scripts/run-vitest.mjs run src/trajectory/runtime.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000` passed 13 tests.
- Lint: `node scripts/run-oxlint.mjs src/trajectory/runtime.ts src/trajectory/runtime.test.ts` passed.
- Format: `./node_modules/.bin/oxfmt --check --threads=1 src/trajectory/runtime.ts src/trajectory/runtime.test.ts` passed.
- Whitespace: `git diff --check` passed.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.84)`.
- Broad proof attempted but blocked: `blacksmith testbox list --all` reported not authenticated.
