### PR TITLE
refactor: add SQLite transcript identity adapter

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -10,6 +10,10 @@ import {
   TranscriptFileState,
   writeTranscriptFileAtomic,
 } from "./transcript-file-state.js";
+import {
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type ReadonlySessionManagerForRotation = Pick<
   TranscriptFileState,
@@ -91,6 +95,24 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   return rotateTranscriptAfterCompaction({
     sessionManager: state,
     sessionFile: params.sessionFile,
+    ...(params.now ? { now: params.now } : {}),
+  });
+}
+
+/**
+ * Rotates a runtime transcript after compaction using agent/session identity.
+ */
+export async function rotateRuntimeTranscriptAfterCompaction(params: {
+  sessionManager?: ReadonlySessionManagerForRotation;
+  scope: RuntimeTranscriptScope;
+  now?: () => Date;
+}): Promise<CompactionTranscriptRotation> {
+  const target = await resolveRuntimeTranscriptTarget(params.scope);
+  const sessionManager =
+    params.sessionManager ?? (await readTranscriptFileState(target.sessionFile));
+  return await rotateTranscriptAfterCompaction({
+    sessionManager,
+    sessionFile: target.sessionFile,
     ...(params.now ? { now: params.now } : {}),
   });
 }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -22,6 +22,10 @@ import {
   rewriteTranscriptEntriesInSessionManager,
   rewriteTranscriptEntriesInState,
 } from "./transcript-rewrite.js";
+import {
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -815,6 +819,49 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   }
 }
 
+/**
+ * Truncates oversized tool results for a runtime transcript scope.
+ */
+export async function truncateOversizedToolResultsInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    const target = await resolveRuntimeTranscriptTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    return await truncateOversizedToolResultsInTranscriptState({
+      state,
+      contextWindowTokens: params.contextWindowTokens,
+      maxCharsOverride: params.maxCharsOverride,
+      aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      sessionFile: target.sessionFile,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      agentId: target.agentId,
+      config: params.config,
+    });
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Truncates a named transcript file artifact. Runtime callers should prefer
+ * truncateOversizedToolResultsInRuntimeTranscript with agent/session scope.
+ */
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -663,9 +663,9 @@ export class TranscriptFileState {
   }
 }
 
-export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
-  const raw = await fs.readFile(sessionFile, "utf-8");
-  const fileEntries = (parseSessionEntries(raw) as unknown[]).map(fileEntryOrMigrationSlot);
+/** Builds normalized transcript state from stored transcript entries. */
+export function createTranscriptFileStateFromEntries(rawEntries: unknown[]): TranscriptFileState {
+  const fileEntries = rawEntries.map(fileEntryOrMigrationSlot);
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);
@@ -675,6 +675,11 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const entries = readableSessionEntries(fileEntries);
   return new TranscriptFileState({ header, entries, migrated });
