### PR TITLE
Add Codex session route migration coverage

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3830,6 +3830,45 @@ describe("collectCodexRouteWarnings", () => {
     expect(store.main.agentRuntimeOverride).toBeUndefined();
   });
 
+  it("repairs Telegram direct session routes while preserving canonical OpenAI auth pins", () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:telegram:default:direct:8589344021": {
+        sessionId: "s-telegram",
+        updatedAt: 1,
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.5",
+        modelOverrideSource: "auto",
+        agentHarnessId: "codex",
+        agentRuntimeOverride: "codex",
+        authProfileOverride: "openai:work",
+        authProfileOverrideSource: "auto",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+    const entry = store["agent:main:telegram:default:direct:8589344021"];
+
+    expect(result).toEqual({
+      changed: true,
+      sessionKeys: ["agent:main:telegram:default:direct:8589344021"],
+    });
+    expect(entry.updatedAt).toBe(123);
+    expect(entry.modelProvider).toBe("openai");
+    expect(entry.model).toBe("gpt-5.5");
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-5.5");
+    expect(entry.modelOverrideSource).toBe("auto");
+    expect(entry.authProfileOverride).toBe("openai:work");
+    expect(entry.authProfileOverrideSource).toBe("auto");
+    expect(entry.agentHarnessId).toBeUndefined();
+    expect(entry.agentRuntimeOverride).toBeUndefined();
+  });
+
   it("repairs providerless auto Codex session overrides", () => {
     const store: Record<string, SessionEntry> = {
       main: {

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3832,7 +3832,7 @@ describe("collectCodexRouteWarnings", () => {
 
   it("repairs Telegram direct session routes while preserving canonical OpenAI auth pins", () => {
     const store: Record<string, SessionEntry> = {
-      "agent:main:telegram:default:direct:8589344021": {
+      "agent:main:telegram:default:direct:5550100999": {
         sessionId: "s-telegram",
         updatedAt: 1,
         modelProvider: "openai-codex",
@@ -3851,11 +3851,11 @@ describe("collectCodexRouteWarnings", () => {
       store,
       now: 123,
     });
-    const entry = store["agent:main:telegram:default:direct:8589344021"];
+    const entry = store["agent:main:telegram:default:direct:5550100999"];
 
     expect(result).toEqual({
       changed: true,
-      sessionKeys: ["agent:main:telegram:default:direct:8589344021"],
+      sessionKeys: ["agent:main:telegram:default:direct:5550100999"],
     });
     expect(entry.updatedAt).toBe(123);
     expect(entry.modelProvider).toBe("openai");


### PR DESCRIPTION
## Summary

- add regression coverage for repairing a stale Telegram direct session route from `openai-codex` to canonical `openai`
- assert session-store repair preserves canonical OpenAI OAuth/auth-profile pins such as `openai:work`
- assert stale Codex runtime/session overrides are cleared after route repair

## Context

This is PR2 from the Codex/OpenAI migration follow-up and is scoped only to persisted session-store route state. It intentionally does not change config migration coverage (PR #90317) or model-selection re-persistence behavior.

Related to #90036.

## Verification

- `pnpm tsx .tmp-check-codex-pr2.mts` behavior check: `PR2_BEHAVIOR_OK`
- `git diff --check`

Note: this repository's targeted Vitest startup was very slow locally due repeated Rolldown `PLUGIN_TIMINGS` output during first-run compilation, so I used a direct behavior check for the repaired helper path and left the regression in the Vitest suite for CI.

## Real behavior proof (redacted, Windows official 6.1)

Read-only probe from the real upgraded Windows/Telegram direct session after the 6.1 migration and Telegram smoke test:

```json
{
  "key": "agent:main:telegram:default:direct:<redacted-direct-id>",
  "modelProvider": "openai",
  "model": "gpt-5.5",
  "providerOverride": null,
  "modelOverride": null,
  "authProfileOverride": null,
  "agentHarnessId": null,
  "agentRuntimeOverride": null
}
```

The same upgraded setup successfully completed a real Telegram direct-session smoke (`TELEGRAM_SESSION_SMOKE_OK`) using canonical `openai/gpt-5.5` plus Codex runtime routing, not the stale `openai-codex/*` route.

For the auth-pin preservation edge covered by this test-only PR, the focused helper proof remains:

```text
repairCodexSessionStoreRoutes(...)
modelProvider: "openai-codex" -> "openai"
providerOverride: "openai-codex" -> "openai"
model/modelOverride: "openai-codex/gpt-5.5" -> "gpt-5.5"
authProfileOverride: "openai:work" preserved
agentHarnessId / agentRuntimeOverride cleared
PR2_BEHAVIOR_OK
```

So the real upgraded Telegram session proves the stale route is gone in a live session, while the focused regression proves canonical OpenAI auth pins are preserved when present.

## Real behavior proof (structured for gate)

- Behavior or issue addressed: stale persisted Telegram direct-session Codex routes are repaired from `openai-codex/*` to canonical `openai` / `gpt-*` while preserving canonical OpenAI OAuth auth-profile pins.
- Real environment tested: real upgraded Windows/ROG OpenClaw `2026.6.1` Telegram direct session plus this PR branch on macOS source checkout.
- Exact steps or command run after this patch: inspected the redacted real Telegram session store after the Windows 6.1 migration and smoke, then ran `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts --testNamePattern="repairs Telegram direct session routes"` on this PR head.
- Evidence after fix: copied live terminal/session output:

```text
Real Windows/Telegram direct session after migration:
key: agent:main:telegram:default:direct:<redacted-direct-id>
modelProvider: openai
model: gpt-5.5
providerOverride: null
modelOverride: null
authProfileOverride: null
agentHarnessId: null
agentRuntimeOverride: null
TELEGRAM_SESSION_SMOKE_OK

$ node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts --testNamePattern="repairs Telegram direct session routes"
[test] starting test/vitest/vitest.commands.config.ts
✓ commands src/commands/doctor/shared/codex-route-warnings.test.ts (109 tests | 108 skipped) 130ms
Tests 1 passed | 108 skipped (109)
[test] passed 1 Vitest shard in 18.29s
```

- Observed result after fix: the live Telegram session no longer persisted `openai-codex/*`; the focused regression passed and preserves canonical auth pins while clearing stale Codex runtime/session overrides.
- What was not tested: no OAuth token reset/re-login was performed; unrelated config migration coverage remains in PR #90317 and forward write-boundary protection remains in PR #90321.
