### PR TITLE
fix(ollama): skip unreadable tool schemas

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -649,6 +649,362 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
       },
     );
   });
+
+  it("skips unreadable native Ollama tool schemas while preserving healthy siblings", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const model = {
+          api: "ollama",
+          provider: "ollama",
+          id: "qwen3:32b",
+          contextWindow: 131072,
+        };
+        const unreadableProperties = new Proxy(
+          {},
+          {
+            ownKeys() {
+              throw new Error("properties unavailable");
+            },
+          },
+        );
+        const unreadableParameters = Object.defineProperties(
+          {},
+          {
+            name: { value: "broken_parameters" },
+            description: { value: "broken parameters" },
+            parameters: {
+              get() {
+                throw new Error("parameters unavailable");
+              },
+            },
+          },
+        );
+        const revoked = Proxy.revocable({}, {});
+        revoked.revoke();
+
+        const stream = await Promise.resolve(
+          streamFn(
+            model as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "broken",
+                  description: "broken",
+                  parameters: {
+                    type: "object",
+                    properties: unreadableProperties,
+                  },
+                },
+                unreadableParameters,
+                {
+                  name: "revoked",
+                  description: "revoked",
+                  parameters: revoked.proxy,
+                },
+                {
+                  name: "search",
+                  description: "search",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      query: { type: "string" },
+                    },
+                    required: ["query"],
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{ function?: { name?: string } }>;
+        };
+        expect(requestBody.tools?.map((tool) => tool.function?.name)).toEqual(["search"]);
+      },
+    );
+  });
+
+  it("preserves large native Ollama scalar schema arrays", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const model = {
+          api: "ollama",
+          provider: "ollama",
+          id: "qwen3:32b",
+          contextWindow: 131072,
+        };
+
+        const stream = await Promise.resolve(
+          streamFn(
+            model as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "oversized",
+                  description: "oversized",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      choice: {
+                        type: "string",
+                        enum: Array.from({ length: 129 }, (_value, index) => `value-${index}`),
+                      },
+                    },
+                    required: ["choice"],
+                  },
+                },
+                {
+                  name: "search",
+                  description: "search",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      query: { type: "string" },
+                    },
+                    required: ["query"],
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{
+            function?: {
+              name?: string;
+              parameters?: {
+                properties?: {
+                  choice?: { enum?: string[] };
+                };
+              };
+            };
+          }>;
+        };
+        expect(requestBody.tools?.map((tool) => tool.function?.name)).toEqual([
+          "oversized",
+          "search",
+        ]);
+        expect(requestBody.tools?.[0]?.function?.parameters?.properties?.choice?.enum).toHaveLength(
+          129,
+        );
+      },
+    );
+  });
+
+  it("preserves large native Ollama tool schema property maps", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const model = {
+          api: "ollama",
+          provider: "ollama",
+          id: "qwen3:32b",
+          contextWindow: 131072,
+        };
+        const properties = Object.fromEntries(
+          Array.from({ length: 257 }, (_value, index) => [`field_${index}`, { type: "string" }]),
+        );
+
+        const stream = await Promise.resolve(
+          streamFn(
+            model as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "wide_schema",
+                  description: "wide schema",
+                  parameters: {
+                    type: "object",
+                    properties,
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{
+            function?: {
+              name?: string;
+              parameters?: { properties?: Record<string, unknown> };
+            };
+          }>;
+        };
+        expect(requestBody.tools?.[0]?.function?.name).toBe("wide_schema");
+        expect(
+          Object.keys(requestBody.tools?.[0]?.function?.parameters?.properties ?? {}),
+        ).toHaveLength(257);
+      },
+    );
+  });
+
+  it("preserves shared native Ollama tool subschema instances", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const model = {
+          api: "ollama",
+          provider: "ollama",
+          id: "qwen3:32b",
+          contextWindow: 131072,
+        };
+        const sharedStringSchema = { type: "string" };
+
+        const stream = await Promise.resolve(
+          streamFn(
+            model as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "route",
+                  description: "route",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      from: sharedStringSchema,
+                      to: sharedStringSchema,
+                    },
+                    required: ["from", "to"],
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{
+            function?: {
+              name?: string;
+              parameters?: { properties?: Record<string, { type?: string }> };
+            };
+          }>;
+        };
+        expect(requestBody.tools?.[0]?.function?.name).toBe("route");
+        expect(requestBody.tools?.[0]?.function?.parameters?.properties).toMatchObject({
+          from: { type: "string" },
+          to: { type: "string" },
+        });
+      },
+    );
+  });
+
+  it("skips cyclic native Ollama tool schemas while preserving healthy siblings", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const model = {
+          api: "ollama",
+          provider: "ollama",
+          id: "qwen3:32b",
+          contextWindow: 131072,
+        };
+        const cyclicSchema: Record<string, unknown> = {
+          type: "object",
+          properties: {
+            value: { type: "string" },
+          },
+        };
+        cyclicSchema.$defs = { self: cyclicSchema };
+
+        const stream = await Promise.resolve(
+          streamFn(
+            model as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "cyclic",
+                  description: "cyclic",
+                  parameters: cyclicSchema,
+                },
+                {
+                  name: "search",
+                  description: "search",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      query: { type: "string" },
+                    },
+                    required: ["query"],
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{ function?: { name?: string } }>;
+        };
+        expect(requestBody.tools?.map((tool) => tool.function?.name)).toEqual(["search"]);
+      },
+    );
+  });
 });
 
 describe("convertToOllamaMessages", () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -57,9 +57,16 @@ const GARBLED_VISIBLE_TEXT_MODEL_RE = /\b(?:glm|kimi)\b/i;
 const GARBLED_VISIBLE_TEXT_MIN_CHARS = 80;
 const GARBLED_VISIBLE_TEXT_SYMBOL_RE = /[$#%&="'_~`^|\\/*+\-[\]{}()<>:;,.!?]/gu;
 const LETTER_OR_DIGIT_RE = /[\p{L}\p{N}]/gu;
+const OLLAMA_TOOL_SCHEMA_MAX_DEPTH = 12;
+const OLLAMA_TOOL_SCHEMA_MAX_NODES = 8192;
 
 type OllamaStreamCooperativeScheduler = {
   afterEvent: () => Promise<void>;
+};
+
+type OllamaToolSchemaReadState = {
+  nodes: number;
+  stack: WeakSet<object>;
 };
 
 function throwIfOllamaStreamAborted(signal?: AbortSignal): void {
@@ -766,15 +773,132 @@ function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unkn
   }
 }
 
+function readSchemaProperty(schema: Record<string, unknown>, key: string): unknown {
+  try {
+    return schema[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readRecordEntries(record: Record<string, unknown>): Array<[string, unknown]> | undefined {
+  const entries: Array<[string, unknown]> = [];
+  try {
+    for (const key in record) {
+      if (!Object.hasOwn(record, key)) {
+        continue;
+      }
+      entries.push([key, record[key]]);
+    }
+    return entries;
+  } catch {
+    return undefined;
+  }
+}
+
+function readArrayEntries(value: unknown[]): Array<[number, unknown]> | undefined {
+  const entries: Array<[number, unknown]> = [];
+  try {
+    for (let index = 0; index < value.length; index += 1) {
+      entries.push([index, value[index]]);
+    }
+    return entries;
+  } catch {
+    return undefined;
+  }
+}
+
+function enterOllamaSchemaObject(value: object, state: OllamaToolSchemaReadState): boolean {
+  if (state.stack.has(value)) {
+    return false;
+  }
+  state.nodes += 1;
+  if (state.nodes > OLLAMA_TOOL_SCHEMA_MAX_NODES) {
+    return false;
+  }
+  state.stack.add(value);
+  return true;
+}
+
+function leaveOllamaSchemaObject(value: object, state: OllamaToolSchemaReadState): void {
+  state.stack.delete(value);
+}
+
+function copyOllamaSchemaJsonValue(
+  value: unknown,
+  depth: number,
+  state: OllamaToolSchemaReadState,
+): unknown {
+  if (
+    value == null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (depth > OLLAMA_TOOL_SCHEMA_MAX_DEPTH) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    if (!enterOllamaSchemaObject(value, state)) {
+      return undefined;
+    }
+    try {
+      const entries = readArrayEntries(value);
+      if (!entries) {
+        return undefined;
+      }
+      const result: unknown[] = [];
+      for (const [_index, entry] of entries) {
+        const copied = copyOllamaSchemaJsonValue(entry, depth + 1, state);
+        if (copied === undefined && (Array.isArray(entry) || isRecord(entry))) {
+          return undefined;
+        }
+        result.push(copied);
+      }
+      return result;
+    } finally {
+      leaveOllamaSchemaObject(value, state);
+    }
+  }
+  if (isRecord(value)) {
+    if (!enterOllamaSchemaObject(value, state)) {
+      return undefined;
+    }
+    try {
+      const entries = readRecordEntries(value);
+      if (!entries) {
+        return undefined;
+      }
+      const result: Record<string, unknown> = {};
+      for (const [key, entry] of entries) {
+        const copied = copyOllamaSchemaJsonValue(entry, depth + 1, state);
+        if (copied !== undefined) {
+          result[key] = copied;
+        } else if (Array.isArray(entry) || isRecord(entry)) {
+          return undefined;
+        }
+      }
+      return result;
+    } finally {
+      leaveOllamaSchemaObject(value, state);
+    }
+  }
+  return undefined;
+}
+
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {
-  if (schema.properties && isRecord(schema.properties)) {
+  const properties = readSchemaProperty(schema, "properties");
+  if (properties && isRecord(properties)) {
     return "object";
   }
-  if (schema.items) {
+  if (readSchemaProperty(schema, "items")) {
     return "array";
   }
-  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
-    const values = schema.enum.filter((value) => value !== null);
+  const enumValues = readSchemaProperty(schema, "enum");
+  if (Array.isArray(enumValues) && enumValues.length > 0) {
+    const values = enumValues.filter((value) => value !== null);
     if (values.length > 0 && values.every((value) => typeof value === "string")) {
       return "string";
     }
@@ -786,7 +910,7 @@ function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefi
     }
   }
   for (const unionKey of ["anyOf", "oneOf"] as const) {
-    const variants = schema[unionKey];
+    const variants = readSchemaProperty(schema, unionKey);
     if (!Array.isArray(variants)) {
       continue;
     }
@@ -815,50 +939,116 @@ function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefi
   return undefined;
 }
 
-function normalizeOllamaToolSchema(schema: unknown, isRoot = false): Record<string, unknown> {
+function normalizeOllamaToolSchema(
+  schema: unknown,
+  isRoot = false,
+  depth = 0,
+  state: OllamaToolSchemaReadState = { nodes: 0, stack: new WeakSet() },
+): Record<string, unknown> | undefined {
   if (!isRecord(schema)) {
     return {
       type: "object",
       properties: {},
     };
   }
-
-  const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema)) {
-    if (key === "properties" && isRecord(value)) {
-      normalized.properties = Object.fromEntries(
-        Object.entries(value).map(([propertyName, propertySchema]) => [
-          propertyName,
-          normalizeOllamaToolSchema(propertySchema),
-        ]),
-      );
-      continue;
-    }
-    if (key === "items") {
-      normalized.items = Array.isArray(value)
-        ? value.map((entry) => normalizeOllamaToolSchema(entry))
-        : normalizeOllamaToolSchema(value);
-      continue;
-    }
-    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      normalized[key] = value.map((entry) => normalizeOllamaToolSchema(entry));
-      continue;
-    }
-    normalized[key] = value;
+  if (depth > OLLAMA_TOOL_SCHEMA_MAX_DEPTH) {
+    return undefined;
+  }
+  if (!enterOllamaSchemaObject(schema, state)) {
+    return undefined;
   }
 
-  const schemaType = normalized.type;
-  if (
-    typeof schemaType !== "string" &&
-    (!Array.isArray(schemaType) ||
-      !schemaType.some((entry) => typeof entry === "string" && entry !== "null"))
-  ) {
-    normalized.type = inferOllamaSchemaType(normalized) ?? (isRoot ? "object" : "string");
+  try {
+    const entries = readRecordEntries(schema);
+    if (!entries) {
+      return undefined;
+    }
+    const normalized: Record<string, unknown> = {};
+    for (const [key, value] of entries) {
+      if (key === "properties" && isRecord(value)) {
+        const propertyEntries = readRecordEntries(value);
+        if (!propertyEntries) {
+          return undefined;
+        }
+        const normalizedProperties: Record<string, unknown> = {};
+        for (const [propertyName, propertySchema] of propertyEntries) {
+          const normalizedProperty = normalizeOllamaToolSchema(
+            propertySchema,
+            false,
+            depth + 1,
+            state,
+          );
+          if (!normalizedProperty) {
+            return undefined;
+          }
+          normalizedProperties[propertyName] = normalizedProperty;
+        }
+        normalized.properties = normalizedProperties;
+        continue;
+      }
+      if (key === "items") {
+        if (Array.isArray(value)) {
+          const itemEntries = readArrayEntries(value);
+          if (!itemEntries) {
+            return undefined;
+          }
+          const normalizedItems: Array<Record<string, unknown>> = [];
+          for (const [_index, entry] of itemEntries) {
+            const normalizedItem = normalizeOllamaToolSchema(entry, false, depth + 1, state);
+            if (!normalizedItem) {
+              return undefined;
+            }
+            normalizedItems.push(normalizedItem);
+          }
+          normalized.items = normalizedItems;
+        } else {
+          const normalizedItems = normalizeOllamaToolSchema(value, false, depth + 1, state);
+          if (!normalizedItems) {
+            return undefined;
+          }
+          normalized.items = normalizedItems;
+        }
+        continue;
+      }
+      if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+        const variantEntries = readArrayEntries(value);
+        if (!variantEntries) {
+          return undefined;
+        }
+        const normalizedVariants: Array<Record<string, unknown>> = [];
+        for (const [_index, entry] of variantEntries) {
+          const normalizedVariant = normalizeOllamaToolSchema(entry, false, depth + 1, state);
+          if (!normalizedVariant) {
+            return undefined;
+          }
+          normalizedVariants.push(normalizedVariant);
+        }
+        normalized[key] = normalizedVariants;
+        continue;
+      }
+      const copied = copyOllamaSchemaJsonValue(value, depth + 1, state);
+      if (copied !== undefined) {
+        normalized[key] = copied;
+      } else if (Array.isArray(value) || isRecord(value)) {
+        return undefined;
+      }
+    }
+
+    const schemaType = readSchemaProperty(normalized, "type");
+    if (
+      typeof schemaType !== "string" &&
+      (!Array.isArray(schemaType) ||
+        !schemaType.some((entry) => typeof entry === "string" && entry !== "null"))
+    ) {
+      normalized.type = inferOllamaSchemaType(normalized) ?? (isRoot ? "object" : "string");
+    }
+    if (readSchemaProperty(normalized, "type") === "object" && !isRecord(normalized.properties)) {
+      normalized.properties = {};
+    }
+    return normalized;
+  } finally {
+    leaveOllamaSchemaObject(schema, state);
   }
-  if (normalized.type === "object" && !isRecord(normalized.properties)) {
-    normalized.properties = {};
-  }
-  return normalized;
 }
 
 type OllamaToolCallNameOptions = {
@@ -912,11 +1102,37 @@ function buildOllamaToolNameSet(tools: Tool[] | undefined): ReadonlySet<string> 
   }
   const names = new Set<string>();
   for (const tool of tools) {
-    if (typeof tool.name === "string" && tool.name.trim()) {
-      names.add(tool.name.trim());
+    const name = readToolStringField(tool, "name");
+    if (name?.trim()) {
+      names.add(name.trim());
     }
   }
   return names.size > 0 ? names : undefined;
+}
+
+function readToolStringField(tool: Tool, field: "description" | "name"): string | undefined {
+  try {
+    const value = (tool as unknown as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readToolParameters(tool: Tool): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: tool.parameters };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function safeNormalizeOllamaToolSchema(schema: unknown): Record<string, unknown> | undefined {
+  try {
+    return normalizeOllamaToolSchema(schema, true);
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeOllamaToolCallName(
@@ -1004,15 +1220,26 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
   }
   const result: OllamaTool[] = [];
   for (const tool of tools) {
-    if (typeof tool.name !== "string" || !tool.name) {
+    const name = readToolStringField(tool, "name");
+    if (!name) {
+      continue;
+    }
+    const rawParameters = readToolParameters(tool);
+    if (!rawParameters.ok) {
+      log.warn(`Skipping Ollama tool "${name}" because its input schema could not be read.`);
+      continue;
+    }
+    const parameters = safeNormalizeOllamaToolSchema(rawParameters.value);
+    if (!parameters) {
+      log.warn(`Skipping Ollama tool "${name}" because its input schema could not be read.`);
       continue;
     }
     result.push({
       type: "function",
       function: {
-        name: tool.name,
-        description: typeof tool.description === "string" ? tool.description : "",
-        parameters: normalizeOllamaToolSchema(tool.parameters, true),
+        name,
+        description: readToolStringField(tool, "description") ?? "",
+        parameters,
       },
     });
   }


### PR DESCRIPTION
## Summary

- Hardens native Ollama tool request construction so one unreadable, revoked, cyclic, or otherwise uncopyable tool schema is skipped instead of aborting the whole stream setup.
- Preserves healthy sibling tools and valid large/readable schema shapes, including 129-value scalar enums, 257-property maps, and shared non-cyclic subschema objects.
- Adds focused Ollama provider regressions for unreadable schema properties, throwing `parameters` accessors, revoked proxy schemas, cyclic annotations, shared subschemas, and large readable schemas.
- Out of scope: other provider payload adapters and runtime tool execution validation.

Transcript note: agent transcript finder returned candidate local sessions; no transcript excerpt is included because approval is required before adding session logs.

## Linked context

Closes: none.
Related: ongoing tool-schema fuzzing hardening workstream.
Was this requested by a maintainer or owner? Maintainer fuzzing sweep.

## Real behavior proof

Behavior addressed: a malformed Ollama tool schema no longer aborts native Ollama request construction before the assistant can produce content; only the bad tool is omitted from the provider request while healthy siblings remain available.
Real environment tested: local macOS linked gwt worktree rebased onto `origin/main` at `20c4e9475a7feab03a5a9653d225ae9973fb1798` plus current remote-runner auth probes.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/ollama/src/stream-runtime.test.ts --reporter=dot --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`; `node scripts/run-oxlint.mjs extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`; `git diff --check origin/main...HEAD -- extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"`.
Evidence after fix: focused Vitest passed 1 file / 105 tests; oxfmt passed; oxlint passed; diff whitespace check passed; final branch autoreview returned `autoreview clean: no accepted/actionable findings reported` with `overall: patch is correct (0.82)`.
Observed result after fix: request construction skips tools whose schema cannot be read or safely copied, keeps the healthy `search` sibling in the outgoing Ollama `tools` payload, and preserves large scalar arrays, large property maps, and shared subschema instances that are valid/readable.
What was not tested: live Ollama server execution and non-Ollama provider adapters.
Proof limitations or environment constraints: Blacksmith Testbox is unavailable because `blacksmith testbox list --all` reports `not authenticated`; AWS Crabbox probe is currently blocked by coordinator 401 on run-history/lease creation, so no fresh remote changed gate was available for this PR.
Before evidence: native Ollama schema normalization walked `tool.parameters`, nested `properties`, `items`, and union arrays directly with unguarded object/array traversal, so one hostile plugin tool schema could throw during request setup and prevent the assistant turn from reaching provider streaming.

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs run extensions/ollama/src/stream-runtime.test.ts --reporter=dot --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `node scripts/run-oxlint.mjs extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `git diff --check origin/main...HEAD -- extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Remote proof attempted:
- `blacksmith testbox list --all` -> blocked: not authenticated.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"` -> blocked: coordinator 401 creating run history/lease.

Regression coverage added: `extensions/ollama/src/stream-runtime.test.ts` now covers unreadable nested properties, throwing `parameters`, revoked proxies, cycles, shared subschemas, large enum arrays, and wide property maps in native Ollama tool schemas.

What failed before this fix: malformed schema traversal could throw before native Ollama request dispatch, aborting the stream instead of dropping only the bad tool.

## Risk checklist

Did user-visible behavior change? Yes: native Ollama runs keep working when one tool schema is malformed, but that malformed tool is omitted from the provider request.
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
What is the highest-risk area? Accidentally hiding valid tools while trying to skip malformed schemas.
How is that risk mitigated? Tests cover valid large arrays, wide property maps, and shared subschemas, and autoreview drove fixes for truncation, over-broad caps, cycles, and top-level accessor failures.

## Current review state

What is the next action? Maintainer review and CI once remote runner auth is available.
What is still waiting on author, maintainer, CI, or external proof? GitHub CI/remote changed gate; current local runner auth blocks Testbox and Crabbox proof.
Which bot or reviewer comments were addressed? Local autoreview findings were fixed through multiple passes; final branch autoreview found no accepted/actionable findings.
