### PR TITLE
fix(mcp): quarantine unreadable plugin tool schemas

### DIFF
--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -5,7 +5,10 @@
  */
 import { copyPluginToolMeta } from "../plugins/tools.js";
 import { bindAbortRelay } from "../utils/fetch-timeout.js";
-import { copyBeforeToolCallHookMarker } from "./agent-tools.before-tool-call.js";
+import {
+  copyAgentToolWithExecute,
+  copyBeforeToolCallHookMarker,
+} from "./agent-tools.before-tool-call.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 
@@ -63,16 +66,16 @@ export function wrapToolWithAbortSignal(
   if (!execute) {
     return tool;
   }
-  const wrappedTool: AnyAgentTool = {
-    ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+  const wrappedTool = copyAgentToolWithExecute(
+    tool,
+    async (toolCallId, params, signal, onUpdate) => {
       const combined = combineAbortSignals(signal, abortSignal);
       if (combined?.aborted) {
         throwAbortError();
       }
       return await execute(toolCallId, params, combined, onUpdate);
     },
-  };
+  );
   copyPluginToolMeta(tool, wrappedTool);
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   copyBeforeToolCallHookMarker(tool, wrappedTool);

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -20,6 +20,7 @@ import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
+import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
   getBeforeToolCallPolicyDiagnosticState,
   runBeforeToolCallHook,
@@ -566,6 +567,166 @@ describe("before_tool_call loop detection behavior", () => {
         toolOwner: "bundle-mcp",
       });
     });
