### PR TITLE
fix(memory-core): resolve adapter default model for index identity state

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -39,6 +39,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
+  resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRuntime,
@@ -298,6 +299,14 @@ export abstract class MemoryManagerSyncOps {
     hasIndexedChunks?: boolean;
   }): MemoryIndexIdentityState {
     const hasProviderOverride = params && "provider" in params;
+    const configuredProviderModel =
+      this.settings.model && this.settings.model.trim()
+        ? this.settings.model.trim()
+        : resolveEmbeddingProviderFallbackModel(
+            this.settings.provider,
+            this.settings.model,
+            this.cfg,
+          );
     const configuredProvider =
       this.settings.provider === "none"
         ? null
@@ -305,7 +314,7 @@ export abstract class MemoryManagerSyncOps {
             id:
               resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
               this.settings.provider,
-            model: this.settings.model,
+            model: configuredProviderModel,
           };
     const provider = hasProviderOverride
       ? params.provider!

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -23,6 +23,7 @@ import {
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createEmbeddingProvider,
+  resolveEmbeddingProviderFallbackModel,
   type EmbeddingProvider,
   type EmbeddingProviderId,
   type EmbeddingProviderRequest,
@@ -427,7 +428,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         ? null
         : this.providerInitialized
           ? this.provider
-            ? { id: this.provider.id, model: this.provider.model }
+            ? {
+                id: this.provider.id,
+                model:
+                  this.provider.model ||
+                  resolveEmbeddingProviderFallbackModel(
+                    this.settings.provider,
+                    this.settings.model,
+                    this.cfg,
+                  ),
+              }
             : null
           : undefined;
     const state = this.resolveCurrentIndexIdentityState({


### PR DESCRIPTION
## Summary

`openclaw memory status` reported `Index identity: index was built for model <X>, expected` (blank expected) and `Vector search: paused until memory is rebuilt` whenever `agents.<id>.memorySearch.model` was left at its default empty string and the embedding adapter exposes a `defaultModel` (e.g. OpenAI `text-embedding-3-small`). `memory status --deep` and `memory index --force` reported the system as healthy, but the plain status path declared a mismatch and downstream `memory_search` calls returned `disabled: true, error: "index metadata is missing"`.

## Root cause

`MemoryManagerSyncOps.resolveCurrentIndexIdentityState` built `configuredProvider` directly from `this.settings.model`. With the default empty-string setting, the configured provider's `model` was always `""`, so identity validation compared `meta.model !== ""` and declared a mismatch with a blank "expected" model. The provider init path that runs on `--deep` / `--index` resolves the adapter's `defaultModel` via `resolveProviderModel`, but the cheap status-only path never reached that branch (`providerInitialized: false`, `this.provider === undefined`).

## Fix

- In `resolveCurrentIndexIdentityState`, resolve the adapter's `defaultModel` up front via the existing `resolveEmbeddingProviderFallbackModel` helper when `this.settings.model` is empty/whitespace, so the status path computes the same expected model as the index/deep paths.
- In `refreshIndexIdentityDirty`, apply a symmetric fallback so the initialised-provider branch also tolerates a falsy `this.provider.model`.

Both edits reuse helpers already present in `embeddings.ts`; no new dependencies or configuration surfaces.

## Verification

- TypeScript syntax check via `ts.transpileModule` (Node 22) on both modified files: no diagnostics.
- Logic-level sanity check confirms: empty model + openai provider → `text-embedding-3-small`; explicit model preserved; `provider === "none"` still returns null; whitespace-only model also falls back.
- The existing `cli.test.ts` `"prints index identity mismatch reasons"` test covers the formatting path and is unaffected because the status object shape is unchanged.

Local vitest run is unavailable in this environment (rolldown/oxlint native bindings not installed for this platform); CI will exercise the full test suite.

Closes #90413
