### PR TITLE
test: make install-safe-path symlink tests compatible with Windows

### DIFF
--- a/src/infra/install-safe-path.test.ts
+++ b/src/infra/install-safe-path.test.ts
@@ -1,5 +1,7 @@
 // Covers safe plugin install path normalization and boundary checks.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -11,6 +13,31 @@ import {
   safePathSegmentHashed,
   unscopedPackageName,
 } from "./install-safe-path.js";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+// Vitest evaluates skipIf while declaring tests, so probe before describe().
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-install-safe-dir-symlink-probe-"),
+    );
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
 
 describe("unscopedPackageName", () => {
   it.each([
@@ -155,13 +182,13 @@ describe("assertCanonicalPathWithinBase", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects symlinked candidate directories that escape the base",
     async () => {
       await withTempDir({ prefix: "openclaw-install-safe-" }, async (baseDir) => {
         await withTempDir({ prefix: "openclaw-install-safe-outside-" }, async (outsideDir) => {
           const linkDir = path.join(baseDir, "alias");
-          await fs.symlink(outsideDir, linkDir);
+          await fs.symlink(outsideDir, linkDir, directorySymlinkType);
           await expect(
             assertCanonicalPathWithinBase({
               baseDir,
@@ -174,14 +201,14 @@ describe("assertCanonicalPathWithinBase", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "accepts symlinked base directories when the target stays in the real base",
     async () => {
       await withTempDir({ prefix: "openclaw-install-safe-" }, async (parentDir) => {
         const realBaseDir = path.join(parentDir, "real-base");
         const symlinkBaseDir = path.join(parentDir, "base-link");
         await fs.mkdir(realBaseDir, { recursive: true });
-        await fs.symlink(realBaseDir, symlinkBaseDir);
+        await fs.symlink(realBaseDir, symlinkBaseDir, directorySymlinkType);
         await expect(
           assertCanonicalPathWithinBase({
             baseDir: symlinkBaseDir,
@@ -193,7 +220,7 @@ describe("assertCanonicalPathWithinBase", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects nested symlinked candidate directories",
     async () => {
       await withTempDir({ prefix: "openclaw-install-safe-" }, async (parentDir) => {
@@ -202,7 +229,7 @@ describe("assertCanonicalPathWithinBase", () => {
         const nestedSymlinkDir = path.join(realBaseDir, "nested-link");
         await fs.mkdir(realBaseDir, { recursive: true });
         await fs.mkdir(nestedRealDir, { recursive: true });
-        await fs.symlink(nestedRealDir, nestedSymlinkDir);
+        await fs.symlink(nestedRealDir, nestedSymlinkDir, directorySymlinkType);
         await expect(
           assertCanonicalPathWithinBase({
             baseDir: realBaseDir,


### PR DESCRIPTION
## Summary

- Run the existing install-path symlink boundary tests on Windows when directory junctions are supported.
- Use Windows junctions for directory links while preserving `dir` symlinks elsewhere.
- Keep production install-path behavior unchanged.
- Treat temporary-directory or cleanup failures in the capability probe as unsupported test environments instead of failing module import.

## Linked context

No linked issue. This is a test portability improvement for existing install-path boundary coverage.

## Real behavior proof

- Behavior addressed: Three install-safe-path symlink boundary tests were unconditionally skipped on Windows.
- Real environment tested: Native Windows Azure VM (`Standard_D4ads_v6`) through Crabbox.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/install-safe-path.test.ts`
- Evidence after fix: Native Windows console output from Crabbox lease `cbx_be4230e2069c`, run `run_0fb83e164185`:

```text
RUN  v4.1.8 C:/repo/openclaw

✓ infra src/infra/install-safe-path.test.ts (24 tests) 525ms

Test Files  1 passed (1)
Tests       24 passed (24)
```
- Observed result after fix: The directory-junction cases executed successfully on native Windows instead of being skipped by platform.
- What was not tested: No end-user install flow was exercised because the patch changes tests only.
- Proof limitations or environment constraints: The tests still skip when the host cannot create directory links.
- Before evidence: Current `main` uses `it.runIf(process.platform !== "win32")` for all three cases.

## Tests and validation

- `node scripts/run-vitest.mjs src/infra/install-safe-path.test.ts`
- `node scripts/run-oxlint.mjs src/infra/install-safe-path.test.ts`
- Native Windows Crabbox: 24/24 tests passed
- Blacksmith Testbox `tbx_01kv72nvfyz4fgpny8cyn48xfr`: `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Risk checklist

- Did user-visible behavior change? No
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? No
- Highest-risk area: Windows directory-link capability detection in the test harness.
- Mitigation: Capability-gated execution plus direct native-Windows proof.

## Current review state

- Next action: Refresh CI on the rebased head and merge when required checks pass.
- Addressed review comments: Temporary directory creation and cleanup are contained by the probe; module-level probing remains intentional because Vitest evaluates `skipIf` during test declaration.
