### PR TITLE
fix(memory-lancedb): align apache arrow peer dependency

### DIFF
--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "2026.6.2",
       "dependencies": {
         "@lancedb/lancedb": "0.30.0",
-        "apache-arrow": "21.1.0",
+        "apache-arrow": "18.1.0",
         "openai": "6.39.1",
         "typebox": "1.1.39"
       }
@@ -181,12 +181,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -205,18 +205,18 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
-      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
+      "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
         "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^24.0.3",
-        "command-line-args": "^6.0.1",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "flatbuffers": "^25.1.24",
+        "flatbuffers": "^24.3.25",
         "json-bignum": "^0.0.3",
         "tslib": "^2.6.2"
       },
@@ -225,12 +225,12 @@
       }
     },
     "node_modules/array-back": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
-      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.17"
+        "node": ">=6"
       }
     },
     "node_modules/chalk": {
@@ -283,26 +283,18 @@
       "license": "MIT"
     },
     "node_modules/command-line-args": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
-      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "license": "MIT",
       "dependencies": {
-        "array-back": "^6.2.3",
-        "find-replace": "^5.0.2",
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^7.3.0"
+        "typical": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.20"
-      },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
+        "node": ">=4.0.0"
       }
     },
     "node_modules/command-line-usage": {
@@ -320,27 +312,40 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/find-replace": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
       },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/flatbuffers": {
-      "version": "25.9.23",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
-      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
       "license": "Apache-2.0"
     },
     "node_modules/has-flag": {
@@ -418,6 +423,15 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -431,18 +445,18 @@
       "license": "MIT"
     },
     "node_modules/typical": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
