### PR TITLE
Fix default chat workspace files rail

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1,11 +1,15 @@
 /* Split View Layout */
 .chat-workbench {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
+  grid-template-columns: minmax(0, 1fr);
   gap: 0;
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+.chat-workbench--workspace-rail-open {
+  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
 }
 
 .chat-split-container {
@@ -75,7 +79,14 @@
   line-height: 1.2;
 }
 
-.chat-workspace-rail__refresh {
+.chat-workspace-rail__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-workspace-rail__refresh,
+.chat-workspace-rail__close {
   width: 32px;
   min-width: 32px;
   height: 32px;
@@ -83,6 +94,7 @@
 }
 
 .chat-workspace-rail__refresh svg,
+.chat-workspace-rail__close svg,
 .chat-workspace-rail__file-icon svg {
   width: 15px;
   height: 15px;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -681,6 +681,7 @@ type ChatWorkspaceFilesState = {
   error: string | null;
   list: AgentsFilesListResult | null;
   loading: boolean;
+  open: boolean;
   requestId: number;
 };
 
@@ -701,6 +702,7 @@ function getChatWorkspaceFilesState(state: AppViewState, agentId: string): ChatW
     error: null,
     list: null,
     loading: false,
+    open: false,
     requestId: 0,
   };
   chatWorkspaceFilesStates.set(state, next);
@@ -2096,6 +2098,7 @@ export function renderApp(state: AppViewState) {
   };
   if (
     isChat &&
+    chatWorkspaceFiles.open &&
     state.connected &&
     state.agentsList &&
     !chatWorkspaceFiles.loading &&
@@ -2104,7 +2107,19 @@ export function renderApp(state: AppViewState) {
   ) {
     loadChatWorkspaceFiles();
   }
+  const toggleChatWorkspaceFiles = () => {
+    chatWorkspaceFiles.open = !chatWorkspaceFiles.open;
+    if (chatWorkspaceFiles.open && chatWorkspaceFiles.list?.agentId !== chatAgentId) {
+      loadChatWorkspaceFiles();
+    }
+    requestHostUpdate?.();
+  };
+  const closeChatWorkspaceFiles = () => {
+    chatWorkspaceFiles.open = false;
+    requestHostUpdate?.();
+  };
   const refreshChatWorkspaceFiles = () => {
+    chatWorkspaceFiles.open = true;
     loadChatWorkspaceFiles({ force: true });
   };
   function loadChatWorkspaceFiles(opts?: { force?: boolean }) {
@@ -3524,16 +3539,19 @@ export function renderApp(state: AppViewState) {
                   sessions: state.sessionsResult,
                   composerControls: renderGuardedChatControls(state),
                   workspaceFiles: {
+                    activeName: chatWorkspaceFiles.activeName,
                     agentId: chatAgentId,
+                    error: chatWorkspaceFiles.error,
                     list:
                       chatWorkspaceFiles.list?.agentId === chatAgentId
                         ? chatWorkspaceFiles.list
                         : null,
                     loading: chatWorkspaceFiles.loading,
-                    error: chatWorkspaceFiles.error,
-                    activeName: chatWorkspaceFiles.activeName,
-                    onRefresh: refreshChatWorkspaceFiles,
+                    open: chatWorkspaceFiles.open,
+                    onClose: closeChatWorkspaceFiles,
                     onOpenFile: openChatWorkspaceFile,
+                    onRefresh: refreshChatWorkspaceFiles,
+                    onToggle: toggleChatWorkspaceFiles,
                   },
                   autoExpandToolCalls: false,
                   onRefresh: () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -865,13 +865,51 @@ describe("chat goal status", () => {
 });
 
 describe("chat composer workbench", () => {
-  it("renders session controls in the composer and workspace files in the rail", () => {
+  it("keeps workspace files hidden until explicitly opened", () => {
+    const onToggle = vi.fn();
+    const container = renderChatView({
+      workspaceFiles: {
+        activeName: null,
+        agentId: "main",
+        error: null,
+        list: {
+          agentId: "main",
+          workspace: "/workspace",
+          files: [{ name: "AGENTS.md", path: "/workspace/AGENTS.md", missing: false }],
+        },
+        loading: false,
+        open: false,
+        onClose: () => undefined,
+        onOpenFile: () => undefined,
+        onRefresh: () => undefined,
+        onToggle,
+      },
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '.agent-chat__input-btn[aria-label="Workspace files"]',
+    );
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".chat-workspace-rail")).toBeNull();
+    expect(container.querySelector(".chat-workbench")?.className).not.toContain(
+      "chat-workbench--workspace-rail-open",
+    );
+
+    toggle?.click();
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders session controls in the composer and workspace files in the opened rail", () => {
+    const onClose = vi.fn();
     const onRefresh = vi.fn();
     const onOpenFile = vi.fn();
     const container = renderChatView({
       composerControls: html`<button class="test-composer-control">Model</button>`,
       workspaceFiles: {
+        activeName: "AGENTS.md",
         agentId: "main",
+        error: null,
         list: {
           agentId: "main",
           workspace: "/workspace",
@@ -885,16 +923,25 @@ describe("chat composer workbench", () => {
           ],
         },
         loading: false,
-        error: null,
-        activeName: "AGENTS.md",
+        open: true,
+        onClose,
         onRefresh,
         onOpenFile,
+        onToggle: () => undefined,
       },
     });
 
     expect(
       container.querySelector(".agent-chat__composer-controls .test-composer-control"),
     ).not.toBeNull();
+    expect(
+      container
+        .querySelector('.agent-chat__input-btn[aria-label="Workspace files"]')
+        ?.getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(container.querySelector(".chat-workbench")?.className).toContain(
+      "chat-workbench--workspace-rail-open",
+    );
     expect(container.querySelector(".chat-workspace-rail__path")?.textContent?.trim()).toBe(
       "/workspace",
     );
@@ -903,8 +950,10 @@ describe("chat composer workbench", () => {
     expect(file?.textContent).toContain("2 KB");
 
     file?.click();
+    container.querySelector<HTMLButtonElement>(".chat-workspace-rail__close")?.click();
 
     expect(onOpenFile).toHaveBeenCalledWith("AGENTS.md");
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the secondary New session and Export controls suppressed in the composer", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -184,13 +184,16 @@ export type ChatProps = {
   basePath?: string;
   composerControls?: TemplateResult | typeof nothing | ReturnType<typeof guard>;
   workspaceFiles?: {
+    activeName: string | null;
     agentId: string;
+    error: string | null;
     list: AgentsFilesListResult | null;
     loading: boolean;
-    error: string | null;
-    activeName: string | null;
-    onRefresh: () => void;
+    open: boolean;
+    onClose: () => void;
     onOpenFile: (name: string) => void;
+    onRefresh: () => void;
+    onToggle: () => void;
   };
 };
 
@@ -1008,7 +1011,7 @@ function formatWorkspaceFileSize(file: AgentFileEntry): string {
 function renderWorkspaceFileRail(
   workspaceFiles: NonNullable<ChatProps["workspaceFiles"]> | undefined,
 ): TemplateResult | typeof nothing {
-  if (!workspaceFiles) {
+  if (!workspaceFiles?.open) {
     return nothing;
   }
   const files = workspaceFiles.list?.files ?? [];
@@ -1019,16 +1022,27 @@ function renderWorkspaceFileRail(
           <span class="chat-workspace-rail__eyebrow">Workspace</span>
           <strong>Files</strong>
         </div>
-        <button
-          class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
-          type="button"
-          title="Refresh files"
-          aria-label="Refresh files"
-          ?disabled=${workspaceFiles.loading}
-          @click=${workspaceFiles.onRefresh}
-        >
-          ${icons.refresh}
-        </button>
+        <div class="chat-workspace-rail__actions">
+          <button
+            class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
+            type="button"
+            title="Refresh files"
+            aria-label="Refresh files"
+            ?disabled=${workspaceFiles.loading}
+            @click=${workspaceFiles.onRefresh}
+          >
+            ${icons.refresh}
+          </button>
+          <button
+            class="btn btn--ghost btn--sm chat-workspace-rail__close"
+            type="button"
+            title="Hide workspace files"
+            aria-label="Hide workspace files"
+            @click=${workspaceFiles.onClose}
+          >
+            ${icons.x}
+          </button>
+        </div>
       </div>
       ${workspaceFiles.list?.workspace
         ? html`<div class="chat-workspace-rail__path" title=${workspaceFiles.list.workspace}>
@@ -1997,7 +2011,11 @@ export function renderChat(props: ChatProps) {
         : nothing}
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
-      <div class="chat-workbench">
+      <div
+        class="chat-workbench ${props.workspaceFiles?.open
+          ? "chat-workbench--workspace-rail-open"
+          : ""}"
+      >
         <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
           <div
             class="chat-main"
@@ -2142,6 +2160,24 @@ export function renderChat(props: ChatProps) {
               <span class="agent-chat__control-label">${t("chat.composer.attachFile")}</span>
             </button>
 
+            ${props.workspaceFiles
+              ? html`
+                  <button
+                    type="button"
+                    class="agent-chat__input-btn ${props.workspaceFiles.open
+                      ? "agent-chat__input-btn--active"
+                      : ""}"
+                    @click=${props.workspaceFiles.onToggle}
+                    title="Workspace files"
+                    aria-label="Workspace files"
+                    aria-expanded=${props.workspaceFiles.open ? "true" : "false"}
+                    ?disabled=${!props.connected}
+                  >
+                    ${icons.fileText}
+                    <span class="agent-chat__control-label">Workspace files</span>
+                  </button>
+                `
+              : nothing}
             ${props.onToggleRealtimeTalk
               ? html`
                   <button


### PR DESCRIPTION
## Summary

- Keep the WebChat workspace files rail collapsed on initial chat render.
- Add an explicit composer toolbar toggle plus rail close action for users who want to inspect workspace files.
- Make the chat workbench single-column by default and switch to the two-column rail layout only while the rail is open.

Fixes #90359

## Real behavior proof

Behavior addressed: WebChat no longer shows or reserves the right-side `Workspace Files` rail by default after the v2026.6.1 regression, while preserving an explicit user path to open and close the rail.

Real environment tested: Local Linux checkout with Node v22.22.0, the Control UI Vite dev server, and headless Google Chrome from `/usr/bin/google-chrome`. The browser proof used the real `openclaw-app` DOM with a connected test state and a fake gateway client only for the `agents.files.list` response.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts
node scripts/run-oxlint.mjs ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-render.ts
git diff --check
env -C ui corepack pnpm@11.2.2 build
node --input-type=module <<'NODE'
# Started a Vite dev server for ui/, launched Playwright with /usr/bin/google-chrome,
# injected connected openclaw-app state plus a fake agents.files.list response,
# then asserted default collapsed, explicit open, and close behavior in the real DOM.
NODE
```

Evidence after fix:

```text
node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts
Test Files  1 passed (1)
Tests  95 passed (95)
```

```json
{
  "before": {
    "rail": false,
    "path": null,
    "file": null,
    "columns": "1142px",
    "expanded": "false",
    "disabled": false
  },
  "opened": {
    "rail": true,
    "path": "/workspace",
    "file": "AGENTS.md ... 2 KB",
    "columns": "862px 280px",
    "expanded": "true",
    "disabled": false
  },
  "closed": {
    "rail": false,
    "path": null,
    "file": null,
    "columns": "1142px",
    "expanded": "false",
    "disabled": false
  }
}
```

```text
node scripts/run-oxlint.mjs ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-render.ts
# passed with no output

git diff --check
# passed with no output

env -C ui corepack pnpm@11.2.2 build
✓ built in 2.00s
```

Observed result after fix: The initial chat render remains full-width with no `.chat-workspace-rail` and a single workbench column; clicking `Workspace files` opens the rail, loads and displays `AGENTS.md`, and changes the workbench to a two-column layout; clicking the rail close button hides it and restores the single-column layout.

What was not tested: I did not test a live OpenClaw daemon or a real workspace on disk; the browser proof injects a fake gateway client response because this change is limited to Control UI rendering and state transitions for the workspace files rail.

## Regression Test Plan

- Coverage level: focused UI unit test plus browser DOM verification.
- Target test file: `ui/src/ui/views/chat.test.ts`.
- Scenario locked in: `workspaceFiles.open === false` keeps the rail absent and the workbench unmodified, while `workspaceFiles.open === true` renders the rail and close action.
- Why this is the smallest reliable guardrail: the regression came from rendering the rail whenever workspace file data existed, so the view test directly locks the open-state gate that controls that behavior.

## Root Cause

- Root cause: `renderWorkspaceFileRail()` treated the presence of `workspaceFiles` as an instruction to render the rail, and the workbench CSS always reserved a second grid column.
- Missing detection / guardrail: there was no regression test asserting that workspace file data can exist while the rail remains hidden until the user explicitly opens it.
