### PR TITLE
fix(plugins): drop redundant generic on getPluginRunContext

### DIFF
--- a/src/plugins/host-hook-runtime.ts
+++ b/src/plugins/host-hook-runtime.ts
@@ -209,12 +209,11 @@ export function setPluginRunContext(params: {
   return true;
 }
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Run-context JSON reads are caller-typed by namespace.
 /** Reads previously stored plugin run context for one run/plugin/namespace tuple. */
-export function getPluginRunContext<T extends PluginJsonValue = PluginJsonValue>(params: {
+export function getPluginRunContext(params: {
   pluginId: string;
   get: PluginRunContextGetParams;
-}): T | undefined {
+}): PluginJsonValue | undefined {
   const runId = normalizeOptionalString(params.get.runId);
   const namespace = normalizeNamespace(params.get.namespace);
   if (!runId || !namespace) {
@@ -224,7 +223,7 @@ export function getPluginRunContext<T extends PluginJsonValue = PluginJsonValue>
     runId,
     pluginId: params.pluginId,
   })?.get(namespace);
-  return value === undefined ? undefined : (copyJsonValue(value) as T);
+  return value === undefined ? undefined : copyJsonValue(value);
 }
 
 export function clearPluginRunContext(params: {
@@ -309,7 +308,7 @@ export function dispatchPluginAgentEventSubscriptions(params: {
     const ctx = {
       // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Run-context JSON reads are caller-typed by namespace.
       getRunContext: <T extends PluginJsonValue = PluginJsonValue>(namespace: string) =>
-        getPluginRunContext<T>({ pluginId, get: { runId, namespace } }),
+        getPluginRunContext({ pluginId, get: { runId, namespace } }) as T | undefined,
       setRunContext: (namespace: string, value: PluginJsonValue) => {
         setPluginRunContext({
           pluginId,

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -214,7 +214,7 @@ describe("production lint suppressions", () => {
         "src/plugin-sdk/test-helpers/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugin-sdk/test-helpers/subagent-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/hooks.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/plugins/host-hook-runtime.ts|typescript/no-unnecessary-type-parameters|2",
+        "src/plugins/host-hook-runtime.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hook-state.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary

`main` is red on the `check-lint` (oxlint `core`) shard because of two errors in `src/plugins/host-hook-runtime.ts`:

- `typescript(no-unnecessary-type-parameters)` — `getPluginRunContext<T extends PluginJsonValue = PluginJsonValue>` declared a type parameter used only once (an unchecked output cast).
- `Unused oxlint-disable directive` — the `// oxlint-disable-next-line` for that rule sat **above the JSDoc** instead of immediately before the declaration, so it suppressed nothing and itself tripped the unused-directive rule.

After `no-unnecessary-type-parameters` was enabled (`c95d6049c2 chore(lint): preserve oxlint rule baseline`) this left `check-lint` failing on `main`, and therefore on every PR that inherits the red baseline (cf. #87473).

### Fix

`getPluginRunContext` is internal (not exported through any plugin-sdk barrel), so its `<T>` was only an unchecked cast. Drop the generic and return `PluginJsonValue | undefined`. The plugin-facing `ctx.getRunContext<T>(namespace)` affordance keeps its generic (and its correctly-placed directive) and now casts the read explicitly at the boundary. Non-generic callers already received `PluginJsonValue | undefined`, so behavior is unchanged.

### Scope

This addresses only the `check-lint` failure. The other current red check, `checks-fast-contracts-plugins-a` (`plugin-sdk-package-contract-guardrails.test.ts` drift in `packages/plugin-sdk/src/testing.ts`), is a separate pre-existing failure from the plugin-sdk testing-barrel deprecation (#87120) and is **not** changed here, so it may still show red on this PR until that is fixed independently.

## Verification

Run after this patch (branch based on upstream `main` `5ab430fa`):

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/host-hook-runtime.ts` → exit 0
- `node scripts/run-vitest.mjs src/plugins/contracts/run-context-lifecycle.contract.test.ts src/plugins/contracts/host-hooks.contract.test.ts` → 69 passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` → exit 0

## Real behavior proof

Behavior addressed: `check-lint` (oxlint core) failing on `main` due to `no-unnecessary-type-parameters` + unused-directive errors in `src/plugins/host-hook-runtime.ts`.
Real environment tested: local macOS checkout, Node 24, branch based on upstream `main` `5ab430fa`.
Exact steps or command run after this patch: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/host-hook-runtime.ts` ; `node scripts/run-vitest.mjs src/plugins/contracts/run-context-lifecycle.contract.test.ts src/plugins/contracts/host-hooks.contract.test.ts` ; `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
Evidence after fix: oxlint exit 0 (previously `217:5 no-unnecessary-type-parameters` and `212:1 Unused oxlint-disable directive`); vitest `Test Files 2 passed (2)`, `Tests 69 passed (69)`; tsgo exit 0.
Observed result after fix: core lint, the two run-context contract tests, and core typecheck all pass; no behavior change for callers.
What was not tested: full-repo lint/test suites and CI on this exact SHA. The two `host-hook-runtime.ts` errors were the only core-lint failures in the tree, so the single-file lint pass clears the `check-lint` shard.
