### PR TITLE
fix(gateway): remove device-backed node pairings

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -39,7 +39,13 @@ openclaw nodes status --last-connected 24h
 `nodes list` prints pending/paired tables. Paired rows include the most recent connect age (Last Connect).
 Use `--connected` to only show currently-connected nodes. Use `--last-connected <duration>` to
 filter to nodes that connected within a duration (e.g. `24h`, `7d`).
-Use `nodes remove --node <id|name|ip>` to delete a stale gateway-owned node pairing record.
+Use `nodes remove --node <id|name|ip>` to remove a node pairing. For a
+device-backed node this revokes the device's `node` role in `devices/paired.json`
+and disconnects its node-role sessions (a mixed-role device keeps its row and
+only loses the `node` role; a node-only device is deleted); it also clears any
+matching legacy gateway-owned node pairing record. `operator.pairing` can remove
+non-operator node rows; a device-token caller revoking its own node role on a
+mixed-role device additionally needs `operator.admin`.
 
 Approval note:
 

--- a/docs/gateway/pairing.md
+++ b/docs/gateway/pairing.md
@@ -58,7 +58,14 @@ Methods:
 - `node.pair.list` - list pending + paired nodes (`operator.pairing`).
 - `node.pair.approve` - approve a pending request (issues token).
 - `node.pair.reject` - reject a pending request.
-- `node.pair.remove` - remove a stale paired node entry.
+- `node.pair.remove` - remove a paired node. For device-backed pairings this
+  revokes the device's `node` role: it mutates `devices/paired.json` and
+  invalidates/disconnects that device's node-role sessions. A **mixed-role**
+  device (e.g. it also holds `operator`) keeps its row and only loses the `node`
+  role; a node-only device row is deleted. It also removes any matching legacy
+  gateway-owned node pairing entry. Authz: `operator.pairing` may remove
+  non-operator node rows; a device-token caller revoking its **own** node role on
+  a mixed-role device additionally needs `operator.admin`.
 - `node.pair.verify` - verify `{ nodeId, token }`.
 
 Notes:

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -51,8 +51,14 @@ Notes:
   different role that pairing approval never granted.
 - `node.pair.*` (CLI: `openclaw nodes pending/approve/reject/remove/rename`) is a separate gateway-owned
   node pairing store; it does **not** gate the WS `connect` handshake.
-- `openclaw nodes remove --node <id|name|ip>` deletes stale entries from that
-  separate gateway-owned node pairing store.
+- `openclaw nodes remove --node <id|name|ip>` removes a node pairing. For a
+  device-backed node it revokes the device's `node` role in `devices/paired.json`
+  and disconnects that device's node-role sessions — a mixed-role device keeps
+  its row and only loses the `node` role, while a node-only device row is
+  deleted. It also clears any matching entry from the separate gateway-owned node
+  pairing store. `operator.pairing` may remove non-operator node rows; a
+  device-token caller revoking its own node role on a mixed-role device
+  additionally needs `operator.admin`.
 - Approval scope follows the pending request's declared commands:
   - commandless request: `operator.pairing`
   - non-exec node commands: `operator.pairing` + `operator.write`

--- a/src/gateway/server-methods/device-management-authz.ts
+++ b/src/gateway/server-methods/device-management-authz.ts
@@ -1,7 +1,7 @@
 import type { DeviceAuthToken } from "../../infra/device-pairing.js";
 import type { GatewayClient } from "./types.js";
 
