### PR TITLE
fix(acp): default parent commentary in progress mode

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -548,12 +548,11 @@ Two ways to start an ACP session:
   requester session as system events. Accepted responses include
   `streamLogPath` pointing to a session-scoped JSONL log
   (`<sessionId>.acp-stream.jsonl`) you can tail for full relay history.
-  For Discord, parent progress streams show assistant commentary and ACP status
-  progress by default unless `streaming.progress.commentary=false`. Other
-  parent channels show that text only when
-  `streaming.progress.commentary=true`. Status progress still honors
-  `acp.stream.tagVisibility`, so tags such as `plan` remain hidden unless
-  explicitly enabled.
+  Parent progress streams show assistant commentary and ACP status progress by
+  default unless `streaming.progress.commentary=false`. Discord also defaults
+  parent previews to progress mode when no stream mode is configured. Status
+  progress still honors `acp.stream.tagVisibility`, so tags such as `plan`
+  remain hidden unless explicitly enabled.
 </ParamField>
 
 ACP `sessions_spawn` runs use `agents.defaults.subagents.runTimeoutSeconds` for

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -546,29 +546,44 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
-  it("does not default commentary on for generic progress-mode channels", () => {
+  it.each([
+    {
+      label: "generic",
+      channelId: "forum",
+      deliveryContext: progressCommentaryDeliveryContext,
+    },
+    {
+      label: "Telegram",
+      channelId: "telegram",
+      deliveryContext: {
+        ...progressCommentaryDeliveryContext,
+        channel: "telegram",
+      },
+    },
+  ])("defaults commentary on for $label parent progress mode", ({ channelId, deliveryContext }) => {
+    const runId = `run-${channelId}-commentary-default`;
     const relay = startAcpSpawnParentStreamRelay({
-      runId: "run-generic-commentary-default",
+      runId,
       parentSessionKey: "agent:main:main",
-      childSessionKey: "agent:codex:acp:child-generic-commentary-default",
+      childSessionKey: `agent:codex:acp:child-${channelId}-commentary-default`,
       agentId: "codex",
       cfg: {
         channels: {
-          forum: {
+          [channelId]: {
             streaming: {
               mode: "progress",
             },
           },
         },
       },
-      deliveryContext: progressCommentaryDeliveryContext,
+      deliveryContext,
       streamFlushMs: 10,
       noOutputNoticeMs: 120_000,
       emitStartNotice: false,
     });
 
     emitAgentEvent({
-      runId: "run-generic-commentary-default",
+      runId,
       stream: "assistant",
       data: {
         delta: "checking thread context; then post a tight progress reply here.",
@@ -577,7 +592,10 @@ describe("startAcpSpawnParentStreamRelay", () => {
     });
     vi.advanceTimersByTime(15);
 
-    expect(collectedTexts()).toEqual([]);
+    expectTextWithFragment(
+      collectedTexts(),
+      "codex: checking thread context; then post a tight progress reply here.",
+    );
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -198,10 +198,9 @@ function resolveParentProgressCommentary(params: {
   cfg: OpenClawConfig | undefined;
   deliveryContext: DeliveryContext | undefined;
 }): boolean {
-  const channelId = normalizeOptionalString(params.deliveryContext?.channel);
   return resolveChannelStreamingProgressCommentary(
     resolveParentProgressStreamingEntry(params),
-    channelId === "discord",
+    true,
   );
 }
 


### PR DESCRIPTION
Summary
- Default ACP parent commentary on for any parent channel already using progress mode.
- Keep Discord's existing preview-mode default; Telegram and other channels still need progress mode before commentary appears.
- Update ACP docs and regression coverage for the fixed default.

Verification
- node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/acp-spawn-parent-stream.test.ts --pool forks --maxWorkers=1
- node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --pretty false
- git diff --check origin/main..HEAD
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
