### PR TITLE
fix(diagnostics): reclaim zombie embedded-run counters left idle by handle-mismatch clears

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -3,6 +3,7 @@ import { resolveEmbeddedSessionLane } from "../agents/embedded-agent-runner/lane
 import {
   testing as embeddedRunTesting,
   clearActiveEmbeddedRun,
+  isEmbeddedAgentRunHandleActive,
   setActiveEmbeddedRun,
 } from "../agents/embedded-agent-runner/runs.js";
 import {
@@ -15,10 +16,12 @@ import {
   resetCommandLane,
   resetCommandQueueStateForTest,
 } from "../process/command-queue.js";
+import { markDiagnosticEmbeddedRunStarted } from "./diagnostic-run-activity.js";
 import {
   testing as recoveryTesting,
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
+import { logSessionStateChange, resetDiagnosticStateForTest } from "./diagnostic.js";
 
 function delay(ms: number): Promise<"blocked"> {
   return new Promise((resolve) => {
@@ -30,6 +33,7 @@ describe("stuck session recovery integration", () => {
   afterEach(() => {
     recoveryTesting.resetRecoveriesInFlight();
     embeddedRunTesting.resetActiveEmbeddedRuns();
+    resetDiagnosticStateForTest();
     replyRunTesting.resetReplyRunRegistry();
     resetCommandQueueStateForTest();
   });
@@ -158,6 +162,44 @@ describe("stuck session recovery integration", () => {
     await expect(queued).resolves.toBe("drained");
     expect(outcome.status).toBe("aborted");
     expect(getQueueSize(lane)).toBe(0);
+  });
+
+  it("force-clears a zombie ACTIVE_EMBEDDED_RUNS entry when recovery runs with allowActiveAbort on an idle session", async () => {
+    const sessionKey = "agent:main:zombie-idle";
+    const sessionId = "zombie-idle-session";
+    let selfCleared = false;
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => false,
+      isCompacting: () => false,
+      abort: () => {
+        // Simulate the run's abort handler completing and self-clearing
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+        selfCleared = true;
+      },
+    };
+
+    // Zombie: run registered but never cleared (handle mismatch scenario)
+    logSessionStateChange({ sessionId, sessionKey, state: "processing", reason: "run_started" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+    // Dispatcher marks the session idle (clearActiveEmbeddedRun was skipped)
+    logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "message_completed" });
+
+    expect(isEmbeddedAgentRunHandleActive(sessionId)).toBe(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 420_000,
+      queueDepth: 0,
+      allowActiveAbort: true,
+      expectedState: "idle",
+    });
+
+    expect(outcome.status).toBe("aborted");
+    expect(selfCleared).toBe(true);
+    expect(isEmbeddedAgentRunHandleActive(sessionId)).toBe(false);
   });
 
   it("does not reset a blocked lane while unregistered lane work is still active", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -819,6 +819,106 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("recovers a zombie embedded-run counter when the session is idle with no queued work", () => {
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    // Embedded run starts and the session processes normally...
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    // Dispatcher calls markIdle() — session goes idle — but the embedded-run
+    // counter leaks (clearActiveEmbeddedRun was skipped via handle mismatch).
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    vi.advanceTimersByTime(stuckSessionAbortMs + 30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 0,
+        allowActiveAbort: true,
+        expectedState: "idle",
+      },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
+  it("does not trigger zombie-counter recovery when the embedded run ended cleanly", () => {
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticEmbeddedRunEnded({ sessionId: "s1", sessionKey: "main" });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    vi.advanceTimersByTime(stuckSessionAbortMs + 30_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("recovers a zombie embedded-run counter even after RECENT_DIAGNOSTIC_ACTIVITY_MS with no other session activity", () => {
+    // Regression for the default-threshold gap: stuckSessionAbortMs (≥5 min) exceeds
+    // RECENT_DIAGNOSTIC_ACTIVITY_MS (2 min). Without zombieEmbeddedRunCount in the work
+    // snapshot the heartbeat would return early after 2 min and never reach the idle
+    // zombie scan — recovery would not fire until a manual restart.
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 120_000;
+    const stuckSessionAbortMs = 360_000; // > RECENT_DIAGNOSTIC_ACTIVITY_MS (120_000)
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    vi.advanceTimersByTime(stuckSessionAbortMs + 30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 0,
+        allowActiveAbort: true,
+        expectedState: "idle",
+      },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("does not recover stale model calls without active embedded-run ownership", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -98,6 +98,7 @@ type DiagnosticWorkSnapshot = {
   activeCount: number;
   waitingCount: number;
   queuedCount: number;
+  zombieEmbeddedRunCount: number;
   activeLabels: string[];
   waitingLabels: string[];
   queuedLabels: string[];
@@ -207,6 +208,7 @@ function getDiagnosticWorkSnapshot(now = Date.now()): DiagnosticWorkSnapshot {
   let activeCount = 0;
   let waitingCount = 0;
   let queuedCount = 0;
+  let zombieEmbeddedRunCount = 0;
   const activeLabels: string[] = [];
   const waitingLabels: string[] = [];
   const queuedLabels: string[] = [];
@@ -227,13 +229,38 @@ function getDiagnosticWorkSnapshot(now = Date.now()): DiagnosticWorkSnapshot {
       pushLimitedDiagnosticLabel(queuedLabels, formatDiagnosticWorkLabel(state, now));
     }
     queuedCount += queuedBacklog;
+    // Count idle sessions with stale embedded-run activity so the heartbeat scan
+    // keeps running until the zombie is eligible for recovery (stuckSessionAbortMs),
+    // preventing the activity gate from suppressing isIdleZombieEmbeddedRunStall.
+    if (state.state === "idle" && queuedBacklog <= 0) {
+      const activity = getDiagnosticSessionActivitySnapshot(
+        { sessionId: state.sessionId, sessionKey: state.sessionKey },
+        now,
+      );
+      if (activity.hasActiveEmbeddedRun === true) {
+        zombieEmbeddedRunCount += 1;
+      }
+    }
   }
 
-  return { activeCount, waitingCount, queuedCount, activeLabels, waitingLabels, queuedLabels };
+  return {
+    activeCount,
+    waitingCount,
+    queuedCount,
+    zombieEmbeddedRunCount,
+    activeLabels,
+    waitingLabels,
+    queuedLabels,
+  };
 }
 
 function hasOpenDiagnosticWork(snapshot: DiagnosticWorkSnapshot): boolean {
-  return snapshot.activeCount > 0 || snapshot.waitingCount > 0 || snapshot.queuedCount > 0;
+  return (
+    snapshot.activeCount > 0 ||
+    snapshot.waitingCount > 0 ||
+    snapshot.queuedCount > 0 ||
+    snapshot.zombieEmbeddedRunCount > 0
+  );
 }
 
 function hasRecentDiagnosticActivity(now: number): boolean {
@@ -558,6 +585,25 @@ function isIdleQueuedRecoverableSessionStall(params: {
     params.state.state === "idle" &&
     params.state.queueDepth > 0 &&
     (hasEmbeddedOwner || hasOrphanedActivity) &&
+    (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
+  );
+}
+
+// Detects a zombie embedded-run counter: session is idle with no queue, but diagnostic
+// activity still shows an active embedded run past the abort threshold. Without this,
+// handle-mismatch zombies are invisible to the processing-state and queued-idle paths.
+function isIdleZombieEmbeddedRunStall(params: {
+  state: {
+    state: SessionStateValue;
+    queueDepth: number;
+  };
+  activity: DiagnosticSessionActivitySnapshot;
+  staleMs: number;
+}): boolean {
+  return (
+    params.state.state === "idle" &&
+    params.state.queueDepth <= 0 &&
+    params.activity.hasActiveEmbeddedRun === true &&
     (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
   );
 }
@@ -1249,13 +1295,20 @@ export function startDiagnosticHeartbeat(
         activity,
         staleMs: stuckSessionWarnMs,
       });
+      const idleZombieStall = isIdleZombieEmbeddedRunStall({
+        state,
+        activity,
+        staleMs: stuckSessionAbortMs,
+      });
       if (
         (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
-        idleQueuedRecoverableStall
+        idleQueuedRecoverableStall ||
+        idleZombieStall
       ) {
-        const attentionAgeMs = idleQueuedRecoverableStall
-          ? (activity.lastProgressAgeMs ?? ageMs)
-          : ageMs;
+        const attentionAgeMs =
+          idleQueuedRecoverableStall || idleZombieStall
+            ? (activity.lastProgressAgeMs ?? ageMs)
+            : ageMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,


### PR DESCRIPTION
### Summary

- **Problem**: Issue #90240 reports a 30+ minute session stall: after rapid back-to-back turns, `getActiveEmbeddedRunCount()` stays at 1 despite no active run. All subsequent inbound messages queue as follow-ups to a non-existent run; the session silently stalls until manual gateway restart.
- **Root cause (unconfirmed)**: Something on the cleanup path of a back-to-back turn leaves a stale entry in `ACTIVE_EMBEDDED_RUNS` and/or `activity.activeEmbeddedRuns`. The most likely mechanism is a handle-mismatch clear skip, but the exact production race could not be reproduced deterministically from code analysis alone. The reporter's trajectory confirms the state corruption is real; the precise trigger requires a live reproduction.
- **What this PR fixes (mitigation, not root cause)**: The recovery system is blind to this zombie state. After the dispatch completes, `markIdle()` sets diagnostic state to "idle" with `queueDepth=0`. The heartbeat's two recovery conditions require either `state === "processing"` or `queueDepth > 0` — neither fires. Additionally, after 2 min of no other session activity (`RECENT_DIAGNOSTIC_ACTIVITY_MS`), `shouldRecordMemorySample` returns false and the per-session scan loop is skipped entirely, so the zombie is never even evaluated. This PR adds the missing zombie detection so the system self-heals within `stuckSessionAbortMs` (~6 min default) instead of requiring a manual restart.
- **Fix**:
  - `isIdleZombieEmbeddedRunStall`: new heartbeat predicate — fires when a session is idle with no queue depth, `hasActiveEmbeddedRun=true` in diagnostic activity, and `lastProgressAgeMs > stuckSessionAbortMs`.
  - `zombieEmbeddedRunCount` in `getDiagnosticWorkSnapshot`: keeps `shouldRecordMemorySample=true` while zombie sessions exist, preventing `RECENT_DIAGNOSTIC_ACTIVITY_MS` from suppressing the per-session scan loop before `stuckSessionAbortMs` is reached.
  - Both changes together route through the existing `isStalledEmbeddedRunRecoveryEligible` → `allowActiveAbort:true` → `forceClearEmbeddedAgentRun` path to reclaim the stale counter.
- **What changed**:
  - `src/logging/diagnostic.ts` — add `isIdleZombieEmbeddedRunStall`; add `zombieEmbeddedRunCount` to `getDiagnosticWorkSnapshot`/`hasOpenDiagnosticWork`; include `idleZombieStall` in heartbeat condition.
  - `src/logging/diagnostic.test.ts` — three new cases: zombie detection fires with `allowActiveAbort:true/expectedState:"idle"`; no recovery when run ended cleanly; zombie detection fires even after `RECENT_DIAGNOSTIC_ACTIVITY_MS` with no other session activity (default-threshold regression).
  - `src/logging/diagnostic-stuck-session-recovery.integration.test.ts` — new case: `recoverStuckDiagnosticSession` with `allowActiveAbort:true/expectedState:"idle"` force-clears a zombie `ACTIVE_EMBEDDED_RUNS` entry.
- **What did NOT change (scope boundary)**:
  - The zombie creation path itself (root cause) is unchanged — this PR does not prevent the zombie from forming.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.

### Reproduction

1. Start a Slack DM session on `anthropic/claude-opus-4-7`.
2. Send a prompt that produces a single very large assistant turn (~48k output tokens, 9 min wall clock).
3. Immediately send a follow-up message so turn N+1 starts within the same second turn N ends — two rapid back-to-back turns.
4. Send further messages ~10 minutes later.
5. Run `openclaw gateway restart` and observe the drain banner at SIGTERM.

**Before this PR**: drain banner reports `1 active embedded run(s)` even though the last `model.completed` fired ~24 min earlier; all messages sent during the silent window produce no model turn. Only a manual restart unblocks the session.

**After this PR**: at `stuckSessionAbortMs` (~6 min default) after the last diagnostic progress event, the heartbeat's `isIdleZombieEmbeddedRunStall` fires, recovery force-clears the stale counter, and the next inbound message dispatches normally.

### Real behavior proof

**Behavior addressed (Fixes #90240)**: the zombie counter in `ACTIVE_EMBEDDED_RUNS` and `activity.activeEmbeddedRuns` is reclaimed by the heartbeat after `stuckSessionAbortMs` of no progress; subsequent messages dispatch without a gateway restart. The outage window is bounded to ~6 min (default) rather than requiring manual intervention.

**Real environment tested (Linux, Node 22 — Vitest against the production heartbeat, diagnostic-run-activity store, and recovery coordinator)**: deterministic zombie state constructed via `setActiveEmbeddedRun` + `logSessionStateChange("idle")` without calling `clearActiveEmbeddedRun`; recovery dispatched through the real `abortAndDrainEmbeddedAgentRun` → `forceClearEmbeddedAgentRun` path.

**Exact steps or command run after this patch**: `pnpm test src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on changed files.

**Evidence after fix**:

```
 diagnostic.test.ts                                      76 passed (76)
 diagnostic-stuck-session-recovery.integration.test.ts   5 passed (5)
```

**Observed result after fix**: zombie recovery fires with `{ allowActiveAbort: true, expectedState: "idle", queueDepth: 0 }` at `stuckSessionAbortMs`; fires even at `stuckSessionAbortMs=360_000 > RECENT_DIAGNOSTIC_ACTIVITY_MS=120_000` with no other session activity (default-threshold regression). `isEmbeddedAgentRunHandleActive` returns false after recovery. Negative case confirms the path does not fire when `markDiagnosticEmbeddedRunEnded` ran cleanly.

**What was not tested**: live Slack DM session with the exact zombie-triggering race. The root cause race is non-deterministic; the zombie state was constructed directly from state primitives.

### Risk / Mitigation

- **Risk**: False positive — a legitimately long-running turn gets aborted. **Mitigation**: `lastProgressAgeMs > stuckSessionAbortMs` (≥6 min default) is far above normal tool/model streaming cadence; active runs emit frequent progress events.
- **Risk**: `zombieEmbeddedRunCount` keeps `shouldRecordMemorySample=true` for sessions in transient idle+embedded_run state (before teardown completes). **Mitigation**: cosmetic only — the actual recovery gate (`isIdleZombieEmbeddedRunStall`) is correctly gated on `stuckSessionAbortMs`; the only effect is the memory sample runs a few extra ticks until teardown finishes.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Diagnostics / logging
- [x] Gateway / session runtime

### Linked Issue/PR

Fixes #90240