-type DeviceSessionAuthz = {
+export type DeviceSessionAuthz = {
   callerDeviceId: string | null;
   callerScopes: string[];
   isAdminCaller: boolean;

--- a/src/gateway/server-methods/device-management-authz.ts
+++ b/src/gateway/server-methods/device-management-authz.ts
@@ -1,0 +1,99 @@
+import type { DeviceAuthToken } from "../../infra/device-pairing.js";
+import type { GatewayClient } from "./types.js";
+
+type DeviceSessionAuthz = {
+  callerDeviceId: string | null;
+  callerScopes: string[];
+  isAdminCaller: boolean;
+};
+
+export type DeviceManagementAuthz = DeviceSessionAuthz & {
+  normalizedTargetDeviceId: string;
+};
+
+export function resolveDeviceSessionAuthz(client: GatewayClient | null): DeviceSessionAuthz {
+  const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  const rawCallerDeviceId = client?.connect?.device?.id;
+  const callerDeviceId =
+    // Plain shared-auth connections may report device metadata, but only
+    // device-token auth proves ownership for self-service pairing actions.
+    client?.isDeviceTokenAuth && typeof rawCallerDeviceId === "string" && rawCallerDeviceId.trim()
+      ? rawCallerDeviceId.trim()
+      : null;
+  return {
+    callerDeviceId,
+    callerScopes,
+    isAdminCaller: callerScopes.includes("operator.admin"),
+  };
+}
+
+export function resolveDeviceManagementAuthz(
+  client: GatewayClient | null,
+  targetDeviceId: string,
+): DeviceManagementAuthz {
+  return {
+    ...resolveDeviceSessionAuthz(client),
+    normalizedTargetDeviceId: targetDeviceId.trim(),
+  };
+}
+
+export function deniesCrossDeviceManagement(authz: DeviceManagementAuthz): boolean {
+  return Boolean(
+    authz.callerDeviceId &&
+    authz.callerDeviceId !== authz.normalizedTargetDeviceId &&
+    !authz.isAdminCaller,
+  );
+}
+
+export function deniesDeviceTokenRoleManagement(
+  authz: DeviceManagementAuthz,
+  targetRole: string,
+): boolean {
+  const normalizedTargetRole = targetRole.trim();
+  if (!normalizedTargetRole || authz.isAdminCaller) {
+    return false;
+  }
+  return normalizedTargetRole !== "operator";
+}
+
+function hasNonOperatorDeviceRole(input: { role?: string; roles?: string[] }): boolean {
+  const roles = new Set<string>();
+  const role = input.role?.trim();
+  if (role) {
+    roles.add(role);
+  }
+  for (const entry of input.roles ?? []) {
+    const normalized = entry.trim();
+    if (normalized) {
+      roles.add(normalized);
+    }
+  }
+  return [...roles].some((entry) => entry !== "operator");
+}
+
+function hasNonOperatorDeviceTokenRole(
+  tokens: Record<string, DeviceAuthToken> | undefined,
+): boolean {
+  for (const token of Object.values(tokens ?? {})) {
+    const normalized = token.role.trim();
+    if (normalized && normalized !== "operator") {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function requestsNonOperatorDeviceRole(pending: {
+  role?: string;
+  roles?: string[];
+}): boolean {
+  return hasNonOperatorDeviceRole(pending);
+}
+
+export function pairedDeviceHasNonOperatorRole(device: {
+  role?: string;
+  roles?: string[];
+  tokens?: Record<string, DeviceAuthToken>;
+}): boolean {
+  return hasNonOperatorDeviceRole(device) || hasNonOperatorDeviceTokenRole(device.tokens);
+}

--- a/src/gateway/server-methods/device-management-security.ts
+++ b/src/gateway/server-methods/device-management-security.ts
@@ -1,0 +1,55 @@
+import { createHash } from "node:crypto";
+import {
+  emitTrustedSecurityEvent,
+  type DiagnosticSecurityEventInput,
+} from "../../infra/diagnostic-events.js";
+import type { DeviceSessionAuthz } from "./device-management-authz.js";
+
+type DeviceSecurityDecision = NonNullable<DiagnosticSecurityEventInput["policy"]>["decision"];
+
+function hashDeviceSecurityId(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return `sha256:${createHash("sha256").update(normalized).digest("hex").slice(0, 12)}`;
+}
+
+export function emitDeviceManagementSecurityEvent(params: {
+  action: string;
+  outcome: DiagnosticSecurityEventInput["outcome"];
+  severity: DiagnosticSecurityEventInput["severity"];
+  authz: DeviceSessionAuthz;
+  targetDeviceId?: string;
+  policyId: string;
+  decision: DeviceSecurityDecision;
+  controlId: string;
+  reason?: string;
+  attributes?: Record<string, string | number | boolean>;
+}) {
+  emitTrustedSecurityEvent({
+    category: "auth",
+    action: params.action,
+    outcome: params.outcome,
+    severity: params.severity,
+    actor: {
+      kind: "operator",
+      ...(params.authz.callerDeviceId
+        ? { deviceIdHash: hashDeviceSecurityId(params.authz.callerDeviceId) }
+        : {}),
+      role: params.authz.isAdminCaller ? "admin" : "operator",
+    },
+    target: {
+      kind: "device",
+      ...(params.targetDeviceId ? { idHash: hashDeviceSecurityId(params.targetDeviceId) } : {}),
+    },
+    policy: {
+      id: params.policyId,
+      decision: params.decision,
+      ...(params.reason ? { reason: params.reason } : {}),
+    },
+    control: { id: params.controlId, family: "auth" },
+    ...(params.reason ? { reason: params.reason } : {}),
+    ...(params.attributes ? { attributes: params.attributes } : {}),
+  });
+}

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -1,5 +1,4 @@
 // Gateway RPC handlers for device pairing and device-token lifecycle operations.
-import { createHash } from "node:crypto";
 import {
   ErrorCodes,
   errorShape,
@@ -26,10 +25,7 @@ import {
   rotateDeviceToken,
   summarizeDeviceTokens,
 } from "../../infra/device-pairing.js";
-import {
-  emitTrustedSecurityEvent,
-  type DiagnosticSecurityEventInput,
-} from "../../infra/diagnostic-events.js";
+import type { DiagnosticSecurityEventInput } from "../../infra/diagnostic-events.js";
 import {
   deniesCrossDeviceManagement,
   deniesDeviceTokenRoleManagement,
@@ -39,13 +35,13 @@ import {
   resolveDeviceSessionAuthz,
 } from "./device-management-authz.js";
 import type { DeviceManagementAuthz } from "./device-management-authz.js";
+import { emitDeviceManagementSecurityEvent } from "./device-management-security.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 const DEVICE_TOKEN_ROTATION_DENIED_MESSAGE = "device token rotation denied";
 const DEVICE_TOKEN_REVOCATION_DENIED_MESSAGE = "device token revocation denied";
 
 type DeviceSessionAuthz = ReturnType<typeof resolveDeviceSessionAuthz>;
-type DeviceSecurityDecision = NonNullable<DiagnosticSecurityEventInput["policy"]>["decision"];
 
 const DEVICE_PAIR_APPROVAL_DENIED_MESSAGE = "device pairing approval denied";
 const DEVICE_PAIR_REJECTION_DENIED_MESSAGE = "device pairing rejection denied";
@@ -101,14 +97,6 @@ function shouldReturnRotatedDeviceToken(authz: DeviceManagementAuthz): boolean {
   return Boolean(authz.callerDeviceId && authz.callerDeviceId === authz.normalizedTargetDeviceId);
 }
 
-function hashDeviceSecurityId(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-  return `sha256:${createHash("sha256").update(normalized).digest("hex").slice(0, 12)}`;
-}
-
 function emitDeviceSecurityEvent(params: {
   action: string;
   outcome: DiagnosticSecurityEventInput["outcome"];
@@ -116,39 +104,12 @@ function emitDeviceSecurityEvent(params: {
   authz: DeviceSessionAuthz;
   targetDeviceId?: string;
   policyId: string;
-  decision: DeviceSecurityDecision;
+  decision: NonNullable<DiagnosticSecurityEventInput["policy"]>["decision"];
   controlId: string;
   reason?: string;
   attributes?: Record<string, string | number | boolean>;
 }) {
-  emitTrustedSecurityEvent({
-    category: "auth",
-    action: params.action,
-    outcome: params.outcome,
-    severity: params.severity,
-    actor: {
-      kind: "operator",
-      ...(params.authz.callerDeviceId
-        ? { deviceIdHash: hashDeviceSecurityId(params.authz.callerDeviceId) }
-        : {}),
-      role: params.authz.isAdminCaller ? "admin" : "operator",
-    },
-    target: {
-      kind: "device",
-      ...(params.targetDeviceId ? { idHash: hashDeviceSecurityId(params.targetDeviceId) } : {}),
-    },
-    policy: {
-      id: params.policyId,
-      decision: params.decision,
-      ...(params.reason ? { reason: params.reason } : {}),
-    },
-    control: {
-      id: params.controlId,
-      family: "auth",
-    },
-    ...(params.reason ? { reason: params.reason } : {}),
-    ...(params.attributes ? { attributes: params.attributes } : {}),
-  });
+  emitDeviceManagementSecurityEvent(params);
 }
 
 function emitDevicePairingDeniedSecurityEvent(params: {

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -30,21 +30,21 @@ import {
   emitTrustedSecurityEvent,
   type DiagnosticSecurityEventInput,
 } from "../../infra/diagnostic-events.js";
-import type { GatewayClient, GatewayRequestHandlers } from "./types.js";
+import {
+  deniesCrossDeviceManagement,
+  deniesDeviceTokenRoleManagement,
+  pairedDeviceHasNonOperatorRole,
+  requestsNonOperatorDeviceRole,
+  resolveDeviceManagementAuthz,
+  resolveDeviceSessionAuthz,
+} from "./device-management-authz.js";
+import type { DeviceManagementAuthz } from "./device-management-authz.js";
+import type { GatewayRequestHandlers } from "./types.js";
 
 const DEVICE_TOKEN_ROTATION_DENIED_MESSAGE = "device token rotation denied";
 const DEVICE_TOKEN_REVOCATION_DENIED_MESSAGE = "device token revocation denied";
 
-type DeviceSessionAuthz = {
-  callerDeviceId: string | null;
-  callerScopes: string[];
-  isAdminCaller: boolean;
-};
-
-type DeviceManagementAuthz = DeviceSessionAuthz & {
-  normalizedTargetDeviceId: string;
-};
-
+type DeviceSessionAuthz = ReturnType<typeof resolveDeviceSessionAuthz>;
 type DeviceSecurityDecision = NonNullable<DiagnosticSecurityEventInput["policy"]>["decision"];
 
 const DEVICE_PAIR_APPROVAL_DENIED_MESSAGE = "device pairing approval denied";
@@ -95,94 +95,10 @@ function logDeviceTokenRevocationDenied(params: {
   );
 }
 
-function resolveDeviceManagementAuthz(
-  client: GatewayClient | null,
-  targetDeviceId: string,
-): DeviceManagementAuthz {
-  return {
-    ...resolveDeviceSessionAuthz(client),
-    normalizedTargetDeviceId: targetDeviceId.trim(),
-  };
-}
-
-function resolveDeviceSessionAuthz(client: GatewayClient | null): DeviceSessionAuthz {
-  const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  const rawCallerDeviceId = client?.connect?.device?.id;
-  const callerDeviceId =
-    // Plain shared-auth connections may report device metadata, but only
-    // device-token auth proves ownership for self-service pairing actions.
-    client?.isDeviceTokenAuth && typeof rawCallerDeviceId === "string" && rawCallerDeviceId.trim()
-      ? rawCallerDeviceId.trim()
-      : null;
-  return {
-    callerDeviceId,
-    callerScopes,
-    isAdminCaller: callerScopes.includes("operator.admin"),
-  };
-}
-
-function deniesCrossDeviceManagement(authz: DeviceManagementAuthz): boolean {
-  return Boolean(
-    authz.callerDeviceId &&
-    authz.callerDeviceId !== authz.normalizedTargetDeviceId &&
-    !authz.isAdminCaller,
-  );
-}
-
 function shouldReturnRotatedDeviceToken(authz: DeviceManagementAuthz): boolean {
   // Admins can rotate any token, but only a device rotating itself receives
   // the new token in-band; other rotations are notification/invalidations.
   return Boolean(authz.callerDeviceId && authz.callerDeviceId === authz.normalizedTargetDeviceId);
-}
-
-function deniesDeviceTokenRoleManagement(
-  authz: DeviceManagementAuthz,
-  targetRole: string,
-): boolean {
-  const normalizedTargetRole = targetRole.trim();
-  if (!normalizedTargetRole || authz.isAdminCaller) {
-    return false;
-  }
-  return normalizedTargetRole !== "operator";
-}
-
-function hasNonOperatorDeviceRole(input: { role?: string; roles?: string[] }): boolean {
-  const roles = new Set<string>();
-  const role = input.role?.trim();
-  if (role) {
-    roles.add(role);
-  }
-  for (const entry of input.roles ?? []) {
-    const normalized = entry.trim();
-    if (normalized) {
-      roles.add(normalized);
-    }
-  }
-  return [...roles].some((entry) => entry !== "operator");
-}
-
-function hasNonOperatorDeviceTokenRole(
-  tokens: Record<string, DeviceAuthToken> | undefined,
-): boolean {
-  for (const token of Object.values(tokens ?? {})) {
-    const normalized = token.role.trim();
-    if (normalized && normalized !== "operator") {
-      return true;
-    }
-  }
-  return false;
-}
-
-function requestsNonOperatorDeviceRole(pending: { role?: string; roles?: string[] }): boolean {
-  return hasNonOperatorDeviceRole(pending);
-}
-
-function pairedDeviceHasNonOperatorRole(device: {
-  role?: string;
-  roles?: string[];
-  tokens?: Record<string, DeviceAuthToken>;
-}): boolean {
-  return hasNonOperatorDeviceRole(device) || hasNonOperatorDeviceTokenRole(device.tokens);
 }
 
 function hashDeviceSecurityId(value: string | undefined): string | undefined {

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -43,9 +43,13 @@ function createContext() {
   };
 }
 
-function createClient(scopes: string[]) {
+function createClient(scopes: string[], deviceId?: string, opts?: { isDeviceTokenAuth?: boolean }) {
   return {
-    connect: { scopes },
+    ...(opts?.isDeviceTokenAuth !== undefined ? { isDeviceTokenAuth: opts.isDeviceTokenAuth } : {}),
+    connect: {
+      scopes,
+      ...(deviceId ? { device: { id: deviceId } } : {}),
+    },
   } as never;
 }
 
@@ -271,14 +275,46 @@ describe("nodeHandlers node.pair.remove", () => {
     expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
   });
 
-  it("rejects device-backed node removal from non-admin shared-auth sessions", async () => {
-    const state = await createState("node-remove-non-admin-shared-auth");
-    const nodeId = "non-admin-android-node-1";
-    await pairAndroidNodeDevice(state.stateDir, nodeId);
+  it("removes mixed-role device-backed node rows for shared-auth operator.pairing without admin", async () => {
+    // Aligns with device.pair.remove: shared-auth / CLI operators that hold
+    // operator.pairing (but not operator.admin) manage pairings on others'
+    // behalf and must be able to remove the node role from a mixed-role row.
+    const state = await createState("node-remove-mixed-role-shared-auth");
+    const nodeId = "shared-auth-mixed-role-android-node-1";
+    await pairMixedRoleAndroidDevice(state.stateDir, nodeId);
+
+    const before = await readPaired(state.stateDir, "devices");
+    expect((before[nodeId] as { roles?: string[] }).roles).toEqual(["operator", "node"]);
 
     const { context, opts } = createOptions(
       { nodeId },
       { client: createClient(["operator.pairing"]) },
+    );
+
+    await nodeHandlers["node.pair.remove"](opts);
+    await Promise.resolve();
+
+    expect(opts.respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
+    const after = await readPaired(state.stateDir, "devices");
+    expect((after[nodeId] as { roles?: string[] }).roles).toEqual(["operator"]);
+    expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-pair-removed",
+    });
+    expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
+  });
+
+  it("rejects mixed-role device-backed node removal from non-admin device-token self-service callers", async () => {
+    // Mirror device.pair.remove: a device-token self-service caller (proves
+    // ownership of its own device id, no operator.admin) cannot remove the node
+    // role from a mixed-role row it owns.
+    const state = await createState("node-remove-mixed-role-device-token");
+    const nodeId = "device-token-mixed-role-android-node-1";
+    await pairMixedRoleAndroidDevice(state.stateDir, nodeId);
+
+    const { context, opts } = createOptions(
+      { nodeId },
+      { client: createClient(["operator.pairing"], nodeId, { isDeviceTokenAuth: true }) },
     );
 
     await nodeHandlers["node.pair.remove"](opts);

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -1,0 +1,295 @@
+import { readFile } from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { approveDevicePairing, requestDevicePairing } from "../../infra/device-pairing.js";
+import { approveNodePairing, requestNodePairing } from "../../infra/node-pairing.js";
+import { resolvePairingPaths } from "../../infra/pairing-files.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { nodeHandlers } from "./nodes.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const createdStates: OpenClawTestState[] = [];
+
+async function createState(label: string): Promise<OpenClawTestState> {
+  const state = await createOpenClawTestState({ label, layout: "state-only" });
+  createdStates.push(state);
+  return state;
+}
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  while (createdStates.length > 0) {
+    await createdStates.pop()?.cleanup();
+  }
+});
+
+function createContext() {
+  return {
+    broadcast: vi.fn(),
+    disconnectClientsForDevice: vi.fn(),
+    invalidateClientsForDevice: vi.fn(),
+    logGateway: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    nodeRegistry: {
+      listConnected: vi.fn(() => []),
+      updateSurface: vi.fn(),
+    },
+  };
+}
+
+function createClient(scopes: string[]) {
+  return {
+    connect: { scopes },
+  } as never;
+}
+
+function createOptions(
+  params: Record<string, unknown>,
+  overrides?: Partial<GatewayRequestHandlerOptions>,
+): {
+  context: ReturnType<typeof createContext>;
+  opts: GatewayRequestHandlerOptions;
+} {
+  const context = createContext();
+  const opts = {
+    req: { type: "req", id: "req-1", method: "node.pair.remove", params },
+    params,
+    client: createClient(["operator.pairing", "operator.admin"]),
+    isWebchatConnect: () => false,
+    respond: vi.fn(),
+    context,
+    ...overrides,
+  } as unknown as GatewayRequestHandlerOptions;
+  return { context, opts };
+}
+
+async function pairAndroidNodeDevice(stateDir: string, nodeId: string): Promise<void> {
+  const pending = await requestDevicePairing(
+    {
+      deviceId: nodeId,
+      publicKey: `public-key-${nodeId}`,
+      displayName: "Galaxy A54 5G",
+      platform: "android",
+      deviceFamily: "Android",
+      clientId: "openclaw-android",
+      clientMode: "node",
+      role: "node",
+      roles: ["node"],
+      scopes: [],
+    },
+    stateDir,
+  );
+  const approved = await approveDevicePairing(
+    pending.request.requestId,
+    { callerScopes: [] },
+    stateDir,
+  );
+  expect(approved?.status).toBe("approved");
+}
+
+async function pairMixedRoleAndroidDevice(stateDir: string, nodeId: string): Promise<void> {
+  const pending = await requestDevicePairing(
+    {
+      deviceId: nodeId,
+      publicKey: `public-key-${nodeId}`,
+      displayName: "Galaxy A54 5G",
+      platform: "android",
+      deviceFamily: "Android",
+      clientId: "openclaw-android",
+      clientMode: "node",
+      role: "operator",
+      roles: ["operator", "node"],
+      scopes: ["operator.pairing"],
+    },
+    stateDir,
+  );
+  const approved = await approveDevicePairing(
+    pending.request.requestId,
+    { callerScopes: ["operator.pairing"] },
+    stateDir,
+  );
+  expect(approved?.status).toBe("approved");
+}
+
+async function pairLegacyNode(stateDir: string, nodeId: string): Promise<void> {
+  const pending = await requestNodePairing(
+    {
+      nodeId,
+      platform: "android",
+      deviceFamily: "Android",
+      clientId: "openclaw-android",
+      clientMode: "node",
+      displayName: "Galaxy A54 5G",
+    },
+    stateDir,
+  );
+  const approved = await approveNodePairing(
+    pending.request.requestId,
+    { callerScopes: ["operator.pairing"] },
+    stateDir,
+  );
+  expect(approved).toEqual(expect.objectContaining({ node: expect.objectContaining({ nodeId }) }));
+}
+
+async function readPaired(
+  stateDir: string,
+  subdir: "devices" | "nodes",
+): Promise<Record<string, unknown>> {
+  const { pairedPath } = resolvePairingPaths(stateDir, subdir);
+  return JSON.parse(await readFile(pairedPath, "utf8")) as Record<string, unknown>;
+}
+
+describe("nodeHandlers node.pair.remove", () => {
+  it("removes Android device-backed node rows from devices paired.json", async () => {
+    const state = await createState("node-remove-android-device-backed");
+    const nodeId = "android-node-1";
+    await pairAndroidNodeDevice(state.stateDir, nodeId);
+
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(true);
+
+    const { context, opts } = createOptions({ nodeId: ` ${nodeId} ` });
+    const respond = vi.mocked(opts.respond);
+    respond.mockImplementation(() => {
+      expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+        role: "node",
+        reason: "device-pair-removed",
+      });
+      expect(context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    });
+
+    await nodeHandlers["node.pair.remove"](opts);
+    await Promise.resolve();
+
+    expect(respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(false);
+    expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-pair-removed",
+    });
+    expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
+    expect(context.nodeRegistry.updateSurface).toHaveBeenCalledWith(nodeId, {
+      caps: [],
+      commands: [],
+      permissions: undefined,
+    });
+    expect(context.broadcast).toHaveBeenCalledWith(
+      "node.pair.resolved",
+      expect.objectContaining({
+        decision: "removed",
+        nodeId,
+        requestId: "",
+      }),
+      { dropIfSlow: true },
+    );
+  });
+
+  it("removes both backing records when a node row is merged from node and device stores", async () => {
+    const state = await createState("node-remove-merged-backing-stores");
+    const nodeId = "merged-android-node-1";
+    await pairLegacyNode(state.stateDir, nodeId);
+    await pairAndroidNodeDevice(state.stateDir, nodeId);
+
+    expect(Object.hasOwn(await readPaired(state.stateDir, "nodes"), nodeId)).toBe(true);
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(true);
+
+    const { context, opts } = createOptions({ nodeId: ` ${nodeId} ` });
+    const respond = vi.mocked(opts.respond);
+    respond.mockImplementation(() => {
+      expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+        role: "node",
+        reason: "device-pair-removed",
+      });
+      expect(context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    });
+
+    await nodeHandlers["node.pair.remove"](opts);
+    await Promise.resolve();
+
+    expect(respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
+    expect(Object.hasOwn(await readPaired(state.stateDir, "nodes"), nodeId)).toBe(false);
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(false);
+    expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-pair-removed",
+    });
+    expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
+    expect(context.nodeRegistry.updateSurface).toHaveBeenCalledWith(nodeId, {
+      caps: [],
+      commands: [],
+      permissions: undefined,
+    });
+    expect(context.broadcast).toHaveBeenCalledWith(
+      "node.pair.resolved",
+      expect.objectContaining({
+        decision: "removed",
+        nodeId,
+        requestId: "",
+      }),
+      { dropIfSlow: true },
+    );
+  });
+
+  it("preserves non-node device roles when removing a mixed-role node row", async () => {
+    const state = await createState("node-remove-mixed-role-device");
+    const nodeId = "mixed-role-android-node-1";
+    await pairMixedRoleAndroidDevice(state.stateDir, nodeId);
+
+    const before = await readPaired(state.stateDir, "devices");
+    expect(
+      (before[nodeId] as { roles?: string[]; tokens?: Record<string, unknown> }).roles,
+    ).toEqual(["operator", "node"]);
+
+    const { context, opts } = createOptions({ nodeId });
+
+    await nodeHandlers["node.pair.remove"](opts);
+    await Promise.resolve();
+
+    expect(opts.respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
+    const after = await readPaired(state.stateDir, "devices");
+    expect((after[nodeId] as { roles?: string[]; tokens?: Record<string, unknown> }).roles).toEqual(
+      ["operator"],
+    );
+    expect(
+      Object.hasOwn(
+        (after[nodeId] as { tokens?: Record<string, unknown> }).tokens ?? {},
+        "operator",
+      ),
+    ).toBe(true);
+    expect(
+      Object.hasOwn((after[nodeId] as { tokens?: Record<string, unknown> }).tokens ?? {}, "node"),
+    ).toBe(false);
+    expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-pair-removed",
+    });
+    expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
+  });
+
+  it("rejects device-backed node removal from non-admin shared-auth sessions", async () => {
+    const state = await createState("node-remove-non-admin-shared-auth");
+    const nodeId = "non-admin-android-node-1";
+    await pairAndroidNodeDevice(state.stateDir, nodeId);
+
+    const { context, opts } = createOptions(
+      { nodeId },
+      { client: createClient(["operator.pairing"]) },
+    );
+
+    await nodeHandlers["node.pair.remove"](opts);
+
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "node pairing removal denied" }),
+    );
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(true);
+    expect(context.invalidateClientsForDevice).not.toHaveBeenCalled();
+    expect(context.disconnectClientsForDevice).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -1,6 +1,10 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { approveDevicePairing, requestDevicePairing } from "../../infra/device-pairing.js";
+import {
+  approveDevicePairing,
+  requestDevicePairing,
+  revokeDeviceToken,
+} from "../../infra/device-pairing.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -230,6 +234,33 @@ describe("nodeHandlers node.pair.remove", () => {
     expect(JSON.stringify(captured.events)).not.toContain(nodeId);
   });
 
+  it.each(["revoked", "tokenless"] as const)(
+    "removes %s device-backed node approvals",
+    async (tokenState) => {
+      const state = await createState(`node-remove-${tokenState}-device-backed`);
+      const nodeId = `${tokenState}-android-node-1`;
+      await pairAndroidNodeDevice(state.stateDir, nodeId);
+
+      if (tokenState === "revoked") {
+        const revoked = await revokeDeviceToken({ deviceId: nodeId, role: "node" }, state.stateDir);
+        expect(revoked.ok).toBe(true);
+      } else {
+        const { pairedPath } = resolvePairingPaths(state.stateDir, "devices");
+        const paired = await readPaired(state.stateDir, "devices");
+        delete (paired[nodeId] as { tokens?: Record<string, unknown> }).tokens;
+        await writeFile(pairedPath, `${JSON.stringify(paired, null, 2)}\n`, "utf8");
+      }
+
+      const { context, opts } = createOptions({ nodeId });
+      await nodeHandlers["node.pair.remove"](opts);
+      await Promise.resolve();
+
+      expect(opts.respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
+      expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(false);
+      expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
+    },
+  );
+
   it("removes both backing records when a node row is merged from node and device stores", async () => {
     const state = await createState("node-remove-merged-backing-stores");
     const nodeId = "merged-android-node-1";
@@ -274,6 +305,36 @@ describe("nodeHandlers node.pair.remove", () => {
       }),
       { dropIfSlow: true },
     );
+  });
+
+  it("clears and disconnects a removed device-backed node when legacy cleanup fails", async () => {
+    const state = await createState("node-remove-legacy-cleanup-failure");
+    const nodeId = "legacy-cleanup-failure-node-1";
+    await pairLegacyNode(state.stateDir, nodeId);
+    await pairAndroidNodeDevice(state.stateDir, nodeId);
+    const { pairedPath: legacyPairedPath } = resolvePairingPaths(state.stateDir, "nodes");
+    await writeFile(legacyPairedPath, "{invalid-json", "utf8");
+
+    const { context, opts } = createOptions({ nodeId });
+    await nodeHandlers["node.pair.remove"](opts);
+    await Promise.resolve();
+
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("Failed to parse JSON file") }),
+    );
+    expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(false);
+    expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
+      role: "node",
+      reason: "device-pair-removed",
+    });
+    expect(context.nodeRegistry.updateSurface).toHaveBeenCalledWith(nodeId, {
+      caps: [],
+      commands: [],
+      permissions: undefined,
+    });
+    expect(context.disconnectClientsForDevice).toHaveBeenCalledWith(nodeId, { role: "node" });
   });
 
   it("preserves non-node device roles when removing a mixed-role node row", async () => {

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -1,6 +1,11 @@
 import { readFile } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { approveDevicePairing, requestDevicePairing } from "../../infra/device-pairing.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticSecurityEvent,
+} from "../../infra/diagnostic-events.js";
 import { approveNodePairing, requestNodePairing } from "../../infra/node-pairing.js";
 import { resolvePairingPaths } from "../../infra/pairing-files.js";
 import {
@@ -19,11 +24,25 @@ async function createState(label: string): Promise<OpenClawTestState> {
 }
 
 afterEach(async () => {
+  resetDiagnosticEventsForTest();
   vi.clearAllMocks();
   while (createdStates.length > 0) {
     await createdStates.pop()?.cleanup();
   }
 });
+
+function captureSecurityEvents(): {
+  events: DiagnosticSecurityEvent[];
+  stop: () => void;
+} {
+  const events: DiagnosticSecurityEvent[] = [];
+  const stop = onInternalDiagnosticEvent((event, metadata) => {
+    if (metadata.trusted && event.type === "security.event") {
+      events.push(event);
+    }
+  });
+  return { events, stop };
+}
 
 function createContext() {
   return {
@@ -158,6 +177,7 @@ describe("nodeHandlers node.pair.remove", () => {
     expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(true);
 
     const { context, opts } = createOptions({ nodeId: ` ${nodeId} ` });
+    const captured = captureSecurityEvents();
     const respond = vi.mocked(opts.respond);
     respond.mockImplementation(() => {
       expect(context.invalidateClientsForDevice).toHaveBeenCalledWith(nodeId, {
@@ -167,8 +187,12 @@ describe("nodeHandlers node.pair.remove", () => {
       expect(context.disconnectClientsForDevice).not.toHaveBeenCalled();
     });
 
-    await nodeHandlers["node.pair.remove"](opts);
-    await Promise.resolve();
+    try {
+      await nodeHandlers["node.pair.remove"](opts);
+      await Promise.resolve();
+    } finally {
+      captured.stop();
+    }
 
     expect(respond).toHaveBeenCalledWith(true, { nodeId }, undefined);
     expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(false);
@@ -191,6 +215,19 @@ describe("nodeHandlers node.pair.remove", () => {
       }),
       { dropIfSlow: true },
     );
+    expect(captured.events).toHaveLength(1);
+    expect(captured.events[0]).toMatchObject({
+      type: "security.event",
+      category: "auth",
+      action: "device.role.removed",
+      outcome: "success",
+      severity: "medium",
+      target: { kind: "device", idHash: expect.stringMatching(/^sha256:[a-f0-9]{12}$/u) },
+      policy: { id: "gateway.device-pairing", decision: "allow" },
+      control: { id: "node.pair.remove", family: "auth" },
+      attributes: { role: "node", removed_device: true },
+    });
+    expect(JSON.stringify(captured.events)).not.toContain(nodeId);
   });
 
   it("removes both backing records when a node row is merged from node and device stores", async () => {
@@ -316,8 +353,13 @@ describe("nodeHandlers node.pair.remove", () => {
       { nodeId },
       { client: createClient(["operator.pairing"], nodeId, { isDeviceTokenAuth: true }) },
     );
+    const captured = captureSecurityEvents();
 
-    await nodeHandlers["node.pair.remove"](opts);
+    try {
+      await nodeHandlers["node.pair.remove"](opts);
+    } finally {
+      captured.stop();
+    }
 
     expect(opts.respond).toHaveBeenCalledWith(
       false,
@@ -327,5 +369,18 @@ describe("nodeHandlers node.pair.remove", () => {
     expect(Object.hasOwn(await readPaired(state.stateDir, "devices"), nodeId)).toBe(true);
     expect(context.invalidateClientsForDevice).not.toHaveBeenCalled();
     expect(context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    expect(captured.events).toHaveLength(1);
+    expect(captured.events[0]).toMatchObject({
+      action: "device.role.removal_denied",
+      outcome: "denied",
+      severity: "medium",
+      policy: {
+        id: "gateway.device-pairing",
+        decision: "deny",
+        reason: "role-management-requires-admin",
+      },
+      control: { id: "node.pair.remove", family: "auth" },
+      attributes: { role: "node" },
+    });
   });
 });

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -242,7 +242,11 @@ describe("nodeHandlers node.pair.remove", () => {
       await pairAndroidNodeDevice(state.stateDir, nodeId);
 
       if (tokenState === "revoked") {
-        const revoked = await revokeDeviceToken({ deviceId: nodeId, role: "node" }, state.stateDir);
+        const revoked = await revokeDeviceToken({
+          deviceId: nodeId,
+          role: "node",
+          baseDir: state.stateDir,
+        });
         expect(revoked.ok).toBe(true);
       } else {
         const { pairedPath } = resolvePairingPaths(state.stateDir, "devices");

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -74,7 +74,9 @@ import {
   deniesCrossDeviceManagement,
   pairedDeviceHasNonOperatorRole,
   resolveDeviceManagementAuthz,
+  type DeviceManagementAuthz,
 } from "./device-management-authz.js";
+import { emitDeviceManagementSecurityEvent } from "./device-management-security.js";
 import {
   NODE_WAKE_RECONNECT_POLL_MS,
   NODE_WAKE_RECONNECT_RETRY_WAIT_MS,
@@ -370,6 +372,30 @@ function broadcastRemovedNodePairing(params: {
   );
 }
 
+function emitNodeRoleRemovalSecurityEvent(params: {
+  authz: DeviceManagementAuthz;
+  deviceId: string;
+  reason?: string;
+  removedDevice?: boolean;
+}): void {
+  const denied = params.reason !== undefined;
+  emitDeviceManagementSecurityEvent({
+    action: denied ? "device.role.removal_denied" : "device.role.removed",
+    outcome: denied ? "denied" : "success",
+    severity: "medium",
+    authz: params.authz,
+    targetDeviceId: params.deviceId,
+    policyId: "gateway.device-pairing",
+    decision: denied ? "deny" : "allow",
+    controlId: "node.pair.remove",
+    ...(params.reason ? { reason: params.reason } : {}),
+    attributes: {
+      role: "node",
+      ...(params.removedDevice !== undefined ? { removed_device: params.removedDevice } : {}),
+    },
+  });
+}
+
 async function removePairedDeviceBackedNode(params: {
   nodeId: string;
   client: GatewayClient | null;
@@ -396,6 +422,11 @@ async function removePairedDeviceBackedNode(params: {
     params.context.logGateway.warn(
       `node pairing removal denied node=${nodeId} reason=device-ownership-mismatch`,
     );
+    emitNodeRoleRemovalSecurityEvent({
+      authz,
+      deviceId: nodeId,
+      reason: "device-ownership-mismatch",
+    });
     return { status: "denied", message: "node pairing removal denied" };
   }
   // Mirror device.pair.remove: the admin requirement for mixed-role rows only
@@ -406,6 +437,11 @@ async function removePairedDeviceBackedNode(params: {
     params.context.logGateway.warn(
       `node pairing removal denied node=${nodeId} reason=role-management-requires-admin`,
     );
+    emitNodeRoleRemovalSecurityEvent({
+      authz,
+      deviceId: nodeId,
+      reason: "role-management-requires-admin",
+    });
     return { status: "denied", message: "node pairing removal denied" };
   }
 
@@ -414,6 +450,11 @@ async function removePairedDeviceBackedNode(params: {
     return { status: "unknown" };
   }
   params.context.logGateway.info(`node pairing removed device-backed node=${removed.deviceId}`);
+  emitNodeRoleRemovalSecurityEvent({
+    authz,
+    deviceId: removed.deviceId,
+    removedDevice: removed.removedDevice,
+  });
   // Match device.pair.remove: invalidate before responding so pipelined frames
   // on the affected device token are rejected. The caller queues the hard close
   // only after the success response is emitted.

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -28,7 +28,7 @@ import { getRuntimeConfig } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   getPairedDevice,
-  hasEffectivePairedDeviceRole,
+  listApprovedPairedDeviceRoles,
   listDevicePairing,
   removePairedDeviceRole,
 } from "../../infra/device-pairing.js";
@@ -413,7 +413,7 @@ async function removePairedDeviceBackedNode(params: {
     return { status: "unknown" };
   }
   const paired = await getPairedDevice(nodeId);
-  if (!paired || !hasEffectivePairedDeviceRole(paired, "node")) {
+  if (!paired || !listApprovedPairedDeviceRoles(paired).includes("node")) {
     return { status: "unknown" };
   }
 
@@ -1055,24 +1055,37 @@ export const nodeHandlers: GatewayRequestHandlers = {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, deviceBacked.message));
         return;
       }
-      const legacyNodeId =
-        deviceBacked.status === "removed" ? deviceBacked.nodeId : requestedNodeId;
-      const removed = await removePairedNode(legacyNodeId);
-      const removedNodeId =
-        removed?.nodeId ?? (deviceBacked.status === "removed" ? deviceBacked.nodeId : undefined);
-      if (!removedNodeId) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
-        return;
-      }
-      clearRemovedNodeRuntimeState({ nodeId: removedNodeId, context });
-      broadcastRemovedNodePairing({ nodeId: removedNodeId, context });
-      respond(true, { nodeId: removedNodeId }, undefined);
-      if (deviceBacked.status === "removed") {
-        queueMicrotask(() => {
-          context.disconnectClientsForDevice?.(deviceBacked.disconnectDeviceId, {
-            role: "node",
+      const removedDeviceNodeId =
+        deviceBacked.status === "removed" ? deviceBacked.nodeId : undefined;
+      try {
+        // Device pairing removal is already durable. Clear the live node surface
+        // before touching the independent legacy store so a cleanup failure
+        // cannot leave the revoked session invokable.
+        if (removedDeviceNodeId) {
+          clearRemovedNodeRuntimeState({ nodeId: removedDeviceNodeId, context });
+        }
+        const legacyNodeId = removedDeviceNodeId ?? requestedNodeId;
+        const removed = await removePairedNode(legacyNodeId);
+        const removedNodeId = removed?.nodeId ?? removedDeviceNodeId;
+        if (!removedNodeId) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
+          return;
+        }
+        if (!removedDeviceNodeId) {
+          clearRemovedNodeRuntimeState({ nodeId: removedNodeId, context });
+        }
+        broadcastRemovedNodePairing({ nodeId: removedNodeId, context });
+        respond(true, { nodeId: removedNodeId }, undefined);
+      } finally {
+        if (deviceBacked.status === "removed") {
+          // Preserve response-first shutdown on success, while guaranteeing the
+          // hard close when legacy-store cleanup or later bookkeeping throws.
+          queueMicrotask(() => {
+            context.disconnectClientsForDevice?.(deviceBacked.disconnectDeviceId, {
+              role: "node",
+            });
           });
-        });
+        }
       }
     });
   },

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -989,6 +989,14 @@ export const nodeHandlers: GatewayRequestHandlers = {
       respond(true, rejected, undefined);
     });
   },
+  // Remove a node pairing (CLI: `openclaw nodes remove`). For a device-backed
+  // node this revokes the device's `node` role in devices/paired.json and
+  // disconnects its node-role sessions: a mixed-role device keeps its row and
+  // only loses the `node` role, a node-only device row is deleted. Any matching
+  // legacy gateway-owned node pairing entry is also cleared. Authz mirrors
+  // device.pair.remove: operator.pairing may remove non-operator node rows; a
+  // device-token caller revoking its own node role on a mixed-role device
+  // additionally needs operator.admin (see removePairedDeviceBackedNode).
   "node.pair.remove": async ({ params, respond, context, client }) => {
     if (!validateNodePairRemoveParams(params)) {
       respondInvalidParams({

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -398,7 +398,11 @@ async function removePairedDeviceBackedNode(params: {
     );
     return { status: "denied", message: "node pairing removal denied" };
   }
-  if (!authz.isAdminCaller && pairedDeviceHasNonOperatorRole(paired)) {
+  // Mirror device.pair.remove: the admin requirement for mixed-role rows only
+  // applies to device-token self-service callers (callerDeviceId set). Shared-auth
+  // / CLI operators holding operator.pairing manage pairings on others' behalf and
+  // are allowed to remove non-operator (e.g. node) rows without operator.admin.
+  if (authz.callerDeviceId && !authz.isAdminCaller && pairedDeviceHasNonOperatorRole(paired)) {
     params.context.logGateway.warn(
       `node pairing removal denied node=${nodeId} reason=role-management-requires-admin`,
     );

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -26,7 +26,12 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { listDevicePairing } from "../../infra/device-pairing.js";
+import {
+  getPairedDevice,
+  hasEffectivePairedDeviceRole,
+  listDevicePairing,
+  removePairedDeviceRole,
+} from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   approveNodePairing,
@@ -65,6 +70,11 @@ import type { NodeSession } from "../node-registry.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE } from "../operator-scopes.js";
 import { refreshClientPluginNodeCapability } from "../plugin-node-capability.js";
 import type { NodeEventContext } from "../server-node-events-types.js";
+import {
+  deniesCrossDeviceManagement,
+  pairedDeviceHasNonOperatorRole,
+  resolveDeviceManagementAuthz,
+} from "./device-management-authz.js";
 import {
   NODE_WAKE_RECONNECT_POLL_MS,
   NODE_WAKE_RECONNECT_RETRY_WAIT_MS,
@@ -329,6 +339,85 @@ function prunePendingNodeActions(nodeId: string, nowMs: number): PendingNodeActi
   }
   pendingNodeActionsById.set(nodeId, live);
   return live;
+}
+
+function clearRemovedNodeRuntimeState(params: {
+  nodeId: string;
+  context: Pick<GatewayRequestContext, "nodeRegistry">;
+}) {
+  pendingNodeActionsById.delete(params.nodeId);
+  params.context.nodeRegistry.updateSurface(params.nodeId, {
+    caps: [],
+    commands: [],
+    permissions: undefined,
+  });
+  removeRemoteNodeInfo(params.nodeId);
+}
+
+function broadcastRemovedNodePairing(params: {
+  context: Pick<GatewayRequestContext, "broadcast">;
+  nodeId: string;
+}) {
+  params.context.broadcast(
+    "node.pair.resolved",
+    {
+      requestId: "",
+      nodeId: params.nodeId,
+      decision: "removed",
+      ts: Date.now(),
+    },
+    { dropIfSlow: true },
+  );
+}
+
+async function removePairedDeviceBackedNode(params: {
+  nodeId: string;
+  client: GatewayClient | null;
+  context: Pick<
+    GatewayRequestContext,
+    "disconnectClientsForDevice" | "invalidateClientsForDevice" | "logGateway"
+  >;
+}): Promise<
+  | { status: "removed"; nodeId: string; disconnectDeviceId: string }
+  | { status: "denied"; message: string }
+  | { status: "unknown" }
+> {
+  const nodeId = params.nodeId.trim();
+  if (!nodeId) {
+    return { status: "unknown" };
+  }
+  const paired = await getPairedDevice(nodeId);
+  if (!paired || !hasEffectivePairedDeviceRole(paired, "node")) {
+    return { status: "unknown" };
+  }
+
+  const authz = resolveDeviceManagementAuthz(params.client, nodeId);
+  if (deniesCrossDeviceManagement(authz)) {
+    params.context.logGateway.warn(
+      `node pairing removal denied node=${nodeId} reason=device-ownership-mismatch`,
+    );
+    return { status: "denied", message: "node pairing removal denied" };
+  }
+  if (!authz.isAdminCaller && pairedDeviceHasNonOperatorRole(paired)) {
+    params.context.logGateway.warn(
+      `node pairing removal denied node=${nodeId} reason=role-management-requires-admin`,
+    );
+    return { status: "denied", message: "node pairing removal denied" };
+  }
+
+  const removed = await removePairedDeviceRole({ deviceId: nodeId, role: "node" });
+  if (!removed) {
+    return { status: "unknown" };
+  }
+  params.context.logGateway.info(`node pairing removed device-backed node=${removed.deviceId}`);
+  // Match device.pair.remove: invalidate before responding so pipelined frames
+  // on the affected device token are rejected. The caller queues the hard close
+  // only after the success response is emitted.
+  params.context.invalidateClientsForDevice?.(removed.deviceId, {
+    role: "node",
+    reason: "device-pair-removed",
+  });
+  return { status: "removed", nodeId: removed.deviceId, disconnectDeviceId: removed.deviceId };
 }
 
 function enqueuePendingNodeAction(params: {
@@ -896,7 +985,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
       respond(true, rejected, undefined);
     });
   },
-  "node.pair.remove": async ({ params, respond, context }) => {
+  "node.pair.remove": async ({ params, respond, context, client }) => {
     if (!validateNodePairRemoveParams(params)) {
       respondInvalidParams({
         respond,
@@ -907,29 +996,31 @@ export const nodeHandlers: GatewayRequestHandlers = {
     }
     const { nodeId } = params as { nodeId: string };
     await respondUnavailableOnThrow(respond, async () => {
-      const removed = await removePairedNode(nodeId);
-      if (!removed) {
+      const requestedNodeId = nodeId.trim();
+      const deviceBacked = await removePairedDeviceBackedNode({ nodeId, client, context });
+      if (deviceBacked.status === "denied") {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, deviceBacked.message));
+        return;
+      }
+      const legacyNodeId =
+        deviceBacked.status === "removed" ? deviceBacked.nodeId : requestedNodeId;
+      const removed = await removePairedNode(legacyNodeId);
+      const removedNodeId =
+        removed?.nodeId ?? (deviceBacked.status === "removed" ? deviceBacked.nodeId : undefined);
+      if (!removedNodeId) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
         return;
       }
-      pendingNodeActionsById.delete(removed.nodeId);
-      context.nodeRegistry.updateSurface(removed.nodeId, {
-        caps: [],
-        commands: [],
-        permissions: undefined,
-      });
-      removeRemoteNodeInfo(removed.nodeId);
-      context.broadcast(
-        "node.pair.resolved",
-        {
-          requestId: "",
-          nodeId: removed.nodeId,
-          decision: "removed",
-          ts: Date.now(),
-        },
-        { dropIfSlow: true },
-      );
-      respond(true, removed, undefined);
+      clearRemovedNodeRuntimeState({ nodeId: removedNodeId, context });
+      broadcastRemovedNodePairing({ nodeId: removedNodeId, context });
+      respond(true, { nodeId: removedNodeId }, undefined);
+      if (deviceBacked.status === "removed") {
+        queueMicrotask(() => {
+          context.disconnectClientsForDevice?.(deviceBacked.disconnectDeviceId, {
+            role: "node",
+          });
+        });
+      }
     });
   },
   "node.pair.verify": async ({ params, respond }) => {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -78,6 +78,9 @@ const DEVICE_TOKEN_MUTATION_PARAMS = {
   deviceId: "device-1",
   role: "operator",
 } as const satisfies Record<string, unknown>;
+const NODE_PAIR_REMOVE_PARAMS = {
+  nodeId: "device-1",
+} as const satisfies Record<string, unknown>;
 
 function createLogger() {
   return {
@@ -349,6 +352,48 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
     expect(setCloseCause).toHaveBeenCalledWith("client-invalidated", {
       reason: "device-token-revoked",
+      method: "status.summary",
+    });
+  });
+
+  it("waits for device-backed node removal before dispatching later queued requests", async () => {
+    let releaseMutation: (() => void) | undefined;
+    const close = createCloseMock();
+    const setCloseCause = createSetCloseCauseMock();
+    const client = createConnectedTestClient({ connId: "conn-node-invalidating" });
+    vi.mocked(handleGatewayRequest).mockImplementation(async (opts) => {
+      expect(opts.req.method).toBe("node.pair.remove");
+      await new Promise<void>((resolve) => {
+        releaseMutation = resolve;
+      });
+      client.invalidated = true;
+      client.invalidatedReason = "device-pair-removed";
+    });
+
+    const harness = attachGatewayHarness({
+      connId: "conn-node-invalidating",
+      connectNonce: "nonce-node-invalidating",
+      client,
+      close,
+      setCloseCause,
+    });
+
+    harness.sendRequest("remove-node-1", "node.pair.remove", NODE_PAIR_REMOVE_PARAMS);
+    harness.sendRequest("queued-1", "status.summary");
+
+    await vi.waitFor(() => {
+      expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
+      expect(releaseMutation).toBeTypeOf("function");
+    });
+
+    releaseMutation?.();
+
+    await vi.waitFor(() => {
+      expect(close).toHaveBeenCalledWith(4001, "client invalidated: device-pair-removed");
+    });
+    expect(handleGatewayRequest).toHaveBeenCalledTimes(1);
+    expect(setCloseCause).toHaveBeenCalledWith("client-invalidated", {
+      reason: "device-pair-removed",
       method: "status.summary",
     });
   });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -184,6 +184,7 @@ const DEVICE_CREDENTIAL_INVALIDATING_METHODS = new Set([
   "device.pair.remove",
   "device.token.rotate",
   "device.token.revoke",
+  "node.pair.remove",
 ]);
 const unauthorizedHandshakeLogLimiter = new HandshakeAuthLogLimiter();
 

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -909,6 +909,84 @@ export async function removePairedDevice(
   });
 }
 
+/** Remove one active paired-device role while preserving unrelated role tokens. */
+export async function removePairedDeviceRole(params: {
+  deviceId: string;
+  role: string;
+  baseDir?: string;
+}): Promise<{ deviceId: string; role: string; removedDevice: boolean } | null> {
+  return await withLock(async () => {
+    const state = await loadState(params.baseDir);
+    const normalizedDeviceId = normalizeDeviceId(params.deviceId);
+    const role = normalizeRole(params.role);
+    const device = state.pairedByDeviceId[normalizedDeviceId];
+    if (!device || !role || !hasEffectivePairedDeviceRole(device, role)) {
+      return null;
+    }
+
+    const tokens = cloneDeviceTokens(device);
+    delete tokens[role];
+    const remainingRoles = listApprovedPairedDeviceRoles(device).filter((entry) => entry !== role);
+    if (remainingRoles.length === 0) {
+      for (const [requestId, pending] of Object.entries(state.pendingById)) {
+        if (pending.deviceId === normalizedDeviceId) {
+          delete state.pendingById[requestId];
+        }
+      }
+      delete state.pairedByDeviceId[normalizedDeviceId];
+      await persistState(state, params.baseDir, "both");
+      return { deviceId: normalizedDeviceId, role, removedDevice: true };
+    }
+
+    for (const [requestId, pending] of Object.entries(state.pendingById)) {
+      if (pending.deviceId !== normalizedDeviceId) {
+        continue;
+      }
+      const pendingRoles = resolveRequestedRoles(pending);
+      if (!pendingRoles.includes(role)) {
+        continue;
+      }
+      const nextPendingRoles = pendingRoles.filter((entry) => entry !== role);
+      if (nextPendingRoles.length === 0) {
+        delete state.pendingById[requestId];
+        continue;
+      }
+      const pendingScopes = Array.isArray(pending.scopes)
+        ? mergeScopes(
+            ...nextPendingRoles.map((entry) =>
+              preserveRoleScopedApprovalScopes(entry, pending.scopes),
+            ),
+          )
+        : undefined;
+      state.pendingById[requestId] = {
+        ...pending,
+        role: nextPendingRoles[0],
+        roles: nextPendingRoles,
+        scopes: pendingScopes,
+      };
+    }
+
+    const scopeBaseline = device.approvedScopes ?? device.scopes;
+    const preservedScopes = Array.isArray(scopeBaseline)
+      ? mergeScopes(
+          ...remainingRoles.map((entry) => preserveRoleScopedApprovalScopes(entry, scopeBaseline)),
+        )
+      : undefined;
+    const next: PairedDevice = {
+      ...device,
+      role: remainingRoles[0],
+      roles: remainingRoles,
+      ...(preservedScopes !== undefined
+        ? { scopes: preservedScopes, approvedScopes: preservedScopes }
+        : {}),
+      tokens: Object.keys(tokens).length > 0 ? tokens : undefined,
+    };
+    state.pairedByDeviceId[normalizedDeviceId] = next;
+    await persistState(state, params.baseDir, "both");
+    return { deviceId: normalizedDeviceId, role, removedDevice: false };
+  });
+}
+
 /** Update non-auth metadata for a paired device presence/status refresh. */
 export async function updatePairedDeviceMetadata(
   deviceId: string,

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -909,7 +909,7 @@ export async function removePairedDevice(
   });
 }
 
-/** Remove one active paired-device role while preserving unrelated role tokens. */
+/** Remove one approved paired-device role while preserving unrelated role tokens. */
 export async function removePairedDeviceRole(params: {
   deviceId: string;
   role: string;
@@ -920,7 +920,7 @@ export async function removePairedDeviceRole(params: {
     const normalizedDeviceId = normalizeDeviceId(params.deviceId);
     const role = normalizeRole(params.role);
     const device = state.pairedByDeviceId[normalizedDeviceId];
-    if (!device || !role || !hasEffectivePairedDeviceRole(device, role)) {
+    if (!device || !role || !listApprovedPairedDeviceRoles(device).includes(role)) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

Fixes #88488.

`node.list` can surface Android/phone nodes backed by `devices/paired.json`, but `node.pair.remove` previously removed only legacy `nodes/paired.json` records. The visible node therefore remained authorized and reappeared.

This PR:

- removes the effective `node` role from the canonical paired-device store;
- deletes node-only device rows while preserving unrelated roles/tokens on mixed-role devices;
- clears matching pending repair requests and any legacy node pairing;
- applies the same device-management authorization policy as `device.pair.remove`;
- invalidates node-role clients before the success response and disconnects after it;
- places `node.pair.remove` behind the post-connect credential-mutation barrier;
- emits redacted trusted security events for allowed and denied node-role removal;
- documents device-backed and mixed-role removal semantics.

## Real behavior proof

Behavior addressed: Device-backed nodes shown by `node.list` can be removed durably; merged legacy/device records are both cleared; mixed-role devices keep the operator role; removed node credentials cannot pipeline another request; allow/deny decisions are auditable without exposing raw device IDs or tokens.

Real environment tested: Local Node checkout plus AWS Crabbox Linux lease `cbx_a5289b2e7c04` (`swift-lobster`, c7a.32xlarge). Tests drive the real pairing stores, production Gateway handlers, client invalidation/disconnect ordering, diagnostic-event stream, and post-connect mutation barrier.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs +  src/gateway/server-methods/nodes.test.ts +  src/gateway/server-methods/devices.test.ts +  src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts +  src/infra/device-pairing.test.ts +  src/infra/node-pairing.test.ts

node scripts/run-oxlint.mjs <changed runtime and test files>
.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search
```

Evidence after fix: Local focused proof passed 211 tests. AWS Crabbox run `run_bea1e028e58e` passed 226 exact-worktree tests on Linux. Disk readback proves node-only rows disappear from `devices/paired.json`, merged rows disappear from both stores, and mixed-role rows retain only the operator role/token. Handler assertions prove invalidation occurs before response and disconnect after response. Trusted security events contain hashed device identifiers and `role: node`, never the raw ID. Type-aware oxlint is clean. Final autoreview is clean with 0.96 confidence.

Observed result after fix: `node.pair.remove` returns the normalized node ID, removes the effective node credential, clears runtime state, emits the removal event, and blocks queued credential use. Non-admin device-token attempts against mixed-role rows fail without mutation and emit a redacted denial event.

What was not tested: No GUI/screenshot path and no physical Android device. The changed contract is Gateway pairing/storage/authentication behavior and is covered through production handlers with real on-disk stores.

## Tests

- AWS Crabbox `run_bea1e028e58e`: 226 passed.
- Local focused suite: 211 passed.
- Type-aware oxlint: clean.
- Fresh autoreview: clean.
