### PR TITLE
fix(providers): skip unreadable OpenAI completion tool schemas

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1,7 +1,7 @@
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import { describe, expect, it, vi } from "vitest";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
-import type { Context, Model } from "../types.js";
+import type { Context, Model, Tool } from "../types.js";
 
 type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
@@ -117,6 +117,60 @@ function makeFinishChunk(
 }
 
 describe("OpenAI-compatible completions params", () => {
+  it("skips unreadable tool schemas while preserving healthy tools", async () => {
+    const unreadableSchemaTool = {
+      name: "bad_schema",
+      description: "Bad schema",
+      get parameters(): never {
+        throw new Error("parameters getter exploded");
+      },
+    } satisfies Tool;
+    const healthyTool = {
+      name: "lookup",
+      description: "Lookup",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    } satisfies Tool;
+    let capturedTools: unknown;
+
+    const stream = streamOpenAICompletions(
+      createModel(32_000),
+      {
+        messages: [{ role: "user", content: "lookup", timestamp: 1 }],
+        tools: [unreadableSchemaTool, healthyTool],
+      } satisfies Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedTools = (payload as { tools?: unknown }).tools;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedTools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          description: "Lookup",
+          strict: false,
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+        },
+      },
+    ]);
+  });
+
   it("clamps requested max tokens to the model output cap", async () => {
     let capturedMaxTokens: unknown;
     const stream = streamOpenAICompletions(createModel(32_000), context, {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -1155,16 +1155,26 @@ function convertTools(
   tools: Tool[],
   compat: ResolvedOpenAICompletionsCompat,
 ): OpenAI.Chat.Completions.ChatCompletionTool[] {
-  return tools.map((tool) => ({
-    type: "function",
-    function: {
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters as Record<string, unknown>, // TypeBox already generates JSON Schema
-      // Only include strict if provider supports it. Some reject unknown fields.
-      ...(compat.supportsStrictMode && { strict: false }),
-    },
-  }));
+  return tools.flatMap((tool) => {
+    let parameters: Record<string, unknown>;
+    try {
+      parameters = tool.parameters as Record<string, unknown>; // TypeBox already generates JSON Schema
+    } catch {
+      return [];
+    }
+    return [
+      {
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters,
+          // Only include strict if provider supports it. Some reject unknown fields.
+          ...(compat.supportsStrictMode && { strict: false }),
+        },
+      },
+    ];
+  });
 }
 
 function parseChunkUsage(


### PR DESCRIPTION
## Summary

- Skip OpenAI Chat Completions tools whose `parameters` schema getter throws during provider payload construction.
- Preserve healthy sibling tools and existing provider `strict: false` compatibility behavior.
- Add a regression proving a bad schema getter no longer prevents `onPayload` from receiving the healthy tool payload.

## Real behavior proof

Behavior addressed: one bad plugin/extension tool schema getter could abort OpenAI-compatible Chat Completions payload construction before any payload/network step, dropping healthy sibling tools.

Real environment tested: local linked Codex worktree on `origin/main`, with focused provider payload tests; broad remote changed gate attempted but blocked by maintainer auth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts --testNamePattern="skips unreadable tool schemas"`; `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts`; `node scripts/run-oxlint.mjs src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: targeted regression passed; full `openai-completions.test.ts` passed 23 tests; oxlint passed; oxfmt check passed; diff check passed; local autoreview reported `overall: patch is correct (0.78)`; branch autoreview reported `overall: patch is correct (0.83)`.

Observed result after fix: OpenAI Chat Completions skips the unreadable tool schema and sends the healthy `lookup` tool definition in the payload.

What was not tested: `pnpm check:changed` could not run remotely here. Blacksmith reported `not authenticated`; AWS Crabbox reached the coordinator after sparse sync but failed with HTTP 401 for run/lease creation; delegated Blacksmith-through-Crabbox failed on missing Blacksmith auth. The first Crabbox attempt also hit local sparse-sync free-disk preflight until ignored generated build dirs in this worktree were removed.

## Verification

- Red proof before fix: focused regression failed because `capturedTools` stayed `undefined` after the bad schema getter aborted payload construction before `onPayload`.
- `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts --testNamePattern="skips unreadable tool schemas"`
- `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next197-check-changed-retry --shell -- "pnpm check:changed"` blocked: coordinator HTTP 401 for run/lease creation
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next197-check-changed-retry --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` blocked: Blacksmith not authenticated

