### PR TITLE
fix(agents): resolve compaction model alias before dispatch

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -393,4 +393,41 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     });
     expect(result.provider).toBe("anthropic");
   });
+
+  it("resolves a configured compaction model alias to its canonical provider/model (#90340)", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: {
+          defaults: {
+            models: { "openai/gpt-5.4-mini": { alias: "gpt54mini" } },
+            compaction: { model: "gpt54mini" },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai:default",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    // Before #90340: the bare alias "gpt54mini" was forwarded unchanged and
+    // rejected downstream as "Unknown model: openai/gpt54mini". After the fix
+    // it resolves to the canonical configured provider/model.
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4-mini");
+  });
+
+  it("leaves an already provider-qualified compaction model override unchanged (#90340)", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: { defaults: { compaction: { model: "openai/gpt-5.4-mini" } } },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4-mini");
+  });
 });

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../model-selection-shared.js";
+import {
   listActiveProcessSessionReferences,
   type ActiveProcessSessionReference,
 } from "../bash-process-references.js";
@@ -47,6 +51,40 @@ export type EmbeddedCompactionRuntimeContext = {
  * Resolve the effective compaction target from config, falling back to the
  * caller-supplied provider/model and optionally applying runtime defaults.
  */
+/**
+ * Expand a configured model alias (no provider prefix) in
+ * `agents.defaults.compaction.model` to its canonical `provider/model` ref,
+ * reusing the same alias index/resolver as normal agent model selection.
+ *
+ * Idempotent: values that are empty, already provider-qualified (contain "/"),
+ * or do not match any configured alias are returned unchanged, so normal
+ * compaction targets keep their existing behavior.
+ */
+function resolveCompactionModelAlias(
+  rawOverride: string | undefined,
+  config: OpenClawConfig | undefined,
+  defaultProvider: string | undefined,
+): string | undefined {
+  if (!rawOverride || rawOverride.includes("/") || !config) {
+    return rawOverride;
+  }
+  const fallbackProvider = defaultProvider?.trim();
+  if (!fallbackProvider) {
+    return rawOverride;
+  }
+  const aliasIndex = buildModelAliasIndex({
+    cfg: config,
+    defaultProvider: fallbackProvider,
+  });
+  const resolved = resolveModelRefFromString({
+    cfg: config,
+    raw: rawOverride,
+    defaultProvider: fallbackProvider,
+    aliasIndex,
+  });
+  return resolved ? `${resolved.ref.provider}/${resolved.ref.model}` : rawOverride;
+}
+
 export function resolveEmbeddedCompactionTarget(params: {
   config?: OpenClawConfig;
   provider?: string | null;
@@ -64,7 +102,12 @@ export function resolveEmbeddedCompactionTarget(params: {
 } {
   const provider = params.provider?.trim() || params.defaultProvider;
   const model = params.modelId?.trim() || params.defaultModel;
-  const override = params.config?.agents?.defaults?.compaction?.model?.trim();
+  const rawOverride = params.config?.agents?.defaults?.compaction?.model?.trim();
+  // Resolve a configured model alias (e.g. "gpt54mini") in
+  // agents.defaults.compaction.model through the same alias resolver used by
+  // normal agent model selection, so compaction dispatches to the canonical
+  // provider/model instead of forwarding the bare alias (Fixes #90340).
+  const override = resolveCompactionModelAlias(rawOverride, params.config, provider);
   const resolveTargetProviders = (
     targetProvider: string | undefined,
     authProfileId: string | undefined,


### PR DESCRIPTION
## Summary

Auto-compaction read `agents.defaults.compaction.model` verbatim, so a configured alias (no provider prefix) was forwarded unchanged and rejected downstream. With the alias `gpt54mini` configured for `openai/gpt-5.4-mini`, embedded auto-compaction dispatched `openai/gpt54mini` and failed with `Unknown model: openai/gpt54mini`.

`resolveEmbeddedCompactionTarget` now expands the override through the same model alias resolver used by normal agent model selection (`buildModelAliasIndex` + `resolveModelRefFromString`) before dispatch, so the alias resolves to the canonical `openai/gpt-5.4-mini`.

The expansion is idempotent: empty, already provider-qualified (containing `/`), or non-matching values are returned unchanged, so existing compaction targets keep their current behavior.

Fixes #90340

## Real behavior proof

### Behavior or issue addressed
Embedded auto-compaction failed for sessions whose `agents.defaults.compaction.model` is set to a configured alias instead of a fully-qualified `provider/model` id; the alias was sent verbatim and rejected as an unknown model.

### Real environment tested
Local OpenClaw checkout at the PR head (`fix-90340-compaction-model-alias`), Node 24, executed the resolver against a config matching the report's sanitized shape.

### Exact steps or command run
node verify-90340.mjs (a throwaway script importing the real `resolveEmbeddedCompactionTarget` from the source module and invoking it with the report's config shape)

### Evidence after fix
node verify-90340.mjs printed:
alias case -> {"provider":"openai","model":"gpt-5.4-mini"}
already-qualified case -> {"provider":"openai","model":"gpt-5.4-mini"}

### Observed result after fix
With `compaction.model = "gpt54mini"` and `models["openai/gpt-5.4-mini"].alias = "gpt54mini"`, the resolved target is `provider=openai, model=gpt-5.4-mini` (canonical), instead of the previous bare `gpt54mini`. An already provider-qualified override (`openai/gpt-5.4-mini`) is left unchanged, confirming the expansion is idempotent.

## Out-of-scope follow-ups
- Only the embedded auto-compaction path is covered here. The `agents.defaults.compaction.memoryFlush.model` field is left untouched; if it needs the same treatment that can be a separate change.

## What was not tested
- Live end-to-end auto-compaction against a real OpenAI account was not exercised; verification was done at the resolver layer where the alias-to-canonical bug occurs, plus added regression unit tests.
