### PR TITLE
refactor: add SQLite embedded run target adapter

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-19bdf1196ec771a00777a16fd1e9c3662b8fd788a81034e705c41a74ee79c7ec  plugin-sdk-api-baseline.json
-43feff80c90adad0f821d1f1e184a9bff1e93d81e6d53a26a26fd9e2972be759  plugin-sdk-api-baseline.jsonl
+1fc413736b1320d11981317535e791cd40cb7b5ac14d6beef50cc032b4e28afb  plugin-sdk-api-baseline.json
+7a375996b95a8fd4fb4eade436497ea7153faf7061f65a4e4b16b54ed6690561  plugin-sdk-api-baseline.jsonl

--- a/src/agents/cli-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/cli-runner.bundle-mcp.e2e.test.ts
@@ -14,7 +14,7 @@ import {
 import type {
   CliPreparedBackend,
   PreparedCliRunContext,
-  RunCliAgentParams,
+  PreparedRunCliAgentParams,
 } from "./cli-runner/types.js";
 
 // This e2e spins a real stdio MCP server plus a spawned CLI process. Keep the
@@ -151,7 +151,7 @@ async function prepareBundleMcpExecutionContext(params: {
     workspaceDir: params.workspaceDir,
     config: params.config,
   })) as CliPreparedBackend;
