### PR TITLE
fix(sessions): cache warm transcript reads to avoid per-turn re-parse

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1133,6 +1133,37 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.canAdvanceSessionEntryCache(snapshot)).toBe(false);
   });
 
+  it("publishes an exact owned snapshot only while the write lock is active", async () => {
+    const sessionFile = await createTempSessionFile();
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({
+        release: vi.fn(async () => {}),
+      })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const readSnapshot = async () => {
+      const stat = await fs.stat(sessionFile, { bigint: true });
+      return {
+        dev: stat.dev,
+        ino: stat.ino,
+        size: stat.size,
+        mtimeNs: stat.mtimeNs,
+        ctimeNs: stat.ctimeNs,
+      };
+    };
+    const initialSnapshot = await readSnapshot();
+
+    expect(controller.publishOwnedSessionFileSnapshot(initialSnapshot)).toBe(false);
+    await controller.withSessionWriteLock(async () => {
+      expect(controller.publishOwnedSessionFileSnapshot(initialSnapshot)).toBe(true);
+      await fs.appendFile(sessionFile, '{"type":"message","id":"owned"}\n', "utf8");
+      expect(controller.publishOwnedSessionFileSnapshot(initialSnapshot)).toBe(false);
+      expect(controller.publishOwnedSessionFileSnapshot(await readSnapshot())).toBe(true);
+    });
+    expect(controller.publishOwnedSessionFileSnapshot(await readSnapshot())).toBe(false);
+    await controller.dispose();
+  });
+
   it("publishes only an unchanged repair-validated snapshot while retaining the lock", async () => {
     const sessionFile = await createTempSessionFile();
     const acquireSessionWriteLockLocal = vi.fn(async () => ({

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1104,6 +1104,35 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(3);
   });
 
+  it("authorizes entry-cache advancement only under the exact trusted file lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    const stat = await fs.stat(sessionFile, { bigint: true });
+    const snapshot = {
+      dev: stat.dev,
+      ino: stat.ino,
+      size: stat.size,
+      mtimeNs: stat.mtimeNs,
+      ctimeNs: stat.ctimeNs,
+    };
+
+    expect(controller.canAdvanceSessionEntryCache(snapshot)).toBe(false);
+    await expect(
+      controller.withSessionWriteLock(() => {
+        expect(controller.canAdvanceSessionEntryCache(snapshot)).toBe(true);
+        return "locked";
+      }),
+    ).resolves.toBe("locked");
+    expect(controller.canAdvanceSessionEntryCache(snapshot)).toBe(false);
+  });
+
   it("refreshes the prompt fence after an owned session manager append", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -66,6 +66,65 @@ function cloneBigIntStatWith(
 }
 
 describe("embedded attempt session lock lifecycle", () => {
+  it("recognizes an unchanged session file trusted by the previous prompt release", async () => {
+    const sessionFile = await createTempSessionFile();
+    const options = { ...lockOptions, sessionFile };
+    const first = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+
+    expect(await first.readTrustedCurrentSessionFileSnapshot()).toBeUndefined();
+    await first.releaseForPrompt();
+    await first.dispose();
+
+    const second = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeDefined();
+    await second.dispose();
+  });
+
+  it("does not trust a session file changed after the previous prompt release", async () => {
+    const sessionFile = await createTempSessionFile();
+    const options = { ...lockOptions, sessionFile };
+    const first = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    await first.releaseForPrompt();
+    await first.dispose();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    const second = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeUndefined();
+    await second.dispose();
+  });
+
+  it("publishes a known owned append for the next attempt", async () => {
+    const sessionFile = await createTempSessionFile();
+    const options = { ...lockOptions, sessionFile };
+    const first = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    await fs.appendFile(sessionFile, '{"type":"message","id":"owned"}\n', "utf8");
+    first.refreshAfterOwnedSessionWrite();
+    await first.releaseForPrompt();
+    await first.dispose();
+
+    const second = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    expect(await second.readTrustedCurrentSessionFileSnapshot()).toBeDefined();
+    await second.dispose();
+  });
+
   it("serializes embedded attempts that share a session file owner", async () => {
     const sessionFile = await createTempSessionFile();
     const firstOwner = await acquireEmbeddedAttemptSessionFileOwner({ sessionFile });

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1133,6 +1133,30 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.canAdvanceSessionEntryCache(snapshot)).toBe(false);
   });
 
+  it("publishes only an unchanged repair-validated snapshot while retaining the lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    const acquireSessionWriteLockLocal = vi.fn(async () => ({
+      release: vi.fn(async () => {}),
+    }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const stat = await fs.stat(sessionFile, { bigint: true });
+    const snapshot = {
+      dev: stat.dev,
+      ino: stat.ino,
+      size: stat.size,
+      mtimeNs: stat.mtimeNs,
+      ctimeNs: stat.ctimeNs,
+    };
+
+    expect(controller.publishValidatedSessionFileSnapshot(snapshot)).toBe(true);
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+    expect(controller.publishValidatedSessionFileSnapshot(snapshot)).toBe(false);
+    await controller.dispose();
+  });
+
   it("refreshes the prompt fence after an owned session manager append", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -661,6 +661,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 
 export type EmbeddedAttemptSessionLockController = {
   canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
+  publishOwnedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   publishValidatedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined>;
   releaseForPrompt(): Promise<void>;
@@ -1055,6 +1056,23 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         isTrustedSessionFileState(sessionFileFenceKey, fingerprint)
       );
     },
+    publishOwnedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
+      if (takeoverDetected || activeWriteLock.getStore()?.active !== true) {
+        return false;
+      }
+      const fingerprint: SessionFileFingerprint = { exists: true, ...snapshot };
+      const current = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      if (!sameSessionFileFingerprint(fingerprint, current)) {
+        return false;
+      }
+      const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current);
+      if (fenceActive) {
+        fenceFingerprint = current;
+        fenceSnapshot = { fingerprint: current };
+        fenceGeneration = generation;
+      }
+      return true;
+    },
     publishValidatedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
       if (takeoverDetected || !heldLock || heldLockDraining) {
         return false;
@@ -1232,6 +1250,7 @@ export function installPromptSubmissionLockRelease(params: {
     options?: SessionWriteLockRunOptions,
   ) => Promise<T>;
   canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
+  publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
 }): void {
   const agent = (params.session as SessionWithAgentPrompt).agent;
   if (typeof agent?.streamFn !== "function") {
@@ -1253,6 +1272,7 @@ export function installPromptSubmissionLockRelease(params: {
             sessionKey: params.sessionKey,
             withSessionWriteLock: params.withSessionWriteLock,
             canAdvanceSessionEntryCache: params.canAdvanceSessionEntryCache,
+            publishSessionFileSnapshot: params.publishSessionFileSnapshot,
           },
           async () => await originalStreamFn(...args),
         );

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -661,6 +661,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 
 export type EmbeddedAttemptSessionLockController = {
   canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
+  publishValidatedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined>;
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
@@ -1053,6 +1054,22 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         (fenceActive && sameSessionFileFingerprint(fenceFingerprint, fingerprint)) ||
         isTrustedSessionFileState(sessionFileFenceKey, fingerprint)
       );
+    },
+    publishValidatedSessionFileSnapshot(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
+      if (takeoverDetected || !heldLock || heldLockDraining) {
+        return false;
+      }
+      const fingerprint: SessionFileFingerprint = { exists: true, ...snapshot };
+      const current = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      if (!sameSessionFileFingerprint(fingerprint, current)) {
+        return false;
+      }
+      fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, current);
+      if (fenceActive) {
+        fenceFingerprint = current;
+        fenceSnapshot = { fingerprint: current };
+      }
+      return true;
     },
     async readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined> {
       const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -7,7 +7,10 @@ import { createReadStream, readFileSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
+import {
+  type OwnedSessionTranscriptCacheSnapshot,
+  withOwnedSessionTranscriptWrites,
+} from "../../../config/sessions/transcript-write-context.js";
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
@@ -657,6 +660,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 }
 
 export type EmbeddedAttemptSessionLockController = {
+  canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean;
   readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined>;
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
@@ -1040,6 +1044,16 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   }
 
   return {
+    canAdvanceSessionEntryCache(snapshot: OwnedSessionTranscriptCacheSnapshot): boolean {
+      if (takeoverDetected || activeWriteLock.getStore()?.active !== true) {
+        return false;
+      }
+      const fingerprint: SessionFileFingerprint = { exists: true, ...snapshot };
+      return (
+        (fenceActive && sameSessionFileFingerprint(fenceFingerprint, fingerprint)) ||
+        isTrustedSessionFileState(sessionFileFenceKey, fingerprint)
+      );
+    },
     async readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined> {
       const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
       return fingerprint.exists && isTrustedSessionFileState(sessionFileFenceKey, fingerprint)
@@ -1200,6 +1214,7 @@ export function installPromptSubmissionLockRelease(params: {
     run: () => Promise<T> | T,
     options?: SessionWriteLockRunOptions,
   ) => Promise<T>;
+  canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
 }): void {
   const agent = (params.session as SessionWithAgentPrompt).agent;
   if (typeof agent?.streamFn !== "function") {
@@ -1220,6 +1235,7 @@ export function installPromptSubmissionLockRelease(params: {
             sessionFile: params.sessionFile,
             sessionKey: params.sessionKey,
             withSessionWriteLock: params.withSessionWriteLock,
+            canAdvanceSessionEntryCache: params.canAdvanceSessionEntryCache,
           },
           async () => await originalStreamFn(...args),
         );

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -53,6 +53,8 @@ type SessionFileFingerprint =
       ctimeNs: bigint;
     };
 
+export type TrustedSessionFileSnapshot = Extract<SessionFileFingerprint, { exists: true }>;
+
 const TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS = new Set(["delivery-mirror", "gateway-injected"]);
 const MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES = 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES = 8 * 1024 * 1024;
@@ -655,6 +657,7 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 }
 
 export type EmbeddedAttemptSessionLockController = {
+  readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined>;
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
@@ -1037,6 +1040,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   }
 
   return {
+    async readTrustedCurrentSessionFileSnapshot(): Promise<TrustedSessionFileSnapshot | undefined> {
+      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      return fingerprint.exists && isTrustedSessionFileState(sessionFileFenceKey, fingerprint)
+        ? fingerprint
+        : undefined;
+    },
     async releaseForPrompt(): Promise<void> {
       await releaseHeldLockWithFence();
     },
@@ -1044,10 +1053,26 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       await releaseHeldLockWithFence();
     },
     refreshAfterOwnedSessionWrite(): void {
-      if (fenceActive && !takeoverDetected) {
-        fenceFingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
-        fenceSnapshot = { fingerprint: fenceFingerprint };
+      if (takeoverDetected) {
+        return;
       }
+      const beforeWrite = fenceFingerprint;
+      const fingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      if (!fenceActive) {
+        // User-message persistence occurs before the prompt fence activates.
+        // The retained session lock owns that write, so publish its exact state
+        // for the next attempt before release establishes the active fence.
+        fenceGeneration = recordTrustedSessionFileState(sessionFileFenceKey, fingerprint);
+        return;
+      }
+      if (
+        !sameSessionFileFingerprint(beforeWrite, fingerprint) &&
+        isTrustedSessionFileState(sessionFileFenceKey, beforeWrite ?? { exists: false })
+      ) {
+        fenceGeneration = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
+      }
+      fenceFingerprint = fingerprint;
+      fenceSnapshot = { fingerprint };
     },
     withOwnedSessionFileWrite<T>(
       run: () => T,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -465,7 +465,7 @@ vi.mock("../tool-schema-runtime.js", () => ({
 }));
 
 vi.mock("../../session-file-repair.js", () => ({
-  repairSessionFileIfNeeded: async () => {},
+  repairSessionFileIfNeeded: async () => ({ repaired: false, droppedLines: 0 }),
 }));
 
 vi.mock("../session-manager-cache.js", () => ({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4537,7 +4537,7 @@ export async function runEmbeddedAttempt(
             });
             const truncationResult = await withOwnedSessionWriteLock(() =>
               truncateOversizedToolResultsInSessionManager({
-                sessionManager,
+                sessionManager: activeSessionManager,
                 contextWindowTokens: contextTokenBudget,
                 maxCharsOverride: toolResultMaxChars,
                 sessionFile: params.sessionFile,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../config/sessions/store.js";
 import {
   bindOwnedSessionTranscriptWrites,
+  type OwnedSessionTranscriptCacheSnapshot,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import {
@@ -3305,6 +3306,8 @@ export async function runEmbeddedAttempt(
       const ownedTranscriptWriteContext = {
         sessionFile: params.sessionFile,
         sessionKey: params.sessionKey,
+        canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+          sessionLockController.canAdvanceSessionEntryCache(snapshot),
         withSessionWriteLock: <T>(
           operation: () => Promise<T> | T,
           options?: { publishOwnedWrite?: boolean },
@@ -4270,6 +4273,8 @@ export async function runEmbeddedAttempt(
               sessionFile: params.sessionFile,
               withSessionWriteLock: (run, options) =>
                 sessionLockController.withSessionWriteLock(run, options),
+              canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+                sessionLockController.canAdvanceSessionEntryCache(snapshot),
             });
           }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2071,6 +2071,22 @@ export async function runEmbeddedAttempt(
       },
     });
     releaseRetainedSessionLock = () => sessionLockController.dispose();
+    const ownedTranscriptWriteContext = {
+      sessionFile: params.sessionFile,
+      sessionKey: params.sessionKey,
+      canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+        sessionLockController.canAdvanceSessionEntryCache(snapshot),
+      publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+        sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
+      withSessionWriteLock: <T>(
+        operation: () => Promise<T> | T,
+        options?: { publishOwnedWrite?: boolean },
+      ) => sessionLockController.withSessionWriteLock(operation, options),
+    };
+    const withOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T): Promise<T> =>
+      withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
+        sessionLockController.withSessionWriteLock(operation),
+      );
     armExternalAbortSignal();
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
@@ -2149,43 +2165,45 @@ export async function runEmbeddedAttempt(
       });
       trackSessionManagerAccess(params.sessionFile);
 
-      await runAttemptContextEngineBootstrap({
-        hadSessionFile,
-        contextEngine: activeContextEngine,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        sessionManager,
-        runtimeContext: buildAfterTurnRuntimeContext({
-          attempt: params,
-          workspaceDir: effectiveWorkspace,
-          cwd: effectiveCwd,
-          agentDir,
-          tokenBudget: params.contextTokenBudget,
-          activeAgentId: sessionAgentId,
-          contextEnginePluginId: resolveActiveContextEnginePluginId(),
-        }),
-        runMaintenance: async (contextParams) =>
-          await runContextEngineMaintenance({
-            contextEngine: contextParams.contextEngine as never,
-            sessionId: contextParams.sessionId,
-            sessionKey: contextParams.sessionKey,
-            sessionFile: contextParams.sessionFile,
-            reason: contextParams.reason,
-            sessionManager: contextParams.sessionManager as never,
-            runtimeContext: contextParams.runtimeContext,
-            config: params.config,
-            agentId: sessionAgentId,
+      await withOwnedSessionWriteLock(async () => {
+        await runAttemptContextEngineBootstrap({
+          hadSessionFile,
+          contextEngine: activeContextEngine,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          sessionManager,
+          runtimeContext: buildAfterTurnRuntimeContext({
+            attempt: params,
+            workspaceDir: effectiveWorkspace,
+            cwd: effectiveCwd,
+            agentDir,
+            tokenBudget: params.contextTokenBudget,
+            activeAgentId: sessionAgentId,
+            contextEnginePluginId: resolveActiveContextEnginePluginId(),
           }),
-        warn: (message) => log.warn(message),
-      });
+          runMaintenance: async (contextParams) =>
+            await runContextEngineMaintenance({
+              contextEngine: contextParams.contextEngine as never,
+              sessionId: contextParams.sessionId,
+              sessionKey: contextParams.sessionKey,
+              sessionFile: contextParams.sessionFile,
+              reason: contextParams.reason,
+              sessionManager: contextParams.sessionManager as never,
+              runtimeContext: contextParams.runtimeContext,
+              config: params.config,
+              agentId: sessionAgentId,
+            }),
+          warn: (message) => log.warn(message),
+        });
 
-      await prepareSessionManagerForRun({
-        sessionManager,
-        sessionFile: params.sessionFile,
-        hadSessionFile,
-        sessionId: params.sessionId,
-        cwd: effectiveCwd,
+        await prepareSessionManagerForRun({
+          sessionManager,
+          sessionFile: params.sessionFile,
+          hadSessionFile,
+          sessionId: params.sessionId,
+          cwd: effectiveCwd,
+        });
       });
 
       const settingsManager = createPreparedEmbeddedAgentSettingsManager({
@@ -3312,16 +3330,6 @@ export async function runEmbeddedAttempt(
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> =>
         abortableWithSignal(runAbortController.signal, promise);
-      const ownedTranscriptWriteContext = {
-        sessionFile: params.sessionFile,
-        sessionKey: params.sessionKey,
-        canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
-          sessionLockController.canAdvanceSessionEntryCache(snapshot),
-        withSessionWriteLock: <T>(
-          operation: () => Promise<T> | T,
-          options?: { publishOwnedWrite?: boolean },
-        ) => sessionLockController.withSessionWriteLock(operation, options),
-      };
       const promptActiveSession = (
         prompt: string,
         options?: Parameters<typeof activeSession.prompt>[1],
@@ -4172,10 +4180,12 @@ export async function runEmbeddedAttempt(
               },
             };
             try {
-              activeSessionManager.appendMessage(
-                redactedUserMessage as Parameters<typeof activeSessionManager.appendMessage>[0],
-              );
-              flushSessionManagerFile(activeSessionManager);
+              await withOwnedSessionWriteLock(() => {
+                activeSessionManager.appendMessage(
+                  redactedUserMessage as Parameters<typeof activeSessionManager.appendMessage>[0],
+                );
+                flushSessionManagerFile(activeSessionManager);
+              });
               activeSession.agent.state.messages =
                 activeSessionManager.buildSessionContext().messages;
               return true;
@@ -4259,7 +4269,7 @@ export async function runEmbeddedAttempt(
               provider: params.provider,
               sessionManager: {
                 appendCustomEntry: async (customType, data) => {
-                  await sessionLockController.withSessionWriteLock(() => {
+                  await withOwnedSessionWriteLock(() => {
                     activeSessionManager.appendCustomEntry(customType, data);
                   });
                 },
@@ -4284,6 +4294,8 @@ export async function runEmbeddedAttempt(
                 sessionLockController.withSessionWriteLock(run, options),
               canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
                 sessionLockController.canAdvanceSessionEntryCache(snapshot),
+              publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+                sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
             });
           }
 
@@ -4523,15 +4535,17 @@ export async function runEmbeddedAttempt(
               cfg: params.config,
               agentId: sessionAgentId,
             });
-            const truncationResult = truncateOversizedToolResultsInSessionManager({
-              sessionManager,
-              contextWindowTokens: contextTokenBudget,
-              maxCharsOverride: toolResultMaxChars,
-              sessionFile: params.sessionFile,
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              agentId: sessionAgentId,
-            });
+            const truncationResult = await withOwnedSessionWriteLock(() =>
+              truncateOversizedToolResultsInSessionManager({
+                sessionManager,
+                contextWindowTokens: contextTokenBudget,
+                maxCharsOverride: toolResultMaxChars,
+                sessionFile: params.sessionFile,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                agentId: sessionAgentId,
+              }),
+            );
             if (truncationResult.truncated) {
               preflightRecovery = {
                 route: "truncate_tool_results_only",
@@ -4701,7 +4715,7 @@ export async function runEmbeddedAttempt(
             });
             await sessionLockController.releaseHeldLockForAbort();
             await sessionLockController.waitForSessionEvents(activeSession);
-            await sessionLockController.withSessionWriteLock(async () => {
+            await withOwnedSessionWriteLock(async () => {
               stripSessionsYieldArtifacts(activeSession);
               if (yieldMessage) {
                 await persistSessionsYieldContextMessage(activeSession, yieldMessage);
@@ -4709,7 +4723,7 @@ export async function runEmbeddedAttempt(
             });
           } else if (isMidTurnPrecheckSignal(err)) {
             await sessionLockController.waitForSessionEvents(activeSession);
-            await sessionLockController.withSessionWriteLock(() => {
+            await withOwnedSessionWriteLock(() => {
               handleMidTurnPrecheckRequest(err.request);
             });
           } else {
@@ -4726,7 +4740,7 @@ export async function runEmbeddedAttempt(
           const request = pendingMidTurnPrecheckRequest;
           pendingMidTurnPrecheckRequest = null;
           await sessionLockController.waitForSessionEvents(activeSession);
-          await sessionLockController.withSessionWriteLock(() => {
+          await withOwnedSessionWriteLock(() => {
             removeTrailingMidTurnPrecheckAssistantError({
               activeSession,
               sessionManager: activeSessionManager,
@@ -4859,7 +4873,7 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
-        await sessionLockController.withSessionWriteLock(async () => {
+        await withOwnedSessionWriteLock(async () => {
           // Check if ANY compaction occurred during the entire attempt (prompt + retry).
           // Using a cumulative count (> 0) instead of a delta check avoids missing
           // compactions that complete during activeSession.prompt() before the delta
@@ -5007,7 +5021,7 @@ export async function runEmbeddedAttempt(
                 reason: contextParams.reason,
                 sessionManager: contextParams.sessionManager as never,
                 withSessionManagerRewriteLock: async (operation) =>
-                  await sessionLockController.withSessionWriteLock(operation),
+                  await withOwnedSessionWriteLock(operation),
                 runtimeContext: contextParams.runtimeContext,
                 config: params.config,
                 agentId: sessionAgentId,
@@ -5021,7 +5035,7 @@ export async function runEmbeddedAttempt(
 
         if (!beforeAgentFinalizeRevisionReason) {
           await sessionLockController.waitForSessionEvents(activeSession);
-          await sessionLockController.withSessionWriteLock(async () => {
+          await withOwnedSessionWriteLock(async () => {
             if (
               shouldPersistCompletedBootstrapTurn({
                 shouldRecordCompletedBootstrapTurn,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -186,7 +186,10 @@ import {
 import type { AgentMessage } from "../../runtime/index.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
-import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
+import {
+  invalidateSessionFileRepairCache,
+  repairSessionFileIfNeeded,
+} from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
@@ -2081,12 +2084,18 @@ export async function runEmbeddedAttempt(
     try {
       const trustedSessionFileSnapshot =
         await sessionLockController.readTrustedCurrentSessionFileSnapshot();
-      await repairSessionFileIfNeeded({
+      const repairReport = await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
         trustedSnapshot: trustedSessionFileSnapshot,
         debug: (message) => log.debug(message),
         warn: (message) => log.warn(message),
       });
+      if (
+        repairReport.validatedSnapshot &&
+        !sessionLockController.publishValidatedSessionFileSnapshot(repairReport.validatedSnapshot)
+      ) {
+        invalidateSessionFileRepairCache(params.sessionFile);
+      }
       const hadSessionFile = await fs
         .stat(params.sessionFile)
         .then(() => true)

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2078,8 +2078,11 @@ export async function runEmbeddedAttempt(
     let cleanupYieldAborted = false;
     let repairedRejectedThinkingReplay = false;
     try {
+      const trustedSessionFileSnapshot =
+        await sessionLockController.readTrustedCurrentSessionFileSnapshot();
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
+        trustedSnapshot: trustedSessionFileSnapshot,
         debug: (message) => log.debug(message),
         warn: (message) => log.warn(message),
       });

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -3,6 +3,7 @@
  */
 import fs from "node:fs/promises";
 import { serializeJsonlLine, writeJsonlLines } from "../../config/sessions/transcript-jsonl.js";
+import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
 
 type SessionHeaderEntry = { type: "session"; id?: string; cwd?: string };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
@@ -90,6 +91,7 @@ export async function prepareSessionManagerForRun(params: {
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await assertExistingHeaderIsReadable(params.sessionFile);
     await fs.writeFile(params.sessionFile, "", "utf-8");
+    invalidateSessionFileRepairCache(params.sessionFile);
     header.id = params.sessionId;
     header.cwd = params.cwd;
     sm.sessionId = params.sessionId;
@@ -103,10 +105,15 @@ export async function prepareSessionManagerForRun(params: {
   }
 
   if (params.hadSessionFile && header) {
+    const headerChanged = header.id !== params.sessionId || header.cwd !== params.cwd;
     header.id = params.sessionId;
     header.cwd = params.cwd;
     sm.sessionId = params.sessionId;
     sm.cwd = params.cwd;
+    if (!headerChanged) {
+      sm.flushed = true;
+      return;
+    }
     await writeJsonlLines(params.sessionFile, sm.fileEntries.map(serializeJsonlLine), {
       mode: 0o600,
     });

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -58,7 +58,7 @@ export async function prepareSessionManagerForRun(params: {
     labelsById?: Map<string, unknown>;
     leafId?: string | null;
     wasRecoveredFromCorruptHeader?: () => boolean;
-    syncSnapshotAfterHeaderRewrite?: () => void;
+    syncSnapshotAfterHeaderRewrite?: (expectedContent?: string) => void;
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
@@ -80,11 +80,15 @@ export async function prepareSessionManagerForRun(params: {
       header.cwd = params.cwd;
       sm.sessionId = params.sessionId;
       sm.cwd = params.cwd;
-      await writeJsonlLines(params.sessionFile, sm.fileEntries.map(serializeJsonlLine), {
-        mode: 0o600,
-      });
+      const content = await writeJsonlLines(
+        params.sessionFile,
+        sm.fileEntries.map(serializeJsonlLine),
+        {
+          mode: 0o600,
+        },
+      );
       sm.flushed = true;
-      sm.syncSnapshotAfterHeaderRewrite?.();
+      sm.syncSnapshotAfterHeaderRewrite?.(content);
       return;
     }
 
@@ -114,10 +118,14 @@ export async function prepareSessionManagerForRun(params: {
       sm.flushed = true;
       return;
     }
-    await writeJsonlLines(params.sessionFile, sm.fileEntries.map(serializeJsonlLine), {
-      mode: 0o600,
-    });
+    const content = await writeJsonlLines(
+      params.sessionFile,
+      sm.fileEntries.map(serializeJsonlLine),
+      {
+        mode: 0o600,
+      },
+    );
     sm.flushed = true;
-    sm.syncSnapshotAfterHeaderRewrite?.();
+    sm.syncSnapshotAfterHeaderRewrite?.(content);
   }
 }

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -57,6 +57,7 @@ export async function prepareSessionManagerForRun(params: {
     labelsById?: Map<string, unknown>;
     leafId?: string | null;
     wasRecoveredFromCorruptHeader?: () => boolean;
+    syncSnapshotAfterHeaderRewrite?: () => void;
   };
 
   const header = sm.fileEntries.find((e): e is SessionHeaderEntry => e.type === "session");
@@ -82,6 +83,7 @@ export async function prepareSessionManagerForRun(params: {
         mode: 0o600,
       });
       sm.flushed = true;
+      sm.syncSnapshotAfterHeaderRewrite?.();
       return;
     }
 
@@ -109,5 +111,6 @@ export async function prepareSessionManagerForRun(params: {
       mode: 0o600,
     });
     sm.flushed = true;
+    sm.syncSnapshotAfterHeaderRewrite?.();
   }
 }

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -32,6 +32,17 @@ function buildSessionHeaderAndMessage() {
 
 const tempDirs: string[] = [];
 
+async function readTrustedSnapshot(file: string) {
+  const stat = await fs.stat(file, { bigint: true });
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mtimeNs: stat.mtimeNs,
+    ctimeNs: stat.ctimeNs,
+  };
+}
+
 async function createTempSessionPath() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-repair-"));
   tempDirs.push(dir);
@@ -134,6 +145,141 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
     expect(result.repaired).toBe(false);
     expect(result.droppedLines).toBe(0);
+  });
+
+  it("validates only trusted appended entries after a clean repair pass", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    await fs.writeFile(file, `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`, "utf-8");
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+    try {
+      await repairSessionFileIfNeeded({ sessionFile: file });
+      expect(parseCount).toBe(2);
+
+      parseCount = 0;
+      await fs.appendFile(
+        file,
+        `${JSON.stringify({
+          type: "message",
+          id: "msg-2",
+          parentId: message.id,
+          timestamp: new Date().toISOString(),
+          message: { role: "assistant", content: "hello back" },
+        })}\n`,
+        "utf-8",
+      );
+      const trustedSnapshot = await readTrustedSnapshot(file);
+      const result = await repairSessionFileIfNeeded({
+        sessionFile: file,
+        trustedSnapshot,
+      });
+
+      expect(result).toMatchObject({ repaired: false, droppedLines: 0 });
+      expect(parseCount).toBe(1);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("falls back to full repair when a trusted append needs rewriting", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    await fs.writeFile(file, `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`, "utf-8");
+    await repairSessionFileIfNeeded({ sessionFile: file });
+    await fs.appendFile(
+      file,
+      `${JSON.stringify({
+        type: "message",
+        id: "msg-2",
+        parentId: message.id,
+        timestamp: new Date().toISOString(),
+        message: { role: "assistant", content: [], stopReason: "error" },
+      })}\n`,
+      "utf-8",
+    );
+    const trustedSnapshot = await readTrustedSnapshot(file);
+
+    const result = await repairSessionFileIfNeeded({
+      sessionFile: file,
+      trustedSnapshot,
+    });
+
+    expect(result).toMatchObject({ repaired: true, rewrittenAssistantMessages: 1 });
+    expect(await fs.readFile(file, "utf-8")).toContain(
+      "[assistant turn failed before producing content]",
+    );
+  });
+
+  it("rejects incremental repair when the trusted fingerprint becomes stale", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+    await repairSessionFileIfNeeded({ sessionFile: file });
+    const trustedSnapshot = await readTrustedSnapshot(file);
+
+    const invalidMessage = {
+      ...message,
+      message: { role: null, content: "invalid prefix replacement" },
+    };
+    const appendedMessage = {
+      ...message,
+      id: "msg-2",
+      parentId: message.id,
+      message: { role: "assistant", content: "valid tail" },
+    };
+    await fs.writeFile(
+      file,
+      `${JSON.stringify(header)}\n${JSON.stringify(invalidMessage)}\n${JSON.stringify(appendedMessage)}\n`,
+      "utf-8",
+    );
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, trustedSnapshot });
+
+    expect(result).toMatchObject({ repaired: true, droppedLines: 1 });
+  });
+
+  it("does not retain oversized tool-result ID indexes", async () => {
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const entries = Array.from({ length: 4_097 }, (_, index) => ({
+      type: "message",
+      id: `result-${index}`,
+      parentId: index > 0 ? `result-${index - 1}` : null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: `call-${index}`,
+        toolName: "test",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    }));
+    await fs.writeFile(
+      file,
+      `${[header, ...entries].map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf-8",
+    );
+    await repairSessionFileIfNeeded({ sessionFile: file });
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+    try {
+      await repairSessionFileIfNeeded({ sessionFile: file });
+      expect(parseCount).toBe(entries.length + 1);
+    } finally {
+      JSON.parse = originalParse;
+    }
   });
 
   it("warns and skips repair when the session header is invalid", async () => {

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -87,6 +87,7 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(1);
+    expect(result.validatedSnapshot).toEqual(await readTrustedSnapshot(file));
 
     const repaired = await fs.readFile(file, "utf-8");
     const repairedLines = repaired
@@ -159,8 +160,9 @@ describe("repairSessionFileIfNeeded", () => {
       return originalParse.apply(originalParse, args);
     } as typeof JSON.parse;
     try {
-      await repairSessionFileIfNeeded({ sessionFile: file });
+      const initial = await repairSessionFileIfNeeded({ sessionFile: file });
       expect(parseCount).toBe(2);
+      expect(initial.validatedSnapshot).toEqual(await readTrustedSnapshot(file));
 
       parseCount = 0;
       await fs.appendFile(
@@ -181,6 +183,7 @@ describe("repairSessionFileIfNeeded", () => {
       });
 
       expect(result).toMatchObject({ repaired: false, droppedLines: 0 });
+      expect(result.validatedSnapshot).toEqual(trustedSnapshot);
       expect(parseCount).toBe(1);
     } finally {
       JSON.parse = originalParse;

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -33,10 +33,128 @@ type RepairReport = {
   reason?: string;
 };
 
+type SessionRepairFileSnapshot = {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+};
+
+export type TrustedSessionRepairSnapshot = SessionRepairFileSnapshot;
+
+type SessionRepairCacheEntry = {
+  snapshot: SessionRepairFileSnapshot;
+  toolResultIds: Set<string>;
+  endsWithNewline: boolean;
+};
+
+const MAX_CACHED_SESSION_REPAIRS = 8;
+const MAX_INCREMENTAL_REPAIR_BYTES = 8n * 1024n * 1024n;
+const MAX_CACHED_REPAIR_TOOL_RESULT_IDS = 4_096;
+const MAX_CACHED_REPAIR_TOOL_RESULT_ID_BYTES = 512 * 1024;
+const sessionRepairCache = new Map<string, SessionRepairCacheEntry>();
+
+export function invalidateSessionFileRepairCache(sessionFile: string): void {
+  const trimmed = sessionFile.trim();
+  if (trimmed) {
+    sessionRepairCache.delete(path.resolve(trimmed));
+  }
+}
+
 type SessionMessageEntry = {
   type: "message";
   message: { role: string; content?: unknown } & Record<string, unknown>;
 } & Record<string, unknown>;
+
+async function readSessionRepairSnapshot(
+  sessionFile: string,
+): Promise<SessionRepairFileSnapshot | undefined> {
+  try {
+    const stat = await fs.stat(sessionFile, { bigint: true });
+    return {
+      dev: stat.dev,
+      ino: stat.ino,
+      size: stat.size,
+      mtimeNs: stat.mtimeNs,
+      ctimeNs: stat.ctimeNs,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isSameSessionRepairSnapshot(
+  left: SessionRepairFileSnapshot,
+  right: SessionRepairFileSnapshot,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function isSameSessionRepairFile(
+  left: SessionRepairFileSnapshot,
+  right: SessionRepairFileSnapshot,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function rememberSessionRepair(sessionFile: string, state: SessionRepairCacheEntry): void {
+  if (
+    state.toolResultIds.size > MAX_CACHED_REPAIR_TOOL_RESULT_IDS ||
+    countToolResultIdBytes(state.toolResultIds) > MAX_CACHED_REPAIR_TOOL_RESULT_ID_BYTES
+  ) {
+    sessionRepairCache.delete(sessionFile);
+    return;
+  }
+  sessionRepairCache.delete(sessionFile);
+  sessionRepairCache.set(sessionFile, state);
+  while (sessionRepairCache.size > MAX_CACHED_SESSION_REPAIRS) {
+    const oldestKey = sessionRepairCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    sessionRepairCache.delete(oldestKey);
+  }
+}
+
+function countToolResultIdBytes(ids: ReadonlySet<string>): number {
+  let bytes = 0;
+  for (const id of ids) {
+    bytes += Buffer.byteLength(id, "utf8");
+    if (bytes > MAX_CACHED_REPAIR_TOOL_RESULT_ID_BYTES) {
+      break;
+    }
+  }
+  return bytes;
+}
+
+async function readSessionRepairSuffix(
+  sessionFile: string,
+  offset: bigint,
+  length: bigint,
+): Promise<string | undefined> {
+  if (
+    offset > BigInt(Number.MAX_SAFE_INTEGER) ||
+    length > MAX_INCREMENTAL_REPAIR_BYTES ||
+    length > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    return undefined;
+  }
+  const buffer = Buffer.alloc(Number(length));
+  const file = await fs.open(sessionFile, "r");
+  try {
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, Number(offset));
+    return bytesRead === buffer.length ? buffer.toString("utf8") : undefined;
+  } finally {
+    await file.close();
+  }
+}
 
 function isSessionHeader(entry: unknown): entry is { type: string; id: string } {
   if (!entry || typeof entry !== "object") {
@@ -336,11 +454,18 @@ function makeSyntheticToolResultEntry(params: {
   };
 }
 
-function insertMissingCodeModeToolResults(entries: unknown[]): {
+function insertMissingCodeModeToolResults(
+  entries: unknown[],
+  existingResultIds: ReadonlySet<string> = new Set(),
+): {
   entries: unknown[];
   insertedToolResults: number;
+  resultIds: Set<string>;
 } {
-  const resultIds = collectPersistedToolResultIds(entries);
+  const resultIds = new Set(existingResultIds);
+  for (const resultId of collectPersistedToolResultIds(entries)) {
+    resultIds.add(resultId);
+  }
   let insertedToolResults = 0;
   const out: unknown[] = [];
 
@@ -368,41 +493,29 @@ function insertMissingCodeModeToolResults(entries: unknown[]): {
     }
   }
 
-  return { entries: insertedToolResults > 0 ? out : entries, insertedToolResults };
+  return {
+    entries: insertedToolResults > 0 ? out : entries,
+    insertedToolResults,
+    resultIds,
+  };
 }
 
-/** Repair a persisted session JSONL file in place when replay-breaking corruption is found. */
-export async function repairSessionFileIfNeeded(params: {
-  sessionFile: string;
-  debug?: (message: string) => void;
-  warn?: (message: string) => void;
-}): Promise<RepairReport> {
-  const sessionFile = params.sessionFile.trim();
-  if (!sessionFile) {
-    return { repaired: false, droppedLines: 0, reason: "missing session file" };
-  }
+type RepairEntriesResult = {
+  entries: unknown[];
+  droppedLines: number;
+  rewrittenAssistantMessages: number;
+  droppedBlankUserMessages: number;
+  rewrittenUserMessages: number;
+  removedCorruptedImageBlocks: number;
+};
 
-  let content: string;
-  try {
-    content = await fs.readFile(sessionFile, "utf-8");
-  } catch (err) {
-    const code = (err as { code?: unknown } | undefined)?.code;
-    if (code === "ENOENT") {
-      return { repaired: false, droppedLines: 0, reason: "missing session file" };
-    }
-    const reason = `failed to read session file: ${err instanceof Error ? err.message : "unknown error"}`;
-    params.warn?.(`session file repair skipped: ${reason} (${path.basename(sessionFile)})`);
-    return { repaired: false, droppedLines: 0, reason };
-  }
-
-  const lines = content.split(/\r?\n/);
+function repairSessionLines(lines: string[]): RepairEntriesResult {
   const entries: unknown[] = [];
   let droppedLines = 0;
   let rewrittenAssistantMessages = 0;
   let droppedBlankUserMessages = 0;
   let rewrittenUserMessages = 0;
   let removedCorruptedImageBlocks = 0;
-  let insertedToolResults;
 
   for (const line of lines) {
     if (!line.trim()) {
@@ -411,11 +524,6 @@ export async function repairSessionFileIfNeeded(params: {
     try {
       const entry: unknown = JSON.parse(line);
       if (isStructurallyInvalidMessageEntry(entry)) {
-        // Drop "null role" / missing-role message entries the same way we
-        // drop unparseable JSONL: they cannot be replayed to any provider
-        // and preserving them through repair just relocates the corruption
-        // into the post-repair file (#77228: 935+ null-role entries
-        // surviving the auto-repair pass).
         droppedLines += 1;
         continue;
       }
@@ -462,36 +570,166 @@ export async function repairSessionFileIfNeeded(params: {
     }
   }
 
-  if (entries.length === 0) {
-    return { repaired: false, droppedLines, reason: "empty session file" };
+  return {
+    entries,
+    droppedLines,
+    rewrittenAssistantMessages,
+    droppedBlankUserMessages,
+    rewrittenUserMessages,
+    removedCorruptedImageBlocks,
+  };
+}
+
+function hasEntryRepairs(result: RepairEntriesResult): boolean {
+  return (
+    result.droppedLines > 0 ||
+    result.rewrittenAssistantMessages > 0 ||
+    result.droppedBlankUserMessages > 0 ||
+    result.rewrittenUserMessages > 0 ||
+    result.removedCorruptedImageBlocks > 0
+  );
+}
+
+async function tryIncrementalSessionRepair(params: {
+  sessionFile: string;
+  currentSnapshot: SessionRepairFileSnapshot;
+  cached: SessionRepairCacheEntry;
+  trustedSnapshot: TrustedSessionRepairSnapshot | undefined;
+}): Promise<RepairReport | undefined> {
+  if (isSameSessionRepairSnapshot(params.cached.snapshot, params.currentSnapshot)) {
+    return { repaired: false, droppedLines: 0 };
+  }
+  if (
+    !params.trustedSnapshot ||
+    !isSameSessionRepairSnapshot(params.trustedSnapshot, params.currentSnapshot) ||
+    !params.cached.endsWithNewline ||
+    !isSameSessionRepairFile(params.cached.snapshot, params.currentSnapshot) ||
+    params.currentSnapshot.size <= params.cached.snapshot.size
+  ) {
+    return undefined;
   }
 
+  const appendedText = await readSessionRepairSuffix(
+    params.sessionFile,
+    params.cached.snapshot.size,
+    params.currentSnapshot.size - params.cached.snapshot.size,
+  );
+  if (!appendedText?.endsWith("\n")) {
+    return undefined;
+  }
+  const afterReadSnapshot = await readSessionRepairSnapshot(params.sessionFile);
+  if (
+    !afterReadSnapshot ||
+    !isSameSessionRepairSnapshot(params.currentSnapshot, afterReadSnapshot)
+  ) {
+    return undefined;
+  }
+
+  const repairedEntries = repairSessionLines(appendedText.split(/\r?\n/));
+  if (hasEntryRepairs(repairedEntries)) {
+    return undefined;
+  }
+  const repairedToolResults = insertMissingCodeModeToolResults(
+    repairedEntries.entries,
+    params.cached.toolResultIds,
+  );
+  if (repairedToolResults.insertedToolResults > 0) {
+    return undefined;
+  }
+
+  rememberSessionRepair(params.sessionFile, {
+    snapshot: afterReadSnapshot,
+    toolResultIds: repairedToolResults.resultIds,
+    endsWithNewline: true,
+  });
+  return { repaired: false, droppedLines: 0 };
+}
+
+/** Repair a persisted session JSONL file in place when replay-breaking corruption is found. */
+export async function repairSessionFileIfNeeded(params: {
+  sessionFile: string;
+  trustedSnapshot?: TrustedSessionRepairSnapshot;
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+}): Promise<RepairReport> {
+  const sessionFileInput = params.sessionFile.trim();
+  if (!sessionFileInput) {
+    return { repaired: false, droppedLines: 0, reason: "missing session file" };
+  }
+  const sessionFile = path.resolve(sessionFileInput);
+  const beforeReadSnapshot = await readSessionRepairSnapshot(sessionFile);
+  if (beforeReadSnapshot) {
+    const cached = sessionRepairCache.get(sessionFile);
+    if (cached) {
+      const incremental = await tryIncrementalSessionRepair({
+        sessionFile,
+        currentSnapshot: beforeReadSnapshot,
+        cached,
+        trustedSnapshot: params.trustedSnapshot,
+      });
+      if (incremental) {
+        return incremental;
+      }
+    }
+  } else {
+    sessionRepairCache.delete(sessionFile);
+  }
+
+  let content: string;
+  try {
+    content = await fs.readFile(sessionFile, "utf-8");
+  } catch (err) {
+    sessionRepairCache.delete(sessionFile);
+    const code = (err as { code?: unknown } | undefined)?.code;
+    if (code === "ENOENT") {
+      return { repaired: false, droppedLines: 0, reason: "missing session file" };
+    }
+    const reason = `failed to read session file: ${err instanceof Error ? err.message : "unknown error"}`;
+    params.warn?.(`session file repair skipped: ${reason} (${path.basename(sessionFile)})`);
+    return { repaired: false, droppedLines: 0, reason };
+  }
+
+  const repairedEntries = repairSessionLines(content.split(/\r?\n/));
+  const {
+    entries,
+    droppedLines,
+    rewrittenAssistantMessages,
+    droppedBlankUserMessages,
+    rewrittenUserMessages,
+    removedCorruptedImageBlocks,
+  } = repairedEntries;
+
+  if (entries.length === 0) {
+    sessionRepairCache.delete(sessionFile);
+    return { repaired: false, droppedLines, reason: "empty session file" };
+  }
   if (!isSessionHeader(entries[0])) {
+    sessionRepairCache.delete(sessionFile);
     params.warn?.(
       `session file repair skipped: invalid session header (${path.basename(sessionFile)})`,
     );
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
 
-  if (
-    droppedLines === 0 &&
-    rewrittenAssistantMessages === 0 &&
-    droppedBlankUserMessages === 0 &&
-    rewrittenUserMessages === 0 &&
-    removedCorruptedImageBlocks === 0
-  ) {
-    const repairedToolResults = insertMissingCodeModeToolResults(entries);
-    insertedToolResults = repairedToolResults.insertedToolResults;
-    if (insertedToolResults === 0) {
-      return { repaired: false, droppedLines: 0 };
+  const repairedToolResults = insertMissingCodeModeToolResults(entries);
+  const insertedToolResults = repairedToolResults.insertedToolResults;
+  if (!hasEntryRepairs(repairedEntries) && insertedToolResults === 0) {
+    const afterReadSnapshot = await readSessionRepairSnapshot(sessionFile);
+    if (
+      beforeReadSnapshot &&
+      afterReadSnapshot &&
+      isSameSessionRepairSnapshot(beforeReadSnapshot, afterReadSnapshot)
+    ) {
+      rememberSessionRepair(sessionFile, {
+        snapshot: afterReadSnapshot,
+        toolResultIds: repairedToolResults.resultIds,
+        endsWithNewline: content.endsWith("\n"),
+      });
     }
+    return { repaired: false, droppedLines: 0 };
+  }
+  if (insertedToolResults > 0) {
     entries.splice(0, entries.length, ...repairedToolResults.entries);
-  } else {
-    const repairedToolResults = insertMissingCodeModeToolResults(entries);
-    insertedToolResults = repairedToolResults.insertedToolResults;
-    if (insertedToolResults > 0) {
-      entries.splice(0, entries.length, ...repairedToolResults.entries);
-    }
   }
 
   const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
@@ -518,6 +756,7 @@ export async function repairSessionFileIfNeeded(params: {
       );
     });
   } catch (err) {
+    sessionRepairCache.delete(sessionFile);
     return {
       repaired: false,
       droppedLines,
@@ -529,6 +768,14 @@ export async function repairSessionFileIfNeeded(params: {
     };
   }
 
+  const repairedSnapshot = await readSessionRepairSnapshot(sessionFile);
+  if (repairedSnapshot) {
+    rememberSessionRepair(sessionFile, {
+      snapshot: repairedSnapshot,
+      toolResultIds: repairedToolResults.resultIds,
+      endsWithNewline: true,
+    });
+  }
   params.debug?.(
     `session file repaired: ${buildRepairSummaryParts({
       droppedLines,

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -24,6 +24,7 @@ export const CORRUPTED_IMAGE_FALLBACK_TEXT = "[image omitted: corrupted base64 p
 type RepairReport = {
   repaired: boolean;
   droppedLines: number;
+  validatedSnapshot?: SessionRepairFileSnapshot;
   rewrittenAssistantMessages?: number;
   droppedBlankUserMessages?: number;
   rewrittenUserMessages?: number;
@@ -597,7 +598,11 @@ async function tryIncrementalSessionRepair(params: {
   trustedSnapshot: TrustedSessionRepairSnapshot | undefined;
 }): Promise<RepairReport | undefined> {
   if (isSameSessionRepairSnapshot(params.cached.snapshot, params.currentSnapshot)) {
-    return { repaired: false, droppedLines: 0 };
+    return {
+      repaired: false,
+      droppedLines: 0,
+      validatedSnapshot: params.currentSnapshot,
+    };
   }
   if (
     !params.trustedSnapshot ||
@@ -642,7 +647,11 @@ async function tryIncrementalSessionRepair(params: {
     toolResultIds: repairedToolResults.resultIds,
     endsWithNewline: true,
   });
-  return { repaired: false, droppedLines: 0 };
+  return {
+    repaired: false,
+    droppedLines: 0,
+    validatedSnapshot: afterReadSnapshot,
+  };
 }
 
 /** Repair a persisted session JSONL file in place when replay-breaking corruption is found. */
@@ -715,18 +724,26 @@ export async function repairSessionFileIfNeeded(params: {
   const insertedToolResults = repairedToolResults.insertedToolResults;
   if (!hasEntryRepairs(repairedEntries) && insertedToolResults === 0) {
     const afterReadSnapshot = await readSessionRepairSnapshot(sessionFile);
-    if (
+    const validatedSnapshot =
       beforeReadSnapshot &&
       afterReadSnapshot &&
       isSameSessionRepairSnapshot(beforeReadSnapshot, afterReadSnapshot)
-    ) {
+        ? afterReadSnapshot
+        : undefined;
+    if (validatedSnapshot) {
       rememberSessionRepair(sessionFile, {
-        snapshot: afterReadSnapshot,
+        snapshot: validatedSnapshot,
         toolResultIds: repairedToolResults.resultIds,
         endsWithNewline: content.endsWith("\n"),
       });
+    } else {
+      sessionRepairCache.delete(sessionFile);
     }
-    return { repaired: false, droppedLines: 0 };
+    return {
+      repaired: false,
+      droppedLines: 0,
+      ...(validatedSnapshot ? { validatedSnapshot } : {}),
+    };
   }
   if (insertedToolResults > 0) {
     entries.splice(0, entries.length, ...repairedToolResults.entries);
@@ -768,13 +785,30 @@ export async function repairSessionFileIfNeeded(params: {
     };
   }
 
-  const repairedSnapshot = await readSessionRepairSnapshot(sessionFile);
+  let repairedSnapshot: SessionRepairFileSnapshot | undefined;
+  try {
+    const beforeVerifySnapshot = await readSessionRepairSnapshot(sessionFile);
+    const persistedContent = await fs.readFile(sessionFile, "utf8");
+    const afterVerifySnapshot = await readSessionRepairSnapshot(sessionFile);
+    if (
+      beforeVerifySnapshot &&
+      afterVerifySnapshot &&
+      persistedContent === cleaned &&
+      isSameSessionRepairSnapshot(beforeVerifySnapshot, afterVerifySnapshot)
+    ) {
+      repairedSnapshot = afterVerifySnapshot;
+    }
+  } catch {
+    repairedSnapshot = undefined;
+  }
   if (repairedSnapshot) {
     rememberSessionRepair(sessionFile, {
       snapshot: repairedSnapshot,
       toolResultIds: repairedToolResults.resultIds,
       endsWithNewline: true,
     });
+  } else {
+    sessionRepairCache.delete(sessionFile);
   }
   params.debug?.(
     `session file repaired: ${buildRepairSummaryParts({
@@ -789,6 +823,7 @@ export async function repairSessionFileIfNeeded(params: {
   return {
     repaired: true,
     droppedLines,
+    ...(repairedSnapshot ? { validatedSnapshot: repairedSnapshot } : {}),
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
 import {
   CURRENT_SESSION_VERSION,
   loadEntriesFromFile,
@@ -322,6 +323,72 @@ describe("SessionManager.open", () => {
         "message 3",
       ]);
       expect(parseCount).toBeGreaterThanOrEqual(4);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("lets prepareSessionManagerForRun normalize a warm-cached header without re-parsing", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "assistant", content: "carried context" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir, "original-session"))}\n${JSON.stringify(
+        assistantEntry,
+      )}\n`,
+      "utf8",
+    );
+
+    // Warm the process-level entry cache.
+    expect(SessionManager.open(sessionFile, dir, dir).getSessionId()).toBe("original-session");
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      // Two warm hits off the same cache entry: must not re-parse the transcript.
+      const sessionManager = SessionManager.open(sessionFile, dir, dir);
+      const sibling = SessionManager.open(sessionFile, dir, dir);
+      expect(parseCount).toBe(0);
+
+      // The embedded runner normalizes the loaded header in place. With a shared
+      // frozen cache entry this threw "Cannot assign to read only property".
+      await expect(
+        prepareSessionManagerForRun({
+          sessionManager,
+          sessionFile,
+          hadSessionFile: true,
+          sessionId: "run-session",
+          cwd: "/tmp/task-repo",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(sessionManager.getSessionId()).toBe("run-session");
+      expect(sessionManager.getHeader()).toEqual(
+        expect.objectContaining({ type: "session", id: "run-session", cwd: "/tmp/task-repo" }),
+      );
+      expect(sessionManager.getCwd()).toBe("/tmp/task-repo");
+
+      // Each warm hit gets an independent mutable header clone, so normalizing
+      // one manager's header must not bleed into the cached snapshot shared with
+      // the sibling manager.
+      expect(sibling.getHeader()).toEqual(
+        expect.objectContaining({ type: "session", id: "original-session", cwd: dir }),
+      );
+
+      // Header normalization stayed in memory; the warm hits never re-parsed.
+      expect(parseCount).toBe(0);
     } finally {
       JSON.parse = originalParse;
     }

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -431,7 +431,7 @@ describe("SessionManager.open", () => {
     if (hugeEntry.type !== "message") {
       throw new Error("expected message entry fixture");
     }
-    hugeEntry.message.content = "x".repeat(33 * 1024 * 1024);
+    (hugeEntry.message as { content: string }).content = "x".repeat(33 * 1024 * 1024);
     await fs.writeFile(
       sessionFile,
       `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(hugeEntry)}\n`,

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -4,7 +4,7 @@ import { writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
@@ -196,27 +196,38 @@ describe("SessionManager.open", () => {
       expect(parseCount).toBe(0);
 
       const sessionManager = SessionManager.open(sessionFile, dir, dir);
+      let trustedSnapshot = await readTrustedRepairSnapshot(sessionFile);
       let cacheAdvanceChecks = 0;
+      let snapshotPublications = 0;
       await withOwnedSessionTranscriptWrites(
         {
           sessionFile,
-          canAdvanceSessionEntryCache: () => {
+          canAdvanceSessionEntryCache: (snapshot) => {
             cacheAdvanceChecks += 1;
+            expect(snapshot).toEqual(trustedSnapshot);
+            return true;
+          },
+          publishSessionFileSnapshot: (snapshot) => {
+            snapshotPublications += 1;
+            trustedSnapshot = snapshot;
             return true;
           },
           withSessionWriteLock: async (run) => await run(),
         },
         async () => {
           sessionManager.appendMessage(secondMessage);
+          sessionManager.appendMessage(buildAssistantMessage("message 3"));
         },
       );
-      expect(cacheAdvanceChecks).toBe(1);
+      expect(cacheAdvanceChecks).toBe(2);
+      expect(snapshotPublications).toBe(2);
       const persistedEntries = (await fs.readFile(sessionFile, "utf8"))
         .trim()
         .split("\n")
         .map((line) => originalParse(line) as { type: string });
       expect(persistedEntries.map((entry) => entry.type)).toEqual([
         "session",
+        "message",
         "message",
         "message",
       ]);
@@ -226,6 +237,7 @@ describe("SessionManager.open", () => {
       expect(reopened.getEntries().map((entry) => readMessageContent(entry))).toEqual([
         "message 1",
         "message 2",
+        "message 3",
       ]);
       expect(parseCount).toBe(0);
     } finally {
@@ -286,6 +298,7 @@ describe("SessionManager.open", () => {
       {
         sessionFile,
         canAdvanceSessionEntryCache: () => true,
+        publishSessionFileSnapshot: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -333,6 +346,7 @@ describe("SessionManager.open", () => {
       {
         sessionFile,
         canAdvanceSessionEntryCache: () => true,
+        publishSessionFileSnapshot: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -378,6 +392,7 @@ describe("SessionManager.open", () => {
       {
         sessionFile,
         canAdvanceSessionEntryCache: () => true,
+        publishSessionFileSnapshot: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -427,6 +442,7 @@ describe("SessionManager.open", () => {
       {
         sessionFile,
         canAdvanceSessionEntryCache: () => false,
+        publishSessionFileSnapshot: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -467,6 +483,7 @@ describe("SessionManager.open", () => {
       {
         sessionFile,
         canAdvanceSessionEntryCache: () => true,
+        publishSessionFileSnapshot: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -633,6 +650,38 @@ describe("SessionManager.open", () => {
     await fs.writeFile(sessionFile, replacementContent, "utf8");
     sessionManager.syncSnapshotAfterHeaderRewrite();
 
+    expect(
+      SessionManager.open(sessionFile, dir, dir)
+        .getEntries()
+        .map((entry) => readMessageContent(entry)),
+    ).toEqual(["message 2"]);
+  });
+
+  it("does not publish a header rewrite snapshot when the expected bytes do not match", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const header = buildSessionHeader(dir);
+    const originalContent = `${JSON.stringify(header)}\n${JSON.stringify(buildMessageEntry(1, null))}\n`;
+    const replacementContent = `${JSON.stringify(header)}\n${JSON.stringify(
+      buildMessageEntry(2, null),
+    )}\n`;
+    await fs.writeFile(sessionFile, originalContent, "utf8");
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    const publishSessionFileSnapshot = vi.fn(() => true);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        publishSessionFileSnapshot,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        await fs.writeFile(sessionFile, replacementContent, "utf8");
+        sessionManager.syncSnapshotAfterHeaderRewrite(originalContent);
+      },
+    );
+
+    expect(publishSessionFileSnapshot).not.toHaveBeenCalled();
     expect(
       SessionManager.open(sessionFile, dir, dir)
         .getEntries()
@@ -827,26 +876,36 @@ describe("SessionManager.open", () => {
     expect(SessionManager.open(sessionFile, dir, dir).getSessionId()).toBe("original-session");
     const sessionManager = SessionManager.open(sessionFile, dir, dir);
 
-    await prepareSessionManagerForRun({
-      sessionManager,
-      sessionFile,
-      hadSessionFile: true,
-      sessionId: "run-session",
-      cwd: dir,
-    });
-
-    // First append after the embedded header rewrite. Before the fix the stale
-    // snapshot made this drop the warm cache.
+    let trustedSnapshot = await readTrustedRepairSnapshot(sessionFile);
+    let snapshotPublications = 0;
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
-        canAdvanceSessionEntryCache: () => true,
+        canAdvanceSessionEntryCache: (snapshot) => {
+          expect(snapshot).toEqual(trustedSnapshot);
+          return true;
+        },
+        publishSessionFileSnapshot: (snapshot) => {
+          snapshotPublications += 1;
+          trustedSnapshot = snapshot;
+          return true;
+        },
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
+        await prepareSessionManagerForRun({
+          sessionManager,
+          sessionFile,
+          hadSessionFile: true,
+          sessionId: "run-session",
+          cwd: dir,
+        });
+        // First append after the embedded header rewrite. Before the fix the
+        // stale snapshot made this drop the warm cache.
         sessionManager.appendMessage(buildAssistantMessage("after rewrite"));
       },
     );
+    expect(snapshotPublications).toBe(2);
 
     const originalParse = JSON.parse;
     let parseCount = 0;

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -393,6 +393,62 @@ describe("SessionManager.open", () => {
       JSON.parse = originalParse;
     }
   });
+
+  it("keeps the warm cache after prepareSessionManagerForRun rewrites then appends", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "assistant", content: "carried context" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir, "original-session"))}\n${JSON.stringify(
+        assistantEntry,
+      )}\n`,
+      "utf8",
+    );
+
+    // Warm the process-level entry cache, then open the manager the embedded
+    // runner will normalize.
+    expect(SessionManager.open(sessionFile, dir, dir).getSessionId()).toBe("original-session");
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "run-session",
+      cwd: dir,
+    });
+
+    // First append after the embedded header rewrite. Before the fix the stale
+    // snapshot made this drop the warm cache.
+    sessionManager.appendMessage(buildAssistantMessage("after rewrite"));
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getEntries().map((entry) => readMessageContent(entry))).toEqual([
+        "carried context",
+        "after rewrite",
+      ]);
+      // The next warm open must hit the cache instead of reparsing the whole
+      // transcript that the embedded header rewrite produced.
+      expect(parseCount).toBe(0);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
 });
 
 function readMessageContent(entry: SessionEntry): unknown {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -196,15 +196,21 @@ describe("SessionManager.open", () => {
       expect(parseCount).toBe(0);
 
       const sessionManager = SessionManager.open(sessionFile, dir, dir);
+      let cacheAdvanceChecks = 0;
       await withOwnedSessionTranscriptWrites(
         {
           sessionFile,
+          canAdvanceSessionEntryCache: () => {
+            cacheAdvanceChecks += 1;
+            return true;
+          },
           withSessionWriteLock: async (run) => await run(),
         },
         async () => {
           sessionManager.appendMessage(secondMessage);
         },
       );
+      expect(cacheAdvanceChecks).toBe(1);
       const persistedEntries = (await fs.readFile(sessionFile, "utf8"))
         .trim()
         .split("\n")
@@ -279,6 +285,7 @@ describe("SessionManager.open", () => {
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
+        canAdvanceSessionEntryCache: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -325,6 +332,7 @@ describe("SessionManager.open", () => {
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
+        canAdvanceSessionEntryCache: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -348,6 +356,102 @@ describe("SessionManager.open", () => {
     expect(warmEntry).toMatchObject({ data: { value: "first" } });
   });
 
+  it("validates the transcript prefix after a custom entry is serialized", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const originalEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: buildAssistantMessage("message 1"),
+    };
+    const replacementEntry = {
+      ...originalEntry,
+      message: buildAssistantMessage("changed 1"),
+    };
+    const headerLine = JSON.stringify(buildSessionHeader(dir));
+    await fs.writeFile(sessionFile, `${headerLine}\n${JSON.stringify(originalEntry)}\n`, "utf8");
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        canAdvanceSessionEntryCache: () => true,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendCustomEntry("rewrite-during-serialization", {
+          value: {
+            toJSON() {
+              writeFileSync(
+                sessionFile,
+                `${headerLine}\n${JSON.stringify(replacementEntry)}\n`,
+                "utf8",
+              );
+              return "persisted";
+            },
+          },
+        });
+      },
+    );
+
+    expect(
+      SessionManager.open(sessionFile, dir, dir)
+        .getEntries()
+        .filter((entry) => entry.type === "message")
+        .map((entry) => readMessageContent(entry)),
+    ).toEqual(["changed 1"]);
+  });
+
+  it("invalidates incremental repair when append ownership cannot be proven", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: buildAssistantMessage("message 1"),
+    };
+    const headerLine = JSON.stringify(buildSessionHeader(dir));
+    const assistantLine = JSON.stringify(assistantEntry);
+    await fs.writeFile(sessionFile, `${headerLine}\n${assistantLine}\n`, "utf8");
+    await repairSessionFileIfNeeded({
+      sessionFile,
+      trustedSnapshot: await readTrustedRepairSnapshot(sessionFile),
+    });
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        canAdvanceSessionEntryCache: () => false,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendCustomEntry("corrupt-prefix-during-serialization", {
+          value: {
+            toJSON() {
+              writeFileSync(sessionFile, `${headerLine}\n!${assistantLine.slice(1)}\n`, "utf8");
+              return "persisted";
+            },
+          },
+        });
+      },
+    );
+
+    await repairSessionFileIfNeeded({
+      sessionFile,
+      trustedSnapshot: await readTrustedRepairSnapshot(sessionFile),
+    });
+    const repairedEntries = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string });
+    expect(repairedEntries.map((entry) => entry.type)).toEqual(["session", "custom"]);
+  });
+
   it("separates an owned append from an unterminated transcript entry", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");
@@ -362,6 +466,7 @@ describe("SessionManager.open", () => {
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
+        canAdvanceSessionEntryCache: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {
@@ -382,10 +487,17 @@ describe("SessionManager.open", () => {
   it("caches the persisted JSON shape after a deferred full write", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");
+    let serializationCount = 0;
     const sessionManager = SessionManager.open(sessionFile, dir, dir);
     sessionManager.appendCustomEntry("json-shape", {
       kept: "value",
       dropped: () => "not persisted",
+      stateful: {
+        toJSON() {
+          serializationCount += 1;
+          return serializationCount === 1 ? "first" : "later";
+        },
+      },
     });
 
     expect(() => {
@@ -395,7 +507,8 @@ describe("SessionManager.open", () => {
     const warmEntry = SessionManager.open(sessionFile, dir, dir)
       .getEntries()
       .find((entry) => entry.type === "custom");
-    expect(warmEntry).toMatchObject({ data: { kept: "value" } });
+    expect(serializationCount).toBe(1);
+    expect(warmEntry).toMatchObject({ data: { kept: "value", stateful: "first" } });
     expect((warmEntry as { data?: Record<string, unknown> }).data).not.toHaveProperty("dropped");
   });
 
@@ -727,6 +840,7 @@ describe("SessionManager.open", () => {
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
+        canAdvanceSessionEntryCache: () => true,
         withSessionWriteLock: async (run) => await run(),
       },
       async () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -304,6 +304,81 @@ describe("SessionManager.open", () => {
     expect((warmEntry as { data?: Record<string, unknown> }).data).not.toHaveProperty("dropped");
   });
 
+  it("serializes owned appends once and caches those exact bytes", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: buildAssistantMessage("message 1"),
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(assistantEntry)}\n`,
+      "utf8",
+    );
+
+    let serializationCount = 0;
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendCustomEntry("stateful-json", {
+          value: {
+            toJSON() {
+              serializationCount += 1;
+              return serializationCount === 1 ? "first" : "later";
+            },
+          },
+        });
+      },
+    );
+
+    const warmEntry = SessionManager.open(sessionFile, dir, dir)
+      .getEntries()
+      .find((entry) => entry.type === "custom");
+    const freshEntry = loadEntriesFromFile(sessionFile).find((entry) => entry.type === "custom");
+    expect(serializationCount).toBe(1);
+    expect(warmEntry).toEqual(freshEntry);
+    expect(warmEntry).toMatchObject({ data: { value: "first" } });
+  });
+
+  it("separates an owned append from an unterminated transcript entry", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}`,
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendMessage(buildAssistantMessage("message 2"));
+      },
+    );
+
+    const content = await fs.readFile(sessionFile, "utf8");
+    expect(content.endsWith("\n")).toBe(true);
+    expect(content.trimEnd().split("\n")).toHaveLength(3);
+    expect(
+      loadEntriesFromFile(sessionFile)
+        .filter((entry) => entry.type === "message")
+        .map((entry) => readMessageContent(entry)),
+    ).toEqual(["message 1", "message 2"]);
+  });
+
   it("caches the persisted JSON shape after a deferred full write", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -259,6 +259,71 @@ describe("SessionManager.open", () => {
     }
   });
 
+  it("caches the persisted JSON shape for owned appends", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: buildAssistantMessage("message 1"),
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(assistantEntry)}\n`,
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendCustomEntry("json-shape", {
+          date: new Date("2026-06-15T00:00:00.000Z"),
+          dropped: () => "not persisted",
+          nan: Number.NaN,
+        });
+      },
+    );
+
+    const warmEntry = SessionManager.open(sessionFile, dir, dir)
+      .getEntries()
+      .find((entry) => entry.type === "custom");
+    const freshEntry = loadEntriesFromFile(sessionFile).find((entry) => entry.type === "custom");
+    expect(warmEntry).toEqual(freshEntry);
+    expect(warmEntry).toMatchObject({
+      data: {
+        date: "2026-06-15T00:00:00.000Z",
+        nan: null,
+      },
+    });
+    expect((warmEntry as { data?: Record<string, unknown> }).data).not.toHaveProperty("dropped");
+  });
+
+  it("caches the persisted JSON shape after a deferred full write", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    sessionManager.appendCustomEntry("json-shape", {
+      kept: "value",
+      dropped: () => "not persisted",
+    });
+
+    expect(() => {
+      sessionManager.appendMessage(buildAssistantMessage("first assistant"));
+    }).not.toThrow();
+
+    const warmEntry = SessionManager.open(sessionFile, dir, dir)
+      .getEntries()
+      .find((entry) => entry.type === "custom");
+    expect(warmEntry).toMatchObject({ data: { kept: "value" } });
+    expect((warmEntry as { data?: Record<string, unknown> }).data).not.toHaveProperty("dropped");
+  });
+
   it("keeps the exported file loader mutable and separate from warm SessionManager entries", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");
@@ -543,8 +608,9 @@ describe("SessionManager.open", () => {
         expect.objectContaining({ type: "session", id: "original-session", cwd: dir }),
       );
 
-      // Header normalization stayed in memory; the warm hits never re-parsed.
-      expect(parseCount).toBe(0);
+      // The warm hits stayed parse-free. The required header rewrite parses
+      // its two persisted lines once so the cache matches JSON round-tripping.
+      expect(parseCount).toBe(2);
     } finally {
       JSON.parse = originalParse;
     }

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -4,7 +4,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { SessionManager } from "./session-manager.js";
+import {
+  CURRENT_SESSION_VERSION,
+  loadEntriesFromFile,
+  SessionManager,
+  type SessionEntry,
+} from "./session-manager.js";
 
 const tempPaths: string[] = [];
 
@@ -110,4 +115,263 @@ describe("SessionManager.open", () => {
     expect(entries.map((entry) => entry.type)).toEqual(["session", "message", "message"]);
     expect(entries.filter((entry) => entry.type === "session")).toHaveLength(1);
   });
+
+  it("still migrates old transcript versions while bypassing the warm cache", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const legacyHeader = {
+      type: "session",
+      version: 2,
+      id: "legacy-session",
+      timestamp: "2026-06-04T00:00:00.000Z",
+      cwd: dir,
+    };
+    const legacyEntry = {
+      type: "message",
+      id: "legacy-entry",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: {
+        role: "hookMessage",
+        content: "legacy hook content",
+      },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(legacyHeader)}\n${JSON.stringify(legacyEntry)}\n`,
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+
+    expect(sessionManager.getHeader()?.version).toBe(CURRENT_SESSION_VERSION);
+    expect(sessionManager.getEntries()).toEqual([
+      {
+        ...legacyEntry,
+        message: { ...legacyEntry.message, role: "custom" },
+      },
+    ]);
+    const persistedEntries = (await fs.readFile(sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; version?: number; message?: unknown });
+    expect(persistedEntries[0]).toMatchObject({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+    });
+    expect(persistedEntries[1]).toMatchObject({
+      type: "message",
+      message: { role: "custom" },
+    });
+  });
+
+  it("reuses current transcript entries across warm opens and appends without stale readback", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    const secondMessage = buildAssistantMessage("message 2");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      expect(loadEntriesFromFile(sessionFile).map((entry) => entry.type)).toEqual([
+        "session",
+        "message",
+      ]);
+      expect(parseCount).toBe(2);
+
+      parseCount = 0;
+      expect(SessionManager.open(sessionFile, dir, dir).getEntries()).toEqual([firstEntry]);
+      expect(parseCount).toBe(0);
+
+      const sessionManager = SessionManager.open(sessionFile, dir, dir);
+      sessionManager.appendMessage(secondMessage);
+      const persistedEntries = (await fs.readFile(sessionFile, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => originalParse(line) as { type: string });
+      expect(persistedEntries.map((entry) => entry.type)).toEqual([
+        "session",
+        "message",
+        "message",
+      ]);
+
+      parseCount = 0;
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getEntries().map((entry) => readMessageContent(entry))).toEqual([
+        "message 1",
+        "message 2",
+      ]);
+      expect(parseCount).toBe(0);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("invalidates the transcript entry cache when the file is externally replaced", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    const replacementEntry = buildMessageEntry(2, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    expect(SessionManager.open(sessionFile, dir, dir).getEntries()).toEqual([firstEntry]);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir, "replacement-session"))}\n${JSON.stringify(
+        replacementEntry,
+      )}\n`,
+      "utf8",
+    );
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getSessionId()).toBe("replacement-session");
+      expect(reopened.getEntries()).toEqual([replacementEntry]);
+      expect(parseCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("does not persist caller-side entry mutations into warm cache hits", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    const opened = SessionManager.open(sessionFile, dir, dir);
+    const returnedEntry = opened.getEntries()[0];
+    if (!returnedEntry || returnedEntry.type !== "message") {
+      throw new Error("expected message entry");
+    }
+    expect(() => {
+      (returnedEntry.message as { content: unknown }).content = "mutated only in caller";
+    }).toThrow(TypeError);
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getEntries().map((entry) => readMessageContent(entry))).toEqual([
+        "message 1",
+      ]);
+      expect(parseCount).toBe(0);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("invalidates the warm cache when another writer appends before this manager persists", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    const externalEntry = buildMessageEntry(2, firstEntry.id);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await fs.appendFile(sessionFile, `${JSON.stringify(externalEntry)}\n`, "utf8");
+    sessionManager.appendMessage(buildAssistantMessage("message 3"));
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getEntries().map((entry) => readMessageContent(entry))).toEqual([
+        "message 1",
+        "message 2",
+        "message 3",
+      ]);
+      expect(parseCount).toBeGreaterThanOrEqual(4);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
 });
+
+function readMessageContent(entry: SessionEntry): unknown {
+  const content = (entry as { message: { content: unknown } }).message.content;
+  if (Array.isArray(content)) {
+    return content.map((part) => (part as { text?: string }).text ?? "").join("");
+  }
+  return content;
+}
+
+function buildAssistantMessage(text: string) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "messages" as const,
+    provider: "anthropic" as const,
+    model: "sonnet-4.6" as const,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  };
+}
+
+function buildSessionHeader(cwd: string, id = "test-session") {
+  return {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id,
+    timestamp: "2026-06-04T00:00:00.000Z",
+    cwd,
+  };
+}
+
+function buildMessageEntry(index: number, parentId: string | null): SessionEntry {
+  return {
+    type: "message",
+    id: `entry-${index}`,
+    parentId,
+    timestamp: `2026-06-04T00:00:0${index}.000Z`,
+    message: { role: "user", content: `message ${index}`, timestamp: index },
+  };
+}

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -1,10 +1,13 @@
 // Session manager tests cover JSONL recovery behavior for interrupted or
 // corrupted transcript writes.
+import { writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
+import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import {
   CURRENT_SESSION_VERSION,
   loadEntriesFromFile,
@@ -185,10 +188,7 @@ describe("SessionManager.open", () => {
     } as typeof JSON.parse;
 
     try {
-      expect(loadEntriesFromFile(sessionFile).map((entry) => entry.type)).toEqual([
-        "session",
-        "message",
-      ]);
+      expect(SessionManager.open(sessionFile, dir, dir).getEntries()).toEqual([firstEntry]);
       expect(parseCount).toBe(2);
 
       parseCount = 0;
@@ -196,7 +196,15 @@ describe("SessionManager.open", () => {
       expect(parseCount).toBe(0);
 
       const sessionManager = SessionManager.open(sessionFile, dir, dir);
-      sessionManager.appendMessage(secondMessage);
+      await withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          withSessionWriteLock: async (run) => await run(),
+        },
+        async () => {
+          sessionManager.appendMessage(secondMessage);
+        },
+      );
       const persistedEntries = (await fs.readFile(sessionFile, "utf8"))
         .trim()
         .split("\n")
@@ -217,6 +225,63 @@ describe("SessionManager.open", () => {
     } finally {
       JSON.parse = originalParse;
     }
+  });
+
+  it("invalidates warm entries after an append outside the owned write context", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    sessionManager.appendMessage(buildAssistantMessage("message 2"));
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+
+    try {
+      expect(
+        SessionManager.open(sessionFile, dir, dir)
+          .getEntries()
+          .map((entry) => readMessageContent(entry)),
+      ).toEqual(["message 1", "message 2"]);
+      expect(parseCount).toBeGreaterThanOrEqual(3);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("keeps the exported file loader mutable and separate from warm SessionManager entries", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+
+    const loaded = loadEntriesFromFile(sessionFile);
+    const messageEntry = loaded[1];
+    if (!messageEntry || messageEntry.type !== "message") {
+      throw new Error("expected message entry");
+    }
+    (messageEntry.message as { content: unknown }).content = "caller-owned mutation";
+
+    expect(readMessageContent(messageEntry)).toBe("caller-owned mutation");
+    expect(
+      SessionManager.open(sessionFile, dir, dir)
+        .getEntries()
+        .map((entry) => readMessageContent(entry)),
+    ).toEqual(["message 1"]);
   });
 
   it("invalidates the transcript entry cache when the file is externally replaced", async () => {
@@ -256,6 +321,72 @@ describe("SessionManager.open", () => {
     }
   });
 
+  it("revalidates a transcript changed while the initial load is parsing", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    const replacementEntry = buildMessageEntry(2, null);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+    const replacementContent =
+      `${JSON.stringify(buildSessionHeader(dir, "intermediate-session"))}\n` +
+      `${JSON.stringify(replacementEntry)}\n`;
+    const finalEntry = buildMessageEntry(3, null);
+    const finalContent =
+      `${JSON.stringify(buildSessionHeader(dir, "replacement-session"))}\n` +
+      `${JSON.stringify(finalEntry)}\n`;
+
+    const originalParse = JSON.parse;
+    let replacementCount = 0;
+    JSON.parse = function replaceDuringParse(...args: Parameters<typeof JSON.parse>) {
+      const parsed = originalParse.apply(originalParse, args);
+      if (replacementCount === 0) {
+        replacementCount += 1;
+        writeFileSync(sessionFile, replacementContent, "utf8");
+      } else if (replacementCount === 1 && args[0].includes("intermediate-session")) {
+        replacementCount += 1;
+        writeFileSync(sessionFile, finalContent, "utf8");
+      }
+      return parsed;
+    } as typeof JSON.parse;
+
+    try {
+      const reopened = SessionManager.open(sessionFile, dir, dir);
+      expect(reopened.getSessionId()).toBe("replacement-session");
+      expect(reopened.getEntries()).toEqual([finalEntry]);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("does not cache manager entries over a same-length external replacement", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = buildMessageEntry(1, null);
+    const replacementEntry = {
+      ...buildMessageEntry(2, null),
+      id: firstEntry.id,
+    };
+    const header = buildSessionHeader(dir);
+    const originalContent = `${JSON.stringify(header)}\n${JSON.stringify(firstEntry)}\n`;
+    const replacementContent = `${JSON.stringify(header)}\n${JSON.stringify(replacementEntry)}\n`;
+    expect(Buffer.byteLength(replacementContent)).toBe(Buffer.byteLength(originalContent));
+    await fs.writeFile(sessionFile, originalContent, "utf8");
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await fs.writeFile(sessionFile, replacementContent, "utf8");
+    sessionManager.syncSnapshotAfterHeaderRewrite();
+
+    expect(
+      SessionManager.open(sessionFile, dir, dir)
+        .getEntries()
+        .map((entry) => readMessageContent(entry)),
+    ).toEqual(["message 2"]);
+  });
+
   it("does not persist caller-side entry mutations into warm cache hits", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");
@@ -291,6 +422,31 @@ describe("SessionManager.open", () => {
     } finally {
       JSON.parse = originalParse;
     }
+  });
+
+  it("keeps current-version entries immutable when the transcript exceeds the cache limit", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const hugeEntry = buildMessageEntry(1, null);
+    if (hugeEntry.type !== "message") {
+      throw new Error("expected message entry fixture");
+    }
+    hugeEntry.message.content = "x".repeat(33 * 1024 * 1024);
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(hugeEntry)}\n`,
+      "utf8",
+    );
+
+    const opened = SessionManager.open(sessionFile, dir, dir);
+    const returnedEntry = opened.getEntries()[0];
+    if (!returnedEntry || returnedEntry.type !== "message") {
+      throw new Error("expected message entry");
+    }
+
+    expect(() => {
+      (returnedEntry.message as { content: unknown }).content = "mutated";
+    }).toThrow(TypeError);
   });
 
   it("invalidates the warm cache when another writer appends before this manager persists", async () => {
@@ -427,7 +583,15 @@ describe("SessionManager.open", () => {
 
     // First append after the embedded header rewrite. Before the fix the stale
     // snapshot made this drop the warm cache.
-    sessionManager.appendMessage(buildAssistantMessage("after rewrite"));
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        withSessionWriteLock: async (run) => await run(),
+      },
+      async () => {
+        sessionManager.appendMessage(buildAssistantMessage("after rewrite"));
+      },
+    );
 
     const originalParse = JSON.parse;
     let parseCount = 0;
@@ -449,6 +613,80 @@ describe("SessionManager.open", () => {
       JSON.parse = originalParse;
     }
   });
+
+  it("invalidates incremental repair state after a full header rewrite", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const firstEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: buildAssistantMessage("message 1"),
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(firstEntry)}\n`,
+      "utf8",
+    );
+    await repairSessionFileIfNeeded({ sessionFile });
+
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "longer-rewritten-session-id",
+      cwd: dir,
+    });
+
+    const originalParse = JSON.parse;
+    let parseCount = 0;
+    JSON.parse = function countedParse(...args: Parameters<typeof JSON.parse>) {
+      parseCount += 1;
+      return originalParse.apply(originalParse, args);
+    } as typeof JSON.parse;
+    try {
+      await repairSessionFileIfNeeded({
+        sessionFile,
+        trustedSnapshot: await readTrustedRepairSnapshot(sessionFile),
+      });
+      expect(parseCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      JSON.parse = originalParse;
+    }
+  });
+
+  it("does not rewrite a warm transcript when its header already matches the run", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const assistantEntry = {
+      type: "message",
+      id: "assistant-1",
+      parentId: null,
+      timestamp: "2026-06-04T00:00:01.000Z",
+      message: { role: "assistant", content: "carried context" },
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify(buildSessionHeader(dir))}\n${JSON.stringify(assistantEntry)}\n`,
+      "utf8",
+    );
+    await fs.utimes(sessionFile, new Date(1_000), new Date(1_000));
+    const before = await fs.stat(sessionFile);
+    const sessionManager = SessionManager.open(sessionFile, dir, dir);
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "test-session",
+      cwd: dir,
+    });
+
+    const after = await fs.stat(sessionFile);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
 });
 
 function readMessageContent(entry: SessionEntry): unknown {
@@ -457,6 +695,17 @@ function readMessageContent(entry: SessionEntry): unknown {
     return content.map((part) => (part as { text?: string }).text ?? "").join("");
   }
   return content;
+}
+
+async function readTrustedRepairSnapshot(sessionFile: string) {
+  const stat = await fs.stat(sessionFile, { bigint: true });
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mtimeNs: stat.mtimeNs,
+    ctimeNs: stat.ctimeNs,
+  };
 }
 
 function buildAssistantMessage(text: string) {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -20,10 +20,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   appendJsonlEntrySync,
-  serializeJsonlEntries,
+  appendSerializedJsonlEntrySync,
+  serializeJsonlEntry,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
-import { hasOwnedSessionTranscriptWriteContext } from "../../config/sessions/transcript-write-context.js";
+import { canAdvanceOwnedSessionEntryCache } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -557,7 +558,7 @@ function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
 
 function rememberWrittenSessionEntries(
   filePath: string,
-  entries: FileEntry[],
+  expectedContent?: string,
 ): SessionFileSnapshot | undefined {
   const resolvedPath = resolve(filePath);
   // Full rewrites break append continuity used by the pre-run repair cache,
@@ -575,7 +576,6 @@ function rememberWrittenSessionEntries(
     return beforeReadSnapshot;
   }
 
-  const expectedContent = serializeJsonlEntries(entries);
   let content: string;
   let afterReadSnapshot: SessionFileSnapshot;
   try {
@@ -586,7 +586,7 @@ function rememberWrittenSessionEntries(
     return undefined;
   }
   if (
-    content !== expectedContent ||
+    (expectedContent !== undefined && content !== expectedContent) ||
     !isSameSessionFileSnapshot(beforeReadSnapshot, afterReadSnapshot)
   ) {
     sessionEntriesCache.delete(resolvedPath);
@@ -611,6 +611,7 @@ function rememberAppendedSessionEntry(
   const resolvedPath = resolve(filePath);
   if (!cacheOwnedAppend) {
     sessionEntriesCache.delete(resolvedPath);
+    invalidateSessionFileRepairCache(resolvedPath);
     return readSessionFileSnapshotIfExists(resolvedPath);
   }
   if (
@@ -619,6 +620,7 @@ function rememberAppendedSessionEntry(
     !isSameSessionFileSnapshot(previousSnapshot, beforeAppendSnapshot)
   ) {
     sessionEntriesCache.delete(resolvedPath);
+    invalidateSessionFileRepairCache(resolvedPath);
     return readSessionFileSnapshotIfExists(resolvedPath);
   }
 
@@ -640,6 +642,7 @@ function rememberAppendedSessionEntry(
     !isSameSessionFileSnapshot(cached.snapshot, previousSnapshot)
   ) {
     sessionEntriesCache.delete(resolvedPath);
+    invalidateSessionFileRepairCache(resolvedPath);
     return snapshot;
   }
   if (snapshot.size > MAX_CACHED_SESSION_BYTES) {
@@ -1239,8 +1242,8 @@ export class SessionManager {
     if (!this.shouldPersist || !this.sessionFile) {
       return;
     }
-    writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
-    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+    const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
+    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, content);
   }
 
   isPersisted(): boolean {
@@ -1282,12 +1285,23 @@ export class SessionManager {
     }
 
     if (!this.flushed) {
-      writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
+      const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
       this.flushed = true;
-      this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+      this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, content);
     } else {
+      // Serialize before taking the prefix snapshot. Custom toJSON methods are
+      // user code and can mutate the transcript; the cache must validate the
+      // prefix state that immediately precedes the exact bytes being appended.
+      const serializedEntry = serializeJsonlEntry(entry);
       const beforeAppendSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
-      const serializedAppend = appendJsonlEntrySync(this.sessionFile, entry, {
+      const cacheOwnedAppend = Boolean(
+        beforeAppendSnapshot &&
+        canAdvanceOwnedSessionEntryCache({
+          sessionFile: this.sessionFile,
+          snapshot: beforeAppendSnapshot,
+        }),
+      );
+      const serializedAppend = appendSerializedJsonlEntrySync(this.sessionFile, serializedEntry, {
         prefixNewline: sessionFileNeedsAppendSeparator(this.sessionFile, beforeAppendSnapshot),
       });
       this.sessionFileSnapshot = rememberAppendedSessionEntry(
@@ -1295,7 +1309,7 @@ export class SessionManager {
         this.sessionFileSnapshot,
         beforeAppendSnapshot,
         serializedAppend,
-        hasOwnedSessionTranscriptWriteContext({ sessionFile: this.sessionFile }),
+        cacheOwnedAppend,
       );
     }
   }
@@ -1312,7 +1326,7 @@ export class SessionManager {
     if (!this.sessionFile) {
       return;
     }
-    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile);
   }
 
   private appendEntry(entry: SessionEntry): void {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -20,8 +20,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   appendJsonlEntrySync,
+  serializeJsonlEntries,
+  serializeJsonlEntry,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
+import { hasOwnedSessionTranscriptWriteContext } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -31,6 +34,7 @@ import {
   type SessionTreeEntry as CoreSessionTreeEntry,
   uuidv7,
 } from "../runtime/index.js";
+import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 
 export { CURRENT_SESSION_VERSION };
@@ -389,7 +393,12 @@ export function getDefaultSessionDir(cwd: string, agentDir: string = getDefaultA
 
 /** Exported for testing */
 export function loadEntriesFromFile(filePath: string): FileEntry[] {
-  return loadEntriesFromFileWithSnapshot(filePath).entries;
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  const entries = parseJsonlEntries(readFileSync(filePath, "utf8"));
+  return hasReadableSessionHeader(entries) ? entries : [];
 }
 
 function loadEntriesFromFileWithSnapshot(filePath: string): {
@@ -397,22 +406,37 @@ function loadEntriesFromFileWithSnapshot(filePath: string): {
   snapshot: SessionFileSnapshot | undefined;
 } {
   const resolvedPath = resolve(filePath);
-  let snapshot: SessionFileSnapshot;
-  try {
-    snapshot = readSessionFileSnapshot(resolvedPath);
-  } catch {
-    sessionEntriesCache.delete(resolvedPath);
-    return { entries: [], snapshot: undefined };
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let beforeReadSnapshot: SessionFileSnapshot;
+    try {
+      beforeReadSnapshot = readSessionFileSnapshot(resolvedPath);
+    } catch {
+      sessionEntriesCache.delete(resolvedPath);
+      return { entries: [], snapshot: undefined };
+    }
+
+    const cached = sessionEntriesCache.get(resolvedPath);
+    if (cached && isSameSessionFileSnapshot(cached.snapshot, beforeReadSnapshot)) {
+      const afterCacheSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
+      if (afterCacheSnapshot && isSameSessionFileSnapshot(beforeReadSnapshot, afterCacheSnapshot)) {
+        return { entries: copyFileEntries(cached.entries), snapshot: afterCacheSnapshot };
+      }
+      continue;
+    }
+
+    const content = readFileSync(resolvedPath, "utf8");
+    const entries = parseJsonlEntries(content);
+    const afterParseSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
+    if (afterParseSnapshot && isSameSessionFileSnapshot(beforeReadSnapshot, afterParseSnapshot)) {
+      return {
+        entries: rememberSessionEntries(resolvedPath, afterParseSnapshot, entries),
+        snapshot: afterParseSnapshot,
+      };
+    }
   }
 
-  const cached = sessionEntriesCache.get(resolvedPath);
-  if (cached && isSameSessionFileSnapshot(cached.snapshot, snapshot)) {
-    return { entries: copyFileEntries(cached.entries), snapshot };
-  }
-
-  const content = readFileSync(resolvedPath, "utf8");
-  const entries = parseJsonlEntries(content);
-  return { entries: rememberSessionEntries(resolvedPath, snapshot, entries), snapshot };
+  sessionEntriesCache.delete(resolvedPath);
+  throw new Error(`session file changed repeatedly while loading: ${resolvedPath}`);
 }
 
 interface SessionFileSnapshot {
@@ -429,6 +453,9 @@ interface CachedSessionEntries {
 }
 
 const MAX_CACHED_SESSION_FILES = 8;
+// Bound approximate retained payload bytes as well as file count; parsed JSON
+// has higher overhead than the transcript bytes used for this conservative cap.
+const MAX_CACHED_SESSION_BYTES = 32n * 1024n * 1024n;
 const sessionEntriesCache = new Map<string, CachedSessionEntries>();
 
 function readSessionFileSnapshot(filePath: string): SessionFileSnapshot {
@@ -456,7 +483,7 @@ function rememberSessionEntries(
   filePath: string,
   snapshot: SessionFileSnapshot,
   entries: FileEntry[],
-  cloneForCache = false,
+  copyMutableEntries = false,
 ): FileEntry[] {
   if (!hasReadableSessionHeader(entries)) {
     sessionEntriesCache.delete(filePath);
@@ -468,25 +495,46 @@ function rememberSessionEntries(
     sessionEntriesCache.delete(filePath);
     return entries;
   }
+  if (snapshot.size > MAX_CACHED_SESSION_BYTES) {
+    sessionEntriesCache.delete(filePath);
+    return copyFileEntries(entries.map(freezeFileEntry));
+  }
 
   // Current-version session entries are append-only after load. Freeze the
   // cached snapshot so warm hits cannot drift away from the file metadata that
   // validated the cache key.
-  const cachedEntries = freezeFileEntries(cloneForCache ? entries.map(cloneFileEntry) : entries);
+  const cachedEntries = entries.map((entry) => {
+    if (Object.isFrozen(entry)) {
+      return entry;
+    }
+    return freezeFileEntry(copyMutableEntries ? cloneFileEntry(entry) : entry);
+  });
   const cached: CachedSessionEntries = {
     snapshot,
     entries: cachedEntries,
   };
   sessionEntriesCache.delete(filePath);
   sessionEntriesCache.set(filePath, cached);
-  while (sessionEntriesCache.size > MAX_CACHED_SESSION_FILES) {
+  trimSessionEntriesCache();
+  return copyFileEntries(cachedEntries);
+}
+
+function trimSessionEntriesCache(): void {
+  let cachedBytes = 0n;
+  for (const cached of sessionEntriesCache.values()) {
+    cachedBytes += cached.snapshot.size;
+  }
+  while (
+    sessionEntriesCache.size > MAX_CACHED_SESSION_FILES ||
+    cachedBytes > MAX_CACHED_SESSION_BYTES
+  ) {
     const oldestKey = sessionEntriesCache.keys().next().value;
     if (!oldestKey) {
       break;
     }
+    cachedBytes -= sessionEntriesCache.get(oldestKey)?.snapshot.size ?? 0n;
     sessionEntriesCache.delete(oldestKey);
   }
-  return copyFileEntries(cachedEntries);
 }
 
 function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
@@ -501,16 +549,45 @@ function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
   return header.version === CURRENT_SESSION_VERSION;
 }
 
-function rememberWrittenSessionEntries(filePath: string, entries: FileEntry[]): void {
+function rememberWrittenSessionEntries(
+  filePath: string,
+  entries: FileEntry[],
+): SessionFileSnapshot | undefined {
   const resolvedPath = resolve(filePath);
-  let snapshot: SessionFileSnapshot;
+  // Full rewrites break append continuity used by the pre-run repair cache,
+  // even when the filesystem preserves the inode and the rewritten file grows.
+  invalidateSessionFileRepairCache(resolvedPath);
+  let beforeReadSnapshot: SessionFileSnapshot;
   try {
-    snapshot = readSessionFileSnapshot(resolvedPath);
+    beforeReadSnapshot = readSessionFileSnapshot(resolvedPath);
   } catch {
     sessionEntriesCache.delete(resolvedPath);
-    return;
+    return undefined;
   }
-  rememberSessionEntries(resolvedPath, snapshot, entries, true);
+  if (beforeReadSnapshot.size > MAX_CACHED_SESSION_BYTES) {
+    sessionEntriesCache.delete(resolvedPath);
+    return beforeReadSnapshot;
+  }
+
+  const expectedContent = serializeJsonlEntries(entries);
+  let content: string;
+  let afterReadSnapshot: SessionFileSnapshot;
+  try {
+    content = readFileSync(resolvedPath, "utf8");
+    afterReadSnapshot = readSessionFileSnapshot(resolvedPath);
+  } catch {
+    sessionEntriesCache.delete(resolvedPath);
+    return undefined;
+  }
+  if (
+    content !== expectedContent ||
+    !isSameSessionFileSnapshot(beforeReadSnapshot, afterReadSnapshot)
+  ) {
+    sessionEntriesCache.delete(resolvedPath);
+    return afterReadSnapshot;
+  }
+  rememberSessionEntries(resolvedPath, afterReadSnapshot, entries, true);
+  return afterReadSnapshot;
 }
 
 function rememberAppendedSessionEntry(
@@ -518,8 +595,13 @@ function rememberAppendedSessionEntry(
   previousSnapshot: SessionFileSnapshot | undefined,
   beforeAppendSnapshot: SessionFileSnapshot | undefined,
   entry: FileEntry,
+  cacheOwnedAppend: boolean,
 ): SessionFileSnapshot | undefined {
   const resolvedPath = resolve(filePath);
+  if (!cacheOwnedAppend) {
+    sessionEntriesCache.delete(resolvedPath);
+    return readSessionFileSnapshotIfExists(resolvedPath);
+  }
   if (
     !previousSnapshot ||
     !beforeAppendSnapshot ||
@@ -531,7 +613,21 @@ function rememberAppendedSessionEntry(
 
   const cached = sessionEntriesCache.get(resolvedPath);
   const snapshot = readSessionFileSnapshotIfExists(resolvedPath);
-  if (!snapshot || !cached || !isSameSessionFileSnapshot(cached.snapshot, previousSnapshot)) {
+  // Owned transcript writes serialize appenders under the session lock. Full
+  // rewrites refresh the cache explicitly, so identity and size are sufficient
+  // to advance this append-only snapshot without reading the whole file.
+  const expectedSize =
+    beforeAppendSnapshot.size + BigInt(Buffer.byteLength(serializeJsonlEntry(entry), "utf8"));
+  if (
+    !snapshot ||
+    !cached ||
+    cached.snapshot.dev !== previousSnapshot.dev ||
+    cached.snapshot.ino !== previousSnapshot.ino ||
+    snapshot.dev !== beforeAppendSnapshot.dev ||
+    snapshot.ino !== beforeAppendSnapshot.ino ||
+    snapshot.size !== expectedSize ||
+    !isSameSessionFileSnapshot(cached.snapshot, previousSnapshot)
+  ) {
     sessionEntriesCache.delete(resolvedPath);
     return snapshot;
   }
@@ -540,6 +636,7 @@ function rememberAppendedSessionEntry(
   cached.snapshot = snapshot;
   sessionEntriesCache.delete(resolvedPath);
   sessionEntriesCache.set(resolvedPath, cached);
+  trimSessionEntriesCache();
   return snapshot;
 }
 
@@ -549,6 +646,30 @@ function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot 
   } catch {
     return undefined;
   }
+}
+
+function revalidateLoadedSessionFile(
+  filePath: string,
+  loaded: {
+    entries: FileEntry[];
+    snapshot: SessionFileSnapshot | undefined;
+  },
+): {
+  entries: FileEntry[];
+  snapshot: SessionFileSnapshot | undefined;
+} {
+  const currentSnapshot = readSessionFileSnapshotIfExists(resolve(filePath));
+  if (
+    loaded.snapshot &&
+    currentSnapshot &&
+    isSameSessionFileSnapshot(loaded.snapshot, currentSnapshot)
+  ) {
+    return loaded;
+  }
+  if (!loaded.snapshot && !currentSnapshot) {
+    return loaded;
+  }
+  return loadEntriesFromFileWithSnapshot(filePath);
 }
 
 // Cached entries are deep-frozen so warm hits cannot drift from the file bytes
@@ -568,13 +689,6 @@ function copyFileEntries(entries: readonly FileEntry[]): FileEntry[] {
 
 function cloneFileEntry(entry: FileEntry): FileEntry {
   return structuredClone(entry);
-}
-
-function freezeFileEntries(entries: FileEntry[]): FileEntry[] {
-  for (const entry of entries) {
-    freezeJsonLikeValue(entry);
-  }
-  return entries;
 }
 
 function freezeFileEntry(entry: FileEntry): FileEntry {
@@ -949,6 +1063,10 @@ export class SessionManager {
     sessionDir: string,
     sessionFile: string | undefined,
     persist: boolean,
+    loadedSessionFile?: {
+      entries: FileEntry[];
+      snapshot: SessionFileSnapshot | undefined;
+    },
   ) {
     this.cwd = cwd;
     this.sessionDir = sessionDir;
@@ -958,7 +1076,10 @@ export class SessionManager {
     }
 
     if (sessionFile) {
-      this.setSessionFile(sessionFile);
+      this.setLoadedSessionFile(
+        sessionFile,
+        loadedSessionFile ?? loadEntriesFromFileWithSnapshot(sessionFile),
+      );
     } else {
       this.newSession();
     }
@@ -966,11 +1087,20 @@ export class SessionManager {
 
   /** Switch to a different session file (used for resume and branching) */
   setSessionFile(sessionFile: string): void {
+    this.setLoadedSessionFile(sessionFile, loadEntriesFromFileWithSnapshot(sessionFile));
+  }
+
+  private setLoadedSessionFile(
+    sessionFile: string,
+    loaded: {
+      entries: FileEntry[];
+      snapshot: SessionFileSnapshot | undefined;
+    },
+  ): void {
     this.sessionFile = resolve(sessionFile);
     this.sessionFileSnapshot = undefined;
     this.recoveredCorruptHeader = false;
     if (existsSync(this.sessionFile)) {
-      const loaded = loadEntriesFromFileWithSnapshot(this.sessionFile);
       this.fileEntries = loaded.entries;
       this.sessionFileSnapshot = loaded.snapshot;
 
@@ -1067,8 +1197,7 @@ export class SessionManager {
       return;
     }
     writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
-    rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
-    this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
+    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
   }
 
   isPersisted(): boolean {
@@ -1112,8 +1241,7 @@ export class SessionManager {
     if (!this.flushed) {
       writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
       this.flushed = true;
-      rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
-      this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
+      this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
     } else {
       const beforeAppendSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
       appendJsonlEntrySync(this.sessionFile, entry);
@@ -1122,6 +1250,7 @@ export class SessionManager {
         this.sessionFileSnapshot,
         beforeAppendSnapshot,
         entry,
+        hasOwnedSessionTranscriptWriteContext({ sessionFile: this.sessionFile }),
       );
     }
   }
@@ -1138,8 +1267,7 @@ export class SessionManager {
     if (!this.sessionFile) {
       return;
     }
-    rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
-    this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
+    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
   }
 
   private appendEntry(entry: SessionEntry): void {
@@ -1612,13 +1740,15 @@ export class SessionManager {
    * @param cwdOverride Optional cwd override instead of the session header cwd.
    */
   static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
-    // Extract cwd from session header if possible, otherwise use process.cwd()
-    const entries = loadEntriesFromFile(path);
-    const header = entries.find((e) => e.type === "session");
+    // Re-stat before construction so the single parsed load cannot become
+    // stale while deriving cwd/session metadata. Stable warm opens pay only
+    // the extra stat; changed files retry through the normal loader.
+    const loaded = revalidateLoadedSessionFile(path, loadEntriesFromFileWithSnapshot(path));
+    const header = loaded.entries.find((e) => e.type === "session");
     const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
     // If no sessionDir provided, derive from file's parent directory
     const dir = sessionDir ?? resolve(path, "..");
-    return new SessionManager(cwd, dir, path, true);
+    return new SessionManager(cwd, dir, path, true, loaded);
   }
 
   /**

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -483,7 +483,6 @@ function rememberSessionEntries(
   filePath: string,
   snapshot: SessionFileSnapshot,
   entries: FileEntry[],
-  copyMutableEntries = false,
 ): FileEntry[] {
   if (!hasReadableSessionHeader(entries)) {
     sessionEntriesCache.delete(filePath);
@@ -507,7 +506,7 @@ function rememberSessionEntries(
     if (Object.isFrozen(entry)) {
       return entry;
     }
-    return freezeFileEntry(copyMutableEntries ? cloneFileEntry(entry) : entry);
+    return freezeFileEntry(entry);
   });
   const cached: CachedSessionEntries = {
     snapshot,
@@ -586,7 +585,7 @@ function rememberWrittenSessionEntries(
     sessionEntriesCache.delete(resolvedPath);
     return afterReadSnapshot;
   }
-  rememberSessionEntries(resolvedPath, afterReadSnapshot, entries, true);
+  rememberSessionEntries(resolvedPath, afterReadSnapshot, parseJsonlEntries(content));
   return afterReadSnapshot;
 }
 
@@ -631,8 +630,13 @@ function rememberAppendedSessionEntry(
     sessionEntriesCache.delete(resolvedPath);
     return snapshot;
   }
+  if (snapshot.size > MAX_CACHED_SESSION_BYTES) {
+    sessionEntriesCache.delete(resolvedPath);
+    return snapshot;
+  }
 
-  cached.entries.push(freezeFileEntry(cloneFileEntry(entry)));
+  const persistedEntry = JSON.parse(serializeJsonlEntry(entry)) as FileEntry;
+  cached.entries.push(freezeFileEntry(persistedEntry));
   cached.snapshot = snapshot;
   sessionEntriesCache.delete(resolvedPath);
   sessionEntriesCache.set(resolvedPath, cached);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -24,7 +24,10 @@ import {
   serializeJsonlEntry,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
-import { canAdvanceOwnedSessionEntryCache } from "../../config/sessions/transcript-write-context.js";
+import {
+  canAdvanceOwnedSessionEntryCache,
+  publishOwnedSessionFileSnapshot,
+} from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
@@ -559,7 +562,7 @@ function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
 function rememberWrittenSessionEntries(
   filePath: string,
   expectedContent?: string,
-): SessionFileSnapshot | undefined {
+): { snapshot: SessionFileSnapshot | undefined; verifiedWrite: boolean } {
   const resolvedPath = resolve(filePath);
   // Full rewrites break append continuity used by the pre-run repair cache,
   // even when the filesystem preserves the inode and the rewritten file grows.
@@ -569,11 +572,11 @@ function rememberWrittenSessionEntries(
     beforeReadSnapshot = readSessionFileSnapshot(resolvedPath);
   } catch {
     sessionEntriesCache.delete(resolvedPath);
-    return undefined;
+    return { snapshot: undefined, verifiedWrite: false };
   }
   if (beforeReadSnapshot.size > MAX_CACHED_SESSION_BYTES) {
     sessionEntriesCache.delete(resolvedPath);
-    return beforeReadSnapshot;
+    return { snapshot: beforeReadSnapshot, verifiedWrite: false };
   }
 
   let content: string;
@@ -583,14 +586,14 @@ function rememberWrittenSessionEntries(
     afterReadSnapshot = readSessionFileSnapshot(resolvedPath);
   } catch {
     sessionEntriesCache.delete(resolvedPath);
-    return undefined;
+    return { snapshot: undefined, verifiedWrite: false };
   }
   if (
     (expectedContent !== undefined && content !== expectedContent) ||
     !isSameSessionFileSnapshot(beforeReadSnapshot, afterReadSnapshot)
   ) {
     sessionEntriesCache.delete(resolvedPath);
-    return afterReadSnapshot;
+    return { snapshot: afterReadSnapshot, verifiedWrite: false };
   }
   rememberSessionEntries(
     resolvedPath,
@@ -598,7 +601,10 @@ function rememberWrittenSessionEntries(
     parseJsonlEntries(content),
     content.endsWith("\n"),
   );
-  return afterReadSnapshot;
+  return {
+    snapshot: afterReadSnapshot,
+    verifiedWrite: expectedContent !== undefined,
+  };
 }
 
 function rememberAppendedSessionEntry(
@@ -607,12 +613,15 @@ function rememberAppendedSessionEntry(
   beforeAppendSnapshot: SessionFileSnapshot | undefined,
   serializedAppend: string,
   cacheOwnedAppend: boolean,
-): SessionFileSnapshot | undefined {
+): { snapshot: SessionFileSnapshot | undefined; cacheAdvanced: boolean } {
   const resolvedPath = resolve(filePath);
   if (!cacheOwnedAppend) {
     sessionEntriesCache.delete(resolvedPath);
     invalidateSessionFileRepairCache(resolvedPath);
-    return readSessionFileSnapshotIfExists(resolvedPath);
+    return {
+      snapshot: readSessionFileSnapshotIfExists(resolvedPath),
+      cacheAdvanced: false,
+    };
   }
   if (
     !previousSnapshot ||
@@ -621,7 +630,10 @@ function rememberAppendedSessionEntry(
   ) {
     sessionEntriesCache.delete(resolvedPath);
     invalidateSessionFileRepairCache(resolvedPath);
-    return readSessionFileSnapshotIfExists(resolvedPath);
+    return {
+      snapshot: readSessionFileSnapshotIfExists(resolvedPath),
+      cacheAdvanced: false,
+    };
   }
 
   const cached = sessionEntriesCache.get(resolvedPath);
@@ -643,11 +655,11 @@ function rememberAppendedSessionEntry(
   ) {
     sessionEntriesCache.delete(resolvedPath);
     invalidateSessionFileRepairCache(resolvedPath);
-    return snapshot;
+    return { snapshot, cacheAdvanced: false };
   }
   if (snapshot.size > MAX_CACHED_SESSION_BYTES) {
     sessionEntriesCache.delete(resolvedPath);
-    return snapshot;
+    return { snapshot, cacheAdvanced: false };
   }
 
   const persistedEntry = JSON.parse(
@@ -659,7 +671,21 @@ function rememberAppendedSessionEntry(
   sessionEntriesCache.delete(resolvedPath);
   sessionEntriesCache.set(resolvedPath, cached);
   trimSessionEntriesCache();
-  return snapshot;
+  return { snapshot, cacheAdvanced: true };
+}
+
+function publishRememberedSessionFileSnapshot(
+  filePath: string,
+  snapshot: SessionFileSnapshot | undefined,
+): void {
+  if (!snapshot) {
+    return;
+  }
+  const published = publishOwnedSessionFileSnapshot({ sessionFile: filePath, snapshot });
+  if (published === false) {
+    sessionEntriesCache.delete(resolve(filePath));
+    invalidateSessionFileRepairCache(filePath);
+  }
 }
 
 function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot | undefined {
@@ -1243,7 +1269,11 @@ export class SessionManager {
       return;
     }
     const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
-    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, content);
+    const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
+    this.sessionFileSnapshot = rememberedWrite.snapshot;
+    if (rememberedWrite.verifiedWrite) {
+      publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
+    }
   }
 
   isPersisted(): boolean {
@@ -1287,7 +1317,11 @@ export class SessionManager {
     if (!this.flushed) {
       const content = writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
       this.flushed = true;
-      this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, content);
+      const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, content);
+      this.sessionFileSnapshot = rememberedWrite.snapshot;
+      if (rememberedWrite.verifiedWrite) {
+        publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
+      }
     } else {
       // Serialize before taking the prefix snapshot. Custom toJSON methods are
       // user code and can mutate the transcript; the cache must validate the
@@ -1304,13 +1338,17 @@ export class SessionManager {
       const serializedAppend = appendSerializedJsonlEntrySync(this.sessionFile, serializedEntry, {
         prefixNewline: sessionFileNeedsAppendSeparator(this.sessionFile, beforeAppendSnapshot),
       });
-      this.sessionFileSnapshot = rememberAppendedSessionEntry(
+      const rememberedAppend = rememberAppendedSessionEntry(
         this.sessionFile,
         this.sessionFileSnapshot,
         beforeAppendSnapshot,
         serializedAppend,
         cacheOwnedAppend,
       );
+      this.sessionFileSnapshot = rememberedAppend.snapshot;
+      if (rememberedAppend.cacheAdvanced) {
+        publishRememberedSessionFileSnapshot(this.sessionFile, rememberedAppend.snapshot);
+      }
     }
   }
 
@@ -1322,11 +1360,15 @@ export class SessionManager {
    * snapshot-mismatch branch in rememberAppendedSessionEntry, drops the warm
    * cache, and the next open reparses the whole transcript.
    */
-  syncSnapshotAfterHeaderRewrite(): void {
+  syncSnapshotAfterHeaderRewrite(expectedContent?: string): void {
     if (!this.sessionFile) {
       return;
     }
-    this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile);
+    const rememberedWrite = rememberWrittenSessionEntries(this.sessionFile, expectedContent);
+    this.sessionFileSnapshot = rememberedWrite.snapshot;
+    if (rememberedWrite.verifiedWrite) {
+      publishRememberedSessionFileSnapshot(this.sessionFile, rememberedWrite.snapshot);
+    }
   }
 
   private appendEntry(entry: SessionEntry): void {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -389,23 +389,206 @@ export function getDefaultSessionDir(cwd: string, agentDir: string = getDefaultA
 
 /** Exported for testing */
 export function loadEntriesFromFile(filePath: string): FileEntry[] {
-  if (!existsSync(filePath)) {
-    return [];
+  return loadEntriesFromFileWithSnapshot(filePath).entries;
+}
+
+function loadEntriesFromFileWithSnapshot(filePath: string): {
+  entries: FileEntry[];
+  snapshot: SessionFileSnapshot | undefined;
+} {
+  const resolvedPath = resolve(filePath);
+  let snapshot: SessionFileSnapshot;
+  try {
+    snapshot = readSessionFileSnapshot(resolvedPath);
+  } catch {
+    sessionEntriesCache.delete(resolvedPath);
+    return { entries: [], snapshot: undefined };
   }
 
-  const content = readFileSync(filePath, "utf8");
-  const entries = parseJsonlEntries(content);
+  const cached = sessionEntriesCache.get(resolvedPath);
+  if (cached && isSameSessionFileSnapshot(cached.snapshot, snapshot)) {
+    return { entries: copyFileEntries(cached.entries), snapshot };
+  }
 
-  // Validate session header
-  if (entries.length === 0) {
+  const content = readFileSync(resolvedPath, "utf8");
+  const entries = parseJsonlEntries(content);
+  return { entries: rememberSessionEntries(resolvedPath, snapshot, entries), snapshot };
+}
+
+interface SessionFileSnapshot {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+}
+
+interface CachedSessionEntries {
+  snapshot: SessionFileSnapshot;
+  entries: FileEntry[];
+}
+
+const MAX_CACHED_SESSION_FILES = 8;
+const sessionEntriesCache = new Map<string, CachedSessionEntries>();
+
+function readSessionFileSnapshot(filePath: string): SessionFileSnapshot {
+  const fileStat = statSync(filePath, { bigint: true });
+  return {
+    dev: fileStat.dev,
+    ino: fileStat.ino,
+    size: fileStat.size,
+    mtimeNs: fileStat.mtimeNs,
+    ctimeNs: fileStat.ctimeNs,
+  };
+}
+
+function isSameSessionFileSnapshot(left: SessionFileSnapshot, right: SessionFileSnapshot): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function rememberSessionEntries(
+  filePath: string,
+  snapshot: SessionFileSnapshot,
+  entries: FileEntry[],
+  cloneForCache = false,
+): FileEntry[] {
+  if (!hasReadableSessionHeader(entries)) {
+    sessionEntriesCache.delete(filePath);
+    return entries.length === 0 ? entries : [];
+  }
+  // Cache only current transcripts. Older versions still go through migration
+  // with fresh mutable entries so cache hits never share objects that migrate.
+  if (!hasCacheableSessionHeader(entries)) {
+    sessionEntriesCache.delete(filePath);
     return entries;
+  }
+
+  // Current-version session entries are append-only after load. Freeze the
+  // cached snapshot so warm hits cannot drift away from the file metadata that
+  // validated the cache key.
+  const cachedEntries = freezeFileEntries(cloneForCache ? entries.map(cloneFileEntry) : entries);
+  const cached: CachedSessionEntries = {
+    snapshot,
+    entries: cachedEntries,
+  };
+  sessionEntriesCache.delete(filePath);
+  sessionEntriesCache.set(filePath, cached);
+  while (sessionEntriesCache.size > MAX_CACHED_SESSION_FILES) {
+    const oldestKey = sessionEntriesCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    sessionEntriesCache.delete(oldestKey);
+  }
+  return copyFileEntries(cachedEntries);
+}
+
+function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
+  if (entries.length === 0) {
+    return true;
   }
   const header = entries[0];
   if (header.type !== "session" || typeof (header as { id?: unknown }).id !== "string") {
-    return [];
+    return false;
   }
 
+  return header.version === CURRENT_SESSION_VERSION;
+}
+
+function rememberWrittenSessionEntries(filePath: string, entries: FileEntry[]): void {
+  const resolvedPath = resolve(filePath);
+  let snapshot: SessionFileSnapshot;
+  try {
+    snapshot = readSessionFileSnapshot(resolvedPath);
+  } catch {
+    sessionEntriesCache.delete(resolvedPath);
+    return;
+  }
+  rememberSessionEntries(resolvedPath, snapshot, entries, true);
+}
+
+function rememberAppendedSessionEntry(
+  filePath: string,
+  previousSnapshot: SessionFileSnapshot | undefined,
+  beforeAppendSnapshot: SessionFileSnapshot | undefined,
+  entry: FileEntry,
+): SessionFileSnapshot | undefined {
+  const resolvedPath = resolve(filePath);
+  if (
+    !previousSnapshot ||
+    !beforeAppendSnapshot ||
+    !isSameSessionFileSnapshot(previousSnapshot, beforeAppendSnapshot)
+  ) {
+    sessionEntriesCache.delete(resolvedPath);
+    return readSessionFileSnapshotIfExists(resolvedPath);
+  }
+
+  const cached = sessionEntriesCache.get(resolvedPath);
+  const snapshot = readSessionFileSnapshotIfExists(resolvedPath);
+  if (!snapshot || !cached || !isSameSessionFileSnapshot(cached.snapshot, previousSnapshot)) {
+    sessionEntriesCache.delete(resolvedPath);
+    return snapshot;
+  }
+
+  cached.entries.push(freezeFileEntry(cloneFileEntry(entry)));
+  cached.snapshot = snapshot;
+  sessionEntriesCache.delete(resolvedPath);
+  sessionEntriesCache.set(resolvedPath, cached);
+  return snapshot;
+}
+
+function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot | undefined {
+  try {
+    return readSessionFileSnapshot(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function copyFileEntries(entries: readonly FileEntry[]): FileEntry[] {
+  return entries.slice();
+}
+
+function cloneFileEntry(entry: FileEntry): FileEntry {
+  return structuredClone(entry);
+}
+
+function freezeFileEntries(entries: FileEntry[]): FileEntry[] {
+  for (const entry of entries) {
+    freezeJsonLikeValue(entry);
+  }
   return entries;
+}
+
+function freezeFileEntry(entry: FileEntry): FileEntry {
+  freezeJsonLikeValue(entry);
+  return entry;
+}
+
+// The cache key proves only the file bytes at a specific stat snapshot. Freezing
+// cached JSONL objects prevents caller mutations from creating transcript state
+// that was never read from or written to disk.
+function freezeJsonLikeValue(value: unknown, seen = new WeakSet<object>()): void {
+  if (typeof value !== "object" || value === null || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      freezeJsonLikeValue(item, seen);
+    }
+  } else {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      freezeJsonLikeValue(item, seen);
+    }
+  }
+  Object.freeze(value);
 }
 
 function parseJsonlEntries(content: string): FileEntry[] {
@@ -748,6 +931,7 @@ export class SessionManager {
   private labelTimestampsById: Map<string, string> = new Map();
   private leafId: string | null = null;
   private recoveredCorruptHeader = false;
+  private sessionFileSnapshot: SessionFileSnapshot | undefined;
 
   private constructor(
     cwd: string,
@@ -772,9 +956,12 @@ export class SessionManager {
   /** Switch to a different session file (used for resume and branching) */
   setSessionFile(sessionFile: string): void {
     this.sessionFile = resolve(sessionFile);
+    this.sessionFileSnapshot = undefined;
     this.recoveredCorruptHeader = false;
     if (existsSync(this.sessionFile)) {
-      this.fileEntries = loadEntriesFromFile(this.sessionFile);
+      const loaded = loadEntriesFromFileWithSnapshot(this.sessionFile);
+      this.fileEntries = loaded.entries;
+      this.sessionFileSnapshot = loaded.snapshot;
 
       // If file was empty or corrupted (no valid header), truncate and start fresh
       // to avoid appending messages without a session header (which breaks the session)
@@ -817,6 +1004,7 @@ export class SessionManager {
 
   newSession(options?: NewSessionOptions): string | undefined {
     this.recoveredCorruptHeader = false;
+    this.sessionFileSnapshot = undefined;
     this.sessionId = options?.id ?? createSessionId();
     const timestamp = new Date().toISOString();
     const header: SessionHeader = {
@@ -868,6 +1056,8 @@ export class SessionManager {
       return;
     }
     writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
+    rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+    this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
   }
 
   isPersisted(): boolean {
@@ -911,8 +1101,17 @@ export class SessionManager {
     if (!this.flushed) {
       writeJsonlEntriesSync(this.sessionFile, this.fileEntries);
       this.flushed = true;
+      rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+      this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
     } else {
+      const beforeAppendSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
       appendJsonlEntrySync(this.sessionFile, entry);
+      this.sessionFileSnapshot = rememberAppendedSessionEntry(
+        this.sessionFile,
+        this.sessionFileSnapshot,
+        beforeAppendSnapshot,
+        entry,
+      );
     }
   }
 
@@ -1327,6 +1526,7 @@ export class SessionManager {
       this.fileEntries = [header, ...pathWithoutLabels, ...labelEntries];
       this.sessionId = newSessionId;
       this.sessionFile = newSessionFile;
+      this.sessionFileSnapshot = undefined;
       this.buildIndex();
 
       // Only write the file now if it contains an assistant message.

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1126,6 +1126,22 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Resync the in-memory snapshot/cache after the transcript file was rewritten
+   * out-of-band (for example the embedded-run header normalization in
+   * prepareSessionManagerForRun). Without this the cached sessionFileSnapshot
+   * still describes the pre-rewrite file, so the first append takes the
+   * snapshot-mismatch branch in rememberAppendedSessionEntry, drops the warm
+   * cache, and the next open reparses the whole transcript.
+   */
+  syncSnapshotAfterHeaderRewrite(): void {
+    if (!this.sessionFile) {
+      return;
+    }
+    rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
+    this.sessionFileSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
+  }
+
   private appendEntry(entry: SessionEntry): void {
     this.fileEntries.push(entry);
     this.byId.set(entry.id, entry);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -21,7 +21,6 @@ import { join, resolve } from "node:path";
 import {
   appendJsonlEntrySync,
   serializeJsonlEntries,
-  serializeJsonlEntry,
   writeJsonlEntriesSync,
 } from "../../config/sessions/transcript-jsonl.js";
 import { hasOwnedSessionTranscriptWriteContext } from "../../config/sessions/transcript-write-context.js";
@@ -429,7 +428,12 @@ function loadEntriesFromFileWithSnapshot(filePath: string): {
     const afterParseSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
     if (afterParseSnapshot && isSameSessionFileSnapshot(beforeReadSnapshot, afterParseSnapshot)) {
       return {
-        entries: rememberSessionEntries(resolvedPath, afterParseSnapshot, entries),
+        entries: rememberSessionEntries(
+          resolvedPath,
+          afterParseSnapshot,
+          entries,
+          content.endsWith("\n"),
+        ),
         snapshot: afterParseSnapshot,
       };
     }
@@ -450,6 +454,7 @@ interface SessionFileSnapshot {
 interface CachedSessionEntries {
   snapshot: SessionFileSnapshot;
   entries: FileEntry[];
+  endsWithNewline: boolean;
 }
 
 const MAX_CACHED_SESSION_FILES = 8;
@@ -483,6 +488,7 @@ function rememberSessionEntries(
   filePath: string,
   snapshot: SessionFileSnapshot,
   entries: FileEntry[],
+  endsWithNewline: boolean,
 ): FileEntry[] {
   if (!hasReadableSessionHeader(entries)) {
     sessionEntriesCache.delete(filePath);
@@ -511,6 +517,7 @@ function rememberSessionEntries(
   const cached: CachedSessionEntries = {
     snapshot,
     entries: cachedEntries,
+    endsWithNewline,
   };
   sessionEntriesCache.delete(filePath);
   sessionEntriesCache.set(filePath, cached);
@@ -585,7 +592,12 @@ function rememberWrittenSessionEntries(
     sessionEntriesCache.delete(resolvedPath);
     return afterReadSnapshot;
   }
-  rememberSessionEntries(resolvedPath, afterReadSnapshot, parseJsonlEntries(content));
+  rememberSessionEntries(
+    resolvedPath,
+    afterReadSnapshot,
+    parseJsonlEntries(content),
+    content.endsWith("\n"),
+  );
   return afterReadSnapshot;
 }
 
@@ -593,7 +605,7 @@ function rememberAppendedSessionEntry(
   filePath: string,
   previousSnapshot: SessionFileSnapshot | undefined,
   beforeAppendSnapshot: SessionFileSnapshot | undefined,
-  entry: FileEntry,
+  serializedAppend: string,
   cacheOwnedAppend: boolean,
 ): SessionFileSnapshot | undefined {
   const resolvedPath = resolve(filePath);
@@ -616,7 +628,7 @@ function rememberAppendedSessionEntry(
   // rewrites refresh the cache explicitly, so identity and size are sufficient
   // to advance this append-only snapshot without reading the whole file.
   const expectedSize =
-    beforeAppendSnapshot.size + BigInt(Buffer.byteLength(serializeJsonlEntry(entry), "utf8"));
+    beforeAppendSnapshot.size + BigInt(Buffer.byteLength(serializedAppend, "utf8"));
   if (
     !snapshot ||
     !cached ||
@@ -635,9 +647,12 @@ function rememberAppendedSessionEntry(
     return snapshot;
   }
 
-  const persistedEntry = JSON.parse(serializeJsonlEntry(entry)) as FileEntry;
+  const persistedEntry = JSON.parse(
+    serializedAppend.startsWith("\n") ? serializedAppend.slice(1) : serializedAppend,
+  ) as FileEntry;
   cached.entries.push(freezeFileEntry(persistedEntry));
   cached.snapshot = snapshot;
+  cached.endsWithNewline = true;
   sessionEntriesCache.delete(resolvedPath);
   sessionEntriesCache.set(resolvedPath, cached);
   trimSessionEntriesCache();
@@ -649,6 +664,30 @@ function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot 
     return readSessionFileSnapshot(filePath);
   } catch {
     return undefined;
+  }
+}
+
+function sessionFileNeedsAppendSeparator(
+  filePath: string,
+  snapshot: SessionFileSnapshot | undefined,
+): boolean {
+  if (!snapshot || snapshot.size === 0n) {
+    return false;
+  }
+
+  const resolvedPath = resolve(filePath);
+  const cached = sessionEntriesCache.get(resolvedPath);
+  if (cached && isSameSessionFileSnapshot(cached.snapshot, snapshot)) {
+    return !cached.endsWithNewline;
+  }
+
+  const fileDescriptor = openSync(resolvedPath, "r");
+  try {
+    const lastByte = Buffer.allocUnsafe(1);
+    const bytesRead = readSync(fileDescriptor, lastByte, 0, 1, snapshot.size - 1n);
+    return bytesRead === 1 && lastByte[0] !== 0x0a;
+  } finally {
+    closeSync(fileDescriptor);
   }
 }
 
@@ -1248,12 +1287,14 @@ export class SessionManager {
       this.sessionFileSnapshot = rememberWrittenSessionEntries(this.sessionFile, this.fileEntries);
     } else {
       const beforeAppendSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
-      appendJsonlEntrySync(this.sessionFile, entry);
+      const serializedAppend = appendJsonlEntrySync(this.sessionFile, entry, {
+        prefixNewline: sessionFileNeedsAppendSeparator(this.sessionFile, beforeAppendSnapshot),
+      });
       this.sessionFileSnapshot = rememberAppendedSessionEntry(
         this.sessionFile,
         this.sessionFileSnapshot,
         beforeAppendSnapshot,
-        entry,
+        serializedAppend,
         hasOwnedSessionTranscriptWriteContext({ sessionFile: this.sessionFile }),
       );
     }

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -551,8 +551,19 @@ function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot 
   }
 }
 
+// Cached entries are deep-frozen so warm hits cannot drift from the file bytes
+// that validated the cache key. The session header (entries[0]) is the one entry
+// callers legitimately mutate in place — `prepareSessionManagerForRun` rewrites
+// its id/cwd before an embedded run. Return a mutable clone of just the header so
+// that mutation does not throw on a frozen object, while the append-only message
+// entries stay shared frozen (preserving cache performance and preventing caller
+// mutations from leaking back into the cache).
 function copyFileEntries(entries: readonly FileEntry[]): FileEntry[] {
-  return entries.slice();
+  const copy = entries.slice();
+  if (copy.length > 0 && copy[0].type === "session" && Object.isFrozen(copy[0])) {
+    copy[0] = cloneFileEntry(copy[0]);
+  }
+  return copy;
 }
 
 function cloneFileEntry(entry: FileEntry): FileEntry {

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -15,7 +15,6 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
-  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -335,12 +334,7 @@ async function appendSessionTranscriptEventLocked(
   params: AppendSessionTranscriptEventParams,
 ): Promise<void> {
   await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
-  const handle = await fs.open(params.transcriptPath, "a", 0o600);
-  try {
-    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
-  } finally {
-    await handle.close();
-  }
+  await appendJsonlEntry(params.transcriptPath, params.event);
 }
 
 async function appendSessionTranscriptMessageLocked<TMessage>(

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -84,5 +84,18 @@ export async function writeJsonlLines(
 }
 
 export async function appendJsonlEntry(filePath: string, entry: unknown): Promise<void> {
-  await fs.appendFile(filePath, serializeJsonlEntry(entry), "utf-8");
+  const serializedEntry = serializeJsonlEntry(entry);
+  const handle = await fs.open(filePath, "a+", 0o600);
+  try {
+    const stat = await handle.stat();
+    let prefixNewline = false;
+    if (stat.size > 0) {
+      const lastByte = Buffer.allocUnsafe(1);
+      const { bytesRead } = await handle.read(lastByte, 0, 1, stat.size - 1);
+      prefixNewline = bytesRead === 1 && lastByte[0] !== 0x0a;
+    }
+    await handle.appendFile(`${prefixNewline ? "\n" : ""}${serializedEntry}`, "utf-8");
+  } finally {
+    await handle.close();
+  }
 }

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -26,8 +26,10 @@ export function serializeJsonlLines(lines: readonly string[]): string {
   return lines.length > 0 ? `${lines.join("\n")}\n` : "";
 }
 
-export function writeJsonlEntriesSync(filePath: string, entries: readonly unknown[]): void {
-  writeFileSync(filePath, serializeJsonlEntries(entries), "utf-8");
+export function writeJsonlEntriesSync(filePath: string, entries: readonly unknown[]): string {
+  const content = serializeJsonlEntries(entries);
+  writeFileSync(filePath, content, "utf-8");
+  return content;
 }
 
 export function appendJsonlEntrySync(
@@ -35,7 +37,14 @@ export function appendJsonlEntrySync(
   entry: unknown,
   options?: { prefixNewline?: boolean },
 ): string {
-  const serializedEntry = serializeJsonlEntry(entry);
+  return appendSerializedJsonlEntrySync(filePath, serializeJsonlEntry(entry), options);
+}
+
+export function appendSerializedJsonlEntrySync(
+  filePath: string,
+  serializedEntry: string,
+  options?: { prefixNewline?: boolean },
+): string {
   const content = options?.prefixNewline ? `\n${serializedEntry}` : serializedEntry;
   appendFileSync(filePath, content, "utf-8");
   return content;

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -73,12 +73,14 @@ export async function writeJsonlLines(
   filePath: string,
   lines: readonly string[],
   options?: WriteJsonlFileOptions,
-): Promise<void> {
-  await fs.writeFile(filePath, serializeJsonlLines(lines), {
+): Promise<string> {
+  const content = serializeJsonlLines(lines);
+  await fs.writeFile(filePath, content, {
     encoding: options?.encoding ?? "utf-8",
     ...(options?.flag ? { flag: options.flag } : {}),
     ...(options?.mode !== undefined ? { mode: options.mode } : {}),
   });
+  return content;
 }
 
 export async function appendJsonlEntry(filePath: string, entry: unknown): Promise<void> {

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -30,8 +30,15 @@ export function writeJsonlEntriesSync(filePath: string, entries: readonly unknow
   writeFileSync(filePath, serializeJsonlEntries(entries), "utf-8");
 }
 
-export function appendJsonlEntrySync(filePath: string, entry: unknown): void {
-  appendFileSync(filePath, serializeJsonlEntry(entry), "utf-8");
+export function appendJsonlEntrySync(
+  filePath: string,
+  entry: unknown,
+  options?: { prefixNewline?: boolean },
+): string {
+  const serializedEntry = serializeJsonlEntry(entry);
+  const content = options?.prefixNewline ? `\n${serializedEntry}` : serializedEntry;
+  appendFileSync(filePath, content, "utf-8");
+  return content;
 }
 
 export function appendJsonlEntriesSync(filePath: string, entries: readonly unknown[]): void {

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -84,6 +84,14 @@ export function resolveOwnedSessionTranscriptWriteLockRunner(params: {
   return context.withSessionWriteLock;
 }
 
+export function hasOwnedSessionTranscriptWriteContext(params: {
+  sessionFile?: string;
+  sessionKey?: string;
+}): boolean {
+  const context = ownedTranscriptWriteContext.getStore();
+  return Boolean(context && contextMatches({ context, ...params }));
+}
+
 async function runWithOwnedSessionTranscriptWriteContext<T>(
   params: {
     sessionFile?: string;

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -5,10 +5,19 @@ import path from "node:path";
 type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
+  canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   withSessionWriteLock: <T>(
     run: () => Promise<T> | T,
     options?: { publishOwnedWrite?: boolean },
   ) => Promise<T>;
+};
+
+export type OwnedSessionTranscriptCacheSnapshot = {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
 };
 
 const ownedTranscriptWriteContext = new AsyncLocalStorage<OwnedSessionTranscriptWriteContext>();
@@ -90,6 +99,19 @@ export function hasOwnedSessionTranscriptWriteContext(params: {
 }): boolean {
   const context = ownedTranscriptWriteContext.getStore();
   return Boolean(context && contextMatches({ context, ...params }));
+}
+
+export function canAdvanceOwnedSessionEntryCache(params: {
+  sessionFile?: string;
+  sessionKey?: string;
+  snapshot: OwnedSessionTranscriptCacheSnapshot;
+}): boolean {
+  const context = ownedTranscriptWriteContext.getStore();
+  return Boolean(
+    context &&
+    contextMatches({ context, ...params }) &&
+    context.canAdvanceSessionEntryCache?.(params.snapshot),
+  );
 }
 
 async function runWithOwnedSessionTranscriptWriteContext<T>(

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -6,6 +6,7 @@ type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
   canAdvanceSessionEntryCache?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
+  publishSessionFileSnapshot?: (snapshot: OwnedSessionTranscriptCacheSnapshot) => boolean;
   withSessionWriteLock: <T>(
     run: () => Promise<T> | T,
     options?: { publishOwnedWrite?: boolean },
@@ -110,8 +111,21 @@ export function canAdvanceOwnedSessionEntryCache(params: {
   return Boolean(
     context &&
     contextMatches({ context, ...params }) &&
+    context.publishSessionFileSnapshot &&
     context.canAdvanceSessionEntryCache?.(params.snapshot),
   );
+}
+
+export function publishOwnedSessionFileSnapshot(params: {
+  sessionFile?: string;
+  sessionKey?: string;
+  snapshot: OwnedSessionTranscriptCacheSnapshot;
+}): boolean | undefined {
+  const context = ownedTranscriptWriteContext.getStore();
+  if (!context || !contextMatches({ context, ...params }) || !context.publishSessionFileSnapshot) {
+    return undefined;
+  }
+  return context.publishSessionFileSnapshot(params.snapshot);
 }
 
 async function runWithOwnedSessionTranscriptWriteContext<T>(

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -9,7 +9,10 @@ import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.j
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
 import { updateSessionStoreEntry } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
-import { appendSessionTranscriptMessage } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import {
   bindOwnedSessionTranscriptWrites,
   withOwnedSessionTranscriptWrites,
@@ -1189,6 +1192,82 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     for (let index = 1; index < records.length; index += 1) {
       expect(records[index]?.parentId).toBe(records[index - 1]?.id);
     }
+  });
+
+  it("separates message and event appends from an unterminated transcript entry", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: sessionId,
+          timestamp: "2026-06-15T00:00:00.000Z",
+          cwd: fixture.sessionsDir(),
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "existing",
+          parentId: null,
+          timestamp: "2026-06-15T00:00:01.000Z",
+          message: { role: "user", content: "existing" },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    await appendSessionTranscriptMessage({
+      transcriptPath: sessionFile,
+      message: { role: "assistant", content: "appended message" },
+    });
+    fs.writeFileSync(sessionFile, fs.readFileSync(sessionFile, "utf8").trimEnd(), "utf8");
+    await appendSessionTranscriptEvent({
+      transcriptPath: sessionFile,
+      event: { type: "custom", id: "event", parentId: null },
+    });
+
+    const entries = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string });
+    expect(entries.map((entry) => entry.type)).toEqual(["session", "message", "message", "custom"]);
+  });
+
+  it("serializes transcript events before inspecting the append separator", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    const replacementHeader = JSON.stringify({
+      type: "session",
+      version: 3,
+      id: sessionId,
+      timestamp: "2026-06-15T00:00:00.000Z",
+      cwd: fixture.sessionsDir(),
+    });
+    fs.writeFileSync(sessionFile, `${replacementHeader}\n`, "utf8");
+
+    await appendSessionTranscriptEvent({
+      transcriptPath: sessionFile,
+      event: {
+        type: "custom",
+        toJSON() {
+          fs.writeFileSync(sessionFile, replacementHeader, "utf8");
+          return { type: "custom", id: "serialized-first", parentId: null };
+        },
+      },
+    });
+
+    const entries = fs
+      .readFileSync(sessionFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { type: string; id?: string });
+    expect(entries).toEqual([
+      expect.objectContaining({ type: "session", id: sessionId }),
+      { type: "custom", id: "serialized-first", parentId: null },
+    ]);
   });
 
   it("requires explicit idempotency scanning for direct transcript appends", async () => {


### PR DESCRIPTION
## Summary

Fixes #83943.

The session resource loader re-parsed the entire transcript on every warm turn. `loadEntriesFromFile` ran `readFileSync` + line-by-line `JSON.parse` over the whole JSONL each time `SessionManager.open` was called, so the per-warm-turn cost grew O(n) with transcript length. The reporter measured the session-resource-loader stage climbing from ~14.5s → 31.5s → 42.3s across consecutive warm turns of a single session, eventually tripping a WebSocket timeout.

## What changed

**`src/agents/sessions/session-manager.ts`** — add a bounded (max 8) snapshot-keyed cache for `loadEntriesFromFile`. The cache key is a high-resolution file snapshot (`dev`/`ino`/`size` + nanosecond `mtime`/`ctime` via `statSync({ bigint: true })`); a warm open whose snapshot still matches returns the cached entries without re-reading or re-parsing the file. Only current-version (v3) transcripts are cached — older versions still go through migration with fresh mutable entries, so cache hits never share objects that migrate. Cached entries are deep-frozen and handed out as a shallow array copy (`.slice()`), so callers cannot mutate the cached prefix and manager appends land on a separate array, while avoiding a per-open deep clone. Appends update the cache incrementally; the cache invalidates when the file snapshot changes (external replace / another writer). Adds `syncSnapshotAfterHeaderRewrite()` so an out-of-band transcript rewrite can refresh the manager snapshot/cache (see follow-up below).

**`src/agents/embedded-agent-runner/session-manager-init.ts`** — after `prepareSessionManagerForRun` rewrites the on-disk header (the recovered-header and normalization branches), call `syncSnapshotAfterHeaderRewrite()` so the manager's snapshot/cache match the rewritten file before the first append.

**`src/agents/sessions/session-manager.test.ts`** — 9 tests: warm reuse without re-parse, append without stale readback, cache invalidation on external file replacement, invalidation when another writer appends before this manager persists, old-version transcripts still migrating while bypassing the cache, embedded header normalization without re-parse, and (new) keeping the warm cache across an embedded prepare-plus-append so the next warm open does not reparse.

## Real behavior proof

**Behavior addressed:** `loadEntriesFromFile` no longer re-parses the whole transcript on every warm `SessionManager.open`. Warm opens of an unchanged current-version session reuse cached entries, eliminating the per-warm-turn O(n) re-parse cost, while session correctness (no stale or shared-mutation, cache invalidation on external change) is preserved.

**Real environment tested:** Local worktree of `origin/main` at base `ca9249e357291890125a5a801a5681defbc816ff` with this patch applied, Node v22.22.0. Drove the real exported `loadEntriesFromFile` via `node --import tsx` — the actual production loader, no mocks. `JSON.parse` call count measured by wrapping the global parse around the loop.

**Exact steps or command run after this patch:**
```
# Real production loader, 4000-entry transcript, 12 warm opens:
node --import tsx ./proof-83943.mts
# Baseline measured by git-stashing this patch and re-running the same harness.

# Regression suite:
node scripts/run-vitest.mjs run src/agents/sessions/session-manager.test.ts
```

**Evidence after fix:** Real output driving the production `loadEntriesFromFile` over a 4000-entry transcript, 12 warm opens:
```
# AFTER (this patch):
transcript entries = 4000 (+1 session header), warm opens = 12
entries returned per open = 4001 (correctness: stable across opens)
JSON.parse calls = 4001
wall time = 45.0ms

# BASELINE (origin/main, this patch stashed):
JSON.parse calls = 48012
wall time = 198.0ms
```

**Observed result after fix:** `JSON.parse` calls drop from 48012 (12 × full re-parse) to 4001 (one initial parse; the 11 warm hits do zero parsing) — a 91.7% reduction — and wall time drops from 198.0ms to 45.0ms (~4.4× faster). Every open still returns all 4001 entries, so correctness is preserved.

**What was not tested:** No live end-to-end Windows + Feishu + MiniMax reproduction of the original ~42s stall (that environment is unavailable); the change is in the deterministic transcript loader, exercised directly with the real exported function and disk readback. This PR addresses only the per-warm-turn transcript-growth subpath, not the constant `reload()` baseline cost discussed in #82536.

## Follow-up: embedded prepare-plus-append cache gap (code-review finding)

Code review found that the embedded runner's `prepareSessionManagerForRun` rewrites the transcript header *after* `SessionManager.open`, leaving the cached `sessionFileSnapshot` describing the pre-rewrite file. The first append then took the snapshot-mismatch branch in `rememberAppendedSessionEntry`, dropped the cache, and the next warm embedded turn reparsed the whole transcript — so the warm cache did not survive the embedded path.

**Fix:** the header rewrite now calls `syncSnapshotAfterHeaderRewrite()`, which refreshes the snapshot and cache from the rewritten file, so the first append stays on the incremental cache path.

**Proof (real `SessionManager` + real on-disk transcript, `JSON.parse` readback):** new regression `keeps the warm cache after prepareSessionManagerForRun rewrites then appends` drives the real `SessionManager.open` → `prepareSessionManagerForRun` (real header rewrite to disk) → `appendMessage` (real append to disk) → another warm `SessionManager.open`, counting global `JSON.parse`:
```
# WITH FIX:
node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts
Tests  9 passed (9)
# the new test asserts JSON.parse calls == 0 on the warm open after prepare+append

# NEGATIVE CONTROL (git-stash the session-manager-init.ts sync calls):
Tests  1 failed | 8 passed (9)
# the new test fails: the post-rewrite append drops the cache, so the next warm open reparses (JSON.parse > 0)
```

## Validation (supplemental)

- `node scripts/run-vitest.mjs run src/agents/sessions/session-manager.test.ts` → `Tests 9 passed (9)`
- negative control (stash the embedded sync calls) → the new embedded-cache test fails, the other 8 pass — proves the fix is required and the test is not a tautology
- `tsgo:core` / `tsgo:core:test` → no new errors in changed files; `oxfmt` → clean
