### PR TITLE
fix(codex): guard trajectory tool schema capture

### DIFF
--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createCodexTrajectoryRecorder,
+  recordCodexTrajectoryContext,
   resolveCodexTrajectoryAppendFlags,
   resolveCodexTrajectoryPointerFlags,
 } from "./trajectory.js";
@@ -201,5 +202,114 @@ describe("Codex trajectory recorder", () => {
     ) as { data?: { truncated?: boolean; reason?: string } };
     expect(parsed.data?.truncated).toBe(true);
     expect(parsed.data?.reason).toBe("trajectory-event-size-limit");
+  });
+
+  it("keeps compiled context when tool schema descriptors throw", async () => {
+    const tmpDir = makeTempDir();
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        model: { api: "responses" },
+      } as never,
+      env: {},
+    });
+    let nameReads = 0;
+    const unreadableNameTool = {
+      inputSchema: { type: "object" },
+      get name() {
+        throw new Error("tool name getter exploded");
+      },
+    };
+    const unreadableDescriptionTool = {
+      name: "descriptionless",
+      inputSchema: { type: "object" },
+      get description() {
+        throw new Error("tool description getter exploded");
+      },
+    };
+    const unreadableSchemaTool = {
+      name: "schema",
+      description: "bad schema",
+      get inputSchema() {
+        throw new Error("tool schema getter exploded");
+      },
+    };
+    const singleReadNameTool = {
+      description: "single read",
+      inputSchema: { type: "object" },
+      get name() {
+        nameReads += 1;
+        if (nameReads > 1) {
+          throw new Error("tool name read twice");
+        }
+        return " single_read ";
+      },
+    };
+    const nestedSchema = { type: "object" };
+    Object.defineProperty(nestedSchema, "properties", {
+      get() {
+        throw new Error("schema field getter exploded");
+      },
+      enumerable: true,
+    });
+    const proxySchema = new Proxy(
+      { type: "object" },
+      {
+        ownKeys() {
+          throw new Error("schema keys exploded");
+        },
+      },
+    );
+    const proxyArray = new Proxy([{ ok: true }], {
+      get(target, property, receiver) {
+        if (property === "0") {
+          throw new Error("schema array item exploded");
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    recordCodexTrajectoryContext(trajectoryRecorder, {
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-1",
+        prompt: "hello",
+        model: { api: "responses" },
+      },
+      developerInstructions: "system",
+      tools: [
+        unreadableNameTool,
+        unreadableDescriptionTool,
+        unreadableSchemaTool,
+        singleReadNameTool,
+        { name: "nested", description: "nested schema", inputSchema: nestedSchema },
+        { name: "proxy", inputSchema: proxySchema },
+        { name: "array", inputSchema: proxyArray },
+        { name: "healthy", inputSchema: { type: "object", properties: { value: {} } } },
+      ],
+    } as never);
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.data?.tools).toEqual([
+      { name: "array", parameters: ["<unreadable>"] },
+      { name: "descriptionless", parameters: { type: "object" } },
+      { name: "healthy", parameters: { type: "object", properties: { value: {} } } },
+      {
+        name: "nested",
+        description: "nested schema",
+        parameters: { type: "object", properties: "<unreadable>" },
+      },
+      { name: "proxy", parameters: "<unreadable>" },
+      { name: "schema", description: "bad schema", parameters: "<unreadable>" },
+      { name: "single_read", description: "single read", parameters: { type: "object" } },
+    ]);
+    expect(nameReads).toBe(1);
   });
 });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -305,19 +305,49 @@ function toTrajectoryToolDefinitions(
   }
   return tools
     .flatMap((tool) => {
-      const name = tool.name?.trim();
+      const name = readTrajectoryToolName(tool);
       if (!name) {
         return [];
       }
+      const description = readTrajectoryToolDescription(tool);
       return [
         {
           name,
-          description: tool.description,
-          parameters: sanitizeValue(tool.inputSchema),
+          ...(description ? { description } : {}),
+          parameters: sanitizeValue(readTrajectoryToolInputSchema(tool)),
         },
       ];
     })
     .toSorted((left, right) => left.name.localeCompare(right.name));
