### PR TITLE
Improve TUI Gateway queue reliability

### DIFF
--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -75,8 +75,18 @@ export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean
   );
 }
 
+function commandTextContainsGatewaySubcommand(commandText: string): boolean {
+  return /(?:^|[\s"'`])gateway(?:$|[\s"'`]|--|\r?\n)/i.test(commandText);
+}
+
 function hasGatewaySubcommand(programArguments?: string[]): boolean {
-  return Boolean(programArguments?.some((arg) => arg === "gateway"));
+  if (!programArguments || programArguments.length === 0) {
+    return false;
+  }
+  if (programArguments.some((arg) => arg === "gateway")) {
+    return true;
+  }
+  return commandTextContainsGatewaySubcommand(programArguments.join(" "));
 }
 
 function parseSystemdUnit(content: string): {
@@ -254,6 +264,11 @@ export function readGatewayServiceCommandPort(programArguments?: string[]): numb
     if (arg.startsWith("--port=")) {
       return parseGatewayPortArg(arg.slice("--port=".length));
     }
+  }
+  const commandText = programArguments.join(" ");
+  const inlinePort = commandText.match(/(?:^|[\s"'`])--port(?:=|\s+)(\d{1,5})(?:$|[\s"'`]|\r?\n)/i);
+  if (inlinePort?.[1]) {
+    return parseGatewayPortArg(inlinePort[1]);
   }
   return undefined;
 }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -345,6 +345,14 @@ export class GatewayClient {
     const wsOptions: FingerprintCheckingClientOptions = {
       maxPayload: 25 * 1024 * 1024,
     };
+    const explicitOrigin =
+      this.opts.env?.OPENCLAW_GATEWAY_CLIENT_ORIGIN ?? process.env.OPENCLAW_GATEWAY_CLIENT_ORIGIN;
+    if (explicitOrigin?.trim()) {
+      wsOptions.headers = {
+        ...(wsOptions.headers ?? {}),
+        Origin: explicitOrigin.trim(),
+      };
+    }
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
       wsOptions.rejectUnauthorized = false;
       wsOptions.checkServerIdentity = (_hostValue: string, cert: CertMeta) => {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -40,7 +40,11 @@ export async function logGatewayStartup(params: {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const modelRef = `${agentProvider}/${agentModel}`;
+  const modelRef = formatStartupModelRef({
+    cfg: params.cfg,
+    provider: agentProvider,
+    model: agentModel,
+  });
   const modelDetails = formatAgentModelStartupDetails({
     cfg: params.cfg,
     provider: agentProvider,
@@ -72,6 +76,34 @@ export async function logGatewayStartup(params: {
       "Run `openclaw security audit`.";
     params.log.warn(warning);
   }
+}
+
+function formatStartupModelRef(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  model: string;
+}): string {
+  const configuredRef = `${params.provider}/${params.model}`;
+  if (params.provider !== "openai") {
+    return configuredRef;
+  }
+
+  const models = params.cfg.agents?.defaults?.models;
+  const canonicalKey = modelKey(params.provider, params.model);
+  const legacyKey = legacyModelKey(params.provider, params.model);
+  const runtimeId =
+    models?.[canonicalKey]?.agentRuntime?.id ??
+    (legacyKey ? models?.[legacyKey]?.agentRuntime?.id : undefined);
+  const openAIOrder = params.cfg.auth?.order?.openai;
+  const codexAuthPreferred =
+    Array.isArray(openAIOrder) &&
+    openAIOrder.some(
+      (profileId) => typeof profileId === "string" && profileId.trim().startsWith("openai-codex:"),
+    );
+
+  return runtimeId === "codex" || codexAuthPreferred
+    ? `openai-codex/${params.model}`
+    : configuredRef;
 }
 
 function normalizeStartupThinkLevel(value: unknown): StartupThinkLevel | undefined {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -33,6 +33,7 @@ const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
 const DEFERRED_SIDECAR_START_DELAY_MS = 100;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
+const SKIP_STARTUP_PROVIDER_AUTH_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_PROVIDER_AUTH_PREWARM";
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
@@ -104,6 +105,11 @@ function shouldCheckRestartSentinel(env: NodeJS.ProcessEnv = process.env): boole
 
 function shouldSkipStartupModelPrewarm(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[SKIP_STARTUP_MODEL_PREWARM_ENV]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function shouldSkipStartupProviderAuthPrewarm(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[SKIP_STARTUP_PROVIDER_AUTH_PREWARM_ENV]?.trim().toLowerCase();
   return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
 }
 
@@ -183,6 +189,13 @@ function scheduleProviderAuthStatePrewarm(params: {
   };
   delayMs?: number;
 }): GatewayPostReadySidecarHandle {
+  if (shouldSkipStartupProviderAuthPrewarm()) {
+    params.log.info(
+      `provider auth state pre-warm skipped by ${SKIP_STARTUP_PROVIDER_AUTH_PREWARM_ENV}`,
+    );
+    return { stop: () => {} };
+  }
+
   let stopped = false;
   let startupTimer: ReturnType<typeof setTimeout> | undefined;
   let rewarmTimer: ReturnType<typeof setTimeout> | undefined;
@@ -1282,6 +1295,7 @@ export const testing = {
   scheduleProviderAuthStatePrewarm,
   schedulePrimaryModelPrewarm,
   shouldSkipStartupModelPrewarm,
+  shouldSkipStartupProviderAuthPrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };
 export { testing as __testing };

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -25,6 +25,7 @@ import { resolveRegistryPluginModuleLocationFromRecords } from "./facade-resolut
 
 const ALWAYS_ALLOWED_RUNTIME_DIR_NAMES = new Set([
   "image-generation-core",
+  "memory-core",
   "media-understanding-core",
   "speech-core",
 ]);

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -147,7 +147,7 @@ describe("plugin-sdk facade runtime", () => {
     });
 
     expect(resolved?.boundaryRoot).not.toBe(overrideDir);
-    expect(resolved?.modulePath).toMatch(
+    expect(resolved?.modulePath.replaceAll("\\", "/")).toMatch(
       /(?:^|\/)(?:extensions|dist-runtime\/extensions)\/browser\/browser-maintenance\.(?:ts|js)$/u,
     );
   });
@@ -505,7 +505,12 @@ describe("plugin-sdk facade runtime", () => {
   it("keeps shared runtime-core facades available without plugin activation", () => {
     setRuntimeConfigSnapshot({});
 
-    for (const dirName of ["speech-core", "image-generation-core", "media-understanding-core"]) {
+    for (const dirName of [
+      "speech-core",
+      "image-generation-core",
+      "media-understanding-core",
+      "memory-core",
+    ]) {
       expect(
         resolveActivationCheckBundledPluginPublicSurfaceAccess({
           dirName,

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -188,13 +188,13 @@ export class GatewayChatClient implements TuiBackend {
 
   async sendChat(opts: ChatSendOptions): Promise<{ runId: string }> {
     const runId = opts.runId ?? randomUUID();
-    await this.client.request("chat.send", {
+    await this.client.request("agent", {
       sessionKey: opts.sessionKey,
       ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
       message: opts.message,
       thinking: opts.thinking,
       deliver: opts.deliver,
-      timeoutMs: opts.timeoutMs,
+      timeout: opts.timeoutMs ? Math.ceil(opts.timeoutMs / 1000) : undefined,
       idempotencyKey: runId,
     });
     return { runId };

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -502,7 +502,7 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
 
-  it("sends local prompts while a run is active so queue policy can handle them", async () => {
+  it("blocks local prompts while a non-finishing run is active", async () => {
     const {
       handleCommand,
       sendChat,
@@ -519,37 +519,41 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(reserveAssistantSlot).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
+      "agent is busy — press Esc to abort before sending a new message",
+    );
+    expect(requestRender).toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(state.pendingChatRunId).toBeNull();
+  });
+
+  it("sends gateway slash prompts while a run is active so gateway queue mode can handle them", async () => {
+    const { handleCommand, sendChat, addUser, addSystem, state, setActivityStatus } = createHarness(
+      {
+        activeChatRunId: "run-active",
+        activityStatus: "streaming",
+      },
+    );
+
+    await handleCommand("/context detail");
+
     expect(sendChat).toHaveBeenCalledTimes(1);
     expectSendChatFields(sendChat, {
       message: "/context detail",
       sessionKey: "agent:main:main",
     });
-    expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
-    const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
-    const addUserCallOrder = addUser.mock.invocationCallOrder[0];
-    expect(reserveCallOrder).toBeLessThan(addUserCallOrder);
     expect(addUser).toHaveBeenCalledWith("/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
-    expect(requestRender).toHaveBeenCalled();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("sending");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("waiting");
     expect(state.activeChatRunId).toBe("run-active");
-    expect(state.pendingChatRunId).toEqual(expect.any(String));
-  });
-
-  it("blocks gateway slash prompts while a run is active", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
-      activeChatRunId: "run-active",
-      activityStatus: "streaming",
-    });
-
-    await handleCommand("/context detail");
-
-    expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
-    expect(addSystem).toHaveBeenCalledWith(
-      "agent is busy — press Esc to abort before sending a new message",
-    );
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
   });
 
   it("routes slash stop to the abort path instead of queueing a chat send", async () => {
@@ -593,7 +597,7 @@ describe("tui command handlers", () => {
     expect(addUser).toHaveBeenCalledWith("do not do that");
   });
 
-  it("rejects normal sends while a queued submit is pending registration", async () => {
+  it("allows gateway sends while an active run has pending queue state", async () => {
     const { handleCommand, sendChat, addUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       pendingChatRunId: "run-queued",
@@ -602,11 +606,39 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
-    expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
-    expect(addSystem).toHaveBeenCalledWith(
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      message: "/context detail",
+      sessionKey: "agent:main:main",
+    });
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
+  });
+
+  it("allows gateway sends while a queued submit is pending registration and no active run exists", async () => {
+    const { handleCommand, sendChat, addUser, addSystem, state, setActivityStatus } = createHarness(
+      {
+        pendingChatRunId: "run-queued",
+        activityStatus: "waiting",
+      },
+    );
+
+    await handleCommand("/context detail");
+
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      message: "/context detail",
+      sessionKey: "agent:main:main",
+    });
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addSystem).not.toHaveBeenCalledWith(
+      "agent is busy — press Esc to abort before sending a new message",
+    );
+    expect(setActivityStatus).not.toHaveBeenCalledWith("sending");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("waiting");
+    expect(state.pendingChatRunId).toBe("run-queued");
   });
 
   it("allows local sends to queue while the current run is finishing", async () => {
@@ -625,7 +657,7 @@ describe("tui command handlers", () => {
     );
   });
 
-  it("blocks gateway sends while the current run is finishing", async () => {
+  it("sends gateway prompts while the current run is finishing", async () => {
     const { handleCommand, sendChat, addUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "finishing context",
@@ -633,9 +665,9 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
-    expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
-    expect(addSystem).toHaveBeenCalledWith(
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
   });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -658,11 +658,21 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       await abortActive({ preferActive: true });
       return;
     }
+    const queueingBehindGatewayRun =
+      !isBtw &&
+      opts.local !== true &&
+      Boolean(
+        state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage,
+      );
+    const hasPendingSubmission =
+      Boolean(state.pendingChatRunId) || state.pendingOptimisticUserMessage === true;
+    const canQueueBehindLocalFinishingTurn =
+      opts.local === true && state.activityStatus === "finishing context" && !hasPendingSubmission;
     if (
       !isBtw &&
-      (state.pendingChatRunId ||
-        state.pendingOptimisticUserMessage ||
-        (opts.local !== true && state.activeChatRunId))
+      opts.local === true &&
+      !canQueueBehindLocalFinishingTurn &&
+      (state.activeChatRunId || hasPendingSubmission)
     ) {
       chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
       tui.requestRender();
@@ -680,8 +690,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.reserveAssistantSlot(state.activeChatRunId);
         }
         chatLog.addUser(text);
-        state.pendingOptimisticUserMessage = true;
-        setActivityStatus("sending");
+        if (!queueingBehindGatewayRun) {
+          state.pendingOptimisticUserMessage = true;
+          setActivityStatus("sending");
+        }
       } else {
         noteLocalBtwRunId?.(runId);
       }
@@ -696,18 +708,20 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         runId,
       });
       if (!isBtw) {
-        state.pendingChatRunId = runId;
-        setActivityStatus("waiting");
+        if (!queueingBehindGatewayRun) {
+          state.pendingChatRunId = runId;
+          setActivityStatus("waiting");
+        }
         tui.requestRender();
       }
     } catch (err) {
       if (isBtw) {
         forgetLocalBtwRunId?.(runId);
       }
-      if (!isBtw && state.activeChatRunId) {
+      if (!isBtw && !queueingBehindGatewayRun && state.activeChatRunId) {
         forgetLocalRunId?.(state.activeChatRunId);
       }
-      if (!isBtw) {
+      if (!isBtw && !queueingBehindGatewayRun) {
         state.pendingOptimisticUserMessage = false;
         state.pendingChatRunId = null;
         state.activeChatRunId = null;

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -92,22 +92,44 @@ describe("canSubmitTuiChatMessage", () => {
     expect(canSubmitTuiChatMessage({})).toBe(true);
   });
 
-  it("allows local submit while a run is active", () => {
+  it("blocks local submit while a non-finishing run is active", () => {
     expect(
       canSubmitTuiChatMessage({
         local: true,
         activeChatRunId: "run-active",
+        activityStatus: "streaming",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows local submit while the active run is finishing", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: true,
+        activeChatRunId: "run-active",
+        activityStatus: "finishing context",
       }),
     ).toBe(true);
   });
 
-  it("blocks gateway submit while a run is active", () => {
+  it("allows gateway submit while a run is active so gateway queue mode can handle it", () => {
     expect(
       canSubmitTuiChatMessage({
         local: false,
         activeChatRunId: "run-active",
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("allows gateway submit while an active run has pending local queue state", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: false,
+        activeChatRunId: "run-active",
+        pendingChatRunId: "run-queued",
+        pendingOptimisticUserMessage: true,
+      }),
+    ).toBe(true);
   });
 
   it("allows gateway stop text while a run is active", () => {
@@ -131,17 +153,37 @@ describe("canSubmitTuiChatMessage", () => {
     ).toBe(true);
   });
 
-  it("blocks submits with pending optimistic state", () => {
+  it("allows gateway submits with pending optimistic state so gateway queue mode can handle it", () => {
     expect(
       canSubmitTuiChatMessage({
+        local: false,
+        pendingOptimisticUserMessage: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows gateway submits with a pending chat run id so gateway queue mode can handle it", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: false,
+        pendingChatRunId: "run-pending",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks local submits with pending optimistic state", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: true,
         pendingOptimisticUserMessage: true,
       }),
     ).toBe(false);
   });
 
-  it("blocks submits with a pending chat run id", () => {
+  it("blocks local submits with a pending chat run id", () => {
     expect(
       canSubmitTuiChatMessage({
+        local: true,
         pendingChatRunId: "run-pending",
       }),
     ).toBe(false);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -372,6 +372,7 @@ export function canSubmitTuiChatMessage(params: {
   activeChatRunId?: string | null;
   pendingChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
+  activityStatus?: string;
   message?: string;
 }): boolean {
   const stopText = params.message ? isChatStopCommandText(params.message) : false;
@@ -379,8 +380,11 @@ export function canSubmitTuiChatMessage(params: {
     return true;
   }
   const pending = Boolean(params.pendingChatRunId) || params.pendingOptimisticUserMessage === true;
-  if (!params.local && params.activeChatRunId) {
-    return false;
+  if (!params.local) {
+    return true;
+  }
+  if (params.activeChatRunId) {
+    return params.activityStatus === "finishing context" && !pending;
   }
   return !pending;
 }
@@ -1330,6 +1334,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,
+      activityStatus: state.activityStatus,
       message,
     });
   const notifyBlockedChatSubmit = () => {


### PR DESCRIPTION
## Summary
- Sends Gateway-backed TUI chat through the Gateway agent RPC so queue mode can handle active runs.
- Keeps local TUI submit blocking strict except while finishing context.
- Adds optional Gateway client Origin header support.
- Adds startup/provider prewarm controls and clearer openai-codex startup route display.
- Improves Windows service command parsing and allows memory-core runtime facade access.

## Validation
- node scripts/run-vitest.mjs run src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/plugin-sdk/facade-runtime.test.ts
- 3 test files passed, 111 tests passed
- git diff --check

## Operational context
This supports Gateway-backed GUI/TUI reliability by reducing stale local busy locks and allowing Gateway queue policy to own Gateway-mode submits.