### PR TITLE
fix(feishu): disable ambient proxy inheritance for WebSocket by default

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -504,7 +504,20 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toBeUndefined();
   });
 
-  it("creates a ws proxy agent when lowercase https_proxy is set", async () => {
+  it("does not inherit ambient proxy env by default", async () => {
+    process.env.https_proxy = "http://lower-https:8001";
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.HTTP_PROXY = "http://upper-http:8999";
+
+    await createFeishuWSClient(baseAccount);
+
+    expect(proxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("creates a ws proxy agent when explicitly enabled and lowercase https_proxy is set", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.https_proxy = "http://lower-https:8001";
 
     await createFeishuWSClient(baseAccount);
@@ -514,7 +527,8 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxied: true });
   });
 
-  it("creates a ws proxy agent when uppercase HTTPS_PROXY is set", async () => {
+  it("creates a ws proxy agent when explicitly enabled and uppercase HTTPS_PROXY is set", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.HTTPS_PROXY = "http://upper-https:8002";
 
     await createFeishuWSClient(baseAccount);
@@ -524,7 +538,8 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxied: true });
   });
 
-  it("falls back to HTTP_PROXY for ws proxy agent creation", async () => {
+  it("falls back to HTTP_PROXY when explicitly enabled", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.HTTP_PROXY = "http://upper-http:8999";
 
     await createFeishuWSClient(baseAccount);

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -91,6 +91,7 @@ function setRequestUserAgent(req: unknown) {
   inst.interceptors?.request?.use(setRequestUserAgent);
 }
 
+export const FEISHU_WS_USE_PROXY_ENV_VAR = "OPENCLAW_FEISHU_WS_USE_PROXY";
 export { FEISHU_HTTP_TIMEOUT_ENV_VAR, FEISHU_HTTP_TIMEOUT_MAX_MS, FEISHU_HTTP_TIMEOUT_MS };
 
 type FeishuHttpInstanceLike = Pick<
@@ -99,7 +100,10 @@ type FeishuHttpInstanceLike = Pick<
 >;
 
 async function getWsProxyAgent() {
-  return resolveAmbientNodeProxyAgent<Agent>();
+  if (process.env[FEISHU_WS_USE_PROXY_ENV_VAR] === "1") {
+    return resolveAmbientNodeProxyAgent<Agent>();
+  }
+  return undefined;
 }
 
 // Multi-account client cache


### PR DESCRIPTION
## Summary

Fixes #65799.

Feishu WebSocket currently inherits ambient proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) via `resolveAmbientNodeProxyAgent()`. When a proxy is configured for unrelated outbound traffic (e.g. Gemini API) and that proxy endpoint is unavailable or misconfigured for Feishu's long-poll WebSocket, the connection silently fails with only:

```
[ws] ws connect failed
```

Direct connection with the same app credentials succeeds, making the failure hard to diagnose.

**Fix:** `getWsProxyAgent()` returns `undefined` by default. Ambient proxy inheritance is only enabled when `OPENCLAW_FEISHU_WS_USE_PROXY=1` is set explicitly.

**Files changed:**
- `extensions/feishu/src/client.ts` — gate proxy agent on env var
- `extensions/feishu/src/client.test.ts` — cover default (no proxy) and opt-in cases

## Real behavior proof

Behavior or issue addressed: Feishu WebSocket was silently inheriting ambient proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) even when the proxy was only intended for unrelated outbound traffic (e.g. Gemini API). This caused `[ws] ws connect failed` with no actionable message when the proxy endpoint was unavailable for Feishu's WebSocket. After this patch, `getWsProxyAgent()` returns `undefined` by default; ambient proxy is only used when `OPENCLAW_FEISHU_WS_USE_PROXY=1` is set explicitly.

Real environment tested: Local macOS OpenClaw checkout at `~/openclaw-dev`, branch `fix/feishu-ws-proxy-no-inherit`, commit `48b654cd36 fix(feishu): disable ambient proxy inheritance for WebSocket by default`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts --reporter=verbose
git diff --check
```

Evidence after fix: Terminal output copied from the local OpenClaw checkout:

```text
 RUN  v4.1.7 /Users/googlerest/openclaw-dev

 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > passes a custom httpInstance with default timeout to Lark.Client 2ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > injects default timeout into HTTP request options 1ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > allows explicit timeout override per-request 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > uses config-configured default timeout when provided 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > falls back to default timeout when configured timeout is invalid 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > uses env timeout override when provided and no direct timeout is set 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishu HTTP timeout > ignores non-decimal env timeout overrides 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > prefers direct timeout over env override 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > clamps env timeout override to max bound 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuClient HTTP timeout > recreates cached client when configured timeout changes 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > passes heartbeat wsConfig defaults to Lark.WSClient 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > passes lifecycle callbacks while preserving heartbeat wsConfig defaults 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > does not set a ws proxy agent when proxy env is absent 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > does not inherit ambient proxy env by default 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > creates a ws proxy agent when explicitly enabled and lowercase https_proxy is set 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > creates a ws proxy agent when explicitly enabled and uppercase HTTPS_PROXY is set 0ms
 ✓ |extension-feishu| extensions/feishu/src/client.test.ts > createFeishuWSClient proxy handling > falls back to HTTP_PROXY when explicitly enabled 0ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  01:14:17
   Duration  342ms (transform 75ms, setup 23ms, import 108ms, tests 87ms, environment 0ms)
```

`git diff --check` completed with no output.

Observed result after fix: The `createFeishuWSClient proxy handling` suite asserts that `createAmbientNodeProxyAgent` is not called when proxy env vars are present but `OPENCLAW_FEISHU_WS_USE_PROXY` is unset (`does not inherit ambient proxy env by default`), and is called exactly once when `OPENCLAW_FEISHU_WS_USE_PROXY=1` is set (`creates a ws proxy agent when explicitly enabled`). All 17 tests in `client.test.ts` pass.

What was not tested: I did not run a live Feishu WebSocket connection because this local environment does not have live Feishu app credentials. The behavioral contract is fully covered by the unit tests via `@openclaw/proxyline` mock.