### PR TITLE
fix(auto-reply): keep the message_sending gate when a channel sets beforeDeliver

### DIFF
--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -313,6 +313,83 @@ describe("withReplyDispatcher", () => {
     );
   });
 
+  it("still runs message_sending when a channel supplies a beforeDeliver", async () => {
+    // Regression: a channel that installs any beforeDeliver — even an identity
+    // no-op, like the Telegram bot dispatch — must not bypass the message_sending
+    // gate. Before the fix the channel hook replaced the canonical chain entirely.
+    const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending,
+    });
+    hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx({
+        From: "telegram:1155284475",
+        To: "telegram:1155284475",
+        OriginatingTo: "telegram:1155284475",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+        beforeDeliver: async (payload) => payload, // channel identity no-op
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = requireReplyDispatcherOptions();
+    if (!dispatcherOptions?.beforeDeliver) {
+      throw new Error("expected beforeDeliver hook");
+    }
+    const payload = await dispatcherOptions.beforeDeliver(
+      { text: "original reply" },
+      { kind: "final" },
+    );
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(payload).toEqual({ text: "sanitized reply" });
+  });
+
+  it("cancels delivery when message_sending vetoes, even with a channel beforeDeliver", async () => {
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending,
+    });
+    hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    const channelBeforeDeliver: ReplyDispatchBeforeDeliver = vi.fn(async (payload) => payload);
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx({
+        From: "telegram:1",
+        To: "telegram:1",
+        OriginatingTo: "telegram:1",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+        beforeDeliver: channelBeforeDeliver,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = requireReplyDispatcherOptions();
+    if (!dispatcherOptions?.beforeDeliver) {
+      throw new Error("expected beforeDeliver hook");
+    }
+    const payload = await dispatcherOptions.beforeDeliver(
+      { text: "original reply" },
+      { kind: "final" },
+    );
+
+    // The message_sending veto cancels delivery even though the channel hook ran.
+    expect(payload).toBeNull();
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+  });
+
   it("runs reply_payload_sending hooks before inbound dispatcher delivery", async () => {
     const runReplyPayloadSending = vi.fn(async ({ payload }: { payload: { text?: string } }) => ({
       payload: {
@@ -711,7 +788,6 @@ describe("withReplyDispatcher", () => {
 
     expect(customBeforeDeliver).toHaveBeenCalledTimes(1);
     expect(customBeforeDeliver).toHaveBeenCalledWith({ text: "original" }, { kind: "final" });
-    expect(runMessageSending).not.toHaveBeenCalled();
     expect(runReplyPayloadSending).toHaveBeenCalledTimes(1);
     expect(runReplyPayloadSending).toHaveBeenCalledWith(
       {
@@ -728,7 +804,15 @@ describe("withReplyDispatcher", () => {
         runId: undefined,
       },
     );
-    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+    // message_sending now composes after the channel hook + reply_payload_sending
+    // (previously a channel-supplied beforeDeliver silently disabled it), so it
+    // gates the fully-composed payload.
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "original [custom] [plugin]" }),
+      expect.anything(),
+    );
+    expect(payload).toEqual({ text: "message hook" });
   });
 
   it("does not copy source conversation type onto cross-session native silent-reply targets", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -526,8 +526,13 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(finalized),
   );
+  // A channel-supplied beforeDeliver must compose WITH the canonical gates
+  // (reply_payload_sending + message_sending), not replace them. Composing against
+  // replyPayloadBeforeDeliver alone dropped the message_sending gate, so a channel
+  // that installs any beforeDeliver — even an identity no-op, like the Telegram bot
+  // dispatch — silently disabled message_sending for that channel's replies.
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, globalBeforeDeliver)
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -617,8 +622,11 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(params.ctx),
   );
+  // See dispatchInboundMessageWithBufferedDispatcher: compose the channel-supplied
+  // beforeDeliver WITH the canonical gates (incl. message_sending) so a channel
+  // hook cannot silently disable the message_sending gate.
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, globalBeforeDeliver)
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,


### PR DESCRIPTION
## Problem

When a channel installs its own dispatcher `beforeDeliver`, the `message_sending` hook is silently skipped for that channel's replies.

In both `dispatchInboundMessageWithBufferedDispatcher` and `dispatchInboundMessageWithDispatcher`, a channel-supplied `beforeDeliver` is composed against `replyPayloadBeforeDeliver` **alone**:

```ts
const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
  ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
  : globalBeforeDeliver; // globalBeforeDeliver = reply_payload_sending + message_sending
```

The `globalBeforeDeliver` chain — which includes `message_sending` — is only used when **no** channel `beforeDeliver` is present. But the Telegram bot dispatch (and native commands) install an **identity no-op** `beforeDeliver: async (payload) => payload`, which is enough to take the channel branch and drop the gate. As a result, `message_sending` plugins (content gating, redaction, banners, policy checks, …) never run for those channels' interactive replies.

## Fix

Compose the channel hook **with** `globalBeforeDeliver` instead of `replyPayloadBeforeDeliver`, in both functions:

```ts
? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, globalBeforeDeliver)
```

Channel-first ordering is preserved (the channel hook runs first, then `reply_payload_sending`, then `message_sending`); `message_sending` now gates the fully-composed payload, and a `message_sending` veto still cancels delivery.

## Behavior change

`dispatch.test.ts` previously asserted `expect(runMessageSending).not.toHaveBeenCalled()` when a channel supplied a `beforeDeliver` — i.e. it codified the skip. That assertion is updated to expect `message_sending` to run, on the basis that a channel-supplied `beforeDeliver` (especially an identity no-op) should *compose* with the canonical gate, not disable it. Flagging this explicitly since it's an intentional behavior change, not just a refactor.

## Tests

- Updated `composes custom beforeDeliver with reply_payload_sending hooks` to assert `message_sending` runs over the composed payload.
- Added `still runs message_sending when a channel supplies a beforeDeliver` (the Telegram identity-no-op case).
- Added `cancels delivery when message_sending vetoes, even with a channel beforeDeliver`.

All `src/auto-reply/dispatch.test.ts` tests pass.

## Real behavior proof

Driving the **real** `dispatchInboundMessageWithDispatcher` compose path with the exact identity-no-op `beforeDeliver` the Telegram bot dispatch installs (`async (p) => p`) and a `message_sending` hook that redacts a sensitive name (standing in for a gating plugin). Same input, run on current `main` vs this PR:

**Before (current `main`):**
```
reply text in : "Meeting with Frolov at 3pm"
delivered out : "Meeting with Frolov at 3pm"
message_sending hook invoked: NO
sensitive name gated: NO
```

**After (this PR):**
```
reply text in : "Meeting with Frolov at 3pm"
delivered out : "Meeting with █████ at 3pm"
message_sending hook invoked: YES
sensitive name gated: YES
```

The channel's no-op `beforeDeliver` no longer bypasses the gate — `message_sending` runs and redacts the name.

> Honest scope: this is real-**code-path** terminal output, not a production channel capture. The dispatch compose (the actual fix) runs for real; `createReplyDispatcher` is stubbed only to capture the composed hook, and the `message_sending` hook is a representative redactor. The channel `beforeDeliver` is the literal identity no-op from the Telegram bot dispatch. A live Telegram-desktop capture would require deploying this build to a gateway — happy to provide one if a maintainer requires it.

## CI note

The `build-artifacts` red is unrelated to this change — it fails on a `lint-suppressions` allowlist test and a `gateway-cpu` startup build (`spawn ENOENT`), neither of which this 2-file dispatch change touches; it reproduces on `main`.
