### PR TITLE
fix(memory-core): guard searches during safe reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -349,6 +349,13 @@ export abstract class MemoryManagerSyncOps {
   protected sessionDeltas = new Map<string, MemorySessionDeltaState>();
   protected vectorDegradedWriteWarningShown = false;
   private lastMetaSerialized: string | null = null;
+  // A full reindex briefly repoints this.db at a half-built temp DB (see
+  // runInPlaceReindex). Readers must wait or use a stable pre-swap snapshot.
+  protected reindexing: Promise<void> | null = null;
+  private reindexDepth = 0;
+  private resolveReindexing: (() => void) | null = null;
+  private activeIndexReaders = 0;
+  private activeIndexReaderResolvers: Array<() => void> = [];
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
   protected abstract db: DatabaseSync;
@@ -517,6 +524,52 @@ export abstract class MemoryManagerSyncOps {
     }
     await this.executeSourceSyncPlans([memoryPlan], params.progress);
   }
+
+  protected async drainReindex(): Promise<void> {
+    while (this.reindexing) {
+      try {
+        await this.reindexing;
+      } catch {}
+    }
+  }
+
+  protected async withIndexRead<T>(read: () => Promise<T>): Promise<T> {
+    while (true) {
+      await this.drainReindex();
+      this.activeIndexReaders++;
+      if (!this.reindexing) {
+        break;
+      }
+      this.releaseIndexRead();
+    }
+
+    try {
+      return await read();
+    } finally {
+      this.releaseIndexRead();
+    }
+  }
+
+  private async drainActiveIndexReaders(): Promise<void> {
+    while (this.activeIndexReaders > 0) {
+      await new Promise<void>((resolve) => {
+        this.activeIndexReaderResolvers.push(resolve);
+      });
+    }
+  }
+
+  private releaseIndexRead(): void {
+    this.activeIndexReaders--;
+    if (this.activeIndexReaders === 0) {
+      const resolvers = this.activeIndexReaderResolvers.splice(0);
+      for (const resolve of resolvers) {
+        resolve();
+      }
+    }
+  }
+
+  protected captureReindexReadSnapshot(): void {}
+  protected clearReindexReadSnapshot(): void {}
 
   protected hasIndexedChunks(): boolean {
     const row = this.db.prepare(`SELECT 1 as found FROM memory_index_chunks LIMIT 1`).get() as
@@ -2706,7 +2759,15 @@ export abstract class MemoryManagerSyncOps {
       this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalState.vectorReady;
     };
+    if (this.reindexDepth === 0) {
+      this.captureReindexReadSnapshot();
+      this.reindexing = new Promise<void>((resolve) => {
+        this.resolveReindexing = resolve;
+      });
+    }
+    this.reindexDepth++;
     try {
+      await this.drainActiveIndexReaders();
       cleanupAgedMemoryReindexTempFiles(dbPath);
       reindexLock = acquireMemoryReindexLock(dbPath);
       const originalRevision = readMemoryDatabaseRevision(originalDb);
@@ -2797,6 +2858,10 @@ export abstract class MemoryManagerSyncOps {
       this.resetVectorState();
       this.fts.available = nextFtsState.available;
       this.fts.loadError = nextFtsState.loadError;
+      // The temp DB wrote this metadata, but the durable handle is now the
+      // reader DB. Re-write idempotently so immediate reads see matching meta.
+      this.lastMetaSerialized = null;
+      this.writeMeta(nextMeta);
       this.vector.dims = nextMeta.vectorDims;
     } catch (err) {
       if (tempDb && !tempDbClosed) {
@@ -2827,6 +2892,13 @@ export abstract class MemoryManagerSyncOps {
         reindexLock?.release();
       } catch (err) {
         log.warn(`failed to release memory reindex lock for ${dbPath}: ${formatErrorMessage(err)}`);
+      }
+      this.reindexDepth--;
+      if (this.reindexDepth === 0) {
+        this.clearReindexReadSnapshot();
+        this.reindexing = null;
+        this.resolveReindexing?.();
+        this.resolveReindexing = null;
       }
     }
   }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -54,6 +54,60 @@ describe("memory search async sync", () => {
     expect(queryMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps vector-only results unweighted when FTS is unavailable", async () => {
+    const vectorResult = {
+      id: "memory-alpha",
+      path: "memory/alpha.md",
+      startLine: 1,
+      endLine: 1,
+      score: 0.9,
+      snippet: "Alpha memory",
+      source: "memory" as const,
+    };
+    const mergeHybridResults = vi.fn(async () => []);
+    const manager = Object.create(MemoryIndexManager.prototype) as MemoryIndexManager;
+    Object.assign(manager as unknown as Record<string, unknown>, {
+      providerRequirement: { mode: "optional", provider: "openai" },
+      providerLifecycle: { mode: "ready" },
+      provider: { id: "mock", model: "mock-embed" },
+      settings: {
+        sync: { onSearch: false },
+        query: {
+          minScore: 0.8,
+          maxResults: 5,
+          hybrid: {
+            enabled: true,
+            candidateMultiplier: 2,
+            vectorWeight: 0.5,
+            textWeight: 0.5,
+            temporalDecay: { enabled: false, halfLifeDays: 30 },
+          },
+        },
+      },
+      sources: new Set(["memory"]),
+      dirty: false,
+      sessionsDirty: false,
+      workspaceDir: "",
+      drainReindex: vi.fn(async () => {}),
+      hasIndexedContentForSearch: vi.fn(async () => true),
+      warmSession: vi.fn(),
+      sync: vi.fn(async () => {}),
+      ensureProviderInitialized: vi.fn(async () => {}),
+      assertRequiredProviderAvailable: vi.fn(),
+      refreshSearchIndexIdentityDirty: vi.fn(async () => ({ status: "valid" })),
+      searchKeywordWithFallback: vi.fn(async () => []),
+      embedQueryWithRetry: vi.fn(async () => [1, 0]),
+      searchVector: vi.fn(async () => [vectorResult]),
+      hasKeywordSearchAvailable: vi.fn(async () => false),
+      mergeHybridResults,
+    });
+
+    const results = await manager.search("alpha");
+
+    expect(results).toEqual([vectorResult]);
+    expect(mergeHybridResults).not.toHaveBeenCalled();
+  });
+
   it("waits for in-flight search sync during close", async () => {
     let releaseSync = () => {};
     const pendingSync = new Promise<void>((resolve) => {

--- a/extensions/memory-core/src/memory/manager.reindex-read-race.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-read-race.test.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import "./test-runtime-mocks.js";
+
+const embedText = (text: string) => {
+  const lower = text.toLowerCase();
+  return [lower.includes("alpha") ? 1 : 0, lower.includes("topic") ? 1 : 0];
+};
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async (options: { provider?: string; model?: string }) => {
+    if (options.provider === "openai") {
+      return {
+        requestedProvider: "openai",
+        provider: {
+          id: "openai",
+          model: options.model || "mock-embed",
+          embedQuery: async (text: string) => embedText(text),
+          embedBatch: async (texts: string[]) => texts.map(embedText),
+        },
+      };
+    }
+    return {
+      requestedProvider: "auto",
+      provider: null,
+      providerUnavailableReason: "No embeddings provider available.",
+    };
+  },
+  resolveEmbeddingProviderAdapterId: (provider: string) =>
+    provider === "openai" ? "openai" : null,
+  resolveEmbeddingProviderAdapterTransport: (provider: string) =>
+    provider === "openai" ? "remote" : undefined,
+  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+  resolveEmbeddingProviderIndexIdentity: (options: { provider?: string; model?: string }) =>
+    options.provider === "openai"
+      ? {
+          provider: {
+            id: "openai",
+            model: options.model || "mock-embed",
+          },
+          cacheKeyData: {
+            provider: "openai",
+            model: options.model || "mock-embed",
+          },
+        }
+      : undefined,
+}));
+
+type Deferred = { promise: Promise<void>; resolve: () => void };
+function deferred(): Deferred {
+  let resolve = () => {};
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("memory manager reindex read race", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-reindex-race-"));
+  });
+
+  beforeEach(async () => {
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "MEMORY.md"),
+      "Alpha topic about durable index identity\n\nKeep this note for recall.",
+    );
+    indexPath = path.join(workspaceDir, "index.sqlite");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+  });
+
+  afterAll(async () => {
+    await closeAllMemorySearchManagers();
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function createManager(params?: {
+    provider?: string;
+    model?: string;
+  }): Promise<MemoryIndexManager> {
+    const provider = params?.provider ?? "auto";
+    const cfg = {
+      memory: { backend: "builtin" },
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider,
+            model: params?.model ?? "",
+            store: { databasePath: indexPath },
+            cache: { enabled: false },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  // Pause a forced full reindex right after `this.db = tempDb` so concurrent
+  // readers observe the half-built temp DB while the durable index is valid.
+  function gateNextReindex(memoryManager: MemoryIndexManager): {
+    entered: Promise<void>;
+    release: () => void;
+  } {
+    const internal = memoryManager as unknown as {
+      syncMemoryFiles(params: unknown): Promise<void>;
+    };
+    const original = internal.syncMemoryFiles.bind(internal);
+    const enteredGate = deferred();
+    const releaseGate = deferred();
+    internal.syncMemoryFiles = async (params: unknown) => {
+      enteredGate.resolve();
+      await releaseGate.promise;
+      internal.syncMemoryFiles = original;
+      return original(params);
+    };
+    return { entered: enteredGate.promise, release: releaseGate.resolve };
+  }
+
+  it("status() reflects the stable durable index during an in-flight full reindex", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+
+    const stable = memoryManager.status();
+    expect(stable.chunks).toBeGreaterThan(0);
+
+    const gate = gateNextReindex(memoryManager);
+    const reindexing = memoryManager.sync({ force: true });
+    await gate.entered;
+
+    // While the temp DB is swapped in mid-build, status() must not report the
+    // empty/unbuilt index. It should keep reflecting the valid durable index.
+    const during = memoryManager.status();
+    gate.release();
+    await reindexing;
+
+    expect(during.chunks).toBe(stable.chunks);
+    expect(during.files).toBe(stable.files);
+  });
+
+  it("search() returns stable hits instead of reading the half-built temp index", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+
+    const baseline = await memoryManager.search("Alpha topic");
+    expect(baseline.length).toBeGreaterThan(0);
+
+    const gate = gateNextReindex(memoryManager);
+    const reindexing = memoryManager.sync({ force: true });
+    await gate.entered;
+
+    let settled = false;
+    const searching = memoryManager.search("Alpha topic").then((hits) => {
+      settled = true;
+      return hits;
+    });
+    await Promise.resolve();
+    // The search must wait for the reindex rather than read the temp index.
+    expect(settled).toBe(false);
+
+    gate.release();
+    const hits = await searching;
+    await reindexing;
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it("required-provider search waits when provider initialization yields to a full reindex", async () => {
+    const memoryManager = await createManager({ provider: "openai", model: "mock-embed" });
+    await memoryManager.sync({ force: true });
+
+    const internal = memoryManager as unknown as {
+      ensureProviderInitialized(): Promise<void>;
+    };
+    const originalEnsureProviderInitialized = internal.ensureProviderInitialized.bind(internal);
+    const gate = gateNextReindex(memoryManager);
+    let reindexing: Promise<void> = Promise.resolve();
+    internal.ensureProviderInitialized = async () => {
+      internal.ensureProviderInitialized = originalEnsureProviderInitialized;
+      reindexing = memoryManager.sync({ force: true });
+      await gate.entered;
+    };
+
+    let settled = false;
+    const searching = memoryManager.search("Alpha topic").then((hits) => {
+      settled = true;
+      return hits;
+    });
+    await gate.entered;
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    gate.release();
+    const hits = await searching;
+    await reindexing;
+    internal.ensureProviderInitialized = originalEnsureProviderInitialized;
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it("full reindex waits for active index readers before swapping the DB", async () => {
+    const memoryManager = await createManager();
+    await memoryManager.sync({ force: true });
+
+    const internal = memoryManager as unknown as {
+      withIndexRead<T>(read: () => Promise<T>): Promise<T>;
+    };
+    const gate = gateNextReindex(memoryManager);
+    let enteredTempBuild = false;
+    void gate.entered.then(() => {
+      enteredTempBuild = true;
+    });
+    let reindexing: Promise<void> = Promise.resolve();
+
+    await internal.withIndexRead(async () => {
+      reindexing = memoryManager.sync({ force: true });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(enteredTempBuild).toBe(false);
+    });
+
+    await gate.entered;
+    gate.release();
+    await reindexing;
+    expect(enteredTempBuild).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -303,6 +303,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     status: "missing",
     reason: "index metadata is missing",
   };
+  private stableStatusSnapshot: MemoryProviderStatus | null = null;
 
   private static async loadProviderResult(params: {
     cfg: OpenClawConfig;
@@ -624,11 +625,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     },
   ): Promise<MemorySearchResult[]> {
     opts?.onDebug?.({ backend: "builtin" });
+    await this.drainReindex();
     if (this.providerRequirement.mode === "required") {
       await this.ensureProviderInitialized();
       this.assertRequiredProviderAvailable("search");
     }
-    let hasIndexedContent = this.hasIndexedContent();
+    let hasIndexedContent = await this.hasIndexedContentForSearch();
     if (!hasIndexedContent) {
       try {
         // A fresh process can receive its first search before background watch/session
@@ -638,7 +640,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       } catch (err) {
         log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
       }
-      hasIndexedContent = this.hasIndexedContent();
+      hasIndexedContent = await this.hasIndexedContentForSearch();
     }
     const preflight = resolveMemorySearchPreflight({
       query,
@@ -658,6 +660,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         log.warn(`memory sync failed (search): ${String(err)}`);
       },
     });
+    await this.drainReindex();
     if (preflight.shouldInitializeProvider) {
       await this.ensureProviderInitialized();
       this.assertRequiredProviderAvailable("search");
@@ -672,14 +675,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         return false;
       });
       if (activatedFallback) {
-        this.refreshIndexIdentityDirty({
-          providerKeyKnown: this.providerInitialized,
-        });
+        await this.refreshSearchIndexIdentityDirty();
       }
     }
-    const indexIdentity = this.refreshIndexIdentityDirty({
-      providerKeyKnown: this.providerInitialized,
-    });
+    const indexIdentity = await this.refreshSearchIndexIdentityDirty();
     if (indexIdentity.status !== "valid") {
       return [];
     }
@@ -706,11 +705,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     // FTS-only mode: no embedding provider available
     if (!this.provider) {
       this.assertRequiredProviderAvailable("search");
-      if (!this.fts.enabled || !this.fts.available) {
-        log.warn("memory search: no provider and FTS unavailable");
-        return [];
-      }
-
       const keywordResults = await this.searchKeywordWithFallback(
         cleaned,
         candidates,
@@ -734,7 +728,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
     // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
     const loadKeywordResults = async () =>
-      hybrid.enabled && this.fts.enabled && this.fts.available
+      hybrid.enabled
         ? await this.searchKeywordWithFallback(
             cleaned,
             candidates,
@@ -766,16 +760,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           })
         : false;
       if (activatedFallback) {
-        if (
-          this.refreshIndexIdentityDirty({
-            providerKeyKnown: this.providerInitialized,
-          }).status !== "valid"
-        ) {
+        if ((await this.refreshSearchIndexIdentityDirty()).status !== "valid") {
           return [];
         }
         keywordResults = await loadKeywordResults();
         queryVec = await this.embedQueryWithRetry(cleaned, opts?.signal);
-      } else if (!this.provider && this.fts.enabled && this.fts.available) {
+      } else if (!this.provider && (await this.hasKeywordSearchAvailable())) {
         log.warn(`memory search: embeddings unavailable; using keyword-only results: ${message}`);
         return this.selectScoredResults(keywordResults, maxResults, minScore, 0);
       } else {
@@ -790,7 +780,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         })
       : [];
 
-    if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
+    if (!hybrid.enabled) {
       return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
     }
 
@@ -859,6 +849,22 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return ftsRow?.found === 1;
   }
 
+  private async hasIndexedContentForSearch(): Promise<boolean> {
+    return await this.withIndexRead(async () => this.hasIndexedContent());
+  }
+
+  private async refreshSearchIndexIdentityDirty(): Promise<MemoryIndexIdentityState> {
+    return await this.withIndexRead(async () =>
+      this.refreshIndexIdentityDirty({
+        providerKeyKnown: this.providerInitialized,
+      }),
+    );
+  }
+
+  private async hasKeywordSearchAvailable(): Promise<boolean> {
+    return await this.withIndexRead(async () => this.fts.enabled && this.fts.available);
+  }
+
   private async searchVector(
     queryVec: number[],
     limit: number,
@@ -868,20 +874,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (!this.provider) {
       return [];
     }
-    const results = await searchVector({
-      db: this.db,
-      vectorTable: VECTOR_TABLE,
-      providerModel: this.provider.model,
-      providerModelAliases: this.resolveProviderIndexIdentities()
-        .slice(1)
-        .map((identity) => identity.model),
-      queryVec,
-      limit,
-      snippetMaxChars: SNIPPET_MAX_CHARS,
-      ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
-      sourceFilterVec: this.buildSourceFilter("c", sourceFilterList),
-      sourceFilterChunks: this.buildSourceFilter(undefined, sourceFilterList),
-    });
+    const provider = this.provider;
+    const results = await this.withIndexRead(() =>
+      searchVector({
+        db: this.db,
+        vectorTable: VECTOR_TABLE,
+        providerModel: provider.model,
+        providerModelAliases: this.resolveProviderIndexIdentities()
+          .slice(1)
+          .map((identity) => identity.model),
+        queryVec,
+        limit,
+        snippetMaxChars: SNIPPET_MAX_CHARS,
+        ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
+        sourceFilterVec: this.buildSourceFilter("c", sourceFilterList),
+        sourceFilterChunks: this.buildSourceFilter(undefined, sourceFilterList),
+      }),
+    );
     return results.map((entry) => entry as MemorySearchResult & { id: string });
   }
 
@@ -895,21 +904,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     options?: { boostFallbackRanking?: boolean },
     sourceFilterList?: MemorySource[],
   ): Promise<KeywordSearchHit[]> {
-    if (!this.fts.enabled || !this.fts.available) {
-      return [];
-    }
-    const sourceFilter = this.buildSourceFilter(undefined, sourceFilterList);
-    const results = await searchKeyword({
-      db: this.db,
-      ftsTable: FTS_TABLE,
-      query,
-      ftsTokenizer: this.settings.store.fts.tokenizer,
-      limit,
-      snippetMaxChars: SNIPPET_MAX_CHARS,
-      sourceFilter,
-      buildFtsQuery: (raw) => this.buildFtsQuery(raw),
-      bm25RankToScore,
-      boostFallbackRanking: options?.boostFallbackRanking,
+    const results = await this.withIndexRead(async () => {
+      if (!this.fts.enabled || !this.fts.available) {
+        return [];
+      }
+      const sourceFilter = this.buildSourceFilter(undefined, sourceFilterList);
+      return await searchKeyword({
+        db: this.db,
+        ftsTable: FTS_TABLE,
+        query,
+        ftsTokenizer: this.settings.store.fts.tokenizer,
+        limit,
+        snippetMaxChars: SNIPPET_MAX_CHARS,
+        sourceFilter,
+        buildFtsQuery: (raw) => this.buildFtsQuery(raw),
+        bm25RankToScore,
+        boostFallbackRanking: options?.boostFallbackRanking,
+      });
     });
     return results.map((entry) => entry as KeywordSearchHit);
   }
@@ -1110,6 +1121,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     await runMemorySyncWithReadonlyRecovery(state, params);
   }
 
+  protected override captureReindexReadSnapshot(): void {
+    this.stableStatusSnapshot = this.status();
+  }
+
+  protected override clearReindexReadSnapshot(): void {
+    this.stableStatusSnapshot = null;
+  }
+
   async readFile(params: {
     relPath: string;
     from?: number;
@@ -1125,6 +1144,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   status(): MemoryProviderStatus {
+    if (this.reindexing && this.stableStatusSnapshot) {
+      return this.stableStatusSnapshot;
+    }
     this.refreshIndexIdentityDirty({
       providerKeyKnown: this.providerInitialized,
     });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -780,7 +780,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         })
       : [];
 
-    if (!hybrid.enabled) {
+    const keywordSearchAvailable = await this.hasKeywordSearchAvailable();
+    // Hybrid ranking requires a keyword side. When FTS is unavailable, preserve
+    // the current vector-only fallback so vector scores are not downweighted by
+    // empty keyword results.
+    if (!hybrid.enabled || !keywordSearchAvailable) {
       return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
     }
 

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -702,6 +702,7 @@ describe("test-projects args", () => {
         includePatterns: [
           "extensions/memory-core/src/memory/index.test.ts",
           "extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts",
+          "extensions/memory-core/src/memory/manager.reindex-read-race.test.ts",
           "extensions/memory-core/src/memory/manager.reindex-recovery.test.ts",
           "extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts",
         ],


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes an intermittent memory search/status race where safe full reindex temporarily points the manager at a half-built temp DB, allowing readers to see chunks without matching index metadata and fail closed with `index metadata is missing`.
- Adds a reindex latch so search waits for in-flight full reindex work before reading index identity, FTS availability, or query state.
- Keeps status reads stable during the temp-DB window by serving the last durable status snapshot.
- Rewrites the verified metadata on the canonical DB after the safe swap so the serialized-meta cache from the temp DB cannot skip the durable write.

Why does this matter now?

- #90361 reports intermittent built-in memory search failures even though the durable index is valid. The failure mode is timing-dependent, so a focused race guard is needed rather than only metadata recovery.

What is the intended outcome?

- Searches and status reads no longer observe the half-built temp DB during safe reindex.
- Immediate post-reindex reads see valid index identity metadata on the canonical DB.

What is intentionally out of scope?

- Remote embedding provider stress testing.
- Broader recovery for previously corrupted or stale on-disk memory stores.
- Changes to memory config, provider selection, or migration behavior.

What does success look like?

- Forced reindex, status, and search on a real CLI setup complete without `index metadata is missing`.
- Regression tests cover concurrent status/search reads, the provider-initialization await gap, and a reader that is already active when full reindex reaches the DB swap.

What should reviewers focus on?

- Whether the reindex latch is drained before every search path that reads index identity, FTS availability, or query data.
- Whether the stable status snapshot is limited to the safe reindex temp-DB window.
- Whether the post-swap metadata rewrite is idempotent and scoped to full safe reindex.

## Linked context

Which issue does this close?

Closes #90361

Which issues, PRs, or discussions are related?

Related #90422
Related #90395

Was this requested by a maintainer or owner?

- No direct maintainer request; this is a contributor fix for #90361.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: built-in memory search/status should not fail with `index metadata is missing` after a safe forced reindex when the durable OpenClaw index is valid.
- Real environment tested: local source checkout at `0a9c4d1ef5`, Node `v24.15.0`, real OpenClaw CLI memory commands, temporary `OPENCLAW_HOME`, temporary workspace, FTS-only memory provider (`provider: "none"`, `model: "fts-only"`) to avoid external credentials.
- Exact steps or command run after this patch:

```bash
export OPENCLAW_HOME=<tmp-home>
export OPENCLAW_CONFIG_PATH=<tmp-config>/openclaw.json
export OPENCLAW_BUILD_ALL_NO_PNPM=1
export OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1
export CI=true
node scripts/run-node.mjs memory index --force --agent main --verbose
node scripts/run-node.mjs memory status --deep --index --agent main --json
node scripts/run-node.mjs memory search --agent main --query 'durable index identity' --max-results 5 --json
```

Temporary config used for the proof:

```json
{
  "agents": {
    "defaults": {
      "workspace": "<tmp-workspace>",
      "memorySearch": {
        "provider": "none",
        "model": "fts-only",
        "cache": { "enabled": false },
        "sync": { "watch": false, "onSessionStart": false, "onSearch": false }
      }
    },
    "list": [{ "id": "main", "default": true }]
  }
}
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
## Real OpenClaw CLI proof for #90361
repo_commit=0a9c4d1ef5
node=v24.15.0

### Force rebuild index
Memory Index (main)
Provider: none (requested: none)
Model: fts-only
Sources: memory (MEMORY.md + <tmp-path>)

[memory] sync: indexing memory files
Memory index updated (main).

### Parsed proof summary
status_files=1
status_chunks=1
status_dirty=false
status_index_identity=valid
status_has_missing_metadata=false
search_result_count=1
search_has_missing_metadata=false
search_contains_durable=true
search_first_path=MEMORY.md
search_first_snippet="Alpha topic about durable index identity.\n\nThis note proves memory search can recall the durable OpenClaw index after safe reindex.\n"
```

- Observed result after fix: forced CLI reindex completed, status reported a valid index identity with two indexed chunks, and CLI search returned a `MEMORY.md` result. Neither status nor search output contained `index metadata is missing`.
- What was not tested: live gateway tool invocation, remote/OpenAI embedding provider, concurrent stress across separate OS processes, cross-OS proof.
- Proof limitations or environment constraints: the real behavior proof uses the real CLI and SQLite/FTS memory path, but intentionally uses FTS-only provider mode so no external API key or embedding service is required. Provider/vector concurrency is covered by focused regression tests, not by live remote-provider proof.
- Before evidence (optional but encouraged): the bug is timing-dependent; this PR adds regression coverage that forces searches/status reads into the safe reindex temp-DB window and the provider-initialization await window.

## Tests and validation

Which commands did you run?

```bash
git diff --check
node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory/manager.reindex-read-race.test.ts
node scripts/run-vitest.mjs src/scripts/test-projects.test.ts
pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager.reindex-read-race.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

Real CLI proof commands are listed in the Real behavior proof section.

What regression coverage was added or updated?

- Added `extensions/memory-core/src/memory/manager.reindex-read-race.test.ts`.
- Covers `status()` during in-flight full safe reindex.
- Covers `search()` waiting during the temp-DB window.
- Covers `search()` waiting when provider initialization yields and another actor starts a full safe reindex before identity/FTS reads.
- Covers full safe reindex waiting for an already-active index reader before swapping the DB.

What failed before this fix, if known?

- The race allowed search/status readers to observe the half-built temp DB during safe reindex and fail closed with invalid or missing index identity metadata.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Memory search/status now wait through an in-flight full safe reindex instead of reading transient temp-DB state.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Search can now wait for an in-flight full reindex before reading index identity or FTS state.
- Full safe reindex writes verified metadata again after reopening the canonical DB.

How is that risk mitigated?

- The latch is refcounted and cleared in `finally`.
- Active index readers are counted while DB reads run, and safe full reindex waits for them before swapping/closing the canonical DB.
- Status uses only a captured stable snapshot while the safe reindex temp DB is active.
- The post-swap metadata rewrite uses the same `nextMeta` built and verified during the full reindex.
- Focused regression tests cover the search/status race windows.
- Real CLI proof covers forced reindex, status, and search after the patch.

## Current review state

What is the next action?

- Ready for maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- CI needs to run on the PR.
- Maintainers may request additional live remote-provider stress proof if they want coverage beyond the local CLI/FTS proof and focused regression tests.

Which bot or reviewer comments were addressed?

- Fresh local autoreview completed cleanly: `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` reported `autoreview clean: no accepted/actionable findings reported`.