+  });
+
+  it("wraps plugin tools without eagerly reading parameter schema getters", async () => {
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const execute = vi.fn().mockResolvedValue(result);
+    const rawTool = {
+      name: "hostile_schema",
+      description: "Hostile schema",
+      execute,
+    } as unknown as AnyAgentTool;
+    Object.defineProperty(rawTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    let tool: AnyAgentTool | undefined;
+    expect(() => {
+      tool = wrapToolWithBeforeToolCallHook(rawTool, {
+        agentId: "main",
+        sessionKey: "session-key",
+        loopDetection: { enabled: false },
+      });
+    }).not.toThrow();
+
+    expect(() => tool?.parameters).toThrow("parameters getter exploded");
+    await expect(tool?.execute("tool-call-hostile-schema", {}, undefined, undefined)).resolves.toBe(
+      result,
+    );
+    expect(execute).toHaveBeenCalledWith("tool-call-hostile-schema", {}, undefined, undefined);
+  });
+
+  it("keeps unreadable schema getters lazy when abort wrapping a hooked tool", async () => {
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const execute = vi.fn().mockResolvedValue(result);
+    const rawTool = {
+      name: "hostile_schema_abort",
+      description: "Hostile schema abort",
+      execute,
+    } as unknown as AnyAgentTool;
+    Object.defineProperty(rawTool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+    const hooked = wrapToolWithBeforeToolCallHook(rawTool, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    let tool: AnyAgentTool | undefined;
+    expect(() => {
+      tool = wrapToolWithAbortSignal(hooked, new AbortController().signal);
+    }).not.toThrow();
+
+    await expect(
+      tool?.execute("tool-call-hostile-schema-abort", {}, undefined, undefined),
+    ).resolves.toBe(result);
+  });
+
+  it("preserves source receiver semantics for wrapped tool schema getters", () => {
+    const parameters = { type: "object", properties: { query: { type: "string" } } };
+    const parameterState = new WeakMap<object, typeof parameters>();
+    const execute = vi.fn();
+    const rawTool = {
+      name: "stateful_schema",
+      description: "Stateful schema",
+      execute,
+    } as unknown as AnyAgentTool;
+    Object.defineProperty(rawTool, "parameters", {
+      enumerable: true,
+      get() {
+        const value = parameterState.get(this);
+        if (!value) {
+          throw new Error("missing schema state");
+        }
+        return value;
+      },
+    });
+    parameterState.set(rawTool, parameters);
+
+    const tool = wrapToolWithBeforeToolCallHook(rawTool, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    expect(tool.parameters).toBe(parameters);
+  });
+
+  it("preserves class-backed private schema getters when wrapping tools", () => {
+    const parameters = { type: "object", properties: { query: { type: "string" } } };
+    const executeMock = vi.fn();
+    class PrivateSchemaTool {
+      #name = "private_schema";
+      #parameters = parameters;
+      #executionMode = "sequential" as const;
+      description = "Private schema";
+      execute = executeMock;
+
+      get name() {
+        return this.#name;
+      }
+
+      get parameters() {
+        return this.#parameters;
+      }
+
+      get executionMode() {
+        return this.#executionMode;
+      }
+
+      prepareArguments(args: unknown) {
+        return { [this.#name]: args };
+      }
+    }
+
+    const rawTool = new PrivateSchemaTool() as unknown as AnyAgentTool;
+    const tool = wrapToolWithBeforeToolCallHook(rawTool, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    expect(tool.name).toBe("private_schema");
+    expect(tool.parameters).toBe(parameters);
+    expect(tool.executionMode).toBe("sequential");
+    expect(tool.prepareArguments?.("status")).toEqual({ private_schema: "status" });
+  });
+
+  it("can wrap an already wrapped tool without copying internal wrapper markers", async () => {
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const execute = vi.fn().mockResolvedValue(result);
+    const rawTool = {
+      name: "double_wrapped",
+      description: "Double wrapped",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+    const first = wrapToolWithBeforeToolCallHook(rawTool, {
+      agentId: "main",
+      sessionKey: "session-key",
+      loopDetection: { enabled: false },
+    });
+
+    let second: AnyAgentTool | undefined;
+    expect(() => {
+      second = wrapToolWithBeforeToolCallHook(first, {
+        agentId: "main",
+        sessionKey: "session-key",
+        loopDetection: { enabled: false },
+      });
+    }).not.toThrow();
+
+    await expect(second?.execute("tool-call-double", {}, undefined, undefined)).resolves.toBe(
+      result,
+    );
   });
 
   it("emits skill usage diagnostics when a run reads a known skill instruction file", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -199,6 +199,12 @@ const BEFORE_TOOL_CALL_SOURCE_TOOL = Symbol("beforeToolCallSourceTool");
 const BEFORE_TOOL_CALL_HOOK_CONTEXT = Symbol("beforeToolCallHookContext");
 const BEFORE_TOOL_CALL_HOOK_FAILURE_REASON =
   "Tool call blocked because before_tool_call hook failed";
+const BEFORE_TOOL_CALL_INTERNAL_KEYS = new Set<PropertyKey>([
+  BEFORE_TOOL_CALL_WRAPPED,
+  BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
+  BEFORE_TOOL_CALL_SOURCE_TOOL,
+  BEFORE_TOOL_CALL_HOOK_CONTEXT,
+]);
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
@@ -284,6 +290,21 @@ type ToolDiagnosticIdentity = {
   toolOwner?: string;
 };
 
+const TOOL_FORWARD_KEYS = [
+  "name",
+  "label",
+  "description",
+  "promptSnippet",
+  "promptGuidelines",
+  "parameters",
+  "renderShell",
+  "prepareArguments",
+  "executionMode",
+  "displaySummary",
+  "prepareBeforeToolCallParams",
+  "finalizeBeforeToolCallParams",
+] as const;
+
 function resolveToolDiagnosticIdentity(tool: AnyAgentTool): ToolDiagnosticIdentity {
   const pluginMeta = getPluginToolMeta(tool);
   if (pluginMeta) {
@@ -296,6 +317,94 @@ function resolveToolDiagnosticIdentity(tool: AnyAgentTool): ToolDiagnosticIdenti
     return { toolSource: "channel", toolOwner: channelMeta.channelId };
   }
   return { toolSource: "core" };
+}
+
+function findPropertyDescriptor(source: object, key: PropertyKey): PropertyDescriptor | undefined {
+  let candidate: object | null = source;
+  while (candidate) {
+    const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+    if (descriptor) {
+      return descriptor;
+    }
+    candidate = Object.getPrototypeOf(candidate);
+  }
+  return undefined;
+}
+
+function defineForwardedToolProperty(params: {
+  target: object;
+  source: AnyAgentTool;
+  key: PropertyKey;
+  enumerable: boolean;
+  configurable: boolean;
+}): void {
+  Object.defineProperty(params.target, params.key, {
+    enumerable: params.enumerable,
+    configurable: params.configurable,
+    get: () => {
+      const value = Reflect.get(params.source, params.key, params.source);
+      return typeof value === "function" ? value.bind(params.source) : value;
+    },
+    set: (value: unknown) => {
+      Reflect.set(params.source, params.key, value, params.source);
+    },
+  });
+}
+
+export function copyAgentToolWithExecute(
+  tool: AnyAgentTool,
+  execute: AnyAgentTool["execute"],
+): AnyAgentTool {
+  // Preserve plugin-owned descriptors so schema getters stay lazy until the
+  // caller that needs the schema decides how to handle unreadable input.
+  const wrappedTool = {} as AnyAgentTool;
+  for (const key of Reflect.ownKeys(tool)) {
+    if (key === "execute" || BEFORE_TOOL_CALL_INTERNAL_KEYS.has(key)) {
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(tool, key);
+    if (!descriptor) {
+      continue;
+    }
+    if (descriptor.get || descriptor.set) {
+      defineForwardedToolProperty({
+        target: wrappedTool,
+        source: tool,
+        key,
+        enumerable: descriptor.enumerable,
+        configurable: descriptor.configurable,
+      });
+      continue;
+    }
+    Object.defineProperty(wrappedTool, key, descriptor);
+  }
+  for (const key of TOOL_FORWARD_KEYS) {
+    if (Object.hasOwn(wrappedTool, key)) {
+      continue;
+    }
+    try {
+      if (!Reflect.has(tool, key)) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    const descriptor = findPropertyDescriptor(tool, key);
+    defineForwardedToolProperty({
+      target: wrappedTool,
+      source: tool,
+      key,
+      enumerable: descriptor?.enumerable ?? false,
+      configurable: descriptor?.configurable ?? true,
+    });
+  }
+  Object.defineProperty(wrappedTool, "execute", {
+    value: execute,
+    enumerable: Object.getOwnPropertyDescriptor(tool, "execute")?.enumerable ?? true,
+    configurable: true,
+    writable: true,
+  });
+  return wrappedTool;
 }
 
 type SkillUsageMatch = {
@@ -1117,9 +1226,9 @@ export function wrapToolWithBeforeToolCallHook(
     ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
     emitDiagnostics: options.emitDiagnostics !== false,
   };
-  const wrappedTool: AnyAgentTool = {
-    ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+  const wrappedTool = copyAgentToolWithExecute(
+    tool,
+    async (toolCallId, params, signal, onUpdate) => {
       const prepare = (tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
       const preparedParams = prepare
         ? await prepare(params, {
@@ -1264,7 +1373,7 @@ export function wrapToolWithBeforeToolCallHook(
         throw err;
       }
     },
-  };
+  );
   copyPluginToolMeta(tool, wrappedTool);
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -12,12 +12,20 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
-function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
-  const params = tool.parameters;
-  if (params && typeof params === "object" && "type" in params) {
-    return params as Record<string, unknown>;
-  }
+function emptyInputSchema(): Record<string, unknown> {
   return { type: "object", properties: {} };
+}
+
+function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> | undefined {
+  try {
+    const params = Reflect.get(tool, "parameters");
+    if (params && typeof params === "object" && Reflect.has(params, "type")) {
+      return params as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return emptyInputSchema();
 }
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
@@ -29,17 +37,27 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
     // as the agent and HTTP tool execution paths.
     return wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
   });
-  const toolMap = new Map<string, AnyAgentTool>();
+  const listedTools: Array<{
+    tool: AnyAgentTool;
+    inputSchema: Record<string, unknown>;
+  }> = [];
   for (const tool of wrappedTools) {
+    const inputSchema = resolveJsonSchemaForTool(tool);
+    if (inputSchema) {
+      listedTools.push({ tool, inputSchema });
+    }
+  }
+  const toolMap = new Map<string, AnyAgentTool>();
+  for (const { tool } of listedTools) {
     toolMap.set(tool.name, tool);
   }
 
   return {
     listTools: async () => ({
-      tools: wrappedTools.map((tool) => ({
+      tools: listedTools.map(({ tool, inputSchema }) => ({
         name: tool.name,
         description: tool.description ?? "",
-        inputSchema: resolveJsonSchemaForTool(tool),
+        inputSchema,
       })),
     }),
     callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -174,6 +174,32 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
+  it("omits MCP tools with unreadable plugin tool parameters", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: "Stored." });
+    const tool = {
+      name: "hostile_schema",
+      description: "Hostile schema",
+      execute,
+    } as unknown as AnyAgentTool;
+    Object.defineProperty(tool, "parameters", {
+      enumerable: true,
+      get() {
+        throw new Error("parameters getter exploded");
+      },
+    });
+
+    const handlers = createPluginToolsMcpHandlers([tool]);
+    const listed = await handlers.listTools();
+    const result = await handlers.callTool({ name: "hostile_schema", arguments: {} });
+
+    expect(listed.tools).toEqual([]);
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Unknown tool: hostile_schema" }],
+      isError: true,
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {
     const execute = vi.fn().mockResolvedValue({
       provider: "kitchen-sink-search",


### PR DESCRIPTION
## Summary
- replace eager tool-object spreading in before_tool_call and abort wrappers with descriptor-preserving execution wrappers
- keep plugin/class-backed tool schema getters lazy and bound to the original tool receiver while forwarding expected AgentTool fields
- quarantine MCP plugin tools whose `parameters` schema cannot be read so they are neither listed nor callable through the MCP bridge

Related: https://github.com/openclaw/openclaw/pull/89493 covers the adjacent MCP-only invalid plugin schema quarantine path; this PR adds the wrapper-side guard that keeps before_tool_call/abort composition from forcing hostile schema getters.

## Verification
- `node scripts/run-vitest.mjs run src/mcp/plugin-tools-serve.test.ts` - passed 1 file / 8 tests on final head `ad76bdd0919`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/agent-tools.before-tool-call.e2e.test.ts` - passed 1 file / 55 tests on final head `ad76bdd0919`
- `./node_modules/.bin/oxfmt --check src/agents/agent-tools.before-tool-call.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.abort.ts src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `./node_modules/.bin/oxlint src/agents/agent-tools.before-tool-call.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.abort.ts src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings before the final docs-only rebase; focused tests and hygiene were rerun after that rebase

Blocked broader proof:
- `blacksmith testbox list --all` failed: not authenticated; requires `blacksmith auth login`
- `node scripts/crabbox-wrapper.mjs run --provider aws --label next203-check-changed --shell -- "pnpm check:changed"` failed before launch: Crabbox sparse-sync requires 1.00 GiB free; local cache filesystem had about 408 MiB free
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --label next203-check-changed --shell -- "env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed"` failed before launch for the same Crabbox sparse-sync disk preflight

## Real behavior proof
Behavior addressed: before this patch, before_tool_call wrapping and abort wrapping could eagerly read enumerable plugin tool `parameters` getters via object spread. The MCP plugin-tools bridge also read unreadable schemas during listing and could expose a tool without a readable input contract.

Real environment tested: focused local macOS Vitest coverage for the before_tool_call wrapper, abort wrapper composition, and plugin-tools MCP list/call behavior.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/mcp/plugin-tools-serve.test.ts`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`; focused `oxfmt`, `oxlint`, and `git diff --check` commands listed above.

Evidence after fix: the wrapper e2e test now covers lazy plugin schema getters, abort wrapping after before_tool_call wrapping, source receiver semantics, class private-field getters, and double wrapping without copying internal marker symbols. The MCP focused test verifies unreadable-schema tools are omitted from `listTools()` and return unknown-tool errors without executing.

Observed result after fix: schema access stays lazy until the consumer intentionally reads it; wrapper composition preserves plugin metadata and AgentTool fields; unreadable plugin MCP tools are quarantined from both listing and dispatch instead of crashing or executing with an unsafe fallback schema.

What was not tested: `pnpm check:changed` / broad remote gate, because Blacksmith auth is unavailable and Crabbox sparse-sync is blocked by local free disk; no live third-party MCP client session.
