### PR TITLE
fix(matrix): preserve threaded replies and owner commands

### DIFF
--- a/extensions/matrix/src/matrix/monitor/access-state.test.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.test.ts
@@ -158,6 +158,28 @@ describe("resolveMatrixMonitorAccessState", () => {
     );
   });
 
+  it("authorizes room control commands through explicit Matrix command owners", async () => {
+    const state = await resolveMatrixMonitorAccessState({
+      allowFrom: [],
+      storeAllowFrom: [],
+      commandOwnerAllowFrom: ["matrix:@owner:example.org"],
+      groupAllowFrom: [],
+      roomUsers: [],
+      senderId: "@owner:example.org",
+      isRoom: true,
+    });
+
+    await expectCommandAccess(
+      state,
+      {
+        useAccessGroups: true,
+        allowTextCommands: true,
+        hasControlCommand: true,
+      },
+      { authorized: true, shouldBlockControlCommand: false },
+    );
+  });
+
   it("keeps command allow mode when access groups are disabled", async () => {
     const state = await resolveMatrixMonitorAccessState({
       allowFrom: [],

--- a/extensions/matrix/src/matrix/monitor/access-state.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.ts
@@ -9,6 +9,7 @@ import { normalizeMatrixAllowList, resolveMatrixAllowListMatch } from "./allowli
 type MatrixMonitorAccessState = {
   effectiveGroupAllowFrom: string[];
   effectiveRoomUsers: string[];
+  effectiveCommandOwnerAllowFrom: string[];
   messageIngress: ResolvedChannelMessageIngress;
   accountId: string;
   senderId: string;
@@ -54,6 +55,7 @@ function resolveMatrixGroupIngress(params: {
 export async function resolveMatrixMonitorAccessState(params: {
   allowFrom: Array<string | number>;
   storeAllowFrom: Array<string | number>;
+  commandOwnerAllowFrom?: Array<string | number>;
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
   groupPolicy?: "open" | "allowlist" | "disabled";
   groupAllowFrom: Array<string | number>;
@@ -67,6 +69,7 @@ export async function resolveMatrixMonitorAccessState(params: {
   const groupPolicy = params.groupPolicy ?? "open";
   const effectiveGroupAllowFrom = normalizeMatrixAllowList(params.groupAllowFrom);
   const effectiveRoomUsers = normalizeMatrixAllowList(params.roomUsers);
+  const effectiveCommandOwnerAllowFrom = normalizeMatrixAllowList(params.commandOwnerAllowFrom);
   const groupIngress = resolveMatrixGroupIngress({
     groupPolicy,
     effectiveGroupAllowFrom,
@@ -101,6 +104,7 @@ export async function resolveMatrixMonitorAccessState(params: {
   return {
     effectiveGroupAllowFrom,
     effectiveRoomUsers,
+    effectiveCommandOwnerAllowFrom,
     messageIngress: resolved,
     accountId,
     senderId: params.senderId,
@@ -117,8 +121,15 @@ export async function resolveMatrixMonitorCommandAccess(
   },
 ) {
   const commandAllowFrom = state.isRoom ? [] : state.messageIngress.senderAccess.effectiveAllowFrom;
+  const commandDirectAllowFrom = state.isRoom
+    ? []
+    : Array.from(new Set([...commandAllowFrom, ...state.effectiveCommandOwnerAllowFrom]));
   const commandGroupAllowFrom =
-    state.effectiveRoomUsers.length > 0 ? state.effectiveRoomUsers : state.effectiveGroupAllowFrom;
+    state.effectiveRoomUsers.length > 0
+      ? Array.from(new Set([...state.effectiveRoomUsers, ...state.effectiveCommandOwnerAllowFrom]))
+      : Array.from(
+          new Set([...state.effectiveGroupAllowFrom, ...state.effectiveCommandOwnerAllowFrom]),
+        );
   const resolved = await createChannelIngressResolver({
     channelId: "matrix",
     accountId: state.accountId,
@@ -132,7 +143,7 @@ export async function resolveMatrixMonitorCommandAccess(
     dmPolicy: "allowlist",
     groupPolicy: "allowlist",
     policy: { groupAllowFromFallbackToAllowFrom: false },
-    allowFrom: commandAllowFrom,
+    allowFrom: commandDirectAllowFrom,
     groupAllowFrom: commandGroupAllowFrom,
     command: {
       useAccessGroups: params.useAccessGroups,

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -147,7 +147,7 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
 
     const finalized = latestFinalizedReplyContext(finalizeInboundContext);
     expect(finalized.MessageThreadId).toBe("$thread-root");
-    expect(finalized.ReplyToId).toBeUndefined();
+    expect(finalized.ReplyToId).toBe("$thread-root");
     expect(latestSessionKey(recordInboundSession)).toBe("agent:ops:main:thread:$thread-root");
   });
 
@@ -271,7 +271,7 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
 
     const finalized = latestFinalizedReplyContext(finalizeInboundContext);
     expect(finalized.MessageThreadId).toBe("$thread-root");
-    expect(finalized.ReplyToId).toBeUndefined();
+    expect(finalized.ReplyToId).toBe("$reply1");
     expect(finalized.ReplyToSender).toBe("Alice");
     expect(finalized.ReplyToBody).toBe("[Poll]\nLunch?\n\n1. Pizza\n2. Sushi");
     expect(finalized.ThreadStarterBody).toBe(
@@ -313,7 +313,7 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
 
     const finalized = latestFinalizedReplyContext(finalizeInboundContext);
     expect(finalized.MessageThreadId).toBe("$thread-root");
-    expect(finalized.ReplyToId).toBeUndefined();
+    expect(finalized.ReplyToId).toBe("$reply1");
     expect(finalized.ReplyToSender).toBe("Alice");
     expect(finalized.ReplyToBody).toBe("Root topic");
     expect(finalized.ThreadStarterBody).toBe(

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -866,6 +866,44 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).toHaveBeenCalled();
   });
 
+  it.each(["/status", "/model"])(
+    "allows Matrix owner room text command %s before core command dispatch",
+    async (body) => {
+      const hasControlCommand = vi.fn((text?: string) => text === body);
+      const { handler, finalizeInboundContext, recordInboundSession } =
+        createMatrixHandlerTestHarness({
+          cfg: {
+            commands: {
+              useAccessGroups: true,
+              ownerAllowFrom: ["matrix:@owner:example.org"],
+            },
+          },
+          isDirectMessage: false,
+          shouldHandleTextCommands: () => true,
+          hasControlCommand,
+          getMemberDisplayName: async () => "owner",
+        });
+
+      await handler(
+        "!room:example.org",
+        createMatrixTextMessageEvent({
+          eventId: `$owner-command-${body.slice(1)}`,
+          sender: "@owner:example.org",
+          body,
+        }),
+      );
+
+      expect(callArg(hasControlCommand, 0, 0, "control command")).toBe(body);
+      const context = requireRecord(
+        callArg(finalizeInboundContext, 0, 0, "finalized context"),
+        "finalized context",
+      );
+      expect(context.CommandBody).toBe(body);
+      expect(context.CommandAuthorized).toBe(true);
+      expect(recordInboundSession).toHaveBeenCalled();
+    },
+  );
+
   it("processes room messages mentioned via displayName in formatted_body", async () => {
     const recordInboundSession = vi.fn(async () => {});
     const { handler } = createMatrixHandlerTestHarness({
@@ -1104,6 +1142,7 @@ describe("matrix monitor handler pairing account scope", () => {
       "finalized context",
     );
     expect(context.MessageThreadId).toBe("$root");
+    expect(context.ReplyToId).toBe("$reply1");
     expect(context.ThreadStarterBody).toBe("Matrix thread root $root from Alice:\nRoot topic");
     expectMockCallWithFields(recordInboundSession, { sessionKey: "agent:ops:main:thread:$root" });
   });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -868,6 +868,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         const accessState = await resolveMatrixMonitorAccessState({
           allowFrom: liveDmAllowFrom,
           storeAllowFrom,
+          commandOwnerAllowFrom: Array.isArray(liveCfg.commands?.ownerAllowFrom)
+            ? liveCfg.commands.ownerAllowFrom
+            : [],
           dmPolicy,
           groupPolicy,
           groupAllowFrom: liveGroupAllowFrom,
@@ -1660,7 +1663,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         },
         reply: {
           to: `room:${roomId}`,
-          replyToId: threadTarget ? undefined : (replyToEventId ?? undefined),
+          replyToId: threadTarget ? messageId : (replyToEventId ?? undefined),
           messageThreadId: threadTarget,
           nativeChannelId: roomId,
         },
@@ -1791,7 +1794,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const draftStreamingEnabled = streaming !== "off";
       const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
       const progressDraftStreaming = streaming === "progress";
-      const draftReplyToId = replyToMode !== "off" && !threadTarget ? messageId : undefined;
+      const draftReplyToId = replyToMode !== "off" ? messageId : undefined;
       const draftStream: MatrixDraftStreamHandle | undefined = draftStreamingEnabled
         ? await loadMatrixDraftStream().then(({ createMatrixDraftStream }) =>
             createMatrixDraftStream({

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -647,6 +647,32 @@ describe("sendMessageMatrix threads", () => {
     });
   });
 
+  it("uses replyToId as the fallback target for threaded replies", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "hello thread", {
+      client,
+      cfg: {} as never,
+      threadId: "$thread-root",
+      replyToId: "$current-thread-message",
+    });
+
+    const content = sentContent(sendMessage) as {
+      "m.relates_to"?: {
+        rel_type?: string;
+        event_id?: string;
+        "m.in_reply_to"?: { event_id?: string };
+      };
+    };
+
+    expect(content["m.relates_to"]).toEqual({
+      rel_type: "m.thread",
+      event_id: "$thread-root",
+      is_falling_back: true,
+      "m.in_reply_to": { event_id: "$current-thread-message" },
+    });
+  });
+
   it("resolves text chunk limit using the active Matrix account", async () => {
     const { client } = makeClient();
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes Matrix replies in threads so outbound messages preserve the thread root and the current-event reply fallback.
- Fixes Matrix owner commands such as `/status` and `/model` being rejected by the Matrix pre-dispatch access gate before the core command dispatcher can authorize them.
- Adds regression coverage for Matrix send payloads, reply delivery, monitor access state, handler command dispatch, and agent context.

Why does this matter now?

- A real Matrix deployment with `threadReplies = "always"` and explicit Matrix owners reproduced both failures after upgrading beyond the previously working stable version.
- Threaded conversations were hard to follow because bot responses rendered as ordinary replies instead of staying in the active Matrix thread.
- Owner commands appeared broken from Matrix even when the owner was explicitly configured.

What is the intended outcome?

- Matrix thread replies include `m.relates_to.rel_type = "m.thread"`, keep `event_id` as the thread root, and include `m.in_reply_to.event_id` for the triggering thread message.
- Explicit Matrix entries in `commands.ownerAllowFrom` are included in the Matrix-specific command pre-dispatch allow list.
- `/status` and `/model` can reach the core command dispatcher for authorized Matrix owners.

What is intentionally out of scope?

- No Matrix authentication, encryption, room discovery, or sync-loop behavior is changed.
- No channel wildcard allow list is treated as owner authorization.
- No config migration is added.

What does success look like?

- Bot responses to Matrix thread messages render inside the active thread.
- Authorized Matrix owners can run `/status` and `/model` from Matrix.
- Existing Matrix monitor tests continue to pass with the added regression cases.

What should reviewers focus on?

- Whether preserving `replyToId` alongside `threadId` is the correct Matrix relation behavior for thread replies.
- Whether merging explicit `commands.ownerAllowFrom` entries into the Matrix command pre-gate is scoped tightly enough and does not broaden normal message ingress.
- Whether the added tests cover both the reply payload shape and the command dispatch path.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #87307

Which issues, PRs, or discussions are related?

Related #87307

Was this requested by a maintainer or owner?

No maintainer request. This was reported from a real Matrix deployment and narrowed down through local source testing.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Matrix bot replies to thread messages rendered as ordinary replies instead of staying in the active thread; Matrix owner commands `/status` and `/model` produced no response.
- Real environment tested: A live OpenClaw gateway built from source at `v2026.6.1` with the Matrix plugin loaded from the source checkout, using a real Matrix account and rooms. Runtime identifiers and account details are redacted.
- Exact steps or command run after this patch: Rebuilt OpenClaw from source, restarted the gateway service, verified the Matrix plugin resolved to the source checkout, then sent Matrix messages from a real client: `/status`, `/model`, and a bot mention inside an existing Matrix thread.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Redacted local verification showed the gateway active, Matrix plugin version `2026.6.1` loaded from the source checkout, Matrix config using `threadReplies = "always"`, `dm.threadReplies = "always"`, `replyToMode = "all"`, and explicit Matrix owner entries present. The reporter confirmed after live Matrix testing: `nice, it works!`.
- Observed result after fix: `/status` and `/model` returned Matrix responses, and bot replies to messages sent inside a Matrix thread appeared in that thread.
- Proof limitations or environment constraints: The live Matrix logs and config contain private room IDs, account IDs, homeserver details, and tokens, so only redacted behavior proof is included here.
- Before evidence (optional but encouraged): Before the patch, regression tests reproduced that `deliverMatrixReplies` dropped `replyToId` when `threadId` was present, and Matrix command pre-dispatch ignored explicit `commands.ownerAllowFrom` Matrix owners.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

```sh
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-matrix.config.ts \
  extensions/matrix/src/matrix/send.test.ts \
  extensions/matrix/src/matrix/monitor/replies.test.ts \
  extensions/matrix/src/matrix/monitor/access-state.test.ts \
  extensions/matrix/src/matrix/monitor/handler.test.ts \
  extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
```

Result: 5 test files passed, 180 tests passed.

```sh
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extension-matrix.config.ts \
  extensions/matrix/src
```

Result: 117 test files passed, 1327 tests passed.

```sh
pnpm build
```

Result: completed successfully.

What regression coverage was added or updated?

- Threaded Matrix send payloads now assert `m.in_reply_to` points at the current thread message while `event_id` remains the thread root.
- Matrix reply delivery now asserts `replyToId` is preserved for threaded replies unless `replyToMode` is off.
- Matrix command access now asserts explicit Matrix owners pass the Matrix command pre-dispatch gate.
- Matrix handler tests now assert `/status` and `/model` dispatch for authorized Matrix owners and threaded inbound context carries the current event as `ReplyToId`.

What failed before this fix, if known?

- The new thread reply tests failed because `replyToId` was stripped whenever `threadId` was set.
- The new owner command tests failed because `commands.ownerAllowFrom` was not part of the Matrix command pre-dispatch allow list.

If no test was added, why not?

Tests were added.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly: Matrix owner command pre-dispatch now includes explicit `commands.ownerAllowFrom` entries.

What is the highest-risk area?

Command authorization scope for Matrix owner-only commands.

How is that risk mitigated?

Only explicit `commands.ownerAllowFrom` entries are merged into the Matrix command pre-gate. Wildcard Matrix channel allow lists are not treated as owners, normal message ingress is unchanged, and regression tests cover the owner-command path.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and maintainer feedback. Additional redacted live proof can be provided if requested.

Which bot or reviewer comments were addressed?

None yet.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
