### PR TITLE
fix(openai): accept missing content-type on ChatGPT Responses SSE stream

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -589,6 +589,36 @@ describe("openai transport stream", () => {
       version: "2026.3.22",
       "User-Agent": "openclaw/2026.3.22",
     });
+    expect(headers.Accept).toBeUndefined();
+    expect(headers.accept).toBeUndefined();
+  });
+
+  it("adds SSE Accept only to native ChatGPT Responses stream requests", () => {
+    const codexModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 400000,
+      maxTokens: 128000,
+    } satisfies Model<"openai-chatgpt-responses">;
+    const openAIModel = {
+      ...codexModel,
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies Model<"openai-responses">;
+
+    expect(testing.buildOpenAISdkRequestOptions(codexModel, undefined, { stream: true })).toEqual({
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(testing.buildOpenAISdkRequestOptions(codexModel)).toBeUndefined();
+    expect(
+      testing.buildOpenAISdkRequestOptions(openAIModel, undefined, { stream: true }),
+    ).toBeUndefined();
   });
 
   it("moves Azure OpenAI completions api-version headers into default query params", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1846,12 +1846,18 @@ function buildOpenAISdkClientOptions(model: Model): { timeout?: number } {
 function buildOpenAISdkRequestOptions(
   model: Model,
   signal?: AbortSignal,
-): { signal?: AbortSignal; timeout?: number } | undefined {
+  options?: { stream?: boolean },
+): { signal?: AbortSignal; timeout?: number; headers?: Record<string, string> } | undefined {
   const timeout = resolveOpenAISdkTimeoutMs(model);
-  if (timeout === undefined && !signal) {
+  const headers =
+    options?.stream === true && model.api === "openai-chatgpt-responses"
+      ? { Accept: "text/event-stream" }
+      : undefined;
+  if (timeout === undefined && !signal && !headers) {
     return undefined;
   }
   return {
+    ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
   };
@@ -1938,7 +1944,9 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           assertCodeModeResponsesToolSurface(params);
         }
         const requestStartedAt = Date.now();
-        const requestOptions = buildOpenAISdkRequestOptions(model, options?.signal);
+        const requestOptions = buildOpenAISdkRequestOptions(model, options?.signal, {
+          stream: true,
+        });
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -203,6 +203,112 @@ describe("buildGuardedModelFetch", () => {
     expect(release).toHaveBeenCalled();
   });
 
+  it("accepts missing content-type on successful ChatGPT Responses streams", async () => {
+    const release = vi.fn(async () => undefined);
+    const encoder = new TextEncoder();
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } as unknown as Model<"openai-chatgpt-responses">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('event: response.created\ndata: {"ok": true}\n\n'));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      ),
+      finalUrl: "https://chatgpt.com/backend-api/codex/responses",
+      release,
+    });
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      },
+    );
+
+    await expect(response.text()).resolves.toContain("response.created");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects HTML content on successful ChatGPT Responses streams", async () => {
+    const release = vi.fn(async () => undefined);
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    } as unknown as Model<"openai-chatgpt-responses">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("<html>not the API</html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+      finalUrl: "https://chatgpt.com/backend-api/codex/responses",
+      release,
+    });
+
+    await expect(
+      buildGuardedModelFetch(model)("https://chatgpt.com/backend-api/codex/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderHttpError",
+      status: 200,
+      code: "invalid_provider_content_type",
+      errorType: "invalid_response",
+    });
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("rejects missing content-type on successful non-ChatGPT Responses streams", async () => {
+    const release = vi.fn(async () => undefined);
+    const encoder = new TextEncoder();
+    const model = {
+      id: "gpt-5.5",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } as unknown as Model<"openai-responses">;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('event: response.created\ndata: {"ok": true}\n\n'));
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      ),
+      finalUrl: "https://api.openai.com/v1/responses",
+      release,
+    });
+
+    await expect(
+      buildGuardedModelFetch(model)("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-5.5", stream: true }),
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderHttpError",
+      status: 200,
+      code: "invalid_provider_content_type",
+      errorType: "invalid_response",
+    });
+    expect(release).toHaveBeenCalled();
+  });
+
   it("ensures configured local services before the model request", async () => {
     const release = vi.fn();
     ensureModelProviderLocalServiceMock.mockResolvedValue({ release });

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -240,7 +240,19 @@ async function assertOpenAISdkStreamContentType(params: {
   localServiceLease?: ProviderLocalServiceLease;
 }): Promise<void> {
   const contentType = params.response.headers.get("content-type") ?? "";
-  if (!params.response.ok || !params.response.body || isOpenAISdkStreamContentType(contentType)) {
+  // The ChatGPT/Codex Responses backend (api=openai-chatgpt-responses) streams valid SSE
+  // but omits the content-type header entirely (Cloudflare + openai-proxy-wasm). Treat a
+  // missing content-type on a successful Responses stream as SSE instead of rejecting it.
+  // Scoped to empty (not wrong) content-type on this one api, so HTML/error envelopes -
+  // which carry their own content-type - are still rejected. (openclaw/openclaw#90382)
+  const allowMissingContentTypeForResponses =
+    contentType === "" && params.model.api === "openai-chatgpt-responses";
+  if (
+    !params.response.ok ||
+    !params.response.body ||
+    isOpenAISdkStreamContentType(contentType) ||
+    allowMissingContentTypeForResponses
+  ) {
     return;
   }
   const body = await readResponseTextLimited(params.response).catch(() => "");

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -256,5 +256,9 @@ export function promptMigrationSkillSelectionValues(
   return prompt.prompt();
 }
 
-/** Back-compat alias for plugin selection prompts that share the same picker. */
+/**
+ * Back-compat alias for plugin selection prompts that share the same picker.
+ *
+ * @deprecated Use promptMigrationSkillSelectionValues.
+ */
 export const promptMigrationSelectionValues = promptMigrationSkillSelectionValues;


### PR DESCRIPTION
## Summary

Fixes #90382.

ChatGPT-OAuth `openai-chatgpt-responses` streams can return HTTP 200 with a valid SSE body but no `content-type` header from `https://chatgpt.com/backend-api/codex/responses`. The existing stream guard rejected that successful stream as `invalid_provider_content_type`, so `openai/gpt-5.5` failed before the SDK could consume the SSE events.

This PR now does two things:

- keeps the defensive `Accept: text/event-stream` request option for native ChatGPT Responses SDK streaming calls
- makes the real fix in `assertOpenAISdkStreamContentType`: allow an empty/missing `content-type` only when the model API is `openai-chatgpt-responses`, the response is OK, and a body exists

Wrong content types such as `text/html` still fail, and missing content type on other OpenAI-compatible stream APIs still fails.

## Root cause

Captured live behavior showed the server returning a valid SSE body such as `event: response.created` / `response.output_text.done`, but with no `content-type` header. The response path then hit the guard in `src/agents/provider-transport-fetch.ts` and threw solely because the header was missing.

The earlier Accept-header-only patch was not enough: with `Accept: text/event-stream` compiled in, the live endpoint still returned HTTP 200 with no content type. The Accept override remains useful hygiene, but the guard tolerance is the fix that handles the captured server behavior.

Relevant source points:

- `src/agents/provider-transport-fetch.ts:236`: `assertOpenAISdkStreamContentType`
- `src/agents/provider-transport-fetch.ts:248`: missing content type is allowed only for `api === "openai-chatgpt-responses"`
- `src/agents/openai-transport-stream.ts:1846`: SDK request options helper
- `src/agents/openai-transport-stream.ts:1947`: streaming Responses dispatch passes `{ stream: true }`

## Tests

Added provider transport regression coverage in `src/agents/provider-transport-fetch.test.ts`:

- missing `content-type` + `api=openai-chatgpt-responses` + 2xx + body is accepted
- `text/html` on the same API is still rejected
- missing `content-type` on `api=openai-responses` is still rejected

Existing OpenAI transport coverage still asserts the defensive `Accept: text/event-stream` option is scoped to native ChatGPT Responses stream requests and not added to normal/default OpenAI request options.

## Real behavior proof

- **Behavior or issue addressed:** ChatGPT-OAuth `openai/gpt-5.5` using `api=openai-chatgpt-responses` failed when the live `chatgpt.com/backend-api/codex/responses` stream returned HTTP 200 with valid SSE bytes but an empty/missing `content-type` header. The after-fix behavior should accept that stream instead of throwing `ProviderHttpError code=invalid_provider_content_type`.

- **Real environment tested:** Reporter's local OpenClaw checkout with OAuth auth live, using the compiled guard-tolerance patch in `src/agents/provider-transport-fetch.ts` against `openai/gpt-5.5` through ChatGPT OAuth.

- **Exact steps or command run after this patch:** Rebuilt/ran the local OpenClaw checkout containing the guard-tolerance patch, then ran the provider probe for `openai/gpt-5.5` and a default-chain model resolution run using the same OAuth setup that reproduced #90382.

- **Evidence after fix:** Copied live terminal output from the reporter's local OpenClaw setup:

```text
openai/gpt-5.5 ... ok
default chain resolved winnerProvider=openai winnerModel=gpt-5.5
```

- **Observed result after fix:** The same OAuth setup that failed with HTTP 200 + missing `content-type` now accepts the ChatGPT Responses SSE stream. The direct `openai/gpt-5.5` probe returns `ok`, and the default model chain resolves to `winnerProvider=openai` / `winnerModel=gpt-5.5` instead of falling through to fallback providers.

- **What was not tested:** I did not personally run a live ChatGPT-OAuth endpoint call from this CI/local author environment because that requires the reporter's OAuth account. The reporter-provided after-fix live output above is the real behavior proof; local author validation covers unit tests, typecheck, formatting, lint, and build smoke.

## Local validation

Commands run locally:

```text
node scripts/test-projects.mjs src/agents/provider-transport-fetch.test.ts -- -t "ChatGPT Responses streams|non-ChatGPT Responses streams"
node scripts/test-projects.mjs src/agents/provider-transport-fetch.test.ts
node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts -- -t "adds SSE Accept only to native ChatGPT Responses stream requests"
node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts
pnpm exec oxfmt --check src/agents/provider-transport-fetch.ts src/agents/provider-transport-fetch.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
pnpm exec oxlint src/agents/provider-transport-fetch.ts src/agents/provider-transport-fetch.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
pnpm build:strict-smoke
node scripts/check-deprecated-jsdoc.mjs
```

Results:

- focused provider transport tests: 3 passed
- full provider transport file: 71 passed
- focused OpenAI transport Accept regression: 1 passed
- full OpenAI transport file: 241 passed
- file-scoped format and lint checks passed
- core typecheck and core test typecheck exited 0
- `pnpm build:strict-smoke` exited 0
- `node scripts/check-deprecated-jsdoc.mjs` exited 0 locally after the CI topology failure report

One broader local lint command did not complete cleanly:

```text
pnpm lint:core
```

It failed in an unrelated `qa-channel` boundary DTS path (`extensions/qa-channel/src/bus-client.ts` missing `QaBus*` exports from `./protocol.js` / `openclaw/plugin-sdk/qa-channel-protocol`). That failure is outside this PR's changed files.

## Risk

Highest risk: accepting a real error envelope with a missing/misleading content type.

Mitigation: the tolerance is scoped to empty content type only, on successful responses with a body, and only for `api=openai-chatgpt-responses`. HTML and other wrong content types still go through the existing rejection path, and missing content type for other OpenAI-compatible APIs remains rejected.