-  const runParams: RunCliAgentParams = {
+  const runParams: PreparedRunCliAgentParams = {
     sessionId: params.sessionId,
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -30,10 +30,15 @@ import {
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
+import {
+  applyAgentRunSessionTargetIdentity,
+  resolveAgentRunSessionTarget,
+} from "./run-session-target.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { SessionManager } from "./sessions/session-manager.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
+type RunCliAgentParamsWithSessionFile = RunCliAgentParams & { sessionFile: string };
 
 const cliRunnerDeps = {
   claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
@@ -197,7 +202,9 @@ async function runCliAgentEndHook(
   runAgentEndSideEffects(hookParams);
 }
 
-async function persistApprovedCliUserTurnTranscript(params: RunCliAgentParams): Promise<void> {
+async function persistApprovedCliUserTurnTranscript(
+  params: RunCliAgentParamsWithSessionFile,
+): Promise<void> {
   if (params.suppressNextUserMessagePersistence === true || !params.userTurnTranscriptRecorder) {
     return;
   }
@@ -281,7 +288,16 @@ async function finalizeCliContextEngineTurn(params: {
   }
 }
 
-export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+export async function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+  const paramsBase = applyAgentRunSessionTargetIdentity(paramsInput);
+  const runSessionTarget = await resolveAgentRunSessionTarget(paramsBase);
+  const params: RunCliAgentParamsWithSessionFile = {
+    ...paramsBase,
+    agentId: paramsBase.agentId ?? runSessionTarget.agentId,
+    sessionId: runSessionTarget.sessionId,
+    sessionKey: paramsBase.sessionKey ?? runSessionTarget.sessionKey,
+    sessionFile: runSessionTarget.sessionFile,
+  };
   // Cron gate must fire before prepareCliRunContext — that call allocates
   // backend resources released only by runPreparedCliAgent's try…finally.
   params.onExecutionStarted?.();

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -76,7 +76,11 @@ import {
   loadCliSessionReseedMessages,
   resolveAutoCliSessionReseedHistoryChars,
 } from "./session-history.js";
-import type { CliReusableSession, PreparedCliRunContext, RunCliAgentParams } from "./types.js";
+import type {
+  CliReusableSession,
+  PreparedCliRunContext,
+  PreparedRunCliAgentParams,
+} from "./types.js";
 
 const prepareDeps = {
   makeBootstrapWarn: makeBootstrapWarnImpl,
@@ -132,7 +136,7 @@ export function shouldSkipLocalCliCredentialEpoch(params: {
 }
 
 export async function prepareCliRunContext(
-  params: RunCliAgentParams,
+  params: PreparedRunCliAgentParams,
 ): Promise<PreparedCliRunContext> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -638,7 +642,7 @@ export async function prepareCliRunContext(
       config: contextEngineConfig,
     });
     const contextEngineTurnPrompt = params.transcriptPrompt ?? params.prompt;
-    const preparedParams: RunCliAgentParams = {
+    const preparedParams: PreparedRunCliAgentParams = {
       ...params,
       config: contextEngineConfig,
       prompt: preparedPrompt,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -24,15 +24,19 @@ import type {
   CurrentInboundPromptContext,
   EmbeddedRunTrigger,
 } from "../embedded-agent-runner/run/params.js";
+import type { AgentRunSessionTarget } from "../run-session-target.js";
 import type { SilentReplyPromptMode } from "../system-prompt.types.js";
 
 export type RunCliAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  /** Storage-neutral transcript/session target. Defaults to sessionId/sessionKey/agentId. */
+  sessionTarget?: AgentRunSessionTarget;
   sessionEntry?: SessionEntry;
   agentId?: string;
   trigger?: EmbeddedRunTrigger;
-  sessionFile: string;
+  /** @deprecated Use sessionTarget plus sessionId/sessionKey/agentId for runtime identity. */
+  sessionFile?: string;
   workspaceDir: string;
   /** Task working directory for CLI execution. Defaults to workspaceDir. */
   cwd?: string;
@@ -130,8 +134,10 @@ export type CliReusableSession = {
     | "orphaned-tool-use";
 };
 
+export type PreparedRunCliAgentParams = RunCliAgentParams & { sessionFile: string };
+
 export type PreparedCliRunContext = {
-  params: RunCliAgentParams;
+  params: PreparedRunCliAgentParams;
   effectiveAuthProfileId?: string;
   started: number;
   workspaceDir: string;

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -730,6 +730,8 @@ export async function loadCompactHooksHarness(): Promise<{
     );
     return {
       ...actual,
+      rotateAgentRunSessionTargetAfterCompaction: rotateTranscriptAfterCompactionMock,
+      rotateAgentRunSessionTargetFileAfterCompaction: rotateTranscriptAfterCompactionMock,
       rotateTranscriptAfterCompaction: rotateTranscriptAfterCompactionMock,
     };
   });

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2330,7 +2330,14 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(rotateTranscriptAfterCompactionMock).not.toHaveBeenCalled();
+    expect(rotateTranscriptAfterCompactionMock).toHaveBeenCalledWith({
+      runSessionTarget: expect.objectContaining({
+        sessionFile: TEST_SESSION_FILE,
+        sessionId: TEST_SESSION_ID,
+        storageKind: "file",
+      }),
+      sessionFile: TEST_SESSION_FILE,
+    });
     expect(result.result?.sessionId).toBeUndefined();
     expect(result.result?.sessionFile).toBeUndefined();
     expectRecordFields(mockCallArg(maintain), {

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -29,6 +29,7 @@ import {
   resolveAgentHarnessPolicy,
 } from "../harness/selection.js";
 import { isOpenAIProvider } from "../openai-routing.js";
+import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
 import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
@@ -42,7 +43,7 @@ import {
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
 import {
-  rotateTranscriptFileAfterCompaction,
+  rotateAgentRunSessionTargetFileAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "./compaction-successor-transcript.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
@@ -172,6 +173,7 @@ export async function compactEmbeddedAgentSession(
     agentDir,
     workspaceDir: resolvedWorkspaceDir,
   });
+  const runSessionTarget = await resolveAgentRunSessionTarget(params);
   const runtimePolicySessionKey = params.sandboxSessionKey ?? params.sessionKey;
   const runtimePolicyAgentId =
     params.sandboxSessionKey && parseAgentSessionKey(params.sandboxSessionKey)
@@ -403,7 +405,8 @@ export async function compactEmbeddedAgentSession(
         if (result.ok && result.compacted) {
           if (shouldRotateCompactionTranscript(params.config) && !delegatedRotatedTranscript) {
             try {
-              const rotation = await rotateTranscriptFileAfterCompaction({
+              const rotation = await rotateAgentRunSessionTargetFileAfterCompaction({
+                runSessionTarget,
                 sessionFile: params.sessionFile,
               });
               if (rotation.rotated) {

--- a/src/agents/embedded-agent-runner/compact.runtime.types.ts
+++ b/src/agents/embedded-agent-runner/compact.runtime.types.ts
@@ -1,6 +1,6 @@
-import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
+import type { CompactEmbeddedAgentSessionRuntimeParams } from "./compact.types.js";
 import type { EmbeddedAgentCompactResult } from "./types.js";
 
 export type CompactEmbeddedAgentSessionDirect = (
-  params: CompactEmbeddedAgentSessionParams,
+  params: CompactEmbeddedAgentSessionRuntimeParams,
 ) => Promise<EmbeddedAgentCompactResult>;

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -95,6 +95,10 @@ import { ensureOpenClawModelsJson } from "../models-config.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
+import {
+  applyAgentRunSessionTargetIdentity,
+  resolveAgentRunSessionTarget,
+} from "../run-session-target.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
@@ -123,6 +127,7 @@ import {
 } from "./compact-reasons.js";
 import type {
   CompactEmbeddedAgentSessionParams,
+  CompactEmbeddedAgentSessionRuntimeParams,
   CompactionMessageMetrics,
 } from "./compact.types.js";
 import { dedupeDuplicateUserMessagesForCompaction } from "./compaction-duplicate-user-messages.js";
@@ -174,6 +179,10 @@ import type { EmbeddedAgentCompactResult } from "./types.js";
 import { mapThinkingLevel, normalizeContextTokenBudget } from "./utils.js";
 import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
 export type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
+
+type CompactEmbeddedAgentSessionParamsWithSessionFile = CompactEmbeddedAgentSessionRuntimeParams & {
+  sessionFile: string;
+};
 
 function hasRealConversationContent(
   msg: AgentMessage,
@@ -417,8 +426,17 @@ function fallbackFailureToCompactionResult(err: unknown): EmbeddedAgentCompactRe
  * Use this when already inside a session/global lane to avoid deadlocks.
  */
 export async function compactEmbeddedAgentSessionDirect(
-  params: CompactEmbeddedAgentSessionParams,
+  paramsInput: CompactEmbeddedAgentSessionRuntimeParams,
 ): Promise<EmbeddedAgentCompactResult> {
+  const paramsBase = applyAgentRunSessionTargetIdentity(paramsInput);
+  const runSessionTarget = await resolveAgentRunSessionTarget(paramsBase);
+  const params: CompactEmbeddedAgentSessionParamsWithSessionFile = {
+    ...paramsBase,
+    agentId: paramsBase.agentId ?? runSessionTarget.agentId,
+    sessionId: runSessionTarget.sessionId,
+    sessionKey: paramsBase.sessionKey ?? runSessionTarget.sessionKey,
+    sessionFile: runSessionTarget.sessionFile,
+  };
   if (hasExplicitCompactionModel(params) || !hasCompactionModelFallbackCandidates(params)) {
     return await compactEmbeddedAgentSessionDirectOnce(params);
   }
@@ -483,7 +501,7 @@ export async function compactEmbeddedAgentSessionDirect(
 }
 
 async function compactEmbeddedAgentSessionDirectOnce(
-  params: CompactEmbeddedAgentSessionParams,
+  params: CompactEmbeddedAgentSessionParamsWithSessionFile,
 ): Promise<EmbeddedAgentCompactResult> {
   const startedAt = Date.now();
   const diagId = params.diagId?.trim() || createCompactionDiagId();

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -98,6 +98,7 @@ import { registerProviderStreamForModel } from "../provider-stream.js";
 import {
   applyAgentRunSessionTargetIdentity,
   resolveAgentRunSessionTarget,
+  type ResolvedAgentRunSessionTarget,
 } from "../run-session-target.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -146,6 +147,7 @@ import {
 } from "./compaction-safety-timeout.js";
 import {
   type CompactionTranscriptRotation,
+  rotateAgentRunSessionTargetAfterCompaction,
   rotateTranscriptAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "./compaction-successor-transcript.js";
@@ -181,6 +183,7 @@ import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.j
 export type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
 
 type CompactEmbeddedAgentSessionParamsWithSessionFile = CompactEmbeddedAgentSessionRuntimeParams & {
+  runSessionTarget: ResolvedAgentRunSessionTarget;
   sessionFile: string;
 };
 
@@ -433,6 +436,7 @@ export async function compactEmbeddedAgentSessionDirect(
   const params: CompactEmbeddedAgentSessionParamsWithSessionFile = {
     ...paramsBase,
     agentId: paramsBase.agentId ?? runSessionTarget.agentId,
+    runSessionTarget,
     sessionId: runSessionTarget.sessionId,
     sessionKey: paramsBase.sessionKey ?? runSessionTarget.sessionKey,
     sessionFile: runSessionTarget.sessionFile,
@@ -1427,7 +1431,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
           let transcriptRotation: CompactionTranscriptRotation = { rotated: false };
           if (shouldRotateCompactionTranscript(params.config)) {
             try {
-              transcriptRotation = await rotateTranscriptAfterCompaction({
+              transcriptRotation = await rotateAgentRunSessionTargetAfterCompaction({
+                runSessionTarget: params.runSessionTarget,
                 sessionManager: transcriptRotationSessionManager,
                 sessionFile: params.sessionFile,
               });

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -5,6 +5,7 @@ import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-e
 import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
+import type { AgentRunSessionTarget } from "../run-session-target.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 
 export type CompactEmbeddedAgentSessionParams = {
@@ -35,6 +36,9 @@ export type CompactEmbeddedAgentSessionParams = {
   groupSpace?: string | null;
   /** Parent session key for subagent policy inheritance. */
   spawnedBy?: string | null;
+  /** Storage-neutral transcript/session target. Defaults to sessionId/sessionKey/agentId. */
+  sessionTarget?: AgentRunSessionTarget;
+  /** Active file-backed artifact for current compaction internals. */
   sessionFile: string;
   /** Optional caller-observed live prompt tokens used for compaction diagnostics. */
   currentTokenCount?: number;
@@ -95,6 +99,14 @@ export type CompactEmbeddedAgentSessionParams = {
   }) => void | Promise<void>;
   /** Allow runtime plugins for this compaction to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
+};
+
+export type CompactEmbeddedAgentSessionRuntimeParams = Omit<
+  CompactEmbeddedAgentSessionParams,
+  "sessionFile"
+> & {
+  /** @deprecated Use sessionTarget plus sessionId/sessionKey/agentId for runtime identity. */
+  sessionFile?: string;
 };
 
 export type CompactionMessageMetrics = {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -3,8 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadSqliteSessionEntry } from "../../config/sessions/session-accessor.sqlite.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { resolveAgentRunSessionTarget } from "../run-session-target.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
+  rotateAgentRunSessionTargetAfterCompaction,
   rotateTranscriptAfterCompaction,
   rotateTranscriptFileAfterCompaction,
   shouldRotateCompactionTranscript,
@@ -19,6 +24,7 @@ async function createTmpDir(): Promise<string> {
 }
 
 afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
     tmpDir = undefined;
@@ -209,6 +215,43 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(context.thinkingLevel).toBe("medium");
     expect(successor.getLabel(firstKeptId)).toBe("kept bookmark");
     expect(successor.getLabel(oldUserId)).toBeUndefined();
+  });
+
+  it("persists rotated SQLite active target identity through the rotation operation", async () => {
+    const dir = await createTmpDir();
+    const sqlitePath = path.join(dir, "helper", "openclaw-agent.sqlite");
+    const sessionKey = "agent:helper:commitments:compaction-rotation";
+    const runSessionTarget = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionId: "sqlite-source",
+      sessionKey,
+    });
+    const { manager, sessionFile } = createCompactedSession(
+      path.dirname(runSessionTarget.sessionFile),
+    );
+
+    const result = await rotateAgentRunSessionTargetAfterCompaction({
+      runSessionTarget,
+      sessionManager: manager,
+      sessionFile,
+      now: () => new Date("2026-04-27T12:15:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    expect(result.targetIdentityPersisted).toBe(true);
+    const rotatedSessionId = requireString(result.sessionId, "rotated session id");
+    const rotatedSessionFile = requireString(result.sessionFile, "rotated session file");
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      }),
+    ).toMatchObject({
+      sessionId: rotatedSessionId,
+      sessionFile: rotatedSessionFile,
+    });
   });
 
   it("rotates with a fallback timestamp when the injected clock is invalid", async () => {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  persistAgentRunSessionTargetIdentity,
+  type ResolvedAgentRunSessionTarget,
+} from "../run-session-target.js";
 import type { CompactionEntry, SessionEntry, SessionHeader } from "../sessions/index.js";
 import { collectDuplicateUserMessageEntryIdsForCompaction } from "./compaction-duplicate-user-messages.js";
 import {
@@ -21,6 +25,7 @@ export type CompactionTranscriptRotation = {
   reason?: string;
   sessionId?: string;
   sessionFile?: string;
+  targetIdentityPersisted?: boolean;
   compactionEntryId?: string;
   leafId?: string;
   entriesWritten?: number;
@@ -83,6 +88,44 @@ export async function rotateTranscriptAfterCompaction(params: {
   };
 }
 
+/** Rotates a compaction successor and persists the active run target in one operation. */
+export async function rotateAgentRunSessionTargetAfterCompaction(params: {
+  allowTargetPersistenceRetry?: boolean;
+  runSessionTarget: ResolvedAgentRunSessionTarget;
+  sessionManager: ReadonlySessionManagerForRotation;
+  sessionFile: string;
+  now?: () => Date;
+}): Promise<CompactionTranscriptRotation> {
+  const rotation = await rotateTranscriptAfterCompaction({
+    sessionManager: params.sessionManager,
+    sessionFile: params.sessionFile,
+    ...(params.now ? { now: params.now } : {}),
+  });
+  const targetIdentityPersisted = await persistRotatedAgentRunSessionTarget({
+    allowTargetPersistenceRetry: params.allowTargetPersistenceRetry,
+    runSessionTarget: params.runSessionTarget,
+    rotation,
+  });
+  return rotation.rotated ? { ...rotation, targetIdentityPersisted } : rotation;
+}
+
+/** Opens a transcript file, rotates its compaction successor, and persists the active target. */
+export async function rotateAgentRunSessionTargetFileAfterCompaction(params: {
+  allowTargetPersistenceRetry?: boolean;
+  runSessionTarget: ResolvedAgentRunSessionTarget;
+  sessionFile: string;
+  now?: () => Date;
+}): Promise<CompactionTranscriptRotation> {
+  const state = await readTranscriptFileState(params.sessionFile);
+  return rotateAgentRunSessionTargetAfterCompaction({
+    allowTargetPersistenceRetry: params.allowTargetPersistenceRetry,
+    runSessionTarget: params.runSessionTarget,
+    sessionManager: state,
+    sessionFile: params.sessionFile,
+    ...(params.now ? { now: params.now } : {}),
+  });
+}
+
 export async function rotateTranscriptFileAfterCompaction(params: {
   sessionFile: string;
   now?: () => Date;
@@ -93,6 +136,31 @@ export async function rotateTranscriptFileAfterCompaction(params: {
     sessionFile: params.sessionFile,
     ...(params.now ? { now: params.now } : {}),
   });
+}
+
+async function persistRotatedAgentRunSessionTarget(params: {
+  allowTargetPersistenceRetry?: boolean;
+  runSessionTarget: ResolvedAgentRunSessionTarget;
+  rotation: CompactionTranscriptRotation;
+}): Promise<boolean> {
+  if (!params.rotation.rotated || !params.rotation.sessionId || !params.rotation.sessionFile) {
+    return false;
+  }
+  try {
+    await persistAgentRunSessionTargetIdentity({
+      target: params.runSessionTarget,
+      sessionFile: params.rotation.sessionFile,
+      sessionId: params.rotation.sessionId,
+    });
+    return true;
+  } catch (err) {
+    if (params.allowTargetPersistenceRetry !== true) {
+      throw err;
+    }
+    // The successor transcript already exists. Return it so callers can adopt
+    // the rotation and, when they own the run loop, retry target persistence.
+    return false;
+  }
 }
 
 function findLatestCompactionIndex(entries: SessionEntry[]): number {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadSqliteSessionEntry,
+  patchSqliteSessionEntry,
+} from "../../config/sessions/session-accessor.sqlite.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import type { AgentHarness } from "../harness/types.js";
 import type { AgentInternalEvent } from "../internal-events.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
@@ -1976,6 +1981,130 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       expect(stored.cacheWrite).toBeUndefined();
       expect(stored.contextBudgetStatus).toBeUndefined();
     } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers empty-transcript preflight compaction through a forced SQLite target", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-empty-preflight-sqlite-"));
+    const storePath = path.join(dir, "state", "agents", "helper", "sessions", "sessions.json");
+    const sqlitePath = path.join(
+      dir,
+      "state",
+      "agents",
+      "helper",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "test-key": {
+          sessionId: "test-session",
+          updatedAt: 1,
+          totalTokens: 1_500_000,
+          totalTokensFresh: true,
+          contextBudgetStatus: { stale: true },
+        },
+      }),
+      "utf8",
+    );
+    await patchSqliteSessionEntry(
+      { agentId: "helper", sessionKey: "test-key", storePath: sqlitePath },
+      () => ({
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "claude-cli",
+          model: "claude-opus-4-7",
+          route: "compact_only",
+          shouldCompact: true,
+          estimatedPromptTokens: 1_794_391,
+          contextTokenBudget: 1_048_576,
+          promptBudgetBeforeReserve: 1_044_480,
+          reserveTokens: 4_096,
+          effectiveReserveTokens: 4_096,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 749_911,
+          toolResultReducibleChars: 0,
+          messageCount: 0,
+          unwindowedMessageCount: 0,
+        },
+        sessionId: "test-session",
+        totalTokens: 1_500_000,
+        totalTokensFresh: true,
+        updatedAt: 1,
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "test-session",
+          updatedAt: 1,
+        },
+      },
+    );
+
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(),
+          promptErrorSource: "precheck",
+          preflightRecovery: { route: "compact_only" },
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 1,
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+            route: "compact_only",
+            shouldCompact: true,
+            estimatedPromptTokens: 1_794_391,
+            contextTokenBudget: 1_048_576,
+            promptBudgetBeforeReserve: 1_044_480,
+            reserveTokens: 4_096,
+            effectiveReserveTokens: 4_096,
+            remainingPromptBudgetTokens: 0,
+            overflowTokens: 749_911,
+            toolResultReducibleChars: 0,
+            messageCount: 0,
+            unwindowedMessageCount: 0,
+          },
+          assistantTexts: [],
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "no real conversation messages",
+    });
+
+    try {
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        agentId: "helper",
+        config: {
+          session: {
+            store: storePath,
+          },
+        } as RunEmbeddedAgentParams["config"],
+        sessionFile: undefined,
+        sessionTarget: { storageKind: "sqlite" },
+      });
+
+      const sqliteEntry = loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey: "test-key",
+        storePath: sqlitePath,
+      });
+      expect(sqliteEntry?.totalTokens).toBe(0);
+      expect(sqliteEntry?.totalTokensFresh).toBe(true);
+      expect(sqliteEntry?.contextBudgetStatus).toBeUndefined();
+      const jsonEntry = JSON.parse(await fs.readFile(storePath, "utf8"))["test-key"];
+      expect(jsonEntry.totalTokens).toBe(1_500_000);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
       await fs.rm(dir, { recursive: true, force: true });
     }
   });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -6,6 +6,7 @@ import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { resolveStorePath, updateSessionStoreEntry } from "../../config/sessions.js";
+import { updateSqliteSessionEntry } from "../../config/sessions/session-accessor.sqlite.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import {
   resolveContextEngine,
@@ -94,6 +95,12 @@ import {
 } from "../openai-routing.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
+import {
+  applyAgentRunSessionTargetIdentity,
+  persistAgentRunSessionTargetIdentity,
+  resolveAgentRunSessionTarget,
+  type ResolvedAgentRunSessionTarget,
+} from "../run-session-target.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
@@ -201,6 +208,7 @@ import type {
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
+type RunEmbeddedAgentParamsWithSessionFile = RunEmbeddedAgentParams & { sessionFile: string };
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 const EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS = 30_000;
@@ -227,27 +235,51 @@ async function resetNoRealConversationTokenSnapshot(params: {
   config?: RunEmbeddedAgentParams["config"];
   sessionKey?: string;
   agentId?: string;
+  runSessionTarget?: ResolvedAgentRunSessionTarget;
 }): Promise<void> {
   if (!params.sessionKey) {
     return;
   }
-  const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
+  const resetPatch = () => ({
+    totalTokens: 0,
+    totalTokensFresh: true,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+    contextBudgetStatus: undefined,
+    updatedAt: Date.now(),
+  });
   try {
+    if (params.runSessionTarget?.storageKind === "sqlite") {
+      await updateSqliteSessionEntry(
+        {
+          agentId: params.runSessionTarget.agentId,
+          storePath: params.runSessionTarget.sqlitePath,
+          sessionKey: params.sessionKey,
+        },
+        async () => resetPatch(),
+      );
+      return;
+    }
+    const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
+    if (storePath.trim().toLowerCase().endsWith(".sqlite")) {
+      await updateSqliteSessionEntry(
+        {
+          ...(params.agentId ? { agentId: params.agentId } : {}),
+          storePath,
+          sessionKey: params.sessionKey,
+        },
+        async () => resetPatch(),
+      );
+      return;
+    }
     await updateSessionStoreEntry({
       storePath,
       sessionKey: params.sessionKey,
       skipMaintenance: true,
       takeCacheOwnership: true,
-      update: async () => ({
-        totalTokens: 0,
-        totalTokensFresh: true,
-        inputTokens: undefined,
-        outputTokens: undefined,
-        cacheRead: undefined,
-        cacheWrite: undefined,
-        contextBudgetStatus: undefined,
-        updatedAt: Date.now(),
-      }),
+      update: async () => resetPatch(),
     });
   } catch (err) {
     log.warn(
@@ -458,18 +490,36 @@ function buildHandledReplyPayloads(reply?: ReplyPayload) {
 export async function runEmbeddedAgent(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
-  let params = paramsInput;
+  let paramsBase = applyAgentRunSessionTargetIdentity(paramsInput);
   // Resolve sessionKey early so all downstream consumers (hooks, LCM, compaction)
   // receive a non-null key even when callers omit it. See #60552.
   const effectiveSessionKey = backfillSessionKey({
-    config: params.config,
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
+    config: paramsBase.config,
+    sessionId: paramsBase.sessionId,
+    sessionKey: paramsBase.sessionKey,
+    agentId: paramsBase.agentId,
   });
-  if (effectiveSessionKey !== params.sessionKey) {
-    params = { ...params, sessionKey: effectiveSessionKey };
+  if (effectiveSessionKey !== paramsBase.sessionKey) {
+    paramsBase = { ...paramsBase, sessionKey: effectiveSessionKey };
   }
+  const runSessionTarget = await resolveAgentRunSessionTarget(paramsBase);
+  const params: RunEmbeddedAgentParamsWithSessionFile = {
+    ...paramsBase,
+    agentId: paramsBase.agentId ?? runSessionTarget.agentId,
+    sessionId: runSessionTarget.sessionId,
+    sessionKey: paramsBase.sessionKey ?? runSessionTarget.sessionKey,
+    sessionFile: runSessionTarget.sessionFile,
+  };
+  const persistActiveRunSessionTarget = async (identity: {
+    sessionFile: string;
+    sessionId: string;
+  }) => {
+    await persistAgentRunSessionTargetIdentity({
+      target: runSessionTarget,
+      sessionFile: identity.sessionFile,
+      sessionId: identity.sessionId,
+    });
+  };
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
   const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(params.trigger);
@@ -1347,8 +1397,10 @@ export async function runEmbeddedAgent(
         ) => {
           const nextSessionId = compactResult.result?.sessionId;
           const nextSessionFile = compactResult.result?.sessionFile;
+          let changed = false;
           if (nextSessionId && nextSessionId !== activeSessionId) {
             activeSessionId = nextSessionId;
+            changed = true;
             // Keep the run context's sessionId tracking the live session so
             // lifecycle persistence isn't treated as stale after a legitimate
             // mid-run compaction rotation (#88538).
@@ -1356,7 +1408,9 @@ export async function runEmbeddedAgent(
           }
           if (nextSessionFile && nextSessionFile !== activeSessionFile) {
             activeSessionFile = nextSessionFile;
+            changed = true;
           }
+          return changed;
         };
         const onCompactionHookMessages = async (payload: {
           phase: "before" | "after";
@@ -1709,13 +1763,22 @@ export async function runEmbeddedAgent(
             currentAttemptAssistant,
           } = attempt;
           const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
+          let activeTargetChanged = false;
           if (sessionIdUsed && sessionIdUsed !== activeSessionId) {
             activeSessionId = sessionIdUsed;
+            activeTargetChanged = true;
             // Track the live session for lifecycle persistence identity (#88538).
             registerAgentRunContext(params.runId, { sessionId: activeSessionId });
           }
           if (sessionFileUsed && sessionFileUsed !== activeSessionFile) {
             activeSessionFile = sessionFileUsed;
+            activeTargetChanged = true;
+          }
+          if (activeTargetChanged) {
+            await persistActiveRunSessionTarget({
+              sessionFile: activeSessionFile,
+              sessionId: activeSessionId,
+            });
           }
           bootstrapPromptWarningSignaturesSeen =
             attempt.bootstrapPromptWarningSignaturesSeen ??
@@ -1978,7 +2041,12 @@ export async function runEmbeddedAgent(
                 };
               }
               if (timeoutCompactResult.compacted) {
-                adoptCompactionTranscript(timeoutCompactResult);
+                if (adoptCompactionTranscript(timeoutCompactResult)) {
+                  await persistActiveRunSessionTarget({
+                    sessionFile: activeSessionFile,
+                    sessionId: activeSessionId,
+                  });
+                }
               }
               await runOwnsCompactionAfterHook("timeout recovery", timeoutCompactResult);
               if (timeoutCompactResult.compacted) {
@@ -2165,7 +2233,12 @@ export async function runEmbeddedAgent(
                   params.abortSignal,
                 );
                 if (compactResult.ok && compactResult.compacted) {
-                  adoptCompactionTranscript(compactResult);
+                  if (adoptCompactionTranscript(compactResult)) {
+                    await persistActiveRunSessionTarget({
+                      sessionFile: activeSessionFile,
+                      sessionId: activeSessionId,
+                    });
+                  }
                   await runContextEngineMaintenance({
                     contextEngine,
                     sessionId: activeSessionId,
@@ -2195,6 +2268,7 @@ export async function runEmbeddedAgent(
                   config: params.config,
                   sessionKey: params.sessionKey,
                   agentId: sessionAgentId,
+                  runSessionTarget,
                 });
                 log.info(
                   `[context-overflow-precheck] stale token state had no real conversation messages for ` +
@@ -2206,7 +2280,12 @@ export async function runEmbeddedAgent(
                 continue;
               }
               if (compactResult.compacted) {
-                adoptCompactionTranscript(compactResult);
+                if (adoptCompactionTranscript(compactResult)) {
+                  await persistActiveRunSessionTarget({
+                    sessionFile: activeSessionFile,
+                    sessionId: activeSessionId,
+                  });
+                }
                 if (
                   typeof compactResult.result?.tokensAfter === "number" &&
                   Number.isFinite(compactResult.result.tokensAfter) &&

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1648,6 +1648,7 @@ export async function runEmbeddedAgent(
             // attempt too. Otherwise plugin-owned transports can skip OpenClaw auth
             // bootstrap but drift back to OpenClaw when the attempt is created.
             agentHarnessId: agentHarness.id,
+            runSessionTarget,
             ...(params.sessionKey
               ? {
                   agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
@@ -1774,7 +1775,7 @@ export async function runEmbeddedAgent(
             activeSessionFile = sessionFileUsed;
             activeTargetChanged = true;
           }
-          if (activeTargetChanged) {
+          if (activeTargetChanged && attempt.sessionTargetIdentityPersisted !== true) {
             await persistActiveRunSessionTarget({
               sessionFile: activeSessionFile,
               sessionId: activeSessionId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -314,7 +314,7 @@ import {
 } from "./attempt.bootstrap-context.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import {
-  rotateTranscriptAfterCompaction,
+  rotateAgentRunSessionTargetAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "../compaction-successor-transcript.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
@@ -758,6 +758,20 @@ function collectAttemptExplicitToolAllowlistSources(params: {
     { label: "inherited tools.allow", allow: inheritedToolPolicy?.allow },
     { label: "runtime toolsAllow", allow: params.toolsAllow, enforceWhenToolsDisabled: true },
   ]);
+}
+
+function resolveAttemptRunSessionTarget(params: EmbeddedRunAttemptParams) {
+  if (params.runSessionTarget) {
+    return params.runSessionTarget;
+  }
+  return {
+    agentId: params.agentId ?? "",
+    sessionFile: params.sessionFile,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey ?? "",
+    storageKind: "file" as const,
+    targetKind: "active-session-file" as const,
+  };
 }
 
 export async function runEmbeddedAttempt(
@@ -3285,6 +3299,7 @@ export async function runEmbeddedAttempt(
       let messagesSnapshot: AgentMessage[] = [];
       let sessionIdUsed = activeSession.sessionId;
       let sessionFileUsed: string | undefined = params.sessionFile;
+      let sessionTargetIdentityPersisted = false;
       const onAbort = () => {
         externalAbort = true;
         const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
@@ -4588,13 +4603,16 @@ export async function runEmbeddedAttempt(
             shouldRotateCompactionTranscript(params.config)
           ) {
             try {
-              const rotation = await rotateTranscriptAfterCompaction({
+              const rotation = await rotateAgentRunSessionTargetAfterCompaction({
+                allowTargetPersistenceRetry: true,
+                runSessionTarget: resolveAttemptRunSessionTarget(params),
                 sessionManager: activeSessionManager,
                 sessionFile: params.sessionFile,
               });
               if (rotation.rotated) {
                 sessionIdUsed = rotation.sessionId ?? sessionIdUsed;
                 sessionFileUsed = rotation.sessionFile ?? sessionFileUsed;
+                sessionTargetIdentityPersisted = rotation.targetIdentityPersisted === true;
                 updateActiveEmbeddedRunSessionFile(params.sessionId, sessionFileUsed);
                 log.info(
                   `[compaction] rotated active transcript after automatic compaction ` +
@@ -4981,6 +4999,7 @@ export async function runEmbeddedAttempt(
         preflightRecovery,
         sessionIdUsed,
         sessionFileUsed,
+        sessionTargetIdentityPersisted,
         diagnosticTrace,
         bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
         bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -22,6 +22,7 @@ import type {
   ToolResultFormat,
 } from "../../embedded-agent-subscribe.shared-types.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
+import type { AgentRunSessionTarget } from "../../run-session-target.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { SilentReplyPromptMode } from "../../system-prompt.types.js";
 import type { PromptMode } from "../../system-prompt.types.js";
@@ -40,6 +41,8 @@ export type CurrentInboundPromptContext = {
 export type RunEmbeddedAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  /** Storage-neutral transcript/session target. Defaults to sessionId/sessionKey/agentId. */
+  sessionTarget?: AgentRunSessionTarget;
   /** Provider prompt-cache affinity key; distinct from transcript/session identity. */
   promptCacheKey?: string;
   /** Session-like key for sandbox and tool-policy resolution. Defaults to sessionKey. */
@@ -102,7 +105,8 @@ export type RunEmbeddedAgentParams = {
   forceHeartbeatTool?: boolean;
   /** Allow runtime plugins for this run to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
-  sessionFile: string;
+  /** @deprecated Use sessionTarget plus sessionId/sessionKey/agentId for runtime identity. */
+  sessionFile?: string;
   workspaceDir: string;
   /** Task working directory for tool/runtime execution. Defaults to workspaceDir. */
   cwd?: string;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -29,8 +29,15 @@ import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js
 
 type EmbeddedRunAttemptBase = Omit<
   RunEmbeddedAgentParams,
-  "provider" | "model" | "authProfileId" | "authProfileIdSource" | "thinkLevel" | "lane" | "enqueue"
->;
+  | "provider"
+  | "model"
+  | "authProfileId"
+  | "authProfileIdSource"
+  | "thinkLevel"
+  | "lane"
+  | "enqueue"
+  | "sessionFile"
+> & { sessionFile: string };
 
 export type EmbeddedRunContextWindowInfo = {
   tokens: number;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -16,6 +16,7 @@ import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
 } from "../../embedded-agent-messaging.types.js";
+import type { ResolvedAgentRunSessionTarget } from "../../run-session-target.js";
 import type { AgentRunTimeoutPhase } from "../../run-timeout-attribution.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
@@ -65,6 +66,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   agentHarnessId?: string;
   /** OpenClaw-owned runtime policy prepared by the orchestrator for this attempt. */
   runtimePlan?: AgentRuntimePlan;
+  /** Resolved storage target for operation-sized transcript/session mutations. */
+  runSessionTarget?: ResolvedAgentRunSessionTarget;
   /** Host-issued scope for harnesses that mirror native child runs into task state. */
   agentHarnessTaskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   /** Live observer called after wrapped tool outcomes are recorded. */
@@ -120,6 +123,8 @@ export type EmbeddedRunAttemptResult = {
       };
   sessionIdUsed: string;
   sessionFileUsed?: string;
+  /** True when a compaction rotation already persisted the active run target. */
+  sessionTargetIdentityPersisted?: boolean;
   diagnosticTrace?: DiagnosticTraceContext;
   agentHarnessId?: string;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";

--- a/src/agents/run-session-target.test.ts
+++ b/src/agents/run-session-target.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadSqliteSessionEntry,
+  patchSqliteSessionEntry,
+} from "../config/sessions/session-accessor.sqlite.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  persistAgentRunSessionTargetIdentity,
+  resolveAgentRunSessionTarget,
+} from "./run-session-target.js";
+
+describe("agent run session target", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-run-session-target-"));
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("resolves runtime identity through the run config store", async () => {
+    const storePath = path.join(tempDir, "custom-sessions", "sessions.json");
+    const sessionKey = "agent:helper:commitments:test-run";
+
+    const target = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: storePath } } as OpenClawConfig,
+      sessionId: "test-run",
+      sessionKey,
+    });
+
+    expect(target).toMatchObject({
+      agentId: "helper",
+      sessionId: "test-run",
+      sessionKey,
+      targetKind: "runtime-session",
+    });
+    expect(path.dirname(target.sessionFile)).toBe(path.dirname(storePath));
+    expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]?.sessionFile).toBe(
+      target.sessionFile,
+    );
+  });
+
+  it("uses the agent from an agent-scoped session key when agentId is omitted", async () => {
+    const storeRoot = path.join(tempDir, "agents", "{agentId}", "sessions.json");
+    const sessionKey = "agent:helper:main";
+
+    const target = await resolveAgentRunSessionTarget({
+      config: { session: { store: storeRoot } } as OpenClawConfig,
+      sessionId: "helper-session",
+      sessionKey,
+    });
+
+    const helperStorePath = path.join(tempDir, "agents", "helper", "sessions.json");
+    expect(target.agentId).toBe("helper");
+    expect(path.dirname(target.sessionFile)).toBe(path.dirname(helperStorePath));
+    expect(loadSessionStore(helperStorePath, { skipCache: true })[sessionKey]?.sessionFile).toBe(
+      target.sessionFile,
+    );
+  });
+
+  it("resolves SQLite identity through the persisted active file artifact", async () => {
+    const sqlitePath = path.join(tempDir, "helper", "openclaw-agent.sqlite");
+    const sessionKey = "agent:helper:commitments:sqlite-run";
+
+    const target = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionId: "sqlite-run",
+      sessionKey,
+    });
+
+    expect(target).toMatchObject({
+      activeArtifactKind: "embedded-run-session-file",
+      agentId: "helper",
+      sessionId: "sqlite-run",
+      sessionKey,
+      sqlitePath,
+      storageKind: "sqlite",
+      targetKind: "sqlite-runtime-session",
+    });
+    expect(path.dirname(target.sessionFile)).toBe(
+      path.join(path.dirname(sqlitePath), "embedded-run-session-files"),
+    );
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      }),
+    ).toMatchObject({
+      sessionFile: target.sessionFile,
+      sessionId: "sqlite-run",
+    });
+
+    const rotatedSessionFile = path.join(
+      path.dirname(target.sessionFile),
+      "2026-06-04T12-00-00-000Z_sqlite-run-compact.jsonl",
+    );
+    await persistAgentRunSessionTargetIdentity({
+      sessionFile: rotatedSessionFile,
+      sessionId: "sqlite-run-compact",
+      target,
+    });
+
+    const rotatedTarget = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionId: "sqlite-run-compact",
+      sessionKey,
+    });
+
+    expect(rotatedTarget).toMatchObject({
+      sessionFile: rotatedSessionFile,
+      sessionId: "sqlite-run-compact",
+      storageKind: "sqlite",
+    });
+
+    const nextTarget = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionId: "sqlite-run-next",
+      sessionKey,
+    });
+
+    expect(nextTarget).toMatchObject({
+      sessionId: "sqlite-run-next",
+      storageKind: "sqlite",
+    });
+    expect(nextTarget.sessionFile).toContain("sqlite-run-next.jsonl");
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      })?.sessionId,
+    ).toBe("sqlite-run-next");
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      })?.sessionFile,
+    ).toBe(nextTarget.sessionFile);
+  });
+
+  it("ignores stale SQLite session files outside the active artifact boundary", async () => {
+    const sqlitePath = path.join(tempDir, "helper", "openclaw-agent.sqlite");
+    const sessionKey = "agent:helper:commitments:sqlite-stale-file";
+    const legacySessionFile = path.join(tempDir, "legacy", "session.jsonl");
+    await patchSqliteSessionEntry(
+      {
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      },
+      () => ({
+        sessionFile: legacySessionFile,
+        sessionId: "sqlite-stale-file",
+        updatedAt: Date.now(),
+      }),
+      {
+        fallbackEntry: {
+          sessionFile: legacySessionFile,
+          sessionId: "sqlite-stale-file",
+          updatedAt: Date.now(),
+        },
+      },
+    );
+
+    const target = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionId: "sqlite-stale-file",
+      sessionKey,
+    });
+
+    expect(target.sessionFile).not.toBe(legacySessionFile);
+    expect(path.dirname(target.sessionFile)).toBe(
+      path.join(path.dirname(sqlitePath), "embedded-run-session-files"),
+    );
+  });
+
+  it("can force SQLite resolution for canonical agent session stores", async () => {
+    const storeRoot = path.join(
+      tempDir,
+      "state",
+      "agents",
+      "{agentId}",
+      "sessions",
+      "sessions.json",
+    );
+    const sqlitePath = path.join(
+      tempDir,
+      "state",
+      "agents",
+      "helper",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    const sessionKey = "agent:helper:main";
+
+    const target = await resolveAgentRunSessionTarget({
+      config: { session: { store: storeRoot } } as OpenClawConfig,
+      sessionId: "helper-session",
+      sessionKey,
+      sessionTarget: { storageKind: "sqlite" },
+    });
+
+    expect(target).toMatchObject({
+      agentId: "helper",
+      sessionId: "helper-session",
+      sessionKey,
+      sqlitePath,
+      storageKind: "sqlite",
+    });
+    expect(
+      loadSqliteSessionEntry({
+        agentId: "helper",
+        sessionKey,
+        storePath: sqlitePath,
+      })?.sessionId,
+    ).toBe("helper-session");
+  });
+});

--- a/src/agents/run-session-target.test.ts
+++ b/src/agents/run-session-target.test.ts
@@ -191,6 +191,31 @@ describe("agent run session target", () => {
     );
   });
 
+  it("keeps SQLite identity when callers pass the active bridge file", async () => {
+    const sqlitePath = path.join(tempDir, "helper", "openclaw-agent.sqlite");
+    const sessionKey = "agent:helper:commitments:sqlite-active-file";
+    const activeSessionFile = path.join(
+      path.dirname(sqlitePath),
+      "embedded-run-session-files",
+      "sqlite-active-file.jsonl",
+    );
+
+    const target = await resolveAgentRunSessionTarget({
+      agentId: "helper",
+      config: { session: { store: sqlitePath } } as OpenClawConfig,
+      sessionFile: activeSessionFile,
+      sessionId: "sqlite-active-file",
+      sessionKey,
+    });
+
+    expect(target).toMatchObject({
+      sessionFile: activeSessionFile,
+      sessionId: "sqlite-active-file",
+      sqlitePath,
+      storageKind: "sqlite",
+    });
+  });
+
   it("can force SQLite resolution for canonical agent session stores", async () => {
     const storeRoot = path.join(
       tempDir,

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -1,0 +1,139 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import {
+  resolveSessionTranscriptRuntimeTarget,
+  type SessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
+import {
+  patchSqliteSessionEntry,
+  resolveSqliteSessionTranscriptRuntimeTarget,
+  type SqliteSessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.sqlite.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+
+/** Identifies a run transcript target without naming the current storage artifact. */
+export type AgentRunSessionTarget = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  storageKind?: "file" | "sqlite";
+  storePath?: string;
+  threadId?: string | number;
+};
+
+/** Target resolved from storage-neutral run identity for current run internals. */
+export type ResolvedAgentRunSessionTarget =
+  | SessionTranscriptRuntimeTarget
+  | SqliteSessionTranscriptRuntimeTarget;
+
+/** Resolves the active file-backed target used by current run/session internals. */
+export async function resolveAgentRunSessionTarget(params: {
+  agentId?: string;
+  config?: OpenClawConfig;
+  sessionFile?: string;
+  sessionId: string;
+  sessionKey?: string;
+  sessionTarget?: AgentRunSessionTarget;
+}): Promise<ResolvedAgentRunSessionTarget> {
+  const sessionTarget = params.sessionTarget;
+  const agentId = normalizeOptionalString(sessionTarget?.agentId) ?? params.agentId;
+  const sessionId = normalizeOptionalString(sessionTarget?.sessionId) ?? params.sessionId;
+  const sessionKey = normalizeOptionalString(sessionTarget?.sessionKey) ?? params.sessionKey;
+  const effectiveAgentId = agentId ?? resolveAgentIdFromSessionKey(sessionKey);
+  const sessionFile = normalizeOptionalString(params.sessionFile);
+  if (sessionFile) {
+    return {
+      agentId: effectiveAgentId ?? "",
+      sessionFile,
+      sessionId,
+      sessionKey: sessionKey ?? "",
+      storageKind: "file",
+      targetKind: "active-session-file",
+    };
+  }
+  if (!sessionKey) {
+    throw new Error(`Cannot resolve run session target without a session key: ${sessionId}`);
+  }
+  const storePath =
+    normalizeOptionalString(sessionTarget?.storePath) ??
+    resolveStorePath(params.config?.session?.store, { agentId: effectiveAgentId });
+  const scope = {
+    ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
+    sessionId,
+    sessionKey,
+    storePath,
+    ...(sessionTarget?.threadId !== undefined ? { threadId: sessionTarget.threadId } : {}),
+  };
+  if (shouldUseSqliteSessionTarget({ sessionTarget, storePath })) {
+    return await resolveSqliteSessionTranscriptRuntimeTarget(scope);
+  }
+  return await resolveSessionTranscriptRuntimeTarget({
+    ...scope,
+  });
+}
+
+/** Persists the current active artifact for storage-neutral run/session targets. */
+export async function persistAgentRunSessionTargetIdentity(params: {
+  sessionFile: string;
+  sessionId: string;
+  target: ResolvedAgentRunSessionTarget;
+}): Promise<void> {
+  if (params.target.storageKind !== "sqlite") {
+    return;
+  }
+  const now = Date.now();
+  await patchSqliteSessionEntry(
+    {
+      agentId: params.target.agentId,
+      sessionKey: params.target.sessionKey,
+      storePath: params.target.sqlitePath,
+    },
+    () => ({
+      sessionFile: params.sessionFile,
+      sessionId: params.sessionId,
+      updatedAt: now,
+    }),
+    {
+      fallbackEntry: {
+        sessionFile: params.sessionFile,
+        sessionId: params.sessionId,
+        updatedAt: now,
+      },
+    },
+  );
+}
+
+function shouldUseSqliteSessionTarget(params: {
+  sessionTarget?: AgentRunSessionTarget;
+  storePath: string;
+}): boolean {
+  if (params.sessionTarget?.storageKind === "sqlite") {
+    return true;
+  }
+  if (params.sessionTarget?.storageKind === "file") {
+    return false;
+  }
+  return params.storePath.trim().toLowerCase().endsWith(".sqlite");
+}
+
+/** Applies identity fields from the explicit target before legacy backfills run. */
+export function applyAgentRunSessionTargetIdentity<
+  T extends {
+    agentId?: string;
+    sessionId: string;
+    sessionKey?: string;
+    sessionTarget?: AgentRunSessionTarget;
+  },
+>(params: T): T {
+  const target = params.sessionTarget;
+  if (!target) {
+    return params;
+  }
+  return {
+    ...params,
+    agentId: normalizeOptionalString(target.agentId) ?? params.agentId,
+    sessionId: normalizeOptionalString(target.sessionId) ?? params.sessionId,
+    sessionKey: normalizeOptionalString(target.sessionKey) ?? params.sessionKey,
+  };
+}

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
@@ -42,7 +43,11 @@ export async function resolveAgentRunSessionTarget(params: {
   const sessionKey = normalizeOptionalString(sessionTarget?.sessionKey) ?? params.sessionKey;
   const effectiveAgentId = agentId ?? resolveAgentIdFromSessionKey(sessionKey);
   const sessionFile = normalizeOptionalString(params.sessionFile);
-  if (sessionFile) {
+  const storePath =
+    normalizeOptionalString(sessionTarget?.storePath) ??
+    resolveStorePath(params.config?.session?.store, { agentId: effectiveAgentId });
+  const useSqliteSessionTarget = shouldUseSqliteSessionTarget({ sessionTarget, storePath });
+  if (sessionFile && !useSqliteSessionTarget) {
     return {
       agentId: effectiveAgentId ?? "",
       sessionFile,
@@ -55,9 +60,6 @@ export async function resolveAgentRunSessionTarget(params: {
   if (!sessionKey) {
     throw new Error(`Cannot resolve run session target without a session key: ${sessionId}`);
   }
-  const storePath =
-    normalizeOptionalString(sessionTarget?.storePath) ??
-    resolveStorePath(params.config?.session?.store, { agentId: effectiveAgentId });
   const scope = {
     ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
     sessionId,
@@ -65,8 +67,13 @@ export async function resolveAgentRunSessionTarget(params: {
     storePath,
     ...(sessionTarget?.threadId !== undefined ? { threadId: sessionTarget.threadId } : {}),
   };
-  if (shouldUseSqliteSessionTarget({ sessionTarget, storePath })) {
-    return await resolveSqliteSessionTranscriptRuntimeTarget(scope);
+  if (useSqliteSessionTarget) {
+    const target = await resolveSqliteSessionTranscriptRuntimeTarget(scope);
+    const activeSessionFile = resolveCurrentSqliteEmbeddedRunSessionFile(
+      target.sqlitePath,
+      sessionFile,
+    );
+    return activeSessionFile ? { ...target, sessionFile: activeSessionFile } : target;
   }
   return await resolveSessionTranscriptRuntimeTarget({
     ...scope,
@@ -115,6 +122,22 @@ function shouldUseSqliteSessionTarget(params: {
     return false;
   }
   return params.storePath.trim().toLowerCase().endsWith(".sqlite");
+}
+
+function resolveCurrentSqliteEmbeddedRunSessionFile(
+  sqlitePath: string,
+  sessionFile: string | undefined,
+): string | undefined {
+  const trimmed = sessionFile?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const artifactDir = path.resolve(path.dirname(sqlitePath), "embedded-run-session-files");
+  const candidate = path.resolve(trimmed);
+  const relative = path.relative(artifactDir, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative)
+    ? trimmed
+    : undefined;
 }
 
 /** Applies identity fields from the explicit target before legacy backfills run. */

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -1,4 +1,7 @@
+import path from "node:path";
+import { resolveStorePath } from "../../config/sessions/paths.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 
 /**
@@ -23,6 +26,20 @@ export type ParentForkDecision =
       message: string;
     };
 
+type ParentForkDecisionParams = {
+  parentEntry: SessionEntry;
+  agentId?: string;
+  config?: OpenClawConfig;
+  storePath?: string;
+};
+
+type ForkSessionFromParentParams = {
+  parentEntry: SessionEntry;
+  agentId: string;
+  config?: OpenClawConfig;
+  sessionsDir?: string;
+};
+
 function loadSessionForkRuntime(): Promise<typeof import("./session-fork.runtime.js")> {
   return sessionForkRuntimeLoader.load();
 }
@@ -37,14 +54,31 @@ function formatParentForkTooLargeMessage(params: {
   );
 }
 
-export async function resolveParentForkDecision(params: {
-  parentEntry: SessionEntry;
-  storePath: string;
-}): Promise<ParentForkDecision> {
+function resolveParentForkStorePath(params: {
+  agentId?: string;
+  config?: OpenClawConfig;
+  storePath?: string;
+}): string {
+  return (
+    params.storePath ?? resolveStorePath(params.config?.session?.store, { agentId: params.agentId })
+  );
+}
+
+function resolveParentForkSessionsDir(params: {
+  agentId: string;
+  config?: OpenClawConfig;
+  sessionsDir?: string;
+}): string {
+  return params.sessionsDir ?? path.dirname(resolveParentForkStorePath(params));
+}
+
+export async function resolveParentForkDecision(
+  params: ParentForkDecisionParams,
+): Promise<ParentForkDecision> {
   const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
   const parentTokens = await resolveParentForkTokenCount({
     parentEntry: params.parentEntry,
-    storePath: params.storePath,
+    storePath: resolveParentForkStorePath(params),
   });
   if (typeof parentTokens === "number" && parentTokens > maxTokens) {
     return {
@@ -62,13 +96,14 @@ export async function resolveParentForkDecision(params: {
   };
 }
 
-export async function forkSessionFromParent(params: {
-  parentEntry: SessionEntry;
-  agentId: string;
-  sessionsDir: string;
-}): Promise<{ sessionId: string; sessionFile: string } | null> {
+export async function forkSessionFromParent(
+  params: ForkSessionFromParentParams,
+): Promise<{ sessionId: string; sessionFile: string } | null> {
   const runtime = await loadSessionForkRuntime();
-  return runtime.forkSessionFromParentRuntime(params);
+  return runtime.forkSessionFromParentRuntime({
+    ...params,
+    sessionsDir: resolveParentForkSessionsDir(params),
+  });
 }
 
 async function resolveParentForkTokenCount(params: {

--- a/src/commitments/runtime.test.ts
+++ b/src/commitments/runtime.test.ts
@@ -25,6 +25,7 @@ vi.mock("./model-selection.runtime.js", () => ({
 }));
 
 function requireFirstEmbeddedAgentRequest(): {
+  config?: OpenClawConfig;
   provider?: string;
   model?: string;
   disableTools?: boolean;
@@ -224,6 +225,9 @@ describe("commitment extraction runtime", () => {
     expect(request.provider).toBe("openai");
     expect(request.model).toBe("gpt-5.5");
     expect(request.disableTools).toBe(true);
+    expect(request.config?.session?.store).toMatch(
+      /commitments\/extractor-sessions\/main\/sessions\.json$/,
+    );
   });
 
   it("backs off hidden extraction after terminal model or auth failures", async () => {

--- a/src/commitments/runtime.ts
+++ b/src/commitments/runtime.ts
@@ -191,16 +191,6 @@ function openTerminalFailureCooldown(
   });
 }
 
-function resolveExtractionSessionFile(agentId: string, runId: string): string {
-  return path.join(
-    resolveStateDir(),
-    "commitments",
-    "extractor-sessions",
-    agentId,
-    `${runId}.jsonl`,
-  );
-}
-
 function joinPayloadText(result: EmbeddedAgentPayloadResult): string {
   return (
     result.payloads
@@ -208,6 +198,16 @@ function joinPayloadText(result: EmbeddedAgentPayloadResult): string {
       .filter((text): text is string => Boolean(text?.trim()))
       .join("\n")
       .trim() ?? ""
+  );
+}
+
+function resolveExtractionSessionStore(agentId: string): string {
+  return path.join(
+    resolveStateDir(),
+    "commitments",
+    "extractor-sessions",
+    agentId,
+    "sessions.json",
   );
 }
 
@@ -234,15 +234,21 @@ async function defaultExtractBatch(params: {
   const resolved = resolveCommitmentsConfig(cfg);
   const runId = `commitments-${randomUUID()}`;
   const modelRef = await resolveDefaultModel({ cfg, agentId: first.agentId });
+  const helperConfig = {
+    ...cfg,
+    session: {
+      ...cfg.session,
+      store: resolveExtractionSessionStore(first.agentId),
+    },
+  } as OpenClawConfig;
   const { runEmbeddedAgent } = await import("../agents/embedded-agent.js");
   const result = await runEmbeddedAgent({
     sessionId: runId,
     sessionKey: `agent:${first.agentId}:commitments:${runId}`,
     agentId: first.agentId,
     trigger: "manual",
-    sessionFile: resolveExtractionSessionFile(first.agentId, runId),
     workspaceDir: resolveAgentWorkspaceDir(cfg, first.agentId),
-    config: cfg,
+    config: helperConfig,
     provider: modelRef.provider,
     model: modelRef.model,
     prompt: buildCommitmentExtractionPrompt({ cfg, items: params.items }),

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -289,6 +289,42 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(loadSqliteTranscriptEventsSync(readScope)).toEqual([event]);
     });
 
+    it("maps canonical sessions.json store paths to the agent SQLite database", async () => {
+      const legacyStorePath = path.join(
+        paths.stateDir,
+        "agents",
+        "main",
+        "sessions",
+        "sessions.json",
+      );
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "main",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        agentId: "main",
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "agent:main:main",
+        storePath: legacyStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(loadSqliteSessionEntry({ ...scope, storePath: sqlitePath })).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(legacyStorePath)).toBe(false);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -293,21 +293,20 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       const legacyStorePath = path.join(
         paths.stateDir,
         "agents",
-        "main",
+        "voice",
         "sessions",
         "sessions.json",
       );
       const sqlitePath = path.join(
         paths.stateDir,
         "agents",
-        "main",
+        "voice",
         "agent",
         "openclaw-agent.sqlite",
       );
       const scope = {
-        agentId: "main",
         env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
-        sessionKey: "agent:main:main",
+        sessionKey: "voice:123",
         storePath: legacyStorePath,
       };
 
@@ -317,7 +316,9 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
         updatedAt: 10,
       });
 
-      expect(loadSqliteSessionEntry({ ...scope, storePath: sqlitePath })).toMatchObject({
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
         model: "gpt-5.5",
         sessionId: "session-1",
       });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -9,6 +9,7 @@ import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -17,6 +18,7 @@ import {
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
+  type ExactSessionEntry,
   type SessionAccessScope,
   type SessionEntrySummary,
   type SessionTranscriptAccessScope,
@@ -31,6 +33,7 @@ import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
   listSqliteSessionEntries,
+  loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
   loadSqliteTranscriptEvents,
   loadSqliteTranscriptEventsSync,
@@ -48,6 +51,7 @@ type AccessorAdapter = {
   entryScope(paths: TestPaths): SessionAccessScope;
   transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
   transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
+  loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined;
   loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
   listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
   readSessionUpdatedAt(scope: SessionAccessScope): number | undefined;
@@ -106,6 +110,7 @@ const fileBackedAdapter: AccessorAdapter = {
     storePath: paths.storePath,
   }),
   loadSessionEntry,
+  loadExactSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
   upsertSessionEntry,
@@ -140,6 +145,7 @@ const sqliteAdapter: AccessorAdapter = {
     storePath: paths.sqlitePath,
   }),
   loadSessionEntry: loadSqliteSessionEntry,
+  loadExactSessionEntry: loadExactSqliteSessionEntry,
   listSessionEntries: listSqliteSessionEntries,
   readSessionUpdatedAt: readSqliteSessionUpdatedAt,
   upsertSessionEntry: upsertSqliteSessionEntry,
@@ -252,6 +258,30 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
         providerOverride: "anthropic",
         sessionId: "session-1",
         updatedAt: beforePreservePatch?.updatedAt,
+      });
+    });
+
+    it("conforms for exact persisted-key lookup without canonical alias fallback", async () => {
+      const scope = adapter.entryScope(paths);
+      const mixedCaseScope = { ...scope, sessionKey: "AGENT:MAIN:MAIN" };
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(mixedCaseScope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "exact-session",
+      });
+      expect(adapter.loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+      expect(adapter.loadExactSessionEntry(scope)).toEqual({
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "exact-session",
+        }),
       });
     });
 

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -326,6 +326,37 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(fs.existsSync(legacyStorePath)).toBe(false);
     });
 
+    it("does not treat custom JSON store paths as SQLite database files", async () => {
+      const customStorePath = path.join(paths.tempDir, "custom-sessions.json");
+      const sqlitePath = path.join(
+        paths.stateDir,
+        "agents",
+        "voice",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = {
+        env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+        sessionKey: "agent:voice:main",
+        storePath: customStorePath,
+      };
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(
+        loadSqliteSessionEntry({ ...scope, agentId: "voice", storePath: sqlitePath }),
+      ).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+      expect(fs.existsSync(sqlitePath)).toBe(true);
+      expect(fs.existsSync(customStorePath)).toBe(false);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1,0 +1,309 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
+  replaceSessionEntry,
+  updateSessionEntry,
+  upsertSessionEntry,
+  type SessionAccessScope,
+  type SessionEntrySummary,
+  type SessionTranscriptAccessScope,
+  type SessionTranscriptWriteScope,
+  type TranscriptEvent,
+  type TranscriptMessageAppendOptions,
+  type TranscriptMessageAppendResult,
+  type TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import {
+  appendSqliteTranscriptEvent,
+  appendSqliteTranscriptMessage,
+  listSqliteSessionEntries,
+  loadSqliteSessionEntry,
+  loadSqliteTranscriptEvents,
+  patchSqliteSessionEntry,
+  publishSqliteTranscriptUpdate,
+  readSqliteSessionUpdatedAt,
+  replaceSqliteSessionEntry,
+  updateSqliteSessionEntry,
+  upsertSqliteSessionEntry,
+} from "./session-accessor.sqlite.js";
+import type { SessionEntry } from "./types.js";
+
+type AccessorAdapter = {
+  name: string;
+  entryScope(paths: TestPaths): SessionAccessScope;
+  transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
+  loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
+  listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
+  readSessionUpdatedAt(scope: SessionAccessScope): number | undefined;
+  upsertSessionEntry(
+    scope: SessionAccessScope,
+    patch: Partial<SessionEntry>,
+  ): Promise<SessionEntry | null>;
+  replaceSessionEntry(scope: SessionAccessScope, entry: SessionEntry): Promise<SessionEntry | null>;
+  patchSessionEntry(
+    scope: SessionAccessScope,
+    update: (
+      entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
+    ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+    options?: { fallbackEntry?: SessionEntry; replaceEntry?: boolean },
+  ): Promise<SessionEntry | null>;
+  updateSessionEntry(
+    scope: SessionAccessScope,
+    update: (entry: SessionEntry) => Partial<SessionEntry> | null,
+  ): Promise<SessionEntry | null>;
+  loadTranscriptEvents(scope: SessionTranscriptAccessScope): Promise<TranscriptEvent[]>;
+  appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
+  appendTranscriptMessage<TMessage>(
+    scope: SessionTranscriptWriteScope,
+    options: TranscriptMessageAppendOptions<TMessage>,
+  ): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+  publishTranscriptUpdate(
+    scope: SessionTranscriptWriteScope,
+    update?: TranscriptUpdatePayload,
+  ): Promise<void>;
+};
+
+type TestPaths = {
+  sqlitePath: string;
+  stateDir: string;
+  storePath: string;
+  tempDir: string;
+  transcriptPath: string;
+};
+
+const fileBackedAdapter: AccessorAdapter = {
+  name: "file-backed",
+  entryScope: (paths) => ({
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.storePath,
+  }),
+  loadSessionEntry,
+  listSessionEntries,
+  readSessionUpdatedAt,
+  upsertSessionEntry,
+  replaceSessionEntry,
+  patchSessionEntry,
+  updateSessionEntry,
+  loadTranscriptEvents,
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  publishTranscriptUpdate,
+};
+
+const sqliteAdapter: AccessorAdapter = {
+  name: "sqlite",
+  entryScope: (paths) => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionId: id,
+    sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  loadSessionEntry: loadSqliteSessionEntry,
+  listSessionEntries: listSqliteSessionEntries,
+  readSessionUpdatedAt: readSqliteSessionUpdatedAt,
+  upsertSessionEntry: upsertSqliteSessionEntry,
+  replaceSessionEntry: replaceSqliteSessionEntry,
+  patchSessionEntry: patchSqliteSessionEntry,
+  updateSessionEntry: updateSqliteSessionEntry,
+  loadTranscriptEvents: loadSqliteTranscriptEvents,
+  appendTranscriptEvent: appendSqliteTranscriptEvent,
+  appendTranscriptMessage: appendSqliteTranscriptMessage,
+  publishTranscriptUpdate: publishSqliteTranscriptUpdate,
+};
+
+describe.each([fileBackedAdapter, sqliteAdapter])(
+  "session accessor conformance: $name",
+  (adapter) => {
+    let paths: TestPaths;
+
+    beforeEach(() => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-conf-"));
+      paths = {
+        sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+        stateDir: path.join(tempDir, "state"),
+        storePath: path.join(tempDir, "sessions.json"),
+        tempDir,
+        transcriptPath: path.join(tempDir, "session.jsonl"),
+      };
+    });
+
+    afterEach(() => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      fs.rmSync(paths.tempDir, { recursive: true, force: true });
+    });
+
+    it("conforms for entry load/list/timestamp/upsert/update/replace/patch", async () => {
+      const scope = adapter.entryScope(paths);
+
+      await adapter.upsertSessionEntry(scope, {
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: 10,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+        updatedAt: expect.any(Number),
+      });
+      expect(adapter.readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
+      expect(adapter.listSessionEntries(scope)).toEqual([
+        {
+          sessionKey: "agent:main:main",
+          entry: expect.objectContaining({
+            model: "gpt-5.5",
+            sessionId: "session-1",
+          }),
+        },
+      ]);
+
+      await expect(
+        adapter.updateSessionEntry(scope, () => ({ model: "sonnet-4.6", updatedAt: 20 })),
+      ).resolves.toMatchObject({
+        model: "sonnet-4.6",
+        sessionId: "session-1",
+      });
+
+      await adapter.replaceSessionEntry(scope, {
+        providerOverride: "openai",
+        sessionId: "session-1",
+        updatedAt: 30,
+      });
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        providerOverride: "openai",
+        sessionId: "session-1",
+      });
+      expect(adapter.loadSessionEntry(scope)?.model).toBeUndefined();
+
+      let existingContext: SessionEntry | undefined;
+      await adapter.patchSessionEntry(
+        scope,
+        (entry, context) => {
+          existingContext = context.existingEntry;
+          return {
+            ...entry,
+            model: "gpt-5.5",
+          };
+        },
+        { replaceEntry: true },
+      );
+
+      expect(existingContext).toMatchObject({ providerOverride: "openai" });
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        sessionId: "session-1",
+      });
+    });
+
+    it("conforms for raw transcript event load and append", async () => {
+      const scope = adapter.transcriptScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+      await adapter.appendTranscriptEvent(scope, event);
+
+      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+        { type: "session", sessionId: "session-1" },
+        event,
+      ]);
+    });
+
+    it("conforms for transcript message append, idempotency, and update publication", async () => {
+      const scope = adapter.transcriptScope(paths, "session-2");
+      const updates: unknown[] = [];
+      const unsubscribe = onSessionTranscriptUpdate((update) => {
+        updates.push(update);
+      });
+
+      const appended = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      const replayed = await adapter.appendTranscriptMessage(scope, {
+        cwd: paths.tempDir,
+        idempotencyLookup: "scan",
+        message: {
+          role: "assistant",
+          content: "hello again",
+          idempotencyKey: "assistant-once",
+        },
+      });
+      await adapter.publishTranscriptUpdate(scope, {
+        agentId: "main",
+        message: appended?.message,
+        messageId: appended?.messageId,
+        sessionKey: scope.sessionKey,
+      });
+      unsubscribe();
+
+      expect(appended).toMatchObject({
+        appended: true,
+        message: expect.objectContaining({ content: "hello" }),
+        messageId: expect.any(String),
+      });
+      expect(replayed).toMatchObject({
+        appended: false,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        messageId: appended?.messageId,
+      });
+      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+        expect.objectContaining({ type: "session" }),
+        expect.objectContaining({
+          id: appended?.messageId,
+          message: expect.objectContaining({ content: "hello" }),
+          type: "message",
+        }),
+      ]);
+      expect(updates).toEqual([
+        expect.objectContaining({
+          agentId: "main",
+          message: appended?.message,
+          messageId: appended?.messageId,
+          sessionKey: scope.sessionKey,
+        }),
+      ]);
+    });
+  },
+);

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -357,6 +357,126 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(fs.existsSync(customStorePath)).toBe(false);
     });
 
+    it("serializes concurrent SQLite entry patches and updates", async () => {
+      const scope = sqliteAdapter.entryScope(paths);
+
+      await upsertSqliteSessionEntry(scope, {
+        model: "base",
+        sessionId: "patch-session",
+        updatedAt: 10,
+      });
+
+      let firstPatch!: Promise<SessionEntry | null>;
+      let releasePatch!: () => void;
+      const patchStarted = new Promise<void>((resolve) => {
+        const blockedPatch = new Promise<void>((release) => {
+          releasePatch = release;
+        });
+        firstPatch = patchSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedPatch;
+          return { model: "first" };
+        });
+      });
+      await patchStarted;
+      const secondPatch = patchSqliteSessionEntry(scope, () => ({
+        providerOverride: "openai",
+      }));
+      releasePatch();
+      await Promise.all([firstPatch, secondPatch]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "first",
+        providerOverride: "openai",
+      });
+
+      let firstUpdate!: Promise<SessionEntry | null>;
+      let releaseUpdate!: () => void;
+      const updateStarted = new Promise<void>((resolve) => {
+        const blockedUpdate = new Promise<void>((release) => {
+          releaseUpdate = release;
+        });
+        firstUpdate = updateSqliteSessionEntry(scope, async () => {
+          resolve();
+          await blockedUpdate;
+          return { model: "updated" };
+        });
+      });
+      await updateStarted;
+      const secondUpdate = updateSqliteSessionEntry(scope, () => ({
+        providerOverride: "anthropic",
+      }));
+      releaseUpdate();
+      await Promise.all([firstUpdate, secondUpdate]);
+
+      expect(loadSqliteSessionEntry(scope)).toMatchObject({
+        model: "updated",
+        providerOverride: "anthropic",
+      });
+    });
+
+    it("dedupes SQLite transcript identities inside the writer path", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-dedupe");
+      const event = {
+        id: "event-dedupe",
+        message: { role: "assistant", content: "first" },
+        parentId: null,
+        type: "message",
+      };
+
+      await appendSqliteTranscriptEvent(scope, event);
+      await appendSqliteTranscriptEvent(scope, {
+        ...event,
+        message: { role: "assistant", content: "duplicate" },
+      });
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          appendSqliteTranscriptMessage(scope, {
+            idempotencyLookup: "scan",
+            message: {
+              role: "assistant",
+              content: "keyed",
+              idempotencyKey: "keyed-once",
+            },
+          }),
+        ),
+      );
+
+      expect(new Set(results.map((result) => result?.messageId)).size).toBe(1);
+      expect(results.filter((result) => result?.appended)).toHaveLength(1);
+      await expect(loadSqliteTranscriptEvents(scope)).resolves.toEqual([
+        event,
+        expect.objectContaining({
+          message: expect.objectContaining({ idempotencyKey: "keyed-once" }),
+          type: "message",
+        }),
+      ]);
+    });
+
+    it("does not report success for unchecked duplicate SQLite transcript keys", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths, "session-unchecked-dedupe");
+      const message = {
+        role: "assistant",
+        content: "unchecked",
+        idempotencyKey: "unchecked-once",
+      };
+
+      await appendSqliteTranscriptMessage(scope, { message });
+      await expect(appendSqliteTranscriptMessage(scope, { message })).rejects.toThrow();
+
+      const events = await loadSqliteTranscriptEvents(scope);
+      const keyedEvents = events.filter((event): event is { message: typeof message } => {
+        return (
+          Boolean(event) &&
+          typeof event === "object" &&
+          !Array.isArray(event) &&
+          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+            "unchecked-once"
+        );
+      });
+      expect(keyedEvents).toHaveLength(1);
+    });
+
     it("conforms for transcript message append, idempotency, and update publication", async () => {
       const scope = adapter.transcriptScope(paths, "session-2");
       const updates: unknown[] = [];

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -62,7 +62,7 @@ type AccessorAdapter = {
       entry: SessionEntry,
       context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
-    options?: { fallbackEntry?: SessionEntry; replaceEntry?: boolean },
+    options?: { fallbackEntry?: SessionEntry; preserveActivity?: boolean; replaceEntry?: boolean },
   ): Promise<SessionEntry | null>;
   updateSessionEntry(
     scope: SessionAccessScope,
@@ -235,6 +235,23 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       expect(adapter.loadSessionEntry(scope)).toMatchObject({
         model: "gpt-5.5",
         sessionId: "session-1",
+      });
+
+      const beforePreservePatch = adapter.loadSessionEntry(scope);
+      await adapter.patchSessionEntry(
+        scope,
+        () => ({
+          providerOverride: "anthropic",
+          updatedAt: 40,
+        }),
+        { preserveActivity: true },
+      );
+
+      expect(adapter.loadSessionEntry(scope)).toMatchObject({
+        model: "gpt-5.5",
+        providerOverride: "anthropic",
+        sessionId: "session-1",
+        updatedAt: beforePreservePatch?.updatedAt,
       });
     });
 

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -2,8 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   appendTranscriptEvent,
@@ -419,6 +424,28 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       });
       if (adapter.name === "sqlite") {
         expect(fs.existsSync(cleanupStorePath)).toBe(false);
+        const database = openOpenClawAgentDatabase({
+          agentId: "main",
+          env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+          path: path.join(paths.stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+        });
+        const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+        const removedRoute = executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("session_routes")
+            .select("session_id")
+            .where("session_key", "=", "agent:main:lifecycle-cleanup-removed"),
+        );
+        expect(removedRoute).toBeUndefined();
+        const freshRoute = executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("session_routes")
+            .select("session_id")
+            .where("session_key", "=", "agent:main:lifecycle-cleanup-fresh"),
+        );
+        expect(freshRoute).toEqual({ session_id: "fresh-lifecycle" });
         await expect(
           adapter.loadTranscriptEvents(scopedTranscript("agent:main:regular", "referenced")),
         ).resolves.not.toEqual([]);
@@ -727,3 +754,119 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
     });
   },
 );
+
+describe("sqlite session normalization", () => {
+  let paths: TestPaths;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-sqlite-norm-"));
+    paths = {
+      sqlitePath: path.join(tempDir, "openclaw-agent.sqlite"),
+      stateDir: path.join(tempDir, "state"),
+      storePath: path.join(tempDir, "sessions.json"),
+      tempDir,
+      transcriptPath: path.join(tempDir, "session.jsonl"),
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(paths.tempDir, { recursive: true, force: true });
+  });
+
+  it("maintains normalized session root and route rows", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:group:example",
+        storePath: paths.sqlitePath,
+      },
+      {
+        agentHarnessId: "codex",
+        chatType: "group",
+        channel: "discord",
+        deliveryContext: {
+          accountId: "acct-1",
+          channel: "discord",
+          threadId: "thread-1",
+          to: "group-1",
+        },
+        displayName: "Example group",
+        endedAt: 90,
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        parentSessionKey: "agent:main:parent",
+        sessionId: "normalized-session",
+        sessionStartedAt: 50,
+        spawnedBy: "agent:main:spawner",
+        startedAt: 60,
+        status: "done",
+        updatedAt: 100,
+      },
+    );
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: paths.sqlitePath,
+    });
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const session = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("sessions")
+        .select([
+          "account_id",
+          "agent_harness_id",
+          "channel",
+          "chat_type",
+          "created_at",
+          "display_name",
+          "ended_at",
+          "model",
+          "model_provider",
+          "parent_session_key",
+          "session_key",
+          "session_scope",
+          "spawned_by",
+          "started_at",
+          "status",
+          "updated_at",
+        ])
+        .where("session_id", "=", "normalized-session"),
+    );
+    expect(session).toEqual({
+      account_id: "acct-1",
+      agent_harness_id: "codex",
+      channel: "discord",
+      chat_type: "group",
+      created_at: 50,
+      display_name: "Example group",
+      ended_at: 90,
+      model: "gpt-5.5",
+      model_provider: "openai",
+      parent_session_key: "agent:main:parent",
+      session_key: "agent:main:group:example",
+      session_scope: "group",
+      spawned_by: "agent:main:spawner",
+      started_at: 60,
+      status: "done",
+      updated_at: expect.any(Number),
+    });
+
+    const route = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_routes")
+        .select(["session_id", "updated_at"])
+        .where("session_key", "=", "agent:main:group:example"),
+    );
+    expect(route).toEqual({
+      session_id: "normalized-session",
+      updated_at: expect.any(Number),
+    });
+  });
+});

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -20,6 +20,7 @@ import {
   type SessionAccessScope,
   type SessionEntrySummary,
   type SessionTranscriptAccessScope,
+  type SessionTranscriptReadScope,
   type SessionTranscriptWriteScope,
   type TranscriptEvent,
   type TranscriptMessageAppendOptions,
@@ -32,6 +33,7 @@ import {
   listSqliteSessionEntries,
   loadSqliteSessionEntry,
   loadSqliteTranscriptEvents,
+  loadSqliteTranscriptEventsSync,
   patchSqliteSessionEntry,
   publishSqliteTranscriptUpdate,
   readSqliteSessionUpdatedAt,
@@ -44,6 +46,7 @@ import type { SessionEntry } from "./types.js";
 type AccessorAdapter = {
   name: string;
   entryScope(paths: TestPaths): SessionAccessScope;
+  transcriptReadScope(paths: TestPaths, id?: string): SessionTranscriptReadScope;
   transcriptScope(paths: TestPaths, id?: string): SessionTranscriptAccessScope;
   loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined;
   listSessionEntries(scope: Partial<Omit<SessionAccessScope, "sessionKey">>): SessionEntrySummary[];
@@ -65,7 +68,7 @@ type AccessorAdapter = {
     scope: SessionAccessScope,
     update: (entry: SessionEntry) => Partial<SessionEntry> | null,
   ): Promise<SessionEntry | null>;
-  loadTranscriptEvents(scope: SessionTranscriptAccessScope): Promise<TranscriptEvent[]>;
+  loadTranscriptEvents(scope: SessionTranscriptReadScope): Promise<TranscriptEvent[]>;
   appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
   appendTranscriptMessage<TMessage>(
     scope: SessionTranscriptWriteScope,
@@ -97,6 +100,11 @@ const fileBackedAdapter: AccessorAdapter = {
     sessionKey: "agent:main:main",
     storePath: paths.storePath,
   }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    sessionFile: paths.transcriptPath,
+    sessionId: id,
+    storePath: paths.storePath,
+  }),
   loadSessionEntry,
   listSessionEntries,
   readSessionUpdatedAt,
@@ -123,6 +131,12 @@ const sqliteAdapter: AccessorAdapter = {
     env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
     sessionId: id,
     sessionKey: "agent:main:main",
+    storePath: paths.sqlitePath,
+  }),
+  transcriptReadScope: (paths, id = "session-1") => ({
+    agentId: "main",
+    env: { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir },
+    sessionId: id,
     storePath: paths.sqlitePath,
   }),
   loadSessionEntry: loadSqliteSessionEntry,
@@ -226,6 +240,7 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
 
     it("conforms for raw transcript event load and append", async () => {
       const scope = adapter.transcriptScope(paths);
+      const readScope = adapter.transcriptReadScope(paths);
       const event = {
         id: "event-1",
         message: { role: "user", content: "hello" },
@@ -236,10 +251,25 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
       await adapter.appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
       await adapter.appendTranscriptEvent(scope, event);
 
-      await expect(adapter.loadTranscriptEvents(scope)).resolves.toEqual([
+      await expect(adapter.loadTranscriptEvents(readScope)).resolves.toEqual([
         { type: "session", sessionId: "session-1" },
         event,
       ]);
+    });
+
+    it("loads raw SQLite transcript events synchronously through a read scope", async () => {
+      const scope = sqliteAdapter.transcriptScope(paths);
+      const readScope = sqliteAdapter.transcriptReadScope(paths);
+      const event = {
+        id: "event-1",
+        message: { role: "user", content: "hello" },
+        parentId: null,
+        type: "message",
+      };
+
+      await sqliteAdapter.appendTranscriptEvent(scope, event);
+
+      expect(loadSqliteTranscriptEventsSync(readScope)).toEqual([event]);
     });
 
     it("conforms for transcript message append, idempotency, and update publication", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -8,6 +8,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
+  cleanupSessionLifecycleArtifacts,
   listSessionEntries,
   loadExactSessionEntry,
   loadSessionEntry,
@@ -32,6 +33,7 @@ import {
 import {
   appendSqliteTranscriptEvent,
   appendSqliteTranscriptMessage,
+  cleanupSqliteSessionLifecycleArtifacts,
   listSqliteSessionEntries,
   loadExactSqliteSessionEntry,
   loadSqliteSessionEntry,
@@ -72,6 +74,13 @@ type AccessorAdapter = {
     scope: SessionAccessScope,
     update: (entry: SessionEntry) => Partial<SessionEntry> | null,
   ): Promise<SessionEntry | null>;
+  cleanupSessionLifecycleArtifacts(params: {
+    storePath: string;
+    sessionKeySegmentPrefix: string;
+    transcriptContentMarker: string;
+    orphanTranscriptMinAgeMs: number;
+    nowMs?: number;
+  }): Promise<{ removedEntries: number; archivedTranscriptArtifacts: number }>;
   loadTranscriptEvents(scope: SessionTranscriptReadScope): Promise<TranscriptEvent[]>;
   appendTranscriptEvent(scope: SessionTranscriptAccessScope, event: TranscriptEvent): Promise<void>;
   appendTranscriptMessage<TMessage>(
@@ -117,6 +126,7 @@ const fileBackedAdapter: AccessorAdapter = {
   replaceSessionEntry,
   patchSessionEntry,
   updateSessionEntry,
+  cleanupSessionLifecycleArtifacts,
   loadTranscriptEvents,
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -152,6 +162,7 @@ const sqliteAdapter: AccessorAdapter = {
   replaceSessionEntry: replaceSqliteSessionEntry,
   patchSessionEntry: patchSqliteSessionEntry,
   updateSessionEntry: updateSqliteSessionEntry,
+  cleanupSessionLifecycleArtifacts: cleanupSqliteSessionLifecycleArtifacts,
   loadTranscriptEvents: loadSqliteTranscriptEvents,
   appendTranscriptEvent: appendSqliteTranscriptEvent,
   appendTranscriptMessage: appendSqliteTranscriptMessage,
@@ -283,6 +294,150 @@ describe.each([fileBackedAdapter, sqliteAdapter])(
           sessionId: "exact-session",
         }),
       });
+    });
+
+    it("conforms for lifecycle entry and transcript cleanup", async () => {
+      const nowMs = Date.now();
+      const oldTimestamp = nowMs - 600_000;
+      const cleanupStorePath =
+        adapter.name === "sqlite"
+          ? path.join(paths.stateDir, "agents", "main", "sessions", "sessions.json")
+          : paths.storePath;
+      const scopedEntry = (sessionKey: string): SessionAccessScope => ({
+        ...adapter.entryScope(paths),
+        sessionKey,
+        storePath: cleanupStorePath,
+      });
+      const scopedTranscript = (
+        sessionKey: string,
+        sessionId: string,
+      ): SessionTranscriptAccessScope => ({
+        ...adapter.transcriptScope(paths, sessionId),
+        sessionKey,
+        storePath: cleanupStorePath,
+      });
+      const writeTranscript = async (params: {
+        sessionKey: string;
+        sessionId: string;
+        old?: boolean;
+      }) => {
+        const timestamp = params.old ? oldTimestamp : nowMs;
+        const event = {
+          id: `${params.sessionId}-event`,
+          message: { role: "assistant", content: "cleanup" },
+          runId: "lifecycle-marker-run",
+          timestamp: new Date(timestamp).toISOString(),
+          type: "message",
+        };
+        if (adapter.name === "sqlite") {
+          await adapter.appendTranscriptEvent(
+            scopedTranscript(params.sessionKey, params.sessionId),
+            event,
+          );
+          return;
+        }
+        const transcriptPath = path.join(
+          path.dirname(cleanupStorePath),
+          `${params.sessionId}.jsonl`,
+        );
+        fs.writeFileSync(transcriptPath, `${JSON.stringify(event)}\n`, "utf-8");
+        if (params.old) {
+          const oldDate = new Date(oldTimestamp);
+          fs.utimesSync(transcriptPath, oldDate, oldDate);
+        }
+      };
+
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-missing"), {
+        sessionId: "missing-lifecycle",
+        updatedAt: oldTimestamp,
+      });
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-removed"), {
+        sessionId: "removed-lifecycle",
+        updatedAt: oldTimestamp,
+      });
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-fresh"), {
+        sessionId: "fresh-lifecycle",
+        updatedAt: nowMs,
+      });
+      await adapter.upsertSessionEntry(
+        scopedEntry("agent:main:telegram:group:lifecycle-cleanup-room"),
+        {
+          sessionId: "kept-by-segment",
+          updatedAt: oldTimestamp,
+        },
+      );
+      await adapter.upsertSessionEntry(scopedEntry("agent:main:regular"), {
+        sessionId: "referenced",
+        updatedAt: oldTimestamp,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:lifecycle-cleanup-removed",
+        sessionId: "removed-lifecycle",
+        old: true,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:lifecycle-cleanup-fresh",
+        sessionId: "fresh-lifecycle",
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:regular",
+        sessionId: "referenced",
+        old: true,
+      });
+      await writeTranscript({
+        sessionKey: "agent:main:orphan",
+        sessionId: "orphan-lifecycle",
+        old: true,
+      });
+
+      await expect(
+        adapter.cleanupSessionLifecycleArtifacts({
+          storePath: cleanupStorePath,
+          sessionKeySegmentPrefix: "lifecycle-cleanup-",
+          transcriptContentMarker: "lifecycle-marker-",
+          orphanTranscriptMinAgeMs: 300_000,
+          nowMs,
+        }),
+      ).resolves.toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 2 });
+
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-missing")),
+      ).toBeUndefined();
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-removed")),
+      ).toBeUndefined();
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:lifecycle-cleanup-fresh")),
+      ).toMatchObject({
+        sessionId: "fresh-lifecycle",
+      });
+      expect(
+        adapter.loadSessionEntry(scopedEntry("agent:main:telegram:group:lifecycle-cleanup-room")),
+      ).toMatchObject({ sessionId: "kept-by-segment" });
+      expect(adapter.loadSessionEntry(scopedEntry("agent:main:regular"))).toMatchObject({
+        sessionId: "referenced",
+      });
+      if (adapter.name === "sqlite") {
+        expect(fs.existsSync(cleanupStorePath)).toBe(false);
+        await expect(
+          adapter.loadTranscriptEvents(scopedTranscript("agent:main:regular", "referenced")),
+        ).resolves.not.toEqual([]);
+        await expect(
+          adapter.loadTranscriptEvents(
+            scopedTranscript("agent:main:lifecycle-cleanup-removed", "removed-lifecycle"),
+          ),
+        ).resolves.toEqual([]);
+      } else {
+        const files = fs.readdirSync(path.dirname(cleanupStorePath));
+        expect(
+          files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
+        ).toHaveLength(1);
+        expect(
+          files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted.")),
+        ).toHaveLength(1);
+        expect(files).toContain("fresh-lifecycle.jsonl");
+        expect(files).toContain("referenced.jsonl");
+      }
     });
 
     it("conforms for raw transcript event load and append", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -869,4 +869,90 @@ describe("sqlite session normalization", () => {
       updated_at: expect.any(Number),
     });
   });
+
+  it("normalizes missing entry updatedAt before writing root and entry rows", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    await replaceSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:minimal",
+        storePath: paths.sqlitePath,
+      },
+      {
+        sessionId: "minimal-session",
+        sessionStartedAt: 123,
+      } as SessionEntry,
+    );
+
+    const loaded = loadSqliteSessionEntry({
+      agentId: "main",
+      env,
+      sessionKey: "agent:main:minimal",
+      storePath: paths.sqlitePath,
+    });
+    expect(loaded).toMatchObject({
+      sessionId: "minimal-session",
+      sessionStartedAt: 123,
+      updatedAt: 123,
+    });
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env,
+      path: paths.sqlitePath,
+    });
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("sessions as s")
+        .innerJoin("session_entries as se", "se.session_id", "s.session_id")
+        .innerJoin("session_routes as sr", "sr.session_key", "se.session_key")
+        .select([
+          "s.created_at as root_created_at",
+          "s.updated_at as root_updated_at",
+          "se.entry_json",
+          "se.updated_at as entry_updated_at",
+          "sr.updated_at as route_updated_at",
+        ])
+        .where("s.session_id", "=", "minimal-session"),
+    );
+    expect(row).toEqual({
+      entry_json: JSON.stringify({
+        sessionId: "minimal-session",
+        sessionStartedAt: 123,
+        updatedAt: 123,
+      }),
+      entry_updated_at: 123,
+      root_created_at: 123,
+      root_updated_at: 123,
+      route_updated_at: 123,
+    });
+
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:minimal-upsert",
+        storePath: paths.sqlitePath,
+      },
+      {
+        sessionId: "minimal-upsert-session",
+      },
+    );
+    const upsertRow = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("session_entries")
+        .select(["entry_json", "updated_at"])
+        .where("session_key", "=", "agent:main:minimal-upsert"),
+    );
+    const upsertEntry = JSON.parse(upsertRow?.entry_json ?? "{}") as Partial<SessionEntry>;
+    expect(upsertEntry).toMatchObject({
+      sessionId: "minimal-upsert-session",
+      updatedAt: expect.any(Number),
+    });
+    expect(upsertRow?.updated_at).toBe(upsertEntry.updatedAt);
+  });
 });

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -607,16 +607,15 @@ function sqliteTranscriptStateHasMarker(params: {
   transcriptContentMarker: string;
 }): boolean {
   const db = getSessionKysely(params.database.db);
-  const row = executeSqliteQueryTakeFirstSync(
+  const rows = executeSqliteQuerySync(
     params.database.db,
     db
       .selectFrom("transcript_events")
-      .select("seq")
+      .select("event_json")
       .where("session_id", "=", params.sessionId)
-      .where("event_json", "like", `%${params.transcriptContentMarker}%`)
-      .limit(1),
-  );
-  return row !== undefined;
+      .orderBy("seq", "asc"),
+  ).rows;
+  return rows.some((row) => row.event_json.includes(params.transcriptContentMarker));
 }
 
 function readReferencedSqliteSessionIds(database: OpenClawAgentDatabase): Set<string> {

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import type { Selectable } from "kysely";
 import type { AgentMessage } from "../../agents/runtime/index.js";
@@ -303,7 +304,7 @@ function resolveSqliteScope(
       ? normalizeAgentId(scope.agentId)
       : resolveAgentIdFromSessionKey(scope.sessionKey),
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
     sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
   };
 }
@@ -323,9 +324,25 @@ function resolveSqliteReadScope(
   return {
     agentId,
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };
+}
+
+function resolveSqlitePathFromSessionStorePath(storePath: string): string {
+  const resolved = path.resolve(storePath);
+  if (path.basename(resolved) !== "sessions.json") {
+    return resolved;
+  }
+  const sessionsDir = path.dirname(resolved);
+  if (path.basename(sessionsDir) !== "sessions") {
+    return resolved;
+  }
+  const agentDir = path.dirname(sessionsDir);
+  if (path.basename(path.dirname(agentDir)) !== "agents") {
+    return resolved;
+  }
+  return path.join(agentDir, "agent", "openclaw-agent.sqlite");
 }
 
 function resolveSqliteTranscriptScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -27,6 +27,8 @@ import type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
   SessionEntrySummary,
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
   SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
   SessionTranscriptReadScope,
@@ -229,6 +231,34 @@ export async function updateSqliteSessionEntry(
       const next = mergeSessionEntry(fresh, patch);
       writeSessionEntry(writeDatabase, resolved.sessionKey, next);
       result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
+}
+
+/** Cleans scoped session lifecycle rows and associated SQLite transcript state. */
+export async function cleanupSqliteSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  const sessionKeySegmentPrefix = params.sessionKeySegmentPrefix.trim();
+  const transcriptContentMarker = params.transcriptContentMarker;
+  if (!sessionKeySegmentPrefix || !transcriptContentMarker) {
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
+
+  const resolved = resolveSqliteReadScope({ storePath: params.storePath });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: SessionLifecycleArtifactCleanupResult = {
+      removedEntries: 0,
+      archivedTranscriptArtifacts: 0,
+    };
+    runOpenClawAgentWriteTransaction((database) => {
+      result = cleanupSqliteSessionLifecycleArtifactsInTransaction(database, {
+        sessionKeySegmentPrefix,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs: params.nowMs ?? Date.now(),
+      });
     }, toDatabaseOptions(resolved));
     return result;
   });
@@ -531,6 +561,196 @@ function readExactSessionEntryRow(
   }
   const entry = parseSessionEntryRow(row);
   return entry ? { entry, row } : undefined;
+}
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function readSessionTranscriptUpdatedAt(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): number | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("created_at").as("updated_at"))
+      .where("session_id", "=", sessionId),
+  );
+  if (row?.updated_at === null || row?.updated_at === undefined) {
+    return undefined;
+  }
+  return normalizeSqliteNumber(row.updated_at);
+}
+
+function sqliteTranscriptStateIsReclaimable(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  const updatedAt = readSessionTranscriptUpdatedAt(params.database, params.sessionId);
+  return updatedAt === undefined || params.nowMs - updatedAt >= params.orphanTranscriptMinAgeMs;
+}
+
+function sqliteTranscriptStateHasMarker(params: {
+  database: OpenClawAgentDatabase;
+  sessionId: string;
+  transcriptContentMarker: string;
+}): boolean {
+  const db = getSessionKysely(params.database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", params.sessionId)
+      .where("event_json", "like", `%${params.transcriptContentMarker}%`)
+      .limit(1),
+  );
+  return row !== undefined;
+}
+
+function readReferencedSqliteSessionIds(database: OpenClawAgentDatabase): Set<string> {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_entries").select("session_id"),
+  ).rows;
+  return new Set(rows.map((row) => row.session_id));
+}
+
+function deleteSqliteSessionStateIfUnreferenced(params: {
+  database: OpenClawAgentDatabase;
+  referencedSessionIds: ReadonlySet<string>;
+  sessionId: string;
+}): number {
+  if (params.referencedSessionIds.has(params.sessionId)) {
+    return 0;
+  }
+  const hadTranscriptState =
+    readSessionTranscriptUpdatedAt(params.database, params.sessionId) !== undefined;
+  const db = getSessionKysely(params.database.db);
+  executeSqliteQuerySync(
+    params.database.db,
+    db.deleteFrom("sessions").where("session_id", "=", params.sessionId),
+  );
+  return hadTranscriptState ? 1 : 0;
+}
+
+function cleanupSqliteOrphanLifecycleTranscriptState(params: {
+  database: OpenClawAgentDatabase;
+  referencedSessionIds: ReadonlySet<string>;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+}): number {
+  const db = getSessionKysely(params.database.db);
+  const rows = executeSqliteQuerySync(
+    params.database.db,
+    db.selectFrom("sessions").select("session_id").orderBy("session_id", "asc"),
+  ).rows;
+
+  let removed = 0;
+  // Orphan transcript state is represented by a sessions row without a live
+  // session entry. The marker keeps this scoped to the caller-owned lifecycle.
+  for (const row of rows) {
+    if (params.referencedSessionIds.has(row.session_id)) {
+      continue;
+    }
+    if (
+      !sqliteTranscriptStateIsReclaimable({
+        database: params.database,
+        sessionId: row.session_id,
+        nowMs: params.nowMs,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+      }) ||
+      !sqliteTranscriptStateHasMarker({
+        database: params.database,
+        sessionId: row.session_id,
+        transcriptContentMarker: params.transcriptContentMarker,
+      })
+    ) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      params.database.db,
+      db.deleteFrom("sessions").where("session_id", "=", row.session_id),
+    );
+    removed += 1;
+  }
+  return removed;
+}
+
+function cleanupSqliteSessionLifecycleArtifactsInTransaction(
+  database: OpenClawAgentDatabase,
+  params: {
+    sessionKeySegmentPrefix: string;
+    transcriptContentMarker: string;
+    orphanTranscriptMinAgeMs: number;
+    nowMs: number;
+  },
+): SessionLifecycleArtifactCleanupResult {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select(["session_key", "session_id"])
+      .orderBy("session_key", "asc"),
+  ).rows;
+
+  const removedSessionIds = new Set<string>();
+  let removedEntries = 0;
+  // Delete matching lifecycle entries first; session/transcript state is only
+  // removed after we rebuild the post-delete reference set below.
+  for (const row of rows) {
+    if (!sessionKeySegmentStartsWith(row.session_key, params.sessionKeySegmentPrefix)) {
+      continue;
+    }
+    if (
+      !sqliteTranscriptStateIsReclaimable({
+        database,
+        sessionId: row.session_id,
+        nowMs: params.nowMs,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+      })
+    ) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("session_entries").where("session_key", "=", row.session_key),
+    );
+    removedSessionIds.add(row.session_id);
+    removedEntries += 1;
+  }
+
+  const referencedSessionIds = readReferencedSqliteSessionIds(database);
+  let archivedTranscriptArtifacts = 0;
+  for (const sessionId of removedSessionIds) {
+    archivedTranscriptArtifacts += deleteSqliteSessionStateIfUnreferenced({
+      database,
+      referencedSessionIds,
+      sessionId,
+    });
+  }
+  archivedTranscriptArtifacts += cleanupSqliteOrphanLifecycleTranscriptState({
+    database,
+    referencedSessionIds,
+    transcriptContentMarker: params.transcriptContentMarker,
+    orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+    nowMs: params.nowMs,
+  });
+  return { removedEntries, archivedTranscriptArtifacts };
 }
 
 function writeSessionEntry(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,0 +1,643 @@
+import { randomUUID } from "node:crypto";
+import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import type { Selectable } from "kysely";
+import type { AgentMessage } from "../../agents/runtime/index.js";
+import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { redactSecrets } from "../../logging/redact.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+  type OpenClawAgentDatabaseOptions,
+} from "../../state/openclaw-agent-db.js";
+import type {
+  SessionAccessScope,
+  SessionEntryPatchContext,
+  SessionEntryPatchOptions,
+  SessionEntrySummary,
+  SessionEntryUpdateOptions,
+  SessionTranscriptAccessScope,
+  SessionTranscriptWriteScope,
+  TranscriptEvent,
+  TranscriptMessageAppendOptions,
+  TranscriptMessageAppendResult,
+  TranscriptUpdatePayload,
+} from "./session-accessor.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
+import { createSessionTranscriptHeader } from "./transcript-header.js";
+import type { SessionEntry } from "./types.js";
+import { mergeSessionEntry } from "./types.js";
+
+type SessionSqliteDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_entries" | "sessions" | "transcript_event_identities" | "transcript_events"
+>;
+type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
+
+type ResolvedSqliteScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey: string;
+};
+
+type ResolvedTranscriptScope = ResolvedSqliteScope & {
+  sessionId: string;
+};
+
+/** Loads one session entry from the additive SQLite session store. */
+export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return readSessionEntryRow(database, resolved.sessionKey)?.entry;
+}
+
+/** Lists session entries from the additive SQLite session store. */
+export function listSqliteSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select(["session_key", "entry_json", "session_id", "updated_at"])
+      .orderBy("session_key", "asc"),
+  ).rows;
+  return rows
+    .map((row) => {
+      const entry = parseSessionEntryRow(row);
+      return entry ? { sessionKey: row.session_key, entry } : undefined;
+    })
+    .filter((entry): entry is SessionEntrySummary => entry !== undefined);
+}
+
+/** Reads a session activity timestamp from the additive SQLite session store. */
+export function readSqliteSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .select("updated_at")
+      .where("session_key", "=", resolved.sessionKey),
+  );
+  return row ? normalizeSqliteNumber(row.updated_at) : undefined;
+}
+
+/** Applies a partial entry update to the additive SQLite session store. */
+export async function upsertSqliteSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => patch, {
+    fallbackEntry: createFallbackSessionEntry(patch),
+  });
+}
+
+/** Replaces one entry in the additive SQLite session store. */
+export async function replaceSqliteSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchSqliteSessionEntry(scope, () => entry, {
+    fallbackEntry: entry,
+    replaceEntry: true,
+  });
+}
+
+/** Patches one entry in the additive SQLite session store. */
+export async function patchSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+    context: SessionEntryPatchContext,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  const resolved = resolveSqliteScope(scope);
+  const existing = loadSqliteSessionEntry(scope);
+  const base = existing ?? options.fallbackEntry;
+  if (!base) {
+    return null;
+  }
+  const patch = await update(cloneSessionEntry(base), {
+    existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+  });
+  if (!patch) {
+    return cloneSessionEntry(base);
+  }
+  const next = options.replaceEntry
+    ? cloneSessionEntry(patch as SessionEntry)
+    : mergeSessionEntry(base, patch);
+  runOpenClawAgentWriteTransaction((database) => {
+    writeSessionEntry(database, resolved.sessionKey, next);
+  }, toDatabaseOptions(resolved));
+  return cloneSessionEntry(next);
+}
+
+/** Updates an existing entry in the additive SQLite session store. */
+export async function updateSqliteSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  _options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  const existing = loadSqliteSessionEntry(scope);
+  if (!existing) {
+    return null;
+  }
+  const patch = await update(cloneSessionEntry(existing));
+  if (!patch) {
+    return cloneSessionEntry(existing);
+  }
+  const next = mergeSessionEntry(existing, patch);
+  const resolved = resolveSqliteScope(scope);
+  runOpenClawAgentWriteTransaction((database) => {
+    writeSessionEntry(database, resolved.sessionKey, next);
+  }, toDatabaseOptions(resolved));
+  return cloneSessionEntry(next);
+}
+
+/** Loads raw transcript events from the additive SQLite transcript store. */
+export async function loadSqliteTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", resolved.sessionId)
+      .orderBy("seq", "asc"),
+  ).rows;
+  return rows.map((row) => JSON.parse(row.event_json) as TranscriptEvent);
+}
+
+/** Appends one raw transcript event to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  runOpenClawAgentWriteTransaction((database) => {
+    appendTranscriptEventInTransaction(database, resolved, event);
+  }, toDatabaseOptions(resolved));
+}
+
+/** Appends one transcript message to the additive SQLite transcript store. */
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendSqliteTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const idempotencyKey = readMessageIdempotencyKey(options.message);
+  if (idempotencyKey && options.idempotencyLookup === "scan") {
+    const existing = readTranscriptMessageByIdempotencyKey(resolved, idempotencyKey);
+    if (existing) {
+      return {
+        appended: false,
+        message: existing.message as TMessage,
+        messageId: existing.messageId,
+      };
+    }
+  }
+
+  const prepared = options.prepareMessageAfterIdempotencyCheck
+    ? options.prepareMessageAfterIdempotencyCheck(options.message)
+    : options.message;
+  if (prepared === undefined) {
+    return undefined;
+  }
+
+  const messageId = randomUUID();
+  const now = options.now ?? Date.now();
+  const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+  runOpenClawAgentWriteTransaction((database) => {
+    ensureTranscriptHeader(database, resolved, options.cwd, now);
+    const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
+    const event = {
+      type: "message",
+      id: messageId,
+      parentId: parentId ?? null,
+      timestamp: resolveTimestampMsToIsoString(now),
+      message: finalMessage,
+    };
+    appendTranscriptEventInTransaction(database, resolved, event);
+  }, toDatabaseOptions(resolved));
+  return {
+    appended: true,
+    message: finalMessage,
+    messageId,
+  };
+}
+
+/** Publishes a transcript update using the SQLite transcript scope target. */
+export async function publishSqliteTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: formatSqliteTranscriptTarget(resolved),
+  });
+}
+
+function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
+  return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+function resolveSqliteScope(
+  scope: Pick<SessionAccessScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteScope {
+  return {
+    agentId: scope.agentId
+      ? normalizeAgentId(scope.agentId)
+      : resolveAgentIdFromSessionKey(scope.sessionKey),
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.storePath ? { path: scope.storePath } : {}),
+    sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
+  };
+}
+
+function resolveSqliteTranscriptScope(
+  scope: Pick<
+    SessionTranscriptWriteScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptScope {
+  if (!scope.sessionId) {
+    throw new Error(
+      `Cannot resolve SQLite transcript scope without a session id: ${scope.sessionKey}`,
+    );
+  }
+  return {
+    ...resolveSqliteScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
+function toDatabaseOptions(
+  scope: Pick<ResolvedSqliteScope, "agentId" | "env" | "path">,
+): OpenClawAgentDatabaseOptions {
+  return {
+    agentId: scope.agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.path ? { path: scope.path } : {}),
+  };
+}
+
+function normalizeSqliteSessionKey(sessionKey: string): string {
+  return normalizeStoreSessionKey(sessionKey);
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+function cloneSessionEntry(entry: SessionEntry): SessionEntry {
+  return structuredClone(entry);
+}
+
+function normalizeSqliteNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+function parseSessionEntryRow(row: Pick<SessionEntryRow, "entry_json">): SessionEntry | null {
+  try {
+    const parsed = JSON.parse(row.entry_json) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as SessionEntry)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_entries")
+      .selectAll()
+      .where("session_key", "=", normalizeSqliteSessionKey(sessionKey)),
+  );
+  if (!row) {
+    return undefined;
+  }
+  const entry = parseSessionEntryRow(row);
+  return entry ? { entry, row } : undefined;
+}
+
+function writeSessionEntry(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+  entry: SessionEntry,
+): void {
+  const db = getSessionKysely(database.db);
+  const updatedAt = entry.updatedAt;
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: entry.sessionId,
+        session_key: sessionKey,
+        created_at: entry.sessionStartedAt ?? updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("session_entries")
+      .values({
+        session_key: sessionKey,
+        session_id: entry.sessionId,
+        entry_json: JSON.stringify(entry),
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: entry.sessionId,
+          entry_json: JSON.stringify(entry),
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function ensureTranscriptSessionRoot(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  updatedAt: number,
+): void {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("sessions")
+      .values({
+        session_id: scope.sessionId,
+        session_key: scope.sessionKey,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          session_key: scope.sessionKey,
+          updated_at: updatedAt,
+        }),
+      ),
+  );
+}
+
+function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId: string): number {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select((eb) => eb.fn.max<number | bigint>("seq").as("max_seq"))
+      .where("session_id", "=", sessionId),
+  );
+  const maxSeq =
+    row?.max_seq === null || row?.max_seq === undefined ? -1 : normalizeSqliteNumber(row.max_seq);
+  return maxSeq + 1;
+}
+
+function appendTranscriptEventInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  event: TranscriptEvent,
+): void {
+  const db = getSessionKysely(database.db);
+  const createdAt = readEventTimestamp(event) ?? Date.now();
+  ensureTranscriptSessionRoot(database, scope, createdAt);
+  const seq = readNextTranscriptSeq(database, scope.sessionId);
+  executeSqliteQuerySync(
+    database.db,
+    db.insertInto("transcript_events").values({
+      session_id: scope.sessionId,
+      seq,
+      event_json: JSON.stringify(event),
+      created_at: createdAt,
+    }),
+  );
+  const identity = readTranscriptEventIdentity(event);
+  if (!identity) {
+    return;
+  }
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("transcript_event_identities")
+      .values({
+        session_id: scope.sessionId,
+        event_id: identity.eventId,
+        seq,
+        event_type: identity.eventType,
+        parent_id: identity.parentId,
+        message_idempotency_key: identity.messageIdempotencyKey,
+        created_at: createdAt,
+      })
+      .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
+  );
+}
+
+function ensureTranscriptHeader(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  cwd: string | undefined,
+  now: number,
+): void {
+  const db = getSessionKysely(database.db);
+  const existing = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", scope.sessionId)
+      .limit(1),
+  );
+  if (existing) {
+    return;
+  }
+  appendTranscriptEventInTransaction(
+    database,
+    scope,
+    createSessionTranscriptHeader({
+      cwd,
+      sessionId: scope.sessionId,
+    }),
+  );
+  ensureTranscriptSessionRoot(database, scope, now);
+}
+
+function readLatestTranscriptMessageId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): string | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id"])
+      .where("session_id", "=", sessionId)
+      .where("event_type", "=", "message")
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  return row?.event_id;
+}
+
+function readTranscriptMessageByIdempotencyKey(
+  scope: ResolvedTranscriptScope,
+  idempotencyKey: string,
+): { messageId: string; message: unknown } | undefined {
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(scope));
+  const db = getSessionKysely(database.db);
+  const identity = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", scope.sessionId)
+      .where("message_idempotency_key", "=", idempotencyKey)
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  if (!identity) {
+    return undefined;
+  }
+  const eventRow = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", scope.sessionId)
+      .where("seq", "=", identity.seq),
+  );
+  if (!eventRow) {
+    return undefined;
+  }
+  const event = JSON.parse(eventRow.event_json) as { message?: unknown };
+  return {
+    messageId: identity.event_id,
+    message: event.message,
+  };
+}
+
+function readTranscriptEventIdentity(event: unknown):
+  | {
+      eventId: string;
+      eventType: string | null;
+      parentId: string | null;
+      messageIdempotencyKey: string | null;
+    }
+  | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const record = event as Record<string, unknown>;
+  const eventId = typeof record.id === "string" && record.id.trim() ? record.id.trim() : undefined;
+  if (!eventId) {
+    return undefined;
+  }
+  return {
+    eventId,
+    eventType: typeof record.type === "string" ? record.type : null,
+    parentId: typeof record.parentId === "string" ? record.parentId : null,
+    messageIdempotencyKey: readMessageIdempotencyKey(record.message),
+  };
+}
+
+function readMessageIdempotencyKey(message: unknown): string | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const value = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readEventTimestamp(event: unknown): number | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const value = (event as { timestamp?: unknown }).timestamp;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function redactTranscriptMessageForStorage<TMessage>(
+  message: TMessage,
+  options: Pick<TranscriptMessageAppendOptions<TMessage>, "config">,
+): TMessage {
+  if (isTranscriptAgentMessage(message)) {
+    return redactTranscriptMessage(message, options.config) as TMessage;
+  }
+  return redactSecrets(message);
+}
+
+function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { role?: unknown }).role === "string"
+  );
+}
+
+function formatSqliteTranscriptTarget(scope: ResolvedTranscriptScope): string {
+  const pathPart = scope.path ? `:${scope.path}` : "";
+  return `sqlite:${scope.agentId}:${scope.sessionId}${pathPart}`;
+}

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -25,6 +25,7 @@ import type {
   SessionEntrySummary,
   SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
+  SessionTranscriptReadScope,
   SessionTranscriptWriteScope,
   TranscriptEvent,
   TranscriptMessageAppendOptions,
@@ -49,7 +50,18 @@ type ResolvedSqliteScope = {
   sessionKey: string;
 };
 
+type ResolvedSqliteReadScope = {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  sessionKey?: string;
+};
+
 type ResolvedTranscriptScope = ResolvedSqliteScope & {
+  sessionId: string;
+};
+
+type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
   sessionId: string;
 };
 
