### PR TITLE
test: make zalo token resolver symlink test compatible with Windows

### DIFF
--- a/extensions/zalo/src/token.test.ts
+++ b/extensions/zalo/src/token.test.ts
@@ -6,6 +6,21 @@ import { describe, expect, it } from "vitest";
 import { resolveZaloToken } from "./token.js";
 import type { ZaloConfig } from "./types.js";
 
+const canCreateFileSymlinks = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-zalo-token-probe-"));
+  const targetFile = path.join(probeDir, "target.txt");
+  const linkFile = path.join(probeDir, "link.txt");
+  try {
+    fs.writeFileSync(targetFile, "target", "utf8");
+    fs.symlinkSync(targetFile, linkFile, "file");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
 describe("resolveZaloToken", () => {
   it("falls back to top-level token for non-default accounts without overrides", () => {
     const cfg = {
@@ -75,7 +90,7 @@ describe("resolveZaloToken", () => {
     expect(res.source).toBe("config");
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked token files", () => {
+  it.skipIf(!canCreateFileSymlinks)("rejects symlinked token files", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-zalo-token-"));
     const tokenFile = path.join(dir, "token.txt");
     const tokenLink = path.join(dir, "token-link.txt");


### PR DESCRIPTION
Replaces the hardcoded Windows skip in the Zalo token resolver test suite with a dynamic `canCreateFileSymlinks` capability check. If file symlinking is supported by the OS environment, the test executes. Otherwise, it skips gracefully, allowing correct platform-specific testing.

### Verified Windows Proof

The following test execution log shows the test run on Windows. Since file symlink creation is not permitted on this host, the symlinked token file rejection test was skipped gracefully as expected (1 skipped, 5 passed), rather than failing the whole suite:

```
 RUN  v4.1.7 C:/Users/ANIRUDDHA/.gemini/antigravity/scratch/openclaw

 ✓  extension-zalo  ../../extensions/zalo/src/token.test.ts (6 tests | 1 skipped) 167ms

 Test Files  1 passed (1)
      Tests  5 passed | 1 skipped (6)
```
