### PR TITLE
[codex] fix(agents): run reply payload hooks for agent delivery

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -109,6 +109,13 @@ function latestOutboundDeliveryArgs(): {
   payloads: ReplyPayload[];
   bestEffort?: boolean;
   queuePolicy?: string;
+  replyPayloadSendingHook?: {
+    kind?: string;
+    channel?: string;
+    sessionKey?: string;
+    runId?: string;
+    context?: Record<string, unknown>;
+  };
 } {
   const args = lastMockArg(deliverOutboundPayloadsMock, "outbound delivery arguments");
   if (!args || typeof args !== "object") {
@@ -121,6 +128,13 @@ function latestOutboundDeliveryArgs(): {
     payloads: ReplyPayload[];
     bestEffort?: boolean;
     queuePolicy?: string;
+    replyPayloadSendingHook?: {
+      kind?: string;
+      channel?: string;
+      sessionKey?: string;
+      runId?: string;
+      context?: Record<string, unknown>;
+    };
   };
 }
 
@@ -393,6 +407,62 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       status: "sent",
       succeeded: true,
       resultCount: 1,
+    });
+  });
+
+  it("passes reply payload hook metadata through recovered agent delivery", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+
+    await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      opts: {
+        message: "resume interrupted turn",
+        deliver: true,
+        bestEffortDeliver: true,
+        channel: "slack",
+        to: "#general",
+        accountId: "workspace-1",
+        threadId: "thread-7",
+        sessionKey: "agent:tester:slack:direct:alice",
+        runId: "run-recovered",
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        restartRecoveryDeliveryContext: {
+          channel: "slack",
+          to: "#general",
+          accountId: "workspace-1",
+          threadId: "thread-7",
+        },
+        restartRecoveryDeliveryRunId: "run-recovered",
+      },
+      payloads: [{ text: "after restart" }],
+      result: createResult(),
+    });
+
+    expect(latestOutboundDeliveryArgs().replyPayloadSendingHook).toEqual({
+      kind: "final",
+      channel: "slack",
+      sessionKey: "agent:tester:slack:direct:alice",
+      runId: "run-recovered",
+      context: {
+        channelId: "slack",
+        accountId: "workspace-1",
+        conversationId: "#general",
+        sessionKey: "agent:tester:slack:direct:alice",
+        runId: "run-recovered",
+      },
     });
   });
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -18,6 +18,7 @@ import {
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import type { QueuedReplyPayloadSendingHook } from "../../infra/outbound/delivery-queue-storage.js";
 import { buildOutboundResultEnvelope } from "../../infra/outbound/envelope.js";
 import {
   createOutboundPayloadPlan,
@@ -307,6 +308,33 @@ function noVisiblePayloadStatus(): AgentCommandDeliveryStatus {
     succeeded: true,
     reason: "no_visible_payload",
     resultCount: 0,
+  };
+}
+
+function buildReplyPayloadSendingHook(params: {
+  channel: string;
+  to: string;
+  accountId?: string;
+  sessionKey?: string;
+  runId?: string;
+}): QueuedReplyPayloadSendingHook {
+  const sessionKey = hasNonEmptyString(params.sessionKey) ? params.sessionKey : undefined;
+  const runId = hasNonEmptyString(params.runId) ? params.runId : undefined;
+
+  // Agent-command delivery bypasses the auto-reply dispatcher, so rebuild the
+  // same pre-delivery hook context before handing payloads to durable send.
+  return {
+    kind: "final",
+    channel: params.channel,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+    context: {
+      channelId: params.channel,
+      ...(hasNonEmptyString(params.accountId) ? { accountId: params.accountId } : {}),
+      conversationId: params.to,
+      ...(sessionKey ? { sessionKey } : {}),
+      ...(runId ? { runId } : {}),
+    },
   };
 }
 
@@ -712,6 +740,13 @@ export async function deliverAgentCommandResult(
         threadId: resolvedThreadTarget ?? null,
         bestEffort: bestEffortDeliver,
         durability: bestEffortDeliver ? "best_effort" : "required",
+        replyPayloadSendingHook: buildReplyPayloadSendingHook({
+          channel: deliveryChannel,
+          to: deliveryTarget,
+          accountId: resolvedAccountId,
+          sessionKey: effectiveSessionKey,
+          runId: opts.runId,
+        }),
         onError: logDeliveryError,
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),


### PR DESCRIPTION
## Summary

Fixes #90282.

- Thread the existing `reply_payload_sending` hook metadata through agent-command durable delivery.
- Add regression coverage for restart-recovered agent delivery so final replies still enter the documented pre-delivery hook pipeline.

## Root Cause

Restart recovery resumes interrupted main sessions by calling Gateway `agent` with `deliver: true`. That path eventually uses `deliverAgentCommandResult`, which sends final payloads through `sendDurableMessageBatch`. The normal inbound auto-reply path already passes `replyPayloadSendingHook`, but the agent-command durable delivery path did not, so channel plugins relying on `reply_payload_sending` never saw recovered final replies.

## Real behavior proof

Behavior addressed: restart-recovered agent final delivery now carries `reply_payload_sending` hook metadata into durable outbound delivery, giving channel plugins the same pre-delivery hook opportunity as normal inbound replies.

Real environment tested: local OpenClaw checkout on branch `codex/restart-recovery-reply-payload-hook`, Node v24.13.1, dependencies installed with `corepack pnpm install --frozen-lockfile`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/agents/command/delivery.test.ts
node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/delivery.test.ts src/infra/outbound/deliver.test.ts src/auto-reply/dispatch.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/route-reply.test.ts
corepack pnpm exec oxfmt --check --threads=1 src/agents/command/delivery.ts src/agents/command/delivery.test.ts
git diff --check
```

Evidence after fix:

```text
src/agents/command/delivery.test.ts: 21 passed
issue acceptance set: 3 Vitest shards passed, 203 tests passed
src/auto-reply/reply/route-reply.test.ts: 31 passed
oxfmt: All matched files use the correct format
git diff --check: clean
```

Additional equivalent live channel-plugin proof run locally after ClawSweeper feedback:

```bash
corepack pnpm exec tsx .artifacts/issue-90282-proof/run-proof.ts
```

This proof harness used the real global hook runner, active plugin registry, durable outbound queue, `deliverAgentCommandResult`, `sendDurableMessageBatch`, and a local proof channel plugin with a real `outbound.sendText` adapter. It did not mock `deliverOutboundPayloadsInternal` or the channel send call.

Redacted output:

```json
{
  "proof": "issue-90282-recovered-agent-delivery-reply-payload-hook",
  "assertion": "reply_payload_sending ran before recovered agent final reply reached the channel adapter",
  "hookCalls": [
    {
      "kind": "final",
      "channel": "issue-90282-proof",
      "sessionKey": "agent:main:issue-90282-proof:direct:redacted",
      "runId": "run-redacted",
      "context": {
        "channelId": "issue-90282-proof",
        "accountId": "account-redacted",
        "conversationId": "conversation-redacted",
        "sessionKey": "agent:main:issue-90282-proof:direct:redacted",
        "runId": "run-redacted"
      },
      "inputText": "recovered final reply",
      "outputText": "recovered final reply [hook-proof]"
    }
  ],
  "outboundSends": [
    {
      "channel": "issue-90282-proof",
      "to": "conversation-redacted",
      "accountId": "account-redacted",
      "threadId": null,
      "text": "recovered final reply [hook-proof]",
      "messageId": "proof-message-1"
    }
  ],
  "deliveryStatus": {
    "requested": true,
    "attempted": true,
    "status": "sent",
    "succeeded": true,
    "resultCount": 1,
    "payloadOutcomes": [
      {
        "index": 0,
        "status": "sent",
        "resultCount": 1
      }
    ]
  },
  "durableQueue": {
    "stateDir": "<local-artifact-state-dir>",
    "pendingAfter": 0
  }
}
```

Observed result after fix: the recovered agent delivery test observes `replyPayloadSendingHook` with `kind: "final"`, channel, conversation id, session key, and run id on the durable delivery call. The live channel-plugin proof also shows `reply_payload_sending` receiving the recovered final payload, mutating it, and the channel adapter receiving the mutated text before delivery completes with `status: "sent"`; the durable queue drains to `pendingAfter: 0`.

What was not tested: a full live Gateway process restart with an external network-backed third-party channel. The local proof covers the equivalent live channel-plugin setup and the missing core handoff that #90282 identified.

## Verification

- `node scripts/run-vitest.mjs src/agents/command/delivery.test.ts`
- `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/delivery.test.ts src/infra/outbound/deliver.test.ts src/auto-reply/dispatch.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/route-reply.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/command/delivery.ts src/agents/command/delivery.test.ts`
- `git diff --check`
- `corepack pnpm exec tsx .artifacts/issue-90282-proof/run-proof.ts` (local proof harness; output redacted above)

## Changelog

No `CHANGELOG.md` edit. This is a contributor fix; release-note context is in this PR body.