+}
+
+export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return createTranscriptFileStateFromEntries(parseSessionEntries(raw) as unknown[]);
 }
 
 export async function writeTranscriptFileAtomic(

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -19,6 +19,11 @@ import {
   readTranscriptFileState,
   type TranscriptFileState,
 } from "./transcript-file-state.js";
+import {
+  persistRuntimeTranscriptStateMutation,
+  resolveRuntimeTranscriptTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 type SessionManagerLike = ReturnType<typeof SessionManager.open>;
 type SessionBranchEntry = ReturnType<SessionManagerLike["getBranch"]>[number];
@@ -369,8 +374,65 @@ export function rewriteTranscriptEntriesInState(params: {
 }
 
 /**
- * Open a transcript file, rewrite message entries on the active branch, and
- * emit a transcript update when the active branch changed.
+ * Rewrites message entries for a runtime transcript without using the
+ * file-backed path as caller identity.
+ */
+export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  request: TranscriptRewriteRequest;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<TranscriptRewriteResult> {
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+  try {
+    const target = await resolveRuntimeTranscriptTarget(params.scope);
+    sessionLock = await acquireSessionWriteLock({
+      sessionFile: target.sessionFile,
+      ...resolveSessionWriteLockOptions(params.config),
+    });
+    const state = await readTranscriptFileState(target.sessionFile);
+    const result = rewriteTranscriptEntriesInState({
+      state,
+      replacements: params.request.replacements,
+      ...(params.request.allowedRewriteSuffixEntryIds
+        ? { allowedRewriteSuffixEntryIds: params.request.allowedRewriteSuffixEntryIds }
+        : {}),
+    });
+    if (result.changed) {
+      await persistRuntimeTranscriptStateMutation({
+        target,
+        state,
+        appendedEntries: result.appendedEntries,
+      });
+      emitSessionTranscriptUpdate({
+        sessionFile: target.sessionFile,
+        sessionKey: target.sessionKey,
+        agentId: target.agentId,
+      });
+      log.info(
+        `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
+          `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
+          `bytesFreed=${result.bytesFreed} ` +
+          `sessionKey=${target.sessionKey}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const reason = formatErrorMessage(err);
+    log.warn(`[transcript-rewrite] failed: ${reason}`);
+    return {
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason,
+    };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
+/**
+ * Rewrites a named transcript file artifact. Runtime callers should prefer
+ * rewriteTranscriptEntriesInRuntimeTranscript with agent/session scope.
  */
 export async function rewriteTranscriptEntriesInSessionFile(params: {
   sessionFile: string;

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.sqlite.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.sqlite.ts
@@ -3,7 +3,7 @@ import type {
   SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import {
-  appendSqliteTranscriptEvent,
+  appendSqliteTranscriptEvents,
   deleteSqliteTranscript,
   loadSqliteTranscriptEvents,
   replaceSqliteTranscriptEvents,
@@ -62,9 +62,7 @@ export async function persistSqliteRuntimeTranscriptStateMutation(params: {
     });
     return;
   }
-  for (const entry of params.appendedEntries) {
-    await appendSqliteTranscriptEvent(params.target, entry);
-  }
+  await appendSqliteTranscriptEvents(params.target, params.appendedEntries);
 }
 
 /** Fully replaces the SQLite transcript rows for a runtime transcript. */

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.sqlite.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.sqlite.ts
@@ -1,0 +1,117 @@
+import type {
+  SessionTranscriptRuntimeScope,
+  SessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import {
+  appendSqliteTranscriptEvent,
+  deleteSqliteTranscript,
+  loadSqliteTranscriptEvents,
+  replaceSqliteTranscriptEvents,
+  resolveSqliteSessionTranscriptRuntimeTarget,
+  sqliteTranscriptExists,
+  type SqliteSessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.sqlite.js";
+import type { SessionEntry, SessionHeader } from "../sessions/index.js";
+import {
+  createTranscriptFileStateFromEntries,
+  type TranscriptFileState,
+} from "./transcript-file-state.js";
+
+export type SqliteRuntimeTranscriptScope = SessionTranscriptRuntimeScope;
+export type SqliteRuntimeTranscriptTarget = SqliteSessionTranscriptRuntimeTarget;
+
+export type SqliteRuntimeTranscriptState = {
+  state: TranscriptFileState;
+  target: SqliteRuntimeTranscriptTarget;
+};
+
+/** Resolves the additive SQLite runtime transcript target for test-only flip proof. */
+export function resolveSqliteRuntimeTranscriptTarget(
+  scope: SqliteRuntimeTranscriptScope,
+): SqliteRuntimeTranscriptTarget {
+  return resolveSqliteSessionTranscriptRuntimeTarget(scope);
+}
+
+/** Reads transcript state from ordered SQLite transcript rows. */
+export async function readSqliteRuntimeTranscriptState(
+  scope: SqliteRuntimeTranscriptScope,
+): Promise<SqliteRuntimeTranscriptState> {
+  const target = resolveSqliteRuntimeTranscriptTarget(scope);
+  return {
+    state: createTranscriptFileStateFromEntries(await loadSqliteTranscriptEvents(target)),
+    target,
+  };
+}
+
+/** Persists an append or migrated rewrite for a resolved SQLite runtime transcript. */
+export async function persistSqliteRuntimeTranscriptStateMutation(params: {
+  appendedEntries: SessionEntry[];
+  state: TranscriptFileState;
+  target: SqliteRuntimeTranscriptTarget;
+}): Promise<void> {
+  if (params.appendedEntries.length === 0 && !params.state.migrated) {
+    return;
+  }
+  if (params.state.migrated) {
+    await replaceSqliteRuntimeTranscriptEntries({
+      entries: [
+        ...(params.state.getHeader() ? [params.state.getHeader() as SessionHeader] : []),
+        ...params.state.getEntries(),
+      ],
+      target: params.target,
+    });
+    return;
+  }
+  for (const entry of params.appendedEntries) {
+    await appendSqliteTranscriptEvent(params.target, entry);
+  }
+}
+
+/** Fully replaces the SQLite transcript rows for a runtime transcript. */
+export async function replaceSqliteRuntimeTranscriptEntries(params: {
+  entries: Array<SessionHeader | SessionEntry>;
+  target: SessionTranscriptRuntimeTarget;
+}): Promise<void> {
+  await replaceSqliteTranscriptEvents(params.target, params.entries);
+}
+
+/** Checks existence of the SQLite runtime transcript rows. */
+export async function sqliteRuntimeTranscriptExists(
+  scope: SqliteRuntimeTranscriptScope,
+): Promise<boolean> {
+  return sqliteTranscriptExists(scope);
+}
+
+/** Deletes the SQLite runtime transcript rows without deleting the session entry. */
+export async function deleteSqliteRuntimeTranscript(
+  scope: SqliteRuntimeTranscriptScope,
+): Promise<boolean> {
+  return await deleteSqliteTranscript(scope);
+}
+
+/** Reads the latest leaf id for a SQLite runtime transcript scope. */
+export async function readSqliteRuntimeSessionLeafId(
+  scope: SqliteRuntimeTranscriptScope,
+): Promise<string | null> {
+  return (await readSqliteRuntimeTranscriptState(scope)).state.getLeafId();
+}
+
+/** Captures checkpoint metadata for a SQLite runtime transcript scope. */
+export async function captureSqliteRuntimeCompactionCheckpointSnapshot(params: {
+  sessionManager?: Pick<TranscriptFileState, "getLeafId">;
+  scope: SqliteRuntimeTranscriptScope;
+}): Promise<{ leafId: string; sessionId: string } | null> {
+  const liveLeafId = params.sessionManager?.getLeafId();
+  if (params.sessionManager && !liveLeafId) {
+    return null;
+  }
+  const { state, target } = await readSqliteRuntimeTranscriptState(params.scope);
+  const leafId = liveLeafId ?? state.getLeafId();
+  if (!leafId) {
+    return null;
+  }
+  return {
+    leafId,
+    sessionId: state.getHeader()?.id ?? target.sessionId,
+  };
+}

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
@@ -206,6 +206,49 @@ describe("runtime transcript state", () => {
     ]);
   });
 
+  it("rolls back SQLite append-only runtime mutations as one transaction", async () => {
+    const sqlitePath = path.join(tempDir, "openclaw-agent.sqlite");
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") },
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: sqlitePath,
+    };
+    const target = resolveSqliteRuntimeTranscriptTarget(scope);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "msg-1", content: "hello" })],
+    });
+    const readBeforeAppend = await readSqliteRuntimeTranscriptState(scope);
+    const appended = readBeforeAppend.state.appendMessage({
+      role: "user",
+      content: "there",
+      timestamp: TEST_TIMESTAMP_MS,
+    });
+    const unserializableAppend = {
+      ...createUserMessageEntry({ id: "bad-msg", content: "bad", parentId: appended.id }),
+      message: {
+        role: "user",
+        content: 1n,
+        timestamp: TEST_TIMESTAMP_MS,
+      },
+    } as unknown as SessionEntry;
+
+    await expect(
+      persistSqliteRuntimeTranscriptStateMutation({
+        appendedEntries: [appended, unserializableAppend],
+        state: readBeforeAppend.state,
+        target: readBeforeAppend.target,
+      }),
+    ).rejects.toThrow("Do not know how to serialize a BigInt");
+
+    expect((await readSqliteRuntimeTranscriptState(scope)).state.getBranch()).toEqual([
+      expect.objectContaining({ id: "msg-1" }),
+    ]);
+  });
+
   it("fully replaces SQLite transcript rows", async () => {
     const scope = {
       agentId: "main",

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import {
+  deleteRuntimeTranscript,
+  readRuntimeTranscriptState,
+  runtimeTranscriptExists,
+} from "./transcript-runtime-state.js";
+
+describe("runtime transcript state", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-runtime-transcript-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads and deletes transcript state through runtime scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    });
+
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(true);
+    const { state, target } = await readRuntimeTranscriptState(scope);
+    expect(fs.realpathSync(target.sessionFile)).toBe(
+      fs.realpathSync(path.join(tempDir, "session-1.jsonl")),
+    );
+    expect(state.getBranch()).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "hello" }),
+        type: "message",
+      }),
+    ]);
+
+    await expect(deleteRuntimeTranscript(scope)).resolves.toBe(true);
+    await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.test.ts
@@ -6,11 +6,56 @@ import {
   appendTranscriptEvent,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type { SessionEntry, SessionHeader } from "../sessions/index.js";
 import {
   deleteRuntimeTranscript,
   readRuntimeTranscriptState,
   runtimeTranscriptExists,
 } from "./transcript-runtime-state.js";
+import {
+  captureSqliteRuntimeCompactionCheckpointSnapshot,
+  deleteSqliteRuntimeTranscript,
+  persistSqliteRuntimeTranscriptStateMutation,
+  readSqliteRuntimeSessionLeafId,
+  readSqliteRuntimeTranscriptState,
+  replaceSqliteRuntimeTranscriptEntries,
+  resolveSqliteRuntimeTranscriptTarget,
+  sqliteRuntimeTranscriptExists,
+} from "./transcript-runtime-state.sqlite.js";
+
+const TEST_TIMESTAMP_ISO = "2026-01-01T00:00:00.000Z";
+const TEST_TIMESTAMP_MS = Date.parse(TEST_TIMESTAMP_ISO);
+
+function createSessionHeader(version = CURRENT_SESSION_VERSION): SessionHeader {
+  return {
+    type: "session",
+    id: "session-1",
+    version,
+    timestamp: TEST_TIMESTAMP_ISO,
+    cwd: "/tmp/openclaw-test",
+  };
+}
+
+function createUserMessageEntry(params: {
+  id: string;
+  content: string;
+  parentId?: string | null;
+}): SessionEntry {
+  return {
+    type: "message",
+    id: params.id,
+    message: {
+      role: "user",
+      content: params.content,
+      timestamp: TEST_TIMESTAMP_MS,
+    },
+    parentId: params.parentId ?? null,
+    timestamp: TEST_TIMESTAMP_ISO,
+  };
+}
 
 describe("runtime transcript state", () => {
   let tempDir: string;
@@ -22,6 +67,8 @@ describe("runtime transcript state", () => {
   });
 
   afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -58,5 +105,150 @@ describe("runtime transcript state", () => {
 
     await expect(deleteRuntimeTranscript(scope)).resolves.toBe(true);
     await expect(runtimeTranscriptExists(scope)).resolves.toBe(false);
+  });
+
+  it("reads and deletes transcript state through SQLite runtime scope", async () => {
+    const sqlitePath = path.join(tempDir, "openclaw-agent.sqlite");
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") },
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: sqlitePath,
+    };
+    const target = resolveSqliteRuntimeTranscriptTarget(scope);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "msg-1", content: "hello" })],
+    });
+
+    await expect(sqliteRuntimeTranscriptExists(scope)).resolves.toBe(true);
+    const { state } = await readSqliteRuntimeTranscriptState(scope);
+    expect(state.getHeader()).toMatchObject({ id: "session-1", type: "session" });
+    expect(state.getBranch()).toEqual([
+      expect.objectContaining({
+        id: "msg-1",
+        message: expect.objectContaining({ content: "hello" }),
+        type: "message",
+      }),
+    ]);
+
+    await expect(deleteSqliteRuntimeTranscript(scope)).resolves.toBe(true);
+    await expect(sqliteRuntimeTranscriptExists(scope)).resolves.toBe(false);
+  });
+
+  it("persists SQLite transcript appends and migrated rewrites", async () => {
+    const sqlitePath = path.join(tempDir, "openclaw-agent.sqlite");
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") },
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: sqlitePath,
+    };
+    const target = resolveSqliteRuntimeTranscriptTarget(scope);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "msg-1", content: "hello" })],
+    });
+    const readBeforeAppend = await readSqliteRuntimeTranscriptState(scope);
+    const appended = readBeforeAppend.state.appendMessage({
+      role: "user",
+      content: "there",
+      timestamp: TEST_TIMESTAMP_MS,
+    });
+
+    await persistSqliteRuntimeTranscriptStateMutation({
+      appendedEntries: [appended],
+      state: readBeforeAppend.state,
+      target: readBeforeAppend.target,
+    });
+
+    await expect(readSqliteRuntimeSessionLeafId(scope)).resolves.toBe(appended.id);
+    expect((await readSqliteRuntimeTranscriptState(scope)).state.getBranch()).toEqual([
+      expect.objectContaining({ id: "msg-1" }),
+      expect.objectContaining({ id: appended.id }),
+    ]);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [
+        createSessionHeader(1),
+        createUserMessageEntry({ id: "legacy-msg", content: "legacy" }),
+      ],
+    });
+    const migrated = await readSqliteRuntimeTranscriptState(scope);
+    const migratedAppend = migrated.state.appendMessage({
+      role: "user",
+      content: "migrated",
+      timestamp: TEST_TIMESTAMP_MS,
+    });
+
+    await persistSqliteRuntimeTranscriptStateMutation({
+      appendedEntries: [migratedAppend],
+      state: migrated.state,
+      target: migrated.target,
+    });
+
+    const afterMigration = await readSqliteRuntimeTranscriptState(scope);
+    expect(afterMigration.state.getHeader()).toMatchObject({
+      id: "session-1",
+      version: CURRENT_SESSION_VERSION,
+    });
+    expect(afterMigration.state.getBranch()).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({ content: "legacy" }),
+        type: "message",
+      }),
+      expect.objectContaining({ id: migratedAppend.id }),
+    ]);
+  });
+
+  it("fully replaces SQLite transcript rows", async () => {
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") },
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: path.join(tempDir, "openclaw-agent.sqlite"),
+    };
+    const target = resolveSqliteRuntimeTranscriptTarget(scope);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "old-msg", content: "old" })],
+    });
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "new-msg", content: "new" })],
+    });
+
+    expect((await readSqliteRuntimeTranscriptState(scope)).state.getBranch()).toEqual([
+      expect.objectContaining({ id: "new-msg" }),
+    ]);
+  });
+
+  it("reads SQLite checkpoint leaf and snapshot metadata", async () => {
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(tempDir, "state") },
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath: path.join(tempDir, "openclaw-agent.sqlite"),
+    };
+    const target = resolveSqliteRuntimeTranscriptTarget(scope);
+
+    await replaceSqliteRuntimeTranscriptEntries({
+      target,
+      entries: [createSessionHeader(), createUserMessageEntry({ id: "leaf-msg", content: "leaf" })],
+    });
+
+    await expect(readSqliteRuntimeSessionLeafId(scope)).resolves.toBe("leaf-msg");
+    await expect(captureSqliteRuntimeCompactionCheckpointSnapshot({ scope })).resolves.toEqual({
+      leafId: "leaf-msg",
+      sessionId: "session-1",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/transcript-runtime-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-runtime-state.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import type {
+  SessionTranscriptRuntimeScope,
+  SessionTranscriptRuntimeTarget,
+} from "../../config/sessions/session-accessor.js";
+import { resolveSessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry, SessionHeader } from "../sessions/index.js";
+import {
+  persistTranscriptStateMutation,
+  readTranscriptFileState,
+  type TranscriptFileState,
+  writeTranscriptFileAtomic,
+} from "./transcript-file-state.js";
+
+export type RuntimeTranscriptScope = SessionTranscriptRuntimeScope;
+export type RuntimeTranscriptTarget = SessionTranscriptRuntimeTarget;
+
+export type RuntimeTranscriptState = {
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+};
+
+/**
+ * Resolves the current file-backed transcript target for runtime state
+ * operations. The returned path is an implementation detail, not identity.
+ */
+export async function resolveRuntimeTranscriptTarget(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptTarget> {
+  return await resolveSessionTranscriptRuntimeTarget(scope);
+}
+
+/**
+ * Reads transcript state through the runtime transcript identity contract.
+ */
+export async function readRuntimeTranscriptState(
+  scope: RuntimeTranscriptScope,
+): Promise<RuntimeTranscriptState> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  return {
+    state: await readTranscriptFileState(target.sessionFile),
+    target,
+  };
+}
+
+/**
+ * Persists an append or migration rewrite for a resolved runtime transcript.
+ */
+export async function persistRuntimeTranscriptStateMutation(params: {
+  appendedEntries: SessionEntry[];
+  state: TranscriptFileState;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await persistTranscriptStateMutation({
+    sessionFile: params.target.sessionFile,
+    state: params.state,
+    appendedEntries: params.appendedEntries,
+  });
+}
+
+/**
+ * Atomically replaces the file-backed transcript for a runtime transcript.
+ */
+export async function replaceRuntimeTranscriptEntries(params: {
+  entries: Array<SessionHeader | SessionEntry>;
+  target: RuntimeTranscriptTarget;
+}): Promise<void> {
+  await writeTranscriptFileAtomic(params.target.sessionFile, params.entries);
+}
+
+/**
+ * Checks existence of the current runtime transcript without exposing path
+ * identity to callers.
+ */
+export async function runtimeTranscriptExists(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  try {
+    const stat = await fs.stat(target.sessionFile);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deletes the current runtime transcript. This remains file-backed until the
+ * SQLite implementation owns transcript deletion in 3.2.
+ */
+export async function deleteRuntimeTranscript(scope: RuntimeTranscriptScope): Promise<boolean> {
+  const target = await resolveRuntimeTranscriptTarget(scope);
+  try {
+    await fs.unlink(target.sessionFile);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -32,6 +32,7 @@ import {
 import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
+  branchSqliteCompactionCheckpointSession,
   listSqliteSessionEntries,
   loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
@@ -41,11 +42,13 @@ import {
   persistSqliteSessionTranscriptTurn,
   publishSqliteTranscriptUpdate,
   readSqliteSessionUpdatedAt,
+  replaceSqliteTranscriptEvents,
   replaceSqliteSessionEntry,
+  restoreSqliteCompactionCheckpointSession,
   updateSqliteSessionEntry,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
-import type { SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 type AccessorAdapter = {
   name: string;
@@ -768,6 +771,142 @@ describe("sqlite transcript turn persistence", () => {
         id: result.messages[0]?.messageId,
         type: "message",
       }),
+    ]);
+  });
+
+  it("branches a checkpoint by copying rows and creating the branch entry atomically", async () => {
+    const sourceScope = sqliteAdapter.transcriptScope(paths, "source-session");
+    const sourceEntryScope = sqliteAdapter.entryScope(paths);
+    const branchKey = "agent:main:checkpoint-branch";
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-1",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "source-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 42,
+      tokensAfter: 84,
+      preCompaction: {
+        sessionId: "pre-compaction-session",
+        leafId: "pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "msg-2",
+      },
+    };
+
+    await replaceSqliteTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "msg-1", parentId: null, message: { content: "one" } },
+      { type: "message", id: "msg-2", parentId: "msg-1", message: { content: "two" } },
+      { type: "message", id: "msg-3", parentId: "msg-2", message: { content: "three" } },
+    ]);
+    await upsertSqliteSessionEntry(sourceEntryScope, {
+      label: "Source",
+      sessionId: "source-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    });
+
+    const result = await branchSqliteCompactionCheckpointSession({
+      agentId: "main",
+      env: sourceScope.env,
+      storePath: paths.sqlitePath,
+      sourceKey: sourceEntryScope.sessionKey,
+      nextKey: branchKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (result.status !== "created") {
+      throw new Error(`expected branch creation, got ${result.status}`);
+    }
+
+    const branchScope = {
+      ...sourceScope,
+      sessionId: result.entry.sessionId,
+      sessionKey: branchKey,
+    };
+    expect(loadSqliteSessionEntry({ ...sourceEntryScope, sessionKey: branchKey })).toEqual(
+      result.entry,
+    );
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        label: "Source (checkpoint)",
+        parentSessionKey: sourceEntryScope.sessionKey,
+        sessionFile: expect.stringContaining(result.entry.sessionId),
+        totalTokens: 84,
+        totalTokensFresh: true,
+      }),
+    );
+    await expect(loadSqliteTranscriptEvents(branchScope)).resolves.toEqual([
+      expect.objectContaining({ type: "session", id: result.entry.sessionId }),
+      expect.objectContaining({ id: "msg-1", type: "message" }),
+      expect.objectContaining({ id: "msg-2", type: "message" }),
+    ]);
+  });
+
+  it("restores a checkpoint by copying rows and replacing the session entry atomically", async () => {
+    const sourceScope = sqliteAdapter.transcriptScope(paths, "source-session");
+    const sourceEntryScope = sqliteAdapter.entryScope(paths);
+    const checkpoint: SessionCompactionCheckpoint = {
+      checkpointId: "checkpoint-restore",
+      sessionKey: sourceEntryScope.sessionKey,
+      sessionId: "current-session",
+      createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
+      reason: "manual",
+      tokensBefore: 12,
+      tokensAfter: 24,
+      preCompaction: {
+        sessionId: "pre-compaction-session",
+        leafId: "pre-msg",
+      },
+      postCompaction: {
+        sessionId: "source-session",
+        entryId: "msg-1",
+      },
+    };
+
+    await replaceSqliteTranscriptEvents(sourceScope, [
+      { type: "session", id: "source-session", cwd: paths.tempDir },
+      { type: "message", id: "msg-1", parentId: null, message: { content: "restore" } },
+      { type: "message", id: "msg-2", parentId: "msg-1", message: { content: "skip" } },
+    ]);
+    await upsertSqliteSessionEntry(sourceEntryScope, {
+      label: "Current",
+      sessionId: "current-session",
+      sessionFile: "sqlite:main:current-session",
+      updatedAt: 10,
+      compactionCheckpoints: [checkpoint],
+    });
+
+    const result = await restoreSqliteCompactionCheckpointSession({
+      agentId: "main",
+      env: sourceScope.env,
+      storePath: paths.sqlitePath,
+      sessionKey: sourceEntryScope.sessionKey,
+      checkpointId: checkpoint.checkpointId,
+    });
+    if (result.status !== "created") {
+      throw new Error(`expected restore creation, got ${result.status}`);
+    }
+
+    const restoredScope = {
+      ...sourceScope,
+      sessionId: result.entry.sessionId,
+    };
+    expect(loadSqliteSessionEntry(sourceEntryScope)).toEqual(result.entry);
+    expect(result.entry).toEqual(
+      expect.objectContaining({
+        label: "Current",
+        compactionCheckpoints: [checkpoint],
+        sessionFile: expect.stringContaining(result.entry.sessionId),
+        totalTokens: 24,
+        totalTokensFresh: true,
+      }),
+    );
+    await expect(loadSqliteTranscriptEvents(restoredScope)).resolves.toEqual([
+      expect.objectContaining({ type: "session", id: result.entry.sessionId }),
+      expect.objectContaining({ id: "msg-1", type: "message" }),
     ]);
   });
 });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -38,6 +38,7 @@ import {
   loadSqliteTranscriptEvents,
   loadSqliteTranscriptEventsSync,
   patchSqliteSessionEntry,
+  persistSqliteSessionTranscriptTurn,
   publishSqliteTranscriptUpdate,
   readSqliteSessionUpdatedAt,
   replaceSqliteSessionEntry,
@@ -607,3 +608,166 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
     });
   },
 );
+
+describe("sqlite transcript turn persistence", () => {
+  let paths: TestPaths;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-turn-"));
+    paths = {
+      sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+      stateDir: path.join(tempDir, "state"),
+      storePath: path.join(tempDir, "sessions.json"),
+      tempDir,
+      transcriptPath: path.join(tempDir, "session.jsonl"),
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(paths.tempDir, { recursive: true, force: true });
+  });
+
+  it("persists multiple messages, touches the entry, and publishes after commit", async () => {
+    const entryScope = sqliteAdapter.entryScope(paths);
+    const scope = sqliteAdapter.transcriptScope(paths, "session-turn");
+    const updates: unknown[] = [];
+    let rowsVisibleDuringUpdate = 0;
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+      rowsVisibleDuringUpdate = loadSqliteTranscriptEventsSync(scope).length;
+    });
+
+    await upsertSqliteSessionEntry(entryScope, {
+      sessionId: "session-turn",
+      updatedAt: 10,
+    });
+    const result = await persistSqliteSessionTranscriptTurn(scope, {
+      cwd: paths.tempDir,
+      touchSessionEntry: true,
+      messages: [
+        {
+          message: { role: "user", content: "hello" },
+          now: Date.parse("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          message: { role: "assistant", content: "hi" },
+          now: Date.parse("2026-01-01T00:00:01.000Z"),
+        },
+      ],
+    });
+    unsubscribe();
+
+    expect(result).toMatchObject({
+      appendedCount: 2,
+      messages: [
+        expect.objectContaining({ appended: true, message: { role: "user", content: "hello" } }),
+        expect.objectContaining({
+          appended: true,
+          message: { role: "assistant", content: "hi" },
+        }),
+      ],
+      sessionFile: paths.transcriptPath,
+    });
+    await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: result.messages[0]?.messageId,
+        parentId: null,
+        type: "message",
+      }),
+      expect.objectContaining({
+        id: result.messages[1]?.messageId,
+        parentId: result.messages[0]?.messageId,
+        type: "message",
+      }),
+    ]);
+    expect(loadSqliteSessionEntry(entryScope)).toEqual(
+      expect.objectContaining({
+        sessionFile: paths.transcriptPath,
+        sessionId: "session-turn",
+        updatedAt: expect.any(Number),
+      }),
+    );
+    expect(updates).toEqual([
+      expect.objectContaining({
+        agentId: "main",
+        message: { role: "assistant", content: "hi" },
+        messageId: result.messages[1]?.messageId,
+        sessionFile: paths.transcriptPath,
+        sessionKey: scope.sessionKey,
+      }),
+    ]);
+    expect(rowsVisibleDuringUpdate).toBe(3);
+  });
+
+  it("rejects expected-session rebound without appending messages", async () => {
+    const entryScope = sqliteAdapter.entryScope(paths);
+    const reboundScope = sqliteAdapter.transcriptScope(paths, "old-session");
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    await upsertSqliteSessionEntry(entryScope, {
+      sessionFile: paths.transcriptPath,
+      sessionId: "current-session",
+      updatedAt: 10,
+    });
+    const seededEntry = loadSqliteSessionEntry(entryScope);
+    const result = await persistSqliteSessionTranscriptTurn(reboundScope, {
+      expectedSessionId: "old-session",
+      touchSessionEntry: true,
+      messages: [
+        {
+          message: { role: "assistant", content: "stale" },
+        },
+      ],
+    });
+    unsubscribe();
+
+    expect(result).toMatchObject({
+      appendedCount: 0,
+      messages: [],
+      rejectedReason: "session-rebound",
+      sessionEntry: expect.objectContaining({ sessionId: "current-session" }),
+      sessionFile: paths.transcriptPath,
+    });
+    await expect(loadSqliteTranscriptEvents(reboundScope)).resolves.toEqual([]);
+    expect(loadSqliteSessionEntry(entryScope)).toEqual(seededEntry);
+    expect(updates).toEqual([]);
+  });
+
+  it("materializes a touched session entry for a fresh transcript turn", async () => {
+    const entryScope = sqliteAdapter.entryScope(paths);
+    const scope = sqliteAdapter.transcriptScope(paths, "fresh-session");
+
+    const result = await persistSqliteSessionTranscriptTurn(scope, {
+      touchSessionEntry: true,
+      updateMode: "none",
+      messages: [
+        {
+          message: { role: "user", content: "first turn" },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      appendedCount: 1,
+      sessionEntry: expect.objectContaining({
+        sessionFile: paths.transcriptPath,
+        sessionId: "fresh-session",
+        updatedAt: expect.any(Number),
+      }),
+    });
+    expect(loadSqliteSessionEntry(entryScope)).toEqual(result.sessionEntry);
+    await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: result.messages[0]?.messageId,
+        type: "message",
+      }),
+    ]);
+  });
+});

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1,0 +1,609 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  listSessionEntries,
+  loadExactSessionEntry,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
+  replaceSessionEntry,
+  updateSessionEntry,
+  upsertSessionEntry,
+  type ExactSessionEntry,
+  type SessionAccessScope,
+  type SessionEntrySummary,
+  type SessionTranscriptAccessScope,
+  type SessionTranscriptReadScope,
+  type SessionTranscriptWriteScope,
+  type TranscriptEvent,
+  type TranscriptMessageAppendOptions,
+  type TranscriptMessageAppendResult,
+  type TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import {
+  appendSqliteTranscriptEvent,
+  appendSqliteTranscriptMessage,
+  listSqliteSessionEntries,
+  loadExactSqliteSessionEntry,
+  loadSqliteSessionEntry,
+  loadSqliteTranscriptEvents,
+  loadSqliteTranscriptEventsSync,
+  patchSqliteSessionEntry,
+  publishSqliteTranscriptUpdate,
+  readSqliteSessionUpdatedAt,
+  replaceSqliteSessionEntry,
+  updateSqliteSessionEntry,
+  upsertSqliteSessionEntry,
+} from "./session-accessor.sqlite.js";
+import type { SessionEntry } from "./types.js";
+
+type AccessorAdapter = {
+  name: string;
+  entryScope(paths: TestPaths): SessionAccessScope;
+  transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
+  transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
+  loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined;
+  loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
+  listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
+  readSessionUpdatedAt(scope: SessionAccessScope): number | undefined;
+  upsertSessionEntry(
+    scope: SessionAccessScope,
+    patch: Partial<SessionEntry>,
+  ): Promise<SessionEntry | null>;
+  replaceSessionEntry(scope: SessionAccessScope, entry: SessionEntry): Promise<SessionEntry | null>;
+  patchSessionEntry(
+    scope: SessionAccessScope,
+    update: (
+      entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
+    ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+    options?: { fallbackEntry?: SessionEntry; preserveActivity?: boolean; replaceEntry?: boolean },
+  ): Promise<SessionEntry | null>;
+  updateSessionEntry(
+    scope: SessionAccessScope,
+    update: (entry: SessionEntry) => Partial<SessionEntry> | null,
+  ): Promise<SessionEntry | null>;
+  loadTranscriptEvents(scope: SessionTranscriptReadScope): Promise<TranscriptEvent[]>;
+  appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
+  appendTranscriptMessage<TMessage>(
+    scope: SessionTranscriptWriteScope,
+    options: TranscriptMessageAppendOptions<TMessage>,
+  ): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+  publishTranscriptUpdate(
+    scope: SessionTranscriptWriteScope,
+    update?: TranscriptUpdatePayload,
+  ): Promise<void>;
+};
+
+type TestPaths = {
+  sqlitePath: string;
+  stateDir: string;
+  storePath: string;
+  tempDir: string;
+  transcriptPath: string;
+};
+
+const fileBackedAdapter: AccessorAdapter = {
+  name: "file-backed",
+  entryScope: (paths) => ({
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    storePath: paths.storePath,
+  }),
+  loadSessionEntry,
+  loadExactSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
+  upsertSessionEntry,
+  replaceSessionEntry,
+  patchSessionEntry,
+  updateSessionEntry,
+  loadTranscriptEvents,
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  publishTranscriptUpdate,
+};
+
+const sqliteAdapter: AccessorAdapter = {
+  name: "sqlite",
+  entryScope: (paths) => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionId: id,
+    storePath: paths.sqlitePath,
+  }),
+  loadSessionEntry: loadSqliteSessionEntry,
+  loadExactSessionEntry: loadExactSqliteSessionEntry,
+  listSessionEntries: listSqliteSessionEntries,
+  readSessionUpdatedAt: readSqliteSessionUpdatedAt,
+  upsertSessionEntry: upsertSqliteSessionEntry,
+  replaceSessionEntry: replaceSqliteSessionEntry,
+  patchSessionEntry: patchSqliteSessionEntry,
+  updateSessionEntry: updateSqliteSessionEntry,
+  loadTranscriptEvents: loadSqliteTranscriptEvents,
+  appendTranscriptEvent: appendSqliteTranscriptEvent,
+  appendTranscriptMessage: appendSqliteTranscriptMessage,
+  publishTranscriptUpdate: publishSqliteTranscriptUpdate,
+};
+
+describe.each([fileBackedAdapter, sqliteAdapter])(
+  "session accessor conformance: $name",
+  (adapter) => {
+    let paths: TestPaths;
+
+    beforeEach(() => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-conf-"));
+      paths = {
+        sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+        stateDir: path.join(tempDir, "state"),
+        storePath: path.join(tempDir, "sessions.json"),
+        tempDir,
+        transcriptPath: path.join(tempDir, "session.jsonl"),
+      };
+    });
+
+    afterEach(() => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      fs.rmSync(paths.tempDir, { recursive: true, force: true });
+    });
+
+    it("conforms for entry load/list/timestamp/upsert/update/replace/patch", async () => {
+      const scope = adapter.entryScope(paths);
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: expect.any(Number),
+      });
+      expect(adapter.readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
+      expect(adapter.listSessionEntries(scope)).toEqual([
+        {
+          sessionKey: "agent:main:main",
+          entry: expect.objectContaining({
+            model: "gpt-5.5",
+            sessionId: "session-1",
+          }),
+        },
+      ]);
+
+      await expect(
+        adapter.updateSessionEntry(scope, () => ({ model: "sonnet-4.6", updatedAt: 20 })),
+      ).resolves.toMatchObject({
+        model: "sonnet-4.6",
+        sessionId: "session-1",
+      });
+
+      await adapter.replaceSessionEntry(scope, {
+        providerOverride: "openai",
+        sessionId: "session-1",
+        updatedAt: 30,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        providerOverride: "openai",
+        sessionId: "session-1",
+      });
+      expect(adapter.loadSessionEntry(scope)?.model).toBeUndefined();
+
+      let existingContext: SessionEntry | undefined;
+      await adapter.patchSessionEntry(
+        scope,
+        (entry, context) => {
+          existingContext = context.existingEntry;
+          return {
+            ...entry,
+            model: "gpt-5.5",
+          };
+        },
+        { replaceEntry: true },
+      );
+
+      expect(existingContext).toMatchObject({ providerOverride: "openai" });
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+
+      const beforePreservePatch = adapter.loadSessionEntry(scope);
+      await adapter.patchSessionEntry(
+        scope,
+        () => ({
+          providerOverride: "anthropic",
+          updatedAt: 40,
+        }),
+        { preserveActivity: true },
+      );
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        providerOverride: "anthropic",
+        sessionId: "session-1",
+        updatedAt: beforePreservePatch?.updatedAt,
+      });
+    });
+
+    it("conforms for exact persisted-key lookup without canonical alias fallback", async () => {
+      const scope = adapter.entryScope(paths);
+      const mixedCaseScope = { ...scope, sessionKey: "AGENT:MAIN:MAIN" };
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(mixedCaseScope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+      });
+      expect(adapter.loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+      expect(adapter.loadExactSessionEntry(scope)).toEqual({
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "exact-session",
+        }),
+      });
+    });
+
+    it("conforms for raw transcript event load and append", async () => {
+      const scope = adapter.transcriptScope(paths);
+      const readScope = adapter.transcriptReadScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+      await adapter.appendTranscriptEvent(scope, event);
+
+      await expect(adapter.loadTranscriptEvents(readScope)).resolves.toEqual([
+        { type: "session", sessionId: "session-1" },
+        event,
+      ]);
+    });
+
+    it("loads raw SQLite transcript events synchronously through a read scope", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths);
+      const readScope = sqliteAdapter.transcriptReadScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await sqliteAdapter.appendTranscriptEvent(scope, event);
+
+      expect(loadSqliteTranscriptEventsSync(readScope)).toEqual([event]);
+    });
+
+    it("maps canonical sessions.json store paths to the agent SQLite database", async () => {
+      const legacyStorePath = path.join(
+        paths.stateDir,
+        "agents",
+        "voice",
+        "sessions",
+        "sessions.json",
+      );
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "voice",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "voice:123",
+        storePath: legacyStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(legacyStorePath)).toBe(false);
+    });
+
+    it("does not treat custom JSON store paths as SQLite database files", async () => {
+      const customStorePath = path.join(paths.tempDir, "custom-sessions.json");
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "voice",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "agent:voice:main",
+        storePath: customStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(customStorePath)).toBe(false);
+    });
+
+    it("serializes concurrent SQLite entry patches and updates", async () => {
+      const scope = sqliteAdapter.entryScope(paths);
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "base",
+        sessionId: "patch-session",
+        updatedAt: 10,
+      });
+
+      let firstPatch!: Promise<SessionEntry | null>;
+      let releasePatch!: () => void;
+      const patchStarted = new Promise<void>((resolve) => {
+        const blockedPatch = new Promise<void>((release) => {
+          releasePatch = release;
+        });
+        firstPatch = patchSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedPatch;
+          return { model: "first" };
+        });
+      });
+      await patchStarted;
+      const secondPatch = patchSqliteSessionEntry(scope, () => ({
+        providerOverride: "openai",
+      }));
+      releasePatch();
+      await Promise.all([firstPatch, secondPatch]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "first",
+        providerOverride: "openai",
+      });
+
+      let firstUpdate!: Promise<SessionEntry | null>;
+      let releaseUpdate!: () => void;
+      const updateStarted = new Promise<void>((resolve) => {
+        const blockedUpdate = new Promise<void>((release) => {
+          releaseUpdate = release;
+        });
+        firstUpdate = updateSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedUpdate;
+          return { model: "updated" };
+        });
+      });
+      await updateStarted;
+      const secondUpdate = updateSqliteSessionEntry(scope, () => ({
+        providerOverride: "anthropic",
+      }));
+      releaseUpdate();
+      await Promise.all([firstUpdate, secondUpdate]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "updated",
+        providerOverride: "anthropic",
+      });
+    });
+
+    it("dedupes SQLite transcript identities inside the writer path", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-dedupe");
+      const event = {
+        id: "event-dedupe",
+        message: { role: "assistant", content: "first" },
+        parentId: null,
+        type: "message",
+      };
+
+      await appendSqliteTranscriptEvent(scope, event);
+      await appendSqliteTranscriptEvent(scope, {
+        ...event,
+        message: { role: "assistant", content: "duplicate" },
+      });
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          appendSqliteTranscriptMessage(scope, {
+            idempotencyLookup: "scan",
+            message: {
+              role: "assistant",
+              content: "keyed",
+              idempotencyKey: "keyed-once",
+            },
+          }),
+        ),
+      );
+
+      expect(new Set(results.map((result) => result?.messageId)).size).toBe(1);
+      expect(results.filter((result) => result?.appended)).toHaveLength(1);
+      await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+        event,
+        expect.objectContaining({
+          message: expect.objectContaining({ idempotencyKey: "keyed-once" }),
+          type: "message",
+        }),
+      ]);
+    });
+
+    it("does not report success for unchecked duplicate SQLite transcript keys", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-unchecked-dedupe");
+      const message = {
+        role: "assistant",
+        content: "unchecked",
+        idempotencyKey: "unchecked-once",
+      };
+
+      await appendSqliteTranscriptMessage(scope, { message });
+      await expect(appendSqliteTranscriptMessage(scope, { message })).rejects.toThrow();
+
+      const events = await loadSqliteTranscriptEvents(scope);
+      const keyedEvents = events.filter((event): event is { message: typeof message } => {
+        return (
+          Boolean(event) &&
+          typeof event === "object" &&
+          !Array.isArray(event) &&
+          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+            "unchecked-once"
+        );
+      });
+      expect(keyedEvents).toHaveLength(1);
+    });
+
+    it("parents SQLite message appends to the latest non-session transcript entry", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-parent");
+
+      await appendSqliteTranscriptEvent(scope, {
+        type: "session",
+        id: "session-parent",
+      });
+      await appendSqliteTranscriptEvent(scope, {
+        type: "model_change",
+        id: "model-entry",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        provider: "openai",
+        modelId: "gpt-5.5",
+      });
+      const appended = await appendSqliteTranscriptMessage(scope, {
+        message: {
+          role: "user",
+          content: "after model change",
+          timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+        },
+      });
+
+      await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({ id: "model-entry", type: "model_change" }),
+        expect.objectContaining({
+          id: appended.messageId,
+          parentId: "model-entry",
+          type: "message",
+        }),
+      ]);
+    });
+
+    it("conforms for transcript message append, idempotency, and update publication", async () => {
+      const scope = adapter.transcriptScope(paths, "session-2");
+      const updates: unknown[] = [];
+      const unsubscribe = onSessionTranscriptUpdate((update) => {
+        updates.push(update);
+      });
+
+      const appended = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      const replayed = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello again",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      await adapter.publishTranscriptUpdate(scope, {
+        agentId: "main",
+        message: appended?.message,
+        messageId: appended?.messageId,
+        sessionKey: scope.sessionKey,
+      });
+      unsubscribe();
+
+      expect(appended).toMatchObject({
+        appended: true,
+        message: expect.objectContaining({ content: "hello" }),
+        messageId: expect.any(String),
+      });
+      expect(replayed).toMatchObject({
+        appended: false,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        messageId: appended?.messageId,
+      });
+      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({
+          id: appended?.messageId,
+          message: expect.objectContaining({ content: "hello" }),
+          type: "message",
+        }),
+      ]);
+      expect(updates).toEqual([
+        expect.objectContaining({
+          agentId: "main",
+          message: appended?.message,
+          messageId: appended?.messageId,
+          sessionKey: scope.sessionKey,
+        }),
+      ]);
+    });
+  },
+);

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -349,6 +349,24 @@ export async function appendSqliteTranscriptEvent(
   });
 }
 
+/** Appends raw transcript events to the additive SQLite transcript store in one transaction. */
+export async function appendSqliteTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+  events: TranscriptEvent[],
+): Promise<void> {
+  if (events.length === 0) {
+    return;
+  }
+  const resolved = resolveSqliteTranscriptScope(scope);
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      for (const event of events) {
+        appendTranscriptEventInTransaction(database, resolved, event);
+      }
+    }, toDatabaseOptions(resolved));
+  });
+}
+
 /** Appends one transcript message to the additive SQLite transcript store. */
 export async function appendSqliteTranscriptMessage<TMessage>(
   scope: SessionTranscriptWriteScope,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -76,6 +76,43 @@ export type SqliteSessionTranscriptRuntimeTarget = SessionTranscriptRuntimeTarge
   storePath?: string;
 };
 
+/** SQLite transcript turn update mode, matching the file-backed turn writer seam. */
+export type SqliteSessionTranscriptTurnUpdateMode = "inline" | "file-only" | "none";
+
+/** In-transaction context exposed to SQLite transcript turn append guards. */
+export type SqliteSessionTranscriptTurnWriteContext = {
+  agentId?: string;
+  sessionFile: string;
+  sessionId?: string;
+  sessionKey?: string;
+};
+
+/** One candidate message for SQLite transcript turn persistence. */
+export type SqliteSessionTranscriptTurnMessageAppend = TranscriptMessageAppendOptions<unknown> & {
+  /** Synchronous SQLite guard evaluated inside the write transaction. */
+  shouldAppend?: (context: SqliteSessionTranscriptTurnWriteContext) => boolean;
+};
+
+/** Options for persisting a logical transcript turn into SQLite. */
+export type SqliteSessionTranscriptTurnPersistOptions = {
+  config?: TranscriptMessageAppendOptions<unknown>["config"];
+  cwd?: string;
+  expectedSessionId?: string;
+  messages: readonly SqliteSessionTranscriptTurnMessageAppend[];
+  updateMode?: SqliteSessionTranscriptTurnUpdateMode;
+  publishWhen?: "always" | "when-appended";
+  touchSessionEntry?: boolean;
+};
+
+/** Result from persisting a logical transcript turn into SQLite. */
+export type SqliteSessionTranscriptTurnPersistResult = {
+  appendedCount: number;
+  messages: TranscriptMessageAppendResult<unknown>[];
+  rejectedReason?: "session-rebound";
+  sessionEntry: SessionEntry | undefined;
+  sessionFile: string;
+};
+
 type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
@@ -386,64 +423,65 @@ export async function appendSqliteTranscriptMessage<TMessage>(
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     let result: TranscriptMessageAppendResult<TMessage> | undefined;
     runOpenClawAgentWriteTransaction((database) => {
-      const idempotencyKey = readMessageIdempotencyKey(options.message);
-      if (idempotencyKey && options.idempotencyLookup === "scan") {
-        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
-        if (existing) {
-          result = {
-            appended: false,
-            message: existing.message as TMessage,
-            messageId: existing.messageId,
-          };
-          return;
-        }
-      }
-
-      const prepared = options.prepareMessageAfterIdempotencyCheck
-        ? options.prepareMessageAfterIdempotencyCheck(options.message)
-        : options.message;
-      if (prepared === undefined) {
-        result = undefined;
-        return;
-      }
-
-      const messageId = randomUUID();
-      const now = options.now ?? Date.now();
-      const finalMessage = redactTranscriptMessageForStorage(prepared, options);
-      ensureTranscriptHeader(database, resolved, options.cwd, now);
-      const parentId = readLatestTranscriptEntryId(database, resolved.sessionId);
-      const event = {
-        type: "message",
-        id: messageId,
-        parentId: parentId ?? null,
-        timestamp: resolveTimestampMsToIsoString(now),
-        message: finalMessage,
-      };
-      const appended = appendTranscriptEventInTransaction(database, resolved, event, {
-        dedupeByMessageIdempotency: options.idempotencyLookup === "scan",
-      });
-      if (!appended && idempotencyKey && options.idempotencyLookup === "scan") {
-        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
-        if (existing) {
-          result = {
-            appended: false,
-            message: existing.message as TMessage,
-            messageId: existing.messageId,
-          };
-          return;
-        }
-      }
-      if (!appended) {
-        throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
-      }
-      result = {
-        appended: true,
-        message: finalMessage,
-        messageId,
-      };
+      result = appendSqliteTranscriptMessageInTransaction(database, resolved, options);
     }, toDatabaseOptions(resolved));
     return result;
   });
+}
+
+/** Persists one logical transcript turn into SQLite in one queued write transaction. */
+export async function persistSqliteSessionTranscriptTurn(
+  scope: SessionTranscriptWriteScope,
+  options: SqliteSessionTranscriptTurnPersistOptions,
+): Promise<SqliteSessionTranscriptTurnPersistResult> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const target = resolveSqliteTranscriptTurnTarget(resolved, scope);
+  const result = await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let transactionResult: SqliteSessionTranscriptTurnPersistResult | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+      if (options.expectedSessionId && existing?.sessionId !== options.expectedSessionId) {
+        transactionResult = {
+          appendedCount: 0,
+          messages: [],
+          rejectedReason: "session-rebound",
+          sessionEntry: existing ? cloneSessionEntry(existing) : undefined,
+          sessionFile: target.sessionFile,
+        };
+        return;
+      }
+
+      const messages = appendSqliteTranscriptTurnMessages(database, resolved, target, options);
+      const appendedCount = countAppendedTranscriptMessages(messages);
+      const sessionEntry = touchSqliteTranscriptTurnSessionEntry(database, {
+        appendedCount,
+        existing,
+        resolved,
+        shouldTouch: options.touchSessionEntry === true,
+        target,
+      });
+      transactionResult = {
+        appendedCount,
+        messages,
+        sessionEntry,
+        sessionFile: target.sessionFile,
+      };
+    }, toDatabaseOptions(resolved));
+    if (!transactionResult) {
+      throw new Error("SQLite transcript turn transaction did not return a result.");
+    }
+    return transactionResult;
+  });
+
+  if (!result.rejectedReason) {
+    publishSqliteTranscriptTurnUpdate({
+      appendedMessages: result.messages,
+      publishWhen: options.publishWhen ?? "when-appended",
+      target,
+      updateMode: options.updateMode ?? "inline",
+    });
+  }
+  return result;
 }
 
 /** Publishes a transcript update using the SQLite transcript scope target. */
@@ -677,6 +715,110 @@ function writeSessionEntry(
   );
 }
 
+function resolveSqliteTranscriptTurnTarget(
+  resolved: ResolvedTranscriptScope,
+  scope: Pick<SessionTranscriptWriteScope, "sessionFile">,
+): SqliteSessionTranscriptTurnWriteContext {
+  const sessionFile = scope.sessionFile?.trim() || formatSqliteTranscriptTarget(resolved);
+  return {
+    agentId: resolved.agentId,
+    sessionFile,
+    sessionId: resolved.sessionId,
+    sessionKey: resolved.sessionKey,
+  };
+}
+
+function appendSqliteTranscriptTurnMessages(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedTranscriptScope,
+  target: SqliteSessionTranscriptTurnWriteContext,
+  options: SqliteSessionTranscriptTurnPersistOptions,
+): TranscriptMessageAppendResult<unknown>[] {
+  const messages: TranscriptMessageAppendResult<unknown>[] = [];
+  for (const append of options.messages) {
+    if (append.shouldAppend && !append.shouldAppend(target)) {
+      continue;
+    }
+    const appendOptions = {
+      message: append.message,
+      ...((append.cwd ?? options.cwd) ? { cwd: append.cwd ?? options.cwd } : {}),
+      ...((append.config ?? options.config) ? { config: append.config ?? options.config } : {}),
+      ...(append.idempotencyLookup ? { idempotencyLookup: append.idempotencyLookup } : {}),
+      ...(append.now !== undefined ? { now: append.now } : {}),
+      ...(append.prepareMessageAfterIdempotencyCheck
+        ? { prepareMessageAfterIdempotencyCheck: append.prepareMessageAfterIdempotencyCheck }
+        : {}),
+      ...(append.useRawWhenLinear !== undefined
+        ? { useRawWhenLinear: append.useRawWhenLinear }
+        : {}),
+    } satisfies TranscriptMessageAppendOptions<unknown>;
+    const result = appendSqliteTranscriptMessageInTransaction(database, resolved, appendOptions);
+    if (result) {
+      messages.push(result);
+    }
+  }
+  return messages;
+}
+
+function countAppendedTranscriptMessages(
+  messages: readonly TranscriptMessageAppendResult<unknown>[],
+): number {
+  return messages.filter((message) => message.appended).length;
+}
+
+function touchSqliteTranscriptTurnSessionEntry(
+  database: OpenClawAgentDatabase,
+  params: {
+    appendedCount: number;
+    existing: SessionEntry | undefined;
+    resolved: ResolvedTranscriptScope;
+    shouldTouch: boolean;
+    target: SqliteSessionTranscriptTurnWriteContext;
+  },
+): SessionEntry | undefined {
+  if (
+    !params.shouldTouch ||
+    params.appendedCount === 0 ||
+    (params.existing !== undefined && params.existing.sessionId !== params.resolved.sessionId)
+  ) {
+    return params.existing ? cloneSessionEntry(params.existing) : undefined;
+  }
+  const markerUpdatedAt = Date.now();
+  const base = params.existing ?? {
+    sessionId: params.resolved.sessionId,
+    updatedAt: markerUpdatedAt,
+  };
+  const next = mergeSessionEntry(base, {
+    sessionFile: params.target.sessionFile,
+    updatedAt: Math.max(base.updatedAt, markerUpdatedAt),
+  });
+  writeSessionEntry(database, params.resolved.sessionKey, next);
+  return cloneSessionEntry(next);
+}
+
+function publishSqliteTranscriptTurnUpdate(params: {
+  target: SqliteSessionTranscriptTurnWriteContext;
+  updateMode: SqliteSessionTranscriptTurnUpdateMode;
+  publishWhen: "always" | "when-appended";
+  appendedMessages: TranscriptMessageAppendResult<unknown>[];
+}): void {
+  if (params.updateMode === "none") {
+    return;
+  }
+  const lastAppended = params.appendedMessages.findLast((message) => message.appended);
+  if (params.publishWhen === "when-appended" && !lastAppended) {
+    return;
+  }
+  emitSessionTranscriptUpdate({
+    ...(params.target.sessionKey ? { sessionKey: params.target.sessionKey } : {}),
+    ...(params.target.agentId ? { agentId: params.target.agentId } : {}),
+    ...(params.updateMode === "inline" && lastAppended
+      ? { message: lastAppended.message, messageId: lastAppended.messageId }
+      : {}),
+    sessionFile: params.target.sessionFile,
+  });
+}
+
 function ensureTranscriptSessionRoot(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
@@ -798,6 +940,65 @@ function ensureTranscriptHeader(
     }),
   );
   ensureTranscriptSessionRoot(database, scope, now);
+}
+
+function appendSqliteTranscriptMessageInTransaction<TMessage>(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedTranscriptScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): TranscriptMessageAppendResult<TMessage> | undefined {
+  const idempotencyKey = readMessageIdempotencyKey(options.message);
+  if (idempotencyKey && options.idempotencyLookup === "scan") {
+    const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+    if (existing) {
+      return {
+        appended: false,
+        message: existing.message as TMessage,
+        messageId: existing.messageId,
+      };
+    }
+  }
+
+  const prepared = options.prepareMessageAfterIdempotencyCheck
+    ? options.prepareMessageAfterIdempotencyCheck(options.message)
+    : options.message;
+  if (prepared === undefined) {
+    return undefined;
+  }
+
+  const messageId = randomUUID();
+  const now = options.now ?? Date.now();
+  const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+  ensureTranscriptHeader(database, resolved, options.cwd, now);
+  const parentId = readLatestTranscriptEntryId(database, resolved.sessionId);
+  const event = {
+    type: "message",
+    id: messageId,
+    parentId: parentId ?? null,
+    timestamp: resolveTimestampMsToIsoString(now),
+    message: finalMessage,
+  };
+  const appended = appendTranscriptEventInTransaction(database, resolved, event, {
+    dedupeByMessageIdempotency: options.idempotencyLookup === "scan",
+  });
+  if (!appended && idempotencyKey && options.idempotencyLookup === "scan") {
+    const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+    if (existing) {
+      return {
+        appended: false,
+        message: existing.message as TMessage,
+        messageId: existing.messageId,
+      };
+    }
+  }
+  if (!appended) {
+    throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
+  }
+  return {
+    appended: true,
+    message: finalMessage,
+    messageId,
+  };
 }
 
 function readLatestTranscriptEntryId(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -40,7 +40,7 @@ import type {
 } from "./session-accessor.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
-import type { SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
 
 type SessionSqliteDatabase = Pick<
@@ -111,6 +111,40 @@ export type SqliteSessionTranscriptTurnPersistResult = {
   rejectedReason?: "session-rebound";
   sessionEntry: SessionEntry | undefined;
   sessionFile: string;
+};
+
+/** Result from SQLite compaction checkpoint branch or restore operations. */
+export type SqliteCompactionCheckpointSessionMutationResult =
+  | {
+      status: "created";
+      key: string;
+      checkpoint: SessionCompactionCheckpoint;
+      entry: SessionEntry;
+    }
+  | { status: "missing-session" }
+  | { status: "missing-checkpoint" }
+  | { status: "missing-boundary" }
+  | { status: "failed" };
+
+/** Parameters for branching a SQLite session from a compaction checkpoint. */
+export type SqliteBranchCheckpointSessionParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+  sourceKey: string;
+  sourceStoreKey?: string;
+  nextKey: string;
+  checkpointId: string;
+};
+
+/** Parameters for restoring a SQLite session from a compaction checkpoint. */
+export type SqliteRestoreCheckpointSessionParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+  sessionKey: string;
+  sessionStoreKey?: string;
+  checkpointId: string;
 };
 
 type ResolvedSqliteStoreTarget = {
@@ -484,6 +518,59 @@ export async function persistSqliteSessionTranscriptTurn(
   return result;
 }
 
+/** Branches a SQLite session from a compaction checkpoint in one queued transaction. */
+export async function branchSqliteCompactionCheckpointSession(
+  params: SqliteBranchCheckpointSessionParams,
+): Promise<SqliteCompactionCheckpointSessionMutationResult> {
+  const sourceKey = normalizeSqliteSessionKey(params.sourceStoreKey ?? params.sourceKey);
+  const targetKey = normalizeSqliteSessionKey(params.nextKey);
+  const resolved = resolveSqliteScope({
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.env ? { env: params.env } : {}),
+    sessionKey: sourceKey,
+    ...(params.storePath ? { storePath: params.storePath } : {}),
+  });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      result = branchSqliteCompactionCheckpointSessionInTransaction(database, {
+        checkpointId: params.checkpointId,
+        parentSessionKey: normalizeSqliteSessionKey(params.sourceKey),
+        resolved,
+        sourceKey,
+        targetKey,
+      });
+    }, toDatabaseOptions(resolved));
+    return result ?? { status: "failed" };
+  });
+}
+
+/** Restores a SQLite session from a compaction checkpoint in one queued transaction. */
+export async function restoreSqliteCompactionCheckpointSession(
+  params: SqliteRestoreCheckpointSessionParams,
+): Promise<SqliteCompactionCheckpointSessionMutationResult> {
+  const sessionKey = normalizeSqliteSessionKey(params.sessionStoreKey ?? params.sessionKey);
+  const targetKey = normalizeSqliteSessionKey(params.sessionKey);
+  const resolved = resolveSqliteScope({
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.env ? { env: params.env } : {}),
+    sessionKey,
+    ...(params.storePath ? { storePath: params.storePath } : {}),
+  });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      result = restoreSqliteCompactionCheckpointSessionInTransaction(database, {
+        checkpointId: params.checkpointId,
+        resolved,
+        sourceKey: sessionKey,
+        targetKey,
+      });
+    }, toDatabaseOptions(resolved));
+    return result ?? { status: "failed" };
+  });
+}
+
 /** Publishes a transcript update using the SQLite transcript scope target. */
 export async function publishSqliteTranscriptUpdate(
   scope: SessionTranscriptWriteScope,
@@ -817,6 +904,272 @@ function publishSqliteTranscriptTurnUpdate(params: {
       : {}),
     sessionFile: params.target.sessionFile,
   });
+}
+
+function branchSqliteCompactionCheckpointSessionInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    checkpointId: string;
+    parentSessionKey: string;
+    resolved: ResolvedSqliteScope;
+    sourceKey: string;
+    targetKey: string;
+  },
+): SqliteCompactionCheckpointSessionMutationResult {
+  const currentEntry = readSessionEntryRow(database, params.sourceKey)?.entry;
+  if (!currentEntry?.sessionId) {
+    return { status: "missing-session" };
+  }
+  const checkpoint = readSessionCompactionCheckpoint(currentEntry, params.checkpointId);
+  if (!checkpoint) {
+    return { status: "missing-checkpoint" };
+  }
+  const forked = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+    checkpoint,
+    targetSessionKey: params.targetKey,
+  });
+  if (forked.status !== "created") {
+    return forked;
+  }
+
+  const label = currentEntry.label?.trim()
+    ? `${currentEntry.label.trim()} (checkpoint)`
+    : "Checkpoint branch";
+  const nextEntry = cloneSqliteCheckpointSessionEntry({
+    currentEntry,
+    label,
+    nextSessionFile: forked.sessionFile,
+    nextSessionId: forked.sessionId,
+    parentSessionKey: params.parentSessionKey,
+    totalTokens: forked.totalTokens,
+  });
+  writeSessionEntry(database, params.targetKey, nextEntry);
+  return {
+    status: "created",
+    key: params.targetKey,
+    checkpoint,
+    entry: nextEntry,
+  };
+}
+
+function restoreSqliteCompactionCheckpointSessionInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    checkpointId: string;
+    resolved: ResolvedSqliteScope;
+    sourceKey: string;
+    targetKey: string;
+  },
+): SqliteCompactionCheckpointSessionMutationResult {
+  const currentEntry = readSessionEntryRow(database, params.sourceKey)?.entry;
+  if (!currentEntry?.sessionId) {
+    return { status: "missing-session" };
+  }
+  const checkpoint = readSessionCompactionCheckpoint(currentEntry, params.checkpointId);
+  if (!checkpoint) {
+    return { status: "missing-checkpoint" };
+  }
+  const restored = forkSqliteCheckpointTranscriptInTransaction(database, params.resolved, {
+    checkpoint,
+    targetSessionKey: params.targetKey,
+  });
+  if (restored.status !== "created") {
+    return restored;
+  }
+
+  const nextEntry = cloneSqliteCheckpointSessionEntry({
+    currentEntry,
+    nextSessionFile: restored.sessionFile,
+    nextSessionId: restored.sessionId,
+    preserveCompactionCheckpoints: true,
+    totalTokens: restored.totalTokens,
+  });
+  writeSessionEntry(database, params.targetKey, nextEntry);
+  return {
+    status: "created",
+    key: params.targetKey,
+    checkpoint,
+    entry: nextEntry,
+  };
+}
+
+function forkSqliteCheckpointTranscriptInTransaction(
+  database: OpenClawAgentDatabase,
+  resolved: ResolvedSqliteScope,
+  params: {
+    checkpoint: SessionCompactionCheckpoint;
+    targetSessionKey: string;
+  },
+):
+  | {
+      status: "created";
+      sessionId: string;
+      sessionFile: string;
+      totalTokens?: number;
+    }
+  | { status: "missing-boundary" }
+  | { status: "failed" } {
+  const source = resolveSqliteCheckpointTranscriptForkSource(params.checkpoint);
+  if (!source) {
+    return { status: "missing-boundary" };
+  }
+  const rows = readSqliteTranscriptRowsForFork(database, source);
+  if (rows.status !== "created") {
+    return rows;
+  }
+
+  const sessionId = randomUUID();
+  const targetScope = {
+    ...resolved,
+    sessionId,
+    sessionKey: params.targetSessionKey,
+  };
+  const sessionFile = formatSqliteTranscriptTarget(targetScope);
+  appendTranscriptEventInTransaction(
+    database,
+    targetScope,
+    createSessionTranscriptHeader({
+      cwd: readTranscriptHeaderCwd(rows.events),
+      sessionId,
+    }),
+  );
+  for (const event of rows.events) {
+    if (isSessionTranscriptHeader(event)) {
+      continue;
+    }
+    appendTranscriptEventInTransaction(database, targetScope, event);
+  }
+  return {
+    status: "created",
+    sessionId,
+    sessionFile,
+    ...(typeof source.totalTokens === "number" ? { totalTokens: source.totalTokens } : {}),
+  };
+}
+
+function resolveSqliteCheckpointTranscriptForkSource(
+  checkpoint: SessionCompactionCheckpoint,
+): { sessionId: string; leafId?: string; totalTokens?: number } | null {
+  const postLeafId = checkpoint.postCompaction.leafId ?? checkpoint.postCompaction.entryId;
+  if (checkpoint.postCompaction.sessionId && postLeafId) {
+    return {
+      sessionId: checkpoint.postCompaction.sessionId,
+      leafId: postLeafId,
+      ...(typeof checkpoint.tokensAfter === "number"
+        ? { totalTokens: checkpoint.tokensAfter }
+        : {}),
+    };
+  }
+
+  if (checkpoint.preCompaction.sessionId) {
+    return {
+      sessionId: checkpoint.preCompaction.sessionId,
+      ...(checkpoint.preCompaction.leafId ? { leafId: checkpoint.preCompaction.leafId } : {}),
+      ...(typeof checkpoint.tokensBefore === "number"
+        ? { totalTokens: checkpoint.tokensBefore }
+        : {}),
+    };
+  }
+
+  return null;
+}
+
+function readSqliteTranscriptRowsForFork(
+  database: OpenClawAgentDatabase,
+  source: { sessionId: string; leafId?: string },
+): { status: "created"; events: TranscriptEvent[] } | { status: "missing-boundary" | "failed" } {
+  const boundarySeq = source.leafId
+    ? readTranscriptIdentityByEventId(database, source.sessionId, source.leafId)?.seq
+    : undefined;
+  if (source.leafId && boundarySeq === undefined) {
+    return { status: "missing-boundary" };
+  }
+
+  const db = getSessionKysely(database.db);
+  const query = db
+    .selectFrom("transcript_events")
+    .select(["event_json", "seq"])
+    .where("session_id", "=", source.sessionId)
+    .orderBy("seq", "asc");
+  const rows = executeSqliteQuerySync(
+    database.db,
+    boundarySeq === undefined ? query : query.where("seq", "<=", boundarySeq),
+  ).rows;
+  if (rows.length === 0) {
+    return { status: "failed" };
+  }
+  try {
+    return {
+      status: "created",
+      events: rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent),
+    };
+  } catch {
+    return { status: "failed" };
+  }
+}
+
+function readSessionCompactionCheckpoint(
+  entry: Pick<SessionEntry, "compactionCheckpoints">,
+  checkpointId: string,
+): SessionCompactionCheckpoint | undefined {
+  const normalizedCheckpointId = checkpointId.trim();
+  if (!normalizedCheckpointId || !Array.isArray(entry.compactionCheckpoints)) {
+    return undefined;
+  }
+  return entry.compactionCheckpoints.find(
+    (checkpoint) => checkpoint.checkpointId === normalizedCheckpointId,
+  );
+}
+
+function cloneSqliteCheckpointSessionEntry(params: {
+  currentEntry: SessionEntry;
+  nextSessionId: string;
+  nextSessionFile: string;
+  label?: string;
+  parentSessionKey?: string;
+  totalTokens?: number;
+  preserveCompactionCheckpoints?: boolean;
+}): SessionEntry {
+  const hasTotalTokens =
+    typeof params.totalTokens === "number" && Number.isFinite(params.totalTokens);
+  return {
+    ...params.currentEntry,
+    sessionId: params.nextSessionId,
+    sessionFile: params.nextSessionFile,
+    updatedAt: Date.now(),
+    systemSent: false,
+    abortedLastRun: false,
+    startedAt: undefined,
+    endedAt: undefined,
+    runtimeMs: undefined,
+    status: undefined,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+    estimatedCostUsd: undefined,
+    totalTokens: hasTotalTokens ? params.totalTokens : undefined,
+    totalTokensFresh: hasTotalTokens ? true : undefined,
+    label: params.label ?? params.currentEntry.label,
+    parentSessionKey: params.parentSessionKey ?? params.currentEntry.parentSessionKey,
+    compactionCheckpoints: params.preserveCompactionCheckpoints
+      ? params.currentEntry.compactionCheckpoints
+      : undefined,
+  };
+}
+
+function readTranscriptHeaderCwd(events: readonly TranscriptEvent[]): string | undefined {
+  const header = events.find(isSessionTranscriptHeader) as { cwd?: unknown } | undefined;
+  return typeof header?.cwd === "string" && header.cwd.trim() ? header.cwd : undefined;
+}
+
+function isSessionTranscriptHeader(event: TranscriptEvent): boolean {
+  return Boolean(
+    event &&
+    typeof event === "object" &&
+    !Array.isArray(event) &&
+    (event as { type?: unknown }).type === "session",
+  );
 }
 
 function ensureTranscriptSessionRoot(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,0 +1,939 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import type { Selectable } from "kysely";
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { redactSecrets } from "../../logging/redact.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+  type OpenClawAgentDatabaseOptions,
+} from "../../state/openclaw-agent-db.js";
+import type {
+  ExactSessionEntry,
+  SessionAccessScope,
+  SessionEntryPatchContext,
+  SessionEntryPatchOptions,
+  SessionEntrySummary,
+  SessionEntryUpdateOptions,
+  SessionTranscriptAccessScope,
+  SessionTranscriptReadScope,
+  SessionTranscriptRuntimeScope,
+  SessionTranscriptRuntimeTarget,
+  SessionTranscriptWriteScope,
+  TranscriptEvent,
+  TranscriptMessageAppendOptions,
+  TranscriptMessageAppendResult,
+  TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
+import { createSessionTranscriptHeader } from "./transcript-header.js";
+import type { SessionEntry } from "./types.js";
+import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
+
+type SessionSqliteDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_entries" | "sessions" | "transcript_event_identities" | "transcript_events"
+>;
+type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
+
+type ResolvedSqliteScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey: string;
+};
+
+type ResolvedSqliteReadScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey?: string;
+};
+
+type ResolvedTranscriptScope = ResolvedSqliteScope & {
+  sessionId: string;
+};
+
+type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
+  sessionId: string;
+};
+
+export type SqliteSessionTranscriptRuntimeTarget = SessionTranscriptRuntimeTarget & {
+  env?: NodeJS.ProcessEnv;
+  storePath?: string;
+};
+
+type ResolvedSqliteStoreTarget = {
+  agentId?: string;
+  path?: string;
+};
+
+const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
+
+/** Loads one session entry from the additive SQLite session store. */
+export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return readSessionEntryRow(database, resolved.sessionKey)?.entry;
+}
+
+/** Loads one exact persisted-key entry from the additive SQLite session store. */
+export function loadExactSqliteSessionEntry(
+  scope: SessionAccessScope,
+): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const row = readExactSessionEntryRow(database, sessionKey);
+  return row ? { sessionKey, entry: row.entry } : undefined;
+}
+
+/** Lists session entries from the additive SQLite session store. */
+export function listSqliteSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select(["session_key", "entry_json", "session_id", "updated_at"])
+      .orderBy("session_key", "asc"),
+  ).rows;
+  return rows
+    .map((row) => {
+      const entry = parseSessionEntryRow(row);
+      return entry ? { sessionKey: row.session_key, entry } : undefined;
+    })
+    .filter((entry): entry is SessionEntrySummary => entry !== undefined);
+}
+
+/** Reads a session activity timestamp from the additive SQLite session store. */
+export function readSqliteSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select("updated_at")
+      .where("session_key", "=", resolved.sessionKey),
+  );
+  return row ? normalizeSqliteNumber(row.updated_at) : undefined;
+}
+
+/** Applies a partial entry update to the additive SQLite session store. */
+export async function upsertSqliteSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => patch, {
+    fallbackEntry: createFallbackSessionEntry(patch),
+  });
+}
+
+/** Replaces one entry in the additive SQLite session store. */
+export async function replaceSqliteSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => entry, {
+    fallbackEntry: entry,
+    replaceEntry: true,
+  });
+}
+
+/** Patches one entry in the additive SQLite session store. */
+export async function patchSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  const resolved = resolveSqliteScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    const base = existing ?? options.fallbackEntry;
+    if (!base) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(base), {
+      existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+    });
+    if (!patch) {
+      return cloneSessionEntry(base);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      const writeBase = fresh ?? options.fallbackEntry;
+      if (!writeBase) {
+        result = null;
+        return;
+      }
+      const next = options.replaceEntry
+        ? cloneSessionEntry(patch as SessionEntry)
+        : options.preserveActivity
+          ? mergeSessionEntryPreserveActivity(writeBase, patch)
+          : mergeSessionEntry(writeBase, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
+}
+
+/** Updates an existing entry in the additive SQLite session store. */
+export async function updateSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  _options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  const resolved = resolveSqliteScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    if (!existing) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(existing));
+    if (!patch) {
+      return cloneSessionEntry(existing);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      if (!fresh) {
+        result = null;
+        return;
+      }
+      const next = mergeSessionEntry(fresh, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
+}
+
+/** Loads raw transcript events from the additive SQLite transcript store. */
+export async function loadSqliteTranscriptEvents(
+  scope: SessionTranscriptReadScope,
+): Promise<TranscriptEvent[]> {
+  return loadSqliteTranscriptEventsSync(scope);
+}
+
+/** Loads raw transcript events synchronously from the additive SQLite transcript store. */
+export function loadSqliteTranscriptEventsSync(
+  scope: SessionTranscriptReadScope,
+): TranscriptEvent[] {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", resolved.sessionId)
+      .orderBy("seq", "asc"),
+  ).rows;
+  return rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent);
+}
+
+/** Resolves a runtime transcript identity to the additive SQLite store target. */
+export function resolveSqliteSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptRuntimeScope,
+): SqliteSessionTranscriptRuntimeTarget {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  return {
+    agentId: resolved.agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    sessionFile: formatSqliteTranscriptTarget(resolved),
+    sessionId: resolved.sessionId,
+    sessionKey: resolved.sessionKey,
+    ...(resolved.path ? { storePath: resolved.path } : {}),
+  };
+}
+
+/** Checks whether the additive SQLite transcript store has rows for a runtime transcript. */
+export function sqliteTranscriptExists(scope: SessionTranscriptRuntimeScope): boolean {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", resolved.sessionId)
+      .limit(1),
+  );
+  return row !== undefined;
+}
+
+/** Deletes rows for one runtime transcript from the additive SQLite transcript store. */
+export async function deleteSqliteTranscript(
+  scope: SessionTranscriptRuntimeScope,
+): Promise<boolean> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let deleted = false;
+    runOpenClawAgentWriteTransaction((database) => {
+      const db = getSessionKysely(database.db);
+      const result = executeSqliteQuerySync(
+        database.db,
+        db.deleteFrom("transcript_events").where("session_id", "=", resolved.sessionId),
+      );
+      deleted = (result.numAffectedRows ?? 0n) > 0n;
+    }, toDatabaseOptions(resolved));
+    return deleted;
+  });
+}
+
+/** Fully replaces rows for one runtime transcript in the additive SQLite transcript store. */
+export async function replaceSqliteTranscriptEvents(
+  scope: SessionTranscriptRuntimeScope,
+  events: TranscriptEvent[],
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      const db = getSessionKysely(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db.deleteFrom("transcript_events").where("session_id", "=", resolved.sessionId),
+      );
+      for (const event of events) {
+        appendTranscriptEventInTransaction(database, resolved, event);
+      }
+    }, toDatabaseOptions(resolved));
+  });
+}
+
+/** Appends one raw transcript event to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      appendTranscriptEventInTransaction(database, resolved, event);
+    }, toDatabaseOptions(resolved));
+  });
+}
+
+/** Appends one transcript message to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: TranscriptMessageAppendResult<TMessage> | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      const idempotencyKey = readMessageIdempotencyKey(options.message);
+      if (idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+
+      const prepared = options.prepareMessageAfterIdempotencyCheck
+        ? options.prepareMessageAfterIdempotencyCheck(options.message)
+        : options.message;
+      if (prepared === undefined) {
+        result = undefined;
+        return;
+      }
+
+      const messageId = randomUUID();
+      const now = options.now ?? Date.now();
+      const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+      ensureTranscriptHeader(database, resolved, options.cwd, now);
+      const parentId = readLatestTranscriptEntryId(database, resolved.sessionId);
+      const event = {
+        type: "message",
+        id: messageId,
+        parentId: parentId ?? null,
+        timestamp: resolveTimestampMsToIsoString(now),
+        message: finalMessage,
+      };
+      const appended = appendTranscriptEventInTransaction(database, resolved, event, {
+        dedupeByMessageIdempotency: options.idempotencyLookup === "scan",
+      });
+      if (!appended && idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+      if (!appended) {
+        throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
+      }
+      result = {
+        appended: true,
+        message: finalMessage,
+        messageId,
+      };
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
+}
+
+/** Publishes a transcript update using the SQLite transcript scope target. */
+export async function publishSqliteTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const sessionFile = scope.sessionFile?.trim();
+  if (!sessionFile) {
+    throw new Error(
+      "SQLite transcript update publication requires a path-compatible sessionFile until transcript updates carry SQLite identity.",
+    );
+  }
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile,
+  });
+}
+
+function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
+  return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+async function runExclusiveSqliteSessionWrite<T>(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const databaseOptions = toDatabaseOptions(scope);
+  return await runQueuedStoreWrite({
+    queues: SQLITE_SESSION_WRITER_QUEUES,
+    storePath: resolveOpenClawAgentSqlitePath(databaseOptions),
+    label: "runExclusiveSqliteSessionWrite",
+    fn,
+  });
+}
+
+function resolveSqliteScope(
+  scope: Pick<SessionAccessScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
+  return {
+    agentId: scope.agentId
+      ? normalizeAgentId(scope.agentId)
+      : (storeTarget?.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey)),
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
+    sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
+  };
+}
+
+function resolveSqliteReadScope(
+  scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteReadScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
+  const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
+  const agentId = scope.agentId
+    ? normalizeAgentId(scope.agentId)
+    : (storeTarget?.agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined));
+  if (!agentId) {
+    throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
+  }
+  return {
+    agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
+function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
+  const resolved = path.resolve(storePath);
+  if (path.basename(resolved) === "openclaw-agent.sqlite" || resolved.endsWith(".sqlite")) {
+    return { path: resolved };
+  }
+  if (path.basename(resolved) !== "sessions.json") {
+    return {};
+  }
+  const sessionsDir = path.dirname(resolved);
+  if (path.basename(sessionsDir) !== "sessions") {
+    return {};
+  }
+  const agentDir = path.dirname(sessionsDir);
+  if (path.basename(path.dirname(agentDir)) !== "agents") {
+    return {};
+  }
+  return {
+    agentId: normalizeAgentId(path.basename(agentDir)),
+    path: path.join(agentDir, "agent", "openclaw-agent.sqlite"),
+  };
+}
+
+function resolveSqliteTranscriptScope(
+  scope: Pick<
+    SessionTranscriptWriteScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptScope {
+  if (!scope.sessionId) {
+    throw new Error(
+      `Cannot resolve SQLite transcript scope without a session id: ${scope.sessionKey}`,
+    );
+  }
+  return {
+    ...resolveSqliteScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
+function resolveSqliteTranscriptReadScope(
+  scope: Pick<
+    SessionTranscriptReadScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptReadScope {
+  return {
+    ...resolveSqliteReadScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
+function toDatabaseOptions(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
+): OpenClawAgentDatabaseOptions {
+  return {
+    agentId: scope.agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.path ? { path: scope.path } : {}),
+  };
+}
+
+function normalizeSqliteSessionKey(sessionKey: string): string {
+  return normalizeStoreSessionKey(sessionKey);
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+function cloneSessionEntry(entry: SessionEntry): SessionEntry {
+  return structuredClone(entry);
+}
+
+function normalizeSqliteNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+function parseSessionEntryRow(row: Pick<SessionEntryRow, "entry_json">): SessionEntry | null {
+  try {
+    const parsed = JSON.parse(row.entry_json) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as SessionEntry)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  return readExactSessionEntryRow(database, normalizeSqliteSessionKey(sessionKey));
+}
+
+function readExactSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db.selectFrom("session_entries").selectAll().where("session_key", "=", sessionKey),
+  );
+  if (!row) {
+    return undefined;
+  }
+  const entry = parseSessionEntryRow(row);
+  return entry ? { entry, row } : undefined;
+}
+
+function writeSessionEntry(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+  entry: SessionEntry,
+): void {
+  const db = getSessionKysely(database.db);
+  const updatedAt = entry.updatedAt;
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: entry.sessionId,
+        session_key: sessionKey,
+        created_at: entry.sessionStartedAt ?? updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("session_entries")
+      .values({
+        session_key: sessionKey,
+        session_id: entry.sessionId,
+        entry_json: JSON.stringify(entry),
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: entry.sessionId,
+          entry_json: JSON.stringify(entry),
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function ensureTranscriptSessionRoot(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  updatedAt: number,
+): void {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: scope.sessionId,
+        session_key: scope.sessionKey,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: scope.sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId: string): number {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("seq").as("max_seq"))
+      .where("session_id", "=", sessionId),
+  );
+  const maxSeq =
+    row?.max_seq === null || row?.max_seq === undefined ? -1 : normalizeSqliteNumber(row.max_seq);
+  return maxSeq + 1;
+}
+
+function appendTranscriptEventInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  event: TranscriptEvent,
+  options: { dedupeByMessageIdempotency?: boolean } = {},
+): boolean {
+  const db = getSessionKysely(database.db);
+  const createdAt = readEventTimestamp(event) ?? Date.now();
+  ensureTranscriptSessionRoot(database, scope, createdAt);
+  const identity = readTranscriptEventIdentity(event);
+  if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
+    return false;
+  }
+  if (
+    identity?.messageIdempotencyKey &&
+    options.dedupeByMessageIdempotency &&
+    readTranscriptIdentityByMessageIdempotencyKey(
+      database,
+      scope.sessionId,
+      identity.messageIdempotencyKey,
+    )
+  ) {
+    return false;
+  }
+  const seq = readNextTranscriptSeq(database, scope.sessionId);
+  executeSqliteQuerySync(
+    database.db,
+    db.insertInto("transcript_events").values({
+      session_id: scope.sessionId,
+      seq,
+      event_json: JSON.stringify(event),
+      created_at: createdAt,
+    }),
+  );
+  if (!identity) {
+    return true;
+  }
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("transcript_event_identities")
+      .values({
+        session_id: scope.sessionId,
+        event_id: identity.eventId,
+        seq,
+        event_type: identity.eventType,
+        parent_id: identity.parentId,
+        message_idempotency_key: identity.messageIdempotencyKey,
+        created_at: createdAt,
+      })
+      .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
+  );
+  return true;
+}
+
+function ensureTranscriptHeader(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  cwd: string | undefined,
+  now: number,
+): void {
+  const db = getSessionKysely(database.db);
+  const existing = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", scope.sessionId)
+      .limit(1),
+  );
+  if (existing) {
+    return;
+  }
+  appendTranscriptEventInTransaction(
+    database,
+    scope,
+    createSessionTranscriptHeader({
+      cwd,
+      sessionId: scope.sessionId,
+    }),
+  );
+  ensureTranscriptSessionRoot(database, scope, now);
+}
+
+function readLatestTranscriptEntryId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): string | undefined {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "event_type"])
+      .where("session_id", "=", sessionId)
+      .orderBy("seq", "desc"),
+  ).rows;
+  const row = rows.find((candidate) => candidate.event_type !== "session");
+  return row?.event_id;
+}
+
+function readTranscriptIdentityByEventId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  eventId: string,
+): { eventId: string; seq: number } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", sessionId)
+      .where("event_id", "=", eventId),
+  );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptIdentityByMessageIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  idempotencyKey: string,
+): { eventId: string; seq: number } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", sessionId)
+      .where("message_idempotency_key", "=", idempotencyKey)
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptMessageByIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  idempotencyKey: string,
+): { messageId: string; message: unknown } | undefined {
+  const identity = readTranscriptIdentityByMessageIdempotencyKey(
+    database,
+    scope.sessionId,
+    idempotencyKey,
+  );
+  if (!identity) {
+    return undefined;
+  }
+  const db = getSessionKysely(database.db);
+  const eventRow = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", scope.sessionId)
+      .where("seq", "=", identity.seq),
+  );
+  if (!eventRow) {
+    return undefined;
+  }
+  const event = JSON.parse(eventRow.event_json) as { message?: unknown };
+  return {
+    messageId: identity.eventId,
+    message: event.message,
+  };
+}
+
+function readTranscriptEventIdentity(event: unknown):
+  | {
+      eventId: string;
+      eventType: string | null;
+      parentId: string | null;
+      messageIdempotencyKey: string | null;
+    }
+  | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const record = event as Record<string, unknown>;
+  const eventId = typeof record.id === "string" && record.id.trim() ? record.id.trim() : undefined;
+  if (!eventId) {
+    return undefined;
+  }
+  return {
+    eventId,
+    eventType: typeof record.type === "string" ? record.type : null,
+    parentId: typeof record.parentId === "string" ? record.parentId : null,
+    messageIdempotencyKey: readMessageIdempotencyKey(record.message),
+  };
+}
+
+function readMessageIdempotencyKey(message: unknown): string | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const value = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readEventTimestamp(event: unknown): number | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const value = (event as { timestamp?: unknown }).timestamp;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function redactTranscriptMessageForStorage<TMessage>(
+  message: TMessage,
+  options: Pick<TranscriptMessageAppendOptions<TMessage>, "config">,
+): TMessage {
+  if (isTranscriptAgentMessage(message)) {
+    return redactTranscriptMessage(message, options.config) as TMessage;
+  }
+  return redactSecrets(message);
+}
+
+function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { role?: unknown }).role === "string"
+  );
+}
+
+function formatSqliteTranscriptTarget(scope: ResolvedTranscriptScope): string {
+  const pathPart = scope.path ? `:${scope.path}` : "";
+  return `sqlite:${scope.agentId}:${scope.sessionId}${pathPart}`;
+}

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -159,13 +160,18 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    let missingContextEntry: SessionEntry | undefined;
+    let existingContextEntry: SessionEntry | undefined;
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: "gpt-5.5",
-      }),
+      (entry, context) => {
+        missingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: "gpt-5.5",
+        };
+      },
       {
         fallbackEntry: {
           sessionId: "session-1",
@@ -177,14 +183,19 @@ describe("session accessor file-backed seam", () => {
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: undefined,
-        providerOverride: "openai",
-      }),
+      (entry, context) => {
+        existingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: undefined,
+          providerOverride: "openai",
+        };
+      },
       { replaceEntry: true },
     );
 
+    expect(missingContextEntry).toBeUndefined();
+    expect(existingContextEntry).toMatchObject({ model: "gpt-5.5" });
     expect(loadSessionEntry(scope)).toMatchObject({
       providerOverride: "openai",
       sessionId: "session-1",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -124,6 +125,32 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("replaces entries so deleted fields stay removed", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      providerOverride: "openai",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    await replaceSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 20,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
+    expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
 
@@ -75,6 +76,34 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("updates existing entries without creating missing sessions", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(updateSessionEntry(scope, () => ({ model: "gpt-5.5" }))).resolves.toBeNull();
+    expect(listSessionEntries({ storePath })).toEqual([]);
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforeNullUpdate = loadSessionEntry(scope);
+    await expect(updateSessionEntry(scope, () => null)).resolves.toEqual(beforeNullUpdate);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: beforeNullUpdate?.updatedAt,
+    });
+    await expect(
+      updateSessionEntry(scope, () => ({ model: "gpt-5.5", updatedAt: 20 })),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+
+describe("session accessor file-backed seam", () => {
+  let tempDir: string;
+  let storePath: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    storePath = path.join(tempDir, "sessions.json");
+    transcriptPath = path.join(tempDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads, lists, and patches session entries without exposing the file store shape", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(listSessionEntries({ storePath })).toEqual([
+      {
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "session-1",
+          updatedAt: expect.any(Number),
+        }),
+      },
+    ]);
+
+    await upsertSessionEntry(scope, { model: "sonnet-4.6", updatedAt: 20 });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "sonnet-4.6",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("creates durable session ids for metadata-only inserts", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    const inserted = await upsertSessionEntry(scope, { model: "gpt-5.5" });
+
+    expect(inserted?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(inserted?.sessionId).not.toBe(scope.sessionKey);
+    expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("loads and appends transcript events through a session scope", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+    await appendTranscriptEvent(scope, event);
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", sessionId: "session-1" },
+      event,
+    ]);
+    expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors thread fallback paths when resolving transcript scope from the store", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:demo-channel:1234:thread:456",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, event);
+
+    const expectedTranscriptPath = path.join(tempDir, "session-1-topic-456.jsonl");
+    expect(fs.existsSync(expectedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "session-1.jsonl"))).toBe(false);
+    expect(fs.realpathSync(loadSessionEntry(scope)?.sessionFile ?? "")).toBe(
+      fs.realpathSync(expectedTranscriptPath),
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("persists transcript metadata under the normalized session key", async () => {
+    const canonicalScope = {
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(canonicalScope, {
+      sessionId: canonicalScope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: canonicalScope.sessionId,
+        sessionKey: "AGENT:MAIN:MAIN",
+        storePath,
+      },
+      { id: "msg-1", type: "message" },
+    );
+
+    expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([
+      canonicalScope.sessionKey,
+    ]);
+    expect(loadSessionEntry(canonicalScope)?.sessionFile).toBeTruthy();
+  });
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -10,6 +10,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { loadSessionStore } from "./store.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -76,6 +77,25 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("can borrow cached entry objects for read-only hot paths", async () => {
+    const scope = {
+      clone: false,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+
+    expect(loadSessionEntry(scope)).toBe(cachedStore["agent:main:main"]);
+    expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
+      cachedStore["agent:main:main"],
+    );
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -47,6 +51,7 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+    expect(readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
     expect(listSessionEntries({ storePath })).toEqual([
       {
         sessionKey: "agent:main:main",
@@ -225,6 +230,75 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends messages and publishes updates through a session scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    const appended = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    const replayed = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello again",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    await publishTranscriptUpdate(scope, {
+      agentId: "main",
+      message: appended.message,
+      messageId: appended.messageId,
+      sessionKey: scope.sessionKey,
+    });
+    unsubscribe();
+
+    expect(replayed).toMatchObject({
+      appended: false,
+      messageId: appended.messageId,
+      message: expect.objectContaining({
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      }),
+    });
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: appended.messageId,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        type: "message",
+      }),
+    ]);
+    expect(updates).toEqual([
+      {
+        agentId: "main",
+        message: appended.message,
+        messageId: appended.messageId,
+        sessionFile: transcriptPath,
+        sessionKey: scope.sessionKey,
+      },
+    ]);
   });
 
   it("honors thread fallback paths when resolving transcript scope from the store", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  patchSessionEntry,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -151,6 +152,44 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
     expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
+  });
+
+  it("patches entries atomically with a fallback entry", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: "gpt-5.5",
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "session-1",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+      },
+    );
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: undefined,
+        providerOverride: "openai",
+      }),
+      { replaceEntry: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
+  resolveSessionTranscriptRuntimeTarget,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -328,6 +329,31 @@ describe("session accessor file-backed seam", () => {
       fs.realpathSync(expectedTranscriptPath),
     );
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("resolves runtime transcript targets from scope without caller-owned paths", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+
+    const target = await resolveSessionTranscriptRuntimeTarget(scope);
+
+    expect(target).toMatchObject({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    expect(fs.realpathSync(path.dirname(target.sessionFile))).toBe(fs.realpathSync(tempDir));
+    expect(path.basename(target.sessionFile)).toBe("session-1.jsonl");
+    expect(loadSessionEntry(scope)?.sessionFile).toBe(target.sessionFile);
   });
 
   it("persists transcript metadata under the normalized session key", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -105,6 +106,35 @@ describe("session accessor file-backed seam", () => {
     expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
       cachedStore["agent:main:main"],
     );
+  });
+
+  it("keeps exact persisted-key lookup separate from canonical entry reads", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-1",
+          updatedAt: 10,
+          model: "gpt-5.5",
+        },
+      }),
+      "utf8",
+    );
+
+    const mixedCaseScope = {
+      sessionKey: "AGENT:MAIN:MAIN",
+      storePath,
+    };
+
+    expect(loadSessionEntry(mixedCaseScope)?.sessionId).toBe("session-1");
+    expect(loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+    expect(loadExactSessionEntry({ sessionKey: "agent:main:main", storePath })).toEqual({
+      sessionKey: "agent:main:main",
+      entry: expect.objectContaining({
+        sessionId: "session-1",
+        model: "gpt-5.5",
+      }),
+    });
   });
 
   it("updates existing entries without creating missing sessions", async () => {
@@ -207,6 +237,34 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
+  });
+
+  it("can patch metadata without refreshing session activity", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforePatch = loadSessionEntry(scope);
+
+    await patchSessionEntry(
+      scope,
+      () => ({
+        model: "gpt-5.5",
+        updatedAt: 20,
+      }),
+      { preserveActivity: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: beforePatch?.updatedAt,
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveAndPersistSessionFile } from "./session-file.js";
+import {
+  getSessionEntry,
+  listSessionEntries as listFileSessionEntries,
+  loadSessionStore,
+  patchSessionEntry as patchFileSessionEntry,
+  resolveSessionStoreEntry,
+} from "./store.js";
+import { parseSessionThreadInfo } from "./thread-info.js";
+import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import { resolveSessionTranscriptFile } from "./transcript.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionAccessScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionKey: string;
+  storePath?: string;
+};
+
+export type SessionTranscriptAccessScope = SessionAccessScope & {
+  sessionFile?: string;
+  sessionId: string;
+  threadId?: string | number;
+};
+
+export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type TranscriptEvent = unknown;
+
+/** Loads one session entry through the storage-neutral accessor seam. */
+export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  return getSessionEntry(scope);
+}
+
+/** Lists session entries through the storage-neutral accessor seam. */
+export function listSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  return listFileSessionEntries(scope);
+}
+
+/** Applies a partial entry update through the storage-neutral accessor seam. */
+export async function upsertSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: createFallbackSessionEntry(patch),
+    update: () => patch,
+  });
+}
+
+/** Loads raw transcript events through the storage-neutral accessor seam. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const transcript = await resolveTranscriptAccess(scope);
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
+
+/** Appends one raw transcript event through the storage-neutral accessor seam. */
+export async function appendTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  await appendSessionTranscriptEvent({
+    event,
+    transcriptPath: transcript.sessionFile,
+  });
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    return await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+  }
+  return await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -9,6 +10,7 @@ import {
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptEvent } from "./transcript-append.js";
@@ -37,6 +39,11 @@ export type SessionEntrySummary = {
 
 export type TranscriptEvent = unknown;
 
+export type SessionEntryUpdateOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   return getSessionEntry(scope);
@@ -58,6 +65,23 @@ export async function upsertSessionEntry(
     ...scope,
     fallbackEntry: createFallbackSessionEntry(patch),
     update: () => patch,
+  });
+}
+
+/** Updates an existing session entry through the storage-neutral accessor seam. */
+export async function updateSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  return await updateFileSessionStoreEntry({
+    storePath: resolveAccessStorePath(scope),
+    sessionKey: scope.sessionKey,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
   });
 }
 
@@ -92,6 +116,17 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
     updatedAt: patch.updatedAt ?? now,
     ...patch,
   };
+}
+
+function resolveAccessStorePath(scope: SessionAccessScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -84,6 +84,19 @@ export async function upsertSessionEntry(
   });
 }
 
+/** Replaces one entry through the storage-neutral accessor seam. */
+export async function replaceSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: entry,
+    replaceEntry: true,
+    update: () => entry,
+  });
+}
+
 /** Updates an existing session entry through the storage-neutral accessor seam. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
@@ -9,11 +12,15 @@ import {
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
+  readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
-import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
@@ -33,12 +40,34 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  sessionId?: string;
+};
+
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
 export type TranscriptEvent = unknown;
+
+export type TranscriptMessageAppendOptions<TMessage> = {
+  config?: OpenClawConfig;
+  cwd?: string;
+  idempotencyLookup?: "scan" | "caller-checked";
+  message: TMessage;
+  now?: number;
+  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  useRawWhenLinear?: boolean;
+};
+
+export type TranscriptMessageAppendResult<TMessage> = {
+  appended: boolean;
+  message: TMessage;
+  messageId: string;
+};
+
+export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -79,6 +108,17 @@ export function listSessionEntries(
     ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
   }
   return listFileSessionEntries(scope);
+}
+
+/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  if (scope.storePath) {
+    return readFileSessionUpdatedAt({
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+    });
+  }
+  return loadSessionEntry(scope)?.updatedAt;
 }
 
 /** Applies a partial entry update through the storage-neutral accessor seam. */
@@ -164,6 +204,51 @@ export async function appendTranscriptEvent(
   });
 }
 
+/** Appends one transcript message through the storage-neutral writer seam. */
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return await appendSessionTranscriptMessage({
+    transcriptPath: transcript.sessionFile,
+    message: options.message,
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.config ? { config: options.config } : {}),
+    ...(options.idempotencyLookup ? { idempotencyLookup: options.idempotencyLookup } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.prepareMessageAfterIdempotencyCheck
+      ? { prepareMessageAfterIdempotencyCheck: options.prepareMessageAfterIdempotencyCheck }
+      : {}),
+    ...(options.useRawWhenLinear !== undefined
+      ? { useRawWhenLinear: options.useRawWhenLinear }
+      : {}),
+  });
+}
+
+/** Publishes a transcript update after resolving the current storage target. */
+export async function publishTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: transcript.sessionFile,
+  });
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -184,11 +269,14 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
   sessionFile: string;
 }> {
   if (scope.sessionFile?.trim()) {
     return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionAccessScope = {
   agentId?: string;
+  clone?: boolean;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -46,6 +47,13 @@ export type SessionEntryUpdateOptions = {
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  if (scope.clone === false) {
+    const store = loadSessionStore(resolveAccessStorePath(scope), {
+      clone: false,
+      ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+    });
+    return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
+  }
   return getSessionEntry(scope);
 }
 
@@ -53,6 +61,14 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
+  if (scope.clone === false) {
+    return Object.entries(
+      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+        clone: false,
+        ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+      }),
+    ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  }
   return listFileSessionEntries(scope);
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -50,6 +50,10 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
 };
 
+export type SessionEntryPatchContext = {
+  existingEntry?: SessionEntry;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -107,6 +111,7 @@ export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
     entry: SessionEntry,
+    context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -40,6 +40,11 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptRuntimeScope = SessionAccessScope & {
+  sessionId: string;
+  threadId?: string | number;
+};
+
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
   sessionId?: string;
 };
@@ -68,6 +73,13 @@ export type TranscriptMessageAppendResult<TMessage> = {
 };
 
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
+
+export type SessionTranscriptRuntimeTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionKey: string;
+};
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -249,6 +261,67 @@ export async function publishTranscriptUpdate(
   });
 }
 
+/**
+ * Resolves the current file-backed target for a storage-neutral runtime
+ * transcript scope. Callers use the scope as identity; sessionFile is returned
+ * only for current file-backed implementation details such as locks/events.
+ */
+export async function resolveSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptRuntimeScope,
+): Promise<SessionTranscriptRuntimeTarget> {
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    const resolved = await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+    return {
+      agentId,
+      sessionFile: resolved.sessionFile,
+      sessionId: scope.sessionId,
+      sessionKey,
+    };
+  }
+  const resolved = await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+  return {
+    agentId,
+    sessionFile: resolved.sessionFile,
+    sessionId: scope.sessionId,
+    sessionKey,
+  };
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -278,43 +351,8 @@ async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Prom
   if (!scope.sessionId) {
     throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
-  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
-  if (!agentId) {
-    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
-  }
-  const sessionStore = scope.storePath
-    ? loadSessionStore(scope.storePath, { skipCache: true })
-    : undefined;
-  const resolvedStoreEntry = sessionStore
-    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
-    : undefined;
-  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
-  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
-  if (sessionStore && scope.storePath) {
-    const sessionsDir = path.dirname(path.resolve(scope.storePath));
-    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
-    const fallbackSessionFile =
-      !sessionEntry?.sessionFile && threadId !== undefined
-        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
-        : undefined;
-    return await resolveAndPersistSessionFile({
-      agentId,
-      fallbackSessionFile,
-      sessionEntry,
-      sessionId: scope.sessionId,
-      sessionKey,
-      sessionStore,
-      sessionsDir,
-      storePath: scope.storePath,
-    });
-  }
-  return await resolveSessionTranscriptFile({
-    agentId,
-    sessionEntry,
+  return await resolveSessionTranscriptRuntimeTarget({
+    ...scope,
     sessionId: scope.sessionId,
-    sessionKey: scope.sessionKey,
-    ...(sessionStore ? { sessionStore } : {}),
-    ...(scope.storePath ? { storePath: scope.storePath } : {}),
-    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
   });
 }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -45,6 +45,11 @@ export type SessionEntryUpdateOptions = {
   takeCacheOwnership?: boolean;
 };
 
+export type SessionEntryPatchOptions = {
+  fallbackEntry?: SessionEntry;
+  replaceEntry?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -94,6 +99,22 @@ export async function replaceSessionEntry(
     fallbackEntry: entry,
     replaceEntry: true,
     update: () => entry,
+  });
+}
+
+/** Patches one entry atomically through the storage-neutral accessor seam. */
+export async function patchSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    replaceEntry: options.replaceEntry,
+    update,
   });
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -40,6 +40,10 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptReadScope = Omit<SessionTranscriptAccessScope, "sessionKey"> & {
+  sessionKey?: string;
+};
+
 export type SessionTranscriptRuntimeScope = SessionAccessScope & {
   sessionId: string;
   threadId?: string | number;
@@ -50,6 +54,12 @@ export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "se
 };
 
 export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+/** Session entry read by the exact persisted session key, without alias resolution. */
+export type ExactSessionEntry = {
   sessionKey: string;
   entry: SessionEntry;
 };
@@ -88,6 +98,7 @@ export type SessionEntryUpdateOptions = {
 
 export type SessionEntryPatchOptions = {
   fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
   replaceEntry?: boolean;
 };
 
@@ -105,6 +116,23 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
     return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
   }
   return getSessionEntry(scope);
+}
+
+/**
+ * Loads one entry only when the persisted key exactly matches the requested key.
+ * Approval routing uses this to avoid canonical alias lookup crossing accounts.
+ */
+export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const store = loadSessionStore(resolveAccessStorePath(scope), {
+    ...(scope.clone === false ? { clone: false } : {}),
+    ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+  });
+  const entry = Object.hasOwn(store, sessionKey) ? store[sessionKey] : undefined;
+  return entry ? { sessionKey, entry } : undefined;
 }
 
 /** Lists session entries through the storage-neutral accessor seam. */
@@ -170,6 +198,7 @@ export async function patchSessionEntry(
   return await patchFileSessionEntry({
     ...scope,
     fallbackEntry: options.fallbackEntry,
+    preserveActivity: options.preserveActivity,
     replaceEntry: options.replaceEntry,
     update,
   });
@@ -194,9 +223,9 @@ export async function updateSessionEntry(
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */
 export async function loadTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const transcript = await resolveTranscriptAccess(scope);
+  const transcript = await resolveTranscriptReadAccess(scope);
   const events: TranscriptEvent[] = [];
   for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
     events.push(JSON.parse(line) as TranscriptEvent);
@@ -354,5 +383,20 @@ async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Prom
   return await resolveSessionTranscriptRuntimeTarget({
     ...scope,
     sessionId: scope.sessionId,
+  });
+}
+
+async function resolveTranscriptReadAccess(scope: SessionTranscriptReadScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionKey) {
+    throw new Error("Cannot resolve transcript read scope without a session file or session key");
+  }
+  return await resolveTranscriptAccess({
+    ...scope,
+    sessionKey: scope.sessionKey,
   });
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1006,6 +1006,7 @@ export async function patchSessionEntry(
     replaceEntry?: boolean;
     update: (
       entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   },
 ): Promise<SessionEntry | null> {
@@ -1017,7 +1018,9 @@ export async function patchSessionEntry(
     if (!existing) {
       return null;
     }
-    const patch = await params.update(cloneSessionEntry(existing));
+    const patch = await params.update(cloneSessionEntry(existing), {
+      existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
+    });
     if (!patch) {
       return existing;
     }

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -14,6 +14,7 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -284,6 +285,31 @@ export async function appendSessionTranscriptMessage<TMessage>(
   );
 }
 
+export type AppendSessionTranscriptEventParams = {
+  config?: OpenClawConfig;
+  event: unknown;
+  transcriptPath: string;
+};
+
+/** Appends a raw transcript event using the same write lock and FIFO as message appends. */
+export async function appendSessionTranscriptEvent(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
+    sessionFile: params.transcriptPath,
+  });
+  if (activeLockRunner) {
+    return await activeLockRunner(() =>
+      withTranscriptAppendQueue(params.transcriptPath, () =>
+        appendSessionTranscriptEventLocked(params),
+      ),
+    );
+  }
+  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+    withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
+  );
+}
+
 async function withSessionTranscriptWriteLock<T>(
   params: Pick<AppendSessionTranscriptMessageParams, "transcriptPath" | "config">,
   run: () => Promise<T> | T,
@@ -297,6 +323,18 @@ async function withSessionTranscriptWriteLock<T>(
     return await run();
   } finally {
     await lock.release();
+  }
+}
+
+async function appendSessionTranscriptEventLocked(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
+  const handle = await fs.open(params.transcriptPath, "a", 0o600);
+  try {
+    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -13,6 +13,10 @@ import type {
   SessionEntry,
 } from "../config/sessions.js";
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
+import {
+  resolveSessionTranscriptRuntimeTarget,
+  type SessionTranscriptRuntimeScope,
+} from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -327,6 +331,17 @@ export async function readSessionLeafIdFromTranscriptAsync(
   return null;
 }
 
+/**
+ * Reads the latest leaf id for a runtime transcript scope.
+ */
+export async function readRuntimeSessionLeafIdFromTranscriptAsync(
+  scope: SessionTranscriptRuntimeScope,
+  maxBytes = MAX_COMPACTION_CHECKPOINT_LEAF_SCAN_BYTES,
+): Promise<string | null> {
+  const target = await resolveSessionTranscriptRuntimeTarget(scope);
+  return await readSessionLeafIdFromTranscriptAsync(target.sessionFile, maxBytes);
+}
+
 export async function forkCompactionCheckpointTranscriptAsync(params: {
   sourceFile: string;
   sourceLeafId?: string;
@@ -421,6 +436,22 @@ export async function captureCompactionCheckpointSnapshotAsync(params: {
     sessionId,
     leafId,
   };
+}
+
+/**
+ * Captures checkpoint metadata for a runtime transcript scope.
+ */
+export async function captureRuntimeCompactionCheckpointSnapshotAsync(params: {
+  sessionManager?: Pick<SessionManager, "getLeafId">;
+  scope: SessionTranscriptRuntimeScope;
+  maxBytes?: number;
+}): Promise<CapturedCompactionCheckpointSnapshot | null> {
+  const target = await resolveSessionTranscriptRuntimeTarget(params.scope);
+  return await captureCompactionCheckpointSnapshotAsync({
+    sessionManager: params.sessionManager,
+    sessionFile: target.sessionFile,
+    maxBytes: params.maxBytes,
+  });
 }
 
 export async function cleanupCompactionCheckpointSnapshot(

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -29,7 +29,42 @@ export interface SchemaMeta {
   updated_at: number;
 }
 
+export interface SessionEntries {
+  entry_json: string;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface Sessions {
+  created_at: number;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface TranscriptEventIdentities {
+  created_at: number;
+  event_id: string;
+  event_type: string | null;
+  message_idempotency_key: string | null;
+  parent_id: string | null;
+  seq: number;
+  session_id: string;
+}
+
+export interface TranscriptEvents {
+  created_at: number;
+  event_json: string;
+  seq: number;
+  session_id: string;
+}
+
 export interface DB {
   cache_entries: CacheEntries;
   schema_meta: SchemaMeta;
+  session_entries: SessionEntries;
+  sessions: Sessions;
+  transcript_event_identities: TranscriptEventIdentities;
+  transcript_events: TranscriptEvents;
 }

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -13,6 +13,62 @@ export const OPENCLAW_AGENT_SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -8,6 +8,62 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,


### PR DESCRIPTION
## What

Adds the SQLite-side transcript runtime identity/state adapter for the canonical transcript identity contract. This keeps the storage-neutral transcript runtime API shape while adding temp-DB backed SQLite coverage for the future storage flip.

## Why

Path 3 needs the file-backed transcript identity contract and SQLite implementation to agree before transcript readers, writers, and plugin/memory consumers can be validated under SQLite without depending on filesystem `sessionFile` identity.

## Changes

- Adds SQLite transcript runtime state adapter
- Adds session accessor conformance coverage
- Extends agent DB transcript schema
- Preserves file-backed transcript behavior

## Testing

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-runtime-state.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base clawdbot-d02.1.9.1.15.1/31b-transcript-identity-state-contract --no-web-search --thinking codex=low`

Refs #88838