@@ -174,9 +186,16 @@ export async function updateSqliteSessionEntry(
 
 /** Loads raw transcript events from the additive SQLite transcript store. */
 export async function loadSqliteTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const resolved = resolveSqliteTranscriptScope(scope);
+  return loadSqliteTranscriptEventsSync(scope);
+}
+
+/** Loads raw transcript events synchronously from the additive SQLite transcript store. */
+export function loadSqliteTranscriptEventsSync(
+  scope: SessionTranscriptReadScope,
+): TranscriptEvent[] {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const db = getSessionKysely(database.db);
   const rows = executeSqliteQuerySync(
@@ -287,6 +306,26 @@ function resolveSqliteScope(
   };
 }
 
+function resolveSqliteReadScope(
+  scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionKey" | "storePath">,
+): ResolvedSqliteReadScope {
+  const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
+  const agentId = scope.agentId
+    ? normalizeAgentId(scope.agentId)
+    : sessionKey
+      ? resolveAgentIdFromSessionKey(sessionKey)
+      : undefined;
+  if (!agentId) {
+    throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
+  }
+  return {
+    agentId,
+    ...(scope.env ? { env: scope.env } : {}),
+    ...(scope.storePath ? { path: scope.storePath } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
 function resolveSqliteTranscriptScope(
   scope: Pick<
     SessionTranscriptWriteScope,
@@ -304,8 +343,20 @@ function resolveSqliteTranscriptScope(
   };
 }
 
+function resolveSqliteTranscriptReadScope(
+  scope: Pick<
+    SessionTranscriptReadScope,
+    "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
+  >,
+): ResolvedTranscriptReadScope {
+  return {
+    ...resolveSqliteReadScope(scope),
+    sessionId: scope.sessionId,
+  };
+}
+
 function toDatabaseOptions(
-  scope: Pick<ResolvedSqliteScope, "agentId" | "env" | "path">,
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
 ): OpenClawAgentDatabaseOptions {
   return {
     agentId: scope.agentId,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -12,9 +12,11 @@ import {
 import { redactSecrets } from "../../logging/redact.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
@@ -70,6 +72,8 @@ type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
 };
+
+const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
 
 /** Loads one session entry from the additive SQLite session store. */
 export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
@@ -146,26 +150,38 @@ export async function patchSqliteSessionEntry(
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {
   const resolved = resolveSqliteScope(scope);
-  const existing = loadSqliteSessionEntry(scope);
-  const base = existing ?? options.fallbackEntry;
-  if (!base) {
-    return null;
-  }
-  const patch = await update(cloneSessionEntry(base), {
-    existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    const base = existing ?? options.fallbackEntry;
+    if (!base) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(base), {
+      existingEntry: existing ? cloneSessionEntry(existing) : undefined,
+    });
+    if (!patch) {
+      return cloneSessionEntry(base);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      const writeBase = fresh ?? options.fallbackEntry;
+      if (!writeBase) {
+        result = null;
+        return;
+      }
+      const next = options.replaceEntry
+        ? cloneSessionEntry(patch as SessionEntry)
+        : options.preserveActivity
+          ? mergeSessionEntryPreserveActivity(writeBase, patch)
+          : mergeSessionEntry(writeBase, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
   });
-  if (!patch) {
-    return cloneSessionEntry(base);
-  }
-  const next = options.replaceEntry
-    ? cloneSessionEntry(patch as SessionEntry)
-    : options.preserveActivity
-      ? mergeSessionEntryPreserveActivity(base, patch)
-      : mergeSessionEntry(base, patch);
-  runOpenClawAgentWriteTransaction((database) => {
-    writeSessionEntry(database, resolved.sessionKey, next);
-  }, toDatabaseOptions(resolved));
-  return cloneSessionEntry(next);
 }
 
 /** Updates an existing entry in the additive SQLite session store. */
@@ -176,20 +192,31 @@ export async function updateSqliteSessionEntry(
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   _options: SessionEntryUpdateOptions = {},
 ): Promise<SessionEntry | null> {
-  const existing = loadSqliteSessionEntry(scope);
-  if (!existing) {
-    return null;
-  }
-  const patch = await update(cloneSessionEntry(existing));
-  if (!patch) {
-    return cloneSessionEntry(existing);
-  }
-  const next = mergeSessionEntry(existing, patch);
   const resolved = resolveSqliteScope(scope);
-  runOpenClawAgentWriteTransaction((database) => {
-    writeSessionEntry(database, resolved.sessionKey, next);
-  }, toDatabaseOptions(resolved));
-  return cloneSessionEntry(next);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    if (!existing) {
+      return null;
+    }
+    const patch = await update(cloneSessionEntry(existing));
+    if (!patch) {
+      return cloneSessionEntry(existing);
+    }
+
+    let result: SessionEntry | null = null;
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      const fresh = readSessionEntryRow(writeDatabase, resolved.sessionKey)?.entry;
+      if (!fresh) {
+        result = null;
+        return;
+      }
+      const next = mergeSessionEntry(fresh, patch);
+      writeSessionEntry(writeDatabase, resolved.sessionKey, next);
+      result = cloneSessionEntry(next);
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
 }
 
 /** Loads raw transcript events from the additive SQLite transcript store. */
@@ -223,9 +250,11 @@ export async function appendSqliteTranscriptEvent(
   event: TranscriptEvent,
 ): Promise<void> {
   const resolved = resolveSqliteTranscriptScope(scope);
-  runOpenClawAgentWriteTransaction((database) => {
-    appendTranscriptEventInTransaction(database, resolved, event);
-  }, toDatabaseOptions(resolved));
+  await runExclusiveSqliteSessionWrite(resolved, async () => {
+    runOpenClawAgentWriteTransaction((database) => {
+      appendTranscriptEventInTransaction(database, resolved, event);
+    }, toDatabaseOptions(resolved));
+  });
 }
 
 /** Appends one transcript message to the additive SQLite transcript store. */
@@ -244,45 +273,67 @@ export async function appendSqliteTranscriptMessage<TMessage>(
   options: TranscriptMessageAppendOptions<TMessage>,
 ): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
   const resolved = resolveSqliteTranscriptScope(scope);
-  const idempotencyKey = readMessageIdempotencyKey(options.message);
-  if (idempotencyKey && options.idempotencyLookup === "scan") {
-    const existing = readTranscriptMessageByIdempotencyKey(resolved, idempotencyKey);
-    if (existing) {
-      return {
-        appended: false,
-        message: existing.message as TMessage,
-        messageId: existing.messageId,
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    let result: TranscriptMessageAppendResult<TMessage> | undefined;
+    runOpenClawAgentWriteTransaction((database) => {
+      const idempotencyKey = readMessageIdempotencyKey(options.message);
+      if (idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+
+      const prepared = options.prepareMessageAfterIdempotencyCheck
+        ? options.prepareMessageAfterIdempotencyCheck(options.message)
+        : options.message;
+      if (prepared === undefined) {
+        result = undefined;
+        return;
+      }
+
+      const messageId = randomUUID();
+      const now = options.now ?? Date.now();
+      const finalMessage = redactTranscriptMessageForStorage(prepared, options);
+      ensureTranscriptHeader(database, resolved, options.cwd, now);
+      const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
+      const event = {
+        type: "message",
+        id: messageId,
+        parentId: parentId ?? null,
+        timestamp: resolveTimestampMsToIsoString(now),
+        message: finalMessage,
       };
-    }
-  }
-
-  const prepared = options.prepareMessageAfterIdempotencyCheck
-    ? options.prepareMessageAfterIdempotencyCheck(options.message)
-    : options.message;
-  if (prepared === undefined) {
-    return undefined;
-  }
-
-  const messageId = randomUUID();
-  const now = options.now ?? Date.now();
-  const finalMessage = redactTranscriptMessageForStorage(prepared, options);
-  runOpenClawAgentWriteTransaction((database) => {
-    ensureTranscriptHeader(database, resolved, options.cwd, now);
-    const parentId = readLatestTranscriptMessageId(database, resolved.sessionId);
-    const event = {
-      type: "message",
-      id: messageId,
-      parentId: parentId ?? null,
-      timestamp: resolveTimestampMsToIsoString(now),
-      message: finalMessage,
-    };
-    appendTranscriptEventInTransaction(database, resolved, event);
-  }, toDatabaseOptions(resolved));
-  return {
-    appended: true,
-    message: finalMessage,
-    messageId,
-  };
+      const appended = appendTranscriptEventInTransaction(database, resolved, event, {
+        dedupeByMessageIdempotency: options.idempotencyLookup === "scan",
+      });
+      if (!appended && idempotencyKey && options.idempotencyLookup === "scan") {
+        const existing = readTranscriptMessageByIdempotencyKey(database, resolved, idempotencyKey);
+        if (existing) {
+          result = {
+            appended: false,
+            message: existing.message as TMessage,
+            messageId: existing.messageId,
+          };
+          return;
+        }
+      }
+      if (!appended) {
+        throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
+      }
+      result = {
+        appended: true,
+        message: finalMessage,
+        messageId,
+      };
+    }, toDatabaseOptions(resolved));
+    return result;
+  });
 }
 
 /** Publishes a transcript update using the SQLite transcript scope target. */
@@ -299,6 +350,19 @@ export async function publishSqliteTranscriptUpdate(
 
 function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+async function runExclusiveSqliteSessionWrite<T>(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const databaseOptions = toDatabaseOptions(scope);
+  return await runQueuedStoreWrite({
+    queues: SQLITE_SESSION_WRITER_QUEUES,
+    storePath: resolveOpenClawAgentSqlitePath(databaseOptions),
+    label: "runExclusiveSqliteSessionWrite",
+    fn,
+  });
 }
 
 function resolveSqliteScope(
@@ -537,10 +601,26 @@ function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
-): void {
+  options: { dedupeByMessageIdempotency?: boolean } = {},
+): boolean {
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(event) ?? Date.now();
   ensureTranscriptSessionRoot(database, scope, createdAt);
+  const identity = readTranscriptEventIdentity(event);
+  if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
+    return false;
+  }
+  if (
+    identity?.messageIdempotencyKey &&
+    options.dedupeByMessageIdempotency &&
+    readTranscriptIdentityByMessageIdempotencyKey(
+      database,
+      scope.sessionId,
+      identity.messageIdempotencyKey,
+    )
+  ) {
+    return false;
+  }
   const seq = readNextTranscriptSeq(database, scope.sessionId);
   executeSqliteQuerySync(
     database.db,
@@ -551,9 +631,8 @@ function appendTranscriptEventInTransaction(
       created_at: createdAt,
     }),
   );
-  const identity = readTranscriptEventIdentity(event);
   if (!identity) {
-    return;
+    return true;
   }
   executeSqliteQuerySync(
     database.db,
@@ -570,6 +649,7 @@ function appendTranscriptEventInTransaction(
       })
       .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
   );
+  return true;
 }
 
 function ensureTranscriptHeader(
@@ -619,25 +699,56 @@ function readLatestTranscriptMessageId(
   return row?.event_id;
 }
 
-function readTranscriptMessageByIdempotencyKey(
-  scope: ResolvedTranscriptScope,
-  idempotencyKey: string,
-): { messageId: string; message: unknown } | undefined {
-  const database = openOpenClawAgentDatabase(toDatabaseOptions(scope));
+function readTranscriptIdentityByEventId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  eventId: string,
+): { eventId: string; seq: number } | undefined {
   const db = getSessionKysely(database.db);
-  const identity = executeSqliteQueryTakeFirstSync(
+  const row = executeSqliteQueryTakeFirstSync(
     database.db,
     db
       .selectFrom("transcript_event_identities")
       .select(["event_id", "seq"])
-      .where("session_id", "=", scope.sessionId)
+      .where("session_id", "=", sessionId)
+      .where("event_id", "=", eventId),
+  );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptIdentityByMessageIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  idempotencyKey: string,
+): { eventId: string; seq: number } | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities")
+      .select(["event_id", "seq"])
+      .where("session_id", "=", sessionId)
       .where("message_idempotency_key", "=", idempotencyKey)
       .orderBy("seq", "desc")
       .limit(1),
   );
+  return row ? { eventId: row.event_id, seq: row.seq } : undefined;
+}
+
+function readTranscriptMessageByIdempotencyKey(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  idempotencyKey: string,
+): { messageId: string; message: unknown } | undefined {
+  const identity = readTranscriptIdentityByMessageIdempotencyKey(
+    database,
+    scope.sessionId,
+    idempotencyKey,
+  );
   if (!identity) {
     return undefined;
   }
+  const db = getSessionKysely(database.db);
   const eventRow = executeSqliteQueryTakeFirstSync(
     database.db,
     db
@@ -651,7 +762,7 @@ function readTranscriptMessageByIdempotencyKey(
   }
   const event = JSON.parse(eventRow.event_json) as { message?: unknown };
   return {
-    messageId: identity.event_id,
+    messageId: identity.eventId,
     message: event.message,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -22,6 +22,7 @@ import {
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import type {
+  ExactSessionEntry,
   SessionAccessScope,
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
@@ -80,6 +81,20 @@ export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry 
   const resolved = resolveSqliteScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   return readSessionEntryRow(database, resolved.sessionKey)?.entry;
+}
+
+/** Loads one exact persisted-key entry from the additive SQLite session store. */
+export function loadExactSqliteSessionEntry(
+  scope: SessionAccessScope,
+): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const resolved = resolveSqliteScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const row = readExactSessionEntryRow(database, sessionKey);
+  return row ? { sessionKey, entry: row.entry } : undefined;
 }
 
 /** Lists session entries from the additive SQLite session store. */
@@ -499,13 +514,17 @@ function readSessionEntryRow(
   database: OpenClawAgentDatabase,
   sessionKey: string,
 ): { entry: SessionEntry; row: SessionEntryRow } | undefined {
+  return readExactSessionEntryRow(database, normalizeSqliteSessionKey(sessionKey));
+}
+
+function readExactSessionEntryRow(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+): { entry: SessionEntry; row: SessionEntryRow } | undefined {
   const db = getSessionKysely(database.db);
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
-    db
-      .selectFrom("session_entries")
-      .selectAll()
-      .where("session_key", "=", normalizeSqliteSessionKey(sessionKey)),
+    db.selectFrom("session_entries").selectAll().where("session_key", "=", sessionKey),
   );
   if (!row) {
     return undefined;

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -35,7 +35,7 @@ import type {
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { SessionEntry } from "./types.js";
-import { mergeSessionEntry } from "./types.js";
+import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
 
 type SessionSqliteDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -153,7 +153,9 @@ export async function patchSqliteSessionEntry(
   }
   const next = options.replaceEntry
     ? cloneSessionEntry(patch as SessionEntry)
-    : mergeSessionEntry(base, patch);
+    : options.preserveActivity
+      ? mergeSessionEntryPreserveActivity(base, patch)
+      : mergeSessionEntry(base, patch);
   runOpenClawAgentWriteTransaction((database) => {
     writeSessionEntry(database, resolved.sessionKey, next);
   }, toDatabaseOptions(resolved));

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -68,7 +68,7 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
 
 type ResolvedSqliteStoreTarget = {
   agentId?: string;
-  path: string;
+  path?: string;
 };
 
 /** Loads one session entry from the additive SQLite session store. */
@@ -340,16 +340,19 @@ function resolveSqliteReadScope(
 
 function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
   const resolved = path.resolve(storePath);
-  if (path.basename(resolved) !== "sessions.json") {
+  if (path.basename(resolved) === "openclaw-agent.sqlite" || resolved.endsWith(".sqlite")) {
     return { path: resolved };
+  }
+  if (path.basename(resolved) !== "sessions.json") {
+    return {};
   }
   const sessionsDir = path.dirname(resolved);
   if (path.basename(sessionsDir) !== "sessions") {
-    return { path: resolved };
+    return {};
   }
   const agentDir = path.dirname(sessionsDir);
   if (path.basename(path.dirname(agentDir)) !== "agents") {
-    return { path: resolved };
+    return {};
   }
   return {
     agentId: normalizeAgentId(path.basename(agentDir)),

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -66,6 +66,11 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
   sessionId: string;
 };
 
+type ResolvedSqliteStoreTarget = {
+  agentId?: string;
+  path: string;
+};
+
 /** Loads one session entry from the additive SQLite session store. */
 export function loadSqliteSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   const resolved = resolveSqliteScope(scope);
@@ -299,12 +304,15 @@ function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
 function resolveSqliteScope(
   scope: Pick<SessionAccessScope, "agentId" | "env" | "sessionKey" | "storePath">,
 ): ResolvedSqliteScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
   return {
     agentId: scope.agentId
       ? normalizeAgentId(scope.agentId)
-      : resolveAgentIdFromSessionKey(scope.sessionKey),
+      : (storeTarget?.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey)),
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
     sessionKey: normalizeSqliteSessionKey(scope.sessionKey),
   };
 }
@@ -312,37 +320,41 @@ function resolveSqliteScope(
 function resolveSqliteReadScope(
   scope: Pick<SessionTranscriptReadScope, "agentId" | "env" | "sessionKey" | "storePath">,
 ): ResolvedSqliteReadScope {
+  const storeTarget = scope.storePath
+    ? resolveSqliteTargetFromSessionStorePath(scope.storePath)
+    : undefined;
   const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
   const agentId = scope.agentId
     ? normalizeAgentId(scope.agentId)
-    : sessionKey
-      ? resolveAgentIdFromSessionKey(sessionKey)
-      : undefined;
+    : (storeTarget?.agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined));
   if (!agentId) {
     throw new Error("Cannot resolve SQLite transcript read scope without an agent id");
   }
   return {
     agentId,
     ...(scope.env ? { env: scope.env } : {}),
-    ...(scope.storePath ? { path: resolveSqlitePathFromSessionStorePath(scope.storePath) } : {}),
+    ...(storeTarget ? { path: storeTarget.path } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };
 }
 
-function resolveSqlitePathFromSessionStorePath(storePath: string): string {
+function resolveSqliteTargetFromSessionStorePath(storePath: string): ResolvedSqliteStoreTarget {
   const resolved = path.resolve(storePath);
   if (path.basename(resolved) !== "sessions.json") {
-    return resolved;
+    return { path: resolved };
   }
   const sessionsDir = path.dirname(resolved);
   if (path.basename(sessionsDir) !== "sessions") {
-    return resolved;
+    return { path: resolved };
   }
   const agentDir = path.dirname(sessionsDir);
   if (path.basename(path.dirname(agentDir)) !== "agents") {
-    return resolved;
+    return { path: resolved };
   }
-  return path.join(agentDir, "agent", "openclaw-agent.sqlite");
+  return {
+    agentId: normalizeAgentId(path.basename(agentDir)),
+    path: path.join(agentDir, "agent", "openclaw-agent.sqlite"),
+  };
 }
 
 function resolveSqliteTranscriptScope(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -45,7 +45,13 @@ import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js
 
 type SessionSqliteDatabase = Pick<
   OpenClawAgentKyselyDatabase,
-  "session_entries" | "sessions" | "transcript_event_identities" | "transcript_events"
+  | "conversations"
+  | "session_conversations"
+  | "session_entries"
+  | "session_routes"
+  | "sessions"
+  | "transcript_event_identities"
+  | "transcript_events"
 >;
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_entries"]>;
 
@@ -525,6 +531,17 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return structuredClone(entry);
 }
 
+function normalizeSqliteText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeSqliteChatType(value: unknown): "direct" | "group" | "channel" | null {
+  if (value === "direct" || value === "group" || value === "channel") {
+    return value;
+  }
+  return null;
+}
+
 function normalizeSqliteNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value;
 }
@@ -727,6 +744,10 @@ function cleanupSqliteSessionLifecycleArtifactsInTransaction(
     }
     executeSqliteQuerySync(
       database.db,
+      db.deleteFrom("session_routes").where("session_key", "=", row.session_key),
+    );
+    executeSqliteQuerySync(
+      database.db,
       db.deleteFrom("session_entries").where("session_key", "=", row.session_key),
     );
     removedSessionIds.add(row.session_id);
@@ -759,23 +780,37 @@ function writeSessionEntry(
 ): void {
   const db = getSessionKysely(database.db);
   const updatedAt = entry.updatedAt;
+  const sessionRow = bindSqliteSessionRoot({ entry, sessionKey, updatedAt });
   executeSqliteQuerySync(
     database.db,
     db
       .insertInto("sessions")
-      .values({
-        session_id: entry.sessionId,
-        session_key: sessionKey,
-        created_at: entry.sessionStartedAt ?? updatedAt,
-        updated_at: updatedAt,
-      })
+      .values(sessionRow)
       .onConflict((conflict) =>
         conflict.column("session_id").doUpdateSet({
           session_key: sessionKey,
+          session_scope: sessionRow.session_scope,
           updated_at: updatedAt,
+          started_at: sessionRow.started_at,
+          ended_at: sessionRow.ended_at,
+          status: sessionRow.status,
+          chat_type: sessionRow.chat_type,
+          channel: sessionRow.channel,
+          account_id: sessionRow.account_id,
+          model_provider: sessionRow.model_provider,
+          model: sessionRow.model,
+          agent_harness_id: sessionRow.agent_harness_id,
+          parent_session_key: sessionRow.parent_session_key,
+          spawned_by: sessionRow.spawned_by,
+          display_name: sessionRow.display_name,
         }),
       ),
   );
+  writeSessionRoute(database, {
+    sessionId: sessionRow.session_id,
+    sessionKey,
+    updatedAt,
+  });
   executeSqliteQuerySync(
     database.db,
     db
@@ -809,6 +844,7 @@ function ensureTranscriptSessionRoot(
       .values({
         session_id: scope.sessionId,
         session_key: scope.sessionKey,
+        session_scope: "conversation",
         created_at: updatedAt,
         updated_at: updatedAt,
       })
@@ -818,6 +854,118 @@ function ensureTranscriptSessionRoot(
           updated_at: updatedAt,
         }),
       ),
+  );
+  writeSessionRoute(database, {
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    updatedAt,
+  });
+}
+
+function bindSqliteSessionRoot(params: {
+  entry: SessionEntry;
+  sessionKey: string;
+  updatedAt: number;
+}) {
+  const updatedAt = Number.isFinite(params.entry.updatedAt)
+    ? params.entry.updatedAt
+    : params.updatedAt;
+  return {
+    session_id: params.entry.sessionId,
+    session_key: params.sessionKey,
+    session_scope: resolveSqliteSessionScope(params.entry, params.sessionKey),
+    created_at: resolveSqliteSessionCreatedAt(params.entry, updatedAt),
+    updated_at: updatedAt,
+    started_at: finiteSqliteNumber(params.entry.startedAt),
+    ended_at: finiteSqliteNumber(params.entry.endedAt),
+    status: normalizeSqliteText(params.entry.status),
+    chat_type: normalizeSqliteChatType(params.entry.chatType),
+    channel: resolveSqliteSessionChannel(params.entry),
+    account_id: resolveSqliteSessionAccountId(params.entry),
+    primary_conversation_id: null,
+    model_provider: normalizeSqliteText(params.entry.modelProvider),
+    model: normalizeSqliteText(params.entry.model),
+    agent_harness_id: normalizeSqliteText(params.entry.agentHarnessId),
+    parent_session_key: normalizeSqliteText(params.entry.parentSessionKey),
+    spawned_by: normalizeSqliteText(params.entry.spawnedBy),
+    display_name: resolveSqliteSessionDisplayName(params.entry),
+  };
+}
+
+function writeSessionRoute(
+  database: OpenClawAgentDatabase,
+  params: { sessionId: string; sessionKey: string; updatedAt: number },
+): void {
+  const db = getSessionKysely(database.db);
+  executeSqliteQuerySync(
+    database.db,
+    db
+      .insertInto("session_routes")
+      .values({
+        session_key: params.sessionKey,
+        session_id: params.sessionId,
+        updated_at: params.updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_key").doUpdateSet({
+          session_id: params.sessionId,
+          updated_at: params.updatedAt,
+        }),
+      ),
+  );
+}
+
+function resolveSqliteSessionScope(
+  entry: Pick<SessionEntry, "chatType">,
+  sessionKey: string,
+): "conversation" | "shared-main" | "group" | "channel" {
+  const chatType = normalizeSqliteChatType(entry.chatType);
+  const normalizedKey = sessionKey.trim().toLowerCase();
+  if (chatType === "direct" && (normalizedKey === "main" || normalizedKey.endsWith(":main"))) {
+    return "shared-main";
+  }
+  if (chatType === "group" || chatType === "channel") {
+    return chatType;
+  }
+  return "conversation";
+}
+
+function resolveSqliteSessionCreatedAt(entry: SessionEntry, updatedAt: number): number {
+  for (const candidate of [entry.sessionStartedAt, entry.startedAt, entry.updatedAt, updatedAt]) {
+    if (typeof candidate === "number" && Number.isFinite(candidate) && candidate >= 0) {
+      return candidate;
+    }
+  }
+  return updatedAt;
+}
+
+function finiteSqliteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function resolveSqliteSessionChannel(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.channel) ??
+    normalizeSqliteText(entry.deliveryContext?.channel) ??
+    normalizeSqliteText(entry.lastChannel) ??
+    normalizeSqliteText(entry.origin?.provider)
+  );
+}
+
+function resolveSqliteSessionAccountId(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.deliveryContext?.accountId) ??
+    normalizeSqliteText(entry.lastAccountId) ??
+    normalizeSqliteText(entry.origin?.accountId)
+  );
+}
+
+function resolveSqliteSessionDisplayName(entry: SessionEntry): string | null {
+  return (
+    normalizeSqliteText(entry.displayName) ??
+    normalizeSqliteText(entry.label) ??
+    normalizeSqliteText(entry.subject) ??
+    normalizeSqliteText(entry.groupId)
   );
 }
 

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import type { Selectable } from "kysely";
@@ -21,6 +22,7 @@ import {
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
+import { validateSessionId } from "./paths.js";
 import type {
   ExactSessionEntry,
   SessionAccessScope,
@@ -32,6 +34,7 @@ import type {
   SessionEntryUpdateOptions,
   SessionTranscriptAccessScope,
   SessionTranscriptReadScope,
+  SessionTranscriptRuntimeTarget,
   SessionTranscriptWriteScope,
   TranscriptEvent,
   TranscriptMessageAppendOptions,
@@ -80,6 +83,17 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
 type ResolvedSqliteStoreTarget = {
   agentId?: string;
   path?: string;
+};
+
+export type SqliteSessionTranscriptRuntimeTarget = Omit<
+  SessionTranscriptRuntimeTarget,
+  "storageKind" | "targetKind"
+> & {
+  /** Current embedded-run internals still need one lock/fence/session-manager file. */
+  activeArtifactKind: "embedded-run-session-file";
+  sqlitePath: string;
+  storageKind: "sqlite";
+  targetKind: "sqlite-runtime-session";
 };
 
 const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
@@ -399,8 +413,85 @@ export async function publishSqliteTranscriptUpdate(
   });
 }
 
+/** Resolves SQLite runtime identity plus the active artifact used by current runners. */
+export async function resolveSqliteSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptAccessScope,
+): Promise<SqliteSessionTranscriptRuntimeTarget> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const sqlitePath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
+  const defaultSessionFile = resolveSqliteEmbeddedRunSessionFile(sqlitePath, resolved.sessionId);
+  const now = Date.now();
+  const entry = await patchSqliteSessionEntry(
+    scope,
+    (current) => {
+      const currentSessionFile = resolveCurrentSqliteEmbeddedRunSessionFile(
+        sqlitePath,
+        current.sessionFile,
+      );
+      const sessionFile =
+        current.sessionId?.trim() === resolved.sessionId && currentSessionFile
+          ? currentSessionFile
+          : defaultSessionFile;
+
+      // Current embedded-run internals still rotate a file-backed active artifact
+      // after compaction. Persist that pointer in SQLite so the next run reopens
+      // the live branch instead of reconstructing the pre-rotation path.
+      return { sessionFile, sessionId: resolved.sessionId, updatedAt: now };
+    },
+    {
+      fallbackEntry: {
+        sessionFile: defaultSessionFile,
+        sessionId: resolved.sessionId,
+        updatedAt: now,
+      },
+    },
+  );
+  const sessionId = entry?.sessionId?.trim() || resolved.sessionId;
+  const sessionFile =
+    resolveCurrentSqliteEmbeddedRunSessionFile(sqlitePath, entry?.sessionFile) ??
+    resolveSqliteEmbeddedRunSessionFile(sqlitePath, sessionId);
+  await fs.mkdir(path.dirname(sessionFile), { recursive: true, mode: 0o700 });
+  return {
+    activeArtifactKind: "embedded-run-session-file",
+    agentId: resolved.agentId,
+    sessionFile,
+    sessionId,
+    sessionKey: resolved.sessionKey,
+    sqlitePath,
+    storageKind: "sqlite",
+    targetKind: "sqlite-runtime-session",
+  };
+}
+
 function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);
+}
+
+function resolveSqliteEmbeddedRunSessionFile(sqlitePath: string, sessionId: string): string {
+  return path.join(
+    resolveSqliteEmbeddedRunSessionFileDir(sqlitePath),
+    `${validateSessionId(sessionId)}.jsonl`,
+  );
+}
+
+function resolveSqliteEmbeddedRunSessionFileDir(sqlitePath: string): string {
+  return path.join(path.dirname(sqlitePath), "embedded-run-session-files");
+}
+
+function resolveCurrentSqliteEmbeddedRunSessionFile(
+  sqlitePath: string,
+  sessionFile: string | undefined,
+): string | undefined {
+  const trimmed = sessionFile?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const artifactDir = path.resolve(resolveSqliteEmbeddedRunSessionFileDir(sqlitePath));
+  const candidate = path.resolve(trimmed);
+  const relative = path.relative(artifactDir, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative)
+    ? trimmed
+    : undefined;
 }
 
 async function runExclusiveSqliteSessionWrite<T>(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -779,8 +779,9 @@ function writeSessionEntry(
   entry: SessionEntry,
 ): void {
   const db = getSessionKysely(database.db);
-  const updatedAt = entry.updatedAt;
-  const sessionRow = bindSqliteSessionRoot({ entry, sessionKey, updatedAt });
+  const normalizedEntry = normalizeSqliteSessionEntryTimestamp(entry);
+  const updatedAt = normalizedEntry.updatedAt;
+  const sessionRow = bindSqliteSessionRoot({ entry: normalizedEntry, sessionKey, updatedAt });
   executeSqliteQuerySync(
     database.db,
     db
@@ -817,18 +818,32 @@ function writeSessionEntry(
       .insertInto("session_entries")
       .values({
         session_key: sessionKey,
-        session_id: entry.sessionId,
-        entry_json: JSON.stringify(entry),
+        session_id: normalizedEntry.sessionId,
+        entry_json: JSON.stringify(normalizedEntry),
         updated_at: updatedAt,
       })
       .onConflict((conflict) =>
         conflict.column("session_key").doUpdateSet({
-          session_id: entry.sessionId,
-          entry_json: JSON.stringify(entry),
+          session_id: normalizedEntry.sessionId,
+          entry_json: JSON.stringify(normalizedEntry),
           updated_at: updatedAt,
         }),
       ),
   );
+}
+
+function normalizeSqliteSessionEntryTimestamp(entry: SessionEntry): SessionEntry {
+  if (typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)) {
+    return entry;
+  }
+  const updatedAt =
+    typeof entry.sessionStartedAt === "number" && Number.isFinite(entry.sessionStartedAt)
+      ? entry.sessionStartedAt
+      : Date.now();
+  return {
+    ...entry,
+    updatedAt,
+  };
 }
 
 function ensureTranscriptSessionRoot(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -208,6 +208,34 @@ describe("session accessor file-backed seam", () => {
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
+  it("can patch metadata without refreshing session activity", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforePatch = loadSessionEntry(scope);
+
+    await patchSessionEntry(
+      scope,
+      () => ({
+        model: "gpt-5.5",
+        updatedAt: 20,
+      }),
+      { preserveActivity: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: beforePatch?.updatedAt,
+    });
+  });
+
   it("loads and appends transcript events through a session scope", async () => {
     const scope = {
       sessionFile: transcriptPath,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -13,6 +13,7 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import { loadSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -159,13 +160,18 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    let missingContextEntry: SessionEntry | undefined;
+    let existingContextEntry: SessionEntry | undefined;
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: "gpt-5.5",
-      }),
+      (entry, context) => {
+        missingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: "gpt-5.5",
+        };
+      },
       {
         fallbackEntry: {
           sessionId: "session-1",
@@ -177,14 +183,19 @@ describe("session accessor file-backed seam", () => {
 
     await patchSessionEntry(
       scope,
-      (entry) => ({
-        ...entry,
-        model: undefined,
-        providerOverride: "openai",
-      }),
+      (entry, context) => {
+        existingContextEntry = context.existingEntry;
+        return {
+          ...entry,
+          model: undefined,
+          providerOverride: "openai",
+        };
+      },
       { replaceEntry: true },
     );
 
+    expect(missingContextEntry).toBeUndefined();
+    expect(existingContextEntry).toMatchObject({ model: "gpt-5.5" });
     expect(loadSessionEntry(scope)).toMatchObject({
       providerOverride: "openai",
       sessionId: "session-1",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -124,6 +125,32 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("replaces entries so deleted fields stay removed", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      providerOverride: "openai",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    await replaceSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 20,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
+    expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
 
@@ -75,6 +76,34 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("updates existing entries without creating missing sessions", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await expect(updateSessionEntry(scope, () => ({ model: "gpt-5.5" }))).resolves.toBeNull();
+    expect(listSessionEntries({ storePath })).toEqual([]);
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const beforeNullUpdate = loadSessionEntry(scope);
+    await expect(updateSessionEntry(scope, () => null)).resolves.toEqual(beforeNullUpdate);
+    expect(loadSessionEntry(scope)).toMatchObject({
+      sessionId: "session-1",
+      updatedAt: beforeNullUpdate?.updatedAt,
+    });
+    await expect(
+      updateSessionEntry(scope, () => ({ model: "gpt-5.5", updatedAt: 20 })),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  listSessionEntries,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntry,
+} from "./session-accessor.js";
+
+describe("session accessor file-backed seam", () => {
+  let tempDir: string;
+  let storePath: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-accessor-"));
+    storePath = path.join(tempDir, "sessions.json");
+    transcriptPath = path.join(tempDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads, lists, and patches session entries without exposing the file store shape", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "gpt-5.5",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+    expect(listSessionEntries({ storePath })).toEqual([
+      {
+        sessionKey: "agent:main:main",
+        entry: expect.objectContaining({
+          model: "gpt-5.5",
+          sessionId: "session-1",
+          updatedAt: expect.any(Number),
+        }),
+      },
+    ]);
+
+    await upsertSessionEntry(scope, { model: "sonnet-4.6", updatedAt: 20 });
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      model: "sonnet-4.6",
+      sessionId: "session-1",
+      updatedAt: expect.any(Number),
+    });
+  });
+
+  it("creates durable session ids for metadata-only inserts", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    const inserted = await upsertSessionEntry(scope, { model: "gpt-5.5" });
+
+    expect(inserted?.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(inserted?.sessionId).not.toBe(scope.sessionKey);
+    expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("loads and appends transcript events through a session scope", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(scope, { type: "session", sessionId: "session-1" });
+    await appendTranscriptEvent(scope, event);
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      { type: "session", sessionId: "session-1" },
+      event,
+    ]);
+    expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("honors thread fallback paths when resolving transcript scope from the store", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:demo-channel:1234:thread:456",
+      storePath,
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(scope, event);
+
+    const expectedTranscriptPath = path.join(tempDir, "session-1-topic-456.jsonl");
+    expect(fs.existsSync(expectedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "session-1.jsonl"))).toBe(false);
+    expect(fs.realpathSync(loadSessionEntry(scope)?.sessionFile ?? "")).toBe(
+      fs.realpathSync(expectedTranscriptPath),
+    );
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("persists transcript metadata under the normalized session key", async () => {
+    const canonicalScope = {
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(canonicalScope, {
+      sessionId: canonicalScope.sessionId,
+      updatedAt: 10,
+    });
+    await appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: canonicalScope.sessionId,
+        sessionKey: "AGENT:MAIN:MAIN",
+        storePath,
+      },
+      { id: "msg-1", type: "message" },
+    );
+
+    expect(listSessionEntries({ storePath }).map((entry) => entry.sessionKey)).toEqual([
+      canonicalScope.sessionKey,
+    ]);
+    expect(loadSessionEntry(canonicalScope)?.sessionFile).toBeTruthy();
+  });
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -10,6 +10,7 @@ import {
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
+import { loadSessionStore } from "./store.js";
 
 describe("session accessor file-backed seam", () => {
   let tempDir: string;
@@ -76,6 +77,25 @@ describe("session accessor file-backed seam", () => {
     );
     expect(inserted?.sessionId).not.toBe(scope.sessionKey);
     expect(loadSessionEntry(scope)?.sessionId).toBe(inserted?.sessionId);
+  });
+
+  it("can borrow cached entry objects for read-only hot paths", async () => {
+    const scope = {
+      clone: false,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntry(scope, {
+      sessionId: "session-1",
+      updatedAt: 10,
+    });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+
+    expect(loadSessionEntry(scope)).toBe(cachedStore["agent:main:main"]);
+    expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
+      cachedStore["agent:main:main"],
+    );
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
+  publishTranscriptUpdate,
+  readSessionUpdatedAt,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -47,6 +51,7 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+    expect(readSessionUpdatedAt(scope)).toEqual(expect.any(Number));
     expect(listSessionEntries({ storePath })).toEqual([
       {
         sessionKey: "agent:main:main",
@@ -225,6 +230,75 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("appends messages and publishes updates through a session scope", async () => {
+    const scope = {
+      agentId: "main",
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => {
+      updates.push(update);
+    });
+
+    const appended = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    const replayed = await appendTranscriptMessage(scope, {
+      cwd: tempDir,
+      idempotencyLookup: "scan",
+      message: {
+        role: "assistant",
+        content: "hello again",
+        idempotencyKey: "assistant-once",
+      },
+    });
+    await publishTranscriptUpdate(scope, {
+      agentId: "main",
+      message: appended.message,
+      messageId: appended.messageId,
+      sessionKey: scope.sessionKey,
+    });
+    unsubscribe();
+
+    expect(replayed).toMatchObject({
+      appended: false,
+      messageId: appended.messageId,
+      message: expect.objectContaining({
+        content: "hello",
+        idempotencyKey: "assistant-once",
+      }),
+    });
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({ type: "session" }),
+      expect.objectContaining({
+        id: appended.messageId,
+        message: expect.objectContaining({
+          content: "hello",
+          idempotencyKey: "assistant-once",
+        }),
+        type: "message",
+      }),
+    ]);
+    expect(updates).toEqual([
+      {
+        agentId: "main",
+        message: appended.message,
+        messageId: appended.messageId,
+        sessionFile: transcriptPath,
+        sessionKey: scope.sessionKey,
+      },
+    ]);
   });
 
   it("honors thread fallback paths when resolving transcript scope from the store", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -270,18 +270,21 @@ describe("session accessor file-backed seam", () => {
   it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
     const nowMs = Date.now();
     const oldDate = new Date(nowMs - 600_000);
-    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
-    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
-    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
-    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
-    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
-    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
-    const siblingDir = `${tempDir}-sibling-sessions`;
+    const lifecycleSessionsDir = path.join(tempDir, "state", "agents", "main", "sessions");
+    const lifecycleStorePath = path.join(lifecycleSessionsDir, "sessions.json");
+    const removedTranscriptPath = path.join(lifecycleSessionsDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(lifecycleSessionsDir, "custom-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(lifecycleSessionsDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(lifecycleSessionsDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(lifecycleSessionsDir, "orphan-lifecycle.jsonl");
+    const siblingDir = path.join(tempDir, "state", "agents", "sibling", "sessions");
     const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(lifecycleSessionsDir, { recursive: true });
     fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
-      storePath,
+      lifecycleStorePath,
       JSON.stringify({
         "agent:main:lifecycle-cleanup-removed": {
           sessionId: "removed-lifecycle",
@@ -324,7 +327,7 @@ describe("session accessor file-backed seam", () => {
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
     const result = await cleanupSessionLifecycleArtifacts({
-      storePath,
+      storePath: lifecycleStorePath,
       sessionKeySegmentPrefix: "lifecycle-cleanup-",
       transcriptContentMarker: "lifecycle-marker-",
       orphanTranscriptMinAgeMs: 300_000,
@@ -332,14 +335,14 @@ describe("session accessor file-backed seam", () => {
     });
 
     expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
-    const loaded = loadSessionStore(storePath, { skipCache: true });
+    const loaded = loadSessionStore(lifecycleStorePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
-    const files = fs.readdirSync(tempDir);
+    const files = fs.readdirSync(lifecycleSessionsDir);
     expect(
       files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
     ).toHaveLength(1);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   appendTranscriptMessage,
   appendTranscriptEvent,
   listSessionEntries,
+  loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
   patchSessionEntry,
@@ -104,6 +105,35 @@ describe("session accessor file-backed seam", () => {
     expect(listSessionEntries({ clone: false, storePath })[0]?.entry).toBe(
       cachedStore["agent:main:main"],
     );
+  });
+
+  it("keeps exact persisted-key lookup separate from canonical entry reads", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "session-1",
+          updatedAt: 10,
+          model: "gpt-5.5",
+        },
+      }),
+      "utf8",
+    );
+
+    const mixedCaseScope = {
+      sessionKey: "AGENT:MAIN:MAIN",
+      storePath,
+    };
+
+    expect(loadSessionEntry(mixedCaseScope)?.sessionId).toBe("session-1");
+    expect(loadExactSessionEntry(mixedCaseScope)).toBeUndefined();
+    expect(loadExactSessionEntry({ sessionKey: "agent:main:main", storePath })).toEqual({
+      sessionKey: "agent:main:main",
+      entry: expect.objectContaining({
+        sessionId: "session-1",
+        model: "gpt-5.5",
+      }),
+    });
   });
 
   it("updates existing entries without creating missing sessions", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -232,6 +232,48 @@ describe("session accessor file-backed seam", () => {
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
   });
 
+  it("loads transcript events without a session key when the read target is explicit", async () => {
+    const scope = {
+      sessionFile: transcriptPath,
+      sessionId: "session-1",
+    };
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    await appendTranscriptEvent(
+      {
+        ...scope,
+        sessionKey: "agent:main:main",
+        storePath,
+      },
+      event,
+    );
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
+  });
+
+  it("loads transcript events from a generated read target without a session key", async () => {
+    const event = {
+      id: "msg-1",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+      type: "message",
+    };
+
+    fs.writeFileSync(path.join(tempDir, "session-1.jsonl"), `${JSON.stringify(event)}\n`, "utf-8");
+
+    await expect(
+      loadTranscriptEvents({
+        sessionId: "session-1",
+        storePath,
+      }),
+    ).resolves.toEqual([event]);
+  });
+
   it("appends messages and publishes updates through a session scope", async () => {
     const scope = {
       agentId: "main",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,7 @@ import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
+  cleanupSessionLifecycleArtifacts,
   listSessionEntries,
   loadExactSessionEntry,
   loadSessionEntry,
@@ -264,6 +265,69 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: beforePatch?.updatedAt,
     });
+  });
+
+  it("cleans scoped lifecycle entries and unreferenced transcript artifacts", async () => {
+    const nowMs = Date.now();
+    const oldDate = new Date(nowMs - 600_000);
+    const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
+    const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
+    const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
+    const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:lifecycle-cleanup-removed": {
+          sessionId: "removed-lifecycle",
+        },
+        "agent:main:lifecycle-cleanup-fresh": {
+          sessionId: "fresh-lifecycle",
+        },
+        "agent:main:telegram:group:lifecycle-cleanup-room": {
+          sessionId: "kept-by-segment",
+        },
+        "agent:main:regular": {
+          sessionId: "referenced",
+        },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(removedTranscriptPath, '{"runId":"lifecycle-marker-removed"}\n', "utf-8");
+    fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(
+      referencedTranscriptPath,
+      '{"runId":"lifecycle-marker-referenced"}\n',
+      "utf-8",
+    );
+    fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
+    fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
+
+    const result = await cleanupSessionLifecycleArtifacts({
+      storePath,
+      sessionKeySegmentPrefix: "lifecycle-cleanup-",
+      transcriptContentMarker: "lifecycle-marker-",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs,
+    });
+
+    expect(result).toEqual({ removedEntries: 1, archivedTranscriptArtifacts: 2 });
+    const loaded = loadSessionStore(storePath, { skipCache: true });
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
+    expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
+    expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
+    expect(loaded).toHaveProperty("agent:main:regular");
+    const files = fs.readdirSync(tempDir);
+    expect(
+      files.filter((file) => file.startsWith("removed-lifecycle.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted."))).toHaveLength(
+      1,
+    );
+    expect(files).toContain("fresh-lifecycle.jsonl");
+    expect(files).toContain("referenced.jsonl");
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadSessionEntry,
   loadTranscriptEvents,
+  patchSessionEntry,
   replaceSessionEntry,
   updateSessionEntry,
   upsertSessionEntry,
@@ -151,6 +152,44 @@ describe("session accessor file-backed seam", () => {
     });
     expect(loadSessionEntry(scope)?.model).toBeUndefined();
     expect(loadSessionEntry(scope)?.providerOverride).toBeUndefined();
+  });
+
+  it("patches entries atomically with a fallback entry", async () => {
+    const scope = {
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: "gpt-5.5",
+      }),
+      {
+        fallbackEntry: {
+          sessionId: "session-1",
+          updatedAt: 10,
+        },
+        replaceEntry: true,
+      },
+    );
+
+    await patchSessionEntry(
+      scope,
+      (entry) => ({
+        ...entry,
+        model: undefined,
+        providerOverride: "openai",
+      }),
+      { replaceEntry: true },
+    );
+
+    expect(loadSessionEntry(scope)).toMatchObject({
+      providerOverride: "openai",
+      sessionId: "session-1",
+    });
+    expect(loadSessionEntry(scope)?.model).toBeUndefined();
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -271,6 +271,8 @@ describe("session accessor file-backed seam", () => {
     const nowMs = Date.now();
     const oldDate = new Date(nowMs - 600_000);
     const removedTranscriptPath = path.join(tempDir, "removed-lifecycle.jsonl");
+    const customTranscriptPath = path.join(tempDir, "custom-lifecycle-old.jsonl");
+    const freshDefaultTranscriptPath = path.join(tempDir, "custom-lifecycle.jsonl");
     const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
     const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
     const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
@@ -284,6 +286,10 @@ describe("session accessor file-backed seam", () => {
         "agent:main:lifecycle-cleanup-fresh": {
           sessionId: "fresh-lifecycle",
         },
+        "agent:main:lifecycle-cleanup-custom": {
+          sessionFile: "custom-lifecycle-old.jsonl",
+          sessionId: "custom-lifecycle",
+        },
         "agent:main:telegram:group:lifecycle-cleanup-room": {
           sessionId: "kept-by-segment",
         },
@@ -294,6 +300,8 @@ describe("session accessor file-backed seam", () => {
       "utf-8",
     );
     fs.writeFileSync(removedTranscriptPath, '{"runId":"lifecycle-marker-removed"}\n', "utf-8");
+    fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
+    fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
     fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
     fs.writeFileSync(
       referencedTranscriptPath,
@@ -302,6 +310,7 @@ describe("session accessor file-backed seam", () => {
     );
     fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
     fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(customTranscriptPath, oldDate, oldDate);
     fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
@@ -313,9 +322,10 @@ describe("session accessor file-backed seam", () => {
       nowMs,
     });
 
-    expect(result).toEqual({ removedEntries: 1, archivedTranscriptArtifacts: 2 });
+    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
     const loaded = loadSessionStore(storePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
@@ -326,6 +336,10 @@ describe("session accessor file-backed seam", () => {
     expect(files.filter((file) => file.startsWith("orphan-lifecycle.jsonl.deleted."))).toHaveLength(
       1,
     );
+    expect(
+      files.filter((file) => file.startsWith("custom-lifecycle-old.jsonl.deleted.")),
+    ).toHaveLength(1);
+    expect(files).toContain("custom-lifecycle.jsonl");
     expect(files).toContain("fresh-lifecycle.jsonl");
     expect(files).toContain("referenced.jsonl");
   });

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -276,6 +276,9 @@ describe("session accessor file-backed seam", () => {
     const freshTranscriptPath = path.join(tempDir, "fresh-lifecycle.jsonl");
     const referencedTranscriptPath = path.join(tempDir, "referenced.jsonl");
     const orphanTranscriptPath = path.join(tempDir, "orphan-lifecycle.jsonl");
+    const siblingDir = `${tempDir}-sibling-sessions`;
+    const siblingTranscriptPath = path.join(siblingDir, "sibling-lifecycle.jsonl");
+    fs.mkdirSync(siblingDir, { recursive: true });
 
     fs.writeFileSync(
       storePath,
@@ -290,6 +293,10 @@ describe("session accessor file-backed seam", () => {
           sessionFile: "custom-lifecycle-old.jsonl",
           sessionId: "custom-lifecycle",
         },
+        "agent:main:lifecycle-cleanup-sibling": {
+          sessionFile: siblingTranscriptPath,
+          sessionId: "sibling-lifecycle",
+        },
         "agent:main:telegram:group:lifecycle-cleanup-room": {
           sessionId: "kept-by-segment",
         },
@@ -303,6 +310,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(customTranscriptPath, '{"runId":"lifecycle-marker-custom"}\n', "utf-8");
     fs.writeFileSync(freshDefaultTranscriptPath, '{"runId":"lifecycle-marker-default"}\n', "utf-8");
     fs.writeFileSync(freshTranscriptPath, '{"runId":"lifecycle-marker-fresh"}\n', "utf-8");
+    fs.writeFileSync(siblingTranscriptPath, '{"runId":"lifecycle-marker-sibling"}\n', "utf-8");
     fs.writeFileSync(
       referencedTranscriptPath,
       '{"runId":"lifecycle-marker-referenced"}\n',
@@ -311,6 +319,7 @@ describe("session accessor file-backed seam", () => {
     fs.writeFileSync(orphanTranscriptPath, '{"runId":"lifecycle-marker-orphan"}\n', "utf-8");
     fs.utimesSync(removedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(customTranscriptPath, oldDate, oldDate);
+    fs.utimesSync(siblingTranscriptPath, oldDate, oldDate);
     fs.utimesSync(referencedTranscriptPath, oldDate, oldDate);
     fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
 
@@ -322,10 +331,11 @@ describe("session accessor file-backed seam", () => {
       nowMs,
     });
 
-    expect(result).toEqual({ removedEntries: 2, archivedTranscriptArtifacts: 3 });
+    expect(result).toEqual({ removedEntries: 3, archivedTranscriptArtifacts: 3 });
     const loaded = loadSessionStore(storePath, { skipCache: true });
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-removed");
     expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-custom");
+    expect(loaded).not.toHaveProperty("agent:main:lifecycle-cleanup-sibling");
     expect(loaded).toHaveProperty("agent:main:lifecycle-cleanup-fresh");
     expect(loaded).toHaveProperty("agent:main:telegram:group:lifecycle-cleanup-room");
     expect(loaded).toHaveProperty("agent:main:regular");
@@ -342,6 +352,8 @@ describe("session accessor file-backed seam", () => {
     expect(files).toContain("custom-lifecycle.jsonl");
     expect(files).toContain("fresh-lifecycle.jsonl");
     expect(files).toContain("referenced.jsonl");
+    expect(fs.existsSync(siblingTranscriptPath)).toBe(true);
+    expect(fs.readdirSync(siblingDir)).toEqual(["sibling-lifecycle.jsonl"]);
   });
 
   it("loads and appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { resolveAndPersistSessionFile } from "./session-file.js";
+import {
+  getSessionEntry,
+  listSessionEntries as listFileSessionEntries,
+  loadSessionStore,
+  patchSessionEntry as patchFileSessionEntry,
+  resolveSessionStoreEntry,
+} from "./store.js";
+import { parseSessionThreadInfo } from "./thread-info.js";
+import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import { resolveSessionTranscriptFile } from "./transcript.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionAccessScope = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  sessionKey: string;
+  storePath?: string;
+};
+
+export type SessionTranscriptAccessScope = SessionAccessScope & {
+  sessionFile?: string;
+  sessionId: string;
+  threadId?: string | number;
+};
+
+export type SessionEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type TranscriptEvent = unknown;
+
+/** Loads one session entry through the storage-neutral accessor seam. */
+export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  return getSessionEntry(scope);
+}
+
+/** Lists session entries through the storage-neutral accessor seam. */
+export function listSessionEntries(
+  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+): SessionEntrySummary[] {
+  return listFileSessionEntries(scope);
+}
+
+/** Applies a partial entry update through the storage-neutral accessor seam. */
+export async function upsertSessionEntry(
+  scope: SessionAccessScope,
+  patch: Partial<SessionEntry>,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: createFallbackSessionEntry(patch),
+    update: () => patch,
+  });
+}
+
+/** Loads raw transcript events through the storage-neutral accessor seam. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptAccessScope,
+): Promise<TranscriptEvent[]> {
+  const transcript = await resolveTranscriptAccess(scope);
+  const events: TranscriptEvent[] = [];
+  for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+    events.push(JSON.parse(line) as TranscriptEvent);
+  }
+  return events;
+}
+
+/** Appends one raw transcript event through the storage-neutral accessor seam. */
+export async function appendTranscriptEvent(
+  scope: SessionTranscriptAccessScope,
+  event: TranscriptEvent,
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  await appendSessionTranscriptEvent({
+    event,
+    transcriptPath: transcript.sessionFile,
+  });
+}
+
+function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
+  const now = Date.now();
+  return {
+    sessionId: patch.sessionId ?? randomUUID(),
+    updatedAt: patch.updatedAt ?? now,
+    ...patch,
+  };
+}
+
+async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const sessionStore = scope.storePath
+    ? loadSessionStore(scope.storePath, { skipCache: true })
+    : undefined;
+  const resolvedStoreEntry = sessionStore
+    ? resolveSessionStoreEntry({ store: sessionStore, sessionKey: scope.sessionKey })
+    : undefined;
+  const sessionEntry = resolvedStoreEntry?.existing ?? loadSessionEntry(scope);
+  const sessionKey = resolvedStoreEntry?.normalizedKey ?? scope.sessionKey;
+  if (sessionStore && scope.storePath) {
+    const sessionsDir = path.dirname(path.resolve(scope.storePath));
+    const threadId = scope.threadId ?? parseSessionThreadInfo(scope.sessionKey).threadId;
+    const fallbackSessionFile =
+      !sessionEntry?.sessionFile && threadId !== undefined
+        ? resolveSessionTranscriptPathInDir(scope.sessionId, sessionsDir, threadId)
+        : undefined;
+    return await resolveAndPersistSessionFile({
+      agentId,
+      fallbackSessionFile,
+      sessionEntry,
+      sessionId: scope.sessionId,
+      sessionKey,
+      sessionStore,
+      sessionsDir,
+      storePath: scope.storePath,
+    });
+  }
+  return await resolveSessionTranscriptFile({
+    agentId,
+    sessionEntry,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    ...(sessionStore ? { sessionStore } : {}),
+    ...(scope.storePath ? { storePath: scope.storePath } : {}),
+    ...(scope.threadId !== undefined ? { threadId: scope.threadId } : {}),
+  });
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -13,12 +13,15 @@ import {
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
+  cleanupSessionLifecycleArtifacts as cleanupFileSessionLifecycleArtifacts,
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
+  type SessionLifecycleArtifactCleanupParams,
+  type SessionLifecycleArtifactCleanupResult,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import {
@@ -98,6 +101,8 @@ export type SessionEntryPatchOptions = {
 export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
+
+export type { SessionLifecycleArtifactCleanupParams, SessionLifecycleArtifactCleanupResult };
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
@@ -212,6 +217,13 @@ export async function updateSessionEntry(
     takeCacheOwnership: options.takeCacheOwnership,
     update,
   });
+}
+
+/** Cleans scoped session lifecycle entries and transcript artifacts through the accessor seam. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  return await cleanupFileSessionLifecycleArtifacts(params);
 }
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { getRuntimeConfig } from "../io.js";
+import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -9,6 +10,7 @@ import {
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
   resolveSessionStoreEntry,
+  updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptEvent } from "./transcript-append.js";
@@ -37,6 +39,11 @@ export type SessionEntrySummary = {
 
 export type TranscriptEvent = unknown;
 
+export type SessionEntryUpdateOptions = {
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   return getSessionEntry(scope);
@@ -58,6 +65,23 @@ export async function upsertSessionEntry(
     ...scope,
     fallbackEntry: createFallbackSessionEntry(patch),
     update: () => patch,
+  });
+}
+
+/** Updates an existing session entry through the storage-neutral accessor seam. */
+export async function updateSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryUpdateOptions = {},
+): Promise<SessionEntry | null> {
+  return await updateFileSessionStoreEntry({
+    storePath: resolveAccessStorePath(scope),
+    sessionKey: scope.sessionKey,
+    skipMaintenance: options.skipMaintenance,
+    takeCacheOwnership: options.takeCacheOwnership,
+    update,
   });
 }
 
@@ -92,6 +116,17 @@ function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry 
     updatedAt: patch.updatedAt ?? now,
     ...patch,
   };
+}
+
+function resolveAccessStorePath(scope: SessionAccessScope): string {
+  if (scope.storePath) {
+    return scope.storePath;
+  }
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  return resolveStorePath(getRuntimeConfig().session?.store, {
+    agentId,
+    env: scope.env,
+  });
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -84,6 +84,19 @@ export async function upsertSessionEntry(
   });
 }
 
+/** Replaces one entry through the storage-neutral accessor seam. */
+export async function replaceSessionEntry(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: entry,
+    replaceEntry: true,
+    update: () => entry,
+  });
+}
+
 /** Updates an existing session entry through the storage-neutral accessor seam. */
 export async function updateSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
@@ -9,11 +12,15 @@ import {
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   patchSessionEntry as patchFileSessionEntry,
+  readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   updateSessionStoreEntry as updateFileSessionStoreEntry,
 } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
-import { appendSessionTranscriptEvent } from "./transcript-append.js";
+import {
+  appendSessionTranscriptEvent,
+  appendSessionTranscriptMessage,
+} from "./transcript-append.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import { resolveSessionTranscriptFile } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
@@ -33,12 +40,34 @@ export type SessionTranscriptAccessScope = SessionAccessScope & {
   threadId?: string | number;
 };
 
+export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
+  sessionId?: string;
+};
+
 export type SessionEntrySummary = {
   sessionKey: string;
   entry: SessionEntry;
 };
 
 export type TranscriptEvent = unknown;
+
+export type TranscriptMessageAppendOptions<TMessage> = {
+  config?: OpenClawConfig;
+  cwd?: string;
+  idempotencyLookup?: "scan" | "caller-checked";
+  message: TMessage;
+  now?: number;
+  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
+  useRawWhenLinear?: boolean;
+};
+
+export type TranscriptMessageAppendResult<TMessage> = {
+  appended: boolean;
+  message: TMessage;
+  messageId: string;
+};
+
+export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
@@ -79,6 +108,17 @@ export function listSessionEntries(
     ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
   }
   return listFileSessionEntries(scope);
+}
+
+/** Reads a session activity timestamp through the storage-neutral accessor seam. */
+export function readSessionUpdatedAt(scope: SessionAccessScope): number | undefined {
+  if (scope.storePath) {
+    return readFileSessionUpdatedAt({
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+    });
+  }
+  return loadSessionEntry(scope)?.updatedAt;
 }
 
 /** Applies a partial entry update through the storage-neutral accessor seam. */
@@ -164,6 +204,51 @@ export async function appendTranscriptEvent(
   });
 }
 
+/** Appends one transcript message through the storage-neutral writer seam. */
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage> & {
+    prepareMessageAfterIdempotencyCheck: (message: TMessage) => TMessage | undefined;
+  },
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage>>;
+export async function appendTranscriptMessage<TMessage>(
+  scope: SessionTranscriptWriteScope,
+  options: TranscriptMessageAppendOptions<TMessage>,
+): Promise<TranscriptMessageAppendResult<TMessage> | undefined> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return await appendSessionTranscriptMessage({
+    transcriptPath: transcript.sessionFile,
+    message: options.message,
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.config ? { config: options.config } : {}),
+    ...(options.idempotencyLookup ? { idempotencyLookup: options.idempotencyLookup } : {}),
+    ...(options.now !== undefined ? { now: options.now } : {}),
+    ...(options.prepareMessageAfterIdempotencyCheck
+      ? { prepareMessageAfterIdempotencyCheck: options.prepareMessageAfterIdempotencyCheck }
+      : {}),
+    ...(options.useRawWhenLinear !== undefined
+      ? { useRawWhenLinear: options.useRawWhenLinear }
+      : {}),
+  });
+}
+
+/** Publishes a transcript update after resolving the current storage target. */
+export async function publishTranscriptUpdate(
+  scope: SessionTranscriptWriteScope,
+  update: TranscriptUpdatePayload = {},
+): Promise<void> {
+  const transcript = await resolveTranscriptAccess(scope);
+  emitSessionTranscriptUpdate({
+    ...update,
+    sessionFile: transcript.sessionFile,
+  });
+}
+
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {
   const now = Date.now();
   return {
@@ -184,11 +269,14 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
   });
 }
 
-async function resolveTranscriptAccess(scope: SessionTranscriptAccessScope): Promise<{
+async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{
   sessionFile: string;
 }> {
   if (scope.sessionFile?.trim()) {
     return { sessionFile: scope.sessionFile };
+  }
+  if (!scope.sessionId) {
+    throw new Error(`Cannot resolve transcript scope without a session id: ${scope.sessionKey}`);
   }
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   if (!agentId) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -87,6 +87,16 @@ export type TranscriptMessageAppendResult<TMessage> = {
 
 export type TranscriptUpdatePayload = Omit<SessionTranscriptUpdate, "sessionFile">;
 
+/** Active transcript target resolved from storage-neutral runtime identity. */
+export type SessionTranscriptRuntimeTarget = {
+  agentId: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionKey: string;
+  storageKind: "file";
+  targetKind: "active-session-file" | "runtime-session";
+};
+
 export type SessionEntryUpdateOptions = {
   skipMaintenance?: boolean;
   takeCacheOwnership?: boolean;
@@ -293,6 +303,21 @@ export async function publishTranscriptUpdate(
     ...update,
     sessionFile: transcript.sessionFile,
   });
+}
+
+/** Resolves the current file-backed transcript artifact for a runtime session scope. */
+export async function resolveSessionTranscriptRuntimeTarget(
+  scope: SessionTranscriptAccessScope,
+): Promise<SessionTranscriptRuntimeTarget> {
+  const transcript = await resolveTranscriptAccess(scope);
+  return {
+    agentId: scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey) ?? "",
+    sessionFile: transcript.sessionFile,
+    sessionId: scope.sessionId,
+    sessionKey: scope.sessionKey,
+    storageKind: "file",
+    targetKind: "runtime-session",
+  };
 }
 
 function createFallbackSessionEntry(patch: Partial<SessionEntry>): SessionEntry {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionAccessScope = {
   agentId?: string;
+  clone?: boolean;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   sessionKey: string;
@@ -46,6 +47,13 @@ export type SessionEntryUpdateOptions = {
 
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
+  if (scope.clone === false) {
+    const store = loadSessionStore(resolveAccessStorePath(scope), {
+      clone: false,
+      ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+    });
+    return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
+  }
   return getSessionEntry(scope);
 }
 
@@ -53,6 +61,14 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
 export function listSessionEntries(
   scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
 ): SessionEntrySummary[] {
+  if (scope.clone === false) {
+    return Object.entries(
+      loadSessionStore(resolveAccessStorePath({ ...scope, sessionKey: "" }), {
+        clone: false,
+        ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+      }),
+    ).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  }
   return listFileSessionEntries(scope);
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -50,6 +50,10 @@ export type SessionEntryPatchOptions = {
   replaceEntry?: boolean;
 };
 
+export type SessionEntryPatchContext = {
+  existingEntry?: SessionEntry;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -107,6 +111,7 @@ export async function patchSessionEntry(
   scope: SessionAccessScope,
   update: (
     entry: SessionEntry,
+    context: SessionEntryPatchContext,
   ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
   options: SessionEntryPatchOptions = {},
 ): Promise<SessionEntry | null> {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -85,6 +85,7 @@ export type SessionEntryUpdateOptions = {
 
 export type SessionEntryPatchOptions = {
   fallbackEntry?: SessionEntry;
+  preserveActivity?: boolean;
   replaceEntry?: boolean;
 };
 
@@ -167,6 +168,7 @@ export async function patchSessionEntry(
   return await patchFileSessionEntry({
     ...scope,
     fallbackEntry: options.fallbackEntry,
+    preserveActivity: options.preserveActivity,
     replaceEntry: options.replaceEntry,
     update,
   });

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -58,6 +58,12 @@ export type SessionEntrySummary = {
   entry: SessionEntry;
 };
 
+/** Session entry read by the exact persisted session key, without alias resolution. */
+export type ExactSessionEntry = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
 export type TranscriptEvent = unknown;
 
 export type TranscriptMessageAppendOptions<TMessage> = {
@@ -103,6 +109,23 @@ export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | unde
     return resolveSessionStoreEntry({ store, sessionKey: scope.sessionKey }).existing;
   }
   return getSessionEntry(scope);
+}
+
+/**
+ * Loads one entry only when the persisted key exactly matches the requested key.
+ * Approval routing uses this to avoid canonical alias lookup crossing accounts.
+ */
+export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+  const sessionKey = scope.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const store = loadSessionStore(resolveAccessStorePath(scope), {
+    ...(scope.clone === false ? { clone: false } : {}),
+    ...(scope.hydrateSkillPromptRefs === false ? { hydrateSkillPromptRefs: false } : {}),
+  });
+  const entry = Object.hasOwn(store, sessionKey) ? store[sessionKey] : undefined;
+  return entry ? { sessionKey, entry } : undefined;
 }
 
 /** Lists session entries through the storage-neutral accessor seam. */

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -45,6 +45,11 @@ export type SessionEntryUpdateOptions = {
   takeCacheOwnership?: boolean;
 };
 
+export type SessionEntryPatchOptions = {
+  fallbackEntry?: SessionEntry;
+  replaceEntry?: boolean;
+};
+
 /** Loads one session entry through the storage-neutral accessor seam. */
 export function loadSessionEntry(scope: SessionAccessScope): SessionEntry | undefined {
   if (scope.clone === false) {
@@ -94,6 +99,22 @@ export async function replaceSessionEntry(
     fallbackEntry: entry,
     replaceEntry: true,
     update: () => entry,
+  });
+}
+
+/** Patches one entry atomically through the storage-neutral accessor seam. */
+export async function patchSessionEntry(
+  scope: SessionAccessScope,
+  update: (
+    entry: SessionEntry,
+  ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null,
+  options: SessionEntryPatchOptions = {},
+): Promise<SessionEntry | null> {
+  return await patchFileSessionEntry({
+    ...scope,
+    fallbackEntry: options.fallbackEntry,
+    replaceEntry: options.replaceEntry,
+    update,
   });
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -5,7 +5,11 @@ import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { resolveSessionTranscriptPathInDir, resolveStorePath } from "./paths.js";
+import {
+  resolveSessionTranscriptPath,
+  resolveSessionTranscriptPathInDir,
+  resolveStorePath,
+} from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import {
   getSessionEntry,
@@ -34,10 +38,15 @@ export type SessionAccessScope = {
   storePath?: string;
 };
 
-export type SessionTranscriptAccessScope = SessionAccessScope & {
+export type SessionTranscriptReadScope = Omit<SessionAccessScope, "sessionKey"> & {
   sessionFile?: string;
   sessionId: string;
+  sessionKey?: string;
   threadId?: string | number;
+};
+
+export type SessionTranscriptAccessScope = SessionTranscriptReadScope & {
+  sessionKey: string;
 };
 
 export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
@@ -182,9 +191,9 @@ export async function updateSessionEntry(
 
 /** Loads raw transcript events through the storage-neutral accessor seam. */
 export async function loadTranscriptEvents(
-  scope: SessionTranscriptAccessScope,
+  scope: SessionTranscriptReadScope,
 ): Promise<TranscriptEvent[]> {
-  const transcript = await resolveTranscriptAccess(scope);
+  const transcript = await resolveTranscriptReadAccess(scope);
   const events: TranscriptEvent[] = [];
   for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
     events.push(JSON.parse(line) as TranscriptEvent);
@@ -267,6 +276,32 @@ function resolveAccessStorePath(scope: SessionAccessScope): string {
     agentId,
     env: scope.env,
   });
+}
+
+async function resolveTranscriptReadAccess(scope: SessionTranscriptReadScope): Promise<{
+  sessionFile: string;
+}> {
+  if (scope.sessionFile?.trim()) {
+    return { sessionFile: scope.sessionFile };
+  }
+  if (scope.sessionKey) {
+    return await resolveTranscriptAccess({ ...scope, sessionKey: scope.sessionKey });
+  }
+  if (scope.storePath) {
+    return {
+      sessionFile: resolveSessionTranscriptPathInDir(
+        scope.sessionId,
+        path.dirname(path.resolve(scope.storePath)),
+        scope.threadId,
+      ),
+    };
+  }
+  if (scope.agentId) {
+    return {
+      sessionFile: resolveSessionTranscriptPath(scope.sessionId, scope.agentId, scope.threadId),
+    };
+  }
+  throw new Error(`Cannot resolve transcript read scope without a session target`);
 }
 
 async function resolveTranscriptAccess(scope: SessionTranscriptWriteScope): Promise<{

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,5 +1,10 @@
 export {
   applySessionStoreEntryPatch,
+  cleanupSessionLifecycleArtifacts,
   updateSessionStore,
   updateSessionStoreEntry,
+} from "./store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "./store.js";

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -15,6 +15,7 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
@@ -186,6 +187,7 @@ type SingleEntryPersistencePatch = {
 
 type SessionEntryWorkflowOptions = {
   agentId?: string;
+  config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   storePath?: string;
@@ -220,7 +222,8 @@ function resolveSessionWorkflowStorePath(
     return options.storePath;
   }
   const agentId = options.agentId ?? resolveAgentIdFromSessionKey(options.sessionKey);
-  return resolveStorePath(getRuntimeConfig().session?.store, {
+  const storeConfig = options.config?.session?.store ?? getRuntimeConfig().session?.store;
+  return resolveStorePath(storeConfig, {
     agentId,
     env: options.env,
   });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -876,60 +876,71 @@ export async function updateSessionStore<T>(
 }
 
 async function archiveUnreferencedLifecycleTranscriptArtifacts(params: {
-  referencedTranscriptPaths: ReadonlySet<string>;
   storePath: string;
   transcriptContentMarker: string;
   orphanTranscriptMinAgeMs: number;
   nowMs: number;
 }): Promise<number> {
   const sessionsDir = path.dirname(path.resolve(params.storePath));
-  let entries: fs.Dirent[];
-  try {
-    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
+  return await runExclusiveSessionStoreWrite(params.storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(params.storePath);
+    const referencedTranscriptPaths = new Set<string>();
+    for (const entry of Object.values(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      if (transcriptPath) {
+        referencedTranscriptPaths.add(normalizePathForLifecycleComparison(transcriptPath));
+      }
+    }
+    restoreUnchangedSessionStoreCache(params.storePath, store);
 
-  const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
-  let archived = 0;
-  // Only archive primary transcripts that are no longer referenced by the
-  // current store and still carry the lifecycle marker supplied by the caller.
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
-      continue;
-    }
-    const transcriptPath = path.join(sessionsDir, entry.name);
-    if (params.referencedTranscriptPaths.has(normalizePathForLifecycleComparison(transcriptPath))) {
-      continue;
-    }
-    let stat: fs.Stats;
+    let entries: fs.Dirent[];
     try {
-      stat = await fs.promises.stat(transcriptPath);
+      entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
     } catch {
-      continue;
+      return 0;
     }
-    if (params.nowMs - stat.mtimeMs < params.orphanTranscriptMinAgeMs) {
-      continue;
+
+    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+    let archived = 0;
+    // Only archive primary transcripts that are no longer referenced by the
+    // current store and still carry the lifecycle marker supplied by the caller.
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+        continue;
+      }
+      const transcriptPath = path.join(sessionsDir, entry.name);
+      if (referencedTranscriptPaths.has(normalizePathForLifecycleComparison(transcriptPath))) {
+        continue;
+      }
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.stat(transcriptPath);
+      } catch {
+        continue;
+      }
+      if (params.nowMs - stat.mtimeMs < params.orphanTranscriptMinAgeMs) {
+        continue;
+      }
+      let content: string;
+      try {
+        content = await fs.promises.readFile(transcriptPath, "utf-8");
+      } catch {
+        continue;
+      }
+      if (!content.includes(params.transcriptContentMarker)) {
+        continue;
+      }
+      const sessionId = entry.name.slice(0, -".jsonl".length);
+      archived += archiveSessionTranscripts({
+        sessionId,
+        storePath: params.storePath,
+        sessionFile: transcriptPath,
+        reason: "deleted",
+        restrictToStoreDir: true,
+      }).length;
     }
-    let content: string;
-    try {
-      content = await fs.promises.readFile(transcriptPath, "utf-8");
-    } catch {
-      continue;
-    }
-    if (!content.includes(params.transcriptContentMarker)) {
-      continue;
-    }
-    const sessionId = entry.name.slice(0, -".jsonl".length);
-    archived += archiveSessionTranscripts({
-      sessionId,
-      storePath: params.storePath,
-      sessionFile: transcriptPath,
-      reason: "deleted",
-      restrictToStoreDir: true,
-    }).length;
-  }
-  return archived;
+    return archived;
+  });
 }
 
 /** Cleans scoped session lifecycle entries and their unreferenced transcript artifacts. */
@@ -945,15 +956,14 @@ export async function cleanupSessionLifecycleArtifacts(
   const nowMs = params.nowMs ?? Date.now();
   const storePath = path.resolve(params.storePath);
   const sessionsDir = path.dirname(storePath);
-  const referencedTranscriptPaths = new Set<string>();
   const removedSessionFiles = new Map<string, string | undefined>();
   let removedEntries = 0;
   let archivedTranscriptArtifacts = 0;
 
   await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
-    // Delete only rows owned by the named lifecycle, then build the remaining
-    // transcript reference set while the store snapshot is writer-owned.
+    // Delete only rows owned by the named lifecycle. Orphan transcript cleanup
+    // reacquires this writer lock later so its reference set cannot go stale.
     for (const [sessionKey, entry] of Object.entries(store)) {
       const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
       const matchesLifecycle = sessionKeySegmentStartsWith(sessionKey, sessionKeySegmentPrefix);
@@ -969,9 +979,6 @@ export async function cleanupSessionLifecycleArtifacts(
         delete store[sessionKey];
         removedEntries += 1;
         continue;
-      }
-      if (transcriptPath) {
-        referencedTranscriptPaths.add(normalizePathForLifecycleComparison(transcriptPath));
       }
     }
 
@@ -1015,7 +1022,6 @@ export async function cleanupSessionLifecycleArtifacts(
     archivedTranscriptArtifacts:
       archivedTranscriptArtifacts +
       (await archiveUnreferencedLifecycleTranscriptArtifacts({
-        referencedTranscriptPaths,
         storePath,
         transcriptContentMarker,
         orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1006,8 +1006,10 @@ export async function cleanupSessionLifecycleArtifacts(
       const sessionId = path.basename(transcriptPath, ".jsonl");
       archivedTranscriptArtifacts += archiveSessionTranscripts({
         sessionId,
+        storePath,
         sessionFile: transcriptPath,
         reason: "deleted",
+        restrictToStoreDir: true,
       }).length;
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -16,7 +16,7 @@ import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
-import { resolveStorePath } from "./paths.js";
+import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
   ensureSessionStorePromptBlobsForPersistence,
   isSessionSkillPromptBlobReadable,
@@ -187,6 +187,24 @@ type SessionEntryWorkflowOptions = {
   env?: NodeJS.ProcessEnv;
   hydrateSkillPromptRefs?: boolean;
   storePath?: string;
+};
+
+export type SessionLifecycleArtifactCleanupParams = {
+  /** Session store to clean. */
+  storePath: string;
+  /** Matches the persisted session-key segment after `agent:<id>:`. */
+  sessionKeySegmentPrefix: string;
+  /** Marker that identifies transcript artifacts owned by this lifecycle. */
+  transcriptContentMarker: string;
+  /** Minimum age before a present transcript can be reclaimed or archived. */
+  orphanTranscriptMinAgeMs: number;
+  /** Testable clock override. */
+  nowMs?: number;
+};
+
+export type SessionLifecycleArtifactCleanupResult = {
+  removedEntries: number;
+  archivedTranscriptArtifacts: number;
 };
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -494,6 +512,55 @@ function sessionEntriesHaveSameSerializedForm(
   next: SessionEntry,
 ): boolean {
   return previous !== undefined && JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function normalizePathForLifecycleComparison(filePath: string): string {
+  try {
+    return path.normalize(fs.realpathSync(filePath));
+  } catch {
+    return path.normalize(path.resolve(filePath));
+  }
+}
+
+function sessionKeySegmentStartsWith(sessionKey: string, prefix: string): boolean {
+  const firstSeparator = sessionKey.indexOf(":");
+  if (firstSeparator < 0) {
+    return sessionKey.startsWith(prefix);
+  }
+  const secondSeparator = sessionKey.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? sessionKey : sessionKey.slice(secondSeparator + 1);
+  return sessionSegment.startsWith(prefix);
+}
+
+function resolveLifecycleTranscriptPath(params: {
+  entry: SessionEntry | undefined;
+  sessionsDir: string;
+}): string | null {
+  const sessionId = params.entry?.sessionId?.trim();
+  if (!sessionId) {
+    return null;
+  }
+  try {
+    return resolveSessionFilePath(sessionId, params.entry, { sessionsDir: params.sessionsDir });
+  } catch {
+    return null;
+  }
+}
+
+function lifecycleTranscriptIsReclaimable(params: {
+  transcriptPath: string | null;
+  nowMs: number;
+  orphanTranscriptMinAgeMs: number;
+}): boolean {
+  if (!params.transcriptPath || !fs.existsSync(params.transcriptPath)) {
+    return true;
+  }
+  try {
+    const stat = fs.statSync(params.transcriptPath);
+    return params.nowMs - stat.mtimeMs >= params.orphanTranscriptMinAgeMs;
+  } catch {
+    return true;
+  }
 }
 
 async function saveSessionStoreUnlocked(
@@ -806,6 +873,155 @@ export async function updateSessionStore<T>(
     });
     return result;
   });
+}
+
+async function archiveUnreferencedLifecycleTranscriptArtifacts(params: {
+  referencedTranscriptPaths: ReadonlySet<string>;
+  storePath: string;
+  transcriptContentMarker: string;
+  orphanTranscriptMinAgeMs: number;
+  nowMs: number;
+}): Promise<number> {
+  const sessionsDir = path.dirname(path.resolve(params.storePath));
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+  let archived = 0;
+  // Only archive primary transcripts that are no longer referenced by the
+  // current store and still carry the lifecycle marker supplied by the caller.
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+    const transcriptPath = path.join(sessionsDir, entry.name);
+    if (params.referencedTranscriptPaths.has(normalizePathForLifecycleComparison(transcriptPath))) {
+      continue;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.stat(transcriptPath);
+    } catch {
+      continue;
+    }
+    if (params.nowMs - stat.mtimeMs < params.orphanTranscriptMinAgeMs) {
+      continue;
+    }
+    let content: string;
+    try {
+      content = await fs.promises.readFile(transcriptPath, "utf-8");
+    } catch {
+      continue;
+    }
+    if (!content.includes(params.transcriptContentMarker)) {
+      continue;
+    }
+    const sessionId = entry.name.slice(0, -".jsonl".length);
+    archived += archiveSessionTranscripts({
+      sessionId,
+      storePath: params.storePath,
+      sessionFile: transcriptPath,
+      reason: "deleted",
+      restrictToStoreDir: true,
+    }).length;
+  }
+  return archived;
+}
+
+/** Cleans scoped session lifecycle entries and their unreferenced transcript artifacts. */
+export async function cleanupSessionLifecycleArtifacts(
+  params: SessionLifecycleArtifactCleanupParams,
+): Promise<SessionLifecycleArtifactCleanupResult> {
+  const sessionKeySegmentPrefix = params.sessionKeySegmentPrefix.trim();
+  const transcriptContentMarker = params.transcriptContentMarker;
+  if (!sessionKeySegmentPrefix || !transcriptContentMarker) {
+    return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const storePath = path.resolve(params.storePath);
+  const sessionsDir = path.dirname(storePath);
+  const referencedTranscriptPaths = new Set<string>();
+  const removedSessionFiles = new Map<string, string | undefined>();
+  let removedEntries = 0;
+  let archivedTranscriptArtifacts = 0;
+
+  await runExclusiveSessionStoreWrite(storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(storePath);
+    // Delete only rows owned by the named lifecycle, then build the remaining
+    // transcript reference set while the store snapshot is writer-owned.
+    for (const [sessionKey, entry] of Object.entries(store)) {
+      const transcriptPath = resolveLifecycleTranscriptPath({ entry, sessionsDir });
+      const matchesLifecycle = sessionKeySegmentStartsWith(sessionKey, sessionKeySegmentPrefix);
+      if (
+        matchesLifecycle &&
+        lifecycleTranscriptIsReclaimable({
+          transcriptPath,
+          nowMs,
+          orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        })
+      ) {
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+        delete store[sessionKey];
+        removedEntries += 1;
+        continue;
+      }
+      if (transcriptPath) {
+        referencedTranscriptPaths.add(normalizePathForLifecycleComparison(transcriptPath));
+      }
+    }
+
+    if (removedEntries === 0) {
+      restoreUnchangedSessionStoreCache(storePath, store);
+      return;
+    }
+
+    const referencedSessionIds = new Set(
+      Object.values(store)
+        .map((entry) => entry?.sessionId)
+        .filter((sessionId): sessionId is string => Boolean(sessionId)),
+    );
+    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+    // Removed entries carry concrete session ids/files, so archive their
+    // session-owned artifacts before persisting the row deletion.
+    for (const [sessionId, sessionFile] of removedSessionFiles) {
+      if (referencedSessionIds.has(sessionId)) {
+        continue;
+      }
+      archivedTranscriptArtifacts += archiveSessionTranscripts({
+        sessionId,
+        storePath,
+        sessionFile,
+        reason: "deleted",
+        restrictToStoreDir: true,
+      }).length;
+    }
+    const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+    await removeRemovedSessionTrajectoryArtifacts({
+      removedSessionFiles,
+      referencedSessionIds,
+      storePath,
+      restrictToStoreDir: true,
+    });
+    await saveSessionStoreUnlocked(storePath, store, { skipMaintenance: true });
+  });
+
+  return {
+    removedEntries,
+    archivedTranscriptArtifacts:
+      archivedTranscriptArtifacts +
+      (await archiveUnreferencedLifecycleTranscriptArtifacts({
+        referencedTranscriptPaths,
+        storePath,
+        transcriptContentMarker,
+        orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
+        nowMs,
+      })),
+  };
 }
 
 export async function runQuotaSuspensionMaintenance(params: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -957,6 +957,7 @@ export async function cleanupSessionLifecycleArtifacts(
   const storePath = path.resolve(params.storePath);
   const sessionsDir = path.dirname(storePath);
   const removedSessionFiles = new Map<string, string | undefined>();
+  const removedTranscriptPaths: Array<{ sessionId: string; transcriptPath: string }> = [];
   let removedEntries = 0;
   let archivedTranscriptArtifacts = 0;
 
@@ -976,6 +977,9 @@ export async function cleanupSessionLifecycleArtifacts(
         })
       ) {
         rememberRemovedSessionFile(removedSessionFiles, entry);
+        if (entry.sessionId && transcriptPath && fs.existsSync(transcriptPath)) {
+          removedTranscriptPaths.push({ sessionId: entry.sessionId, transcriptPath });
+        }
         delete store[sessionKey];
         removedEntries += 1;
         continue;
@@ -993,18 +997,17 @@ export async function cleanupSessionLifecycleArtifacts(
         .filter((sessionId): sessionId is string => Boolean(sessionId)),
     );
     const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
-    // Removed entries carry concrete session ids/files, so archive their
-    // session-owned artifacts before persisting the row deletion.
-    for (const [sessionId, sessionFile] of removedSessionFiles) {
-      if (referencedSessionIds.has(sessionId)) {
+    // Archive only the exact transcript path that passed the age/missing guard.
+    // Broader session-id candidate scans can include fresh sibling transcripts.
+    for (const { sessionId: removedSessionId, transcriptPath } of removedTranscriptPaths) {
+      if (referencedSessionIds.has(removedSessionId)) {
         continue;
       }
+      const sessionId = path.basename(transcriptPath, ".jsonl");
       archivedTranscriptArtifacts += archiveSessionTranscripts({
         sessionId,
-        storePath,
-        sessionFile,
+        sessionFile: transcriptPath,
         reason: "deleted",
-        restrictToStoreDir: true,
       }).length;
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -4,6 +4,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   deliveryContextFromChannelRoute,
   deliveryContextFromSession,
@@ -14,6 +15,7 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
+import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
@@ -563,6 +565,17 @@ function lifecycleTranscriptIsReclaimable(params: {
   }
 }
 
+function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
+  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+  try {
+    fs.renameSync(transcriptPath, archivedPath);
+    emitSessionTranscriptUpdate({ sessionFile: archivedPath });
+    return 1;
+  } catch {
+    return 0;
+  }
+}
+
 async function saveSessionStoreUnlocked(
   storePath: string,
   store: Record<string, SessionEntry>,
@@ -996,21 +1009,13 @@ export async function cleanupSessionLifecycleArtifacts(
         .map((entry) => entry?.sessionId)
         .filter((sessionId): sessionId is string => Boolean(sessionId)),
     );
-    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
     // Archive only the exact transcript path that passed the age/missing guard.
     // Broader session-id candidate scans can include fresh sibling transcripts.
     for (const { sessionId: removedSessionId, transcriptPath } of removedTranscriptPaths) {
       if (referencedSessionIds.has(removedSessionId)) {
         continue;
       }
-      const sessionId = path.basename(transcriptPath, ".jsonl");
-      archivedTranscriptArtifacts += archiveSessionTranscripts({
-        sessionId,
-        storePath,
-        sessionFile: transcriptPath,
-        reason: "deleted",
-        restrictToStoreDir: true,
-      }).length;
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
     await removeRemovedSessionTrajectoryArtifacts({

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1006,6 +1006,7 @@ export async function patchSessionEntry(
     replaceEntry?: boolean;
     update: (
       entry: SessionEntry,
+      context: { existingEntry?: SessionEntry },
     ) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
   },
 ): Promise<SessionEntry | null> {
@@ -1017,7 +1018,9 @@ export async function patchSessionEntry(
     if (!existing) {
       return null;
     }
-    const patch = await params.update(cloneSessionEntry(existing));
+    const patch = await params.update(cloneSessionEntry(existing), {
+      existingEntry: resolved.existing ? cloneSessionEntry(resolved.existing) : undefined,
+    });
     if (!patch) {
       return existing;
     }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -565,10 +565,19 @@ function lifecycleTranscriptIsReclaimable(params: {
   }
 }
 
-function archiveExactLifecycleTranscriptPath(transcriptPath: string): number {
-  const archivedPath = `${transcriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
+function archiveExactLifecycleTranscriptPath(params: {
+  sessionsDir: string;
+  transcriptPath: string;
+}): number {
+  const resolvedSessionsDir = normalizePathForLifecycleComparison(params.sessionsDir);
+  const resolvedTranscriptPath = normalizePathForLifecycleComparison(params.transcriptPath);
+  const relative = path.relative(resolvedSessionsDir, resolvedTranscriptPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return 0;
+  }
+  const archivedPath = `${resolvedTranscriptPath}.deleted.${formatSessionArchiveTimestamp()}`;
   try {
-    fs.renameSync(transcriptPath, archivedPath);
+    fs.renameSync(resolvedTranscriptPath, archivedPath);
     emitSessionTranscriptUpdate({ sessionFile: archivedPath });
     return 1;
   } catch {
@@ -1015,7 +1024,10 @@ export async function cleanupSessionLifecycleArtifacts(
       if (referencedSessionIds.has(removedSessionId)) {
         continue;
       }
-      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath(transcriptPath);
+      archivedTranscriptArtifacts += archiveExactLifecycleTranscriptPath({
+        sessionsDir,
+        transcriptPath,
+      });
     }
     const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
     await removeRemovedSessionTrajectoryArtifacts({

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -14,6 +14,7 @@ import { redactSecrets } from "../../logging/redact.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   appendJsonlEntry,
+  serializeJsonlEntry,
   serializeJsonlLine,
   writeJsonlEntry,
   writeJsonlLines,
@@ -284,6 +285,31 @@ export async function appendSessionTranscriptMessage<TMessage>(
   );
 }
 
+export type AppendSessionTranscriptEventParams = {
+  config?: OpenClawConfig;
+  event: unknown;
+  transcriptPath: string;
+};
+
+/** Appends a raw transcript event using the same write lock and FIFO as message appends. */
+export async function appendSessionTranscriptEvent(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
+    sessionFile: params.transcriptPath,
+  });
+  if (activeLockRunner) {
+    return await activeLockRunner(() =>
+      withTranscriptAppendQueue(params.transcriptPath, () =>
+        appendSessionTranscriptEventLocked(params),
+      ),
+    );
+  }
+  return await withTranscriptAppendQueue(params.transcriptPath, () =>
+    withSessionTranscriptWriteLock(params, () => appendSessionTranscriptEventLocked(params)),
+  );
+}
+
 async function withSessionTranscriptWriteLock<T>(
   params: Pick<AppendSessionTranscriptMessageParams, "transcriptPath" | "config">,
   run: () => Promise<T> | T,
@@ -297,6 +323,18 @@ async function withSessionTranscriptWriteLock<T>(
     return await run();
   } finally {
     await lock.release();
+  }
+}
+
+async function appendSessionTranscriptEventLocked(
+  params: AppendSessionTranscriptEventParams,
+): Promise<void> {
+  await fs.mkdir(path.dirname(params.transcriptPath), { recursive: true });
+  const handle = await fs.open(params.transcriptPath, "a", 0o600);
+  try {
+    await handle.appendFile(serializeJsonlEntry(params.event), "utf-8");
+  } finally {
+    await handle.close();
   }
 }
 

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -447,6 +447,27 @@ describe("Engine contract tests", () => {
     });
   });
 
+  it("delegateCompactionToRuntime uses runtime session identity when available", async () => {
+    const compactRuntimeSpy = installCompactRuntimeSpy();
+
+    await delegateCompactionToRuntime({
+      sessionId: "s3",
+      sessionFile: "/tmp/session.json",
+      runtimeContext: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/runtime-context-session.json",
+        workspaceDir: "/tmp/workspace",
+      },
+    });
+
+    expect(compactRuntimeSpy).toHaveBeenCalledTimes(1);
+    const compactRuntimeParams = requireCompactRuntimeParams(0);
+    expect(compactRuntimeParams.agentId).toBe("main");
+    expect(compactRuntimeParams.sessionKey).toBe("agent:main:main");
+    expect(compactRuntimeParams.sessionFile).toBeUndefined();
+  });
+
   it("builds a normalized memory system prompt addition from the active memory prompt path", () => {
     registerMemoryPromptSection(({ citationsMode }) => [
       "## Memory Recall",

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -41,8 +41,9 @@ export async function delegateCompactionToRuntime(
   // runtimeContext carries the full CompactEmbeddedAgentSessionParams fields set
   // by runtime callers. We spread them and override the fields that come from
   // the public ContextEngine compact() signature directly.
-  const runtimeContext = (params.runtimeContext ?? {}) as ContextEngineRuntimeContext &
+  const runtimeContextWithFile = (params.runtimeContext ?? {}) as ContextEngineRuntimeContext &
     Partial<RuntimeCompactionParams>;
+  const { sessionFile: _runtimeSessionFile, ...runtimeContext } = runtimeContextWithFile;
   const currentTokenCount =
     params.currentTokenCount ??
     (typeof runtimeContext.currentTokenCount === "number" &&
@@ -50,11 +51,21 @@ export async function delegateCompactionToRuntime(
     runtimeContext.currentTokenCount > 0
       ? Math.floor(runtimeContext.currentTokenCount)
       : undefined);
+  const runtimeSessionKey =
+    typeof runtimeContext.sessionKey === "string" && runtimeContext.sessionKey.trim()
+      ? runtimeContext.sessionKey.trim()
+      : undefined;
+  const sessionKey = params.sessionKey ?? runtimeSessionKey;
+  const agentId =
+    typeof runtimeContext.agentId === "string" && runtimeContext.agentId.trim()
+      ? runtimeContext.agentId.trim()
+      : undefined;
 
   const result = await compactEmbeddedAgentSessionDirect({
     ...runtimeContext,
     sessionId: params.sessionId,
-    sessionFile: params.sessionFile,
+    ...(sessionKey ? { sessionKey } : { sessionFile: params.sessionFile }),
+    ...(agentId ? { agentId } : {}),
     tokenBudget: params.tokenBudget,
     ...(currentTokenCount !== undefined ? { currentTokenCount } : {}),
     force: params.force,

--- a/src/crestodian/assistant.test.ts
+++ b/src/crestodian/assistant.test.ts
@@ -149,8 +149,10 @@ describe("Crestodian assistant", () => {
     expect(firstCliCall.model).toBe("claude-opus-4-8");
     expect(firstCliCall.cleanupCliLiveSessionOnRunEnd).toBe(true);
     const firstCliConfig = requireRecord(firstCliCall.config);
+    const firstCliSession = requireRecord(firstCliConfig.session);
     const firstCliAgents = requireRecord(firstCliConfig.agents);
     const firstCliDefaults = requireRecord(firstCliAgents.defaults);
+    expect(firstCliSession.store).toBe("/tmp/crestodian-planner/sessions.json");
     expect(firstCliDefaults.cliBackends).toBeUndefined();
     expect(firstCliCall.extraSystemPrompt).toBeTypeOf("string");
     expect(firstCliCall.extraSystemPrompt).toContain("Do not use tools, shell commands");
@@ -225,12 +227,14 @@ describe("Crestodian assistant", () => {
     expect(firstEmbeddedCall.disableTools).toBe(true);
     expect(firstEmbeddedCall.toolsAllow).toEqual([]);
     const embeddedConfig = requireRecord(firstEmbeddedCall.config);
+    const embeddedSession = requireRecord(embeddedConfig.session);
     const embeddedAgents = requireRecord(embeddedConfig.agents);
     const embeddedDefaults = requireRecord(embeddedAgents.defaults);
     const embeddedModel = requireRecord(embeddedDefaults.model);
     const embeddedPlugins = requireRecord(embeddedConfig.plugins);
     const embeddedEntries = requireRecord(embeddedPlugins.entries);
     const embeddedCodexEntry = requireRecord(embeddedEntries.codex);
+    expect(embeddedSession.store).toBe("/tmp/crestodian-planner/sessions.json");
     expect(embeddedModel.primary).toBe("openai/gpt-5.5");
     expect(embeddedCodexEntry.enabled).toBe(true);
   });

--- a/src/crestodian/assistant.ts
+++ b/src/crestodian/assistant.ts
@@ -181,9 +181,16 @@ async function runLocalRuntimePlanner(
   const tempDir = await (params.deps?.createTempDir ?? createTempPlannerDir)();
   try {
     const runId = `crestodian-planner-${randomUUID()}`;
-    const sessionFile = path.join(tempDir, "session.jsonl");
     const sessionId = `${runId}-session`;
     const sessionKey = `temp:crestodian-planner:${runId}`;
+    const backendConfig = backend.buildConfig(tempDir);
+    const helperConfig = {
+      ...backendConfig,
+      session: {
+        ...backendConfig.session,
+        store: path.join(tempDir, "sessions.json"),
+      },
+    };
     switch (backend.runner) {
       case "cli": {
         const runCli = params.deps?.runCliAgent ?? (await loadRunCliAgent());
@@ -192,9 +199,8 @@ async function runLocalRuntimePlanner(
           sessionKey,
           agentId: "crestodian",
           trigger: "manual",
-          sessionFile,
           workspaceDir: tempDir,
-          config: backend.buildConfig(tempDir),
+          config: helperConfig,
           prompt: params.prompt,
           provider: backend.provider,
           model: backend.model,
@@ -215,9 +221,8 @@ async function runLocalRuntimePlanner(
           sessionKey,
           agentId: "crestodian",
           trigger: "manual",
-          sessionFile,
           workspaceDir: tempDir,
-          config: backend.buildConfig(tempDir),
+          config: helperConfig,
           prompt: params.prompt,
           provider: backend.provider,
           model: backend.model,

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -52,6 +52,10 @@ describe("generateSlugViaLLM", () => {
     const options = requireFirstRunOptions();
     expect(options.timeoutMs).toBe(15_000);
     expect(options.cleanupBundleMcpOnRunEnd).toBe(true);
+    expect(options.sessionKey).toBe("temp:slug-generator");
+    expect(options.sessionId).toMatch(/^slug-generator-/);
+    expect(options.sessionFile).toBeUndefined();
+    expect((options.config as OpenClawConfig).session?.store).toContain("openclaw-slug-");
   });
 
   it("marks the run lane-local so internal-helper failures do not poison shared profile health (#71709)", async () => {

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -2,6 +2,7 @@
  * LLM-based slug generator for session memory filenames
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -35,16 +36,20 @@ export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
 }): Promise<string | null> {
-  let tempSessionFile: string | null = null;
-
+  let tempDir: string | undefined;
   try {
     const agentId = resolveDefaultAgentId(params.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
-
-    // Create a temporary session file for this one-off LLM call
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
-    tempSessionFile = path.join(tempDir, "session.jsonl");
+    const sessionId = `slug-generator-${randomUUID()}`;
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
+    const helperConfig = {
+      ...params.cfg,
+      session: {
+        ...params.cfg.session,
+        store: path.join(tempDir, "sessions.json"),
+      },
+    } as OpenClawConfig;
 
     const prompt = `Based on this conversation, generate a short 1-2 word filename slug (lowercase, hyphen-separated, no file extension).
 
@@ -60,13 +65,12 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
     const timeoutMs = resolveSlugGeneratorTimeoutMs(params.cfg);
 
     const result = await runEmbeddedAgent({
-      sessionId: `slug-generator-${Date.now()}`,
+      sessionId,
       sessionKey: "temp:slug-generator",
       agentId,
-      sessionFile: tempSessionFile,
       workspaceDir,
       agentDir,
-      config: params.cfg,
+      config: helperConfig,
       prompt,
       provider,
       model,
@@ -99,12 +103,11 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
     log.error(`Failed to generate slug: ${message}`);
     return null;
   } finally {
-    // Clean up temporary session file
-    if (tempSessionFile) {
+    if (tempDir) {
       try {
-        await fs.rm(path.dirname(tempSessionFile), { recursive: true, force: true });
+        await fs.rm(tempDir, { recursive: true, force: true });
       } catch {
-        // Ignore cleanup errors
+        // Ignore cleanup errors for one-off helper storage.
       }
     }
   }

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -22,6 +22,7 @@ export { resolveGroupSessionKey } from "../config/sessions/group.js";
 export { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js";
 export {
   clearSessionStoreCacheForTest,
+  cleanupSessionLifecycleArtifacts,
   getSessionEntry,
   listSessionEntries,
   patchSessionEntry,
@@ -32,6 +33,10 @@ export {
   updateSessionStore,
   updateSessionStoreEntry,
   upsertSessionEntry,
+} from "../config/sessions/store.js";
+export type {
+  SessionLifecycleArtifactCleanupParams,
+  SessionLifecycleArtifactCleanupResult,
 } from "../config/sessions/store.js";
 export {
   evaluateSessionFreshness,

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -29,7 +29,42 @@ export interface SchemaMeta {
   updated_at: number;
 }
 
+export interface SessionEntries {
+  entry_json: string;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface Sessions {
+  created_at: number;
+  session_id: string;
+  session_key: string;
+  updated_at: number;
+}
+
+export interface TranscriptEventIdentities {
+  created_at: number;
+  event_id: string;
+  event_type: string | null;
+  message_idempotency_key: string | null;
+  parent_id: string | null;
+  seq: number;
+  session_id: string;
+}
+
+export interface TranscriptEvents {
+  created_at: number;
+  event_json: string;
+  seq: number;
+  session_id: string;
+}
+
 export interface DB {
   cache_entries: CacheEntries;
   schema_meta: SchemaMeta;
+  session_entries: SessionEntries;
+  sessions: Sessions;
+  transcript_event_identities: TranscriptEventIdentities;
+  transcript_events: TranscriptEvents;
 }

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -19,6 +19,22 @@ export interface CacheEntries {
   value_json: string | null;
 }
 
+export interface Conversations {
+  account_id: string;
+  channel: string;
+  conversation_id: string;
+  created_at: number;
+  kind: string;
+  label: string | null;
+  metadata_json: string | null;
+  native_channel_id: string | null;
+  native_direct_user_id: string | null;
+  parent_conversation_id: string | null;
+  peer_id: string;
+  thread_id: string | null;
+  updated_at: number;
+}
+
 export interface SchemaMeta {
   agent_id: string | null;
   app_version: string | null;
@@ -29,6 +45,14 @@ export interface SchemaMeta {
   updated_at: number;
 }
 
+export interface SessionConversations {
+  conversation_id: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  role: Generated<string>;
+  session_id: string;
+}
+
 export interface SessionEntries {
   entry_json: string;
   session_id: string;
@@ -36,10 +60,30 @@ export interface SessionEntries {
   updated_at: number;
 }
 
-export interface Sessions {
-  created_at: number;
+export interface SessionRoutes {
   session_id: string;
   session_key: string;
+  updated_at: number;
+}
+
+export interface Sessions {
+  account_id: string | null;
+  agent_harness_id: string | null;
+  channel: string | null;
+  chat_type: string | null;
+  created_at: number;
+  display_name: string | null;
+  ended_at: number | null;
+  model: string | null;
+  model_provider: string | null;
+  parent_session_key: string | null;
+  primary_conversation_id: string | null;
+  session_id: string;
+  session_key: string;
+  session_scope: Generated<string>;
+  spawned_by: string | null;
+  started_at: number | null;
+  status: string | null;
   updated_at: number;
 }
 
@@ -62,8 +106,11 @@ export interface TranscriptEvents {
 
 export interface DB {
   cache_entries: CacheEntries;
+  conversations: Conversations;
   schema_meta: SchemaMeta;
+  session_conversations: SessionConversations;
   session_entries: SessionEntries;
+  session_routes: SessionRoutes;
   sessions: Sessions;
   transcript_event_identities: TranscriptEventIdentities;
   transcript_events: TranscriptEvents;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -88,7 +88,7 @@ describe("openclaw agent database", () => {
     expect(registered).toMatchObject({
       agentId: "worker-1",
       path: database.path,
-      schemaVersion: 1,
+      schemaVersion: 2,
     });
     expect(registered?.sizeBytes).toBeGreaterThan(0);
   });
@@ -194,7 +194,7 @@ describe("openclaw agent database", () => {
     expect(readSqliteNumberPragma(database.db, "busy_timeout")).toBe(30_000);
     expect(readSqliteNumberPragma(database.db, "foreign_keys")).toBe(1);
     expect(readSqliteNumberPragma(database.db, "synchronous")).toBe(1);
-    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(1);
+    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(2);
     expect(readSqliteNumberPragma(database.db, "wal_autocheckpoint")).toBe(1000);
     const journalMode = database.db.prepare("PRAGMA journal_mode").get() as
       | { journal_mode?: string }
@@ -217,9 +217,123 @@ describe("openclaw agent database", () => {
       ),
     ).toEqual({
       role: "agent",
-      schema_version: 1,
+      schema_version: 2,
       agent_id: "worker-1",
     });
+  });
+
+  it("migrates compact v1 session tables before applying normalized indexes", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = path.join(
+      stateDir,
+      "agents",
+      "worker-1",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(databasePath);
+    db.exec(`
+      CREATE TABLE schema_meta (
+        meta_key TEXT NOT NULL PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        agent_id TEXT,
+        app_version TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO schema_meta
+        (meta_key, role, schema_version, agent_id, app_version, created_at, updated_at)
+      VALUES ('primary', 'agent', 1, 'worker-1', NULL, 1, 1);
+      CREATE TABLE sessions (
+        session_id TEXT NOT NULL PRIMARY KEY,
+        session_key TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO sessions (session_id, session_key, created_at, updated_at)
+      VALUES ('session-1', 'agent:worker-1:main', 10, 20);
+      CREATE TABLE session_entries (
+        session_key TEXT NOT NULL PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+      VALUES (
+        'agent:worker-1:group:example',
+        'session-1',
+        '{"sessionId":"session-1","updatedAt":20,"startedAt":11,"endedAt":19,"status":"done","chatType":"group","channel":"discord","deliveryContext":{"accountId":"acct-1"},"modelProvider":"openai","model":"gpt-5.5","agentHarnessId":"codex","parentSessionKey":"agent:worker-1:parent","spawnedBy":"agent:worker-1:spawner","displayName":"Example group"}',
+        20
+      );
+      PRAGMA user_version = 1;
+    `);
+    db.close();
+
+    const database = openOpenClawAgentDatabase({
+      agentId: "worker-1",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+
+    expect(readSqliteNumberPragma(database.db, "user_version")).toBe(2);
+    const session = database.db
+      .prepare(
+        `
+          SELECT
+            account_id,
+            agent_harness_id,
+            channel,
+            chat_type,
+            display_name,
+            ended_at,
+            model,
+            model_provider,
+            parent_session_key,
+            session_scope,
+            spawned_by,
+            started_at,
+            status
+          FROM sessions
+          WHERE session_id = ?
+        `,
+      )
+      .get("session-1");
+    expect(session).toEqual({
+      account_id: "acct-1",
+      agent_harness_id: "codex",
+      channel: "discord",
+      chat_type: "group",
+      display_name: "Example group",
+      ended_at: 19,
+      model: "gpt-5.5",
+      model_provider: "openai",
+      parent_session_key: "agent:worker-1:parent",
+      session_scope: "group",
+      spawned_by: "agent:worker-1:spawner",
+      started_at: 11,
+      status: "done",
+    });
+    const route = database.db
+      .prepare("SELECT session_id, updated_at FROM session_routes WHERE session_key = ?")
+      .get("agent:worker-1:group:example");
+    expect(route).toEqual({
+      session_id: "session-1",
+      updated_at: 20,
+    });
+    const sessionForeignKeys = database.db.prepare("PRAGMA foreign_key_list(sessions)").all() as
+      | Array<{ from?: unknown; on_delete?: unknown; table?: unknown; to?: unknown }>
+      | undefined;
+    expect(sessionForeignKeys).toContainEqual(
+      expect.objectContaining({
+        from: "primary_conversation_id",
+        on_delete: "SET NULL",
+        table: "conversations",
+        to: "conversation_id",
+      }),
+    );
   });
 
   it("refuses to open newer per-agent schema versions", () => {
@@ -234,7 +348,7 @@ describe("openclaw agent database", () => {
     fs.mkdirSync(path.dirname(databasePath), { recursive: true });
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
-    db.exec("PRAGMA user_version = 2;");
+    db.exec("PRAGMA user_version = 3;");
     db.close();
 
     expect(() =>
@@ -242,6 +356,6 @@ describe("openclaw agent database", () => {
         agentId: "worker-1",
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
-    ).toThrow(/newer schema version 2/);
+    ).toThrow(/newer schema version 3/);
   });
 });

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -22,7 +22,7 @@ import {
 } from "./openclaw-state-db.js";
 export { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 
-const OPENCLAW_AGENT_SCHEMA_VERSION = 1;
+const OPENCLAW_AGENT_SCHEMA_VERSION = 2;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 const OPENCLAW_AGENT_DB_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
@@ -56,6 +56,8 @@ type ExistingSchemaMeta = {
   role: string | null;
 };
 
+type MigratedSessionEntry = Record<string, unknown>;
+
 function readSqliteUserVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: unknown } | undefined;
   return Number(row?.user_version ?? 0);
@@ -66,6 +68,294 @@ function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): 
   if (userVersion > OPENCLAW_AGENT_SCHEMA_VERSION) {
     throw new Error(
       `OpenClaw agent database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+    );
+  }
+}
+
+function readSqliteSessionColumns(db: DatabaseSync): Set<string> | null {
+  const table = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get("sessions");
+  if (!table) {
+    return null;
+  }
+  const rows = db.prepare("PRAGMA table_info(sessions)").all() as Array<{
+    name?: unknown;
+  }>;
+  return new Set(rows.flatMap((row) => (typeof row.name === "string" ? [row.name] : [])));
+}
+
+function migratedSessionColumn(
+  columns: ReadonlySet<string>,
+  columnName: string,
+  fallback: string,
+): string {
+  return columns.has(columnName) ? columnName : fallback;
+}
+
+function migrateOpenClawAgentSchema(db: DatabaseSync): void {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion >= OPENCLAW_AGENT_SCHEMA_VERSION) {
+    return;
+  }
+  const columns = readSqliteSessionColumns(db);
+  if (userVersion > 1 || !columns) {
+    return;
+  }
+  const copyColumns = [
+    "session_id",
+    "session_key",
+    "session_scope",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "ended_at",
+    "status",
+    "chat_type",
+    "channel",
+    "account_id",
+    "primary_conversation_id",
+    "model_provider",
+    "model",
+    "agent_harness_id",
+    "parent_session_key",
+    "spawned_by",
+    "display_name",
+  ];
+  const selectColumns = [
+    "session_id",
+    "session_key",
+    migratedSessionColumn(columns, "session_scope", "'conversation'"),
+    "created_at",
+    "updated_at",
+    migratedSessionColumn(columns, "started_at", "NULL"),
+    migratedSessionColumn(columns, "ended_at", "NULL"),
+    migratedSessionColumn(columns, "status", "NULL"),
+    migratedSessionColumn(columns, "chat_type", "NULL"),
+    migratedSessionColumn(columns, "channel", "NULL"),
+    migratedSessionColumn(columns, "account_id", "NULL"),
+    migratedSessionColumn(columns, "primary_conversation_id", "NULL"),
+    migratedSessionColumn(columns, "model_provider", "NULL"),
+    migratedSessionColumn(columns, "model", "NULL"),
+    migratedSessionColumn(columns, "agent_harness_id", "NULL"),
+    migratedSessionColumn(columns, "parent_session_key", "NULL"),
+    migratedSessionColumn(columns, "spawned_by", "NULL"),
+    migratedSessionColumn(columns, "display_name", "NULL"),
+  ];
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS conversations (
+      conversation_id TEXT NOT NULL PRIMARY KEY,
+      channel TEXT NOT NULL,
+      account_id TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+      peer_id TEXT NOT NULL,
+      parent_conversation_id TEXT,
+      thread_id TEXT,
+      native_channel_id TEXT,
+      native_direct_user_id TEXT,
+      label TEXT,
+      metadata_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  db.exec("PRAGMA foreign_keys = OFF;");
+  try {
+    db.exec(`
+      DROP TABLE IF EXISTS sessions_new;
+      CREATE TABLE sessions_new (
+        session_id TEXT NOT NULL PRIMARY KEY,
+        session_key TEXT NOT NULL,
+        session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        started_at INTEGER,
+        ended_at INTEGER,
+        status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+        chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+        channel TEXT,
+        account_id TEXT,
+        primary_conversation_id TEXT,
+        model_provider TEXT,
+        model TEXT,
+        agent_harness_id TEXT,
+        parent_session_key TEXT,
+        spawned_by TEXT,
+        display_name TEXT,
+        FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+      );
+      INSERT INTO sessions_new (${copyColumns.join(", ")})
+      SELECT ${selectColumns.join(", ")} FROM sessions;
+      DROP TABLE sessions;
+      ALTER TABLE sessions_new RENAME TO sessions;
+    `);
+  } finally {
+    db.exec("PRAGMA foreign_keys = ON;");
+  }
+}
+
+function parseMigratedSessionEntry(value: unknown): MigratedSessionEntry | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as MigratedSessionEntry)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function migratedObjectField(
+  entry: MigratedSessionEntry,
+  key: string,
+): MigratedSessionEntry | null {
+  const value = entry[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as MigratedSessionEntry)
+    : null;
+}
+
+function migratedText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function migratedNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function migratedChatType(value: unknown): "direct" | "group" | "channel" | null {
+  if (value === "direct" || value === "group" || value === "channel") {
+    return value;
+  }
+  return null;
+}
+
+function migratedStatus(
+  value: unknown,
+): "running" | "done" | "failed" | "killed" | "timeout" | null {
+  if (
+    value === "running" ||
+    value === "done" ||
+    value === "failed" ||
+    value === "killed" ||
+    value === "timeout"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function migratedSessionScope(
+  entry: MigratedSessionEntry,
+  sessionKey: string,
+): "conversation" | "shared-main" | "group" | "channel" {
+  const chatType = migratedChatType(entry.chatType);
+  const normalizedKey = sessionKey.trim().toLowerCase();
+  if (chatType === "direct" && (normalizedKey === "main" || normalizedKey.endsWith(":main"))) {
+    return "shared-main";
+  }
+  if (chatType === "group" || chatType === "channel") {
+    return chatType;
+  }
+  return "conversation";
+}
+
+function migratedEntryChannel(entry: MigratedSessionEntry): string | null {
+  const deliveryContext = migratedObjectField(entry, "deliveryContext");
+  const origin = migratedObjectField(entry, "origin");
+  return (
+    migratedText(entry.channel) ??
+    migratedText(deliveryContext?.channel) ??
+    migratedText(entry.lastChannel) ??
+    migratedText(origin?.provider)
+  );
+}
+
+function migratedEntryAccountId(entry: MigratedSessionEntry): string | null {
+  const deliveryContext = migratedObjectField(entry, "deliveryContext");
+  const origin = migratedObjectField(entry, "origin");
+  return (
+    migratedText(deliveryContext?.accountId) ??
+    migratedText(entry.lastAccountId) ??
+    migratedText(origin?.accountId)
+  );
+}
+
+function migratedEntryDisplayName(entry: MigratedSessionEntry): string | null {
+  return (
+    migratedText(entry.displayName) ??
+    migratedText(entry.label) ??
+    migratedText(entry.subject) ??
+    migratedText(entry.groupId)
+  );
+}
+
+function backfillOpenClawAgentSchema(db: DatabaseSync, previousVersion: number): void {
+  if (previousVersion >= 2) {
+    return;
+  }
+  db.exec(`
+    INSERT OR REPLACE INTO session_routes (session_key, session_id, updated_at)
+    SELECT se.session_key, se.session_id, se.updated_at
+    FROM session_entries AS se
+    INNER JOIN sessions AS s ON s.session_id = se.session_id;
+  `);
+  const rows = db
+    .prepare(
+      `
+        SELECT se.session_key, se.session_id, se.entry_json
+        FROM session_entries AS se
+        INNER JOIN sessions AS s ON s.session_id = se.session_id;
+      `,
+    )
+    .all() as Array<{
+    entry_json?: unknown;
+    session_id?: unknown;
+    session_key?: unknown;
+  }>;
+  const update = db.prepare(`
+    UPDATE sessions
+    SET
+      session_scope = ?,
+      started_at = ?,
+      ended_at = ?,
+      status = ?,
+      chat_type = ?,
+      channel = ?,
+      account_id = ?,
+      model_provider = ?,
+      model = ?,
+      agent_harness_id = ?,
+      parent_session_key = ?,
+      spawned_by = ?,
+      display_name = ?
+    WHERE session_id = ?;
+  `);
+  for (const row of rows) {
+    const sessionKey = migratedText(row.session_key);
+    const sessionId = migratedText(row.session_id);
+    const entry = parseMigratedSessionEntry(row.entry_json);
+    if (!sessionKey || !sessionId || !entry) {
+      continue;
+    }
+    update.run(
+      migratedSessionScope(entry, sessionKey),
+      migratedNumber(entry.startedAt),
+      migratedNumber(entry.endedAt),
+      migratedStatus(entry.status),
+      migratedChatType(entry.chatType),
+      migratedEntryChannel(entry),
+      migratedEntryAccountId(entry),
+      migratedText(entry.modelProvider),
+      migratedText(entry.model),
+      migratedText(entry.agentHarnessId),
+      migratedText(entry.parentSessionKey),
+      migratedText(entry.spawnedBy),
+      migratedEntryDisplayName(entry),
+      sessionId,
     );
   }
 }
@@ -138,7 +428,10 @@ function assertExistingSchemaOwner(
 function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingSchemaOwner(readExistingSchemaMeta(db), agentId, pathname);
+  const previousVersion = readSqliteUserVersion(db);
+  migrateOpenClawAgentSchema(db);
   db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+  backfillOpenClawAgentSchema(db, previousVersion);
   const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);
   db.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);
   const now = Date.now();

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -16,12 +16,94 @@ export const OPENCLAW_AGENT_SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,
+  session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  ended_at INTEGER,
+  status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+  chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+  channel TEXT,
+  account_id TEXT,
+  primary_conversation_id TEXT,
+  model_provider TEXT,
+  model TEXT,
+  agent_harness_id TEXT,
+  parent_session_key TEXT,
+  spawned_by TEXT,
+  display_name TEXT,
+  FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated_at
+  ON sessions(updated_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_created_at
+  ON sessions(created_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_conversation
+  ON sessions(primary_conversation_id, updated_at DESC, session_id)
+  WHERE primary_conversation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS session_routes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_routes_session_id
+  ON session_routes(session_id);
+
+CREATE TABLE IF NOT EXISTS conversations (
+  conversation_id TEXT NOT NULL PRIMARY KEY,
+  channel TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+  peer_id TEXT NOT NULL,
+  parent_conversation_id TEXT,
+  thread_id TEXT,
+  native_channel_id TEXT,
+  native_direct_user_id TEXT,
+  label TEXT,
+  metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
-  ON sessions(updated_at DESC, session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_lookup
+  ON conversations(channel, account_id, kind, peer_id, thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_conversations_identity
+  ON conversations(
+    channel,
+    account_id,
+    kind,
+    peer_id,
+    IFNULL(parent_conversation_id, ''),
+    IFNULL(thread_id, '')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_updated
+  ON conversations(updated_at DESC, conversation_id);
+
+CREATE TABLE IF NOT EXISTS session_conversations (
+  session_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'primary' CHECK (role IN ('primary', 'participant', 'related')),
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, conversation_id, role),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation
+  ON session_conversations(conversation_id, last_seen_at DESC, session_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_session_conversations_primary
+  ON session_conversations(session_id)
+  WHERE role = 'primary';
 
 CREATE TABLE IF NOT EXISTS session_entries (
   session_key TEXT NOT NULL PRIMARY KEY,
@@ -31,7 +113,7 @@ CREATE TABLE IF NOT EXISTS session_entries (
   FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated_at
   ON session_entries(updated_at DESC, session_key);
 
 CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id

--- a/src/state/openclaw-agent-schema.generated.ts
+++ b/src/state/openclaw-agent-schema.generated.ts
@@ -13,6 +13,62 @@ export const OPENCLAW_AGENT_SCHEMA_SQL = `CREATE TABLE IF NOT EXISTS schema_meta
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -11,12 +11,94 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,
+  session_scope TEXT NOT NULL DEFAULT 'conversation' CHECK (session_scope IN ('conversation', 'shared-main', 'group', 'channel')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  ended_at INTEGER,
+  status TEXT CHECK (status IS NULL OR status IN ('running', 'done', 'failed', 'killed', 'timeout')),
+  chat_type TEXT CHECK (chat_type IS NULL OR chat_type IN ('direct', 'group', 'channel')),
+  channel TEXT,
+  account_id TEXT,
+  primary_conversation_id TEXT,
+  model_provider TEXT,
+  model TEXT,
+  agent_harness_id TEXT,
+  parent_session_key TEXT,
+  spawned_by TEXT,
+  display_name TEXT,
+  FOREIGN KEY (primary_conversation_id) REFERENCES conversations(conversation_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated_at
+  ON sessions(updated_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_created_at
+  ON sessions(created_at DESC, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_conversation
+  ON sessions(primary_conversation_id, updated_at DESC, session_id)
+  WHERE primary_conversation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS session_routes (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_routes_session_id
+  ON session_routes(session_id);
+
+CREATE TABLE IF NOT EXISTS conversations (
+  conversation_id TEXT NOT NULL PRIMARY KEY,
+  channel TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('direct', 'group', 'channel')),
+  peer_id TEXT NOT NULL,
+  parent_conversation_id TEXT,
+  thread_id TEXT,
+  native_channel_id TEXT,
+  native_direct_user_id TEXT,
+  label TEXT,
+  metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
-  ON sessions(updated_at DESC, session_id);
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_lookup
+  ON conversations(channel, account_id, kind, peer_id, thread_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_conversations_identity
+  ON conversations(
+    channel,
+    account_id,
+    kind,
+    peer_id,
+    IFNULL(parent_conversation_id, ''),
+    IFNULL(thread_id, '')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_updated
+  ON conversations(updated_at DESC, conversation_id);
+
+CREATE TABLE IF NOT EXISTS session_conversations (
+  session_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'primary' CHECK (role IN ('primary', 'participant', 'related')),
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, conversation_id, role),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation
+  ON session_conversations(conversation_id, last_seen_at DESC, session_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_session_conversations_primary
+  ON session_conversations(session_id)
+  WHERE role = 'primary';
 
 CREATE TABLE IF NOT EXISTS session_entries (
   session_key TEXT NOT NULL PRIMARY KEY,
@@ -26,7 +108,7 @@ CREATE TABLE IF NOT EXISTS session_entries (
   FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated_at
   ON session_entries(updated_at DESC, session_key);
 
 CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -8,6 +8,62 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS sessions (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_updated
+  ON sessions(updated_at DESC, session_id);
+
+CREATE TABLE IF NOT EXISTS session_entries (
+  session_key TEXT NOT NULL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  entry_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_updated
+  ON session_entries(updated_at DESC, session_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_entries_session_id
+  ON session_entries(session_id);
+
+CREATE TABLE IF NOT EXISTS transcript_events (
+  session_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, seq),
+  FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_events_session
+  ON transcript_events(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS transcript_event_identities (
+  session_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  event_type TEXT,
+  parent_id TEXT,
+  message_idempotency_key TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, event_id),
+  FOREIGN KEY (session_id, seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_message_idempotency
+  ON transcript_event_identities(session_id, message_idempotency_key)
+  WHERE message_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent
+  ON transcript_event_identities(session_id, parent_id)
+  WHERE parent_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS cache_entries (
   scope TEXT NOT NULL,
   key TEXT NOT NULL,

--- a/src/talk/agent-consult-runtime.test.ts
+++ b/src/talk/agent-consult-runtime.test.ts
@@ -294,13 +294,21 @@ describe("realtime voice agent consult runtime", () => {
 
     expect(resolveParentForkDecision).toHaveBeenCalledWith({
       parentEntry: sessionStore["agent:main:main"],
-      storePath: "/tmp/sessions.json",
+      agentId: "main",
+      config: {},
     });
     expect(forkSessionFromParent).toHaveBeenCalledWith({
       parentEntry: sessionStore["agent:main:main"],
       agentId: "main",
-      sessionsDir: "/tmp",
+      config: {},
     });
+    expect(runtime.session.patchSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        config: {},
+        sessionKey: "agent:main:subagent:google-meet:meet-1",
+      }),
+    );
     const forkedEntry = sessionStore["agent:main:subagent:google-meet:meet-1"];
     if (!forkedEntry) {
       throw new Error("Expected forked consult session entry");
@@ -315,8 +323,68 @@ describe("realtime voice agent consult runtime", () => {
     expectPositiveTimestamp(forkedEntry.updatedAt);
     const call = requireEmbeddedAgentCall(runEmbeddedAgent);
     expect(call.sessionId).toBe("forked-session");
-    expect(call.sessionFile).toBe("/tmp/forked.jsonl");
+    expect(call.sessionFile).toBeUndefined();
     expect(call.spawnedBy).toBe("agent:main:main");
+  });
+
+  it("forks cross-agent requester context from the requester agent store", async () => {
+    const { runtime, runEmbeddedAgent, sessionStore } = createAgentRuntime();
+    sessionStore["agent:main:main"] = {
+      sessionId: "parent-session",
+      sessionFile: "relative-parent.jsonl",
+      totalTokens: 100,
+      updatedAt: 1,
+    };
+    const resolveParentForkDecision = vi.fn(async () => ({
+      status: "fork" as const,
+      maxTokens: 100_000,
+      parentTokens: 100,
+    }));
+    const forkSessionFromParent = vi.fn(async () => ({
+      sessionId: "forked-session",
+      sessionFile: "/tmp/forked.jsonl",
+    }));
+    setRealtimeVoiceAgentConsultDepsForTest({
+      resolveParentForkDecision,
+      forkSessionFromParent,
+    });
+
+    await consultRealtimeVoiceAgent({
+      cfg: {} as never,
+      agentRuntime: runtime as never,
+      logger: { warn: vi.fn() },
+      agentId: "voice-agent",
+      sessionKey: "agent:voice-agent:google-meet:meet-1",
+      spawnedBy: "agent:main:main",
+      contextMode: "fork",
+      messageProvider: "google-meet",
+      lane: "google-meet",
+      runIdPrefix: "google-meet:meet-1",
+      args: { question: "What should I say?" },
+      transcript: [],
+      surface: "a private Google Meet",
+      userLabel: "Participant",
+    });
+
+    expect(resolveParentForkDecision).toHaveBeenCalledWith({
+      parentEntry: sessionStore["agent:main:main"],
+      agentId: "main",
+      config: {},
+    });
+    expect(forkSessionFromParent).toHaveBeenCalledWith({
+      parentEntry: sessionStore["agent:main:main"],
+      agentId: "main",
+      config: {},
+    });
+    expect(runtime.session.patchSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "voice-agent",
+        config: {},
+        sessionKey: "agent:voice-agent:google-meet:meet-1",
+      }),
+    );
+    const call = requireEmbeddedAgentCall(runEmbeddedAgent);
+    expect(call.sessionFile).toBe("/tmp/forked.jsonl");
   });
 
   it("inherits requester message routing for forked consult sessions", async () => {

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import type { RunEmbeddedAgentParams } from "../agents/embedded-agent-runner/run/params.js";
 import {
   forkSessionFromParent,
@@ -81,7 +80,8 @@ function resolveDeliverySessionFields(context?: DeliveryContext): Partial<Sessio
 
 function resolveRealtimeVoiceAgentDeliveryContext(params: {
   agentRuntime: RealtimeVoiceAgentConsultRuntime;
-  storePath: string;
+  agentId: string;
+  cfg: OpenClawConfig;
   sessionKey: string;
   spawnedBy?: string | null;
 }): DeliveryContext | undefined {
@@ -96,8 +96,10 @@ function resolveRealtimeVoiceAgentDeliveryContext(params: {
     }
     candidates.push(params.sessionKey);
     for (const key of candidates) {
+      const parsed = parseAgentSessionKey(key);
       const entry = params.agentRuntime.session.getSessionEntry({
-        storePath: params.storePath,
+        agentId: parsed?.agentId ?? params.agentId,
+        config: params.cfg,
         sessionKey: key,
       });
       const context = deliveryContextFromSession(entry);
@@ -113,11 +115,11 @@ function resolveRealtimeVoiceAgentDeliveryContext(params: {
 
 async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
   agentId: string;
+  cfg: OpenClawConfig;
   sessionKey: string;
   spawnedBy?: string | null;
   contextMode?: RealtimeVoiceAgentConsultContextMode;
   deliveryContext?: DeliveryContext;
-  storePath: string;
   agentRuntime: RealtimeVoiceAgentConsultRuntime;
   logger: Pick<RuntimeLogger, "warn">;
 }): Promise<SessionEntry> {
@@ -125,14 +127,13 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
   const deliveryFields = resolveDeliverySessionFields(params.deliveryContext);
   const requesterSessionKey = params.spawnedBy?.trim();
   const requesterAgentId = parseAgentSessionKey(requesterSessionKey)?.agentId;
-  const shouldFork =
-    params.contextMode === "fork" &&
-    requesterSessionKey &&
-    (!requesterAgentId || requesterAgentId === params.agentId);
+  const parentAgentId = requesterAgentId ?? params.agentId;
+  const shouldFork = params.contextMode === "fork" && requesterSessionKey;
   let forkDecisionWarning: string | undefined;
 
   const patched = await params.agentRuntime.session.patchSessionEntry({
-    storePath: params.storePath,
+    agentId: params.agentId,
+    config: params.cfg,
     sessionKey: params.sessionKey,
     fallbackEntry: {
       sessionId: "",
@@ -144,24 +145,28 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
       }
       if (shouldFork) {
         const parentEntry = params.agentRuntime.session.getSessionEntry({
-          storePath: params.storePath,
+          agentId: parentAgentId,
+          config: params.cfg,
           sessionKey: requesterSessionKey,
         });
         if (parentEntry?.sessionId?.trim()) {
           const decision = await realtimeVoiceAgentConsultDeps.resolveParentForkDecision({
             parentEntry,
-            storePath: params.storePath,
+            agentId: parentAgentId,
+            config: params.cfg,
           });
           if (decision.status === "fork") {
             const fork = await realtimeVoiceAgentConsultDeps.forkSessionFromParent({
               parentEntry,
-              agentId: params.agentId,
-              sessionsDir: path.dirname(params.storePath),
+              agentId: parentAgentId,
+              config: params.cfg,
             });
             if (fork) {
               return {
                 ...deliveryFields,
                 sessionId: fork.sessionId,
+                // Current fork storage is file-backed; persist the artifact on
+                // the entry so the run target resolver reuses the forked branch.
                 sessionFile: fork.sessionFile,
                 spawnedBy: requesterSessionKey,
                 forkedFromParent: true,
@@ -221,35 +226,39 @@ export async function consultRealtimeVoiceAgent(params: {
   const workspaceDir = params.agentRuntime.resolveAgentWorkspaceDir(params.cfg, agentId);
   await params.agentRuntime.ensureAgentWorkspace({ dir: workspaceDir });
 
-  const storePath = params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, {
-    agentId,
-  });
   const resolvedDeliveryContext = resolveRealtimeVoiceAgentDeliveryContext({
     agentRuntime: params.agentRuntime,
-    storePath,
+    agentId,
+    cfg: params.cfg,
     sessionKey: params.sessionKey,
     spawnedBy: params.spawnedBy,
   });
   const sessionEntry = await resolveRealtimeVoiceAgentConsultSessionEntry({
     agentId,
+    cfg: params.cfg,
     sessionKey: params.sessionKey,
     spawnedBy: params.spawnedBy,
     contextMode: params.contextMode,
     deliveryContext: resolvedDeliveryContext,
-    storePath,
     agentRuntime: params.agentRuntime,
     logger: params.logger,
   });
   const consultDeliveryContext =
     resolvedDeliveryContext ?? deliveryContextFromSession(sessionEntry);
   const sessionId = sessionEntry.sessionId;
+  const requesterAgentId = parseAgentSessionKey(params.spawnedBy?.trim())?.agentId;
+  const crossAgentForkSessionFile =
+    sessionEntry.forkedFromParent && requesterAgentId && requesterAgentId !== agentId
+      ? sessionEntry.sessionFile?.trim()
+      : undefined;
 
-  const sessionFile = params.agentRuntime.session.resolveSessionFilePath(sessionId, sessionEntry, {
-    agentId,
-  });
   const result = await params.agentRuntime.runEmbeddedAgent({
     sessionId,
     sessionKey: params.sessionKey,
+    // Cross-agent forks are file-backed active artifacts in the requester store.
+    // Passing the artifact keeps the consult run on the forked branch until
+    // consult forking moves to a storage-neutral parent/child target contract.
+    ...(crossAgentForkSessionFile ? { sessionFile: crossAgentForkSessionFile } : {}),
     sandboxSessionKey: resolveRealtimeVoiceAgentSandboxSessionKey(agentId, params.sessionKey),
     agentId,
     spawnedBy: params.spawnedBy,
@@ -262,7 +271,6 @@ export async function consultRealtimeVoiceAgent(params: {
       consultDeliveryContext?.threadId != null
         ? String(consultDeliveryContext.threadId)
         : undefined,
-    sessionFile,
     workspaceDir,
     config: params.cfg,
     prompt: buildRealtimeVoiceAgentConsultPrompt({


### PR DESCRIPTION
## What

Implements the SQLite adapter side of the embedded-agent run/session target seam. The adapter resolves storage-neutral run/session targets through SQLite-backed session access while retaining the named active artifact boundary needed by current embedded-run internals.

## Why

This is the 3.2 counterpart to the file-backed embedded run/session target seam. It proves the target contract can operate under SQLite wiring before the production storage flip.

## Changes

- Adds SQLite target resolution
- Persists active artifact identity
- Handles stale artifact recovery
- Covers consult fork scoping

## Testing

- `node scripts/run-vitest.mjs src/agents/run-session-target.test.ts src/context-engine/context-engine.test.ts src/commitments/runtime.test.ts src/crestodian/assistant.test.ts src/hooks/llm-slug-generator.test.ts src/talk/agent-consult-runtime.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.test.ts`
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.test.ts src/state/openclaw-agent-db.test.ts src/plugin-sdk/session-transcript-hit.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base clawdbot-587/32-sqlite-store-foundation --no-web-search --thinking codex=low`

Refs #88838
