### PR TITLE
fix(plugin-sdk): keep testing bridge a single re-export line

### DIFF
--- a/packages/plugin-sdk/src/testing.ts
+++ b/packages/plugin-sdk/src/testing.ts
@@ -1,3 +1,1 @@
-// Public package facade for plugin SDK testing helpers.
-
 export * from "../../../src/plugin-sdk/testing.js";


### PR DESCRIPTION
## Summary

`main` is red on `checks-fast-contracts-plugins-a`: the contract test `plugin-sdk-package-contract-guardrails.test.ts` ("keeps the package testing barrel as a single deprecated bridge") fails because `packages/plugin-sdk/src/testing.ts` drifted from its guarded exact form.

The guardrail requires that file to be exactly the single re-export line:

```ts
export * from "../../../src/plugin-sdk/testing.js";
```

`344417c0de` ("docs: document media and sdk package facades") added a `// Public package facade for plugin SDK testing helpers.` comment + blank line to it, which violates the exact-match contract — the bridge is intentionally kept minimal as a single deprecated re-export (cf. #87120). `collectDeprecatedPackageTestingBridgeDrift()` then returns `["packages/plugin-sdk/src/testing.ts"]`.

### Fix

Remove the stray comment to restore the exact single-line bridge. The re-export is unchanged, so there is no functional or type impact — this only restores the guarded contract form.

### Context

This is the second of the two checks currently red on `main` from inherited-baseline breakage (see #87473). Companion PR #90316 fixes the other one (`check-lint`).

## Real behavior proof

Behavior addressed: `checks-fast-contracts-plugins-a` and `Critical Quality (plugin-sdk-package-contract)` failing on `main` — `plugin-sdk-package-contract-guardrails.test.ts` "keeps the package testing barrel as a single deprecated bridge".

Real environment tested: GitHub Actions CI on this PR head `0c15c3df20343020f87de0f0a30e62c1a3bc60a4` (the real check that was red on `main`), plus a local macOS / Node 24 checkout.

Exact steps or command run after this patch: pushed the patch to the PR head and let CI run the plugin contract shards; locally ran `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts`.

Evidence after fix:
- CI `checks-fast-contracts-plugins-a` → **pass** (1m30s) on head `0c15c3df20`: https://github.com/openclaw/openclaw/actions/runs/26951112488/job/79516354366
- CI `Critical Quality (plugin-sdk-package-contract)` → **pass** (51s) on head `0c15c3df20`: https://github.com/openclaw/openclaw/actions/runs/26951112737/job/79516332423
- Local: `Test Files 1 passed (1)`, `Tests 22 passed (22)` (previously the run reported `1 failed`, with `collectDeprecatedPackageTestingBridgeDrift()` returning `["packages/plugin-sdk/src/testing.ts"]`).

Observed result after fix: the guarded drift check returns `[]`; the previously-red contract shard passes in real CI on the PR head and locally; the re-export behavior is unchanged.

What was not tested: not all repo-wide checks are green on this PR because it inherits unrelated red-baseline/infra checks from `main` that this diff does not touch — `check-lint` (fixed separately by companion PR #90316) and a Docker-based runtime-topology architecture job. This change only removes a comment from a pure re-export file.
