### PR TITLE
fix(providers): skip unreadable Anthropic tool schemas

### DIFF
--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -218,6 +218,74 @@ describe("Anthropic provider", () => {
     expect((capturedPayload as { stop_sequences?: unknown }).stop_sequences).toEqual(["STOP"]);
   });
 
+  it("skips unreadable tool schemas while preserving healthy Anthropic tools", async () => {
+    let capturedPayload: unknown;
+    const unreadableTool = {
+      name: "unreadable_schema",
+      description: "bad getter",
+    };
+    Object.defineProperty(unreadableTool, "parameters", {
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+    const nestedSchema = { type: "object" };
+    Object.defineProperty(nestedSchema, "properties", {
+      get() {
+        throw new Error("properties getter exploded");
+      },
+      enumerable: true,
+    });
+
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel(),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          unreadableTool,
+          {
+            name: "nested_schema",
+            description: "nested getter",
+            parameters: nestedSchema,
+          },
+          {
+            name: "healthy_tool",
+            description: "healthy",
+            parameters: {
+              type: "object",
+              properties: { value: { type: "string" } },
+              required: ["value"],
+            },
+          },
+        ] as never,
+      },
+      {
+        apiKey: "sk-ant-provider",
+        cacheRetention: "none",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect((capturedPayload as { tools?: unknown }).tools).toEqual([
+      {
+        name: "healthy_tool",
+        description: "healthy",
+        eager_input_streaming: true,
+        input_schema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        },
+      },
+    ]);
+  });
+
   it("splits the system prompt cache boundary into cached and uncached Anthropic blocks", async () => {
     let capturedPayload: unknown;
     const stream = streamSimpleAnthropic(

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1268,21 +1268,40 @@ function convertTools(
     return [];
   }
 
-  return tools.map((tool, index) => {
-    const schema = tool.parameters as { properties?: unknown; required?: string[] };
+  const converted = tools.flatMap((tool): Anthropic.Messages.Tool[] => {
+    let schema: { properties?: unknown; required?: string[] };
+    let properties: unknown;
+    let required: string[];
+    try {
+      schema = tool.parameters as { properties?: unknown; required?: string[] };
+      properties = schema.properties ?? {};
+      required = schema.required ?? [];
+    } catch {
+      return [];
+    }
 
-    return {
-      name: isOAuthTokenLocal ? toClaudeCodeName(tool.name) : tool.name,
-      description: tool.description,
-      ...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
-      input_schema: {
-        type: "object",
-        properties: schema.properties ?? {},
-        required: schema.required ?? [],
+    return [
+      {
+        name: isOAuthTokenLocal ? toClaudeCodeName(tool.name) : tool.name,
+        description: tool.description,
+        ...(supportsEagerToolInputStreaming ? { eager_input_streaming: true } : {}),
+        input_schema: {
+          type: "object",
+          properties,
+          required,
+        },
       },
-      ...(cacheControl && index === tools.length - 1 ? { cache_control: cacheControl } : {}),
-    };
+    ];
   });
+
+  if (cacheControl && converted.length > 0) {
+    converted[converted.length - 1] = {
+      ...converted[converted.length - 1],
+      cache_control: cacheControl,
+    };
+  }
+
+  return converted;
 }
 
 function mapStopReason(reason: string): StopReason {


### PR DESCRIPTION
## Summary

- skip Anthropic provider tools whose schema accessors throw during payload conversion
- preserve healthy sibling tools in the Anthropic request payload
- move tool cache control onto the last successfully converted Anthropic tool after filtering

## Real behavior proof

Behavior addressed: The Anthropic provider adapter read every tool schema directly while building the request payload. A bad plugin/extension schema getter could abort payload construction before the provider call, dropping healthy sibling tools and failing the turn before model output.

Real environment tested: Local OpenClaw linked Codex worktree on Node/Vitest via repo wrapper; remote broad gate attempted through Blacksmith Testbox and AWS Crabbox.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts --testNamePattern="skips unreadable tool schemas"`
- `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next196-check-changed --shell -- "pnpm check:changed"`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next196-check-changed --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"`

Evidence after fix: Focused Anthropic provider tests passed with 7 tests after rebase; oxlint passed; diff whitespace check passed; local and branch autoreview both returned no accepted/actionable findings.

Observed result after fix: Throwing schema accessors no longer prevent Anthropic payload creation. The bad tool entries are omitted, the healthy tool remains in `tools`, and payload construction reaches `onPayload`.

What was not tested: Full `pnpm check:changed` was not completed because Blacksmith Testbox auth is missing locally (`not authenticated`) and direct AWS Crabbox coordinator calls returned HTTP 401 for run/lease creation.

## Verification

- Red repro before fix: `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts --testNamePattern="skips unreadable tool schemas"` failed because `capturedPayload` was never set after payload conversion aborted.
- Post-fix focused proof: `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts --testNamePattern="skips unreadable tool schemas"` passed 1 test.
- Post-fix full file proof: `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts` passed 7 tests.
- Post-rebase proof: `node scripts/run-vitest.mjs run src/llm/providers/anthropic.test.ts` passed 7 tests.
- Lint: `node scripts/run-oxlint.mjs src/llm/providers/anthropic.ts src/llm/providers/anthropic.test.ts` passed.
- Whitespace: `git diff --check origin/main...HEAD` passed.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local` clean, `overall: patch is correct (0.82)`.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, `overall: patch is correct (0.83)`.
- Broad proof attempted but blocked: `blacksmith testbox list --all` reported not authenticated; AWS Crabbox coordinator returned HTTP 401; delegated Blacksmith-through-Crabbox failed on the same missing Blacksmith auth.
