### PR TITLE
fix(agents): preserve unreadable wrapped tool schemas

### DIFF
--- a/src/agents/sessions/tools/tool-definition-wrapper.test.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentTool } from "../../runtime/index.js";
+import type { ToolDefinition } from "../extensions/types.js";
+import {
+  createToolDefinitionFromAgentTool,
+  wrapToolDefinition,
+} from "./tool-definition-wrapper.js";
+
+describe("tool definition wrapper", () => {
+  it("preserves an unreadable extension tool definition schema without crashing the wrapper", async () => {
+    const execute = vi.fn(async () => ({ content: [] }));
+    const prepareArguments = vi.fn((params: unknown) => params);
+    const definition = {
+      name: "hostile_definition",
+      label: "Hostile Definition",
+      description: "throws while reading parameters",
+      prepareArguments,
+      execute,
+    } as unknown as ToolDefinition;
+    Object.defineProperty(definition, "parameters", {
+      get() {
+        throw new Error("definition parameters exploded");
+      },
+    });
+
+    const tool = wrapToolDefinition(definition, () => ({}) as never);
+
+    expect(() => tool.parameters).toThrow("definition parameters exploded");
+    expect(tool.prepareArguments).toBe(prepareArguments);
+    await tool.execute("call-1", {}, undefined, undefined);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves an unreadable agent tool schema without crashing definition synthesis", async () => {
+    const execute = vi.fn(async () => ({ content: [] }));
+    const prepareArguments = vi.fn((params: unknown) => params);
+    const tool = {
+      name: "hostile_agent_tool",
+      label: "Hostile Agent Tool",
+      description: "throws while reading parameters",
+      prepareArguments,
+      execute,
+    } as unknown as AgentTool;
+    Object.defineProperty(tool, "parameters", {
+      get() {
+        throw new Error("agent parameters exploded");
+      },
+    });
+
+    const definition = createToolDefinitionFromAgentTool(tool);
+
+    expect(() => definition.parameters).toThrow("agent parameters exploded");
+    expect(definition.prepareArguments).toBe(prepareArguments);
+    await definition.execute("call-1", {}, undefined, undefined, {} as never);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -2,6 +2,19 @@ import type { TSchema } from "typebox";
 import type { AgentTool } from "../../runtime/index.js";
 import type { ExtensionContext, ToolDefinition } from "../extensions/types.js";
 
+function defineForwardedParameters<TParams extends TSchema>(
+  target: { parameters?: TParams },
+  source: { parameters: TParams },
+): void {
+  Object.defineProperty(target, "parameters", {
+    enumerable: true,
+    configurable: true,
+    get() {
+      return source.parameters;
+    },
+  });
+}
+
 /** Wrap a ToolDefinition into an AgentTool for the core runtime. */
 export function wrapToolDefinition<
   TParams extends TSchema = TSchema,
@@ -11,16 +24,17 @@ export function wrapToolDefinition<
   definition: ToolDefinition<TParams, TDetails, TState>,
   ctxFactory?: () => ExtensionContext,
 ): AgentTool<TParams, TDetails> {
-  return {
+  const tool = {
     name: definition.name,
     label: definition.label,
     description: definition.description,
-    parameters: definition.parameters,
     prepareArguments: definition.prepareArguments,
     executionMode: definition.executionMode,
     execute: (toolCallId, params, signal, onUpdate) =>
       definition.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext),
-  };
+  } as AgentTool<TParams, TDetails>;
+  defineForwardedParameters(tool, definition);
+  return tool;
 }
 
 /** Wrap multiple ToolDefinitions into AgentTools for the core runtime. */
@@ -38,14 +52,15 @@ export function wrapToolDefinitions(
  * provides plain AgentTool overrides that do not include prompt metadata or renderers.
  */
 export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefinition {
-  return {
+  const definition = {
     name: tool.name,
     label: tool.label,
     description: tool.description,
-    parameters: tool.parameters,
     prepareArguments: tool.prepareArguments,
     executionMode: tool.executionMode,
     execute: async (toolCallId, params, signal, onUpdate) =>
       tool.execute(toolCallId, params, signal, onUpdate),
-  };
+  } as ToolDefinition;
+  defineForwardedParameters(definition, tool);
+  return definition;
 }


### PR DESCRIPTION
## Summary

- preserve unreadable extension `ToolDefinition.parameters` through wrapping without crashing wrapper construction
- preserve unreadable `AgentTool.parameters` when synthesizing session tool definitions
- avoid substituting a fake valid schema so downstream schema quarantine/diagnostics still see the real unreadable schema

## Real behavior proof

Behavior addressed: Extension-owned tool definitions and agent-tool overrides could crash while being adapted between `ToolDefinition` and `AgentTool` if their `parameters` getter threw. The wrapper now constructs successfully and forwards `parameters` through an enumerable getter, so the existing schema inspection/quarantine path can catch the unreadable schema at the right boundary.

Real environment tested: Local OpenClaw linked Codex worktree on Node/Vitest via repo wrapper; remote broad gate attempted through Blacksmith Testbox and AWS Crabbox.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run src/agents/sessions/tools/tool-definition-wrapper.test.ts`
- `node scripts/run-oxlint.mjs src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next195-check-changed-final --shell -- "pnpm check:changed"`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next195-check-changed-final --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Evidence after fix: Focused wrapper tests passed with 2 tests after final rebase; oxlint passed; diff whitespace check passed; local and branch autoreview both returned no accepted/actionable findings after the review-driven correction to preserve unreadable schemas rather than replacing them with empty schemas.

Observed result after fix: Wrapping no longer throws when the source schema getter throws. Reading the wrapped `parameters` still throws the original schema error, preserving downstream quarantine/diagnostic behavior instead of advertising a fake no-argument tool.

What was not tested: Full `pnpm check:changed` was not completed because Blacksmith Testbox auth is missing locally (`not authenticated`) and direct AWS Crabbox coordinator calls returned HTTP 401 for run/lease creation.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs run src/agents/sessions/tools/tool-definition-wrapper.test.ts` failed with `definition parameters exploded` and `agent parameters exploded` while constructing wrappers.
- Post-fix focused proof: `node scripts/run-vitest.mjs run src/agents/sessions/tools/tool-definition-wrapper.test.ts` passed 2 tests.
- Post-rebase proof: `node scripts/run-vitest.mjs run src/agents/sessions/tools/tool-definition-wrapper.test.ts` passed 2 tests.
- Lint: `node scripts/run-oxlint.mjs src/agents/sessions/tools/tool-definition-wrapper.ts src/agents/sessions/tools/tool-definition-wrapper.test.ts` passed.
- Whitespace: `git diff --check origin/main...HEAD` passed.
- Review: local autoreview initially caught fail-open empty-schema behavior and an active `prepareArguments` path; the final local review passed clean, `overall: patch is correct (0.84)`.
- Review: final branch autoreview passed clean, `overall: patch is correct (0.86)`.
- Broad proof attempted but blocked: `blacksmith testbox list --all` reported not authenticated; AWS Crabbox coordinator returned HTTP 401; delegated Blacksmith-through-Crabbox failed on the same missing Blacksmith auth.
