### PR TITLE
Expose model picker agent runtimes

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4702,7 +4702,7 @@ public struct ModelChoice: Codable, Sendable {
         available: Bool? = nil,
         contextwindow: Int?,
         reasoning: Bool?,
-        agentruntime: [String: AnyCodable]?)
+        agentruntime: [String: AnyCodable]? = nil)
     {
         self.id = id
         self.name = name

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4692,6 +4692,7 @@ public struct ModelChoice: Codable, Sendable {
     public let available: Bool?
     public let contextwindow: Int?
     public let reasoning: Bool?
+    public let agentruntime: [String: AnyCodable]?
 
     public init(
         id: String,
@@ -4700,7 +4701,8 @@ public struct ModelChoice: Codable, Sendable {
         alias: String?,
         available: Bool? = nil,
         contextwindow: Int?,
-        reasoning: Bool?)
+        reasoning: Bool?,
+        agentruntime: [String: AnyCodable]?)
     {
         self.id = id
         self.name = name
@@ -4709,6 +4711,7 @@ public struct ModelChoice: Codable, Sendable {
         self.available = available
         self.contextwindow = contextwindow
         self.reasoning = reasoning
+        self.agentruntime = agentruntime
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4719,6 +4722,7 @@ public struct ModelChoice: Codable, Sendable {
         case available
         case contextwindow = "contextWindow"
         case reasoning
+        case agentruntime = "agentRuntime"
     }
 }
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -631,6 +631,18 @@ terminal summary, and sanitized error text.
 - `"configured"`: picker-sized behavior. If `agents.defaults.models` is configured, it still wins, including provider-scoped discovery for `provider/*` entries. Without an allowlist, the response uses explicit `models.providers.*.models` entries, falling back to the full catalog only when no configured model rows exist.
 - `"all"`: full Gateway catalog, bypassing `agents.defaults.models`. Use this for diagnostics and discovery UIs, not normal model pickers.
 
+Each returned model choice includes stable selector fields such as `id`, `name`, `provider`, and optional metadata including `alias`, `available`, `contextWindow`, and `reasoning`. When a model is resolved through a non-default agent runtime backend, the response may also include optional `agentRuntime` metadata:
+
+- `agentRuntime.id`: runtime backend id used for the model choice, such as `codex`.
+- `agentRuntime.label`: human-readable runtime label for picker display.
+- `agentRuntime.source`: where the runtime assignment came from:
+  - `"implicit"`: default runtime implied by provider/model routing.
+  - `"model"`: explicit runtime metadata on the configured model row.
+  - `"provider"`: explicit runtime metadata inherited from the configured provider.
+  - `"session-key"`: runtime selected from session-key model/routing metadata.
+
+Clients should treat `agentRuntime` as optional and preserve `id` as the canonical model value for requests; `label` is display metadata only.
+
 ## Exec approvals
 
 - When an exec request needs approval, the gateway broadcasts `exec.approval.requested`.

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -21,6 +21,21 @@ export const ModelChoiceSchema = Type.Object(
     available: Type.Optional(Type.Boolean()),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
+    agentRuntime: Type.Optional(
+      Type.Object(
+        {
+          id: NonEmptyString,
+          label: NonEmptyString,
+          source: Type.Union([
+            Type.Literal("implicit"),
+            Type.Literal("model"),
+            Type.Literal("provider"),
+            Type.Literal("session-key"),
+          ]),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   },
   { additionalProperties: false },
 );

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -80,7 +80,7 @@ const DEFAULTED_OPTIONAL_INIT_PARAM_ENTRIES: readonly [string, readonly string[]
   ["CronRunLogEntry", ["errorReason", "failureNotificationDelivery"]],
   ["ExecApprovalRequestParams", ["requireDeliveryRoute", "suppressDelivery"]],
   ["AgentSummary", ["thinkingLevels", "thinkingOptions", "thinkingDefault"]],
-  ["ModelChoice", ["available"]],
+  ["ModelChoice", ["available", "agentRuntime"]],
 ];
 
 const DEFAULTED_OPTIONAL_INIT_PARAMS: Record<string, Set<string>> = Object.fromEntries(

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -21,4 +21,9 @@ export type ModelCatalogEntry = {
   input?: ModelInputType[];
   compat?: ModelCompatConfig;
   mediaInput?: ModelMediaInputConfig;
+  agentRuntime?: {
+    id: string;
+    label: string;
+    source: "implicit" | "model" | "provider" | "session-key";
+  };
 };

--- a/src/gateway/server-methods/models-list-result.test.ts
+++ b/src/gateway/server-methods/models-list-result.test.ts
@@ -37,7 +37,7 @@ describe("models-list-result runtime metadata", () => {
     ]);
   });
 
-  it("omits implicit runtime metadata to keep legacy picker payloads compact", () => {
+  it("exposes implicit OpenAI Codex runtime metadata for model picker choices", () => {
     const models = addConfiguredAgentRuntimeMetadata({
       cfg: {} as never,
       agentId: "main",
@@ -55,6 +55,68 @@ describe("models-list-result runtime metadata", () => {
         id: "gpt-5.5",
         name: "gpt-5.5",
         provider: "openai",
+        agentRuntime: {
+          id: "codex",
+          label: "OpenAI Codex",
+          source: "implicit",
+        },
+      },
+    ]);
+  });
+
+  it("omits implicit OpenClaw runtime metadata to keep legacy picker payloads compact", () => {
+    const models = addConfiguredAgentRuntimeMetadata({
+      cfg: {} as never,
+      agentId: "main",
+      catalog: [
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+      },
+    ]);
+  });
+
+  it("keeps explicit OpenClaw runtime metadata visible when it overrides implicit Codex", () => {
+    const models = addConfiguredAgentRuntimeMetadata({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } },
+            },
+          },
+        },
+      } as never,
+      agentId: "main",
+      catalog: [
+        {
+          id: "gpt-5.5",
+          name: "gpt-5.5",
+          provider: "openai",
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        provider: "openai",
+        agentRuntime: {
+          id: "openclaw",
+          label: "OpenClaw Default",
+          source: "model",
+        },
       },
     ]);
   });

--- a/src/gateway/server-methods/models-list-result.test.ts
+++ b/src/gateway/server-methods/models-list-result.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { addConfiguredAgentRuntimeMetadata } from "./models-list-runtime-metadata.js";
+
+describe("models-list-result runtime metadata", () => {
+  it("exposes configured Codex runtime metadata for model picker choices", () => {
+    const models = addConfiguredAgentRuntimeMetadata({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+            },
+          },
+        },
+      } as never,
+      agentId: "main",
+      catalog: [
+        {
+          id: "gpt-5.5",
+          name: "gpt-5.5",
+          provider: "openai",
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        provider: "openai",
+        agentRuntime: {
+          id: "codex",
+          label: "OpenAI Codex",
+          source: "model",
+        },
+      },
+    ]);
+  });
+
+  it("omits implicit runtime metadata to keep legacy picker payloads compact", () => {
+    const models = addConfiguredAgentRuntimeMetadata({
+      cfg: {} as never,
+      agentId: "main",
+      catalog: [
+        {
+          id: "gpt-5.5",
+          name: "gpt-5.5",
+          provider: "openai",
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        provider: "openai",
+      },
+    ]);
+  });
+});

