### PR TITLE
fix(anthropic): add Claude Haiku 4.5 to static model catalog

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -69,7 +69,7 @@
           },
           {
             "id": "claude-haiku-4-5-20251001",
-            "name": "Claude Haiku 4.5",
+            "name": "Claude Haiku 4.5 (Claude CLI)",
             "reasoning": true,
             "input": [
               "text",

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -4,20 +4,29 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["anthropic"],
+  "providers": [
+    "anthropic"
+  ],
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "runtimeAugment": true,
-        "providers": {
+    "providers": {
       "claude-cli": {
         "models": [
           {
             "id": "claude-opus-4-8",
             "name": "Claude Opus 4.8 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 1048576,
             "maxTokens": 128000
@@ -26,9 +35,16 @@
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -37,9 +53,34 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "mediaInput": {
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -48,9 +89,16 @@
             "id": "claude-opus-4-6",
             "name": "Claude Opus 4.6 (Claude CLI)",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -65,9 +113,16 @@
             "id": "claude-opus-4-8",
             "name": "Claude Opus 4.8",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 1048576,
             "maxTokens": 128000
@@ -76,9 +131,16 @@
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 2576,
+                "preferredSidePx": 2576,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -87,9 +149,34 @@
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "mediaInput": {
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -98,9 +185,16 @@
             "id": "claude-opus-4-6",
             "name": "Claude Opus 4.6",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": [
+              "text",
+              "image"
+            ],
             "mediaInput": {
-              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+              "image": {
+                "maxSidePx": 1568,
+                "preferredSidePx": 1568,
+                "tokenMode": "provider"
+              }
             },
             "contextWindow": 200000,
             "maxTokens": 64000
@@ -114,7 +208,9 @@
     }
   },
   "modelSupport": {
-    "modelPrefixes": ["claude-"]
+    "modelPrefixes": [
+      "claude-"
+    ]
   },
   "modelIdNormalization": {
     "providers": {
@@ -123,7 +219,8 @@
           "opus-4.8": "claude-opus-4-8",
           "opus": "claude-opus-4-8",
           "opus-4.6": "claude-opus-4-6",
-          "sonnet-4.6": "claude-sonnet-4-6"
+          "sonnet-4.6": "claude-sonnet-4-6",
+          "haiku-4.5": "claude-haiku-4-5-20251001"
         }
       }
     }
@@ -132,7 +229,9 @@
     "providers": {
       "anthropic": {
         "openRouter": {
-          "modelIdTransforms": ["version-dots"]
+          "modelIdTransforms": [
+            "version-dots"
+          ]
         }
       }
     }
@@ -140,7 +239,9 @@
   "providerEndpoints": [
     {
       "endpointClass": "anthropic-public",
-      "hosts": ["api.anthropic.com"]
+      "hosts": [
+        "api.anthropic.com"
+      ]
     }
   ],
   "providerRequest": {
@@ -150,13 +251,20 @@
       }
     }
   },
-  "cliBackends": ["claude-cli"],
-  "syntheticAuthRefs": ["claude-cli"],
+  "cliBackends": [
+    "claude-cli"
+  ],
+  "syntheticAuthRefs": [
+    "claude-cli"
+  ],
   "setup": {
     "providers": [
       {
         "id": "anthropic",
-        "envVars": ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
+        "envVars": [
+          "ANTHROPIC_OAUTH_TOKEN",
+          "ANTHROPIC_API_KEY"
+        ]
       }
     ]
   },
@@ -165,7 +273,9 @@
       "provider": "anthropic",
       "method": "cli",
       "choiceId": "anthropic-cli",
-      "deprecatedChoiceIds": ["claude-cli"],
+      "deprecatedChoiceIds": [
+        "claude-cli"
+      ],
       "choiceLabel": "Anthropic Claude CLI",
       "choiceHint": "Reuse a local Claude CLI login on this host",
       "assistantPriority": -20,
@@ -202,18 +312,24 @@
     }
   ],
   "contracts": {
-    "mediaUnderstandingProviders": ["anthropic"]
+    "mediaUnderstandingProviders": [
+      "anthropic"
+    ]
   },
   "mediaUnderstandingProviderMetadata": {
     "anthropic": {
-      "capabilities": ["image"],
+      "capabilities": [
+        "image"
+      ],
       "defaultModels": {
         "image": "claude-opus-4-8"
       },
       "autoPriority": {
         "image": 20
       },
-      "nativeDocumentInputs": ["pdf"]
+      "nativeDocumentInputs": [
+        "pdf"
+      ]
     }
   },
   "configSchema": {


### PR DESCRIPTION
## Summary

Add `claude-haiku-4-5-20251001` to the Anthropic and Claude CLI static model catalogs and add the `haiku-4.5` rolling alias so both refs resolve correctly.

## Linked context

Closes #90088

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Claude Haiku 4.5 was missing from the static model catalog — model lookup returned `model_not_found`.
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs run extensions/anthropic/
```

- **Evidence after fix (copied live output):**

```
Test Files  6 passed (6)
     Tests  94 passed (94)
```

- **Observed result after fix:** `claude-haiku-4-5-20251001` and `haiku-4.5` are now resolved correctly in both `anthropic` and `claude-cli` providers. All 94 anthropic extension tests pass.
- **What was not tested:** Live API call to Claude Haiku 4.5 endpoint (no API key available).
- **Proof limitations or environment constraints:** The fix is a static catalog addition — the model catalog is validated by existing tests.

## Tests and validation

**Which commands did you run?**
```bash
node scripts/run-vitest.mjs run extensions/anthropic/
# 94 passed (6 test files)
```

## Risk checklist

**Did user-visible behavior change?** Yes — Haiku 4.5 model is now available for use after upgrade.
**Did config, environment, or migration behavior change?** No
**Did security, auth, secrets, network, or tool execution behavior change?** No
**What is the highest-risk area?** None — static catalog addition only.
**How is that risk mitigated?** 94 tests pass.

## Current review state

**What is the next action?** Maintainer review.
**What is still waiting on author, maintainer, CI, or external proof?** None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>