+}
+
+function readTrajectoryToolName(tool: { name?: string }): string | undefined {
+  try {
+    const rawName = tool.name;
+    if (typeof rawName !== "string") {
+      return undefined;
+    }
+    return rawName.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTrajectoryToolDescription(tool: { description?: string }): string | undefined {
+  try {
+    const description = tool.description;
+    return typeof description === "string" ? description : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTrajectoryToolInputSchema(tool: { inputSchema?: unknown }): unknown {
+  try {
+    return tool.inputSchema;
+  } catch {
+    return "<unreadable>";
+  }
 }
 
 function sanitizeValue(value: unknown, depth = 0, key = ""): unknown {
@@ -343,16 +373,51 @@ function sanitizeValue(value: unknown, depth = 0, key = ""): unknown {
     return "<truncated>";
   }
   if (Array.isArray(value)) {
-    return value.slice(0, 100).map((entry) => sanitizeValue(entry, depth + 1, key));
+    let length: number;
+    try {
+      length = value.length;
+    } catch {
+      return "<unreadable>";
+    }
+    const result: unknown[] = [];
+    for (let index = 0; index < Math.min(length, 100); index += 1) {
+      let entry: unknown;
+      try {
+        entry = value[index];
+      } catch {
+        result.push("<unreadable>");
+        continue;
+      }
+      result.push(sanitizeValue(entry, depth + 1, key));
+    }
+    return result;
   }
   if (typeof value === "object") {
     const next: Record<string, unknown> = {};
-    for (const [keyLocal, child] of Object.entries(value).slice(0, 100)) {
+    let keys: string[];
+    try {
+      keys = Object.keys(value).slice(0, 100);
+    } catch {
+      return "<unreadable>";
+    }
+    const record = value as Record<string, unknown>;
+    for (const keyLocal of keys) {
+      let child: unknown;
+      try {
+        child = record[keyLocal];
+      } catch {
+        next[keyLocal] = "<unreadable>";
+        continue;
+      }
       next[keyLocal] = sanitizeValue(child, depth + 1, keyLocal);
     }
     return next;
   }
-  return JSON.stringify(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "<unreadable>";
+  }
 }
 
 function redactSensitiveString(value: string): string {


### PR DESCRIPTION
## Summary
- Guard Codex app-server trajectory tool-definition capture against throwing tool `name`, `description`, and `inputSchema` getters.
- Keep descriptor reads one-shot, skip tools without readable names, and omit unreadable optional descriptions.
- Bound hostile nested diagnostic schemas, including proxy key traps and array item getters, using the existing Codex trajectory `"<unreadable>"` marker while preserving healthy sibling tools.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-codex-trajectory node scripts/run-vitest.mjs run extensions/codex/src/app-server/trajectory.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts`
- `node scripts/run-oxlint.mjs extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `blacksmith testbox list --all` blocked: local Blacksmith CLI is not authenticated.

## Real behavior proof
Behavior addressed: Codex app-server trajectory context capture no longer lets one hostile dynamic tool/schema descriptor crash trajectory support-data capture before the rest of the turn can be diagnosed.

Real environment tested: local focused Codex extension trajectory test in an OpenClaw linked Codex worktree. Broad Testbox proof was not available because Blacksmith auth is missing in this environment.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/codex/src/app-server/trajectory.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts`; `node scripts/run-oxlint.mjs extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix: focused Vitest passed 1 file / 8 tests; targeted formatter/lint/diff checks passed; branch autoreview reported no accepted/actionable findings with `overall: patch is correct (0.88)`; final head is `743b60231860276085d3b732c48db660fa5d909e`.

Observed result after fix: unreadable Codex trajectory tool names are skipped, unreadable descriptions are omitted, unreadable schemas are recorded as `"<unreadable>"`, hostile nested object/array proxies are bounded, and healthy sibling tools remain captured and sorted.

What was not tested: a full live Codex app-server model turn and broad `pnpm check:changed`/Testbox proof because Blacksmith auth is unavailable here.
