### PR TITLE
test(whatsapp): dynamically skip symlink test in accounts.whatsapp-auth

### DIFF
--- a/extensions/whatsapp/src/accounts.whatsapp-auth.test.ts
+++ b/extensions/whatsapp/src/accounts.whatsapp-auth.test.ts
@@ -1,6 +1,20 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+const canCreateFileSymlinks = (() => {
+  try {
+    const tempLink = path.join(os.tmpdir(), `symlink-file-test-${Math.random().toString(36).substring(2)}`);
+    const tempFile = path.join(os.tmpdir(), `symlink-file-target-${Math.random().toString(36).substring(2)}`);
+    fs.writeFileSync(tempFile, "temp");
+    fs.symlinkSync(tempFile, tempLink, "file");
+    fs.unlinkSync(tempLink);
+    fs.unlinkSync(tempFile);
+    return true;
+  } catch {
+    return false;
+  }
+})();
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hasAnyWhatsAppAuth, listWhatsAppAuthDirs, resolveWhatsAppAuthDir } from "./accounts.js";
@@ -37,11 +51,11 @@ describe("hasAnyWhatsAppAuth", () => {
     expect(hasAnyWhatsAppAuth({})).toBe(true);
   });
 
-  it.runIf(process.platform !== "win32")("ignores symlinked legacy creds", () => {
+  it.skipIf(!canCreateFileSymlinks)("ignores symlinked legacy creds", () => {
     const targetPath = path.join(tempOauthDir ?? "", "target-creds.json");
     const credsPath = path.join(tempOauthDir ?? "", "creds.json");
     fs.writeFileSync(targetPath, JSON.stringify({ me: {} }));
-    fs.symlinkSync(targetPath, credsPath);
+    fs.symlinkSync(targetPath, credsPath, "file");
 
     expect(hasAnyWhatsAppAuth({})).toBe(false);
     expect(resolveWhatsAppAuthDir({ cfg: {}, accountId: "default" })).toEqual({


### PR DESCRIPTION
This PR updates the test suite in `extensions/whatsapp/src/accounts.whatsapp-auth.test.ts` to dynamically skip the legacy auth symlink test depending on the environment's support for file symlink creation, rather than hard-coding a check for Windows.

### Changes
- Implemented `canCreateFileSymlinks` check.
- Gated the test with `it.skipIf(!canCreateFileSymlinks)`.
- Explicitly specified `"file"` type to `fs.symlinkSync` to support Windows.

### Test Execution Proof (Redacted)
```
 ✓  extension-whatsapp  ../../extensions/whatsapp/src/accounts.whatsapp-auth.test.ts (7 tests | 1 skipped) 97ms

 Test Files  1 passed (1)
      Tests  6 passed | 1 skipped (7)
   Start at  20:59:11
   Duration  17.88s (transform 11.49s, setup 1.58s, import 14.55s, tests 97ms, environment 0ms)
```
