### PR TITLE
test(line): replace broad win32 skips with dynamic capability checks in accounts tests

### DIFF
--- a/extensions/line/src/accounts.test.ts
+++ b/extensions/line/src/accounts.test.ts
@@ -1,6 +1,20 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+const canCreateFileSymlinks = (() => {
+  try {
+    const tempLink = path.join(os.tmpdir(), `symlink-file-test-${Math.random().toString(36).substring(2)}`);
+    const tempFile = path.join(os.tmpdir(), `symlink-file-target-${Math.random().toString(36).substring(2)}`);
+    fs.writeFileSync(tempFile, "temp");
+    fs.symlinkSync(tempFile, tempLink, "file");
+    fs.unlinkSync(tempLink);
+    fs.unlinkSync(tempFile);
+    return true;
+  } catch {
+    return false;
+  }
+})();
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -175,7 +189,7 @@ describe("LINE accounts", () => {
       expect(account.tokenSource).toBe("file");
     });
 
-    it.runIf(process.platform !== "win32")("rejects symlinked token and secret files", () => {
+    it.skipIf(!canCreateFileSymlinks)("rejects symlinked token and secret files", () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-line-account-"));
       tempDirs.push(dir);
       const tokenFile = path.join(dir, "token.txt");
@@ -184,8 +198,8 @@ describe("LINE accounts", () => {
       const secretLink = path.join(dir, "secret-link.txt");
       fs.writeFileSync(tokenFile, "file-token\n", "utf8");
       fs.writeFileSync(secretFile, "file-secret\n", "utf8");
-      fs.symlinkSync(tokenFile, tokenLink);
-      fs.symlinkSync(secretFile, secretLink);
+      fs.symlinkSync(tokenFile, tokenLink, "file");
+      fs.symlinkSync(secretFile, secretLink, "file");
 
       const cfg: OpenClawConfig = {
         channels: {


### PR DESCRIPTION
### Description
Replaced unconditional `win32` platform skips in the LINE accounts test suite (`accounts.test.ts`) with a dynamic capability probe checking for file symlink support (`canCreateFileSymlinks`), utilizing `"file"` type symlinks for Windows compatibility.

### Verification Proof
Test run on Windows:
```
✓  extension-line  ../../extensions/line/src/accounts.test.ts (14 tests | 1 skipped) 413ms

 Test Files  1 passed (1)
      Tests  13 passed | 1 skipped (14)
```
