### PR TITLE
fix(mcp): skip unreadable plugin tools

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -12,34 +12,95 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
-function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
-  const params = tool.parameters;
-  if (params && typeof params === "object" && "type" in params) {
-    return params as Record<string, unknown>;
+type PluginMcpToolEntry = {
+  description: string;
+  inputSchema: Record<string, unknown>;
+  name: string;
+  tool: AnyAgentTool;
+};
+
+function readToolName(tool: AnyAgentTool): string | undefined {
+  try {
+    const value = tool.name;
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  } catch {
+    return undefined;
   }
-  return { type: "object", properties: {} };
+}
+
+function readToolDescription(tool: AnyAgentTool): string {
+  try {
+    return typeof tool.description === "string" ? tool.description : "";
+  } catch {
+    return "";
+  }
+}
+
+function readToolParameters(tool: AnyAgentTool): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: tool.parameters };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function resolveJsonSchemaForTool(
+  tool: AnyAgentTool,
+): { ok: true; schema: Record<string, unknown> } | { ok: false } {
+  const params = readToolParameters(tool);
+  if (!params.ok) {
+    return { ok: false };
+  }
+  try {
+    if (params.value && typeof params.value === "object" && "type" in params.value) {
+      return { ok: true, schema: params.value as Record<string, unknown> };
+    }
+  } catch {
+    return { ok: false };
+  }
+  return { ok: true, schema: { type: "object", properties: {} } };
 }
 
 export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
