### PR TITLE
Fix LM Studio wizard prompter binding

### DIFF
--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -182,6 +182,54 @@ function createQueuedWizardPrompterHarness(textValues: string[]): {
   return { prompter, note, text };
 }
 
+function createMethodBoundWizardPrompterHarness(textValues: string[]): {
+  prompter: WizardPrompter;
+  note: ReturnType<typeof vi.fn>;
+  text: ReturnType<typeof vi.fn>;
+} {
+  const queue = [...textValues];
+  const note = vi.fn(async (_message: string, _title?: string) => {});
+  const text = vi.fn(async () => queue.shift() ?? "");
+
+  class MethodBoundWizardPrompter implements WizardPrompter {
+    async intro() {}
+    async outro() {}
+    async note(message: string, title?: string) {
+      await this.recordNote(message, title);
+    }
+    async select<T>(params: { options: Array<{ value: T }> }) {
+      const firstOption = params.options[0];
+      if (!firstOption) {
+        throw new Error("select called without options");
+      }
+      return firstOption.value;
+    }
+    async multiselect() {
+      return [];
+    }
+    async text() {
+      return await this.readText();
+    }
+    async confirm() {
+      return false;
+    }
+    progress() {
+      return {
+        update: () => {},
+        stop: () => {},
+      };
+    }
+    private async readText() {
+      return await text();
+    }
+    private async recordNote(message: string, title?: string) {
+      await note(message, title);
+    }
+  }
+
+  return { prompter: new MethodBoundWizardPrompter(), note, text };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -796,6 +844,43 @@ describe("lmstudio setup", () => {
       contextTokens: 4096,
       maxTokens: 4096,
     });
+  });
+
+  it("interactive setup preserves gateway wizard prompter method binding", async () => {
+    const { prompter, text } = createMethodBoundWizardPrompterHarness([
+      "http://localhost:1234/api/v1/",
+      "lmstudio-test-key",
+      "4096",
+    ]);
+
+    const result = await promptAndConfigureLmstudioInteractive({
+      config: buildConfig(),
+      prompter,
+    });
+
+    expect(text).toHaveBeenCalledTimes(3);
+    expect(result.defaultModel).toBe("lmstudio/qwen3-8b-instruct");
+  });
+
+  it("interactive setup preserves gateway wizard note binding on discovery failure", async () => {
+    fetchLmstudioModelsMock.mockResolvedValueOnce({ reachable: false, models: [] });
+    const { prompter, note, text } = createMethodBoundWizardPrompterHarness([
+      "http://localhost:1234/api/v1/",
+      "lmstudio-test-key",
+    ]);
+
+    await expect(
+      promptAndConfigureLmstudioInteractive({
+        config: buildConfig(),
+        prompter,
+      }),
+    ).rejects.toThrow("LM Studio not reachable");
+
+    expect(text).toHaveBeenCalledTimes(2);
+    expect(note).toHaveBeenCalledWith(
+      "LM Studio could not be reached at http://localhost:1234/v1.\nStart LM Studio (or run lms server start) and re-run setup.",
+      "LM Studio",
+    );
   });
 
   it("interactive setup accepts a blank API key for unauthenticated local LM Studio", async () => {

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -390,11 +390,13 @@ export async function promptAndConfigureLmstudioInteractive(params: {
   promptText?: ProviderPromptText;
   note?: ProviderPromptNote;
 }): Promise<ProviderAuthResult> {
-  const promptText = params.prompter?.text ?? params.promptText;
+  const promptText = params.prompter
+    ? params.prompter.text.bind(params.prompter)
+    : params.promptText;
   if (!promptText) {
     throw new Error("LM Studio interactive setup requires a text prompter.");
   }
-  const note = params.prompter?.note ?? params.note;
+  const note = params.prompter ? params.prompter.note.bind(params.prompter) : params.note;
   const defaultBaseUrl = resolveLmstudioSetupDefaultBaseUrl();
   const baseUrlRaw = await promptText({
     message: `${LMSTUDIO_PROVIDER_LABEL} base URL`,


### PR DESCRIPTION
## Summary
- Bind LM Studio setup prompter methods before storing them as callbacks so gateway wizard class methods keep their receiver.
- Add regression coverage for both `text` and `note` class-method prompter paths.

## Real behavior proof
- **Behavior or issue addressed:** Windows setup wizard selecting **More… → LM Studio** crashed on gateway `2026.5.28` with `TypeError: Cannot read properties of undefined (reading 'prompt')`.
- **Real environment tested:** Windows `openclaw-windows-node` setup UI against a local `OpenClawGateway` WSL gateway. The installed gateway bundle was patched with this PR's LM Studio prompter binding change for B-side validation.
- **Exact steps or command run after this patch:** Restarted `openclaw-gateway.service`, launched the Windows setup wizard, selected **More… → LM Studio**, and reran the headless LM Studio provider probe.
- **Evidence after fix:** Screen recording: https://github.com/user-attachments/assets/30542ff5-59de-4e1d-b5d2-16c37cd985ef
- **Observed result after fix:** The wizard advanced to the `LM Studio base URL` step instead of throwing the prompt TypeError.
- **What was not tested:** Windows app consumption of an official fixed gateway release/LKG; that remains a follow-up after this upstream fix lands and a fixed gateway version is selected.

## Verification
- `pnpm build`
- `pnpm test extensions/lmstudio/src/setup.test.ts` — 38 passed
- `pnpm exec oxfmt --check --threads=1 extensions/lmstudio/src/setup.ts extensions/lmstudio/src/setup.test.ts`
- `pnpm lint:extensions`
- Hanselman dual-model review: no blocking findings. Both reviewers flagged missing `note` binding coverage; this PR now includes that regression test.

## Notes
- `pnpm check:changed` could not run locally because the Crabbox/Testbox wrapper failed its local binary sanity check before starting the remote check.
- Windows consumption should wait for a fixed gateway release/LKG decision; this PR only fixes the gateway-side provider bug.
