### PR TITLE
fix(doctor): consolidate legacy Codex migration cleanup

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3879,6 +3879,35 @@ describe("collectCodexRouteWarnings", () => {
     expect(store.main.agentRuntimeOverride).toBeUndefined();
   });
 
+  it("repairs legacy Codex model refs under canonical OpenAI session providers", () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "openai-codex/gpt-5.5",
+        providerOverride: "openai",
+        modelOverride: "openai-codex/gpt-5.4",
+        agentHarnessId: "codex",
+        agentRuntimeOverride: "codex",
+      },
+    };
+
+    const result = repairCodexSessionStoreRoutes({
+      store,
+      now: 123,
+    });
+
+    expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
+    expect(store.main.updatedAt).toBe(123);
+    expect(store.main.modelProvider).toBe("openai");
+    expect(store.main.model).toBe("gpt-5.5");
+    expect(store.main.providerOverride).toBe("openai");
+    expect(store.main.modelOverride).toBe("gpt-5.4");
+    expect(store.main.agentHarnessId).toBeUndefined();
+    expect(store.main.agentRuntimeOverride).toBeUndefined();
+  });
+
   it("repairs Telegram direct session routes while preserving canonical OpenAI auth pins", () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:telegram:default:direct:5550100999": {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -2899,7 +2899,8 @@ function rewriteSessionModelPair(params: {
     return true;
   }
   if (model && isOpenAICodexModelRef(model)) {
-    const canonicalModel = toCanonicalOpenAIModelRef(model);
+    const canonicalModel =
+      provider === "openai" ? toOpenAIModelId(model) : toCanonicalOpenAIModelRef(model);
     if (canonicalModel) {
       params.entry[params.modelKey] = canonicalModel;
       changed = true;

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -542,6 +542,276 @@ describe("legacy memory search config migrate", () => {
     );
   });
 
+  it("preserves legacy OpenAI Codex model context metadata when merging a missing canonical model", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            models: [
+              {
+                id: "gpt-5.5",
+                name: "Legacy Codex GPT-5.5",
+                api: "openai-codex-responses",
+                contextTokens: 1_050_000,
+                contextWindow: 1_050_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "Legacy Codex GPT-5.5",
+          api: "openai-chatgpt-responses",
+          contextTokens: 1_050_000,
+          contextWindow: 1_050_000,
+          maxTokens: 16_384,
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses".',
+      'Moved models.providers.openai-codex.models[0].api "openai-codex-responses" → "openai-chatgpt-responses".',
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5.",
+    ]);
+  });
+
+  it("merges missing legacy Codex context metadata without overwriting canonical OpenAI values", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            contextTokens: 272_000,
+            models: [
+              {
+                id: "openai/gpt-5.5",
+                contextTokens: 272_000,
+              },
+            ],
+          },
+          "openai-codex": {
+            contextTokens: 1_050_000,
+            contextWindow: 1_050_000,
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+                contextTokens: 1_050_000,
+                contextWindow: 1_050_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      contextTokens: 272_000,
+      models: [
+        {
+          id: "gpt-5.5",
+          contextTokens: 272_000,
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied maxTokens metadata.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
+  it("keeps canonical OpenAI provider-level context budgets authoritative for matching model rows", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            contextTokens: 272_000,
+            models: [
+              {
+                id: "openai/gpt-5.5",
+              },
+            ],
+          },
+          "openai-codex": {
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+                contextTokens: 1_050_000,
+                contextWindow: 1_050_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      contextTokens: 272_000,
+      models: [
+        {
+          id: "gpt-5.5",
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied maxTokens metadata.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
+  it("keeps canonical OpenAI contextWindow metadata authoritative over legacy contextTokens", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            contextWindow: 272_000,
+            models: [
+              {
+                id: "openai/gpt-5.5",
+                contextWindow: 272_000,
+              },
+            ],
+          },
+          "openai-codex": {
+            contextTokens: 1_050_000,
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+                contextTokens: 1_050_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      contextWindow: 272_000,
+      models: [
+        {
+          id: "gpt-5.5",
+          contextWindow: 272_000,
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied maxTokens metadata.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
+  it("keeps canonical OpenAI model-level context budgets authoritative over legacy provider budgets", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            models: [
+              {
+                id: "openai/gpt-5.5",
+                contextWindow: 272_000,
+              },
+            ],
+          },
+          "openai-codex": {
+            contextTokens: 1_050_000,
+            contextWindow: 1_050_000,
+            maxTokens: 16_384,
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      maxTokens: 16_384,
+      models: [
+        {
+          id: "openai/gpt-5.5",
+          contextWindow: 272_000,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Copied models.providers.openai-codex maxTokens metadata to models.providers.openai.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
+  it("normalizes scoped canonical OpenAI model rows before copying legacy Codex context metadata", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            models: [
+              {
+                id: "openai/gpt-5.5",
+              },
+            ],
+          },
+          "openai-codex": {
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+                contextTokens: 1_050_000,
+                contextWindow: 1_050_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      models: [
+        {
+          id: "gpt-5.5",
+          contextTokens: 1_050_000,
+          contextWindow: 1_050_000,
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied contextTokens, contextWindow, maxTokens metadata.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
   it("rewrites top-level legacy auto provider after moving memorySearch into agent defaults", () => {
     const raw = {
       memorySearch: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -851,6 +851,69 @@ describe("legacy memory search config migrate", () => {
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
     ]);
   });
+
+  it("preserves legacy provider-level Codex context budgets on matching canonical rows while merging disjoint models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [
+              {
+                id: "openai/gpt-5.5",
+              },
+            ],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            contextTokens: 1_050_000,
+            contextWindow: 1_050_000,
+            maxTokens: 16_384,
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+              },
+              {
+                id: "gpt-5.6",
+                name: "Legacy Codex GPT-5.6",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://api.openai.com/v1",
+      models: [
+        {
+          id: "gpt-5.5",
+          contextTokens: 1_050_000,
+          contextWindow: 1_050_000,
+          maxTokens: 16_384,
+        },
+        {
+          id: "gpt-5.6",
+          name: "Legacy Codex GPT-5.6",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          api: "openai-chatgpt-responses",
+          contextWindow: 1_050_000,
+          contextTokens: 1_050_000,
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses".',
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied contextTokens, contextWindow, maxTokens metadata.",
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.6.",
+    ]);
+  });
+
   it("rewrites top-level legacy auto provider after moving memorySearch into agent defaults", () => {
     const raw = {
       memorySearch: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -769,6 +769,45 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
+  it("keeps canonical OpenAI model-level context budgets authoritative over legacy provider budgets", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            models: [
+              {
+                id: "openai/gpt-5.5",
+                contextWindow: 272_000,
+              },
+            ],
+          },
+          "openai-codex": {
+            contextTokens: 1_050_000,
+            contextWindow: 1_050_000,
+            maxTokens: 16_384,
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      maxTokens: 16_384,
+      models: [
+        {
+          id: "openai/gpt-5.5",
+          contextWindow: 272_000,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      "Copied models.providers.openai-codex maxTokens metadata to models.providers.openai.",
+      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
   it("normalizes scoped canonical OpenAI model rows before copying legacy Codex context metadata", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -730,7 +730,7 @@ describe("legacy memory search config migrate", () => {
     ]);
   });
 
-  it("keeps canonical OpenAI model-level context budgets authoritative over legacy provider budgets", () => {
+  it("keeps legacy provider-level Codex budgets when no model target can be identified", () => {
     const res = migrateLegacyConfigForTest({
       models: {
         providers: {
@@ -754,7 +754,6 @@ describe("legacy memory search config migrate", () => {
 
     expect(res.config?.models?.providers?.openai).toEqual({
       api: "openai-chatgpt-responses",
-      maxTokens: 16_384,
       models: [
         {
           id: "openai/gpt-5.5",
@@ -762,14 +761,17 @@ describe("legacy memory search config migrate", () => {
         },
       ],
     });
-    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expect(res.config?.models?.providers?.["openai-codex"]).toEqual({
+      contextTokens: 1_050_000,
+      contextWindow: 1_050_000,
+      maxTokens: 16_384,
+    });
     expectMigrationChangesToIncludeFragments(res.changes, [
-      "Copied models.providers.openai-codex maxTokens metadata to models.providers.openai.",
-      "Removed models.providers.openai-codex because models.providers.openai already exists.",
+      "Skipped removing models.providers.openai-codex because provider-level context metadata cannot be mapped safely to a canonical OpenAI model row.",
     ]);
   });
 
-  it("keeps canonical OpenAI model-level context budgets authoritative over legacy provider budgets", () => {
+  it("copies legacy provider-level Codex budgets onto matching canonical model rows", () => {
     const res = migrateLegacyConfigForTest({
       models: {
         providers: {
@@ -786,6 +788,11 @@ describe("legacy memory search config migrate", () => {
             contextTokens: 1_050_000,
             contextWindow: 1_050_000,
             maxTokens: 16_384,
+            models: [
+              {
+                id: "openai-codex/gpt-5.5",
+              },
+            ],
           },
         },
       },
@@ -793,17 +800,17 @@ describe("legacy memory search config migrate", () => {
 
     expect(res.config?.models?.providers?.openai).toEqual({
       api: "openai-chatgpt-responses",
-      maxTokens: 16_384,
       models: [
         {
-          id: "openai/gpt-5.5",
+          id: "gpt-5.5",
           contextWindow: 272_000,
+          maxTokens: 16_384,
         },
       ],
     });
     expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
     expectMigrationChangesToIncludeFragments(res.changes, [
-      "Copied models.providers.openai-codex maxTokens metadata to models.providers.openai.",
+      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied maxTokens metadata.",
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
     ]);
   });
@@ -849,6 +856,61 @@ describe("legacy memory search config migrate", () => {
     expectMigrationChangesToIncludeFragments(res.changes, [
       "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied contextTokens, contextWindow, maxTokens metadata.",
       "Removed models.providers.openai-codex because models.providers.openai already exists.",
+    ]);
+  });
+
+  it("does not promote legacy provider-level Codex budgets to unrelated canonical OpenAI models", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          openai: {
+            api: "openai-chatgpt-responses",
+            models: [
+              {
+                id: "text-embedding-3-small",
+                name: "OpenAI embeddings",
+              },
+            ],
+          },
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            contextTokens: 1_050_000,
+            contextWindow: 1_050_000,
+            maxTokens: 16_384,
+            models: [
+              {
+                id: "gpt-5.5",
+                name: "Legacy Codex GPT-5.5",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.openai).toEqual({
+      api: "openai-chatgpt-responses",
+      models: [
+        {
+          id: "text-embedding-3-small",
+          name: "OpenAI embeddings",
+        },
+        {
+          id: "gpt-5.5",
+          name: "Legacy Codex GPT-5.5",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          api: "openai-chatgpt-responses",
+          contextWindow: 1_050_000,
+          contextTokens: 1_050_000,
+          maxTokens: 16_384,
+        },
+      ],
+    });
+    expect(res.config?.models?.providers).not.toHaveProperty("openai-codex");
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'Moved models.providers.openai-codex.api "openai-codex-responses" → "openai-chatgpt-responses".',
+      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5.",
     ]);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -954,8 +954,8 @@ const CANONICAL_PROVIDER_MODEL_LEAK_KEYS = [
   "request",
 ] as const;
 
-function hasCanonicalOpenAIProvider(providers: Record<string, unknown>): boolean {
-  return Object.keys(providers).some(
+function findCanonicalOpenAIProviderKey(providers: Record<string, unknown>): string | undefined {
+  return Object.keys(providers).find(
     (providerId) => normalizeProviderId(providerId) === OPENAI_PROVIDER_ID,
   );
 }
@@ -1002,6 +1002,189 @@ function normalizeLegacyOpenAIResponsesApi(
 
 function hasOwnDefinedProperty(record: Record<string, unknown>, key: string): boolean {
   return Object.hasOwn(record, key) && record[key] !== undefined;
+}
+
+const OPENAI_CODEX_CONTEXT_METADATA_KEYS = ["contextTokens", "contextWindow", "maxTokens"] as const;
+
+function hasUsableContextMetadata(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function hasContextBudget(value: Record<string, unknown>): boolean {
+  return (
+    hasUsableContextMetadata(value.contextTokens) || hasUsableContextMetadata(value.contextWindow)
+  );
+}
+
+function copyMissingContextMetadata(params: {
+  source: Record<string, unknown>;
+  target: Record<string, unknown>;
+  blockContextBudget?: boolean;
+}): string[] {
+  const copied: string[] = [];
+  const targetHasContextBudget = hasContextBudget(params.target);
+  for (const key of OPENAI_CODEX_CONTEXT_METADATA_KEYS) {
+    if (params.target[key] !== undefined || !hasUsableContextMetadata(params.source[key])) {
+      continue;
+    }
+    if (
+      (key === "contextTokens" || key === "contextWindow") &&
+      (targetHasContextBudget || params.blockContextBudget)
+    ) {
+      continue;
+    }
+    params.target[key] = params.source[key];
+    copied.push(key);
+  }
+  return copied;
+}
+
+function hasProviderLevelContextBudget(provider: Record<string, unknown>): boolean {
+  return hasContextBudget(provider);
+}
+
+function hasModelLevelContextBudget(provider: Record<string, unknown>): boolean {
+  return (
+    Array.isArray(provider.models) &&
+    provider.models.some((model) => {
+      const modelRecord = getRecord(model);
+      return Boolean(modelRecord && hasContextBudget(modelRecord));
+    })
+  );
+}
+
+function normalizeOpenAIModelIdForComparison(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const modelId = value.trim();
+  if (!modelId) {
+    return undefined;
+  }
+  const slashIndex = modelId.indexOf("/");
+  if (slashIndex <= 0) {
+    return modelId.toLowerCase();
+  }
+  const provider = normalizeProviderId(modelId.slice(0, slashIndex));
+  if (provider !== OPENAI_PROVIDER_ID && provider !== LEGACY_OPENAI_CODEX_PROVIDER_ID) {
+    return modelId.toLowerCase();
+  }
+  const unscoped = modelId.slice(slashIndex + 1).trim();
+  return unscoped ? unscoped.toLowerCase() : undefined;
+}
+
+function canonicalOpenAIModelId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const modelId = value.trim();
+  if (!modelId) {
+    return undefined;
+  }
+  const slashIndex = modelId.indexOf("/");
+  if (slashIndex <= 0) {
+    return modelId;
+  }
+  const provider = normalizeProviderId(modelId.slice(0, slashIndex));
+  if (provider !== OPENAI_PROVIDER_ID && provider !== LEGACY_OPENAI_CODEX_PROVIDER_ID) {
+    return modelId;
+  }
+  const unscoped = modelId.slice(slashIndex + 1).trim();
+  return unscoped || undefined;
+}
+
+function findOpenAIModelEntry(
+  models: unknown[],
+  modelId: string,
+): { model: Record<string, unknown>; index: number } | undefined {
+  const comparable = normalizeOpenAIModelIdForComparison(modelId);
+  if (!comparable) {
+    return undefined;
+  }
+  for (const [index, model] of models.entries()) {
+    const record = getRecord(model);
+    if (!record) {
+      continue;
+    }
+    if (normalizeOpenAIModelIdForComparison(record.id) === comparable) {
+      return { model: record, index };
+    }
+  }
+  return undefined;
+}
+
+function normalizeOpenAIModelEntryId(model: Record<string, unknown>, modelId: string): boolean {
+  if (model.id === modelId) {
+    return false;
+  }
+  if (
+    normalizeOpenAIModelIdForComparison(model.id) !== normalizeOpenAIModelIdForComparison(modelId)
+  ) {
+    return false;
+  }
+  model.id = modelId;
+  return true;
+}
+
+function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
+  legacyProvider: Record<string, unknown>;
+  canonicalProvider: Record<string, unknown>;
+  changes: string[];
+}): boolean {
+  let changed = false;
+  const providerKeys = copyMissingContextMetadata({
+    source: params.legacyProvider,
+    target: params.canonicalProvider,
+    blockContextBudget: hasModelLevelContextBudget(params.canonicalProvider),
+  });
+  if (providerKeys.length > 0) {
+    params.changes.push(
+      `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${providerKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.`,
+    );
+    changed = true;
+  }
+
+  const canonicalModels = Array.isArray(params.canonicalProvider.models)
+    ? params.canonicalProvider.models
+    : [];
+  const legacyModels = Array.isArray(params.legacyProvider.models)
+    ? params.legacyProvider.models
+    : [];
+  for (const legacyModelValue of legacyModels) {
+    const legacyModel = getRecord(legacyModelValue);
+    const modelId = canonicalOpenAIModelId(legacyModel?.id);
+    if (!legacyModel || !modelId) {
+      continue;
+    }
+    const existing = findOpenAIModelEntry(canonicalModels, modelId);
+    if (!existing) {
+      continue;
+    }
+    const normalizedId = normalizeOpenAIModelEntryId(existing.model, modelId);
+    const copiedKeys = copyMissingContextMetadata({
+      source: legacyModel,
+      target: existing.model,
+      blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
+    });
+    if (copiedKeys.length === 0 && !normalizedId) {
+      continue;
+    }
+    if (normalizedId && copiedKeys.length > 0) {
+      params.changes.push(
+        `Normalized models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].id to ${modelId} and copied ${copiedKeys.join(", ")} metadata.`,
+      );
+    } else if (normalizedId) {
+      params.changes.push(
+        `Normalized models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].id to ${modelId}.`,
+      );
+    } else {
+      params.changes.push(
+        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.models[].${modelId} ${copiedKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].`,
+      );
+    }
+    changed = true;
+  }
+  return changed;
 }
 
 function collectModelMergeBlockers(params: {
@@ -1210,7 +1393,8 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
       continue;
     }
 
-    if (!hasCanonicalOpenAIProvider(providers)) {
+    const canonicalProviderKey = findCanonicalOpenAIProviderKey(providers);
+    if (!canonicalProviderKey) {
       providers[OPENAI_PROVIDER_ID] = normalized.value;
       changes.push(
         `Moved models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} → models.providers.${OPENAI_PROVIDER_ID}.`,
@@ -1223,6 +1407,11 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
       const canonicalEntry = getCanonicalOpenAIProviderEntry(providers);
       const canonicalKey = canonicalEntry?.key ?? OPENAI_PROVIDER_ID;
       const canonical = canonicalEntry?.value ?? {};
+      copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows({
+        legacyProvider: normalized.value,
+        canonicalProvider: canonical,
+        changes,
+      });
       const canonicalModels: unknown[] = Array.isArray(canonical.models)
         ? (canonical.models as unknown[])
         : [];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1043,14 +1043,8 @@ function hasProviderLevelContextBudget(provider: Record<string, unknown>): boole
   return hasContextBudget(provider);
 }
 
-function hasModelLevelContextBudget(provider: Record<string, unknown>): boolean {
-  return (
-    Array.isArray(provider.models) &&
-    provider.models.some((model) => {
-      const modelRecord = getRecord(model);
-      return Boolean(modelRecord && hasContextBudget(modelRecord));
-    })
-  );
+function hasProviderLevelContextMetadata(provider: Record<string, unknown>): boolean {
+  return OPENAI_CODEX_CONTEXT_METADATA_KEYS.some((key) => hasUsableContextMetadata(provider[key]));
 }
 
 function normalizeOpenAIModelIdForComparison(value: unknown): string | undefined {
@@ -1126,26 +1120,44 @@ function normalizeOpenAIModelEntryId(model: Record<string, unknown>, modelId: st
   return true;
 }
 
+function hasMatchingLegacyOpenAIModelEntry(params: {
+  legacyProvider: Record<string, unknown>;
+  canonicalProvider: Record<string, unknown>;
+}): boolean {
+  const canonicalModels = Array.isArray(params.canonicalProvider.models)
+    ? params.canonicalProvider.models
+    : [];
+  const legacyModels = Array.isArray(params.legacyProvider.models)
+    ? params.legacyProvider.models
+    : [];
+  return legacyModels.some((legacyModelValue) => {
+    const legacyModel = getRecord(legacyModelValue);
+    const modelId = canonicalOpenAIModelId(legacyModel?.id);
+    return Boolean(modelId && findOpenAIModelEntry(canonicalModels, modelId));
+  });
+}
+
+function hasUnmappedLegacyProviderContextMetadata(params: {
+  legacyProvider: Record<string, unknown>;
+  canonicalProvider: Record<string, unknown>;
+  modelsToMerge: unknown[];
+}): boolean {
+  return (
+    hasProviderLevelContextMetadata(params.legacyProvider) &&
+    params.modelsToMerge.length === 0 &&
+    !hasMatchingLegacyOpenAIModelEntry({
+      legacyProvider: params.legacyProvider,
+      canonicalProvider: params.canonicalProvider,
+    })
+  );
+}
+
 function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
   legacyProvider: Record<string, unknown>;
   canonicalProvider: Record<string, unknown>;
   changes: string[];
-  skipProviderLevelMetadata?: boolean;
 }): boolean {
   let changed = false;
-  if (!params.skipProviderLevelMetadata) {
-    const providerKeys = copyMissingContextMetadata({
-      source: params.legacyProvider,
-      target: params.canonicalProvider,
-      blockContextBudget: hasModelLevelContextBudget(params.canonicalProvider),
-    });
-    if (providerKeys.length > 0) {
-      params.changes.push(
-        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${providerKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.`,
-      );
-      changed = true;
-    }
-  }
 
   const canonicalModels = Array.isArray(params.canonicalProvider.models)
     ? params.canonicalProvider.models
@@ -1169,13 +1181,11 @@ function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
       target: existing.model,
       blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
     });
-    const copiedProviderKeys = params.skipProviderLevelMetadata
-      ? copyMissingContextMetadata({
-          source: params.legacyProvider,
-          target: existing.model,
-          blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
-        })
-      : [];
+    const copiedProviderKeys = copyMissingContextMetadata({
+      source: params.legacyProvider,
+      target: existing.model,
+      blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
+    });
     const copiedKeys = [...copiedModelKeys, ...copiedProviderKeys];
     if (copiedKeys.length === 0 && !normalizedId) {
       continue;
@@ -1288,7 +1298,11 @@ function hasAutoFixableLegacyOpenAICodexProvider(providersValue: unknown): boole
       legacy: normalized.value,
     });
     if (modelsToMerge.length === 0) {
-      return true;
+      return !hasUnmappedLegacyProviderContextMetadata({
+        canonicalProvider: canonicalEntry.value,
+        legacyProvider: normalized.value,
+        modelsToMerge,
+      });
     }
     const mergeBlockers = collectModelMergeBlockers({
       canonical: canonicalEntry.value,
@@ -1323,6 +1337,18 @@ export function collectBlockedLegacyOpenAICodexProviderWarnings(raw: unknown): s
       canonical: canonicalEntry.value,
       legacy: normalized.value,
     });
+    if (
+      hasUnmappedLegacyProviderContextMetadata({
+        canonicalProvider: canonicalEntry.value,
+        legacyProvider: normalized.value,
+        modelsToMerge,
+      })
+    ) {
+      warnings.push(
+        `models.providers.${providerId} cannot be removed automatically into models.providers.${canonicalEntry.key} because provider-level context metadata cannot be mapped safely to a canonical OpenAI model row. Add an explicit models.providers.${canonicalEntry.key}.models[] row for the affected Codex model or move the affected defaults manually before removing models.providers.${providerId}.`,
+      );
+      continue;
+    }
     if (modelsToMerge.length === 0) {
       continue;
     }
@@ -1434,11 +1460,25 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
         canonical,
         legacy: normalized.value,
       });
+      const providerContextMetadataNeedsManualMapping = hasUnmappedLegacyProviderContextMetadata({
+        legacyProvider: normalized.value,
+        canonicalProvider: canonical,
+        modelsToMerge,
+      });
+      if (providerContextMetadataNeedsManualMapping) {
+        if (normalized.changed) {
+          providers[providerId] = normalized.value;
+          providersChanged = true;
+        }
+        changes.push(
+          `Skipped removing models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} because provider-level context metadata cannot be mapped safely to a canonical OpenAI model row.`,
+        );
+        continue;
+      }
       copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows({
         legacyProvider: normalized.value,
         canonicalProvider: canonical,
         changes,
-        skipProviderLevelMetadata: modelsToMerge.length > 0,
       });
       const mergeBlockers =
         modelsToMerge.length > 0

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1164,11 +1164,19 @@ function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
       continue;
     }
     const normalizedId = normalizeOpenAIModelEntryId(existing.model, modelId);
-    const copiedKeys = copyMissingContextMetadata({
+    const copiedModelKeys = copyMissingContextMetadata({
       source: legacyModel,
       target: existing.model,
       blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
     });
+    const copiedProviderKeys = params.skipProviderLevelMetadata
+      ? copyMissingContextMetadata({
+          source: params.legacyProvider,
+          target: existing.model,
+          blockContextBudget: hasProviderLevelContextBudget(params.canonicalProvider),
+        })
+      : [];
+    const copiedKeys = [...copiedModelKeys, ...copiedProviderKeys];
     if (copiedKeys.length === 0 && !normalizedId) {
       continue;
     }
@@ -1180,9 +1188,17 @@ function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
       params.changes.push(
         `Normalized models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].id to ${modelId}.`,
       );
+    } else if (copiedModelKeys.length > 0 && copiedProviderKeys.length === 0) {
+      params.changes.push(
+        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.models[].${modelId} ${copiedModelKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].`,
+      );
+    } else if (copiedModelKeys.length === 0 && copiedProviderKeys.length > 0) {
+      params.changes.push(
+        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${copiedProviderKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].`,
+      );
     } else {
       params.changes.push(
-        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.models[].${modelId} ${copiedKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].`,
+        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID}.models[].${modelId} ${copiedModelKeys.join(", ")} metadata and models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${copiedProviderKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.models[${existing.index}].`,
       );
     }
     changed = true;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1130,18 +1130,21 @@ function copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows(params: {
   legacyProvider: Record<string, unknown>;
   canonicalProvider: Record<string, unknown>;
   changes: string[];
+  skipProviderLevelMetadata?: boolean;
 }): boolean {
   let changed = false;
-  const providerKeys = copyMissingContextMetadata({
-    source: params.legacyProvider,
-    target: params.canonicalProvider,
-    blockContextBudget: hasModelLevelContextBudget(params.canonicalProvider),
-  });
-  if (providerKeys.length > 0) {
-    params.changes.push(
-      `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${providerKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.`,
-    );
-    changed = true;
+  if (!params.skipProviderLevelMetadata) {
+    const providerKeys = copyMissingContextMetadata({
+      source: params.legacyProvider,
+      target: params.canonicalProvider,
+      blockContextBudget: hasModelLevelContextBudget(params.canonicalProvider),
+    });
+    if (providerKeys.length > 0) {
+      params.changes.push(
+        `Copied models.providers.${LEGACY_OPENAI_CODEX_PROVIDER_ID} ${providerKeys.join(", ")} metadata to models.providers.${OPENAI_PROVIDER_ID}.`,
+      );
+      changed = true;
+    }
   }
 
   const canonicalModels = Array.isArray(params.canonicalProvider.models)
@@ -1227,8 +1230,9 @@ function getMergeableLegacyOpenAIModels(params: {
   const canonicalModelNames = new Set<string>();
   for (const m of canonicalModels) {
     const mr = getRecord(m);
-    if (typeof mr?.id === "string" && mr.id) {
-      canonicalModelIds.add(mr.id);
+    const normalizedId = normalizeOpenAIModelIdForComparison(mr?.id);
+    if (normalizedId) {
+      canonicalModelIds.add(normalizedId);
     }
     if (typeof mr?.name === "string" && mr.name) {
       canonicalModelNames.add(mr.name);
@@ -1239,7 +1243,7 @@ function getMergeableLegacyOpenAIModels(params: {
     if (!mr) {
       return false;
     }
-    const id = typeof mr.id === "string" ? mr.id : undefined;
+    const id = normalizeOpenAIModelIdForComparison(mr.id);
     const name = typeof mr.name === "string" ? mr.name : undefined;
     if (!id && !name) {
       return false;
@@ -1407,17 +1411,18 @@ function migrateLegacyOpenAICodexProvider(raw: Record<string, unknown>, changes:
       const canonicalEntry = getCanonicalOpenAIProviderEntry(providers);
       const canonicalKey = canonicalEntry?.key ?? OPENAI_PROVIDER_ID;
       const canonical = canonicalEntry?.value ?? {};
-      copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows({
-        legacyProvider: normalized.value,
-        canonicalProvider: canonical,
-        changes,
-      });
       const canonicalModels: unknown[] = Array.isArray(canonical.models)
         ? (canonical.models as unknown[])
         : [];
       const modelsToMerge = getMergeableLegacyOpenAIModels({
         canonical,
         legacy: normalized.value,
+      });
+      copyLegacyOpenAICodexContextMetadataToExistingCanonicalRows({
+        legacyProvider: normalized.value,
+        canonicalProvider: canonical,
+        changes,
+        skipProviderLevelMetadata: modelsToMerge.length > 0,
       });
       const mergeBlockers =
         modelsToMerge.length > 0


### PR DESCRIPTION
## Summary

This PR consolidates legacy Codex/OpenAI doctor migration cleanup after the OpenAI/Codex provider unification.

- When both canonical `models.providers.openai` and legacy `models.providers.openai-codex` exist, doctor now copies missing positive context metadata from the legacy provider before removing it.
- Migrated metadata includes `contextTokens`, `contextWindow`, and `maxTokens` at provider/model scope.
- Canonical `openai` values remain authoritative: existing canonical metadata is not overwritten, explicit canonical provider-level context budgets are not overridden by stale legacy model rows, and `contextTokens`/`contextWindow` are treated as one context-budget group so legacy data cannot reverse runtime precedence.
- Model ids are matched across scoped/unscoped legacy forms such as `gpt-5.5`, `openai/gpt-5.5`, and `openai-codex/gpt-5.5`; scoped canonical OpenAI rows are normalized back to runtime-readable unscoped ids before metadata is copied.
- Session-store doctor repair also normalizes stale `openai-codex/*` model refs when the persisted session provider is already canonical `openai`, so stored model/modelOverride fields become runtime-readable unscoped ids such as `gpt-5.5`.
- This replaces earlier runtime-fallback/shim approaches with update/doctor repair paths; runtime routing remains unified under `openai`.

Why now: 2026.5.28-era installs could store Codex context overrides under `models.providers.openai-codex.models[]`. After 2026.6.1 unification, configs that already had canonical `models.providers.openai` would remove the legacy provider without carrying over that context metadata, causing unified OpenAI/Codex routes to fall back to lower default context budgets.

Out of scope: runtime fallback/shims, changing Codex defaults, changing OAuth/auth routing, or restoring closed runtime write-boundary behavior. This PR only repairs persisted config/session state during doctor/update.

## Linked context

Closes #90448

Related #77858
Related #77861

Consolidates the useful doctor-side session-store edge case from closed PR #90662.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: doctor/config migration removes legacy `models.providers.openai-codex` during OpenAI/Codex route unification. It must preserve legacy Codex `contextTokens` / `contextWindow` / `maxTokens` without turning those Codex-only provider defaults into broad canonical `models.providers.openai` provider defaults for unrelated OpenAI models. It must also repair stale persisted sessions with `modelProvider: "openai"` but `model` / `modelOverride` still scoped as `openai-codex/gpt-*`.
- Real environment tested: macOS local OpenClaw source checkout on this PR branch (`agent/xiaozhua/codex-context-override-migration`, current PR head `2226e281030`) using the real `LEGACY_CONFIG_MIGRATIONS` doctor migration pipeline. The original regression shape comes from official OpenClaw upgrades across the 2026.5.28 → 2026.6.1 OpenAI/Codex unification.
- Exact steps or command run after this patch:

```bash
node --import tsx - <<'EOF'
import { LEGACY_CONFIG_MIGRATIONS } from './src/commands/doctor/shared/legacy-config-migrations.ts';
function migrate(raw) {
  const changes = [];
  for (const migration of LEGACY_CONFIG_MIGRATIONS) migration.apply(raw, changes);
  return { providers: raw.models.providers, changes };
}
// Scenario 1: canonical OpenAI has an unrelated embeddings model; legacy Codex provider
// has provider-level budgets plus a disjoint Codex chat model. The embeddings row must
// not inherit the Codex context budget.
const unrelatedCanonicalModel = migrate({
  models: { providers: {
    openai: { api: 'openai-chatgpt-responses', models: [{ id: 'text-embedding-3-small', name: 'OpenAI embeddings' }] },
    'openai-codex': { api: 'openai-codex-responses', baseUrl: 'https://chatgpt.com/backend-api/codex', contextTokens: 1050000, contextWindow: 1050000, maxTokens: 16384, models: [{ id: 'gpt-5.5', name: 'Legacy Codex GPT-5.5' }] },
  } },
});
// Scenario 2: provider-level legacy budgets must still land on a matching canonical row
// while a second disjoint Codex model is merged.
const matchingPlusDisjoint = migrate({
  models: { providers: {
    openai: { api: 'openai-chatgpt-responses', baseUrl: 'https://api.openai.com/v1', models: [{ id: 'openai/gpt-5.5' }] },
    'openai-codex': { api: 'openai-codex-responses', baseUrl: 'https://chatgpt.com/backend-api/codex', contextTokens: 1050000, contextWindow: 1050000, maxTokens: 16384, models: [{ id: 'openai-codex/gpt-5.5' }, { id: 'gpt-5.6', name: 'Legacy Codex GPT-5.6' }] },
  } },
});
// Scenario 3: if provider-level Codex budgets cannot be mapped to a model row, doctor
// keeps the legacy provider for manual migration instead of copying budgets to all OpenAI.
const unmappedProviderBudget = migrate({
  models: { providers: {
    openai: { api: 'openai-chatgpt-responses', models: [{ id: 'text-embedding-3-small', name: 'OpenAI embeddings' }] },
    'openai-codex': { contextTokens: 1050000, contextWindow: 1050000, maxTokens: 16384 },
  } },
});
console.log(JSON.stringify({ unrelatedCanonicalModel, matchingPlusDisjoint, unmappedProviderBudget }, null, 2));
EOF
```

- Evidence after fix:

```json
{
  "unrelatedCanonicalModel": {
    "providers": {
      "openai": {
        "api": "openai-chatgpt-responses",
        "models": [
          {
            "id": "text-embedding-3-small",
            "name": "OpenAI embeddings"
          },
          {
            "id": "gpt-5.5",
            "name": "Legacy Codex GPT-5.5",
            "baseUrl": "https://chatgpt.com/backend-api/codex",
            "api": "openai-chatgpt-responses",
            "contextWindow": 1050000,
            "contextTokens": 1050000,
            "maxTokens": 16384
          }
        ]
      }
    },
    "changes": [
      "Moved models.providers.openai-codex.api \"openai-codex-responses\" → \"openai-chatgpt-responses\".",
      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.5."
    ]
  },
  "matchingPlusDisjoint": {
    "providers": {
      "openai": {
        "api": "openai-chatgpt-responses",
        "baseUrl": "https://api.openai.com/v1",
        "models": [
          {
            "id": "gpt-5.5",
            "contextTokens": 1050000,
            "contextWindow": 1050000,
            "maxTokens": 16384
          },
          {
            "id": "gpt-5.6",
            "name": "Legacy Codex GPT-5.6",
            "baseUrl": "https://chatgpt.com/backend-api/codex",
            "api": "openai-chatgpt-responses",
            "contextWindow": 1050000,
            "contextTokens": 1050000,
            "maxTokens": 16384
          }
        ]
      }
    },
    "changes": [
      "Moved models.providers.openai-codex.api \"openai-codex-responses\" → \"openai-chatgpt-responses\".",
      "Normalized models.providers.openai.models[0].id to gpt-5.5 and copied contextTokens, contextWindow, maxTokens metadata.",
      "Merged 1 model(s) from models.providers.openai-codex into models.providers.openai: gpt-5.6."
    ]
  },
  "unmappedProviderBudget": {
    "providers": {
      "openai": {
        "api": "openai-chatgpt-responses",
        "models": [
          {
            "id": "text-embedding-3-small",
            "name": "OpenAI embeddings"
          }
        ]
      },
      "openai-codex": {
        "contextTokens": 1050000,
        "contextWindow": 1050000,
        "maxTokens": 16384
      }
    },
    "changes": [
      "Skipped removing models.providers.openai-codex because provider-level context metadata cannot be mapped safely to a canonical OpenAI model row."
    ]
  }
}
```

- Observed result after fix: legacy Codex provider-level budgets are no longer copied onto canonical `models.providers.openai`. In the unrelated canonical model scenario, the existing `text-embedding-3-small` row remains budget-free while the merged Codex `gpt-5.5` row receives the Codex base URL and context budget. In the matching-plus-disjoint scenario, the matching `gpt-5.5` row and merged `gpt-5.6` row both preserve Codex budgets. In the unmapped scenario, doctor keeps `models.providers.openai-codex` and emits a manual-migration change instead of silently broadening the budget to every OpenAI model. Existing canonical provider/model context budgets remain authoritative and are not overwritten. The session-store repair also preserves `modelProvider: "openai"` while rewriting stale `openai-codex/gpt-*` model/modelOverride values to unscoped `gpt-*` and clearing stale Codex runtime pins.
- What was not tested: I did not install this PR branch onto a production Gateway or mutate an existing user config; this was validated with the real source-level doctor migration pipeline, focused tests, full migration tests, and local CI artifact build.
- Before evidence: before this patch, provider-level legacy Codex context metadata could be copied onto canonical `models.providers.openai`, making Codex-only budgets fallback defaults for unrelated OpenAI models; in the earlier mixed path, provider-level budgets could also be skipped before deleting the legacy provider.

## Tests and validation

Commands run after the current-head P1 fixes:

```bash
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts --testNamePattern="legacy OpenAI Codex|context metadata|provider-level|mixed|unrelated canonical OpenAI"
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts
node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts --testNamePattern="legacy Codex|canonical OpenAI"
git diff --check
```

Results:

```text
focused provider/model migration: 10 passed, 113 skipped
full config migration: 123 passed
focused Codex route warnings: 6 passed, 105 skipped
oxfmt --check, oxlint, and git diff --check passed
pnpm build:ci-artifacts passed
```

Earlier validation retained by this PR:

```bash
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts --testNamePattern="canonical OpenAI contextWindow metadata"
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts --testNamePattern="legacy OpenAI Codex|context metadata|canonical OpenAI|scoped canonical"
node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts --testNamePattern="legacy Codex model refs under canonical OpenAI session providers"
node scripts/run-vitest.mjs src/agents/context.test.ts src/agents/context.lookup.test.ts --testNamePattern="contextTokens|contextWindow"
pnpm exec oxlint src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/codex-route-warnings.ts src/commands/doctor/shared/codex-route-warnings.test.ts
git diff --check
```

Regression coverage added:

- Preserves legacy `openai-codex.models[].contextTokens/contextWindow/maxTokens` by creating canonical `openai.models[]` metadata when canonical OpenAI exists but has no matching model row.
- Preserves legacy provider-level `openai-codex.contextTokens/contextWindow/maxTokens` on matching canonical OpenAI model rows when another disjoint legacy model must also be merged.
- Normalizes existing scoped canonical OpenAI model rows such as `openai/gpt-5.5` to runtime-readable `gpt-5.5` before copying missing legacy metadata.
- Merges only missing legacy metadata into canonical `openai` provider/model config.
- Verifies canonical `openai` values are not overwritten by stale legacy Codex values.
- Verifies the legacy provider is still removed after migration.
- Verifies canonical OpenAI provider/model `contextTokens` and `contextWindow` remain authoritative over stale legacy Codex context-budget metadata, including the reverse `contextWindow` versus legacy `contextTokens` case, matching canonical model rows with provider-level budgets, and canonical model-level budgets over legacy provider defaults.
- Repairs stale session-store shape `modelProvider: "openai"` + `model/modelOverride: "openai-codex/gpt-*"` to provider-separated `gpt-*` ids while clearing stale Codex runtime pins.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. After running doctor/update migration, legacy Codex context metadata can continue to affect unified OpenAI/Codex context budgets via canonical `models.providers.openai`, and stale session model refs under canonical OpenAI providers are normalized to runtime-readable unscoped ids.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Doctor migration now preserves missing context metadata before removing `models.providers.openai-codex` when canonical `openai` already exists, and session-store doctor repair handles one additional stale OpenAI/Codex model shape.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This does not change auth, runtime provider routing, network behavior, or tool execution.

What is the highest-risk area?

Copying stale legacy context metadata into canonical `openai` where explicit canonical values should remain authoritative; additionally, normalizing only stale Codex-scoped session model refs without disturbing valid canonical provider/model pairs.

How is that risk mitigated?

The migration copies only positive numeric metadata, only for missing target fields, and tests cover canonical-wins behavior at provider and model scope. Session repair tests cover preserving canonical `modelProvider: "openai"`, rewriting only stale `openai-codex/*` model refs to unscoped ids, and clearing stale Codex runtime pins.

## Current review state

What is the next action?

Wait for CI and ClawSweeper re-review on current head `2226e281030`.

What is still waiting on author, maintainer, CI, or external proof?

CI/ClawSweeper are pending after the latest provider-level budget scoping repair.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's P1 provider-level budget scoping finding, the mixed matching-plus-disjoint provider-budget finding, the earlier scoped canonical-row finding, and consolidated the useful doctor-side edge case from closed #90662 after maintainer feedback to consolidate remaining small migration PRs into a single PR.




