### PR TITLE
fix(agents): harden gateway config self-edits

### DIFF
--- a/src/agents/tools/gateway-tool-guard-coverage.test.ts
+++ b/src/agents/tools/gateway-tool-guard-coverage.test.ts
@@ -64,6 +64,17 @@ describe("gateway config mutation guard coverage", () => {
     // operator-owned config surfaces.
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.promptOverlays");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.model");
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.imageModel");
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain(
+      "agents.defaults.imageGenerationModel",
+    );
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain(
+      "agents.defaults.videoGenerationModel",
+    );
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain(
+      "agents.defaults.musicGenerationModel",
+    );
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).not.toContain("agents.defaults.pdfModel");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.defaults.subagents.thinking");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.list[].id");
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("agents.list[].model");
@@ -87,6 +98,23 @@ describe("gateway config mutation guard coverage", () => {
     expectBlocked(
       { agents: { defaults: { model: { primary: "openai/gpt-5.4" } } } },
       { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } },
+    );
+  });
+
+  it("blocks defaults-level media model routing via config.patch", () => {
+    expectBlocked(
+      {},
+      {
+        agents: {
+          defaults: {
+            imageModel: { primary: "custom/mimo-v2-omni" },
+            imageGenerationModel: { primary: "openai/gpt-image-2" },
+            videoGenerationModel: { primary: "openai/sora-2" },
+            musicGenerationModel: { primary: "google/lyria-3" },
+            pdfModel: { primary: "anthropic/claude-sonnet-4-6" },
+          },
+        },
+      },
     );
   });
 


### PR DESCRIPTION
Summary:

- Keep agent-facing gateway config self-edits within the existing narrow trust boundary; global media/model routing remains operator-owned.
- Add regression coverage proving defaults-level media/PDF model routing fields stay protected from agent config.patch self-edits.

Tests:

- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/tools/gateway-tool-guard-coverage.test.ts

## Real behavior proof

- Behavior or issue addressed: Agent-facing gateway config self-edits keep global media/model routing operator-owned; attempts to change agents.defaults.imageModel, imageGenerationModel, videoGenerationModel, musicGenerationModel, or pdfModel are rejected instead of being applied.
- Real environment tested: Windows 11 host, Node 24, patched OpenClaw checkout at 24bcccdb, temporary isolated OpenClaw gateway on loopback port 19078, temporary OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR. Tokens, local paths, and private endpoints are redacted.
- Exact steps or command run after this patch: Started a temporary isolated gateway from the patched checkout, then invoked the real agent-facing gateway tool with action=config.patch and a patch that tried to set agents.defaults media/PDF model routing fields.
- Evidence after fix: Copied terminal output from the patched checkout:

```text
# commit
24bcccdb
# proof target
temporary isolated gateway on 127.0.0.1:19078
# config path
OPENCLAW_CONFIG_PATH=[REDACTED]/openclaw.json
# attempted agent gateway config.patch
agents.defaults.imageModel / imageGenerationModel / videoGenerationModel / musicGenerationModel / pdfModel
# result
CONFIG_PATCH_REJECTED
# error
gateway config.patch cannot change protected config paths: agents.defaults.imageGenerationModel.primary, agents.defaults.imageModel.primary, agents.defaults.musicGenerationModel.primary, agents.defaults.pdfModel.primary, agents.defaults.videoGenerationModel.primary
# cleanup
temporary gateway stopped
```

- Observed result after fix: The agent-facing gateway tool rejected the media/PDF routing patch before applying it, and the temporary gateway config was not updated with those operator-owned model routing fields.
- What was not tested: Provider failover, production daemon restart, and real TencentCloud config mutation were not tested in this proof; the proof used a temporary loopback gateway and temporary config to avoid touching the production setup.