### PR TITLE
[daemon] Preserve gateway drain during supervised restarts

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -256,10 +256,10 @@ Wants=network-online.target
 ExecStart=/usr/local/bin/openclaw gateway --port 18789
 Restart=always
 RestartSec=5
-TimeoutStopSec=30
+TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
-KillMode=control-group
+KillMode=mixed
 
 [Install]
 WantedBy=default.target

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -83,10 +83,10 @@ Wants=network-online.target
 ExecStart=/usr/local/bin/openclaw gateway --port 18789
 Restart=always
 RestartSec=5
-TimeoutStopSec=30
+TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
-KillMode=control-group
+KillMode=mixed
 
 [Install]
 WantedBy=default.target

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -1,12 +1,13 @@
 /** Reads and renders macOS LaunchAgent plists for gateway service installs. */
 import fs from "node:fs/promises";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 
 // launchd defaults to a 10s spawn throttle. Keep that default explicitly so
 // crash loops back off instead of respawning every second while still allowing
 // explicit kickstart restarts to take effect.
 export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 10;
-export const LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS = 20;
+export const LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS = GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS;
 // launchd stores plist integer values in decimal; 0o077 renders as 63 (owner-only files).
 export const LAUNCH_AGENT_UMASK_DECIMAL = 0o077;
 export const LAUNCH_AGENT_PROCESS_TYPE = "Interactive";

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -26,6 +26,7 @@ import {
   resolveLaunchAgentPlistPath,
   stopLaunchAgent,
 } from "./launchd.js";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 
 const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
@@ -953,7 +954,7 @@ describe("launchd install", () => {
     expect(state.dirModes.get(tmpDir)).toBe(0o700);
   });
 
