### PR TITLE
test(zalouser): dynamically skip symlink test in credentials

### DIFF
--- a/extensions/zalouser/src/zalo-js.credentials.test.ts
+++ b/extensions/zalouser/src/zalo-js.credentials.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import {
   lstat,
   mkdir,
@@ -11,6 +12,20 @@ import {
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+
+const canCreateFileSymlinks = (() => {
+  try {
+    const tempLink = path.join(os.tmpdir(), `symlink-file-test-${Math.random().toString(36).substring(2)}`);
+    const tempFile = path.join(os.tmpdir(), `symlink-file-target-${Math.random().toString(36).substring(2)}`);
+    fsSync.writeFileSync(tempFile, "temp");
+    fsSync.symlinkSync(tempFile, tempLink, "file");
+    fsSync.unlinkSync(tempLink);
+    fsSync.unlinkSync(tempFile);
+    return true;
+  } catch {
+    return false;
+  }
+})();
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { API, Credentials, LoginQRCallbackEvent } from "./zca-client.js";
@@ -411,7 +426,7 @@ describe("zalouser credential persistence", () => {
     },
   );
 
-  it.skipIf(process.platform === "win32")(
+  it.skipIf(!canCreateFileSymlinks)(
     "refuses to write credentials through a symlinked file",
     async () => {
       const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-credentials-"));
@@ -426,7 +441,7 @@ describe("zalouser credential persistence", () => {
 
       await mkdir(path.dirname(filePath), { recursive: true });
       await writeFile(targetPath, "sentinel", "utf8");
-      await symlink(targetPath, filePath);
+      await symlink(targetPath, filePath, "file");
 
       createZaloMock.mockResolvedValueOnce({
         loginQR: async (_options: unknown, callback?: (event: LoginQRCallbackEvent) => unknown) => {


### PR DESCRIPTION
This PR updates the test suite in `extensions/zalouser/src/zalo-js.credentials.test.ts` to dynamically skip the symlinked file write test depending on the environment's support for file symlink creation, rather than hard-coding a check for Windows.

### Changes
- Implemented `canCreateFileSymlinks` capability check.
- Gated the symlinked file credentials test with `it.skipIf(!canCreateFileSymlinks)`.
- Configured the file symlink to explicitly use `"file"` type to support Windows.

### Test Execution Proof (Redacted)
```
 ✓  extension-zalo  ../../extensions/zalouser/src/zalo-js.credentials.test.ts (8 tests | 2 skipped) 300ms

 Test Files  1 passed (1)
      Tests  6 passed | 2 skipped (8)
   Start at  22:23:49
   Duration  11.25s (transform 7.24s, setup 1.09s, import 9.02s, tests 300ms, environment 1ms)
```
