### PR TITLE
Fix unreadable Sessions label column

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2751,6 +2751,22 @@
   white-space: nowrap;
 }
 
+.sessions-table .session-label-col {
+  min-width: calc(8ch + 24px);
+  width: clamp(calc(8ch + 24px), 12vw, calc(16ch + 24px));
+}
+
+.sessions-table .session-label-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: calc(8ch + 20px);
+  max-width: calc(16ch + 20px);
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
 .data-table th {
   position: sticky;
   top: 0;

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -724,7 +724,7 @@ export function renderSessions(props: SessionsProps) {
                     : nothing}
                 </th>
                 ${sortHeader("key", t("sessionsView.key"), "data-table-key-col")}
-                <th>${t("sessionsView.label")}</th>
+                <th class="session-label-col">${t("sessionsView.label")}</th>
                 ${sortHeader("kind", t("sessionsView.kind"))}
                 <th class="session-status-col">${t("sessionsView.status")}</th>
                 <th>${t("agents.context.runtime")}</th>
@@ -931,12 +931,12 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
             : nothing}
         </div>
       </td>
-      <td>
+      <td class="session-label-col">
         <input
+          class="session-label-input"
           .value=${row.label ?? ""}
           ?disabled=${props.loading}
           placeholder=${t("sessionsView.optionalPlaceholder")}
-          style="width: 100%; max-width: 140px; padding: 6px 10px; font-size: 13px; border: 1px solid var(--border); border-radius: var(--radius-sm);"
           @change=${(e: Event) => {
             const value = normalizeOptionalString((e.target as HTMLInputElement).value) ?? null;
             props.onPatch(row.key, { label: value });


### PR DESCRIPTION
## Summary

- give the Sessions table `Label` column an explicit, text-sized width instead of letting the browser table algorithm squeeze it down
- move the label input's inline styling into CSS and size it in `ch`, with room for padding/border
- keep the existing responsive behavior intact; this does not touch `layout.mobile.css` because the table already hides low-priority columns at `<= 900px`

## Problem

The current Control UI Sessions table can make the `Label` column effectively unreadable. In the reporter screenshot, the label input is squeezed to only a few visible characters, so the column is present but not practically usable.

This happens because the column has no dedicated width/min-width while the table is dense and uses the browser's default table layout. The input also had only an inline `max-width: 140px`, which caps it but does not reserve useful space for the column.

## Fix

This patch adds a dedicated `session-label-col` class to the `Label` header/cells and a `session-label-input` class for the input.

The sizing is character-based:

- minimum column/input room: about 8 label characters plus input chrome
- normal/maximum input room: about 16 label characters plus input chrome
- column width uses `clamp(...)` so it can breathe on wider tables without forcing an additional mobile-specific layout

I intentionally did not change `layout.mobile.css`: below 900px the table is already in the mode where cramming more columns in makes the UI worse, not better.

## Validation

- `git diff --check`
- `npm exec --yes --package=oxfmt -- oxfmt --check ui/src/ui/views/sessions.ts ui/src/styles/components.css`
- `npm exec --yes --package=oxlint@1.67.0 -- oxlint ui/src/ui/views/sessions.ts`

`npm run ui:build` was attempted, but this local checkout does not have UI dependencies installed and the wrapper exited before producing build output.
