### PR TITLE
fix(memory): fail fast when embeddings provider is unavailable

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -76,9 +76,16 @@ flowchart LR
 - **BM25 keyword search** finds exact matches (IDs, error strings, config
   keys).
 
-If only one path is available (no embeddings or no FTS), the other runs alone.
+If only one path is available, the other runs alone. Intentional FTS-only mode
+(`provider: "none"`) and automatic/default provider selection can still use
+lexical ranking when embeddings are unavailable.
 
-When embeddings are unavailable, OpenClaw still uses lexical ranking over FTS results instead of falling back to raw exact-match ordering only. That degraded mode boosts chunks with stronger query-term coverage and relevant file paths, which keeps recall useful even without `sqlite-vec` or an embedding provider.
+Explicit non-local embedding providers are different. If you set
+`memorySearch.provider` to a concrete remote-backed provider and that provider
+is unavailable at runtime, `memory_search` reports memory as unavailable instead
+of silently using FTS-only results. This keeps a broken configured semantic
+provider visible. Set `provider: "none"` for deliberate FTS-only recall, or fix
+the provider/auth configuration to restore semantic ranking.
 
 ## Improving search quality
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -67,10 +67,17 @@ automatically re-embedding everything. Rebuild when you are ready with
 `openclaw memory index --force --agent <id>`.
 </Warning>
 
-If OpenAI embeddings are unreachable from your network, memory recall fails open
-instead of blocking the turn. Set the existing `memorySearch.provider` field to a
-reachable local, Ollama, regional, or OpenAI-compatible provider to restore
-semantic ranking.
+When `provider` is unset, legacy `provider: "auto"` is present, or
+`provider: "none"` intentionally selects FTS-only mode, memory recall can still
+use lexical FTS ranking when embeddings are unavailable.
+
+Explicit non-local providers fail closed. If you set `memorySearch.provider` to
+a concrete remote-backed provider such as OpenAI, Gemini, Voyage, Mistral,
+Bedrock, GitHub Copilot, DeepInfra, Ollama, LM Studio, or an OpenAI-compatible
+custom provider, and that provider is unavailable at runtime, `memory_search`
+returns an unavailable result instead of silently using FTS-only recall. Fix the
+provider/auth configuration, switch to a reachable provider, or set
+`provider: "none"` if you want deliberate FTS-only recall.
 
 ### Custom provider ids
 

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3162,7 +3162,7 @@ describe("active-memory plugin", () => {
     expectLinesToContain(lines, "🔎 Active Memory Debug: backend=qmd searchMs=8 hits=0");
   });
 
