### PR TITLE
Add NVIDIA Nemotron 3 Ultra default

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -306,7 +306,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 | MiniMax                                 | `minimax` / `minimax-portal`     | `MINIMAX_API_KEY` / `MINIMAX_OAUTH_TOKEN`                    | `minimax/MiniMax-M3`                                       |
 | Mistral                                 | `mistral`                        | `MISTRAL_API_KEY`                                            | `mistral/mistral-large-latest`                             |
 | Moonshot                                | `moonshot`                       | `MOONSHOT_API_KEY`                                           | `moonshot/kimi-k2.6`                                       |
-| NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                             | `nvidia/nvidia/nemotron-3-super-120b-a12b`                 |
+| NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                             | `nvidia/nvidia/nemotron-3-ultra-550b-a55b`                 |
 | NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                             | `novita/deepseek/deepseek-v3-0324`                         |
 | [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                             | `ollama-cloud/kimi-k2.6`                                   |
 | OpenRouter                              | `openrouter`                     | `OPENROUTER_API_KEY`                                         | `openrouter/auto`                                          |

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -72,8 +72,7 @@ try NVIDIA's public featured-model catalog from
 `https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
 caches the ranked result for 24 hours. New featured models from build.nvidia.com
 therefore appear in setup and model-selection surfaces without waiting for an
-OpenClaw release. OpenClaw also keeps the bundled NVIDIA default selectable if
-the featured feed has not yet listed the model.
+OpenClaw release.
 
 The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
 NVIDIA API key is configured, or if that public catalog is unavailable or
@@ -98,7 +97,7 @@ visible answer instead of exposing reasoning text.
 
 | Model ref                                  | Name                         | Context   | Max output | Notes                             |
 | ------------------------------------------ | ---------------------------- | --------- | ---------- | --------------------------------- |
-| `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | NVIDIA Nemotron 3 Ultra 550B | 1,000,000 | 16,384     | Default; featured-feed supplement |
+| `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | NVIDIA Nemotron 3 Ultra 550B | 1,000,000 | 16,384     | Default                           |
 | `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144   | 8,192      | Featured fallback                 |
 | `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144   | 8,192      | Featured fallback                 |
 | `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608   | 8,192      | Featured fallback                 |
@@ -117,10 +116,9 @@ visible answer instead of exposing reasoning text.
   <Accordion title="Catalog and pricing">
     OpenClaw prefers NVIDIA's public featured-model catalog when NVIDIA auth is
     configured and caches it for 24 hours. The bundled fallback catalog is static
-    and keeps deprecated shipped refs for upgrade compatibility. The bundled
-    default is prepended to live featured rows when NVIDIA's public feed has not
-    caught up with the build page. Costs default to `0` in source since NVIDIA
-    currently offers free API access for the listed models.
+    and keeps deprecated shipped refs for upgrade compatibility. Costs default
+    to `0` in source since NVIDIA currently offers free API access for the
+    listed models.
   </Accordion>
 
   <Accordion title="OpenAI-compatible endpoint">

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -72,11 +72,12 @@ try NVIDIA's public featured-model catalog from
 `https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
 caches the ranked result for 24 hours. New featured models from build.nvidia.com
 therefore appear in setup and model-selection surfaces without waiting for an
-OpenClaw release.
+OpenClaw release. When the live feed is available, the first returned model is
+the default option shown during NVIDIA setup.
 
 The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
 NVIDIA API key is configured, or if that public catalog is unavailable or
-malformed, OpenClaw falls back to the bundled catalog below.
+malformed, OpenClaw falls back to the bundled catalog and bundled default below.
 
 ## Nemotron 3 Ultra
 

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -3,12 +3,15 @@ summary: "Use NVIDIA's OpenAI-compatible API in OpenClaw"
 read_when:
   - You want to use open models in OpenClaw for free
   - You need NVIDIA_API_KEY setup
+  - You want to use Nemotron 3 Ultra through NVIDIA
 title: "NVIDIA"
 ---
 
 NVIDIA provides an OpenAI-compatible API at `https://integrate.api.nvidia.com/v1` for
 open models for free. Authenticate with an API key from
-[build.nvidia.com](https://build.nvidia.com/settings/api-keys).
+[build.nvidia.com](https://build.nvidia.com/settings/api-keys). OpenClaw
+defaults the NVIDIA provider to Nemotron 3 Ultra, NVIDIA's 550B total / 55B
+active reasoning model for long-context agentic work.
 
 ## Getting started
 
@@ -24,7 +27,7 @@ open models for free. Authenticate with an API key from
   </Step>
   <Step title="Set an NVIDIA model">
     ```bash
-    openclaw models set nvidia/nvidia/nemotron-3-super-120b-a12b
+    openclaw models set nvidia/nvidia/nemotron-3-ultra-550b-a55b
     ```
   </Step>
 </Steps>
@@ -56,7 +59,7 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
   },
   agents: {
     defaults: {
-      model: { primary: "nvidia/nvidia/nemotron-3-super-120b-a12b" },
+      model: { primary: "nvidia/nvidia/nemotron-3-ultra-550b-a55b" },
     },
   },
 }
@@ -69,22 +72,39 @@ try NVIDIA's public featured-model catalog from
 `https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
 caches the ranked result for 24 hours. New featured models from build.nvidia.com
 therefore appear in setup and model-selection surfaces without waiting for an
-OpenClaw release.
+OpenClaw release. OpenClaw also keeps the bundled NVIDIA default selectable if
+the featured feed has not yet listed the model.
 
 The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
 NVIDIA API key is configured, or if that public catalog is unavailable or
 malformed, OpenClaw falls back to the bundled catalog below.
 
+## Nemotron 3 Ultra
+
+Nemotron 3 Ultra is the default NVIDIA model in OpenClaw. NVIDIA's build page for
+[`nvidia/nemotron-3-ultra-550b-a55b`](https://build.nvidia.com/nvidia/nemotron-3-ultra-550b-a55b)
+lists it as an available free endpoint with a 1M-token context specification.
+The bundled catalog records a 16,384-token max output to match NVIDIA's current
+OpenAI-compatible sample request for the hosted endpoint.
+
+Use Ultra for the highest-capability NVIDIA default. Keep Super selected when
+you want the smaller Nemotron 3 option, or choose one of the third-party models
+hosted in NVIDIA's catalog when their context, latency, or behavior fits better.
+The bundled Ultra row sends `chat_template_kwargs.enable_thinking: false` and
+`force_nonempty_content: true` by default so normal chat output stays in the
+visible answer instead of exposing reasoning text.
+
 ## Bundled fallback catalog
 
-| Model ref                                  | Name                         | Context | Max output | Notes                             |
-| ------------------------------------------ | ---------------------------- | ------- | ---------- | --------------------------------- |
-| `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144 | 8,192      | Featured fallback                 |
-| `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144 | 8,192      | Featured fallback                 |
-| `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608 | 8,192      | Featured fallback                 |
-| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752 | 8,192      | Featured fallback                 |
-| `nvidia/minimaxai/minimax-m2.5`            | MiniMax M2.5                 | 196,608 | 8,192      | Deprecated, upgrade compatibility |
-| `nvidia/z-ai/glm5`                         | GLM-5                        | 202,752 | 8,192      | Deprecated, upgrade compatibility |
+| Model ref                                  | Name                         | Context   | Max output | Notes                             |
+| ------------------------------------------ | ---------------------------- | --------- | ---------- | --------------------------------- |
+| `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | NVIDIA Nemotron 3 Ultra 550B | 1,000,000 | 16,384     | Default; featured-feed supplement |
+| `nvidia/nvidia/nemotron-3-super-120b-a12b` | NVIDIA Nemotron 3 Super 120B | 262,144   | 8,192      | Featured fallback                 |
+| `nvidia/moonshotai/kimi-k2.5`              | Kimi K2.5                    | 262,144   | 8,192      | Featured fallback                 |
+| `nvidia/minimaxai/minimax-m2.7`            | Minimax M2.7                 | 196,608   | 8,192      | Featured fallback                 |
+| `nvidia/z-ai/glm-5.1`                      | GLM 5.1                      | 202,752   | 8,192      | Featured fallback                 |
+| `nvidia/minimaxai/minimax-m2.5`            | MiniMax M2.5                 | 196,608   | 8,192      | Deprecated, upgrade compatibility |
+| `nvidia/z-ai/glm5`                         | GLM-5                        | 202,752   | 8,192      | Deprecated, upgrade compatibility |
 
 ## Advanced configuration
 
@@ -97,14 +117,45 @@ malformed, OpenClaw falls back to the bundled catalog below.
   <Accordion title="Catalog and pricing">
     OpenClaw prefers NVIDIA's public featured-model catalog when NVIDIA auth is
     configured and caches it for 24 hours. The bundled fallback catalog is static
-    and keeps deprecated shipped refs for upgrade compatibility. Costs default to
-    `0` in source since NVIDIA currently offers free API access for the listed
-    models.
+    and keeps deprecated shipped refs for upgrade compatibility. The bundled
+    default is prepended to live featured rows when NVIDIA's public feed has not
+    caught up with the build page. Costs default to `0` in source since NVIDIA
+    currently offers free API access for the listed models.
   </Accordion>
 
   <Accordion title="OpenAI-compatible endpoint">
     NVIDIA uses the standard `/v1` completions endpoint. Any OpenAI-compatible
     tooling should work out of the box with the NVIDIA base URL.
+  </Accordion>
+
+  <Accordion title="Nemotron 3 Ultra reasoning params">
+    NVIDIA's Ultra sample request uses `chat_template_kwargs.enable_thinking`
+    and `reasoning_budget` for reasoning output. OpenClaw's bundled Ultra row
+    disables template thinking by default for normal chat use. If you need to
+    opt into NVIDIA reasoning output or force other NVIDIA-specific request
+    fields, set per-model params and keep provider-specific overrides scoped to
+    the NVIDIA model:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: {
+            "nvidia/nvidia/nemotron-3-ultra-550b-a55b": {
+              params: {
+                chat_template_kwargs: { enable_thinking: true },
+                extra_body: { reasoning_budget: 16384 },
+              },
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    `params.extra_body` is the final OpenAI-compatible request-body override, so
+    use it only for fields NVIDIA documents for the selected endpoint.
+
   </Accordion>
 
   <Accordion title="Slow custom provider responses">

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -247,10 +247,7 @@ describe("nvidia provider hooks", () => {
 
     const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
 
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "minimaxai/minimax-m2.7",
-    ]);
+    expect(entries?.map((entry) => entry.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {
@@ -305,7 +302,6 @@ describe("nvidia provider hooks", () => {
 
     const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
     expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
-      "live:nvidia/nvidia/nemotron-3-ultra-550b-a55b",
       "live:nvidia/minimaxai/minimax-m2.7",
     ]);
   });

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -201,6 +201,7 @@ describe("nvidia provider hooks", () => {
     const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext());
 
     expect(entries?.map((entry) => entry.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
@@ -219,6 +220,7 @@ describe("nvidia provider hooks", () => {
     const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
 
     expect(entries?.map((entry) => entry.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
@@ -245,7 +247,10 @@ describe("nvidia provider hooks", () => {
 
     const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
 
-    expect(entries?.map((entry) => entry.id)).toEqual(["minimaxai/minimax-m2.7"]);
+    expect(entries?.map((entry) => entry.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "minimaxai/minimax-m2.7",
+    ]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {
@@ -287,6 +292,7 @@ describe("nvidia provider hooks", () => {
 
     const staticRows = await catalogProvider?.staticCatalog?.(buildCatalogContext());
     expect(staticRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
+      "static:nvidia/nvidia/nemotron-3-ultra-550b-a55b",
       "static:nvidia/nvidia/nemotron-3-super-120b-a12b",
       "static:nvidia/moonshotai/kimi-k2.5",
       "static:nvidia/minimaxai/minimax-m2.7",
@@ -299,6 +305,7 @@ describe("nvidia provider hooks", () => {
 
     const liveRows = await catalogProvider?.liveCatalog?.(buildCatalogContext("nvapi-test"));
     expect(liveRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
+      "live:nvidia/nvidia/nemotron-3-ultra-550b-a55b",
       "live:nvidia/minimaxai/minimax-m2.7",
     ]);
   });

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -15,6 +15,7 @@ describe("nvidia onboard", () => {
     expect(provider.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
     expect(provider.api).toBe("openai-completions");
     expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
@@ -26,7 +27,7 @@ describe("nvidia onboard", () => {
     // form via preserveLiteralProviderPrefix.
     expectProviderOnboardPrimaryModel({
       applyConfig: applyNvidiaConfig,
-      modelRef: "nvidia/nemotron-3-super-120b-a12b",
+      modelRef: "nvidia/nemotron-3-ultra-550b-a55b",
     });
   });
 
@@ -42,6 +43,7 @@ describe("nvidia onboard", () => {
     });
     expect(provider?.models.map((model) => model.id)).toEqual([
       "nvidia/custom-model",
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -26,6 +26,22 @@
         "api": "openai-completions",
         "models": [
           {
+            "id": "nvidia/nemotron-3-ultra-550b-a55b",
+            "name": "NVIDIA Nemotron 3 Ultra 550B",
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "requiresStringContent": true
+            }
+          },
+          {
             "id": "nvidia/nemotron-3-super-120b-a12b",
             "name": "NVIDIA Nemotron 3 Super 120B",
             "input": ["text"],

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -40,6 +40,7 @@ describe("nvidia provider catalog", () => {
     expect(provider.api).toBe("openai-completions");
     expect(provider.apiKey).toBe("NVIDIA_API_KEY");
     expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
@@ -50,6 +51,16 @@ describe("nvidia provider catalog", () => {
     expect(provider.models.filter((model) => model.compat?.requiresStringContent !== true)).toEqual(
       [],
     );
+    expect(provider.models[0]).toMatchObject({
+      contextWindow: 1_000_000,
+      maxTokens: 16_384,
+      params: {
+        chat_template_kwargs: {
+          enable_thinking: false,
+          force_nonempty_content: true,
+        },
+      },
+    });
   });
 
   it("promotes ranked models from NVIDIA's featured catalog", async () => {
@@ -73,10 +84,23 @@ describe("nvidia provider catalog", () => {
     const provider = await buildLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
     ]);
     expect(provider.models[0]).toMatchObject({
+      name: "NVIDIA Nemotron 3 Ultra 550B",
+      contextWindow: 1_000_000,
+      maxTokens: 16_384,
+      params: {
+        chat_template_kwargs: {
+          enable_thinking: false,
+          force_nonempty_content: true,
+        },
+      },
+      compat: { requiresStringContent: true },
+    });
+    expect(provider.models[1]).toMatchObject({
       name: "GLM 5.1",
       contextWindow: 202752,
       maxTokens: 8192,
@@ -99,6 +123,7 @@ describe("nvidia provider catalog", () => {
     const provider = await buildLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "nvidia/nemotron-3-super-120b-a12b",
       "moonshotai/kimi-k2.5",
       "minimaxai/minimax-m2.7",
@@ -137,6 +162,7 @@ describe("nvidia provider catalog", () => {
     const provider = await buildSelectableLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
     ]);
@@ -176,7 +202,10 @@ describe("nvidia provider catalog", () => {
 
     const provider = await buildLiveNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "minimaxai/minimax-m2.7",
+    ]);
   });
 
   it("caches the featured catalog for repeated provider builds", async () => {
@@ -223,8 +252,51 @@ describe("nvidia provider catalog", () => {
     const first = await buildLiveNvidiaProvider();
     const second = await buildLiveNvidiaProvider();
 
-    expect(first.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
-    expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.1"]);
+    expect(first.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "minimaxai/minimax-m2.7",
+    ]);
+    expect(second.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "z-ai/glm-5.1",
+    ]);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not duplicate the bundled default when featured catalog returns it", async () => {
+    mockFeaturedCatalogResponse({
+      "featured-models": [
+        {
+          model: "nemotron-3-ultra-550b-a55b",
+          "model-name": "Nemotron 3 Ultra 550B",
+          context: 1000000,
+          "max-output": 16384,
+        },
+        {
+          model: "minimaxai/minimax-m2.7",
+          "model-name": "Minimax M2.7",
+          context: 196608,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "minimaxai/minimax-m2.7",
+    ]);
+    expect(provider.models[0]).toMatchObject({
+      name: "Nemotron 3 Ultra 550B",
+      contextWindow: 1_000_000,
+      maxTokens: 16_384,
+      params: {
+        chat_template_kwargs: {
+          enable_thinking: false,
+          force_nonempty_content: true,
+        },
+      },
+    });
   });
 });

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -84,23 +84,10 @@ describe("nvidia provider catalog", () => {
     const provider = await buildLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
     ]);
     expect(provider.models[0]).toMatchObject({
-      name: "NVIDIA Nemotron 3 Ultra 550B",
-      contextWindow: 1_000_000,
-      maxTokens: 16_384,
-      params: {
-        chat_template_kwargs: {
-          enable_thinking: false,
-          force_nonempty_content: true,
-        },
-      },
-      compat: { requiresStringContent: true },
-    });
-    expect(provider.models[1]).toMatchObject({
       name: "GLM 5.1",
       contextWindow: 202752,
       maxTokens: 8192,
@@ -162,7 +149,6 @@ describe("nvidia provider catalog", () => {
     const provider = await buildSelectableLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
       "z-ai/glm-5.1",
       "nvidia/nemotron-3-super-120b-a12b",
     ]);
@@ -202,10 +188,7 @@ describe("nvidia provider catalog", () => {
 
     const provider = await buildLiveNvidiaProvider();
 
-    expect(provider.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "minimaxai/minimax-m2.7",
-    ]);
+    expect(provider.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
   });
 
   it("caches the featured catalog for repeated provider builds", async () => {
@@ -252,18 +235,12 @@ describe("nvidia provider catalog", () => {
     const first = await buildLiveNvidiaProvider();
     const second = await buildLiveNvidiaProvider();
 
-    expect(first.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "minimaxai/minimax-m2.7",
-    ]);
-    expect(second.models.map((model) => model.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "z-ai/glm-5.1",
-    ]);
+    expect(first.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m2.7"]);
+    expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.1"]);
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
   });
 
-  it("does not duplicate the bundled default when featured catalog returns it", async () => {
+  it("applies bundled Ultra defaults when featured catalog returns Ultra", async () => {
     mockFeaturedCatalogResponse({
       "featured-models": [
         {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -15,7 +15,7 @@ import {
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
-export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-super-120b-a12b";
+export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-ultra-550b-a55b";
 export const NVIDIA_FEATURED_MODELS_URL =
   "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
 
@@ -31,6 +31,12 @@ const FEATURED_MODEL_COST = {
   output: 0,
   cacheRead: 0,
   cacheWrite: 0,
+} as const;
+const NVIDIA_ULTRA_DEFAULT_PARAMS = {
+  chat_template_kwargs: {
+    enable_thinking: false,
+    force_nonempty_content: true,
+  },
 } as const;
 
 type NvidiaFeaturedModel = {
@@ -67,12 +73,16 @@ const lookupNvidiaFeaturedModelHostname = (async (
 }) as LookupFn;
 
 export function buildNvidiaProvider(): ModelProviderConfig {
-  return {
+  const provider = {
     ...buildManifestModelProviderConfig({
       providerId: "nvidia",
       catalog: manifest.modelCatalog.providers.nvidia,
     }),
     apiKey: "NVIDIA_API_KEY",
+  };
+  return {
+    ...provider,
+    models: applyNvidiaModelDefaults(provider.models ?? []),
   };
 }
 
@@ -84,7 +94,9 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   }
   return {
     ...provider,
-    models: featuredModels,
+    models: applyNvidiaModelDefaults(
+      mergeBundledDefaultModel(provider.models ?? [], featuredModels),
+    ),
   };
 }
 
@@ -99,7 +111,9 @@ export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProvider
   }
   return {
     ...provider,
-    models: featuredModels,
+    models: applyNvidiaModelDefaults(
+      mergeBundledDefaultModel(provider.models ?? [], featuredModels),
+    ),
   };
 }
 
@@ -176,6 +190,42 @@ function parseNvidiaFeaturedModels(payload: unknown): ModelDefinitionConfig[] | 
     .map(parseNvidiaFeaturedModel)
     .filter((model) => model !== null);
   return models.length > 0 ? models : null;
+}
+
+function mergeBundledDefaultModel(
+  bundledModels: ModelDefinitionConfig[],
+  featuredModels: ModelDefinitionConfig[],
+): ModelDefinitionConfig[] {
+  if (featuredModels.some((model) => model.id === NVIDIA_DEFAULT_MODEL_ID)) {
+    return featuredModels;
+  }
+  const defaultModel = bundledModels.find((model) => model.id === NVIDIA_DEFAULT_MODEL_ID);
+  // NVIDIA's featured feed can lag the build page. Keep the bundled default
+  // selectable so authenticated setup does not hide the documented default.
+  return defaultModel ? [defaultModel, ...featuredModels] : featuredModels;
+}
+
+function applyNvidiaModelDefaults(models: ModelDefinitionConfig[]): ModelDefinitionConfig[] {
+  return models.map((model) =>
+    model.id === NVIDIA_DEFAULT_MODEL_ID
+      ? {
+          ...model,
+          params: {
+            ...model.params,
+            chat_template_kwargs: {
+              ...NVIDIA_ULTRA_DEFAULT_PARAMS.chat_template_kwargs,
+              ...(isRecord(model.params?.chat_template_kwargs)
+                ? model.params.chat_template_kwargs
+                : {}),
+            },
+          },
+        }
+      : model,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function parseNvidiaFeaturedModel(row: unknown): ModelDefinitionConfig | null {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -94,9 +94,7 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   }
   return {
     ...provider,
-    models: applyNvidiaModelDefaults(
-      mergeBundledDefaultModel(provider.models ?? [], featuredModels),
-    ),
+    models: applyNvidiaModelDefaults(featuredModels),
   };
 }
 
@@ -111,9 +109,7 @@ export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProvider
   }
   return {
     ...provider,
-    models: applyNvidiaModelDefaults(
-      mergeBundledDefaultModel(provider.models ?? [], featuredModels),
-    ),
+    models: applyNvidiaModelDefaults(featuredModels),
   };
 }
 
@@ -190,19 +186,6 @@ function parseNvidiaFeaturedModels(payload: unknown): ModelDefinitionConfig[] | 
     .map(parseNvidiaFeaturedModel)
     .filter((model) => model !== null);
   return models.length > 0 ? models : null;
-}
-
-function mergeBundledDefaultModel(
-  bundledModels: ModelDefinitionConfig[],
-  featuredModels: ModelDefinitionConfig[],
-): ModelDefinitionConfig[] {
-  if (featuredModels.some((model) => model.id === NVIDIA_DEFAULT_MODEL_ID)) {
-    return featuredModels;
-  }
-  const defaultModel = bundledModels.find((model) => model.id === NVIDIA_DEFAULT_MODEL_ID);
-  // NVIDIA's featured feed can lag the build page. Keep the bundled default
-  // selectable so authenticated setup does not hide the documented default.
-  return defaultModel ? [defaultModel, ...featuredModels] : featuredModels;
 }
 
 function applyNvidiaModelDefaults(models: ModelDefinitionConfig[]): ModelDefinitionConfig[] {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -901,6 +901,52 @@ describe("promptDefaultModel", () => {
     ]);
   });
 
+  it("preselects the first live provider row when keep-current is disabled", async () => {
+    loadPreferredProviderPickerCatalog.mockResolvedValue([
+      {
+        provider: "nvidia",
+        id: "z-ai/glm-5.1",
+        name: "GLM 5.1",
+      },
+      {
+        provider: "nvidia",
+        id: "nvidia/nemotron-3-super-120b-a12b",
+        name: "NVIDIA Nemotron 3 Super 120B",
+      },
+    ]);
+    const select = vi.fn(async (params) => params.initialValue as never);
+    const prompter = makePrompter({ select });
+    const config = {
+      agents: {
+        defaults: {
+          model: "nvidia/nemotron-3-ultra-550b-a55b",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      ignoreAllowlist: true,
+      preferredProvider: "nvidia",
+      browseCatalogOnDemand: true,
+    });
+
+    expect(result.model).toBe("nvidia/z-ai/glm-5.1");
+    expect(pickerParams(select as MockCallSource).initialValue).toBe("nvidia/z-ai/glm-5.1");
+    expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
+      "nvidia/z-ai/glm-5.1",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/nemotron-3-ultra-550b-a55b",
+    ]);
+    expect(
+      requireOption(pickerOptions(select as MockCallSource), "nvidia/nemotron-3-ultra-550b-a55b")
+        .hint,
+    ).toBe("current (not in catalog)");
+  });
+
   it("keeps on-demand NVIDIA vendor labels single-prefixed after browsing", async () => {
     loadPreferredProviderPickerCatalog.mockResolvedValue([
       {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -293,6 +293,11 @@ async function resolveLiteralPrefixProviderIds(params: {
   return ids;
 }
 
+function modelCatalogEntryKey(entry: { provider: string; id: string }): string {
+  const normalizedRef = normalizeModelRef(entry.provider, entry.id);
+  return modelKey(normalizedRef.provider, normalizedRef.model);
+}
+
 async function addModelSelectOption(params: {
   entry: {
     provider: string;
@@ -309,7 +314,7 @@ async function addModelSelectOption(params: {
   isVisibleProvider: (provider: string) => boolean;
 }) {
   const normalizedRef = normalizeModelRef(params.entry.provider, params.entry.id);
-  const key = modelKey(normalizedRef.provider, normalizedRef.model);
+  const key = modelCatalogEntryKey(params.entry);
   if (
     params.seen.has(key) ||
     HIDDEN_ROUTER_MODELS.has(key) ||
@@ -917,17 +922,23 @@ export async function promptDefaultModel(
     });
   }
 
+  const firstPreferredModel =
+    preferredProvider && hasPreferredProvider
+      ? filteredModels.find((entry) => matchesPreferredProvider?.(entry.provider))
+      : undefined;
+  const firstPreferredModelKey = firstPreferredModel
+    ? modelCatalogEntryKey(firstPreferredModel)
+    : undefined;
   let initialValue: string | undefined = allowKeep ? KEEP_VALUE : configuredKey || undefined;
-  if (
+  if (!allowKeep && firstPreferredModelKey) {
+    initialValue = firstPreferredModelKey;
+  } else if (
     allowKeep &&
-    hasPreferredProvider &&
+    firstPreferredModelKey &&
     preferredProvider &&
     !matchesPreferredProvider?.(resolved.provider)
   ) {
-    const firstModel = filteredModels[0];
-    if (firstModel) {
-      initialValue = modelKey(firstModel.provider, firstModel.id);
-    }
+    initialValue = firstPreferredModelKey;
   }
 
   const selection = await params.prompter.select({


### PR DESCRIPTION
## Summary

- Add `nvidia/nemotron-3-ultra-550b-a55b` to the bundled NVIDIA catalog and make it the bundled NVIDIA default.
- Keep successful NVIDIA featured-model feeds authoritative, while falling back to the bundled catalog/default when the feed is unavailable.
- Update setup model selection so the first live NVIDIA feed row is treated as the default option when live catalog selection is available.
- Expand NVIDIA provider docs for Nemotron 3 Ultra, live catalog behavior, fallback catalog behavior, and Ultra reasoning params.

## Verification

- `node scripts/run-vitest.mjs src/commands/model-picker.test.ts extensions/nvidia/provider-catalog.test.ts extensions/nvidia/index.test.ts extensions/nvidia/onboard.test.ts`
- `pnpm exec oxfmt --check src/flows/model-picker.ts src/commands/model-picker.test.ts`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --parallel-tests "node scripts/run-vitest.mjs src/commands/model-picker.test.ts extensions/nvidia/provider-catalog.test.ts extensions/nvidia/index.test.ts extensions/nvidia/onboard.test.ts"`

Autoreview result: clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: NVIDIA provider exposes Nemotron 3 Ultra, uses it as the bundled default, and uses the first live feed row as setup default when the live feed succeeds.

Real environment tested: Local OpenClaw checkout plus live NVIDIA API request with a locally configured NVIDIA API key.

Exact steps or command run after this patch: Focused Vitest commands and docs checks above; live probe sent an OpenAI-compatible chat completion request to `nvidia/nemotron-3-ultra-550b-a55b` using NVIDIA's hosted endpoint.

Evidence after fix: Focused model-picker and NVIDIA provider tests pass; docs checks pass; branch autoreview is clean; live Ultra API probe returned the expected sentinel response.

Observed result after fix: NVIDIA setup/catalog tests cover bundled Ultra, live-feed-authoritative catalog behavior, and first-row live default selection.

What was not tested: Full repository check/CI, because this is a scoped provider/model-picker/docs change and focused checks cover the touched behavior.
