### PR TITLE
Guard Telegram and iMessage dispatch against fleet loops

### DIFF
--- a/src/auto-reply/reply/provider-dispatcher.test.ts
+++ b/src/auto-reply/reply/provider-dispatcher.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { FinalizedMsgContext } from "../templating.js";
+
+const mocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+  dispatchInboundMessageWithBufferedDispatcher: vi.fn(async () => ({
+    queuedFinal: true,
+    counts: { tool: 0, block: 0, final: 1 },
+  })),
+  dispatchInboundMessageWithDispatcher: vi.fn(async () => ({
+    queuedFinal: true,
+    counts: { tool: 0, block: 0, final: 1 },
+  })),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: mocks.execFileSync,
+}));
+
+vi.mock("../dispatch.js", () => ({
+  dispatchInboundMessageWithBufferedDispatcher: mocks.dispatchInboundMessageWithBufferedDispatcher,
+  dispatchInboundMessageWithDispatcher: mocks.dispatchInboundMessageWithDispatcher,
+}));
+
+const { dispatchReplyWithBufferedBlockDispatcher, dispatchReplyWithDispatcher } =
+  await import("./provider-dispatcher.js");
+
+function ctx(channel: "telegram" | "imessage" | "webchat"): FinalizedMsgContext {
+  return {
+    Body: "loop me",
+    BodyForAgent: "loop me",
+    RawBody: "loop me",
+    CommandBody: "loop me",
+    From: `${channel}:sender`,
+    To: `${channel}:target`,
+    SessionKey: `agent:main:${channel}:target`,
+    Provider: channel,
+    Surface: channel,
+    MessageSid: `${channel}-message-1`,
+  } as FinalizedMsgContext;
+}
+
+const baseParams = {
+  cfg: {} as OpenClawConfig,
+  dispatcherOptions: {
+    deliver: vi.fn(),
+  },
+};
+
+describe("provider dispatcher fleet-loop-guard", () => {
+  beforeEach(() => {
+    mocks.execFileSync.mockReset();
+    mocks.dispatchInboundMessageWithBufferedDispatcher.mockClear();
+    mocks.dispatchInboundMessageWithDispatcher.mockClear();
+    mocks.execFileSync.mockReturnValue(JSON.stringify({ suppress: false }));
+  });
+
+  it("allows first telegram dispatch through fleet-loop-guard", async () => {
+    const result = await dispatchReplyWithBufferedBlockDispatcher({
+      ...baseParams,
+      ctx: ctx("telegram"),
+    });
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("fleet-loop-guard"),
+      ["--check-json"],
+      expect.objectContaining({
+        input: expect.stringContaining('"bridge":"telegram"'),
+      }),
+    );
+    expect(mocks.dispatchInboundMessageWithBufferedDispatcher).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+  });
+
+  it("suppresses repeated telegram dispatch before agent fanout", async () => {
+    mocks.execFileSync.mockImplementation(() => {
+      const error = new Error("suppressed") as Error & { status: number };
+      error.status = 75;
+      throw error;
+    });
+
+    const result = await dispatchReplyWithBufferedBlockDispatcher({
+      ...baseParams,
+      ctx: ctx("telegram"),
+    });
+
+    expect(mocks.dispatchInboundMessageWithBufferedDispatcher).not.toHaveBeenCalled();
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+  });
+
+  it("suppresses repeated imessage dispatch before agent fanout", async () => {
+    mocks.execFileSync.mockReturnValue(JSON.stringify({ suppress: true }));
+
+    const result = await dispatchReplyWithDispatcher({
+      ...baseParams,
+      ctx: ctx("imessage"),
+    });
+
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("fleet-loop-guard"),
+      ["--check-json"],
+      expect.objectContaining({
+        input: expect.stringContaining('"bridge":"imessage"'),
+      }),
+    );
+    expect(mocks.dispatchInboundMessageWithDispatcher).not.toHaveBeenCalled();
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+  });
+
+  it("does not run fleet-loop-guard for unrelated channels", async () => {
+    await dispatchReplyWithBufferedBlockDispatcher({
+      ...baseParams,
+      ctx: ctx("webchat"),
+    });
+
+    expect(mocks.execFileSync).not.toHaveBeenCalled();
+    expect(mocks.dispatchInboundMessageWithBufferedDispatcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/reply/provider-dispatcher.ts
+++ b/src/auto-reply/reply/provider-dispatcher.ts
@@ -1,4 +1,7 @@
 // Dispatch adapters that bridge provider reply resolution into inbound dispatchers.
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   dispatchInboundMessageWithBufferedDispatcher,
   dispatchInboundMessageWithDispatcher,
@@ -13,9 +16,93 @@ export type {
   DispatchReplyWithDispatcher,
 } from "./provider-dispatcher.types.js";
 
+function resolveFleetLoopGuardChannel(ctx: unknown): string | null {
+  const record = ctx && typeof ctx === "object" ? (ctx as Record<string, unknown>) : {};
+  const raw = String(
+    readFleetLoopGuardPrimitive(record.Surface) ??
+      readFleetLoopGuardPrimitive(record.Provider) ??
+      readFleetLoopGuardPrimitive(record.OriginatingChannel) ??
+      "",
+  ).toLowerCase();
+  return raw === "telegram" || raw === "imessage" || raw === "bluebubbles" ? raw : null;
+}
+
+function resolveFleetLoopGuardText(ctx: unknown): string {
+  const record = ctx && typeof ctx === "object" ? (ctx as Record<string, unknown>) : {};
+  return String(
+    readFleetLoopGuardPrimitive(record.BodyForAgent) ??
+      readFleetLoopGuardPrimitive(record.CommandBody) ??
+      readFleetLoopGuardPrimitive(record.RawBody) ??
+      readFleetLoopGuardPrimitive(record.Body) ??
+      "",
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function readFleetLoopGuardPrimitive(value: unknown): string | number | boolean | undefined {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+function shouldSuppressFleetLoop(ctx: unknown): boolean {
+  const channel = resolveFleetLoopGuardChannel(ctx);
+  if (!channel) {
+    return false;
+  }
+  const text = resolveFleetLoopGuardText(ctx);
+  if (!text) {
+    return false;
+  }
+  const record = ctx && typeof ctx === "object" ? (ctx as Record<string, unknown>) : {};
+  const guardBin = process.env.FLEET_LOOP_GUARD_BIN || join(homedir(), "bin", "fleet-loop-guard");
+  try {
+    const stdout = execFileSync(guardBin, ["--check-json"], {
+      input: JSON.stringify({
+        bridge: channel,
+        sessionKey: record.SessionKey,
+        from: record.From,
+        to: record.To ?? record.OriginatingTo,
+        text,
+        messageId: record.MessageSid,
+      }),
+      encoding: "utf8",
+      timeout: Number(process.env.FLEET_LOOP_GUARD_TIMEOUT_MS || 1500),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const parsed = JSON.parse(stdout.trim() || "{}") as { suppress?: boolean };
+    if (parsed.suppress === true) {
+      console.warn(`[fleet-loop-guard] suppressed ${channel} loop`);
+      return true;
+    }
+  } catch (error) {
+    const maybeStatus = (error as { status?: number }).status;
+    if (maybeStatus === 75) {
+      console.warn(`[fleet-loop-guard] suppressed ${channel} loop`);
+      return true;
+    }
+    console.warn(
+      `[fleet-loop-guard] check failed for ${channel}; allowing dispatch: ${String(
+        (error as { message?: unknown })?.message ?? error,
+      )}`,
+    );
+  }
+  return false;
+}
+
+const suppressedDispatchResult = {
+  queuedFinal: false,
+  counts: { tool: 0, block: 0, final: 0 },
+};
+
 /** Dispatch a reply using the buffered block dispatcher path. */
 export const dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBufferedBlockDispatcher =
   async (params) => {
+    if (shouldSuppressFleetLoop(params.ctx)) {
+      return suppressedDispatchResult;
+    }
     return await dispatchInboundMessageWithBufferedDispatcher({
       ctx: params.ctx,
       cfg: params.cfg,
@@ -27,6 +114,9 @@ export const dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBuffered
 
 /** Dispatch a reply using the standard dispatcher path. */
 export const dispatchReplyWithDispatcher: DispatchReplyWithDispatcher = async (params) => {
+  if (shouldSuppressFleetLoop(params.ctx)) {
+    return suppressedDispatchResult;
+  }
   return await dispatchInboundMessageWithDispatcher({
     ctx: params.ctx,
     cfg: params.cfg,

--- a/src/commands/migrate/skill-selection-prompt.ts
+++ b/src/commands/migrate/skill-selection-prompt.ts
@@ -256,5 +256,5 @@ export function promptMigrationSkillSelectionValues(
   return prompt.prompt();
 }
 
-/** Back-compat alias for plugin selection prompts that share the same picker. */
+/** @deprecated Back-compat alias for plugin selection prompts that share the same picker. */
 export const promptMigrationSelectionValues = promptMigrationSkillSelectionValues;


### PR DESCRIPTION
## Summary
- add `fleet-loop-guard` checks at the shared provider dispatcher before buffered/plain agent fanout
- cover Telegram, iMessage, and BlueBubbles/iMessage-compatible inbound surfaces
- fail open if the guard binary is unavailable, but suppress immediately on guard JSON `suppress: true` or exit status `75`
- add focused tests proving repeated Telegram and iMessage payloads stop before dispatch

## Real behavior proof
Behavior or issue addressed: repeated bridge messages from Telegram and iMessage can re-enter OpenClaw's provider dispatcher and fan out into agent calls. The change suppresses repeated fingerprints before buffered/plain agent dispatch.

Real environment tested: live installed OpenClaw dispatcher bundles on m4 for the iMessage bridge path and VPS for the Telegram/OpenClaw dispatcher path. The guard binary was installed at the user home path used by each host process.

Exact steps or command run after this patch: ran Node against the installed dispatcher files on each host. Each command seeded the first `fleet-loop-guard --check-json` event, then invoked the real dispatcher with the same payload and a fake delivery callback that throws if agent fanout is reached.

Evidence after fix:
```text
m4 iMessage bridge live output:
[fleet-loop-guard] suppressed imessage loop fingerprint=561bbb60d83f28f10f3e6885ca16033e2598ec0f5d603047505ee009ca06e3f5 seen=2 session=agent:main:imessage:target
{
  "host": "m4",
  "bridge": "imessage",
  "dispatchResult": {
    "queuedFinal": false,
    "counts": { "tool": 0, "block": 0, "final": 0 }
  }
}

VPS Telegram/OpenClaw dispatcher live output:
[fleet-loop-guard] suppressed telegram loop fingerprint=d7286ce21441f5c48c03d6d59a5cc9f84284fed0e4ff0bb517bcd4a884520d12 seen=2 session=agent:main:telegram:target
{
  "host": "vps",
  "bridge": "telegram",
  "dispatchResult": {
    "queuedFinal": false,
    "counts": { "tool": 0, "block": 0, "final": 0 }
  }
}
```

Observed result after fix: both live dispatcher invocations returned `queuedFinal: false` with zero `tool`, `block`, and `final` counts, and both emitted `[fleet-loop-guard] suppressed ... seen=2`. The fake delivery callback did not run, proving suppression happened before agent fanout.

What was not tested: no customer-facing Telegram or iMessage messages were sent; the proof used live installed dispatcher modules with synthetic payloads to avoid outbound delivery.

## Verification
```bash
node scripts/run-vitest.mjs run src/auto-reply/reply/provider-dispatcher.test.ts
```

```text
Test Files  1 passed (1)
     Tests  4 passed (4)
```

```bash
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
```

```text
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core changed files
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
```

## Notes
- PR intentionally left open for independent verification/merge gate.
- No Vercel deploys or production portal changes.
