### PR TITLE
Add Codex multi-agent config migration coverage

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -2925,6 +2925,54 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
   });
 
+  it("repairs live multi-agent Codex upgrade configs and enables Codex through allowlists", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["brave", "discord", "whatsapp"],
+          entries: {
+            brave: { enabled: true },
+            discord: { enabled: true },
+            whatsapp: { enabled: true },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.5",
+          },
+          list: [
+            { id: "main", model: "openai-codex/gpt-5.5" },
+            { id: "meimei", model: "openai-codex/gpt-5.5" },
+            { id: "youyou-cli", model: "openai-codex/gpt-5.5" },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.5");
+    expect(result.cfg.agents?.list?.map((agent) => agent.model)).toEqual([
+      "openai/gpt-5.5",
+      "openai/gpt-5.5",
+      "openai/gpt-5.5",
+    ]);
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    for (const agent of result.cfg.agents?.list ?? []) {
+      expect(agent.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({ id: "codex" });
+    }
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual(["brave", "discord", "whatsapp", "codex"]);
+    expect(result.changes.join("\n")).toContain(
+      "agents.defaults.model: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
+    );
+    expect(result.changes.join("\n")).toContain(
+      "agents.list.main.model: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
+    );
+  });
+
   it("keeps repaired OpenAI refs on Codex runtime even when the OpenAI provider is otherwise OpenClaw/API-key routed", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {


### PR DESCRIPTION
## Summary

- add regression coverage for a live 6.1 upgrade shape where `agents.defaults.model` and multiple `agents.list[].model` entries still use `openai-codex/gpt-5.5`
- assert doctor repair rewrites those routes to `openai/gpt-5.5`, preserves Codex intent via per-agent `agentRuntime.id = "codex"`, and enables/allows the `codex` plugin when an allowlist is present

## Context

This is PR1 from the Codex/OpenAI migration follow-up. It focuses only on config migration coverage and does not touch session-store repair or route re-persistence.

Refs #90047. Related to #90036 because stale config defaults/list entries can keep Telegram/direct sessions resolving through the legacy `openai-codex/*` route after upgrade.

## Verification

- `pnpm tsx .tmp-check-codex-pr1.mts` behavior check: `PR1_BEHAVIOR_OK`
- `git diff --check`

Note: targeted Vitest (`pnpm vitest run src/commands/doctor/shared/codex-route-warnings.test.ts -t "repairs live multi-agent Codex upgrade configs" --pool=forks --maxWorkers=1`) was attempted locally, but the first-run build stayed in repeated Rolldown `PLUGIN_TIMINGS` output without reaching test execution in a reasonable time. The added test mirrors the behavior check above.

## Real behavior proof (redacted, Windows official 6.1)

- **Behavior or issue addressed:** `openclaw doctor --fix` must repair a live 6.1 upgrade shape where `agents.defaults.model` and multiple `agents.list[].model` entries still point at `openai-codex/gpt-5.5`, while preserving Codex runtime intent and repairing restrictive plugin allowlists.
- **Real environment tested:** Windows official OpenClaw 2026.6.1 (`2e08f0f`) package, using an isolated temporary config instead of the live `.openclaw` config/token state.
- **Exact steps or command run after this patch:** Ran `openclaw doctor --fix --yes --non-interactive` against the redacted upgrade config shown below.
- **Evidence after fix:** Terminal output / copied live output from the real run:

```text
OpenClaw 2026.6.1 (2e08f0f)
openclaw doctor --fix --yes --non-interactive
DOCTOR_EXIT=0
```

Input config used a restrictive allowlist and multiple legacy Codex routes:

```json
{
  "agents": {
    "defaults": {
      "model": "openai-codex/gpt-5.5",
      "models": {
        "openai-codex/gpt-5.5": { "agentRuntime": { "id": "codex" } }
      }
    },
    "list": [
      { "id": "main", "model": "openai-codex/gpt-5.5" },
      { "id": "telegram", "model": "openai-codex/gpt-5.5" }
    ]
  },
  "plugins": { "allow": ["openai"], "entries": {} }
}
```

After doctor repair:

```json
{
  "agents": {
    "defaults": {
      "model": "openai/gpt-5.5",
      "models": {
        "openai/gpt-5.5": { "agentRuntime": { "id": "codex" } }
      }
    },
    "list": [
      {
        "id": "main",
        "model": "openai/gpt-5.5",
        "models": { "openai/gpt-5.5": { "agentRuntime": { "id": "codex" } } }
      },
      {
        "id": "telegram",
        "model": "openai/gpt-5.5",
        "models": { "openai/gpt-5.5": { "agentRuntime": { "id": "codex" } } }
      }
    ]
  },
  "plugins": {
    "allow": ["openai", "codex", "memory-core", "telegram"],
    "entries": { "codex": { "enabled": true } },
    "bundledDiscovery": "compat"
  }
}
```

- **Observed result after fix:** The real doctor run exited 0, canonicalized legacy `openai-codex/*` config refs to `openai/*`, preserved Codex runtime metadata, enabled `plugins.entries.codex`, and extended the restrictive allowlist to include `codex`.
- **What was not tested:** No additional gaps for this regression; unrelated session-store repair is intentionally covered by a separate PR.