-  const wrappedTools = tools.map((tool) => {
-    if (isToolWrappedWithBeforeToolCallHook(tool)) {
-      return rewrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
+  const toolEntries: PluginMcpToolEntry[] = [];
+  for (const tool of tools) {
+    const name = readToolName(tool);
+    if (!name) {
+      continue;
     }
-    // The ACPX MCP bridge should enforce the same pre-execution hook boundary
-    // as the agent and HTTP tool execution paths.
-    return wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
-  });
+    const inputSchema = resolveJsonSchemaForTool(tool);
+    if (!inputSchema.ok) {
+      continue;
+    }
+    const description = readToolDescription(tool);
+    let wrappedTool: AnyAgentTool;
+    try {
+      // The ACPX MCP bridge should enforce the same pre-execution hook boundary
+      // as the agent and HTTP tool execution paths.
+      wrappedTool = isToolWrappedWithBeforeToolCallHook(tool)
+        ? rewrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" })
+        : wrapToolWithBeforeToolCallHook(tool, undefined, { approvalMode: "report" });
+    } catch {
+      continue;
+    }
+    toolEntries.push({
+      description,
+      inputSchema: inputSchema.schema,
+      name,
+      tool: wrappedTool,
+    });
+  }
   const toolMap = new Map<string, AnyAgentTool>();
-  for (const tool of wrappedTools) {
-    toolMap.set(tool.name, tool);
+  for (const entry of toolEntries) {
+    toolMap.set(entry.name, entry.tool);
   }
 
   return {
     listTools: async () => ({
-      tools: wrappedTools.map((tool) => ({
-        name: tool.name,
-        description: tool.description ?? "",
-        inputSchema: resolveJsonSchemaForTool(tool),
+      tools: toolEntries.map((entry) => ({
+        name: entry.name,
+        description: entry.description,
+        inputSchema: entry.inputSchema,
       })),
     }),
     callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -174,6 +174,77 @@ describe("plugin tools MCP server", () => {
     expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
   });
 
+  it("skips unreadable plugin tool descriptors while keeping healthy MCP siblings", async () => {
+    const healthyExecute = vi.fn().mockResolvedValue({ content: "ok" });
+    const unreadableNameTool = Object.defineProperties(
+      {},
+      {
+        name: {
+          get() {
+            throw new Error("name unavailable");
+          },
+        },
+        description: { value: "Unreadable name" },
+        parameters: { value: { type: "object", properties: {} } },
+        execute: { value: vi.fn() },
+      },
+    );
+    const unreadableParametersTool = Object.defineProperties(
+      {},
+      {
+        name: { value: "broken_parameters" },
+        description: { value: "Unreadable parameters" },
+        parameters: {
+          get() {
+            throw new Error("parameters unavailable");
+          },
+        },
+        execute: { value: vi.fn() },
+      },
+    );
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    const handlers = createPluginToolsMcpHandlers([
+      unreadableNameTool,
+      unreadableParametersTool,
+      {
+        name: "revoked_schema",
+        description: "Revoked schema",
+        parameters: revoked.proxy,
+        execute: vi.fn(),
+      },
+      {
+        name: "healthy_tool",
+        description: "Healthy tool",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+        },
+        execute: healthyExecute,
+      },
+    ] as unknown as AnyAgentTool[]);
+
+    const listed = await handlers.listTools();
+    expect(listed.tools.map((tool) => tool.name)).toEqual(["healthy_tool"]);
+    expect(listed.tools[0]?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    });
+
+    const result = await handlers.callTool({
+      name: "healthy_tool",
+      arguments: { query: "ok" },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+    expect(healthyExecute).toHaveBeenCalledTimes(1);
+  });
+
   it("serializes plugin tool results that do not use the MCP content envelope", async () => {
     const execute = vi.fn().mockResolvedValue({
       provider: "kitchen-sink-search",


### PR DESCRIPTION
## Summary

- Hardens the plugin tools MCP bridge so unreadable or unwrappable plugin tool descriptors are skipped during handler construction instead of crashing `listTools`.
- Keeps healthy sibling plugin tools listed and callable through the MCP bridge, including the existing `before_tool_call` report-mode wrapper behavior.
- Adds focused regression coverage for throwing `name`, throwing `parameters`, and revoked proxy schema descriptors alongside a healthy sibling tool.
- Out of scope: runtime plugin registry validation and non-MCP provider/tool projection paths.

Transcript note: agent transcript finder returned candidate local sessions; no transcript excerpt is included because approval is required before adding session logs.

## Linked context

Closes: none.
Related: ongoing tool-schema fuzzing hardening workstream.
Was this requested by a maintainer or owner? Maintainer fuzzing sweep.

## Real behavior proof

Behavior addressed: a malformed plugin tool descriptor no longer aborts plugin MCP handler construction or `listTools`; only the malformed descriptor is omitted while valid sibling tools remain exposed and callable.
Real environment tested: local macOS linked gwt worktree rebased onto `origin/main` at `4c32553875b86c27439305c8cc163a03044ecd41`; `origin/main` later advanced to `0a351cdf7f42f03d82643774274b0a26aee66f62` with no changes under `src/mcp/plugin-tools-handlers.ts` or `src/mcp/plugin-tools-serve.test.ts`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts src/mcp/openclaw-tools-serve.test.ts --reporter=dot --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`; `node_modules/.bin/oxfmt --check --threads=1 src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`; `node scripts/run-oxlint.mjs src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`; `git diff --check origin/main...HEAD -- src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"`.
Evidence after fix: focused Vitest passed 3 files / 10 tests across 2 shards; oxfmt passed; oxlint passed; diff whitespace check passed; final branch autoreview returned `autoreview clean: no accepted/actionable findings reported` with `overall: patch is correct (0.84)`.
Observed result after fix: the regression builds MCP handlers from bad descriptors plus `healthy_tool`; `listTools` returns only `healthy_tool`, preserves its input schema, and `callTool` executes it successfully.
What was not tested: live stdio MCP client roundtrip beyond the existing in-process cancellation/list/call coverage; broad changed gate was unavailable.
Proof limitations or environment constraints: Blacksmith Testbox is unavailable because `blacksmith testbox list --all` reports `not authenticated`; AWS Crabbox probe is currently blocked by coordinator 401 on run-history/lease creation, so no fresh remote changed gate was available for this PR.
Before evidence: `createPluginToolsMcpHandlers` mapped/wrapped/listed every descriptor with direct `tool.name`, `tool.description`, and `tool.parameters` reads, so one hostile plugin tool descriptor could throw before the MCP bridge listed healthy tools.

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs run src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-handlers.cancel.test.ts src/mcp/openclaw-tools-serve.test.ts --reporter=dot --pool=forks --maxWorkers=1 --fileParallelism=false --teardownTimeout=1000`
- `node_modules/.bin/oxfmt --check --threads=1 src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `node scripts/run-oxlint.mjs src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `git diff --check origin/main...HEAD -- src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-serve.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Remote proof attempted:
- `blacksmith testbox list --all` -> blocked: not authenticated.
- `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 5m --ttl 20m --timing-json --shell -- "pwd >/dev/null"` -> blocked: coordinator 401 creating run history/lease.

Regression coverage added: `src/mcp/plugin-tools-serve.test.ts` now covers unreadable plugin tool names, unreadable plugin tool parameters, revoked proxy schemas, and healthy sibling preservation in MCP listing/calling.

What failed before this fix: descriptor wrapping/listing could throw before MCP `listTools` returned, which made one bad plugin tool poison the whole plugin-tools MCP server surface.

## Risk checklist

Did user-visible behavior change? Yes: malformed plugin tools are omitted from the plugin-tools MCP bridge instead of crashing the bridge.
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
What is the highest-risk area? Accidentally hiding valid plugin tools while filtering malformed descriptors.
How is that risk mitigated? The filter only drops descriptors whose name, parameters, schema readability, or hook wrapping throws; existing valid listing, calling, approval-report wrapping, and cancellation coverage stayed green.

## Current review state

What is the next action? Maintainer review and CI once remote runner auth is available.
What is still waiting on author, maintainer, CI, or external proof? GitHub CI/remote changed gate; current local runner auth blocks Testbox and Crabbox proof.
Which bot or reviewer comments were addressed? Local autoreview found no accepted/actionable findings.
