### PR TITLE
Fix ChatGPT Codex streams without content-type

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -203,6 +203,120 @@ describe("buildGuardedModelFetch", () => {
     expect(release).toHaveBeenCalled();
   });
 
+  it("allows ChatGPT Codex responses streams with missing content-type", async () => {
+    const sseBody = 'event: response.output_text.delta\ndata: {"delta":"ok"}\n\n';
+    const sseBytes = new TextEncoder().encode(sseBody);
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } as unknown as Model<"openai-chatgpt-responses">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(sseBytes, { status: 200 }),
+      finalUrl: "https://chatgpt.com/backend-api/codex/responses",
+      release: vi.fn(async () => undefined),
+    });
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(sseBody);
+  });
+
+  it("allows ChatGPT Codex transport-alias streams with missing content-type", async () => {
+    const sseBody = 'event: response.output_text.delta\ndata: {"delta":"ok"}\n\n';
+    const sseBytes = new TextEncoder().encode(sseBody);
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openclaw-openai-responses-transport",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } as unknown as Model<"openclaw-openai-responses-transport">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(sseBytes, { status: 200 }),
+      finalUrl: "https://chatgpt.com/backend-api/codex/responses",
+      release: vi.fn(async () => undefined),
+    });
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(sseBody);
+  });
+
+  it("still rejects missing content-type for other OpenAI-compatible streams", async () => {
+    const release = vi.fn(async () => undefined);
+    const model = {
+      id: "private-model",
+      provider: "custom-openai",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.com",
+    } as unknown as Model<"openai-completions">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(new TextEncoder().encode('data: {"ok": true}\n\n'), { status: 200 }),
+      finalUrl: "https://proxy.example.com/chat/completions",
+      release,
+    });
+
+    await expect(
+      buildGuardedModelFetch(model)("https://proxy.example.com/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "private-model", stream: true }),
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderHttpError",
+      status: 200,
+      code: "invalid_provider_content_type",
+      errorType: "invalid_response",
+    });
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("still rejects missing content-type for non-Codex ChatGPT responses paths", async () => {
+    const release = vi.fn(async () => undefined);
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex-preview",
+    } as unknown as Model<"openai-chatgpt-responses">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(new TextEncoder().encode('data: {"ok": true}\n\n'), { status: 200 }),
+      finalUrl: "https://chatgpt.com/backend-api/codex-preview/responses",
+      release,
+    });
+
+    await expect(
+      buildGuardedModelFetch(model)("https://chatgpt.com/backend-api/codex-preview/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderHttpError",
+      status: 200,
+      code: "invalid_provider_content_type",
+      errorType: "invalid_response",
+    });
+    expect(release).toHaveBeenCalled();
+  });
+
   it("ensures configured local services before the model request", async () => {
     const release = vi.fn();
     ensureModelProviderLocalServiceMock.mockResolvedValue({ release });

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -228,6 +228,34 @@ function isOpenAISdkStreamContentType(contentType: string): boolean {
   return /\btext\/event-stream\b/i.test(contentType) || isJsonContentType(contentType);
 }
 
+function isChatGptCodexResponsesApi(api: unknown): boolean {
+  return api === "openai-chatgpt-responses" || api === "openclaw-openai-responses-transport";
+}
+
+function isChatGptCodexResponsesMissingContentType(params: {
+  contentType: string;
+  model: Model;
+}): boolean {
+  if (
+    params.contentType !== "" ||
+    params.model.provider !== "openai" ||
+    !isChatGptCodexResponsesApi(params.model.api) ||
+    typeof params.model.baseUrl !== "string"
+  ) {
+    return false;
+  }
+  try {
+    const baseUrl = new URL(params.model.baseUrl);
+    const pathname = baseUrl.pathname.toLowerCase().replace(/\/+$/, "");
+    return (
+      baseUrl.hostname.toLowerCase() === "chatgpt.com" &&
+      (pathname === "/backend-api/codex" || pathname.startsWith("/backend-api/codex/"))
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function assertOpenAISdkStreamContentType(params: {
   response: Response;
   model: Model;
@@ -235,7 +263,12 @@ async function assertOpenAISdkStreamContentType(params: {
   localServiceLease?: ProviderLocalServiceLease;
 }): Promise<void> {
   const contentType = params.response.headers.get("content-type") ?? "";
-  if (!params.response.ok || !params.response.body || isOpenAISdkStreamContentType(contentType)) {
+  if (
+    !params.response.ok ||
+    !params.response.body ||
+    isOpenAISdkStreamContentType(contentType) ||
+    isChatGptCodexResponsesMissingContentType({ contentType, model: params.model })
+  ) {
     return;
   }
   const body = await readResponseTextLimited(params.response).catch(() => "");


### PR DESCRIPTION
## Summary

- Allow successful streamed ChatGPT Codex Responses without a `content-type` header to pass the guarded OpenAI SDK transport check.
- Keep the exception scoped to `openai` models using `openai-chatgpt-responses` or the transport alias `openclaw-openai-responses-transport` against `https://chatgpt.com/backend-api/codex` subpaths.
- Add regression coverage proving the ChatGPT Codex paths pass while other OpenAI-compatible streams and non-Codex ChatGPT paths still reject missing `content-type`.

## Linked context

This PR follows the MFS/FlowerAI production incident where ChatGPT Codex Responses streams reached OpenClaw without a response `content-type` and the OpenAI SDK transport guard rejected them before the stream parser could consume the SSE body.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ChatGPT Codex Responses streams from `https://chatgpt.com/backend-api/codex/responses` can return HTTP 200 with an empty response `content-type`; before this PR, the `openclaw-openai-responses-transport` alias path still failed with `invalid_provider_content_type`.
- Real environment tested: MFS production on `mfs-flowerai`, OpenClaw `2026.6.2-beta.1`, Apolo agent using the OpenClaw harness with the real ChatGPT Codex `openai/gpt-5.5` auth-profile route. The installed production bundle had the prior partial hotfix and was patched with this PR's alias predicate before the live proof run; backup was kept on the host.
- Exact steps or command run after this patch: applied the PR alias predicate to the installed production bundle, restarted `openclaw-gateway.service`, temporarily enabled `OPENCLAW_DEBUG_MODEL_TRANSPORT=1` and `OPENCLAW_DEBUG_SSE=events`, then ran `openclaw agent --agent apolo --session-key pr90330-missing-content-type-proof-20260604T140254Z --message "PR90330 live proof: call the MFS categories tool available to Apolo, specifically mfs_apolo__get_valid_categories if present. Do not create or modify orders. After the tool succeeds, reply exactly: MFS_TOOL_OK category_count=<number>." --json --timeout 600`. Debug env was unset and the gateway was restarted after collecting logs.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
# Redacted live OpenClaw CLI result, 2026-06-04T14:03Z
{
  "status": "ok",
  "summary": "completed",
  "result": {
    "payloads": [{ "text": "MFS_TOOL_OK category_count=146", "mediaUrl": null }],
    "meta": {
      "agentMeta": {
        "provider": "openai",
        "model": "gpt-5.5",
        "agentHarnessId": "openclaw"
      },
      "executionTrace": {
        "winnerProvider": "openai",
        "winnerModel": "gpt-5.5",
        "fallbackUsed": false
      },
      "toolSummary": {
        "calls": 3,
        "tools": ["mfs_apolo__get_valid_categories", "exec"],
        "failures": 0
      }
    }
  }
}

# Redacted production journal excerpt from the same run
2026-06-04T14:03:16.011Z [provider-transport-fetch] [model-fetch] start provider=openai api=openclaw-openai-responses-transport model=gpt-5.5 method=POST url=https://chatgpt.com/backend-api/codex/responses timeoutMs=undefined proxy=none policy=custom
2026-06-04T14:03:16.712Z [provider-transport-fetch] [model-fetch] response provider=openai api=openclaw-openai-responses-transport model=gpt-5.5 status=200 elapsedMs=701 contentType=
2026-06-04T14:03:31.864Z [openai-transport] [responses] stream_done provider=openai api=openclaw-openai-responses-transport model=gpt-5.5 elapsedMs=15149 events=286 types=response.created:1,response.in_progress:1,response.output_item.added:2,response.output_item.done:2,response.content_part.added:1,response.output_text.delta:276,response.output_text.done:1,response.content_part.done:1,response.completed:1 stopReason=stop contentBlocks=2
2026-06-04T14:03:59.348Z MFS_TOOL_OK category_count=146
```

- Observed result after fix: the real `openclaw-openai-responses-transport` request received HTTP 200 with `contentType=` empty, did not raise `invalid_provider_content_type`, streamed to `stream_done`, and the Apolo turn completed with `MFS_TOOL_OK` after using `mfs_apolo__get_valid_categories`.
- What was not tested: no Telegram delivery was performed for this proof run (`--deliver` was not used); the proof intentionally exercised the OpenClaw agent/model/tool path only.
- Proof limitations or environment constraints: production debug logging was limited to model transport/SSE event summaries and then disabled again; no prompts, tokens, cookies, raw tool outputs, or customer data are included in the excerpt.
- Before evidence (optional but encouraged): prior production logs for the same alias path showed `api=openclaw-openai-responses-transport ... causeCode=invalid_provider_content_type message=Connection error` repeatedly before the alias predicate was applied.

## Tests and validation

- `pnpm test src/agents/provider-transport-fetch.test.ts` passed: 72/72 tests.
- `codex review --uncommitted` initially found the missing transport-alias coverage; after fixing it, rerun reported no actionable findings.
- MFS production after the PR alias patch:
  - `flowerai mfs smoke apolo --json` passed (`ok: true`).
  - `flowerai mfs smoke atlas --json` passed (`ok: true`).
  - `flowerai mfs smoke nova --json` passed (`ok: true`) after quarantining one unrelated stale Nova session-memory artifact flagged by `memory.firewall.contamination`.
  - `flowerai doctor --all --json` summary passed with `critical_total: 0` for Apolo, Atlas, Nova, Orion, Paul, and Vega.
  - `flowerai drift check --all --json` summary passed with `critical_total: 0` and no affected sessions for Apolo, Atlas, Nova, Orion, Paul, and Vega.
- Earlier validation on this hotfix branch: targeted test passed 70/70, `pnpm build` passed, and `pnpm check` failed only on the pre-existing lint issue in `src/plugins/host-hook-runtime.ts` already present on `origin/main`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A real ChatGPT Codex streamed model turn that previously failed on missing `content-type` can now complete.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly: this changes provider response validation for successful streamed ChatGPT Codex Responses only. It does not alter auth, request headers, redirects, tool permissions, or non-Codex provider validation.

What is the highest-risk area?

Accidentally accepting missing `content-type` from a non-Codex OpenAI-compatible endpoint.

How is that risk mitigated?

The predicate requires provider `openai`, API `openai-chatgpt-responses` or `openclaw-openai-responses-transport`, hostname `chatgpt.com`, and base path `/backend-api/codex` or its subpaths. Regression tests prove other OpenAI-compatible streams and non-Codex ChatGPT paths still reject missing `content-type`.

## Current review state

PR body updated with real after-fix production proof for the alias path requested by ClawSweeper. No `CHANGELOG.md` changes and no unrelated source fixes included.
