### PR TITLE
test(canvas): dynamically skip symlink test in file-resolver

### DIFF
--- a/extensions/canvas/src/host/file-resolver.test.ts
+++ b/extensions/canvas/src/host/file-resolver.test.ts
@@ -1,8 +1,24 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { describe, expect, it } from "vitest";
 import { normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
+
+const canCreateFileSymlinks = (() => {
+  try {
+    const tempLink = path.join(os.tmpdir(), `symlink-file-test-${Math.random().toString(36).substring(2)}`);
+    const tempFile = path.join(os.tmpdir(), `symlink-file-target-${Math.random().toString(36).substring(2)}`);
+    fsSync.writeFileSync(tempFile, "temp");
+    fsSync.symlinkSync(tempFile, tempLink, "file");
+    fsSync.unlinkSync(tempLink);
+    fsSync.unlinkSync(tempFile);
+    return true;
+  } catch {
+    return false;
+  }
+})();
 
 type ResolvedFile = NonNullable<Awaited<ReturnType<typeof resolveFileWithinRoot>>>;
 
@@ -59,13 +75,13 @@ describe("resolveFileWithinRoot", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlink entries", async () => {
+  it.skipIf(!canCreateFileSymlinks)("rejects symlink entries", async () => {
     await withCanvasTemp("openclaw-canvas-resolver-", async (root) => {
       await withCanvasTemp("openclaw-canvas-resolver-outside-", async (outside) => {
         const target = path.join(outside, "outside.html");
         const link = path.join(root, "link.html");
         await fs.writeFile(target, "outside");
-        await fs.symlink(target, link);
+        await fs.symlink(target, link, "file");
 
         await expect(resolveFileWithinRoot(root, "/link.html")).resolves.toBeNull();
       });


### PR DESCRIPTION
This PR updates the test suite in `extensions/canvas/src/host/file-resolver.test.ts` to dynamically skip the symlink entries test depending on the environment's support for file symlink creation, rather than hard-coding a check for Windows.

### Changes
- Implemented `canCreateFileSymlinks` capability check.
- Gated the symlink test with `it.skipIf(!canCreateFileSymlinks)`.
- Configured the file symlink to explicitly use `"file"` type to support Windows.

### Test Execution Proof (Redacted)
```
 ✓  extensions  ../../extensions/canvas/src/host/file-resolver.test.ts (5 tests | 1 skipped) 189ms

 Test Files  1 passed (1)
      Tests  4 passed | 1 skipped (5)
   Start at  21:44:33
   Duration  4.38s (transform 2.92s, setup 1.03s, import 2.58s, tests 189ms, environment 0ms)
```
