### PR TITLE
fix(mattermost): anchor slash state on globalThis (#68113)

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import type { MattermostRegisteredCommand } from "./slash-commands.js";
@@ -46,6 +46,49 @@ const slashApi = {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
 };
+
+const ACCOUNT_STATES_KEY = Symbol.for("openclaw.mattermost.slash-account-states");
+
+describe("slash-state global singleton", () => {
+  afterEach(() => {
+    deactivateSlashCommands();
+  });
+
+  it("anchors accountStates on globalThis", () => {
+    deactivateSlashCommands();
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a1"),
+      commandTokens: ["tok-a"],
+      registeredCommands: [],
+      api: slashApi,
+    });
+
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    const map = globalStore[ACCOUNT_STATES_KEY];
+    expect(map).toBeInstanceOf(Map);
+    expect((map as Map<string, unknown>).has("a1")).toBe(true);
+  });
+
+  it("preserves slash state across module reloads", async () => {
+    deactivateSlashCommands();
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a1"),
+      commandTokens: ["tok-reload"],
+      registeredCommands: [],
+      api: slashApi,
+    });
+
+    vi.resetModules();
+    const reloaded = await import("./slash-state.js");
+    const match = reloaded.resolveSlashHandlerForToken("tok-reload");
+
+    expect(match.kind).toBe("single");
+    if (match.kind !== "single") {
+      throw new Error("expected single match after module reload");
+    }
+    expect(match.accountIds).toEqual(["a1"]);
+  });
+});
 
 describe("slash-state token routing", () => {
   it("returns single match when token belongs to one account", () => {

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -62,8 +62,29 @@ type SlashCommandAccountState = {
   triggerMap: Map<string, string>;
 };
 
-/** Map from accountId → per-account slash command state. */
-const accountStates = new Map<string, SlashCommandAccountState>();
+/**
+ * Map from accountId → per-account slash command state.
+ *
+ * Anchored to globalThis so that jiti-loaded (route registration) and
+ * native-ESM-loaded (monitor/activation) module instances share the
+ * same Map. Without this, each module loader creates its own copy of
+ * the module-level variable and the HTTP handler never sees the tokens
+ * populated by the monitor.
+ */
+const ACCOUNT_STATES_KEY = Symbol.for("openclaw.mattermost.slash-account-states");
+
+function getSlashAccountStates(): Map<string, SlashCommandAccountState> {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[ACCOUNT_STATES_KEY];
+  if (existing instanceof Map) {
+    return existing as Map<string, SlashCommandAccountState>;
+  }
+  const accountStates = new Map<string, SlashCommandAccountState>();
+  globalStore[ACCOUNT_STATES_KEY] = accountStates;
+  return accountStates;
+}
+
+const accountStates = getSlashAccountStates();
 
 export function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {
   const matches: Array<{


### PR DESCRIPTION
## Summary

- Fixes Mattermost native slash commands returning permanent HTTP 503 with `"Slash commands are not yet initialized"` even after logs show `slash commands activated` (regression reported in #68113 on v2026.4.15+).
- Root cause: slash callback HTTP route registration (jiti-loaded plugin bundle) and monitor activation (native ESM) each held a separate module-level `accountStates` `Map`, so the route handler never saw tokens/handlers populated by `activateSlashCommands()`.
- Fix: anchor `accountStates` on a process-wide `globalThis` singleton via `Symbol.for("openclaw.mattermost.slash-account-states")`, matching the approach from closed PR #69038.
- Adds regression coverage that the shared map survives a simulated second module load (`vi.resetModules()`), modeling the dual-loader failure mode.

**Intentionally out of scope:** Mattermost API registration changes, multi-account routing policy, nginx/proxy config, or unrelated channel work.

**Reviewer focus:** Confirm shutdown/deactivate still clears global state; multi-account ambiguous-token behavior unchanged; no new cross-plugin globals beyond the documented symbol.

## Linked context

Closes #68113

Related #69038

## Real behavior proof

- Behavior or issue addressed: Mattermost slash HTTP callback stayed on 503 "not yet initialized" forever while startup logs claimed slash commands were active; users could not run `/oc_*` commands (#68113).
- Real environment tested: Windows 11 dev host, OpenClaw built from this PR branch (`fix/mattermost-slash-68113`), local gateway on loopback with Mattermost channel configured for native slash commands (same callback path as issue reporter).
- Exact steps or command run after this patch:
  1. `git checkout fix/mattermost-slash-68113` and build/install the local tree.
  2. Ensure `channels.mattermost.commands.native` (and callback URL/path) are enabled in config, matching the issue setup.
  3. Start gateway: `pnpm openclaw gateway run --bind loopback --port 18789 --force`
  4. Wait until gateway log contains `mattermost: slash commands activated` for the account.
  5. Probe the registered callback route (no Mattermost POST body required for this check): `curl -sk -o NUL -w "HTTP %{http_code}\n" http://127.0.0.1:18789/api/channels/mattermost/command`
  6. (Optional) Execute `/oc_status` in Mattermost against the configured callback URL to confirm end-user slash delivery when a server is available.
- Evidence after fix (terminal capture — redacted hostnames):
  ```text
  [gateway] mattermost: slash commands activated for account default (33 commands)
  [gateway] ready (...)

  PS> curl -sk -o NUL -w "HTTP %{http_code}\n" http://127.0.0.1:18789/api/channels/mattermost/command
  HTTP 405
  ```
  Before this patch on the same setup, the same GET returned `HTTP 503` with JSON `"Slash commands are not yet initialized..."` (see #68113 logs).
- Observed result after fix: After activation, the callback route is wired to initialized slash state (GET returns **405 Method Not Allowed**, not **503** uninitialized). This matches the issue's expected "handler is up" signal; Mattermost POST handling uses the same shared `accountStates` map.
- What was not tested: Full Mattermost-hosted slash roundtrip on a shared production gateway behind nginx in this verification pass (no dedicated MM server in the capture above). Issue reporter environment remains the bar for full channel acceptance.
- Proof limitations or environment constraints: Evidence is from a local loopback gateway + `curl` probe plus gateway runtime logs. Maintainer with Mattermost can confirm POST slash execution on the same build.

## Tests and validation

- `pnpm test extensions/mattermost/src/mattermost/slash-state.test.ts` — 6 passed (includes globalThis singleton + module-reload regression)
- CI on PR head: all required checks green except this proof gate until body update lands

## Risk checklist

Did user-visible behavior change? **Yes** — Mattermost slash callbacks stop returning permanent 503 after activation.

Could this break multi-account slash routing? **Low** — only shares state that was always intended to be shared; ambiguous token/conflict paths unchanged.

Could global state leak across restarts? **Mitigated** — `deactivateSlashCommands()` still clears entries; symbol is process-scoped.

## What reviewers should focus on

- Dual-loader hypothesis: jiti route registration vs ESM monitor activation.
- Whether `globalThis` is the smallest fix vs forcing a single module instance (prefer smallest per #69038).
- Live Mattermost POST if available on reviewer side.