-  it("fast-fails unavailable memory_search results without injecting provider errors", async () => {
+  it("fast-fails configured-provider-missing memory_search results without injecting provider errors", async () => {
     const CONFIGURED_TIMEOUT_MS = 1_000;
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
@@ -3185,7 +3185,8 @@ describe("active-memory plugin", () => {
                 disabled: true,
                 warning: "Memory search is unavailable due to an embedding/provider error.",
                 action: "Check the embedding provider configuration, then retry memory_search.",
-                error: "embedding request failed",
+                error:
+                  'Memory search unavailable: embedding provider "openai" is configured but unavailable.',
               },
             },
           },

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -158,6 +158,17 @@ export function resolveEmbeddingProviderAdapterId(
   }
 }
 
+export function resolveEmbeddingProviderAdapterTransport(
+  providerId: string,
+  config?: MemoryEmbeddingProviderCreateOptions["config"],
+): MemoryEmbeddingProviderAdapter["transport"] {
+  try {
+    return getAdapter(providerId, config).transport;
+  } catch {
+    return undefined;
+  }
+}
+
 async function createWithAdapter(
   adapter: MemoryEmbeddingProviderAdapter,
   options: CreateEmbeddingProviderOptions,

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -976,6 +976,25 @@ describe("memory index", () => {
     expect(third).toBe(second);
   });
 
+  it("closes stale default managers when provider requirement changes", async () => {
+    const storePath = path.join(workspaceDir, "index-provider-requirement-cache.sqlite");
+    const implicitCfg = createCfg({ storePath });
+    const implicit = requireManager(
+      await getMemorySearchManager({ cfg: implicitCfg, agentId: "main" }),
+    );
+    managersForCleanup.add(implicit);
+    await implicit.probeEmbeddingAvailability();
+
+    const explicitCfg = createCfg({ storePath, provider: "openai" });
+    const explicit = requireManager(
+      await getMemorySearchManager({ cfg: explicitCfg, agentId: "main" }),
+    );
+    managersForCleanup.add(explicit);
+
+    expect(explicit === implicit).toBe(false);
+    expect(providerCloseCalls).toBe(1);
+  });
+
   it("retries embedding provider close before releasing the manager", async () => {
     providerCloseFailuresRemaining = 1;
     const cfg = createCfg({

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -294,7 +294,7 @@ describe("memory index", () => {
         defaults: {
           workspace: workspaceDir,
           memorySearch: {
-            provider: params.provider ?? "openai",
+            ...(params.provider !== undefined ? { provider: params.provider } : {}),
             model: params.model ?? "mock-embed",
             fallback: params.fallback,
             outputDimensionality: params.outputDimensionality,
@@ -1611,6 +1611,28 @@ describe("memory index", () => {
 
     const noResults = await manager.search("nonexistent_xyz_keyword");
     expect(noResults.length).toBe(0);
+  });
+
+  it("fails fast instead of searching FTS when an explicit provider is unavailable", async () => {
+    forceNoProvider = true;
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-required-provider-missing.sqlite"),
+      provider: "openai",
+      minScore: 0.35,
+      hybrid: { enabled: true },
+    });
+    const manager = await getFreshManager(cfg);
+    try {
+      await expect(manager.search("Alpha")).rejects.toThrow(
+        /Memory search unavailable: embedding provider "openai" is configured but unavailable\.[\s\S]*agentId=main purpose=default[\s\S]*registeredMemoryEmbeddingProviders=local/,
+      );
+      await expect(manager.sync({ reason: "test" })).rejects.toThrow(
+        /Memory sync unavailable: embedding provider "openai" is configured but unavailable\./,
+      );
+    } finally {
+      await manager.close?.();
+    }
   });
 
   it("prefers exact session transcript hits in FTS-only mode", async () => {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1630,6 +1630,10 @@ describe("memory index", () => {
       await expect(manager.sync({ reason: "test" })).rejects.toThrow(
         /Memory sync unavailable: embedding provider "openai" is configured but unavailable\./,
       );
+      forceNoProvider = false;
+      await manager.sync({ reason: "test", force: true });
+      const results = await manager.search("Alpha");
+      expect(results.length).toBeGreaterThan(0);
     } finally {
       await manager.close?.();
     }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -68,6 +68,8 @@ vi.mock("./embeddings.js", () => {
         };
       },
     ) => config?.models?.providers?.[providerId]?.api ?? providerId,
+    resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+      providerId === "local" ? "local" : "remote",
     createEmbeddingProvider: async (options: {
       provider?: string;
       model?: string;

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1606,6 +1606,12 @@ describe("memory index", () => {
     const status = manager.status();
     expect(status.chunks).toBeGreaterThan(0);
     expect(embedBatchCalls).toBe(0);
+    expect(status.custom?.providerUnavailableReason).toBe("No API key found for provider");
+    expect(status.custom?.providerState).toEqual({
+      mode: "fts-only",
+      reason: "No API key found for provider",
+      attemptedProviderId: "openai",
+    });
 
     const results = await manager.search("Alpha");
     expect(results.length).toBeGreaterThan(0);
@@ -1636,6 +1642,30 @@ describe("memory index", () => {
       await manager.sync({ reason: "test", force: true });
       const results = await manager.search("Alpha");
       expect(results.length).toBeGreaterThan(0);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it("fails fast instead of returning FTS when an explicit provider is lost at runtime", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-required-provider-runtime-missing.sqlite"),
+      provider: "openai",
+      minScore: 0.35,
+      hybrid: { enabled: true },
+    });
+    const manager = await getFreshManager(cfg);
+    try {
+      await manager.sync({ reason: "test", force: true });
+      (
+        manager as unknown as {
+          provider: null;
+        }
+      ).provider = null;
+
+      await expect(manager.search("Alpha")).rejects.toThrow(
+        /Memory search unavailable: embedding provider "openai" is configured but unavailable\./,
+      );
     } finally {
       await manager.close?.();
     }

--- a/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
@@ -103,6 +103,8 @@ class SessionDeltaHarness extends MemoryManagerSyncOps {
 
   protected resetProviderInitializationForRetry(): void {}
 
+  protected assertRequiredProviderAvailable(): void {}
+
   protected async indexFile(
     _entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -82,6 +82,8 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
 
   protected resetProviderInitializationForRetry(): void {}
 
+  protected assertRequiredProviderAvailable(): void {}
+
   protected async indexFile(
     _entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -113,6 +113,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   protected resetProviderInitializationForRetry(): void {}
 
+  protected assertRequiredProviderAvailable(): void {}
+
   protected async indexFile(
     _entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -280,6 +280,7 @@ export abstract class MemoryManagerSyncOps {
   protected abstract getIndexConcurrency(): number;
   protected abstract pruneEmbeddingCacheIfNeeded(): void;
   protected abstract resetProviderInitializationForRetry(): void;
+  protected abstract assertRequiredProviderAvailable(operation: "search" | "sync"): void;
   protected abstract indexFile(
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
@@ -1777,6 +1778,7 @@ export abstract class MemoryManagerSyncOps {
     if (this.provider) {
       return;
     }
+    this.assertRequiredProviderAvailable("sync");
     const existingMeta = this.readMeta();
     if (
       !existingMeta ||

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -40,6 +40,8 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => {
 
 vi.mock("./embeddings.js", () => ({
   resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
   createEmbeddingProvider: vi.fn(),
 }));
 

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -132,6 +132,8 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
 
   protected resetProviderInitializationForRetry(): void {}
 
+  protected assertRequiredProviderAvailable(): void {}
+
   protected async indexFile(
     entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -21,6 +21,8 @@ const createEmbeddingProviderMock = vi.hoisted(() =>
 vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: createEmbeddingProviderMock,
   resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderFallbackModel: () => "fts-only",
 }));
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -105,37 +105,12 @@ export async function closeMemoryIndexManagersForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
-  const settings = resolveMemorySearchConfig(params.cfg, params.agentId);
-  if (!settings) {
-    return;
-  }
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
-  const providerRequirement = resolveMemoryEmbeddingProviderRequirement({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    settings,
-  });
-  const key = resolveMemoryIndexManagerCacheKey({
+  await closeMemoryIndexManagersForScope({
     agentId: params.agentId,
     workspaceDir,
-    settings,
-    providerRequirement,
     purpose: "default",
   });
-  const pending = INDEX_CACHE_PENDING.get(key);
-  if (pending) {
-    await Promise.allSettled([pending]);
-  }
-  const manager = INDEX_CACHE.get(key);
-  if (!manager) {
-    return;
-  }
-  INDEX_CACHE.delete(key);
-  try {
-    await manager.close();
-  } catch (err) {
-    log.warn(`failed to close memory index manager for agent ${params.agentId}: ${String(err)}`);
-  }
 }
 
 function resolveEffectiveMemorySearchSettings(
@@ -204,6 +179,45 @@ function resolveMemoryIndexManagerCacheKey(params: {
     JSON.stringify(params.providerRequirement),
     params.purpose,
   ].join(":");
+}
+
+function isMemoryIndexManagerCacheKeyInScope(
+  key: string,
+  params: {
+    agentId: string;
+    workspaceDir: string;
+    purpose: MemoryIndexManagerPurpose;
+  },
+): boolean {
+  return (
+    key.startsWith(`${params.agentId}:${params.workspaceDir}:`) &&
+    key.endsWith(`:${params.purpose}`)
+  );
+}
+
+async function closeMemoryIndexManagersForScope(params: {
+  agentId: string;
+  workspaceDir: string;
+  purpose: MemoryIndexManagerPurpose;
+  exceptKey?: string;
+}): Promise<void> {
+  const isScopedKey = (key: string) =>
+    key !== params.exceptKey && isMemoryIndexManagerCacheKeyInScope(key, params);
+  const pending = Array.from(INDEX_CACHE_PENDING.entries())
+    .filter(([key]) => isScopedKey(key))
+    .map(([, value]) => value);
+  if (pending.length > 0) {
+    await Promise.allSettled(pending);
+  }
+  const entries = Array.from(INDEX_CACHE.entries()).filter(([key]) => isScopedKey(key));
+  for (const [key, manager] of entries) {
+    INDEX_CACHE.delete(key);
+    try {
+      await manager.close();
+    } catch (err) {
+      log.warn(`failed to close memory index manager for agent ${params.agentId}: ${String(err)}`);
+    }
+  }
 }
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
@@ -319,6 +333,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       purpose,
     });
     const transient = purpose === "status" || purpose === "cli";
+    if (!transient) {
+      await closeMemoryIndexManagersForScope({
+        agentId,
+        workspaceDir,
+        purpose,
+        exceptKey: key,
+      });
+    }
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
       pending: INDEX_CACHE_PENDING,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -2,6 +2,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { listRegisteredMemoryEmbeddingProviderAdapters } from "openclaw/plugin-sdk/memory-core-host-embedding-registry";
 import {
   createSubsystemLogger,
   resolveAgentDir,
@@ -139,6 +140,7 @@ function resolveEffectiveMemorySearchSettings(
 
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
+  private readonly purpose: MemoryIndexManagerPurpose;
   protected readonly cfg: OpenClawConfig;
   protected readonly agentId: string;
   protected readonly workspaceDir: string;
@@ -266,6 +268,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     super();
     const effectiveSettings = resolveEffectiveMemorySearchSettings(params.settings);
     this.cacheKey = params.cacheKey;
+    this.purpose =
+      params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
@@ -406,6 +410,40 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     });
   }
 
+  protected isRequiredProviderUnavailable(): boolean {
+    return (
+      this.settings.providerRequirement.mode === "required" &&
+      !this.provider &&
+      this.providerLifecycle.mode === "fts-only" &&
+      this.providerLifecycle.attemptedProviderId === this.settings.provider
+    );
+  }
+
+  protected buildRequiredProviderUnavailableError(operation: "search" | "sync"): Error {
+    const registeredProviderIds = listRegisteredMemoryEmbeddingProviderAdapters()
+      .map((adapter) => adapter.id)
+      .toSorted();
+    const registeredProviders =
+      registeredProviderIds.length > 0 ? registeredProviderIds.join(",") : "none";
+    const reason =
+      this.providerUnavailableReason ??
+      (this.providerLifecycle.mode === "fts-only"
+        ? this.providerLifecycle.reason
+        : "provider is unavailable");
+    return new Error(
+      `Memory ${operation} unavailable: embedding provider "${this.settings.provider}" is configured but unavailable. ` +
+        `Reason: ${reason}. ` +
+        `agentId=${this.agentId} purpose=${this.purpose} lifecycle=${JSON.stringify(this.providerLifecycle)} ` +
+        `registeredMemoryEmbeddingProviders=${registeredProviders}`,
+    );
+  }
+
+  protected assertRequiredProviderAvailable(operation: "search" | "sync"): void {
+    if (this.isRequiredProviderUnavailable()) {
+      throw this.buildRequiredProviderUnavailableError(operation);
+    }
+  }
+
   async warmSession(sessionKey?: string): Promise<void> {
     if (!this.settings.sync.onSessionStart) {
       return;
@@ -455,6 +493,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     },
   ): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
+    if (this.settings.providerRequirement.mode === "required") {
+      await this.ensureProviderInitialized();
+      this.assertRequiredProviderAvailable("search");
+    }
     let hasIndexedContent = this.hasIndexedContent();
     if (!hasIndexedContent) {
       try {
@@ -487,6 +529,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     });
     if (preflight.shouldInitializeProvider) {
       await this.ensureProviderInitialized();
+      this.assertRequiredProviderAvailable("search");
     }
     if (!this.provider && this.providerLifecycle.mode === "degraded") {
       const activatedFallback = await this.activateFallbackProvider(
@@ -531,6 +574,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
     // FTS-only mode: no embedding provider available
     if (!this.provider) {
+      this.assertRequiredProviderAvailable("search");
       if (!this.fts.enabled || !this.fts.available) {
         log.warn("memory search: no provider and FTS unavailable");
         return [];

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -494,12 +494,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   protected isRequiredProviderUnavailable(): boolean {
-    return (
-      this.providerRequirement.mode === "required" &&
-      !this.provider &&
-      this.providerLifecycle.mode === "fts-only" &&
-      this.providerLifecycle.attemptedProviderId === this.settings.provider
-    );
+    return this.providerRequirement.mode === "required" && !this.provider;
   }
 
   protected buildRequiredProviderUnavailableError(operation: "search" | "sync"): Error {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -440,7 +440,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   protected assertRequiredProviderAvailable(operation: "search" | "sync"): void {
     if (this.isRequiredProviderUnavailable()) {
-      throw this.buildRequiredProviderUnavailableError(operation);
+      const error = this.buildRequiredProviderUnavailableError(operation);
+      this.resetProviderInitializationForRetry();
+      throw error;
     }
   }
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -22,9 +22,11 @@ import {
   type MemorySource,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
+  resolveEmbeddingProviderAdapterTransport,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRequest,
@@ -71,6 +73,11 @@ const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCa
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
+type MemoryEmbeddingProviderRequirement = {
+  mode: "fts-only" | "optional" | "required";
+  provider: string;
+  configuredProvider?: string;
+};
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
@@ -103,7 +110,18 @@ export async function closeMemoryIndexManagersForAgent(params: {
     return;
   }
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
-  const key = `${params.agentId}:${workspaceDir}:${JSON.stringify(settings)}:default`;
+  const providerRequirement = resolveMemoryEmbeddingProviderRequirement({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    settings,
+  });
+  const key = resolveMemoryIndexManagerCacheKey({
+    agentId: params.agentId,
+    workspaceDir,
+    settings,
+    providerRequirement,
+    purpose: "default",
+  });
   const pending = INDEX_CACHE_PENDING.get(key);
   if (pending) {
     await Promise.allSettled([pending]);
@@ -138,6 +156,56 @@ function resolveEffectiveMemorySearchSettings(
   };
 }
 
+function resolveConfiguredMemoryEmbeddingProvider(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): string | undefined {
+  const normalizedAgentId = normalizeAgentId(params.agentId);
+  const agentEntry = params.cfg.agents?.list?.find(
+    (entry) => entry && normalizeAgentId(entry.id) === normalizedAgentId,
+  );
+  return agentEntry?.memorySearch?.provider ?? params.cfg.agents?.defaults?.memorySearch?.provider;
+}
+
+function resolveMemoryEmbeddingProviderRequirement(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  settings: ResolvedMemorySearchConfig;
+}): MemoryEmbeddingProviderRequirement {
+  const configuredProvider = resolveConfiguredMemoryEmbeddingProvider(params)?.trim();
+  if (params.settings.provider === "none" || configuredProvider === "none") {
+    return { mode: "fts-only", provider: params.settings.provider };
+  }
+  const adapterTransport = resolveEmbeddingProviderAdapterTransport(
+    params.settings.provider,
+    params.cfg,
+  );
+  if (!configuredProvider || configuredProvider === "auto" || adapterTransport === "local") {
+    return { mode: "optional", provider: params.settings.provider };
+  }
+  return {
+    mode: "required",
+    provider: params.settings.provider,
+    configuredProvider,
+  };
+}
+
+function resolveMemoryIndexManagerCacheKey(params: {
+  agentId: string;
+  workspaceDir: string;
+  settings: ResolvedMemorySearchConfig;
+  providerRequirement: MemoryEmbeddingProviderRequirement;
+  purpose: MemoryIndexManagerPurpose;
+}): string {
+  return [
+    params.agentId,
+    params.workspaceDir,
+    JSON.stringify(params.settings),
+    JSON.stringify(params.providerRequirement),
+    params.purpose,
+  ].join(":");
+}
+
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   private readonly purpose: MemoryIndexManagerPurpose;
@@ -145,6 +213,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly agentId: string;
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
+  private readonly providerRequirement: MemoryEmbeddingProviderRequirement;
   protected override provider: EmbeddingProvider | null;
   private readonly requestedProvider: EmbeddingProviderRequest;
   private providerInitPromise: Promise<void> | null = null;
@@ -237,7 +306,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const purpose =
       params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
-    const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}:${purpose}`;
+    const providerRequirement = resolveMemoryEmbeddingProviderRequirement({
+      cfg,
+      agentId,
+      settings,
+    });
+    const key = resolveMemoryIndexManagerCacheKey({
+      agentId,
+      workspaceDir,
+      settings,
+      providerRequirement,
+      purpose,
+    });
     const transient = purpose === "status" || purpose === "cli";
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
@@ -251,6 +331,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           agentId,
           workspaceDir,
           settings,
+          providerRequirement,
           purpose: params.purpose,
         }),
     });
@@ -262,6 +343,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     agentId: string;
     workspaceDir: string;
     settings: ResolvedMemorySearchConfig;
+    providerRequirement: MemoryEmbeddingProviderRequirement;
     providerResult?: EmbeddingProviderResult;
     purpose?: MemoryIndexManagerPurpose;
   }) {
@@ -274,6 +356,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
     this.settings = effectiveSettings;
+    this.providerRequirement = params.providerRequirement;
     this.provider = null;
     this.requestedProvider = effectiveSettings.provider;
     this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
@@ -412,7 +495,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
   protected isRequiredProviderUnavailable(): boolean {
     return (
-      this.settings.providerRequirement.mode === "required" &&
+      this.providerRequirement.mode === "required" &&
       !this.provider &&
       this.providerLifecycle.mode === "fts-only" &&
       this.providerLifecycle.attemptedProviderId === this.settings.provider
@@ -495,7 +578,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     },
   ): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
-    if (this.settings.providerRequirement.mode === "required") {
+    if (this.providerRequirement.mode === "required") {
       await this.ensureProviderInitialized();
       this.assertRequiredProviderAvailable("search");
     }

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -140,6 +140,8 @@ vi.mock("./sqlite-vec.js", () => ({
 
 vi.mock("./embeddings.js", () => ({
   resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
   createEmbeddingProvider: async () => ({
     requestedProvider: "openai",
     provider: {

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -225,6 +225,12 @@ describe("memory search config", () => {
     });
   });
 
+  it("keeps explicit local providers optional so local degradation can fall back", () => {
+    const resolved = resolveMemorySearchConfig(configWithDefaultProvider("local"), "main");
+
+    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "local" });
+  });
+
   it("marks explicit provider-none as fts-only", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("none"), "main");
 

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -204,6 +204,7 @@ describe("memory search config", () => {
     expect(resolved?.provider).toBe("openai");
     expect(resolved?.model).toBe("text-embedding-3-small");
     expect(resolved?.fallback).toBe("none");
+    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "openai" });
   });
 
   it("normalizes legacy auto provider config to openai", () => {
@@ -211,6 +212,23 @@ describe("memory search config", () => {
 
     expect(resolved?.provider).toBe("openai");
     expect(resolved?.model).toBe("text-embedding-3-small");
+    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "openai" });
+  });
+
+  it("marks explicit concrete providers as required", () => {
+    const resolved = resolveMemorySearchConfig(configWithDefaultProvider("openai"), "main");
+
+    expect(resolved?.providerRequirement).toEqual({
+      mode: "required",
+      provider: "openai",
+      configuredProvider: "openai",
+    });
+  });
+
+  it("marks explicit provider-none as fts-only", () => {
+    const resolved = resolveMemorySearchConfig(configWithDefaultProvider("none"), "main");
+
+    expect(resolved?.providerRequirement).toEqual({ mode: "fts-only", provider: "none" });
   });
 
   it("resolves custom provider ids through their configured api owner", () => {

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -204,7 +204,6 @@ describe("memory search config", () => {
     expect(resolved?.provider).toBe("openai");
     expect(resolved?.model).toBe("text-embedding-3-small");
     expect(resolved?.fallback).toBe("none");
-    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "openai" });
   });
 
   it("normalizes legacy auto provider config to openai", () => {
@@ -212,29 +211,24 @@ describe("memory search config", () => {
 
     expect(resolved?.provider).toBe("openai");
     expect(resolved?.model).toBe("text-embedding-3-small");
-    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "openai" });
   });
 
-  it("marks explicit concrete providers as required", () => {
+  it("resolves explicit concrete providers", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("openai"), "main");
 
-    expect(resolved?.providerRequirement).toEqual({
-      mode: "required",
-      provider: "openai",
-      configuredProvider: "openai",
-    });
+    expect(resolved?.provider).toBe("openai");
   });
 
-  it("keeps explicit local providers optional so local degradation can fall back", () => {
+  it("resolves explicit local providers", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("local"), "main");
 
-    expect(resolved?.providerRequirement).toEqual({ mode: "optional", provider: "local" });
+    expect(resolved?.provider).toBe("local");
   });
 
-  it("marks explicit provider-none as fts-only", () => {
+  it("resolves explicit provider-none", () => {
     const resolved = resolveMemorySearchConfig(configWithDefaultProvider("none"), "main");
 
-    expect(resolved?.providerRequirement).toEqual({ mode: "fts-only", provider: "none" });
+    expect(resolved?.provider).toBe("none");
   });
 
   it("resolves custom provider ids through their configured api owner", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -216,12 +216,13 @@ function getConfiguredMemoryEmbeddingProvider(
 function resolveMemoryEmbeddingProviderRequirement(
   rawProvider: string | undefined,
   provider: string,
+  adapterTransport?: "local" | "remote",
 ): ResolvedMemorySearchConfig["providerRequirement"] {
   const configuredProvider = rawProvider?.trim();
   if (configuredProvider === "none") {
     return { mode: "fts-only", provider };
   }
-  if (!configuredProvider || configuredProvider === "auto") {
+  if (!configuredProvider || configuredProvider === "auto" || adapterTransport === "local") {
     return { mode: "optional", provider };
   }
   return { mode: "required", provider, configuredProvider };
@@ -404,7 +405,11 @@ function mergeConfig(
     extraPaths,
     multimodal,
     provider,
-    providerRequirement: resolveMemoryEmbeddingProviderRequirement(rawProvider, provider),
+    providerRequirement: resolveMemoryEmbeddingProviderRequirement(
+      rawProvider,
+      provider,
+      primaryAdapter?.transport,
+    ),
     remote,
     experimental: {
       sessionMemory,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -34,6 +34,11 @@ export type ResolvedMemorySearchConfig = {
   extraPaths: string[];
   multimodal: MemoryMultimodalSettings;
   provider: string;
+  providerRequirement: {
+    mode: "fts-only" | "optional" | "required";
+    provider: string;
+    configuredProvider?: string;
+  };
   remote?: {
     baseUrl?: string;
     apiKey?: SecretInput;
@@ -206,6 +211,20 @@ function getConfiguredMemoryEmbeddingProvider(
     return undefined;
   }
   return getMemoryEmbeddingProvider(normalizedOwner);
+}
+
+function resolveMemoryEmbeddingProviderRequirement(
+  rawProvider: string | undefined,
+  provider: string,
+): ResolvedMemorySearchConfig["providerRequirement"] {
+  const configuredProvider = rawProvider?.trim();
+  if (configuredProvider === "none") {
+    return { mode: "fts-only", provider };
+  }
+  if (!configuredProvider || configuredProvider === "auto") {
+    return { mode: "optional", provider };
+  }
+  return { mode: "required", provider, configuredProvider };
 }
 
 function mergeConfig(
@@ -385,6 +404,7 @@ function mergeConfig(
     extraPaths,
     multimodal,
     provider,
+    providerRequirement: resolveMemoryEmbeddingProviderRequirement(rawProvider, provider),
     remote,
     experimental: {
       sessionMemory,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -34,11 +34,6 @@ export type ResolvedMemorySearchConfig = {
   extraPaths: string[];
   multimodal: MemoryMultimodalSettings;
   provider: string;
-  providerRequirement: {
-    mode: "fts-only" | "optional" | "required";
-    provider: string;
-    configuredProvider?: string;
-  };
   remote?: {
     baseUrl?: string;
     apiKey?: SecretInput;
@@ -211,21 +206,6 @@ function getConfiguredMemoryEmbeddingProvider(
     return undefined;
   }
   return getMemoryEmbeddingProvider(normalizedOwner);
-}
-
-function resolveMemoryEmbeddingProviderRequirement(
-  rawProvider: string | undefined,
-  provider: string,
-  adapterTransport?: "local" | "remote",
-): ResolvedMemorySearchConfig["providerRequirement"] {
-  const configuredProvider = rawProvider?.trim();
-  if (configuredProvider === "none") {
-    return { mode: "fts-only", provider };
-  }
-  if (!configuredProvider || configuredProvider === "auto" || adapterTransport === "local") {
-    return { mode: "optional", provider };
-  }
-  return { mode: "required", provider, configuredProvider };
 }
 
 function mergeConfig(
@@ -405,11 +385,6 @@ function mergeConfig(
     extraPaths,
     multimodal,
     provider,
-    providerRequirement: resolveMemoryEmbeddingProviderRequirement(
-      rawProvider,
-      provider,
-      primaryAdapter?.transport,
-    ),
     remote,
     experimental: {
       sessionMemory,


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Memory search could silently fall back to keyword-only search when a configured embedding provider was unavailable.
That made `memory_search` look healthy while semantic recall was actually broken.
This change keeps keyword-only search only for intentional or local fallback cases, and fails fast when a concrete remote provider was explicitly configured but cannot be used.

AI-assisted change: implemented and reviewed with a local coding agent.

Fixes #89691

## What Changed

The memory manager now derives an internal provider requirement from the existing memory-search config.
That requirement stays out of the public SDK `ResolvedMemorySearchConfig` shape, but the manager uses it before search and sync so explicit remote provider failures do not degrade into FTS-only behavior.

- Treat `provider: "none"` as explicit FTS-only.
- Treat default, legacy `auto`, and local-transport providers as optional fallback paths.
- Treat explicit concrete non-local providers such as `openai` as required.
- Added memory manager guards so required-provider search and sync fail with a clear diagnostic when provider setup returns no provider.
- Reset required-provider initialization after that failure so a later healthy provider setup can recover.
- Updated active-memory and memory-core tests for the new unavailable-provider behavior.
- Kept the provider requirement internal so external SDK consumers do not need to construct a new required config field.

## Testing

I tested the resolver, active-memory tool behavior, memory manager search/sync behavior, TypeScript compile path, and the guard baselines that current CI exercises.
The focused memory suite covers both the fail-fast case and recovery after provider setup becomes available again.

- `node scripts/run-vitest.mjs src/agents/memory-search.test.ts src/plugins/memory-runtime.test.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/active-memory/index.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts`
- `node scripts/run-vitest.mjs src/agents/memory-search.test.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts`
- `node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts`
- `pnpm tsgo`
- `pnpm check:architecture`
- `git diff --check`
- `codex review --base origin/main`

## Risks

The intended behavior change is that explicit remote provider configuration now fails closed instead of pretending semantic memory is available.
That is safer for this bug, but it can expose existing broken configs that were previously hidden by keyword-only fallback.

- Local embedding provider failures still degrade to keyword-only search because local model availability can be optional and environment-dependent.
- Legacy `provider: "auto"` remains optional at resolver time, but configs that were already migrated by doctor into `provider: "openai"` are indistinguishable from manually explicit OpenAI configs. That upgrade behavior may still need a maintainer/product decision if preserving those already-migrated setups matters.