-  it("writes KeepAlive=true policy with shutdown and throttle limits", async () => {
+  it("writes KeepAlive=true policy with drain, shutdown, and throttle limits", async () => {
     const env = createDefaultLaunchdEnv();
     await installLaunchAgent({
       env,
@@ -971,6 +972,7 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(plist).not.toContain("<key>SuccessfulExit</key>");
     expect(plist).toContain("<key>ExitTimeOut</key>");
+    expect(LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS).toBe(GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS);
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS}</integer>`);
     expect(plist).toContain("<key>ProcessType</key>");
     expect(plist).toContain(`<string>${LAUNCH_AGENT_PROCESS_TYPE}</string>`);

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -426,7 +426,7 @@ describe("auditGatewayServiceConfig", () => {
     expectTokenAudit(audit, { embedded: true, mismatch: true });
   });
 
-  it.each(["process", "none"])(
+  it.each(["control-group", "process", "none"])(
     `warns when KillMode is %s in explicit unit file`,
     async (killMode) => {
       const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
@@ -446,20 +446,17 @@ describe("auditGatewayServiceConfig", () => {
         },
       });
       expect(
-        audit.issues.some(
-          (entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
-        ),
+        audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeNotMixed),
       ).toBe(true);
     },
   );
 
-  it.each(["control-group", "mixed"])("does not warn when KillMode is %s", async (killMode) => {
+  it("warns when systemd KillMode is unset", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
     await writeSystemdUnitForAudit(home, [
       "After=network-online.target",
       "Wants=network-online.target",
       "RestartSec=5",
-      `KillMode=${killMode}`,
     ]);
     const audit = await auditGatewayServiceConfig({
       env: { HOME: home },
@@ -470,7 +467,28 @@ describe("auditGatewayServiceConfig", () => {
       },
     });
     expect(
-      audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone),
+      audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeNotMixed),
+    ).toBe(true);
+  });
+
+  it("does not warn when KillMode is mixed", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(
+      audit.issues.some((entry) => entry.code === SERVICE_AUDIT_CODES.systemdKillModeNotMixed),
     ).toBe(false);
   });
 
@@ -480,7 +498,7 @@ describe("auditGatewayServiceConfig", () => {
       "After=network-online.target",
       "Wants=network-online.target",
       "RestartSec=5s",
-      "KillMode=control-group",
+      "KillMode=mixed",
     ]);
     const audit = await auditGatewayServiceConfig({
       env: { HOME: home },

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -453,13 +453,13 @@ describe("auditGatewayServiceConfig", () => {
     },
   );
 
-  it("does not warn when KillMode is control-group", async () => {
+  it.each(["control-group", "mixed"])("does not warn when KillMode is %s", async (killMode) => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-killmode-"));
     await writeSystemdUnitForAudit(home, [
       "After=network-online.target",
       "Wants=network-online.target",
       "RestartSec=5",
-      "KillMode=control-group",
+      `KillMode=${killMode}`,
     ]);
     const audit = await auditGatewayServiceConfig({
       env: { HOME: home },

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -11,6 +11,7 @@ import {
   SERVICE_AUDIT_CODES,
 } from "./service-audit.js";
 import { buildMinimalServicePath } from "./service-env.js";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 
 function hasIssue(
@@ -67,6 +68,30 @@ async function writeSystemdUnitForAudit(home: string, lines: string[]) {
       "",
       "[Install]",
       "WantedBy=default.target",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function writeLaunchAgentPlistForAudit(home: string, lines: string[]) {
+  const plistDir = path.join(home, "Library", "LaunchAgents");
+  const plistPath = path.join(plistDir, "ai.openclaw.gateway.plist");
+  await fs.mkdir(plistDir, { recursive: true });
+  await fs.writeFile(
+    plistPath,
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<plist version="1.0">',
+      "<dict>",
+      ...lines,
+      "<key>ProgramArguments</key>",
+      "<array>",
+      "<string>/usr/bin/node</string>",
+      "<string>gateway</string>",
+      "</array>",
+      "</dict>",
+      "</plist>",
       "",
     ].join("\n"),
     "utf8",
@@ -477,6 +502,7 @@ describe("auditGatewayServiceConfig", () => {
       "After=network-online.target",
       "Wants=network-online.target",
       "RestartSec=5",
+      `TimeoutStopSec=${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}`,
       "KillMode=mixed",
     ]);
     const audit = await auditGatewayServiceConfig({
@@ -492,12 +518,139 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(false);
   });
 
+  it("warns when systemd TimeoutStopSec is below the gateway stop budget", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "TimeoutStopSec=30",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(true);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdKillModeNotMixed)).toBe(false);
+  });
+
+  it("warns when systemd TimeoutStopSec uses a unit unsupported by service Sec settings", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "TimeoutStopSec=300000000000ns",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(true);
+  });
+
+  it.each(["0", "6 minutes", "10m", "1week", "1M", "1y"])(
+    "accepts systemd TimeoutStopSec=%s when it covers the gateway stop budget",
+    async (timeoutStopSec) => {
+      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+      await writeSystemdUnitForAudit(home, [
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "RestartSec=5",
+        `TimeoutStopSec=${timeoutStopSec}`,
+        "KillMode=mixed",
+      ]);
+      const audit = await auditGatewayServiceConfig({
+        env: { HOME: home },
+        platform: "linux",
+        command: {
+          programArguments: ["/usr/bin/node", "gateway"],
+          environment: { PATH: "/usr/bin:/bin" },
+        },
+      });
+      expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(false);
+    },
+  );
+
+  it("accepts systemd TimeoutSec shorthand when it covers the gateway stop budget", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "TimeoutSec=6min",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(false);
+  });
+
+  it("accepts systemd TimeoutSec shorthand when it overrides an earlier stale TimeoutStopSec", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "TimeoutStopSec=30",
+      "TimeoutSec=6min",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(false);
+  });
+
+  it("warns when explicit systemd TimeoutStopSec is below a larger TimeoutSec shorthand", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-timeout-"));
+    await writeSystemdUnitForAudit(home, [
+      "After=network-online.target",
+      "Wants=network-online.target",
+      "RestartSec=5",
+      "TimeoutSec=6min",
+      "TimeoutStopSec=30",
+      "KillMode=mixed",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "linux",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort)).toBe(true);
+  });
+
   it("accepts systemd RestartSec values with seconds suffixes", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-restartsec-"));
     await writeSystemdUnitForAudit(home, [
       "After=network-online.target",
       "Wants=network-online.target",
-      "RestartSec=5s",
+      "RestartSec=5 seconds",
+      `TimeoutStopSec=${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}`,
       "KillMode=mixed",
     ]);
     const audit = await auditGatewayServiceConfig({
@@ -510,6 +663,57 @@ describe("auditGatewayServiceConfig", () => {
     });
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdRestartSec)).toBe(false);
   });
+
+  it("warns when launchd ExitTimeOut is below the gateway stop budget", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-launchd-"));
+    await writeLaunchAgentPlistForAudit(home, [
+      "<key>RunAtLoad</key>",
+      "<true/>",
+      "<key>KeepAlive</key>",
+      "<true/>",
+      "<key>ExitTimeOut</key>",
+      "<integer>20</integer>",
+    ]);
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "darwin",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: buildMinimalServicePath({ platform: "darwin", env: { HOME: home } }),
+        },
+      },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.launchdExitTimeoutTooShort)).toBe(true);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.launchdRunAtLoad)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.launchdKeepAlive)).toBe(false);
+  });
+
+  it.each(["0", String(GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS)])(
+    "accepts launchd ExitTimeOut=%s when it covers the gateway stop budget",
+    async (exitTimeout) => {
+      const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-launchd-"));
+      await writeLaunchAgentPlistForAudit(home, [
+        "<key>RunAtLoad</key>",
+        "<true/>",
+        "<key>KeepAlive</key>",
+        "<true/>",
+        "<key>ExitTimeOut</key>",
+        `<integer>${exitTimeout}</integer>`,
+      ]);
+      const audit = await auditGatewayServiceConfig({
+        env: { HOME: home },
+        platform: "darwin",
+        command: {
+          programArguments: ["/usr/bin/node", "gateway"],
+          environment: {
+            PATH: buildMinimalServicePath({ platform: "darwin", env: { HOME: home } }),
+          },
+        },
+      });
+      expect(hasIssue(audit, SERVICE_AUDIT_CODES.launchdExitTimeoutTooShort)).toBe(false);
+    },
+  );
 
   it("flags embedded service token even when it matches config token", async () => {
     const audit = await createGatewayAudit({

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -27,6 +27,7 @@ import {
   isEnvironmentFileOnlySource,
 } from "./service-managed-env.js";
 import { isNonMinimalServicePathEntry, normalizeServicePathEntry } from "./service-path-policy.js";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 import { resolveSystemdUserUnitPath } from "./systemd.js";
 
@@ -72,6 +73,8 @@ export const SERVICE_AUDIT_CODES = {
   systemdRestartSec: "systemd-restart-sec",
   systemdWantsNetworkOnline: "systemd-wants-network-online",
   systemdKillModeNotMixed: "systemd-kill-mode-not-mixed",
+  systemdTimeoutStopTooShort: "systemd-timeout-stop-too-short",
+  launchdExitTimeoutTooShort: "launchd-exit-timeout-too-short",
 } as const;
 
 /** Returns whether audit issues require migrating a daemon to a stable Node runtime. */
@@ -92,11 +95,13 @@ function parseSystemdUnit(content: string): {
   wants: Set<string>;
   restartSec?: string;
   killMode?: string;
+  effectiveTimeoutStopSec?: string;
 } {
   const after = new Set<string>();
   const wants = new Set<string>();
   let restartSec: string | undefined;
   let killMode: string | undefined;
+  let effectiveTimeoutStopSec: string | undefined;
 
   // Parse only unit keys relevant to service resilience; this is not a full
   // systemd parser and intentionally ignores sections.
@@ -136,10 +141,14 @@ function parseSystemdUnit(content: string): {
       restartSec = value;
     } else if (key === "KillMode") {
       killMode = value;
+    } else if (key === "TimeoutStopSec") {
+      effectiveTimeoutStopSec = value;
+    } else if (key === "TimeoutSec") {
+      effectiveTimeoutStopSec = value;
     }
   }
 
-  return { after, wants, restartSec, killMode };
+  return { after, wants, restartSec, killMode, effectiveTimeoutStopSec };
 }
 
 function isRestartSecPreferred(value: string | undefined): boolean {
@@ -147,21 +156,121 @@ function isRestartSecPreferred(value: string | undefined): boolean {
     return false;
   }
   const parsed = parseSystemdRestartSecSeconds(value);
-  if (parsed === undefined) {
+  if (parsed === undefined || parsed === "infinity") {
     return false;
   }
   return Math.abs(parsed - 5) < 0.01;
 }
 
-function parseSystemdRestartSecSeconds(value: string): number | undefined {
-  const match = value
-    .trim()
-    .match(/^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(?:\s*(?:s|sec|secs|second|seconds))?$/iu);
+function parseSystemdRestartSecSeconds(value: string): number | "infinity" | undefined {
+  return parseSystemdDurationSeconds(value);
+}
+
+const SYSTEMD_DURATION_UNIT_SECONDS: Record<string, number> = {
+  usec: 0.000001,
+  us: 0.000001,
+  "\u03bcs": 0.000001,
+  msec: 0.001,
+  ms: 0.001,
+  millisecond: 0.001,
+  milliseconds: 0.001,
+  s: 1,
+  sec: 1,
+  secs: 1,
+  second: 1,
+  seconds: 1,
+  m: 60,
+  min: 60,
+  mins: 60,
+  minute: 60,
+  minutes: 60,
+  h: 3600,
+  hr: 3600,
+  hrs: 3600,
+  hour: 3600,
+  hours: 3600,
+  d: 86400,
+  day: 86400,
+  days: 86400,
+  w: 604800,
+  week: 604800,
+  weeks: 604800,
+  M: 2630016,
+  month: 2630016,
+  months: 2630016,
+  y: 31557600,
+  year: 31557600,
+  years: 31557600,
+};
+
+function normalizeSystemdDurationUnit(unit: string): string {
+  return unit === "M" ? unit : unit.toLowerCase();
+}
+
+function parseSystemdDurationSeconds(value: string): number | "infinity" | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (normalizeLowercaseStringOrEmpty(trimmed) === "infinity") {
+    return "infinity";
+  }
+
+  let consumed = 0;
+  let totalSeconds = 0;
+  const tokenRe =
+    /([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*(milliseconds|millisecond|msec|ms|seconds|second|secs|sec|s|minutes|minute|mins|min|months|month|hours|hour|hrs|hr|h|days|day|weeks|week|years|year|usec|us|\u03bcs|M|m|d|w|y)?/gu;
+  for (const match of trimmed.matchAll(tokenRe)) {
+    const [full, valueRaw, unitRaw] = match;
+    const index = match.index ?? -1;
+    if (!full || !valueRaw || index < 0) {
+      return undefined;
+    }
+    if (trimmed.slice(consumed, index).trim()) {
+      return undefined;
+    }
+    const valueNumber = Number(valueRaw);
+    if (!Number.isFinite(valueNumber) || valueNumber < 0) {
+      return undefined;
+    }
+    if (!unitRaw && full.length > valueRaw.length) {
+      return undefined;
+    }
+    const unit = unitRaw ? normalizeSystemdDurationUnit(unitRaw) : "s";
+    const multiplier = SYSTEMD_DURATION_UNIT_SECONDS[unit];
+    if (multiplier === undefined) {
+      return undefined;
+    }
+    totalSeconds += valueNumber * multiplier;
+    consumed = index + full.length;
+  }
+  if (consumed === 0 || trimmed.slice(consumed).trim()) {
+    return undefined;
+  }
+  return Number.isFinite(totalSeconds) ? totalSeconds : undefined;
+}
+
+function isStopTimeoutPreferred(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const parsed = parseSystemdDurationSeconds(value);
+  return (
+    parsed === "infinity" ||
+    (parsed !== undefined && (parsed === 0 || parsed >= GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS))
+  );
+}
+
+function readLaunchdInteger(content: string, key: string): number | undefined {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = content.match(
+    new RegExp(`<key>${escapedKey}</key>\\s*<integer>\\s*([+-]?\\d+)\\s*</integer>`, "iu"),
+  );
   if (!match) {
     return undefined;
   }
   const parsed = Number(match[1]);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 async function auditSystemdUnit(
@@ -198,6 +307,15 @@ async function auditSystemdUnit(
       code: SERVICE_AUDIT_CODES.systemdRestartSec,
       message: "RestartSec does not match the recommended 5s",
       detail: unitPath,
+      level: "recommended",
+    });
+  }
+  const stopTimeout = parsed.effectiveTimeoutStopSec;
+  if (!isStopTimeoutPreferred(stopTimeout)) {
+    issues.push({
+      code: SERVICE_AUDIT_CODES.systemdTimeoutStopTooShort,
+      message: `TimeoutStopSec should be at least ${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}s so the gateway can finish restart drain.`,
+      detail: `${unitPath}: ${stopTimeout || "unset"}`,
       level: "recommended",
     });
   }
@@ -239,6 +357,18 @@ async function auditLaunchdPlist(
       code: SERVICE_AUDIT_CODES.launchdKeepAlive,
       message: "LaunchAgent is missing KeepAlive=true",
       detail: plistPath,
+      level: "recommended",
+    });
+  }
+  const exitTimeout = readLaunchdInteger(content, "ExitTimeOut");
+  if (
+    exitTimeout === undefined ||
+    (exitTimeout !== 0 && exitTimeout < GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS)
+  ) {
+    issues.push({
+      code: SERVICE_AUDIT_CODES.launchdExitTimeoutTooShort,
+      message: `LaunchAgent ExitTimeOut should be at least ${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}s so the gateway can finish restart drain.`,
+      detail: `${plistPath}: ${exitTimeout ?? "unset"}`,
       level: "recommended",
     });
   }

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -71,7 +71,7 @@ export const SERVICE_AUDIT_CODES = {
   systemdAfterNetworkOnline: "systemd-after-network-online",
   systemdRestartSec: "systemd-restart-sec",
   systemdWantsNetworkOnline: "systemd-wants-network-online",
-  systemdKillModeProcessOrNone: "systemd-kill-mode-process-or-none",
+  systemdKillModeNotMixed: "systemd-kill-mode-not-mixed",
 } as const;
 
 /** Returns whether audit issues require migrating a daemon to a stable Node runtime. */
@@ -202,12 +202,11 @@ async function auditSystemdUnit(
     });
   }
   const killMode = normalizeLowercaseStringOrEmpty(parsed.killMode);
-  if (killMode === "process" || killMode === "none") {
+  if (killMode !== "mixed") {
     issues.push({
-      code: SERVICE_AUDIT_CODES.systemdKillModeProcessOrNone,
-      message:
-        "KillMode is process/none; service child processes can survive gateway stops and restarts.",
-      detail: `${unitPath}: ${killMode}`,
+      code: SERVICE_AUDIT_CODES.systemdKillModeNotMixed,
+      message: "KillMode should be mixed so the gateway can drain before child cleanup.",
+      detail: `${unitPath}: ${killMode || "unset"}`,
       level: "recommended",
     });
   }

--- a/src/daemon/service-stop-timeout.ts
+++ b/src/daemon/service-stop-timeout.ts
@@ -1,0 +1,3 @@
+// Default restart drain is 300s; service supervisors need reserve time for
+// close handoff before escalating to a hard kill.
+export const GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS = 330;

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,6 @@
 // Systemd unit tests cover generated systemd unit files.
 import { describe, expect, it } from "vitest";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 import { buildSystemdUnit } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
@@ -20,7 +21,7 @@ describe("buildSystemdUnit", () => {
       environment: {},
     });
     expect(unit).toContain("KillMode=mixed");
-    expect(unit).toContain("TimeoutStopSec=330");
+    expect(unit).toContain(`TimeoutStopSec=${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}`);
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");
     expect(unit).toContain("StartLimitBurst=5");

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -13,14 +13,14 @@ describe("buildSystemdUnit", () => {
     expect(execStart).toBe('ExecStart=/usr/bin/openclaw gateway --name "My Bot"');
   });
 
-  it("renders control-group kill mode for child-process cleanup", () => {
+  it("renders mixed kill mode with enough stop budget for restart drain", () => {
     const unit = buildSystemdUnit({
       description: "OpenClaw Gateway",
       programArguments: ["/usr/bin/openclaw", "gateway", "run"],
       environment: {},
     });
-    expect(unit).toContain("KillMode=control-group");
-    expect(unit).toContain("TimeoutStopSec=30");
+    expect(unit).toContain("KillMode=mixed");
+    expect(unit).toContain("TimeoutStopSec=330");
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");
     expect(unit).toContain("StartLimitBurst=5");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -78,12 +78,12 @@ export function buildSystemdUnit({
     "Restart=always",
     "RestartSec=5",
     "RestartPreventExitStatus=78",
-    "TimeoutStopSec=30",
+    "TimeoutStopSec=330",
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",
-    // Keep service children in the same lifecycle so restarts do not leave
-    // orphan ACP/runtime workers behind.
-    "KillMode=control-group",
+    // Let the gateway drain active runs before systemd terminates child
+    // workers, while still cleaning up the cgroup if the stop timeout expires.
+    "KillMode=mixed",
     workingDirLine,
     ...environmentFileLines,
     ...envLines,

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -1,6 +1,7 @@
 /** Renders and parses systemd unit snippets for managed gateway services. */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
+import { GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS } from "./service-stop-timeout.js";
 import type { GatewayServiceRenderArgs } from "./service-types.js";
 
 const SYSTEMD_LINE_BREAKS = /[\r\n]/;
@@ -78,7 +79,7 @@ export function buildSystemdUnit({
     "Restart=always",
     "RestartSec=5",
     "RestartPreventExitStatus=78",
-    "TimeoutStopSec=330",
+    `TimeoutStopSec=${GATEWAY_SERVICE_STOP_TIMEOUT_SECONDS}`,
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",
     // Let the gateway drain active runs before systemd terminates child


### PR DESCRIPTION
## Summary

- Change generated systemd gateway units from `KillMode=control-group` to `KillMode=mixed` so systemd sends the initial stop signal to the gateway main process before final cgroup cleanup.
- Centralize the managed gateway service stop budget at `330s`, covering the gateway's default 300s restart drain window plus shutdown reserve.
- Apply the same stop budget to macOS LaunchAgent `ExitTimeOut` so launchd does not SIGKILL the gateway before the default restart drain can finish.
- Update daemon tests, service audit, and Linux service docs so non-`mixed` systemd units and stale supervisor stop budgets are flagged instead of left healthy.

## Root Cause / Evidence

This fixes a narrow restart lifecycle mismatch observed on a real systemd-user OpenClaw gateway while applying a Telegram agent config change.

Observed timeline from the user service journal:

- `2026-06-03 15:46:22 UTC`: gateway detected config changes for `agents.list`, bindings, and the new Telegram group.
- `2026-06-03 15:46:23 UTC`: channel reload was deferred because `4 operation(s), 2 reply(ies), 2 embedded run(s)` were still active.
- `2026-06-03 15:49:13 UTC`: the gateway tool requested a restart to apply the Clawtributor agent config.
- `2026-06-03 15:51:08 UTC`: systemd delivered `SIGTERM`; the gateway logged that it was draining `4 active task(s)` and `2 active embedded run(s)` with timeout `300000ms`.
- `2026-06-03 15:51:08 UTC`: active Codex app-server stdio clients closed before turn completion, surfacing `codex app-server client closed before turn completed`.
- `2026-06-03 15:51:15 UTC`: the gateway finished draining and exited cleanly for a full supervisor restart.
- `2026-06-03 15:51:26 UTC`: the replacement gateway was listening again.

Code evidence:

- `src/cli/gateway-cli/run-loop.ts` already gives normal restarts a 300s active-work drain budget.
- `src/agents/embedded-agent-runner/runs.ts` waits for active embedded runs to release session locks during restarts.
- `extensions/codex/src/app-server/run-attempt.ts` converts a closed app-server client before terminal turn notification into the exact prompt error seen in the journal.
- Upstream Codex app-server stdio is single-client style: `--listen stdio://` is the default transport, EOF closes the connection, and app-server exits its accept loop when no stdio connections remain.
- The generated OpenClaw systemd unit previously used `KillMode=control-group` and `TimeoutStopSec=30`, so systemd could signal all child app-server processes in the gateway cgroup while the gateway itself was trying to drain them.
- The generated macOS LaunchAgent previously used `ExitTimeOut=20`, which is also shorter than the default 300s restart drain.

`KillMode=mixed` preserves cgroup cleanup: systemd sends `SIGTERM` to the main process first, then still uses final cgroup cleanup if the stop timeout expires. That matches the gateway's drain ownership better than sending the initial stop signal to every child process.

## Scope Notes

This draft intentionally keeps the fix bounded to the generated supervisor defaults and docs.

One remaining edge is intentionally left as maintainer follow-up: `gateway.reload.deferralTimeoutMs` can be configured above the default 300s drain. This PR aligns systemd and launchd with the default budget, but it does not make service rendering derive `TimeoutStopSec` / `ExitTimeOut` from runtime config. Doing that would require threading reload config into the daemon service render/install path and is a larger config-surface change than this evidence PR needs.

## Real behavior proof

Behavior addressed: planned supervised gateway restarts can interrupt active child-process stdio runtimes before the gateway's own restart drain completes.

Real environment tested: Linux systemd-user OpenClaw gateway running from this checkout with `openclaw-gateway.service`, active child `codex app-server --listen stdio://` processes in the gateway cgroup, and the live incident journal described above.

Exact steps or command run after this patch:

```sh
node --import tsx -e "import { buildSystemdUnit } from './src/daemon/systemd-unit.ts'; const unit = buildSystemdUnit({ description: 'OpenClaw Gateway', programArguments: ['/usr/bin/node', '/repo/dist/index.js', 'gateway'], environment: {} }); console.log(unit.match(/^(TimeoutStopSec|KillMode)=.*$/gm).join('\\n'));"
node scripts/run-vitest.mjs src/daemon/service-audit.test.ts src/daemon/systemd-unit.test.ts src/daemon/launchd.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/daemon/service-audit.ts src/daemon/service-audit.test.ts
node_modules/.bin/oxfmt --write --threads=1 src/daemon/service-audit.ts src/daemon/service-audit.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:

```text
TimeoutStopSec=330
KillMode=mixed
```

Targeted tests passed:

```text
Test Files  1 passed (1)
Tests  4 passed (4)
Test Files  2 passed (2)
Tests  131 passed | 14 skipped (145)
```

Observed result after fix: the generated systemd unit now gives the gateway enough stop budget for the existing 300s restart drain and sends the initial stop signal to the gateway main process before child-process cgroup cleanup. The generated LaunchAgent now gives launchd the same 330s stop budget before SIGKILL. The service audit now flags unset or non-`mixed` systemd `KillMode` values, stale systemd stop budgets via `TimeoutStopSec` / ordered `TimeoutSec`, and stale launchd `ExitTimeOut` values so existing units can be repaired to the new drain-preserving policy.

What was not tested: I did not reinstall this patched unit/plist on a live gateway or trigger a new live restart while active Codex turns were running. This draft intentionally includes the production timeline so maintainers can decide whether they want a broader E2E restart proof before review-ready status.

## Verification

- `node scripts/run-vitest.mjs src/daemon/service-audit.test.ts src/daemon/systemd-unit.test.ts src/daemon/launchd.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/daemon/service-audit.ts src/daemon/service-audit.test.ts`
- `node_modules/.bin/oxfmt --write --threads=1 src/daemon/service-audit.ts src/daemon/service-audit.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings

## AI Assistance

This PR is AI-assisted. I checked the generated service configs, daemon tests, the real systemd journal timeline, launchd/systemd stop-timeout behavior, and the relevant Codex app-server stdio behavior before opening and updating the draft.