--- a/src/gateway/server-methods/models-list-result.test.ts
+++ b/src/gateway/server-methods/models-list-result.test.ts
@@ -120,4 +120,39 @@ describe("models-list-result runtime metadata", () => {
       },
     ]);
   });
+
+  it("resolves configured runtime metadata for provider-native slash ids", () => {
+    const models = addConfiguredAgentRuntimeMetadata({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": { agentRuntime: { id: "openclaw" } },
+            },
+          },
+        },
+      } as never,
+      agentId: "main",
+      catalog: [
+        {
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5",
+          provider: "nvidia",
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        id: "moonshotai/kimi-k2.5",
+        name: "Kimi K2.5",
+        provider: "nvidia",
+        agentRuntime: {
+          id: "openclaw",
+          label: "OpenClaw Default",
+          source: "model",
+        },
+      },
+    ]);
+  });
 });

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -28,6 +28,7 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
+import { addConfiguredAgentRuntimeMetadata } from "./models-list-runtime-metadata.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ModelsListView = ModelCatalogBrowseView;
@@ -249,7 +250,7 @@ async function buildPublicModelsListEntries(params: {
   workspaceDir: string;
 }): Promise<ModelsListEntry[]> {
   const providerAuthChecker = createModelsListProviderAuthChecker(params);
-  return await Promise.all(
+  const publicEntries = await Promise.all(
     params.catalog.map((entry) =>
       buildPublicModelsListEntry({
         entry,
@@ -258,6 +259,11 @@ async function buildPublicModelsListEntries(params: {
       }),
     ),
   );
+  return addConfiguredAgentRuntimeMetadata({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    catalog: publicEntries,
+  });
 }
 
 export async function buildModelsListResult(params: {

--- a/src/gateway/server-methods/models-list-runtime-metadata.ts
+++ b/src/gateway/server-methods/models-list-runtime-metadata.ts
@@ -15,7 +15,12 @@ export function addConfiguredAgentRuntimeMetadata<T extends ModelCatalogEntry>(p
       provider: entry.provider,
       model: entry.id,
     });
-    if (agentRuntime.source === "implicit") {
+    if (
+      agentRuntime.source === "implicit" &&
+      (agentRuntime.id === "openclaw" ||
+        agentRuntime.id === "auto" ||
+        agentRuntime.id === "default")
+    ) {
       return entry;
     }
     return {

--- a/src/gateway/server-methods/models-list-runtime-metadata.ts
+++ b/src/gateway/server-methods/models-list-runtime-metadata.ts
@@ -1,7 +1,21 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveModelAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
+
+function providerQualifiedCatalogModelId(entry: ModelCatalogEntry): string {
+  const modelId = entry.id.trim();
+  const provider = entry.provider?.trim();
+  if (!provider || !modelId) {
+    return modelId;
+  }
+  const slash = modelId.indexOf("/");
+  if (slash > 0 && normalizeProviderId(modelId.slice(0, slash)) === normalizeProviderId(provider)) {
+    return modelId;
+  }
+  return `${provider}/${modelId}`;
+}
 
 export function addConfiguredAgentRuntimeMetadata<T extends ModelCatalogEntry>(params: {
   cfg: OpenClawConfig;
@@ -13,7 +27,7 @@ export function addConfiguredAgentRuntimeMetadata<T extends ModelCatalogEntry>(p
       cfg: params.cfg,
       agentId: params.agentId,
       provider: entry.provider,
-      model: entry.id,
+      model: providerQualifiedCatalogModelId(entry),
     });
     if (
       agentRuntime.source === "implicit" &&

--- a/src/gateway/server-methods/models-list-runtime-metadata.ts
+++ b/src/gateway/server-methods/models-list-runtime-metadata.ts
@@ -1,0 +1,33 @@
+import { resolveModelAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
+
+export function addConfiguredAgentRuntimeMetadata<T extends ModelCatalogEntry>(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  catalog: T[];
+}): T[] {
+  return params.catalog.map((entry) => {
+    const agentRuntime = resolveModelAgentRuntimeMetadata({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      provider: entry.provider,
+      model: entry.id,
+    });
+    if (agentRuntime.source === "implicit") {
+      return entry;
+    }
+    return {
+      ...entry,
+      agentRuntime: {
+        ...agentRuntime,
+        label: resolveAgentRuntimeLabel({
+          config: params.cfg,
+          resolvedHarness: agentRuntime.id,
+          fallbackProvider: entry.provider,
+        }),
+      },
+    } as T;
+  });
+}

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -359,6 +359,7 @@ describe("models.list", () => {
                 provider: "openai",
                 api: "openai-responses",
                 available: true,
+                agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
               },
             ],
           },

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -173,7 +173,17 @@ describe("models.list", () => {
 
         expect(respond).toHaveBeenCalledWith(
           true,
-          { models: [{ id: "gpt-test", name: "GPT Test", provider: "openai", available: false }] },
+          {
+            models: [
+              {
+                id: "gpt-test",
+                name: "GPT Test",
+                provider: "openai",
+                available: false,
+                agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
+              },
+            ],
+          },
           undefined,
         );
         expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ readOnly: false });
@@ -245,8 +255,20 @@ describe("models.list", () => {
       true,
       {
         models: [
-          { id: "gpt-5.4-codex", name: "GPT-5.4 Codex", provider: "openai", available: true },
-          { id: "gpt-codex-test", name: "GPT Codex Test", provider: "openai", available: true },
+          {
+            id: "gpt-5.4-codex",
+            name: "GPT-5.4 Codex",
+            provider: "openai",
+            available: true,
+            agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
+          },
+          {
+            id: "gpt-codex-test",
+            name: "GPT Codex Test",
+            provider: "openai",
+            available: true,
+            agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
+          },
           { id: "llama-local", name: "Llama Local", provider: "vllm", available: true },
           { id: "qwen-local", name: "Qwen Local", provider: "vllm", available: true },
         ],
@@ -268,8 +290,20 @@ describe("models.list", () => {
       {
         models: [
           { id: "claude-test", name: "Claude Test", provider: "anthropic", available: false },
-          { id: "gpt-5.4-codex", name: "GPT-5.4 Codex", provider: "openai", available: true },
-          { id: "gpt-codex-test", name: "GPT Codex Test", provider: "openai", available: true },
+          {
+            id: "gpt-5.4-codex",
+            name: "GPT-5.4 Codex",
+            provider: "openai",
+            available: true,
+            agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
+          },
+          {
+            id: "gpt-codex-test",
+            name: "GPT Codex Test",
+            provider: "openai",
+            available: true,
+            agentRuntime: { id: "codex", label: "OpenAI Codex", source: "implicit" },
+          },
           { id: "llama-local", name: "Llama Local", provider: "vllm", available: true },
           { id: "qwen-local", name: "Qwen Local", provider: "vllm", available: true },
         ],

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -105,6 +105,12 @@ type AgentCatalogFixtureEntry = {
   contextWindow?: number;
 };
 
+const implicitOpenAiCodexRuntime = {
+  id: "codex",
+  label: "OpenAI Codex",
+  source: "implicit" as const,
+};
+
 const buildAgentCatalogFixture = (): AgentCatalogFixtureEntry[] => [
   { id: "gpt-test-z", provider: "openai", contextWindow: 0 },
   {
@@ -148,12 +154,14 @@ const expectedSortedCatalog = (): ModelCatalogRpcEntry[] => [
     provider: "openai",
     available: false,
     contextWindow: 8000,
+    agentRuntime: implicitOpenAiCodexRuntime,
   },
   {
     id: "gpt-test-z",
     name: "gpt-test-z",
     provider: "openai",
     available: false,
+    agentRuntime: implicitOpenAiCodexRuntime,
   },
 ];
 
@@ -669,6 +677,7 @@ describe("gateway server models + voicewake", () => {
             name: "gpt-test-z",
             provider: "openai",
             available: false,
+            agentRuntime: implicitOpenAiCodexRuntime,
           },
         ]);
       },
@@ -715,6 +724,7 @@ describe("gateway server models + voicewake", () => {
           name: "gpt-test-z",
           provider: "openai",
           available: false,
+          agentRuntime: implicitOpenAiCodexRuntime,
         },
       ],
     });
@@ -732,6 +742,7 @@ describe("gateway server models + voicewake", () => {
           name: "not-in-catalog",
           provider: "openai",
           available: false,
+          agentRuntime: implicitOpenAiCodexRuntime,
         },
       ],
     });

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -91,6 +91,11 @@ type ModelCatalogRpcEntry = {
   contextWindow?: number;
   input?: string[];
   reasoning?: boolean;
+  agentRuntime?: {
+    id: string;
+    label: string;
+    source: "implicit" | "model" | "provider" | "session-key";
+  };
 };
 
 type AgentCatalogFixtureEntry = {

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -53,12 +53,17 @@ describe("chat-model-ref helpers", () => {
     ).toBe("openrouter/google/gemma-4-26b-a4b-it");
   });
 
-  it("prefers alias over name for picker labels", () => {
+  it("preserves explicit aliases verbatim for picker labels", () => {
     const aliasedModel = {
       id: "moonshotai/kimi-k2.5",
       alias: "Kimi K2.5 (NVIDIA)",
       name: "Kimi K2.5",
       provider: "nvidia",
+      agentRuntime: {
+        id: "codex",
+        label: "OpenAI Codex",
+        source: "model" as const,
+      },
     };
 
     expect(buildChatModelOption(aliasedModel, [aliasedModel])).toEqual({

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -70,6 +70,27 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it("surfaces configured agent runtime metadata in picker labels", () => {
+    const codexModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      provider: "openai",
+      agentRuntime: {
+        id: "codex",
+        label: "OpenAI Codex",
+        source: "model" as const,
+      },
+    };
+
+    expect(buildChatModelOption(codexModel, [codexModel])).toEqual({
+      value: "openai/gpt-5.5",
+      label: "GPT-5.5 · OpenAI Codex",
+    });
+    expect(formatCatalogChatModelDisplay("openai/gpt-5.5", [codexModel])).toBe(
+      "GPT-5.5 · OpenAI Codex",
+    );
+  });
+
   it("uses friendly catalog names for qualified nested model ids", () => {
     const nestedModel = {
       id: "moonshotai/kimi-k2.5",

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -91,6 +91,27 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it("surfaces explicit OpenClaw runtime overrides in picker labels", () => {
+    const openclawModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      provider: "openai",
+      agentRuntime: {
+        id: "openclaw",
+        label: "OpenClaw Default",
+        source: "model" as const,
+      },
+    };
+
+    expect(buildChatModelOption(openclawModel, [openclawModel])).toEqual({
+      value: "openai/gpt-5.5",
+      label: "GPT-5.5 · OpenClaw Default",
+    });
+    expect(formatCatalogChatModelDisplay("openai/gpt-5.5", [openclawModel])).toBe(
+      "GPT-5.5 · OpenClaw Default",
+    );
+  });
+
   it("uses friendly catalog names for qualified nested model ids", () => {
     const nestedModel = {
       id: "moonshotai/kimi-k2.5",

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -188,8 +188,12 @@ function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
   return appendAgentRuntimeSuffix(rawLabel, entry);
 }
 
+function resolveExplicitCatalogAlias(entry: ModelCatalogEntry): string {
+  return entry.alias?.trim() ?? "";
+}
+
 function resolveCatalogDisplayName(entry: ModelCatalogEntry): string {
-  return entry.alias?.trim() || entry.name.trim();
+  return resolveExplicitCatalogAlias(entry) || entry.name.trim();
 }
 
 function createQualifiedCatalogKey(entry: ModelCatalogEntry): string {
@@ -228,6 +232,12 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   const displayLookup = new Map<string, string>();
   for (const entry of catalog) {
     const qualifiedKey = createQualifiedCatalogKey(entry);
+    const explicitAlias = resolveExplicitCatalogAlias(entry);
+    if (explicitAlias) {
+      displayLookup.set(qualifiedKey, explicitAlias);
+      continue;
+    }
+
     const name = resolveCatalogDisplayName(entry);
     if (!name) {
       displayLookup.set(qualifiedKey, formatRawCatalogLabel(entry));

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -168,7 +168,11 @@ export function formatChatModelDisplay(value: string): string {
 function formatAgentRuntimeSuffix(entry: ModelCatalogEntry): string {
   const id = entry.agentRuntime?.id?.trim().toLowerCase();
   const label = entry.agentRuntime?.label?.trim();
-  if (!id || id === "openclaw" || id === "auto" || id === "default" || !label) {
+  const source = entry.agentRuntime?.source;
+  if (!id || id === "auto" || id === "default" || !label) {
+    return "";
+  }
+  if (id === "openclaw" && source === "implicit") {
     return "";
   }
   return ` · ${label}`;

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -165,9 +165,23 @@ export function formatChatModelDisplay(value: string): string {
   return `${trimmed.slice(separator + 1)} · ${trimmed.slice(0, separator)}`;
 }
 
+function formatAgentRuntimeSuffix(entry: ModelCatalogEntry): string {
+  const id = entry.agentRuntime?.id?.trim().toLowerCase();
+  const label = entry.agentRuntime?.label?.trim();
+  if (!id || id === "openclaw" || id === "auto" || id === "default" || !label) {
+    return "";
+  }
+  return ` · ${label}`;
+}
+
+function appendAgentRuntimeSuffix(label: string, entry: ModelCatalogEntry): string {
+  return `${label}${formatAgentRuntimeSuffix(entry)}`;
+}
+
 function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
   const provider = entry.provider?.trim();
-  return provider ? `${entry.id} · ${provider}` : entry.id;
+  const rawLabel = provider ? `${entry.id} · ${provider}` : entry.id;
+  return appendAgentRuntimeSuffix(rawLabel, entry);
 }
 
 function resolveCatalogDisplayName(entry: ModelCatalogEntry): string {
@@ -218,13 +232,14 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
 
     const normalizedName = name.toLowerCase();
     if ((nameToValues.get(normalizedName)?.size ?? 0) <= 1) {
-      displayLookup.set(qualifiedKey, name);
+      displayLookup.set(qualifiedKey, appendAgentRuntimeSuffix(name, entry));
       continue;
     }
 
     const provider = entry.provider?.trim();
     if ((nameProviderToValues.get(createNameProviderKey(name, provider))?.size ?? 0) <= 1) {
-      displayLookup.set(qualifiedKey, provider ? `${name} · ${provider}` : `${name} · ${entry.id}`);
+      const providerLabel = provider ? `${name} · ${provider}` : `${name} · ${entry.id}`;
+      displayLookup.set(qualifiedKey, appendAgentRuntimeSuffix(providerLabel, entry));
       continue;
     }
 

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -788,6 +788,11 @@ export type ModelCatalogEntry = {
   contextWindow?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image" | "document">;
+  agentRuntime?: {
+    id: string;
+    label: string;
+    source: "implicit" | "model" | "provider" | "session-key";
+  };
 };
 
 export type ToolCatalogProfile =


### PR DESCRIPTION
## Summary

- Adds additive `agentRuntime` metadata to `models.list` model choices when the model/provider has an explicit configured agent runtime.
- Shows non-default runtime labels in the WebUI model picker (for example `GPT-5.5 · OpenAI Codex`) without changing the canonical model value (`openai/gpt-5.5`).
- Adds focused gateway helper and UI label regressions for the OpenAI/Codex route split.

Refs #90420 (real 6.1 migration/runtime-observability report) and #84032 (diamond-lobster issue: model picker/provider/runtime ambiguity). Related to #90036 and #90047 because the live Windows 6.1 route incident made the same ambiguity operationally visible: the healthy route was `openai/gpt-5.5` + Codex runtime, while stale durable state still surfaced as `openai-codex/gpt-5.5`.

## Why

After the 2026.6.1 Codex migration, a healthy route can be:

```text
model ref: openai/gpt-5.5
runtime: codex
```

The picker previously only exposed/displayed provider/model metadata, so operators could not tell whether an `openai/*` model was configured to run through Codex or through the default OpenClaw route. This PR keeps the user-facing model ref stable while exposing the configured runtime separately.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/chat-model-ref.test.ts --testNamePattern "surfaces configured agent runtime metadata"`
- `node --import tsx` behavior script for `addConfiguredAgentRuntimeMetadata` → `MODELS_LIST_RUNTIME_METADATA_OK`
- `git diff --check`
- `pnpm tsgo:test:ui`

Note: `node scripts/run-vitest.mjs src/gateway/server-methods/models-list-result.test.ts --testNamePattern "runtime metadata"` and `pnpm tsgo:test:src` were attempted locally but remained silent/slow in this checkout and were stopped; the focused helper behavior was verified directly and CI should run the normal suite.


## Review fix proof

Addressed ClawSweeper's implicit-runtime feedback in `a971a356`.

Focused proof from the patched branch:

```text
implicitCodex.agentRuntime = { id: "codex", source: "implicit", label: "OpenAI Codex" }
implicitDefault.agentRuntime = omitted
explicitOpenClaw.agentRuntime = { id: "openclaw", source: "model", label: "OpenClaw Default" }
labels = ["GPT-5.5 · OpenAI Codex", "GPT-5.5 · OpenClaw Default"]
RUNTIME_METADATA_REVIEW_FIX_OK

node scripts/run-vitest.mjs ui/src/ui/chat-model-ref.test.ts --testNamePattern "agent runtime|OpenClaw runtime"
✓ ui/src/ui/chat-model-ref.test.ts (25 tests | 23 skipped)
Tests 2 passed | 23 skipped

git diff --check
```

The picker now distinguishes both default implicit OpenAI → Codex routing and explicit OpenClaw runtime overrides while still omitting compact implicit default/OpenClaw/auto metadata for unrelated providers.

## Real behavior proof (actual PR-head Gateway/WebUI; current head: `bc62b391bf7f7c9e6ea722c5fd746ded2a5da612`)

Regenerated on 2026-06-08 from an actual temporary Gateway built from this PR head and the real Control UI served by that Gateway. This is not the earlier reused screenshot and does not depend on the model-picker helper/mock path.

- Behavior or issue addressed: expose material runtime metadata for canonical `openai/gpt-5.5` choices routed through the Codex runtime, and render that runtime in the WebUI Chat model picker as `GPT-5.5 · OpenAI Codex` without changing the canonical model id/provider.
- Real environment tested: PR #90328 head `bc62b391bf7f7c9e6ea722c5fd746ded2a5da612`, built and run with the source CLI/Gateway from that head (`OpenClaw 2026.6.2 (bc62b39)`) using isolated profile/home `/tmp/openclaw-pr90328-proof/home`, profile `pr90328proof`, Gateway `http://127.0.0.1:19129`. Channels were skipped with `OPENCLAW_SKIP_CHANNELS=1`; only the `codex` runtime plugin loaded. Auth/token secrets were not required. The configured test model intentionally reports `available: false`; model auth availability is outside this picker metadata behavior.
- Exact steps or command run after this patch:

```bash
cd /Users/luyifan/.openclaw/workspace/openclaw-src
git rev-parse HEAD
# bc62b391bf7f7c9e6ea722c5fd746ded2a5da612

env -i HOME=/tmp/openclaw-pr90328-proof/home PATH="$PATH" OPENCLAW_GATEWAY_PORT=19129 OPENCLAW_SKIP_CHANNELS=1 \
  node scripts/run-node.mjs --profile pr90328proof gateway run --port 19129 --force --verbose

env -i HOME=/tmp/openclaw-pr90328-proof/home PATH="$PATH" OPENCLAW_GATEWAY_PORT=19129 OPENCLAW_SKIP_CHANNELS=1 \
  node scripts/run-node.mjs --profile pr90328proof gateway call models.list --params '{"view":"configured"}' --json

# Browser/CDP opened the same real Control UI:
# http://127.0.0.1:19129/chat?session=agent%3Amain%3Amain
# and captured the open chat model picker screenshot.
```

- Evidence after fix:
  - Actual PR-head Gateway `models.list` response: [models-list-pr-head-real-gateway-20260608.json](https://raw.githubusercontent.com/ooiuuii/openclaw/refs/heads/proof/90328-model-picker-20260606/proof/90328/models-list-pr-head-real-gateway-20260608.json)
  - Filtered `openai/gpt-5.5` row: [models-list-pr-head-gpt55-row-20260608.json](https://raw.githubusercontent.com/ooiuuii/openclaw/refs/heads/proof/90328-model-picker-20260606/proof/90328/models-list-pr-head-gpt55-row-20260608.json)
  - Actual WebUI picker screenshot from the same Gateway: [pr-head-webui-picker-dropdown-20260608.png](https://raw.githubusercontent.com/ooiuuii/openclaw/refs/heads/proof/90328-model-picker-20260606/proof/90328/pr-head-webui-picker-dropdown-20260608.png)
  - Minimal isolated run config: [pr-head-real-run-config-20260608.json](https://raw.githubusercontent.com/ooiuuii/openclaw/refs/heads/proof/90328-model-picker-20260606/proof/90328/pr-head-real-run-config-20260608.json)
  - Updated proof README: [proof/90328 README](https://github.com/ooiuuii/openclaw/tree/proof/90328-model-picker-20260606/proof/90328)

![Actual PR-head WebUI picker showing GPT-5.5 · OpenAI Codex](https://raw.githubusercontent.com/ooiuuii/openclaw/refs/heads/proof/90328-model-picker-20260606/proof/90328/pr-head-webui-picker-dropdown-20260608.png)

Actual Gateway `models.list` row excerpt from the temporary PR-head Gateway:

```json
{
  "id": "gpt-5.5",
  "name": "GPT-5.5",
  "provider": "openai",
  "api": "openai-responses",
  "available": false,
  "agentRuntime": {
    "id": "codex",
    "source": "model",
    "label": "OpenAI Codex"
  }
}
```

- Observed result after fix: the real PR-head Gateway preserves the canonical public choice (`provider: "openai"`, `id: "gpt-5.5"`) while exposing runtime metadata separately as `agentRuntime.id = "codex"` / `label = "OpenAI Codex"`. The real PR-head Control UI consumes that response and renders the model picker selected option as `GPT-5.5 · OpenAI Codex`; the captured visible label text was `GPT-5.5 · OpenAI Codex · Medium`.
- What was not tested: real OAuth inference, channel delivery, commentary/progress streams, native Swift UI display, or session migration behavior. Those are intentionally outside this PR's WebUI/Gateway metadata scope.

Supporting current-head checks retained from the earlier refresh:

```text
node scripts/run-vitest.mjs src/gateway/server-methods/models-list-result.test.ts ui/src/ui/chat-model-ref.test.ts --testNamePattern="models.list|agentRuntime|label|alias|OpenAI Codex"

✓ src/gateway/server-methods/models-list-result.test.ts (gateway-client) 5 passed
✓ src/gateway/server-methods/models-list-result.test.ts (gateway-methods) 5 passed
✓ ui/src/ui/chat-model-ref.test.ts 6 passed | 19 skipped

node scripts/run-vitest.mjs src/gateway/server-methods/models.test.ts --testNamePattern=models.list
✓ 24 passed

node scripts/run-vitest.mjs src/commands/model-picker.test.ts --testNamePattern="runtime model picker visibility"
✓ 1 passed | 63 skipped

pnpm exec oxfmt --check docs/gateway/protocol.md
git diff --check
# docs protocol formatting and diff checks passed
```