-      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.17"
+        "node": ">=8"
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/wordwrapjs": {

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "dependencies": {
     "@lancedb/lancedb": "0.30.0",
-    "apache-arrow": "21.1.0",
+    "apache-arrow": "18.1.0",
     "openai": "6.39.1",
     "typebox": "1.1.39"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1027,10 +1027,10 @@ importers:
     dependencies:
       '@lancedb/lancedb':
         specifier: 0.30.0
-        version: 0.30.0(apache-arrow@21.1.0)
+        version: 0.30.0(apache-arrow@18.1.0)
       apache-arrow:
-        specifier: 21.1.0
-        version: 21.1.0
+        specifier: 18.1.0
+        version: 18.1.0
       openai:
         specifier: 6.39.1
         version: 6.39.1(ws@8.21.0)(zod@4.4.3)
@@ -4361,12 +4361,16 @@ packages:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
 
-  apache-arrow@21.1.0:
-    resolution: {integrity: sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==}
+  apache-arrow@18.1.0:
+    resolution: {integrity: sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==}
     hasBin: true
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
 
   array-back@6.2.3:
     resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
@@ -4668,14 +4672,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
-  command-line-args@6.0.2:
-    resolution: {integrity: sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==}
-    engines: {node: '>=12.20'}
-    peerDependencies:
-      '@75lb/nature': latest
-    peerDependenciesMeta:
-      '@75lb/nature':
-        optional: true
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
 
   command-line-usage@7.0.4:
     resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
@@ -5068,21 +5067,16 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-replace@5.0.2:
-    resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@75lb/nature': latest
-    peerDependenciesMeta:
-      '@75lb/nature':
-        optional: true
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  flatbuffers@25.9.23:
-    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -6919,6 +6913,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
   typical@7.3.0:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
@@ -8341,9 +8339,9 @@ snapshots:
   '@lancedb/lancedb-win32-x64-msvc@0.30.0':
     optional: true
 
-  '@lancedb/lancedb@0.30.0(apache-arrow@21.1.0)':
+  '@lancedb/lancedb@0.30.0(apache-arrow@18.1.0)':
     dependencies:
-      apache-arrow: 21.1.0
+      apache-arrow: 18.1.0
       reflect-metadata: 0.2.2
     optionalDependencies:
       '@lancedb/lancedb-darwin-arm64': 0.30.0
@@ -9857,21 +9855,21 @@ snapshots:
 
   ansis@4.3.0: {}
 
-  apache-arrow@21.1.0:
+  apache-arrow@18.1.0:
     dependencies:
       '@swc/helpers': 0.5.23
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 24.12.4
-      command-line-args: 6.0.2
+      '@types/node': 20.19.41
+      command-line-args: 5.2.1
       command-line-usage: 7.0.4
-      flatbuffers: 25.9.23
+      flatbuffers: 24.12.23
       json-bignum: 0.0.3
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@75lb/nature'
 
   argparse@2.0.1: {}
+
+  array-back@3.1.0: {}
 
   array-back@6.2.3: {}
 
@@ -10155,12 +10153,12 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  command-line-args@6.0.2:
+  command-line-args@5.2.1:
     dependencies:
-      array-back: 6.2.3
-      find-replace: 5.0.2
+      array-back: 3.1.0
+      find-replace: 3.0.0
       lodash.camelcase: 4.3.0
-      typical: 7.3.0
+      typical: 4.0.0
 
   command-line-usage@7.0.4:
     dependencies:
@@ -10586,14 +10584,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-replace@5.0.2: {}
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
 
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  flatbuffers@25.9.23: {}
+  flatbuffers@24.12.23: {}
 
   follow-redirects@1.16.0: {}
 
@@ -12837,6 +12837,8 @@ snapshots:
   typebox@1.1.39: {}
 
   typescript@6.0.3: {}
+
+  typical@4.0.0: {}
 
   typical@7.3.0: {}
 


### PR DESCRIPTION
## Summary

- Pin `extensions/memory-lancedb` from `apache-arrow@21.1.0` to `18.1.0`, the highest version accepted by `@lancedb/lancedb@0.30.0`.
- Regenerate the plugin `npm-shrinkwrap.json` with the repo shrinkwrap generator (`scripts/generate-npm-shrinkwrap.mjs`) so published npm installs use consistent Arrow 18 transitive metadata.
- Update the root `pnpm-lock.yaml` to match the package manifest.

Fixes #90295.

## Real Behavior Proof

**Behavior or issue addressed:** `@openclaw/memory-lancedb` cannot install under npm 11. Its manifest pinned `apache-arrow@21.1.0`, but `@lancedb/lancedb@0.30.0` only accepts `apache-arrow >=15.0.0 <=18.1.0`, so npm 11 peer resolution aborts with `ERESOLVE`. This PR pins `apache-arrow` to `18.1.0` (the top of the accepted range) and regenerates the plugin shrinkwrap and root lockfile to match.

**Real environment tested:** Reproduced locally on macOS (arm64) against the live npm registry with npm 11.12.1 / Node v26 / pnpm 11.2.2 — the npm 11 / pnpm 11.2.2 line this repo targets. The two installs below use the real published `@lancedb/lancedb@0.30.0` package with `apache-arrow` at each version, isolating the exact peer constraint the manifest change resolves.

**Exact steps or command run after this patch:**

```text
npm view @lancedb/lancedb@0.30.0 peerDependencies --json
# before (current main manifest): apache-arrow 21.1.0
npm install --package-lock-only --ignore-scripts   # in a project requiring lancedb 0.30.0 + apache-arrow@21.1.0
# after (this PR's manifest): apache-arrow 18.1.0
npm install --package-lock-only --ignore-scripts   # in a project requiring lancedb 0.30.0 + apache-arrow@18.1.0
```

**Evidence after fix:** Copied terminal output from the runs above.

Live peer contract from the registry (the version ceiling the fix targets):

```text
$ npm view @lancedb/lancedb@0.30.0 peerDependencies --json
{
  "apache-arrow": ">=15.0.0 <=18.1.0"
}
```

Before — `apache-arrow@21.1.0` (what `main` declares) is rejected by npm 11:

```text
npm error code ERESOLVE
npm error While resolving: repro-bad@1.0.0
npm error Found: apache-arrow@21.1.0
npm error Could not resolve dependency:
npm error peer apache-arrow@">=15.0.0 <=18.1.0" from @lancedb/lancedb@0.30.0
# npm exited 1
```

After — `apache-arrow@18.1.0` (what this PR declares) resolves cleanly:

```text
up to date, audited 31 packages in 2s
found 0 vulnerabilities
# npm exited 0
```

**Observed result after fix:** With `apache-arrow@21.1.0` npm 11 aborts (`ERESOLVE`, exit 1); with `apache-arrow@18.1.0` it resolves the tree and exits 0. This matches the manifest change in this PR (`extensions/memory-lancedb/package.json`: `apache-arrow` `21.1.0` → `18.1.0`), so the regenerated graph installs under npm 11 where `main` does not.

**What was not tested:** Runtime LanceDB query behavior on a physical device, and the full 152-project workspace frozen install — I isolated the peer constraint using the real published packages rather than installing the whole monorepo, and this change only realigns the declared dependency graph without modifying runtime code paths. The repo CI exercises the memory-lancedb suite and the package-manifest / extension-runtime-dependencies contract checks on this PR.

## Limitations

This is a minimal dependency alignment for the current `@lancedb/lancedb@0.30.0` peer contract. A future LanceDB release that supports Arrow 21 can relax this pin separately.

## Dependency-graph guard

This PR intentionally changes the dependency graph (`extensions/memory-lancedb/package.json` `dependencies`, that package's `npm-shrinkwrap.json`, and the root `pnpm-lock.yaml`), so it is correctly held by the dependency-graph guard. The three files must change together: dropping the lockfile/shrinkwrap regeneration leaves `apache-arrow` mismatched against the manifest and a frozen install fails (`ERR_PNPM_OUTDATED_LOCKFILE`), so the lockfile changes are required, not incidental.

Per the guard, this needs an admin or `@openclaw/openclaw-secops` reviewer to inspect the generated graph delta and authorize the current head SHA with `/allow-dependencies-change`.
