### PR TITLE
fix(providers): skip unreadable Anthropic payload tool schemas

### DIFF
--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -1,0 +1,100 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { createOpenAIAnthropicToolPayloadCompatibilityWrapper } from "./anthropic-family-tool-payload-compat.js";
+
+const model = {
+  api: "anthropic-messages",
+  provider: "openai-compatible-anthropic",
+  id: "claude-compatible",
+  compat: { requiresOpenAiAnthropicToolPayload: true },
+} as unknown as Model<"anthropic-messages">;
+
+describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
+  it("skips unreadable tool schemas while preserving healthy payload tools", () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const baseStreamFn: StreamFn = (nextModel, context, options) => {
+      const payload: Record<string, unknown> = {
+        model: nextModel.id,
+        tools: [
+          {
+            name: "bad_schema",
+            description: "Bad schema",
+            get parameters(): never {
+              throw new Error("parameters getter exploded");
+            },
+          },
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+            },
+          },
+        ],
+      };
+      options?.onPayload?.(payload, nextModel);
+      payloads.push(structuredClone(payload));
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenAIAnthropicToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    expect(() => void wrapped(model, { messages: [] }, {})).not.toThrow();
+    expect(payloads[0]?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          description: "Lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      },
+    ]);
+  });
+
+  it("uses Anthropic input_schema without reading a poisoned parameters fallback", () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    const baseStreamFn: StreamFn = (nextModel, context, options) => {
+      const payload: Record<string, unknown> = {
+        model: nextModel.id,
+        tools: [
+          {
+            name: "lookup",
+            input_schema: {
+              type: "object",
+              properties: { query: { type: "string" } },
+            },
+            get parameters(): never {
+              throw new Error("parameters fallback getter exploded");
+            },
+          },
+        ],
+      };
+      options?.onPayload?.(payload, nextModel);
+      payloads.push(structuredClone(payload));
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenAIAnthropicToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    expect(() => void wrapped(model, { messages: [] }, {})).not.toThrow();
+    expect(payloads[0]?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -8,6 +8,7 @@ type AnthropicToolPayloadCompatibilityOptions = {
   toolSchemaMode?: AnthropicToolSchemaMode;
   toolChoiceMode?: AnthropicToolChoiceMode;
 };
+type PayloadFieldRead = { ok: true; value: unknown } | { ok: false };
 
 function hasOpenAiAnthropicToolPayloadCompatFlag(model: { compat?: unknown }): boolean {
   if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
@@ -67,36 +68,70 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
   }
 
   const toolObj = tool as Record<string, unknown>;
-  if (toolObj.function && typeof toolObj.function === "object") {
+  const functionField = readPayloadField(toolObj, "function");
+  if (!functionField.ok) {
+    return undefined;
+  }
+  if (functionField.value && typeof functionField.value === "object") {
     return toolObj;
   }
 
-  const rawName = normalizeOptionalString(toolObj.name) ?? "";
+  const nameField = readPayloadField(toolObj, "name");
+  if (!nameField.ok) {
+    return undefined;
+  }
+  const rawName = normalizeOptionalString(nameField.value) ?? "";
   if (!rawName) {
     return toolObj;
   }
 
+  const inputSchemaField = readPayloadField(toolObj, "input_schema");
+  if (!inputSchemaField.ok) {
+    return undefined;
+  }
+  const inputSchema = inputSchemaField.value;
+  let parameters: unknown = { type: "object", properties: {} };
+  if (inputSchema && typeof inputSchema === "object") {
+    parameters = inputSchema;
+  } else {
+    const parametersField = readPayloadField(toolObj, "parameters");
+    if (!parametersField.ok) {
+      return undefined;
+    }
+    if (parametersField.value && typeof parametersField.value === "object") {
+      parameters = parametersField.value;
+    }
+  }
   const functionSpec: Record<string, unknown> = {
     name: rawName,
-    parameters:
-      toolObj.input_schema && typeof toolObj.input_schema === "object"
-        ? toolObj.input_schema
-        : toolObj.parameters && typeof toolObj.parameters === "object"
-          ? toolObj.parameters
-          : { type: "object", properties: {} },
+    parameters,
   };
 
-  if (typeof toolObj.description === "string" && toolObj.description.trim()) {
-    functionSpec.description = toolObj.description;
+  const descriptionField = readPayloadField(toolObj, "description");
+  if (
+    descriptionField.ok &&
+    typeof descriptionField.value === "string" &&
+    descriptionField.value.trim()
+  ) {
+    functionSpec.description = descriptionField.value;
   }
-  if (typeof toolObj.strict === "boolean") {
-    functionSpec.strict = toolObj.strict;
+  const strictField = readPayloadField(toolObj, "strict");
+  if (strictField.ok && typeof strictField.value === "boolean") {
+    functionSpec.strict = strictField.value;
   }
 
   return {
     type: "function",
     function: functionSpec,
   };
+}
+
+function readPayloadField(record: Record<string, unknown>, field: string): PayloadFieldRead {
+  try {
+    return { ok: true, value: Reflect.get(record, field) };
+  } catch {
+    return { ok: false };
+  }
 }
 
 function normalizeOpenAiStringModeAnthropicToolChoice(toolChoice: unknown): unknown {


### PR DESCRIPTION
## Summary

- guard Anthropic-family OpenAI-compatible payload tool conversion against throwing tool-schema getters
- skip only unreadable tool definitions while preserving healthy payload tools
- add focused wrapper coverage for poisoned `parameters` getters and `input_schema` precedence

## Verification

- `node scripts/run-vitest.mjs run src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts`
- `node scripts/run-oxlint.mjs src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Anthropic-family OpenAI-compatible payload wrapping could throw while normalizing a malformed plugin/provider tool whose schema field was exposed through a throwing getter.

Real environment tested: local linked OpenClaw worktree on `fuzz-tool-schema-next199-20260604`, rebased onto `origin/main` at `045145c7008`, Node wrapper test harness.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts`.

Evidence after fix: focused Vitest passed 1 file / 2 tests; oxlint, oxfmt, diff check, local autoreview, and branch autoreview all passed.

Observed result after fix: the wrapper no longer throws on a poisoned `parameters` getter, drops the unreadable tool, preserves healthy tools, and uses valid `input_schema` without reading the poisoned fallback.

What was not tested: broad `pnpm check:changed` did not run because Blacksmith Testbox was unauthenticated and Crabbox sparse-sync preflight failed before remote execution with less than 1 GiB free in the local Crabbox sparse-sync cache.
