### PR TITLE
fix(memory-core): write meta after sync when identity is missing with existing chunks

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1846,7 +1846,7 @@ export abstract class MemoryManagerSyncOps {
     const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
     const needsExplicitIdentityReindex =
       params?.reason === "cli" && indexIdentity.status !== "valid" && !hasTargetSessionFiles;
-    const needsFullReindex =
+    let needsFullReindex =
       (params?.force && !hasTargetSessionFiles) ||
       needsInitialIndex ||
       needsExplicitIdentityReindex;
@@ -1859,7 +1859,28 @@ export abstract class MemoryManagerSyncOps {
       if (sessionsDirty) {
         this.sessionsDirty = true;
       }
-      return;
+      // If meta is missing but indexed chunks exist, force a verified full
+      // reindex instead of returning with a dirty/paused index. The reindex
+      // prunes stale chunks from deleted paths, old providers, or old scopes
+      // before writing meta (PR #90395, issue #90338).
+      // Guard: when a specific embedding provider is configured but currently
+      // unavailable, the existing chunks may be semantic (vector-backed).
+      // Forcing a reindex without the provider would silently downgrade the
+      // index to FTS-only and wipe vector embeddings. In that case keep the
+      // index dirty/paused so the provider can recover on a later sync.
+      if (!meta && hasIndexedChunks) {
+        const isSpecificProviderConfigured =
+          this.settings.provider &&
+          this.settings.provider !== "none" &&
+          this.settings.provider !== "auto";
+        if (isSpecificProviderConfigured && !this.provider) {
+          return;
+        }
+        needsFullReindex = true;
+        // Fall through to runSafeReindex / runUnsafeReindex below.
+      } else {
+        return;
+      }
     }
     if (!needsFullReindex) {
       const targetedSessionSync = await runMemoryTargetedSessionSync({

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -205,4 +205,99 @@ describe("memory manager FTS-only reindex", () => {
     );
     expect(memoryManager.status().provider).toBe("openai");
   });
+
+  it("triggers verified reindex when identity is missing but indexed chunks exist", async () => {
+    // Explicit "none" provider: FTS-only, no semantic downgrade risk.
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+    await memoryManager.sync({ force: true });
+
+    // Sanity: after initial sync, meta is present and chunks exist.
+    expect(memoryManager.status().chunks).toBeGreaterThan(0);
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+    // Delete meta via the manager's own DB to simulate the dead-loop condition.
+    const internals = memoryManager as unknown as {
+      db: DatabaseSync;
+      readMeta(): MemoryIndexMeta | null;
+    };
+    internals.db.exec("DELETE FROM meta WHERE key = 'memory_index_meta_v1'");
+
+    // Verify meta was actually deleted.
+    expect(internals.readMeta()).toBeNull();
+
+    // Without force, the recovery path triggers a verified full reindex
+    // (runSafeReindex) instead of writing unverified meta. The reindex
+    // prunes stale rows and writes meta only after verification.
+    await memoryManager.sync();
+
+    // After the fix: meta is recreated via verified reindex, dead loop broken.
+    const metaAfter = internals.readMeta();
+    expect(metaAfter).not.toBeNull();
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+  });
+
+  it("prunes stale chunks during missing-meta recovery when memory files are deleted", async () => {
+    // Explicit "none" provider: FTS-only, no semantic downgrade risk.
+    const memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+    await memoryManager.sync({ force: true });
+
+    // Sanity: chunks exist from current MEMORY.md.
+    const initialChunks = memoryManager.status().chunks;
+    expect(initialChunks).toBeGreaterThan(0);
+
+    // Delete the memory file from disk — its chunks are now stale.
+    await fs.rm(path.join(workspaceDir, "MEMORY.md"));
+
+    // Delete meta to trigger the recovery path.
+    const internals = memoryManager as unknown as {
+      db: DatabaseSync;
+      readMeta(): MemoryIndexMeta | null;
+    };
+    internals.db.exec("DELETE FROM meta WHERE key = 'memory_index_meta_v1'");
+    expect(internals.readMeta()).toBeNull();
+
+    // Sync without force — recovery path triggers verified reindex.
+    // The reindex scans current sources, finds no memory files,
+    // and prunes stale chunks from the deleted path.
+    await memoryManager.sync();
+
+    // Stale chunks from deleted paths are pruned.
+    const chunksAfter = (
+      internals.db.prepare("SELECT count(*) as c FROM chunks").get() as { c: number }
+    ).c;
+    expect(chunksAfter).toBe(0);
+
+    // Meta is recreated, identity valid — dead loop broken.
+    expect(internals.readMeta()).not.toBeNull();
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+  });
+
+  it("preserves index when specific provider is configured but unavailable during missing-meta recovery", async () => {
+    // Configure a specific embedding provider that is unavailable.
+    const memoryManager = await createManager({ provider: "openai" });
+    await memoryManager.sync({ force: true });
+
+    expect(memoryManager.status().chunks).toBeGreaterThan(0);
+
+    // Delete meta to simulate the dead-loop condition.
+    const internals = memoryManager as unknown as {
+      db: DatabaseSync;
+      readMeta(): MemoryIndexMeta | null;
+    };
+    internals.db.exec("DELETE FROM meta WHERE key = 'memory_index_meta_v1'");
+    expect(internals.readMeta()).toBeNull();
+
+    // Sync without force — recovery path detects that a specific provider
+    // ("openai") is configured but unavailable. Existing chunks may be
+    // semantic, so the index stays dirty/paused instead of forcing an
+    // FTS-only reindex that would wipe vector embeddings.
+    await memoryManager.sync();
+
+    // Meta stays missing, index stays dirty — provider outage preserved.
+    expect(internals.readMeta()).toBeNull();
+    expect(memoryManager.status().dirty).toBe(true);
+    expect(memoryManager.status().custom?.indexIdentity).toMatchObject({
+      status: "missing",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Gateway memory auto-sync creates a dead loop: it indexes files (creating chunks) but never writes the `memory_index_meta_v1` meta table entry when `indexIdentity.status !== "valid"` and `!needsFullReindex`. All `memory_search` calls return "index metadata is missing" with 0 results.
- Why it matters: Users with fresh or corrupted index state cannot use memory search even though chunks exist in the database.
- What changed: When the early-return path in `runSync()` detects identity is missing but existing chunks prevent a full reindex, the fix forces a verified full reindex via `runSafeReindex`/`runUnsafeReindex`. The reindex path prunes stale chunks from deleted paths, old providers, or old scopes before writing meta.

## Design note on stale-row safety

The recovery path triggers a full reindex rather than stamping fresh metadata onto unverified chunks. The reindex path (`runSafeReindex`/`runUnsafeReindex`) scans current sources, indexes only matching files, prunes stale rows from deleted paths, and writes meta only after verification.

**Guard against semantic-index downgrade:** When a specific embedding provider (e.g. `openai`) is configured but currently unavailable, the recovery path leaves the index dirty/paused instead of forcing a reindex. Without this guard, a provider outage would cause the recovery path to silently rebuild an existing semantic/vector index as FTS-only, permanently losing vector embeddings. For `auto`/`none`/unset providers or when the provider is available, the verified full reindex proceeds safely.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issues

- Closes #90338
- Related: #90361

## Real behavior proof

**Behavior addressed:** Memory index meta never written when auto-sync finds identity missing with existing chunks (#90338). Every sync cycle indexes files, creates chunks, returns early without writing meta — dead loop. The fix triggers a verified full reindex in this recovery path.

**Real environment tested:** Node v22.22.0, Linux x86_64, OpenClaw 2026.6.1, memory-core builtin backend with FTS-only provider.

**Exact steps or command run after this patch:**

Step 1 — Manager-level tests (10 FTS-only tests, 3 recovery scenarios):

```
OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test -- extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
```

Step 2 — Full memory test suite (5 files, 49 tests):

```
OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test -- extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager.session-reindex.test.ts
```

Step 3 — Live memory-search proof using `MemoryIndexManager` with real SQLite (console output):

```
$ node --import tsx/esm -e "
const {MemoryIndexManager}=await import('./extensions/memory-core/src/memory/manager.js');
// ... create manager, force sync, delete meta, verify dead loop, sync recovery, verify search
"
```

**Evidence after fix (terminal capture — full recovery path):**

```
=== OpenClaw Memory Recovery Proof (PR #90395) ===

--- Phase 1: Initial sync ---
  openclaw memory index --force
  Indexed: 1 files, 1 chunks
  Identity: {"status":"valid"}
  search "architecture": 1 result(s)

--- Phase 2: Create dead-loop condition ---
  Meta: MISSING, Chunks: 1
  Dead-loop condition: YES (bug!)

--- Phase 3: Search before recovery ---
  openclaw memory search "architecture"
  Identity: {"status":"missing","reason":"index metadata is missing"}
  Results: 0 (dead loop returns 0)

--- Phase 4: Recovery sync ---
  openclaw memory index
  Identity after: {"status":"valid"}
  Dirty: false, Files: 1, Chunks: 1

--- Phase 5: Search after recovery ---
  openclaw memory search "architecture"
  Results: 1
    - MEMORY.md: ...
  Dead loop broken: YES

=== Proof complete ===
```

**Observed result after fix:**
1. **Dead loop reproduced** — meta deleted, chunks remain, search returns 0 results
2. **Recovery triggered** — calling `sync()` without force enters the recovery path, triggers verified full reindex
3. **Identity restored** — meta is recreated with current provider/scope/chunking settings, identity becomes "valid"
4. **Search works** — `memory_search` returns results again, dead loop permanently broken
5. **Stale rows pruned** — chunks from deleted files are cleaned up during reindex (covered by manager tests)
6. **Semantic guard** — when a specific provider is configured but unavailable, index stays dirty/paused (covered by manager tests)

**What was not tested:** Live OpenClaw gateway with real embedding provider (e.g. OpenAI embeddings). The related safe-reindex race (#90453) and stale-handle fix (#90727) are tracked separately.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
