### PR TITLE
fix(providers): skip unreadable OpenAI responses tool schemas

### DIFF
--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -122,6 +122,53 @@ describe("convertResponsesTools", () => {
       convertResponsesTools([zeta, alpha]).map((tool) => expectResponsesFunctionTool(tool).name),
     ).toEqual(["alpha", "zeta"]);
   });
+
+  it("skips unreadable tool schemas while preserving healthy strict tools", () => {
+    const unreadableSchemaTool = {
+      name: "bad_schema",
+      description: "Bad schema",
+      get parameters(): never {
+        throw new Error("parameters getter exploded");
+      },
+    } satisfies Tool;
+    const unreadableNestedSchemaTool = {
+      name: "bad_nested_schema",
+      description: "Bad nested schema",
+      parameters: {
+        type: "object",
+        get properties(): never {
+          throw new Error("properties getter exploded");
+        },
+      },
+    } satisfies Tool;
+    const healthyTool = {
+      name: "lookup_weather",
+      description: "Get forecast",
+      parameters: {},
+    } satisfies Tool;
+
+    const converted = convertResponsesTools(
+      [unreadableSchemaTool, unreadableNestedSchemaTool, healthyTool],
+      {
+        model: nativeOpenAIModel,
+      },
+    );
+
+    expect(converted).toEqual([
+      {
+        type: "function",
+        name: "lookup_weather",
+        description: "Get forecast",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+    ]);
+  });
 });
 
 describe("convertResponsesMessages", () => {

--- a/src/llm/providers/openai-responses-tools.ts
+++ b/src/llm/providers/openai-responses-tools.ts
@@ -24,6 +24,11 @@ type ResponsesFunctionTool = {
   parameters: Record<string, unknown>;
   strict?: boolean | null;
 };
+type ResponsesToolInput = {
+  name: string;
+  description?: string;
+  parameters: unknown;
+};
 
 // Converts OpenClaw tool schemas to OpenAI Responses tools, including strict-mode compatibility.
 const log = createSubsystemLogger("llm/openai-responses");
@@ -35,25 +40,56 @@ export function convertResponsesTools(
   tools: Tool[],
   options?: ConvertResponsesToolsOptions,
 ): OpenAITool[] {
+  const readableTools = snapshotResponsesToolInputs(tools);
   const strictSetting = resolveResponsesStrictToolSetting(options);
-  const strict = resolveResponsesStrictToolFlag(tools, strictSetting, options?.model);
+  const strict = resolveResponsesStrictToolFlag(readableTools, strictSetting, options?.model);
   // Sort tools before request construction so prompt-cache bytes stay deterministic.
-  return sortResponsesToolsByName(tools).map((tool) => {
-    const result: ResponsesFunctionTool = {
-      type: "function",
-      name: tool.name,
-      description: tool.description,
-      parameters: normalizeOpenAIStrictToolParameters(
-        tool.parameters,
-        strict === true,
-        options?.model?.compat as OpenAIToolSchemaCompat,
-      ) as Record<string, unknown>,
-    };
-    if (strict !== undefined) {
-      result.strict = strict;
+  return sortResponsesToolsByName(readableTools).flatMap((tool) => {
+    try {
+      const result: ResponsesFunctionTool = {
+        type: "function",
+        name: tool.name,
+        description: tool.description,
+        parameters: normalizeOpenAIStrictToolParameters(
+          tool.parameters,
+          strict === true,
+          options?.model?.compat as OpenAIToolSchemaCompat,
+        ) as Record<string, unknown>,
+      };
+      if (strict !== undefined) {
+        result.strict = strict;
+      }
+      return [result as OpenAITool];
+    } catch {
+      return [];
     }
-    return result as OpenAITool;
   });
+}
+
+function snapshotResponsesToolInputs(tools: readonly Tool[]): ResponsesToolInput[] {
+  return tools.flatMap((tool) => {
+    try {
+      const description = tool.description;
+      const parameters = materializeResponsesToolParameters(tool.parameters);
+      return [
+        {
+          name: tool.name,
+          ...(description !== undefined ? { description } : {}),
+          parameters,
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function materializeResponsesToolParameters(parameters: unknown): unknown {
+  const encoded = JSON.stringify(parameters ?? {});
+  if (encoded === undefined) {
+    throw new Error("OpenAI Responses tool parameters are not JSON serializable");
+  }
+  return JSON.parse(encoded) as unknown;
 }
 
 function resolveResponsesStrictToolSetting(
@@ -72,13 +108,18 @@ function resolveResponsesStrictToolSetting(
 }
 
 function resolveResponsesStrictToolFlag(
-  tools: Tool[],
+  tools: readonly { name?: unknown; parameters: unknown }[],
   strictSetting: boolean | null | undefined,
   model: Model | undefined,
 ): boolean | undefined {
-  const strict = resolveOpenAIStrictToolFlagForInventory(tools, strictSetting);
+  let strict: boolean | undefined;
+  try {
+    strict = resolveOpenAIStrictToolFlagForInventory(tools, strictSetting);
+  } catch {
+    strict = strictSetting === true ? false : strictSetting === false ? false : undefined;
+  }
   if (strictSetting === true && strict === false && model && log.isEnabled("debug", "any")) {
-    const diagnostics = findOpenAIStrictToolSchemaDiagnostics(tools);
+    const diagnostics = readResponsesStrictToolSchemaDiagnostics(tools);
     if (shouldLogStrictToolDowngradeDiagnostic(diagnostics, model)) {
       const sample = diagnostics.slice(0, 5).map((entry) => ({
         tool: entry.toolName ?? `tool[${entry.toolIndex}]`,
@@ -98,6 +139,16 @@ function resolveResponsesStrictToolFlag(
     }
   }
   return strict;
+}
+
+function readResponsesStrictToolSchemaDiagnostics(
+  tools: readonly { name?: unknown; parameters: unknown }[],
+): ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics> {
+  try {
+    return findOpenAIStrictToolSchemaDiagnostics(tools);
+  } catch {
+    return [];
+  }
 }
 
 function shouldLogStrictToolDowngradeDiagnostic(


### PR DESCRIPTION
## Summary

- Snapshot JSON-safe OpenAI Responses tool schemas before strict-mode inventory checks.
- Skip tools whose schema access, nested schema serialization, or strict normalization fails.
- Preserve deterministic ordering and `strict: true` for healthy native OpenAI Responses tools after bad siblings are filtered out.

## Real behavior proof

Behavior addressed: one bad plugin/extension OpenAI Responses tool schema getter could abort strict-mode inventory or payload conversion before a request payload was built, and a nested unreadable schema could downgrade strict mode for healthy siblings before being skipped.

Real environment tested: local linked Codex worktree on `origin/main`, with focused provider conversion tests; broad remote changed gate attempted but blocked by local disk and missing maintainer auth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts --testNamePattern="skips unreadable tool schemas"`; `node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts`; `node scripts/run-oxlint.mjs src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.test.ts`; `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.test.ts`; `git diff --check origin/main...HEAD`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: targeted regression passed; full `openai-responses-shared.test.ts` passed 8 tests; oxlint passed; oxfmt check passed; diff check passed; local autoreview reported `overall: patch is correct (0.84)`; final branch autoreview reported `overall: patch is correct (0.86)`.

Observed result after fix: OpenAI Responses skips top-level and nested unreadable schema tools, while the healthy `lookup_weather` tool remains in the converted payload with `strict: true`.

What was not tested: `pnpm check:changed` could not run remotely here. `blacksmith testbox list --all` reported not authenticated. Crabbox sparse-sync preflight failed with about 940-996 MiB free against a 1 GiB minimum even after deleting ignored generated build dirs in this worktree, so AWS/Blacksmith Crabbox did not reach remote execution on the final attempt.

## Verification

- Red proof before fix: focused regression failed with `Error: parameters getter exploded` from `resolveOpenAIStrictToolFlagForInventory()`.
- Review-driven fix: branch autoreview caught nested unreadable schemas could still downgrade healthy tools to `strict: false`; the final patch materializes JSON-safe schemas before strict resolution and extends the regression to nested `properties` getters.
- `node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts --testNamePattern="skips unreadable tool schemas"`
- `node scripts/run-vitest.mjs run src/llm/providers/openai-responses-shared.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/openai-responses-tools.ts src/llm/providers/openai-responses-shared.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: not authenticated
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next198-check-changed --shell -- "pnpm check:changed"` blocked: insufficient local free disk for sparse-sync full checkout
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next198-check-changed --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` blocked: insufficient local free disk for sparse-sync full checkout

