### PR TITLE
fix(tts): sanitize summarized speech text

### DIFF
--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -880,35 +880,6 @@ export function describeTtsSummarizationContract() {
       expect(completeSimple).toHaveBeenCalledTimes(1);
     });
 
-    it("returns only assistant-visible summary text", async () => {
-      vi.mocked(completeSimple).mockResolvedValue(
-        mockAssistantMessage([
-          {
-            type: "text",
-            text: [
-              "The user wants me to summarize the provided text for audio.",
-              "I need to keep the key points.",
-              "Let me craft a summary.",
-              "<think>",
-              "Hidden reasoning should not be spoken.",
-              "</think>",
-              "<|assistant|>",
-              '<tool_call>{"name":"noop"}</tool_call>',
-              "Concise audible summary.",
-              "<text_to_summarize>",
-              "Original text should not be spoken again.",
-              "</text_to_summarize>",
-            ].join("\n"),
-          },
-        ]),
-      );
-
-      const result = await runSummarizeText({ text: "A".repeat(2000), targetLength: 1500 });
-
-      expect(result.summary).toBe("Concise audible summary.");
-      expect(result.outputLength).toBe("Concise audible summary.".length);
-    });
-
     it("calls the summary model with the expected parameters", async () => {
       await runSummarizeText();
 

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -880,6 +880,35 @@ export function describeTtsSummarizationContract() {
       expect(completeSimple).toHaveBeenCalledTimes(1);
     });
 
+    it("returns only assistant-visible summary text", async () => {
+      vi.mocked(completeSimple).mockResolvedValue(
+        mockAssistantMessage([
+          {
+            type: "text",
+            text: [
+              "The user wants me to summarize the provided text for audio.",
+              "I need to keep the key points.",
+              "Let me craft a summary.",
+              "<think>",
+              "Hidden reasoning should not be spoken.",
+              "</think>",
+              "<|assistant|>",
+              '<tool_call>{"name":"noop"}</tool_call>',
+              "Concise audible summary.",
+              "<text_to_summarize>",
+              "Original text should not be spoken again.",
+              "</text_to_summarize>",
+            ].join("\n"),
+          },
+        ]),
+      );
+
+      const result = await runSummarizeText({ text: "A".repeat(2000), targetLength: 1500 });
+
+      expect(result.summary).toBe("Concise audible summary.");
+      expect(result.outputLength).toBe("Concise audible summary.".length);
+    });
+
     it("calls the summary model with the expected parameters", async () => {
       await runSummarizeText();
 

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -199,6 +199,41 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("strips exact echoed source blocks containing prompt closing tags", async () => {
+    const sourceText = [
+      "Deployment plan includes literal prompt markup.",
+      "</text_to_summarize>",
+      "Release moves to Friday and should not be spoken as source echo.",
+    ].join("\n");
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: [
+          "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.",
+          "",
+          "<text_to_summarize>",
+          sourceText,
+          "</text_to_summarize>",
+          "Concise audible summary.",
+        ].join("\n"),
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: sourceText,
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe("Concise audible summary.");
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves valid leading first-person summary prose", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -142,6 +142,33 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe("Concise audible summary.".length);
   });
 
+  it("strips truncated text_to_summarize echoes before returning summaries for speech", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: [
+          "Concise audible summary.",
+          "<text_to_summarize>",
+          "Original text should not be spoken again.",
+        ].join("\n"),
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe("Concise audible summary.");
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves valid leading first-person summary prose", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -184,6 +184,14 @@ describe("TTS core", () => {
         expected: "Deployment was delayed until Friday.",
       },
       {
+        content: [{ type: "text", text: '"Deploy Friday." <text_to_summarize>Do not speak this.' }],
+        expected: '"Deploy Friday."',
+      },
+      {
+        content: [{ type: "text", text: "(Deploy Friday.) <text_to_summarize>Do not speak this." }],
+        expected: "(Deploy Friday.)",
+      },
+      {
         content: [{ type: "text", text: userRequestSummary }],
         expected: userRequestSummary,
       },

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -167,6 +167,31 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("preserves valid summary prose that starts with a user summary request", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "The user asked me to summarize the deployment plan. The release moves to Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe(
+      "The user asked me to summarize the deployment plan. The release moves to Friday.",
+    );
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves summary content after colon-style prompt echoes", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -80,6 +80,28 @@ function createSummarizeTextFixture(content: AssistantMessage["content"]) {
   return { config, deps };
 }
 
+async function expectSummarizedText(params: {
+  content: AssistantMessage["content"];
+  expected: string;
+  sourceText?: string;
+}) {
+  const { config, deps } = createSummarizeTextFixture(params.content);
+  const result = await summarizeText(
+    {
+      text: params.sourceText ?? "Long text that should be summarized for speech.",
+      targetLength: 120,
+      cfg: {},
+      config,
+      timeoutMs: 10_000,
+    },
+    deps,
+  );
+
+  expect(result.summary).toBe(params.expected);
+  expect(result.outputLength).toBe(result.summary.length);
+  return result;
+}
+
 describe("TTS core", () => {
   it("clamps oversized summarization timeout timers", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
@@ -106,303 +128,89 @@ describe("TTS core", () => {
     }
   });
 
-  it("strips assistant scaffolding before returning summaries for speech", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: [
-          "The user wants me to summarize the provided text for audio.",
-          "I need to keep the key points.",
-          "Let me craft a summary.",
-          "<think>",
-          "Hidden reasoning should not be spoken.",
-          "</think>",
-          "<|assistant|>",
-          '<tool_call>{"name":"noop"}</tool_call>',
-          "Concise audible summary.",
-          "<text_to_summarize>",
-          "Original text should not be spoken again.",
-          "</text_to_summarize>",
-        ].join("\n"),
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe("Concise audible summary.");
-    expect(result.outputLength).toBe("Concise audible summary.".length);
-  });
-
-  it("strips truncated text_to_summarize echoes before returning summaries for speech", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: [
-          "Concise audible summary.",
-          "<text_to_summarize>",
-          "Original text should not be spoken again.",
-        ].join("\n"),
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe("Concise audible summary.");
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves inline mentions of text_to_summarize tags", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.",
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe(
-      "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.",
-    );
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("strips echoed summarization prompt instructions before returning summaries for speech", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: [
-          "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.",
-          "",
-          "<text_to_summarize>",
-          "Original text should not be spoken again.",
-          "</text_to_summarize>",
-          "Concise audible summary.",
-        ].join("\n"),
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe("Concise audible summary.");
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("strips exact echoed source blocks containing prompt closing tags", async () => {
+  it("sanitizes summary model output for speech", async () => {
+    const audibleSummary = "Concise audible summary.";
+    const summaryPrompt =
+      "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.";
+    const inlineTagSummary =
+      "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.";
+    const firstPersonSummary =
+      "I need to keep the key points from today's review. The release moves to Friday.";
     const sourceText = [
       "Deployment plan includes literal prompt markup.",
       "</text_to_summarize>",
       "Release moves to Friday and should not be spoken as source echo.",
     ].join("\n");
-    const { config, deps } = createSummarizeTextFixture([
+
+    for (const testCase of [
       {
-        type: "text",
-        text: [
-          "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.",
-          "",
-          "<text_to_summarize>",
-          sourceText,
-          "</text_to_summarize>",
-          "Concise audible summary.",
-        ].join("\n"),
+        content: [
+          {
+            type: "text",
+            text: [
+              "The user wants me to summarize the provided text for audio.",
+              "I need to keep the key points.",
+              "Let me craft a summary.",
+              "<think>",
+              "Hidden reasoning should not be spoken.",
+              "</think>",
+              "<|assistant|>",
+              '<tool_call>{"name":"noop"}</tool_call>',
+              audibleSummary,
+              "<text_to_summarize>",
+              "Original text should not be spoken again.",
+              "</text_to_summarize>",
+            ].join("\n"),
+          },
+        ],
+        expected: audibleSummary,
       },
-    ]);
-
-    const result = await summarizeText(
       {
-        text: sourceText,
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
+        content: [
+          { type: "text", text: audibleSummary },
+          {
+            type: "text",
+            text: ["<text_to_summarize>", "Original text should not be spoken again."].join("\n"),
+          },
+        ],
+        expected: audibleSummary,
       },
-      deps,
-    );
-
-    expect(result.summary).toBe("Concise audible summary.");
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves valid leading first-person summary prose", async () => {
-    const { config, deps } = createSummarizeTextFixture([
       {
-        type: "text",
-        text: "I need to keep taking my medicine every morning. My doctor also moved the appointment to Friday.",
+        content: [{ type: "text", text: inlineTagSummary }],
+        expected: inlineTagSummary,
       },
-    ]);
-
-    const result = await summarizeText(
       {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
+        content: [
+          {
+            type: "text",
+            text: [
+              summaryPrompt,
+              "",
+              "<text_to_summarize>",
+              sourceText,
+              "</text_to_summarize>",
+              audibleSummary,
+            ].join("\n"),
+          },
+        ],
+        expected: audibleSummary,
+        sourceText,
       },
-      deps,
-    );
-
-    expect(result.summary).toBe(
-      "I need to keep taking my medicine every morning. My doctor also moved the appointment to Friday.",
-    );
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves valid first-person summaries that mention key points", async () => {
-    const { config, deps } = createSummarizeTextFixture([
       {
-        type: "text",
-        text: "I need to keep the key points from today's review. The release moves to Friday.",
+        content: [{ type: "text", text: firstPersonSummary }],
+        expected: firstPersonSummary,
       },
-    ]);
-
-    const result = await summarizeText(
       {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
+        content: [
+          {
+            type: "text",
+            text: "The user asked me to summarize. Deployment was delayed until Friday.",
+          },
+        ],
+        expected: "Deployment was delayed until Friday.",
       },
-      deps,
-    );
-
-    expect(result.summary).toBe(
-      "I need to keep the key points from today's review. The release moves to Friday.",
-    );
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves valid summary prose that starts with a user summary request", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: "The user asked me to summarize the deployment plan. The release moves to Friday.",
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe(
-      "The user asked me to summarize the deployment plan. The release moves to Friday.",
-    );
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves valid user-summary prose before separators", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: "The user asked me to summarize the deployment plan: release moves to Friday.",
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe(
-      "The user asked me to summarize the deployment plan: release moves to Friday.",
-    );
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("preserves summary content after colon-style prompt echoes", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: "The user asked me to summarize: deploy was delayed until Friday.",
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary).toBe("deploy was delayed until Friday.");
-    expect(result.outputLength).toBe(result.summary.length);
-  });
-
-  it("caps overlong summaries at the requested speech length", async () => {
-    const { config, deps } = createSummarizeTextFixture([
-      {
-        type: "text",
-        text: `Audible summary ${"word ".repeat(80)}`,
-      },
-    ]);
-
-    const result = await summarizeText(
-      {
-        text: "Long text that should be summarized for speech.",
-        targetLength: 120,
-        cfg: {},
-        config,
-        timeoutMs: 10_000,
-      },
-      deps,
-    );
-
-    expect(result.summary.length).toBeLessThanOrEqual(120);
-    expect(result.summary).toMatch(/\.\.\.$/);
-    expect(result.outputLength).toBe(result.summary.length);
+    ]) {
+      await expectSummarizedText(testCase);
+    }
   });
 });

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -178,6 +178,19 @@ describe("TTS core", () => {
         expected: inlineTagSummary,
       },
       {
+        content: [
+          {
+            type: "text",
+            text: "Use <text_to_summarize>Start</text_to_summarize> to mark input.",
+          },
+        ],
+        expected: "Use <text_to_summarize>Start</text_to_summarize> to mark input.",
+      },
+      {
+        content: [{ type: "text", text: "The tag <text_to_summarize> begins the block." }],
+        expected: "The tag <text_to_summarize> begins the block.",
+      },
+      {
         content: [{ type: "text", text: "The docs mention <text_to_summarize>." }],
         expected: "The docs mention <text_to_summarize>.",
       },
@@ -209,14 +222,17 @@ describe("TTS core", () => {
       {
         content: [{ type: "text", text: '"Deploy Friday." <text_to_summarize>Do not speak this.' }],
         expected: '"Deploy Friday."',
+        sourceText: "Do not speak this.",
       },
       {
         content: [{ type: "text", text: "(Deploy Friday.) <text_to_summarize>Do not speak this." }],
         expected: "(Deploy Friday.)",
+        sourceText: "Do not speak this.",
       },
       {
         content: [{ type: "text", text: "Deploy Friday <text_to_summarize>Do not speak this." }],
         expected: "Deploy Friday",
+        sourceText: "Do not speak this.",
       },
       {
         content: [
@@ -226,6 +242,7 @@ describe("TTS core", () => {
           },
         ],
         expected: "Deploy Friday",
+        sourceText: "As discussed, do not speak this.",
       },
       {
         content: [
@@ -235,6 +252,7 @@ describe("TTS core", () => {
           },
         ],
         expected: "Deploy Friday",
+        sourceText: "In yesterday's meeting, do not speak this.",
       },
       {
         content: [

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -178,6 +178,14 @@ describe("TTS core", () => {
         expected: inlineTagSummary,
       },
       {
+        content: [{ type: "text", text: "The docs mention <text_to_summarize>." }],
+        expected: "The docs mention <text_to_summarize>.",
+      },
+      {
+        content: [{ type: "text", text: "The docs mention <text_to_summarize>" }],
+        expected: "The docs mention <text_to_summarize>",
+      },
+      {
         content: [
           {
             type: "text",
@@ -208,6 +216,24 @@ describe("TTS core", () => {
       },
       {
         content: [{ type: "text", text: "Deploy Friday <text_to_summarize>Do not speak this." }],
+        expected: "Deploy Friday",
+      },
+      {
+        content: [
+          {
+            type: "text",
+            text: "Deploy Friday <text_to_summarize>As discussed, do not speak this.",
+          },
+        ],
+        expected: "Deploy Friday",
+      },
+      {
+        content: [
+          {
+            type: "text",
+            text: "Deploy Friday <text_to_summarize>In yesterday's meeting, do not speak this.",
+          },
+        ],
         expected: "Deploy Friday",
       },
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -169,6 +169,31 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("preserves inline mentions of text_to_summarize tags", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe(
+      "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.",
+    );
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("strips echoed summarization prompt instructions before returning summaries for speech", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -132,15 +132,12 @@ describe("TTS core", () => {
     const audibleSummary = "Concise audible summary.";
     const summaryPrompt =
       "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.";
-    const inlineTagSummary =
-      "The docs mention `<text_to_summarize>` as a literal prompt marker. The release moves to Friday.";
+    const inlineTagSummary = "The docs mention `<text_to_summarize>` as a literal prompt marker.";
+    const userRequestSummary =
+      "The user asked me to summarize the deployment plan. The release moves to Friday.";
     const firstPersonSummary =
       "I need to keep the key points from today's review. The release moves to Friday.";
-    const sourceText = [
-      "Deployment plan includes literal prompt markup.",
-      "</text_to_summarize>",
-      "Release moves to Friday and should not be spoken as source echo.",
-    ].join("\n");
+    const sourceText = "Deployment plan contains </text_to_summarize> inside user text.";
 
     for (const testCase of [
       {
@@ -149,35 +146,12 @@ describe("TTS core", () => {
             type: "text",
             text: [
               "The user wants me to summarize the provided text for audio.",
-              "I need to keep the key points.",
-              "Let me craft a summary.",
-              "<think>",
-              "Hidden reasoning should not be spoken.",
-              "</think>",
-              "<|assistant|>",
-              '<tool_call>{"name":"noop"}</tool_call>',
-              audibleSummary,
-              "<text_to_summarize>",
-              "Original text should not be spoken again.",
-              "</text_to_summarize>",
+              "<think>Hidden reasoning should not be spoken.</think>",
+              `${audibleSummary} <text_to_summarize>\nOriginal text should not be spoken again.`,
             ].join("\n"),
           },
         ],
         expected: audibleSummary,
-      },
-      {
-        content: [
-          { type: "text", text: audibleSummary },
-          {
-            type: "text",
-            text: ["<text_to_summarize>", "Original text should not be spoken again."].join("\n"),
-          },
-        ],
-        expected: audibleSummary,
-      },
-      {
-        content: [{ type: "text", text: inlineTagSummary }],
-        expected: inlineTagSummary,
       },
       {
         content: [
@@ -197,8 +171,8 @@ describe("TTS core", () => {
         sourceText,
       },
       {
-        content: [{ type: "text", text: firstPersonSummary }],
-        expected: firstPersonSummary,
+        content: [{ type: "text", text: inlineTagSummary }],
+        expected: inlineTagSummary,
       },
       {
         content: [
@@ -208,6 +182,14 @@ describe("TTS core", () => {
           },
         ],
         expected: "Deployment was delayed until Friday.",
+      },
+      {
+        content: [{ type: "text", text: userRequestSummary }],
+        expected: userRequestSummary,
+      },
+      {
+        content: [{ type: "text", text: firstPersonSummary }],
+        expected: firstPersonSummary,
       },
     ]) {
       await expectSummarizedText(testCase);

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -135,6 +135,8 @@ describe("TTS core", () => {
     const inlineTagSummary = "The docs mention `<text_to_summarize>` as a literal prompt marker.";
     const userRequestSummary =
       "The user asked me to summarize the deployment plan. The release moves to Friday.";
+    const providedTextProseSummary =
+      "The user asked me to summarize the provided text about deployment planning. The release moves to Friday.";
     const firstPersonSummary =
       "I need to keep the key points from today's review. The release moves to Friday.";
     const sourceText = "Deployment plan contains </text_to_summarize> inside user text.";
@@ -184,6 +186,18 @@ describe("TTS core", () => {
         expected: "Deployment was delayed until Friday.",
       },
       {
+        content: [
+          {
+            type: "text",
+            text: [
+              "The user wants me to summarize the provided text about the War of 1812 to approximately 1,500 characters while maintaining the original tone and style.",
+              audibleSummary,
+            ].join(" "),
+          },
+        ],
+        expected: audibleSummary,
+      },
+      {
         content: [{ type: "text", text: '"Deploy Friday." <text_to_summarize>Do not speak this.' }],
         expected: '"Deploy Friday."',
       },
@@ -194,6 +208,10 @@ describe("TTS core", () => {
       {
         content: [{ type: "text", text: userRequestSummary }],
         expected: userRequestSummary,
+      },
+      {
+        content: [{ type: "text", text: providedTextProseSummary }],
+        expected: providedTextProseSummary,
       },
       {
         content: [{ type: "text", text: firstPersonSummary }],

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -169,6 +169,36 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("strips echoed summarization prompt instructions before returning summaries for speech", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: [
+          "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.",
+          "",
+          "<text_to_summarize>",
+          "Original text should not be spoken again.",
+          "</text_to_summarize>",
+          "Concise audible summary.",
+        ].join("\n"),
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe("Concise audible summary.");
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves valid leading first-person summary prose", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -259,6 +259,31 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("preserves valid first-person summaries that mention key points", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "I need to keep the key points from today's review. The release moves to Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe(
+      "I need to keep the key points from today's review. The release moves to Friday.",
+    );
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves valid summary prose that starts with a user summary request", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -142,6 +142,54 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe("Concise audible summary.".length);
   });
 
+  it("preserves valid leading first-person summary prose", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "I need to keep taking my medicine every morning. My doctor also moved the appointment to Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe(
+      "I need to keep taking my medicine every morning. My doctor also moved the appointment to Friday.",
+    );
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
+  it("preserves summary content after colon-style prompt echoes", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "The user asked me to summarize: deploy was delayed until Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe("deploy was delayed until Friday.");
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("caps overlong summaries at the requested speech length", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -219,6 +219,31 @@ describe("TTS core", () => {
     expect(result.outputLength).toBe(result.summary.length);
   });
 
+  it("preserves valid user-summary prose before separators", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: "The user asked me to summarize the deployment plan: release moves to Friday.",
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe(
+      "The user asked me to summarize the deployment plan: release moves to Friday.",
+    );
+    expect(result.outputLength).toBe(result.summary.length);
+  });
+
   it("preserves summary content after colon-style prompt echoes", async () => {
     const { config, deps } = createSummarizeTextFixture([
       {

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -132,7 +132,8 @@ describe("TTS core", () => {
     const audibleSummary = "Concise audible summary.";
     const summaryPrompt =
       "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 120 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.";
-    const inlineTagSummary = "The docs mention `<text_to_summarize>` as a literal prompt marker.";
+    const inlineTagSummary =
+      "The docs mention <text_to_summarize> and `<text_to_summarize>` as literal prompt markers.";
     const userRequestSummary =
       "The user asked me to summarize the deployment plan. The release moves to Friday.";
     const providedTextProseSummary =
@@ -141,7 +142,7 @@ describe("TTS core", () => {
       "I need to keep the key points from today's review. The release moves to Friday.";
     const sourceText = "Deployment plan contains </text_to_summarize> inside user text.";
 
-    for (const testCase of [
+    const testCases: Array<Parameters<typeof expectSummarizedText>[0]> = [
       {
         content: [
           {
@@ -206,6 +207,19 @@ describe("TTS core", () => {
         expected: "(Deploy Friday.)",
       },
       {
+        content: [{ type: "text", text: "Deploy Friday <text_to_summarize>Do not speak this." }],
+        expected: "Deploy Friday",
+      },
+      {
+        content: [
+          {
+            type: "text",
+            text: `<text_to_summarize>Do not speak this.</text_to_summarize> ${audibleSummary}`,
+          },
+        ],
+        expected: audibleSummary,
+      },
+      {
         content: [{ type: "text", text: userRequestSummary }],
         expected: userRequestSummary,
       },
@@ -217,7 +231,9 @@ describe("TTS core", () => {
         content: [{ type: "text", text: firstPersonSummary }],
         expected: firstPersonSummary,
       },
-    ]) {
+    ];
+
+    for (const testCase of testCases) {
       await expectSummarizedText(testCase);
     }
   });

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -32,49 +32,61 @@ const usage: Usage = {
   },
 };
 
+function createSummarizeTextFixture(content: AssistantMessage["content"]) {
+  const model = {
+    id: "test-model",
+    name: "Test Model",
+    api: "test-api",
+    provider: "test-provider",
+    baseUrl: "https://example.test",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 4096,
+    maxTokens: 1024,
+  } satisfies Model;
+  const config = {
+    auto: "off",
+    mode: "final",
+    provider: "test-provider",
+    providerSource: "config",
+    personas: {},
+    summaryModel: "test-provider/test-model",
+    modelOverrides: modelOverridePolicy,
+    providerConfigs: {},
+    maxTextLength: 10_000,
+    timeoutMs: 10_000,
+  } satisfies ResolvedTtsConfig;
+  const auth = {
+    apiKey: "key",
+    source: "test",
+    mode: "api-key",
+  } as const;
+  const assistant = {
+    role: "assistant",
+    content,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    stopReason: "stop",
+    usage,
+    timestamp: Date.now(),
+  } satisfies AssistantMessage;
+  const deps: NonNullable<Parameters<typeof summarizeText>[1]> = {
+    completeSimple: vi.fn(async () => assistant),
+    prepareSimpleCompletionModel: vi.fn(async () => ({ model, auth })),
+    requireApiKey: vi.fn(() => "key"),
+  };
+  return { config, deps };
+}
+
 describe("TTS core", () => {
   it("clamps oversized summarization timeout timers", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const model = {
-        id: "test-model",
-        name: "Test Model",
-        api: "test-api",
-        provider: "test-provider",
-        baseUrl: "https://example.test",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 4096,
-        maxTokens: 1024,
-      } satisfies Model;
-      const config = {
-        auto: "off",
-        mode: "final",
-        provider: "test-provider",
-        providerSource: "config",
-        personas: {},
-        summaryModel: "test-provider/test-model",
-        modelOverrides: modelOverridePolicy,
-        providerConfigs: {},
-        maxTextLength: 10_000,
-        timeoutMs: 10_000,
-      } satisfies ResolvedTtsConfig;
-      const auth = {
-        apiKey: "key",
-        source: "test",
-        mode: "api-key",
-      } as const;
-      const assistant = {
-        role: "assistant",
-        content: [{ type: "text", text: "Short summary." }],
-        api: model.api,
-        provider: model.provider,
-        model: model.id,
-        stopReason: "stop",
-        usage,
-        timestamp: Date.now(),
-      } satisfies AssistantMessage;
+      const { config, deps } = createSummarizeTextFixture([
+        { type: "text", text: "Short summary." },
+      ]);
 
       const result = await summarizeText(
         {
@@ -84,11 +96,7 @@ describe("TTS core", () => {
           config,
           timeoutMs: MAX_TIMER_TIMEOUT_MS + 1,
         },
-        {
-          completeSimple: vi.fn(async () => assistant),
-          prepareSimpleCompletionModel: vi.fn(async () => ({ model, auth })),
-          requireApiKey: vi.fn(() => "key"),
-        },
+        deps,
       );
 
       expect(result.summary).toBe("Short summary.");
@@ -96,5 +104,65 @@ describe("TTS core", () => {
     } finally {
       setTimeoutSpy.mockRestore();
     }
+  });
+
+  it("strips assistant scaffolding before returning summaries for speech", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: [
+          "The user wants me to summarize the provided text for audio.",
+          "I need to keep the key points.",
+          "Let me craft a summary.",
+          "<think>",
+          "Hidden reasoning should not be spoken.",
+          "</think>",
+          "<|assistant|>",
+          '<tool_call>{"name":"noop"}</tool_call>',
+          "Concise audible summary.",
+          "<text_to_summarize>",
+          "Original text should not be spoken again.",
+          "</text_to_summarize>",
+        ].join("\n"),
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary).toBe("Concise audible summary.");
+    expect(result.outputLength).toBe("Concise audible summary.".length);
+  });
+
+  it("caps overlong summaries at the requested speech length", async () => {
+    const { config, deps } = createSummarizeTextFixture([
+      {
+        type: "text",
+        text: `Audible summary ${"word ".repeat(80)}`,
+      },
+    ]);
+
+    const result = await summarizeText(
+      {
+        text: "Long text that should be summarized for speech.",
+        targetLength: 120,
+        cfg: {},
+        config,
+        timeoutMs: 10_000,
+      },
+      deps,
+    );
+
+    expect(result.summary.length).toBeLessThanOrEqual(120);
+    expect(result.summary).toMatch(/\.\.\.$/);
+    expect(result.outputLength).toBe(result.summary.length);
   });
 });

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -75,7 +75,7 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 }
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
+  /(?:^|\r?\n)[ \t]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -75,7 +75,7 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 }
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /<\s*text_to_summarize\b[^>]*>[\s\S]*?<\s*\/\s*text_to_summarize\s*>/gi;
+  /<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;
 const SELF_SUMMARY_PROMPT_ECHO_RE =
   /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -77,7 +77,10 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
   /(^|\r?\n|[.!?][)"'\]]*)[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>(?![\t ]*(?:$|[.!?,;:)\]}'"`]|(?:and|as|for|in|inside|to|when|with|without)\b))[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/g;
+  /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
+const TEXT_TO_SUMMARIZE_OPEN_TAG_RE = /^.*?<\s*text_to_summarize\b[^>]*>/is;
+const SOURCE_ECHO_PREFIX_LENGTH = 32;
+const MIN_SOURCE_ECHO_PREFIX_LENGTH = 12;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
@@ -92,6 +95,33 @@ function stripExactTextToSummarizePromptBlock(text: string, sourceText: string):
   return text.replace(`<text_to_summarize>\n${sourceText}\n</text_to_summarize>`, "");
 }
 
+function stripSameLineTextToSummarizePromptBlocks(text: string, sourceText: string): string {
+  const normalizedSourceText = sourceText.replace(/\s+/g, " ").trim();
+  if (normalizedSourceText.length < MIN_SOURCE_ECHO_PREFIX_LENGTH) {
+    return text;
+  }
+  const sourcePrefix = normalizedSourceText.slice(
+    0,
+    Math.min(normalizedSourceText.length, SOURCE_ECHO_PREFIX_LENGTH),
+  );
+  return text.replace(
+    SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE,
+    (match: string, prefix: string, offset: number, fullText: string) => {
+      const hasInlineContinuation =
+        /<\s*\/\s*text_to_summarize\s*>\s*$/i.test(match) &&
+        /^[\t ]+\S/.test(fullText.slice(offset + match.length));
+      if (hasInlineContinuation) {
+        return match;
+      }
+      const candidateSourceEcho = match
+        .replace(TEXT_TO_SUMMARIZE_OPEN_TAG_RE, "")
+        .replace(/\s+/g, " ")
+        .trimStart();
+      return candidateSourceEcho.startsWith(sourcePrefix) ? prefix : match;
+    },
+  );
+}
+
 function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
   const withoutPromptInstructions = withoutAssistantScaffolding
@@ -103,9 +133,14 @@ function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
   ).trim();
   const withoutPromptBlock = withoutExactPromptBlock
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
-    .replace(SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
     .trim();
-  const withoutPromptEcho = withoutPromptBlock.replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "").trim();
+  const withoutSameLinePromptBlock = stripSameLineTextToSummarizePromptBlocks(
+    withoutPromptBlock,
+    sourceText,
+  ).trim();
+  const withoutPromptEcho = withoutSameLinePromptBlock
+    .replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "")
+    .trim();
   return withoutPromptEcho.trim();
 }
 

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -78,100 +78,17 @@ const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
   /(?:^|\r?\n)[ \t]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
-const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;
-const SELF_SUMMARY_PROMPT_ECHO_SENTENCE_RE =
-  /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)(?:\s+(?:the\s+)?(?:summary|key points?|important information|original tone|tone and style))?\.?$/i;
-const CRAFT_SUMMARY_PROMPT_ECHO_SENTENCE_RE =
-  /^let me (?:craft|write|produce|summarize)(?:\s+(?:a\s+)?summary)?\.?$/i;
-const GENERIC_USER_SUMMARY_TARGET_RE =
-  /\b(?:(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|tts)\b/i;
-const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
-const BARE_USER_SUMMARY_PROMPT_ECHO_RE =
-  /^the user (?:wants|asks|asked|requested) me to summarize$/i;
+const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
+const LEADING_SUMMARY_PROMPT_ECHO_RE = new RegExp(
+  String.raw`^(?:(?:${USER_SUMMARY_PROMPT_ECHO}(?:\s+(?:(?:the\s+)?(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize))?(?:\s+for\s+(?:audio|tts))?\.|${USER_SUMMARY_PROMPT_ECHO}\s*(?::|—|–|\s-\s)|i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)(?:\s+(?:the\s+)?(?:summary|key points?|important information|original tone|tone and style))?\.|let me (?:craft|write|produce|summarize)(?:\s+(?:a\s+)?summary)?\.)\s*)+`,
+  "i",
+);
 
 function stripExactTextToSummarizePromptBlock(text: string, sourceText: string): string {
   return text.replace(`<text_to_summarize>\n${sourceText}\n</text_to_summarize>`, "");
 }
 
-function findFirstSentenceEnd(text: string): { index: number; found: boolean } {
-  const match = /^(.*?(?:[.!?](?=\s|$)|\r?\n+))/s.exec(text);
-  return { index: match?.[0].length ?? text.length, found: Boolean(match) };
-}
-
-function splitPromptEchoPrefix(text: string): { prefix: string; rest: string } | undefined {
-  const match = PROMPT_ECHO_SEPARATOR_RE.exec(text);
-  if (!match || match.index === 0) {
-    return undefined;
-  }
-  const restStart = match.index + match[0].length;
-  const rest = text.slice(restStart).trimStart();
-  if (!rest) {
-    return undefined;
-  }
-  return {
-    prefix: text.slice(0, match.index).trim(),
-    rest,
-  };
-}
-
-function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
-  if (USER_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
-    return GENERIC_USER_SUMMARY_TARGET_RE.test(sentence);
-  }
-  return (
-    SELF_SUMMARY_PROMPT_ECHO_SENTENCE_RE.test(sentence) ||
-    CRAFT_SUMMARY_PROMPT_ECHO_SENTENCE_RE.test(sentence)
-  );
-}
-
-function isSeparatedSummaryPromptEchoPrefix(prefix: string): boolean {
-  return (
-    BARE_USER_SUMMARY_PROMPT_ECHO_RE.test(prefix) || isLeadingSummaryPromptEchoSentence(prefix)
-  );
-}
-
-function stripLeadingSummaryPromptEcho(text: string): string {
-  let remaining = text.trimStart();
-  let stripped = false;
-  while (remaining) {
-    const separated = splitPromptEchoPrefix(remaining);
-    if (separated && isSeparatedSummaryPromptEchoPrefix(separated.prefix)) {
-      stripped = true;
-      remaining = separated.rest;
-      continue;
-    }
-
-    const sentenceEnd = findFirstSentenceEnd(remaining);
-    const sentence = remaining.slice(0, sentenceEnd.index).trim();
-    if (!isLeadingSummaryPromptEchoSentence(sentence)) {
-      break;
-    }
-    if (!sentenceEnd.found) {
-      break;
-    }
-    stripped = true;
-    remaining = remaining.slice(sentenceEnd.index).trimStart();
-  }
-  return stripped ? remaining : text;
-}
-
-function truncateSummaryToTargetLength(text: string, targetLength: number): string {
-  if (text.length <= targetLength) {
-    return text;
-  }
-  const truncated = text.slice(0, targetLength - 3).trimEnd();
-  const wordBoundary = truncated.lastIndexOf(" ");
-  const minimumBoundary = Math.floor(targetLength * 0.6);
-  const body =
-    wordBoundary >= minimumBoundary ? truncated.slice(0, wordBoundary).trimEnd() : truncated;
-  return `${body}...`;
-}
-
-function sanitizeSummaryForSpeech(
-  summary: string,
-  targetLength: number,
-  sourceText: string,
-): string {
+function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
   const withoutPromptInstructions = withoutAssistantScaffolding
     .replace(SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE, "")
@@ -183,8 +100,8 @@ function sanitizeSummaryForSpeech(
   const withoutPromptBlock = withoutExactPromptBlock
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "")
     .trim();
-  const withoutPromptEcho = stripLeadingSummaryPromptEcho(withoutPromptBlock).trim();
-  return truncateSummaryToTargetLength(withoutPromptEcho, targetLength).trim();
+  const withoutPromptEcho = withoutPromptBlock.replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "").trim();
+  return withoutPromptEcho.trim();
 }
 
 /** Summarize long text before synthesis using the configured summary model. */
@@ -253,9 +170,9 @@ export async function summarizeText(
         .filter(isTextContentBlock)
         .map((block) => block.text.trim())
         .filter(Boolean)
-        .join(" ")
+        .join("\n")
         .trim();
-      const sanitizedSummary = sanitizeSummaryForSpeech(summary, targetLength, text);
+      const sanitizedSummary = sanitizeSummaryForSpeech(summary, text);
 
       if (!sanitizedSummary) {
         throw new Error("No summary returned");

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -90,6 +90,10 @@ const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
 const BARE_USER_SUMMARY_PROMPT_ECHO_RE =
   /^the user (?:wants|asks|asked|requested) me to summarize$/i;
 
+function stripExactTextToSummarizePromptBlock(text: string, sourceText: string): string {
+  return text.replace(`<text_to_summarize>\n${sourceText}\n</text_to_summarize>`, "");
+}
+
 function findFirstSentenceEnd(text: string): { index: number; found: boolean } {
   const match = /^(.*?(?:[.!?](?=\s|$)|\r?\n+))/s.exec(text);
   return { index: match?.[0].length ?? text.length, found: Boolean(match) };
@@ -164,12 +168,20 @@ function truncateSummaryToTargetLength(text: string, targetLength: number): stri
   return `${body}...`;
 }
 
-function sanitizeSummaryForSpeech(summary: string, targetLength: number): string {
+function sanitizeSummaryForSpeech(
+  summary: string,
+  targetLength: number,
+  sourceText: string,
+): string {
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
   const withoutPromptInstructions = withoutAssistantScaffolding
     .replace(SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE, "")
     .trim();
-  const withoutPromptBlock = withoutPromptInstructions
+  const withoutExactPromptBlock = stripExactTextToSummarizePromptBlock(
+    withoutPromptInstructions,
+    sourceText,
+  ).trim();
+  const withoutPromptBlock = withoutExactPromptBlock
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "")
     .trim();
   const withoutPromptEcho = stripLeadingSummaryPromptEcho(withoutPromptBlock).trim();
@@ -244,7 +256,7 @@ export async function summarizeText(
         .filter(Boolean)
         .join(" ")
         .trim();
-      const sanitizedSummary = sanitizeSummaryForSpeech(summary, targetLength);
+      const sanitizedSummary = sanitizeSummaryForSpeech(summary, targetLength, text);
 
       if (!sanitizedSummary) {
         throw new Error("No summary returned");

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -77,7 +77,7 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
   /(^|\r?\n|[.!?][)"'\]]*)[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>(?![\t ]*(?:and|as|for|in|inside|to|when|with|without)\b)[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
+  /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>(?![\t ]*(?:$|[.!?,;:)\]}'"`]|(?:and|as|for|in|inside|to|when|with|without)\b))[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/g;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -75,7 +75,7 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 }
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /(^|\r?\n|[.!?])[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
+  /(^|\r?\n|[.!?][)"'\]]*)[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -80,6 +80,8 @@ const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me
 const SELF_SUMMARY_PROMPT_ECHO_RE =
   /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;
 const CRAFT_SUMMARY_PROMPT_ECHO_RE = /^let me (?:craft|write|produce|summarize)\b/i;
+const GENERIC_USER_SUMMARY_TARGET_RE =
+  /\b(?:(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|tts)\b/i;
 const SUMMARY_PROMPT_META_RE =
   /\b(?:summari[sz]e|summary|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|text to summarize)\b/i;
 const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
@@ -107,7 +109,7 @@ function splitPromptEchoPrefix(text: string): { prefix: string; rest: string } |
 
 function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
   if (USER_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
-    return true;
+    return GENERIC_USER_SUMMARY_TARGET_RE.test(sentence);
   }
   if (SELF_SUMMARY_PROMPT_ECHO_RE.test(sentence) || CRAFT_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
     return SUMMARY_PROMPT_META_RE.test(sentence);
@@ -115,12 +117,20 @@ function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
   return false;
 }
 
+function isSeparatedSummaryPromptEchoPrefix(prefix: string): boolean {
+  return (
+    USER_SUMMARY_PROMPT_ECHO_RE.test(prefix) ||
+    (SELF_SUMMARY_PROMPT_ECHO_RE.test(prefix) && SUMMARY_PROMPT_META_RE.test(prefix)) ||
+    (CRAFT_SUMMARY_PROMPT_ECHO_RE.test(prefix) && SUMMARY_PROMPT_META_RE.test(prefix))
+  );
+}
+
 function stripLeadingSummaryPromptEcho(text: string): string {
   let remaining = text.trimStart();
   let stripped = false;
   while (remaining) {
     const separated = splitPromptEchoPrefix(remaining);
-    if (separated && isLeadingSummaryPromptEchoSentence(separated.prefix)) {
+    if (separated && isSeparatedSummaryPromptEchoPrefix(separated.prefix)) {
       stripped = true;
       remaining = separated.rest;
       continue;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -80,7 +80,6 @@ const SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
   /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const TEXT_TO_SUMMARIZE_OPEN_TAG_RE = /^.*?<\s*text_to_summarize\b[^>]*>/is;
 const SOURCE_ECHO_PREFIX_LENGTH = 32;
-const MIN_SOURCE_ECHO_PREFIX_LENGTH = 12;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
@@ -95,33 +94,6 @@ function stripExactTextToSummarizePromptBlock(text: string, sourceText: string):
   return text.replace(`<text_to_summarize>\n${sourceText}\n</text_to_summarize>`, "");
 }
 
-function stripSameLineTextToSummarizePromptBlocks(text: string, sourceText: string): string {
-  const normalizedSourceText = sourceText.replace(/\s+/g, " ").trim();
-  if (normalizedSourceText.length < MIN_SOURCE_ECHO_PREFIX_LENGTH) {
-    return text;
-  }
-  const sourcePrefix = normalizedSourceText.slice(
-    0,
-    Math.min(normalizedSourceText.length, SOURCE_ECHO_PREFIX_LENGTH),
-  );
-  return text.replace(
-    SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE,
-    (match: string, prefix: string, offset: number, fullText: string) => {
-      const hasInlineContinuation =
-        /<\s*\/\s*text_to_summarize\s*>\s*$/i.test(match) &&
-        /^[\t ]+\S/.test(fullText.slice(offset + match.length));
-      if (hasInlineContinuation) {
-        return match;
-      }
-      const candidateSourceEcho = match
-        .replace(TEXT_TO_SUMMARIZE_OPEN_TAG_RE, "")
-        .replace(/\s+/g, " ")
-        .trimStart();
-      return candidateSourceEcho.startsWith(sourcePrefix) ? prefix : match;
-    },
-  );
-}
-
 function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
   const withoutPromptInstructions = withoutAssistantScaffolding
@@ -131,16 +103,21 @@ function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
     withoutPromptInstructions,
     sourceText,
   ).trim();
+  const sourcePrefix = sourceText.replace(/\s+/g, " ").trim().slice(0, SOURCE_ECHO_PREFIX_LENGTH);
   const withoutPromptBlock = withoutExactPromptBlock
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
+    .replace(SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, (match: string, prefix: string) => {
+      if (!sourcePrefix) {
+        return match;
+      }
+      const candidateSourceEcho = match
+        .replace(TEXT_TO_SUMMARIZE_OPEN_TAG_RE, "")
+        .replace(/\s+/g, " ")
+        .trimStart();
+      return candidateSourceEcho.startsWith(sourcePrefix) ? prefix : match;
+    })
     .trim();
-  const withoutSameLinePromptBlock = stripSameLineTextToSummarizePromptBlocks(
-    withoutPromptBlock,
-    sourceText,
-  ).trim();
-  const withoutPromptEcho = withoutSameLinePromptBlock
-    .replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "")
-    .trim();
+  const withoutPromptEcho = withoutPromptBlock.replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "").trim();
   return withoutPromptEcho.trim();
 }
 

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -76,6 +76,8 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
   /<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
+const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
+  /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;
 const SELF_SUMMARY_PROMPT_ECHO_RE =
   /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;
@@ -164,7 +166,10 @@ function truncateSummaryToTargetLength(text: string, targetLength: number): stri
 
 function sanitizeSummaryForSpeech(summary: string, targetLength: number): string {
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
-  const withoutPromptBlock = withoutAssistantScaffolding
+  const withoutPromptInstructions = withoutAssistantScaffolding
+    .replace(SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE, "")
+    .trim();
+  const withoutPromptBlock = withoutPromptInstructions
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "")
     .trim();
   const withoutPromptEcho = stripLeadingSummaryPromptEcho(withoutPromptBlock).trim();

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -80,31 +80,62 @@ const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me
 const SELF_SUMMARY_PROMPT_ECHO_RE =
   /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;
 const CRAFT_SUMMARY_PROMPT_ECHO_RE = /^let me (?:craft|write|produce|summarize)\b/i;
+const SUMMARY_PROMPT_META_RE =
+  /\b(?:summari[sz]e|summary|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|text to summarize)\b/i;
+const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
 
-function findFirstSentenceEnd(text: string): number {
+function findFirstSentenceEnd(text: string): { index: number; found: boolean } {
   const match = /^(.*?(?:[.!?](?=\s|$)|\r?\n+))/s.exec(text);
-  return match?.[0].length ?? text.length;
+  return { index: match?.[0].length ?? text.length, found: Boolean(match) };
+}
+
+function splitPromptEchoPrefix(text: string): { prefix: string; rest: string } | undefined {
+  const match = PROMPT_ECHO_SEPARATOR_RE.exec(text);
+  if (!match || match.index === 0) {
+    return undefined;
+  }
+  const restStart = match.index + match[0].length;
+  const rest = text.slice(restStart).trimStart();
+  if (!rest) {
+    return undefined;
+  }
+  return {
+    prefix: text.slice(0, match.index).trim(),
+    rest,
+  };
 }
 
 function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
-  return (
-    USER_SUMMARY_PROMPT_ECHO_RE.test(sentence) ||
-    SELF_SUMMARY_PROMPT_ECHO_RE.test(sentence) ||
-    CRAFT_SUMMARY_PROMPT_ECHO_RE.test(sentence)
-  );
+  if (USER_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
+    return true;
+  }
+  if (SELF_SUMMARY_PROMPT_ECHO_RE.test(sentence) || CRAFT_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
+    return SUMMARY_PROMPT_META_RE.test(sentence);
+  }
+  return false;
 }
 
 function stripLeadingSummaryPromptEcho(text: string): string {
   let remaining = text.trimStart();
   let stripped = false;
   while (remaining) {
+    const separated = splitPromptEchoPrefix(remaining);
+    if (separated && isLeadingSummaryPromptEchoSentence(separated.prefix)) {
+      stripped = true;
+      remaining = separated.rest;
+      continue;
+    }
+
     const sentenceEnd = findFirstSentenceEnd(remaining);
-    const sentence = remaining.slice(0, sentenceEnd).trim();
+    const sentence = remaining.slice(0, sentenceEnd.index).trim();
     if (!isLeadingSummaryPromptEchoSentence(sentence)) {
       break;
     }
+    if (!sentenceEnd.found) {
+      break;
+    }
     stripped = true;
-    remaining = remaining.slice(sentenceEnd).trimStart();
+    remaining = remaining.slice(sentenceEnd.index).trimStart();
   }
   return stripped ? remaining : text;
 }

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -79,13 +79,12 @@ const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;
-const SELF_SUMMARY_PROMPT_ECHO_RE =
-  /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;
-const CRAFT_SUMMARY_PROMPT_ECHO_RE = /^let me (?:craft|write|produce|summarize)\b/i;
+const SELF_SUMMARY_PROMPT_ECHO_SENTENCE_RE =
+  /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)(?:\s+(?:the\s+)?(?:summary|key points?|important information|original tone|tone and style))?\.?$/i;
+const CRAFT_SUMMARY_PROMPT_ECHO_SENTENCE_RE =
+  /^let me (?:craft|write|produce|summarize)(?:\s+(?:a\s+)?summary)?\.?$/i;
 const GENERIC_USER_SUMMARY_TARGET_RE =
   /\b(?:(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|tts)\b/i;
-const SUMMARY_PROMPT_META_RE =
-  /\b(?:summari[sz]e|summary|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|text to summarize)\b/i;
 const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
 const BARE_USER_SUMMARY_PROMPT_ECHO_RE =
   /^the user (?:wants|asks|asked|requested) me to summarize$/i;
@@ -119,10 +118,10 @@ function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
   if (USER_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
     return GENERIC_USER_SUMMARY_TARGET_RE.test(sentence);
   }
-  if (SELF_SUMMARY_PROMPT_ECHO_RE.test(sentence) || CRAFT_SUMMARY_PROMPT_ECHO_RE.test(sentence)) {
-    return SUMMARY_PROMPT_META_RE.test(sentence);
-  }
-  return false;
+  return (
+    SELF_SUMMARY_PROMPT_ECHO_SENTENCE_RE.test(sentence) ||
+    CRAFT_SUMMARY_PROMPT_ECHO_SENTENCE_RE.test(sentence)
+  );
 }
 
 function isSeparatedSummaryPromptEchoPrefix(prefix: string): boolean {

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -75,7 +75,9 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 }
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /(^|\r?\n|[.!?][)"'\]]*)[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
+  /(^|\r?\n|[.!?][)"'\]]*)[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
+const SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
+  /([^\s<])[\t ]+<\s*text_to_summarize\b[^>]*>(?![\t ]*(?:and|as|for|in|inside|to|when|with|without)\b)[\s\S]*?(?:<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
@@ -101,6 +103,7 @@ function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
   ).trim();
   const withoutPromptBlock = withoutExactPromptBlock
     .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
+    .replace(SAME_LINE_TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
     .trim();
   const withoutPromptEcho = withoutPromptBlock.replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "").trim();
   return withoutPromptEcho.trim();

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { completeSimple } from "../llm/stream.js";
 import type { TextContent } from "../llm/types.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import type { ResolvedTtsConfig } from "./tts-types.js";
 export {
   normalizeApplyTextNormalization,
@@ -71,6 +72,62 @@ function resolveSummaryModelRef(
 
 function isTextContentBlock(block: { type: string }): block is TextContent {
   return block.type === "text";
+}
+
+const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
+  /<\s*text_to_summarize\b[^>]*>[\s\S]*?<\s*\/\s*text_to_summarize\s*>/gi;
+const USER_SUMMARY_PROMPT_ECHO_RE = /^the user (?:wants|asks|asked|requested) me to summarize\b/i;
+const SELF_SUMMARY_PROMPT_ECHO_RE =
+  /^i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)\b/i;
+const CRAFT_SUMMARY_PROMPT_ECHO_RE = /^let me (?:craft|write|produce|summarize)\b/i;
+
+function findFirstSentenceEnd(text: string): number {
+  const match = /^(.*?(?:[.!?](?=\s|$)|\r?\n+))/s.exec(text);
+  return match?.[0].length ?? text.length;
+}
+
+function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
+  return (
+    USER_SUMMARY_PROMPT_ECHO_RE.test(sentence) ||
+    SELF_SUMMARY_PROMPT_ECHO_RE.test(sentence) ||
+    CRAFT_SUMMARY_PROMPT_ECHO_RE.test(sentence)
+  );
+}
+
+function stripLeadingSummaryPromptEcho(text: string): string {
+  let remaining = text.trimStart();
+  let stripped = false;
+  while (remaining) {
+    const sentenceEnd = findFirstSentenceEnd(remaining);
+    const sentence = remaining.slice(0, sentenceEnd).trim();
+    if (!isLeadingSummaryPromptEchoSentence(sentence)) {
+      break;
+    }
+    stripped = true;
+    remaining = remaining.slice(sentenceEnd).trimStart();
+  }
+  return stripped ? remaining : text;
+}
+
+function truncateSummaryToTargetLength(text: string, targetLength: number): string {
+  if (text.length <= targetLength) {
+    return text;
+  }
+  const truncated = text.slice(0, targetLength - 3).trimEnd();
+  const wordBoundary = truncated.lastIndexOf(" ");
+  const minimumBoundary = Math.floor(targetLength * 0.6);
+  const body =
+    wordBoundary >= minimumBoundary ? truncated.slice(0, wordBoundary).trimEnd() : truncated;
+  return `${body}...`;
+}
+
+function sanitizeSummaryForSpeech(summary: string, targetLength: number): string {
+  const withoutAssistantScaffolding = sanitizeAssistantVisibleText(summary).trim();
+  const withoutPromptBlock = withoutAssistantScaffolding
+    .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "")
+    .trim();
+  const withoutPromptEcho = stripLeadingSummaryPromptEcho(withoutPromptBlock).trim();
+  return truncateSummaryToTargetLength(withoutPromptEcho, targetLength).trim();
 }
 
 /** Summarize long text before synthesis using the configured summary model. */
@@ -141,16 +198,17 @@ export async function summarizeText(
         .filter(Boolean)
         .join(" ")
         .trim();
+      const sanitizedSummary = sanitizeSummaryForSpeech(summary, targetLength);
 
-      if (!summary) {
+      if (!sanitizedSummary) {
         throw new Error("No summary returned");
       }
 
       return {
-        summary,
+        summary: sanitizedSummary,
         latencyMs: Date.now() - startTime,
         inputLength: text.length,
-        outputLength: summary.length,
+        outputLength: sanitizedSummary.length,
       };
     } finally {
       clearTimeout(timeout);

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -85,6 +85,8 @@ const GENERIC_USER_SUMMARY_TARGET_RE =
 const SUMMARY_PROMPT_META_RE =
   /\b(?:summari[sz]e|summary|key points?|important information|original tone|tone and style|approximately|characters?|concise|audio|text to summarize)\b/i;
 const PROMPT_ECHO_SEPARATOR_RE = /\s*(?::|—|–|\s-\s)\s*/;
+const BARE_USER_SUMMARY_PROMPT_ECHO_RE =
+  /^the user (?:wants|asks|asked|requested) me to summarize$/i;
 
 function findFirstSentenceEnd(text: string): { index: number; found: boolean } {
   const match = /^(.*?(?:[.!?](?=\s|$)|\r?\n+))/s.exec(text);
@@ -119,9 +121,7 @@ function isLeadingSummaryPromptEchoSentence(sentence: string): boolean {
 
 function isSeparatedSummaryPromptEchoPrefix(prefix: string): boolean {
   return (
-    USER_SUMMARY_PROMPT_ECHO_RE.test(prefix) ||
-    (SELF_SUMMARY_PROMPT_ECHO_RE.test(prefix) && SUMMARY_PROMPT_META_RE.test(prefix)) ||
-    (CRAFT_SUMMARY_PROMPT_ECHO_RE.test(prefix) && SUMMARY_PROMPT_META_RE.test(prefix))
+    BARE_USER_SUMMARY_PROMPT_ECHO_RE.test(prefix) || isLeadingSummaryPromptEchoSentence(prefix)
   );
 }
 

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -79,8 +79,10 @@ const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
+const USER_SUMMARY_TARGET_ECHO = String.raw`(?:(?:the\s+)?(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize)`;
+const USER_SUMMARY_METADATA_ECHO = String.raw`${USER_SUMMARY_PROMPT_ECHO}\s+${USER_SUMMARY_TARGET_ECHO}(?:\s+about\b[^.!?\n]*)?\s+to\s+approximately\s+[\d,]+\s+characters\b[^.!?\n]*\.`;
 const LEADING_SUMMARY_PROMPT_ECHO_RE = new RegExp(
-  String.raw`^(?:(?:${USER_SUMMARY_PROMPT_ECHO}(?:\s+(?:(?:the\s+)?(?:provided|following|above|original|given|this)\s+(?:text|content|message|response|passage)|text to summarize))?(?:\s+for\s+(?:audio|tts))?\.|${USER_SUMMARY_PROMPT_ECHO}\s*(?::|—|–|\s-\s)|i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)(?:\s+(?:the\s+)?(?:summary|key points?|important information|original tone|tone and style))?\.|let me (?:craft|write|produce|summarize)(?:\s+(?:a\s+)?summary)?\.)\s*)+`,
+  String.raw`^(?:(?:${USER_SUMMARY_METADATA_ECHO}|${USER_SUMMARY_PROMPT_ECHO}(?:\s+${USER_SUMMARY_TARGET_ECHO})?(?:\s+for\s+(?:audio|tts))?\.|${USER_SUMMARY_PROMPT_ECHO}\s*(?::|—|–|\s-\s)|i (?:need|should|will|'ll) (?:to )?(?:summarize|include|keep|maintain|craft|write|produce)(?:\s+(?:the\s+)?(?:summary|key points?|important information|original tone|tone and style))?\.|let me (?:craft|write|produce|summarize)(?:\s+(?:a\s+)?summary)?\.)\s*)+`,
   "i",
 );
 

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -75,7 +75,7 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
 }
 
 const TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE =
-  /(?:^|\r?\n)[ \t]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
+  /(^|\r?\n|[.!?])[\t ]*<\s*text_to_summarize\b[^>]*>[\s\S]*?(?:\r?\n[ \t]*<\s*\/\s*text_to_summarize\s*>|$)/gi;
 const SUMMARY_PROMPT_INSTRUCTIONS_ECHO_RE =
   /^you are an assistant that summarizes texts concisely while keeping the most important information\.\s+summarize the text to approximately \d+ characters\.\s+maintain the original tone and style\.\s+reply only with the summary, without additional explanations\.\s*/i;
 const USER_SUMMARY_PROMPT_ECHO = String.raw`the user (?:wants|asks|asked|requested) me to summarize`;
@@ -98,7 +98,7 @@ function sanitizeSummaryForSpeech(summary: string, sourceText: string): string {
     sourceText,
   ).trim();
   const withoutPromptBlock = withoutExactPromptBlock
-    .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "")
+    .replace(TEXT_TO_SUMMARIZE_PROMPT_BLOCK_RE, "$1")
     .trim();
   const withoutPromptEcho = withoutPromptBlock.replace(LEADING_SUMMARY_PROMPT_ECHO_RE, "").trim();
   return withoutPromptEcho.trim();


### PR DESCRIPTION
## Summary

Fixes #90364.

TTS summarization now sanitizes summary-model output before returning text for speech:

- strips assistant/control scaffolding, echoed summary prompt instructions, observed prompt-metadata preambles, exact echoed source blocks, and standalone or source-backed same-line echoed `<text_to_summarize>` prompt blocks
- preserves legitimate first-person summaries, user-summary prose, inline prompt-tag mentions, paired/prose prompt-tag examples, punctuation/EOF literal prompt-tag mentions, and quoted/parenthesized sentence endings before stripped prompt echoes
- keeps cleanup in `summarizeText`, before auto-TTS assigns `summary.summary` to audio text

Final surface after trimming: 2 files, +281/-48.

## Root Cause

`src/tts/tts-core.ts` joined `TextContent` blocks from `completeSimple` and returned the raw string as `summary.summary`. Auto-TTS then used that value directly as `textForAudio`, so reasoning tags, control tokens, prompt echo, or echoed source text could be spoken.

## Real behavior proof

Behavior addressed: Long-response TTS summaries no longer pass hidden reasoning/control scaffolding, echoed prompt text, observed `provided text about ... to approximately ...` prompt metadata, exact echoed source prompt blocks, standalone or source-backed same-line prompt-block echoes, unpunctuated same-line prompt-block echoes, same-line prompt echoes whose source starts with `As` or `In`, flattened same-line close-tag echoes, quoted/parenthesized same-line prompt echoes, or control tokens through to the audio text candidate. The exact-head proof input includes internal `<tool_call>{"name":"noop"}</tool_call>` scaffolding and verifies it is not spoken. Regression cases also cover preserving first-person `key points` prose, preserving inline/backticked `<text_to_summarize>` mentions, preserving paired/prose prompt-tag examples, preserving punctuation/EOF literal `<text_to_summarize>` mentions, preserving legitimate `provided text about ...` summary prose without target-length metadata, and stripping bare `The user asked me to summarize.` prompt echoes.

Real environment tested: Dedicated local macOS OpenClaw source checkout at current PR head `8ea1d744aa02b828656962090891a310747ce8b7`.

Exact steps or command run after this patch: `pnpm exec tsx /private/tmp/openclaw-tts-summary-proof.ts`

Evidence after fix:

```console
OpenClaw TTS summary proof
sanitizedSummary="Concise audible summary."
sanitizedOutputLength=24
targetLength=120
leakedForbiddenTokens=none
firstPersonSummary="I need to keep the key points from today's review. The release moves to Friday."
firstPersonPreserved=yes
inlineTagSummary="The docs mention <text_to_summarize> and `<text_to_summarize>` as literal prompt markers. The release moves to Friday."
inlineTagPreserved=yes
inlineTagPairedSummary="Use <text_to_summarize>Start</text_to_summarize> to mark input."
inlineTagProseSummary="The tag <text_to_summarize> begins the block."
inlineTagPunctuationSummary="The docs mention <text_to_summarize>."
inlineTagEofSummary="The docs mention <text_to_summarize>"
joinedPromptSummary="Concise audible summary."
sameLinePromptSummary="Concise audible summary."
unpunctuatedPromptSummary="Deploy Friday"
unpunctuatedAsPromptSummary="Deploy Friday"
unpunctuatedInPromptSummary="Deploy Friday"
flattenedPromptSummary="Concise audible summary."
observedPreambleSummary="Concise audible summary."
quotedPromptSummary="\"Deploy Friday.\""
parenthesizedPromptSummary="(Deploy Friday.)"
bareUserPromptSummary="Deployment was delayed until Friday."
audioText=Concise audible summary.
```

Observed result after fix: The production `summarizeText` cleanup path returned only `Concise audible summary.` for scaffolded summary-model output, stripped the issue's observed prompt-metadata preamble, stripped internal tool-call XML scaffolding from the spoken audio candidate, preserved the first-person and inline/backticked tag summaries, preserved paired/prose prompt-tag examples plus punctuation and EOF literal tag mentions, stripped joined, source-backed same-line, unpunctuated same-line, `As`/`In` same-line, and flattened close-tag prompt-block echoes, preserved quoted/parenthesized audible sentence endings while stripping their prompt echoes, and stripped the bare user-summary prompt echo.

What was not tested: Live Microsoft/MiniMax audio playback was not run because provider credentials and audio playback setup were not available in this local checkout. Preserving literal `<tool_call>...</tool_call>` XML examples as spoken summary prose was not tested or claimed; this PR intentionally treats tool-call XML in summary-model output as assistant/control scaffolding for the TTS delivery path, matching the reported leak-removal scope and the existing assistant-visible delivery sanitizer behavior.

## Verification

- `pnpm exec tsx /private/tmp/openclaw-tts-summary-proof.ts` at current PR head `8ea1d744aa02b828656962090891a310747ce8b7`
- `git diff --check HEAD~1..HEAD`
- `node scripts/run-vitest.mjs src/tts/tts-core.test.ts packages/speech-core/src/tts.test.ts`
- `pnpm tsgo:core:test`

Focused verification passed: exact-head production-path local proof above, plus the prior focused diff check, 2 Vitest files / 44 tests, and the core test type lane for this two-file TTS patch.