### PR TITLE
test(telegram): replace broad win32 skips with dynamic capability checks in token tests

### DIFF
--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -1,6 +1,20 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+const canCreateFileSymlinks = (() => {
+  try {
+    const tempLink = path.join(os.tmpdir(), `symlink-file-test-${Math.random().toString(36).substring(2)}`);
+    const tempFile = path.join(os.tmpdir(), `symlink-file-target-${Math.random().toString(36).substring(2)}`);
+    fs.writeFileSync(tempFile, "temp");
+    fs.symlinkSync(tempFile, tempLink, "file");
+    fs.unlinkSync(tempLink);
+    fs.unlinkSync(tempFile);
+    return true;
+  } catch {
+    return false;
+  }
+})();
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -92,13 +106,13 @@ describe("resolveTelegramToken", () => {
     expect(res).toEqual(expected);
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked tokenFile paths", () => {
+  it.skipIf(!canCreateFileSymlinks)("rejects symlinked tokenFile paths", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = createTempDir();
     const tokenFile = path.join(dir, "token.txt");
     const tokenLink = path.join(dir, "token-link.txt");
     fs.writeFileSync(tokenFile, "file-token\n", "utf-8");
-    fs.symlinkSync(tokenFile, tokenLink);
+    fs.symlinkSync(tokenFile, tokenLink, "file");
 
     const cfg = { channels: { telegram: { tokenFile: tokenLink } } } as OpenClawConfig;
     expect(() => resolveTelegramToken(cfg)).toThrow(
@@ -106,13 +120,13 @@ describe("resolveTelegramToken", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked account-level tokenFile paths", () => {
+  it.skipIf(!canCreateFileSymlinks)("rejects symlinked account-level tokenFile paths", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = createTempDir();
     const tokenFile = path.join(dir, "token.txt");
     const tokenLink = path.join(dir, "token-link.txt");
     fs.writeFileSync(tokenFile, "file-token\n", "utf-8");
-    fs.symlinkSync(tokenFile, tokenLink);
+    fs.symlinkSync(tokenFile, tokenLink, "file");
 
     const cfg = {
       channels: {


### PR DESCRIPTION
### Description
Replaced unconditional `win32` platform skips in the Telegram token test suite (`token.test.ts`) with a dynamic capability probe checking for file symlink support (`canCreateFileSymlinks`), utilizing `"file"` type symlinks for Windows compatibility.

### Verification Proof
Test run on Windows:
```
✓  extension-telegram  ../../extensions/telegram/src/token.test.ts (25 tests | 2 skipped) 142ms

 Test Files  1 passed (1)
      Tests  23 passed | 2 skipped (25)
```
