### PR TITLE
fix(models): persist agent catalog cache

### DIFF
--- a/src/agents/model-catalog-state-cache.test.ts
+++ b/src/agents/model-catalog-state-cache.test.ts
@@ -13,6 +13,23 @@ const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 
 let stateDir: string;
 
+function configuredModel(id: string) {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"] as Array<"text">,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+  };
+}
+
 describe("model catalog state cache", () => {
   beforeEach(() => {
     stateDir = mkdtempSync(join(tmpdir(), "openclaw-model-catalog-state-"));
@@ -76,7 +93,13 @@ describe("model catalog state cache", () => {
     const base = buildAgentModelCatalogCacheKey({
       agentDir: "/agent/main",
       workspaceDir: "/workspace",
-      config: { models: { providers: { openai: { models: [{ id: "gpt-5.5" }] } } } },
+      config: {
+        models: {
+          providers: {
+            openai: { baseUrl: "https://api.openai.com/v1", models: [configuredModel("gpt-5.5")] },
+          },
+        },
+      },
       metadataSnapshot: {
         policyHash: "policy",
         configFingerprint: "config",
@@ -87,7 +110,13 @@ describe("model catalog state cache", () => {
     const same = buildAgentModelCatalogCacheKey({
       agentDir: "/agent/main",
       workspaceDir: "/workspace",
-      config: { models: { providers: { openai: { models: [{ id: "gpt-5.5" }] } } } },
+      config: {
+        models: {
+          providers: {
+            openai: { baseUrl: "https://api.openai.com/v1", models: [configuredModel("gpt-5.5")] },
+          },
+        },
+      },
       metadataSnapshot: {
         policyHash: "policy",
         configFingerprint: "config",
@@ -98,7 +127,13 @@ describe("model catalog state cache", () => {
     const changed = buildAgentModelCatalogCacheKey({
       agentDir: "/agent/main",
       workspaceDir: "/workspace",
-      config: { models: { providers: { openai: { models: [{ id: "gpt-5.6" }] } } } },
+      config: {
+        models: {
+          providers: {
+            openai: { baseUrl: "https://api.openai.com/v1", models: [configuredModel("gpt-5.6")] },
+          },
+        },
+      },
       metadataSnapshot: {
         policyHash: "policy",
         configFingerprint: "config",

--- a/src/agents/model-catalog-state-cache.test.ts
+++ b/src/agents/model-catalog-state-cache.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  buildAgentModelCatalogCacheKey,
+  readCachedAgentModelCatalog,
+  writeCachedAgentModelCatalog,
+} from "./model-catalog-state-cache.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+let stateDir: string;
+
+describe("model catalog state cache", () => {
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "openclaw-model-catalog-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("writes and reads agent catalog rows from shared state", () => {
+    const entries = [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }];
+
+    writeCachedAgentModelCatalog({
+      agentDir: "/agent/main",
+      catalogKey: "catalog-key",
+      entries,
+      nowMs: 1_000,
+    });
+
+    expect(
+      readCachedAgentModelCatalog({
+        agentDir: "/agent/main",
+        catalogKey: "catalog-key",
+        nowMs: 1_000,
+      }),
+    ).toEqual(entries);
+  });
+
+  it("rejects stale or mismatched agent catalog rows", () => {
+    writeCachedAgentModelCatalog({
+      agentDir: "/agent/main",
+      catalogKey: "catalog-key",
+      entries: [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }],
+      nowMs: 1_000,
+    });
+
+    expect(
+      readCachedAgentModelCatalog({
+        agentDir: "/agent/other",
+        catalogKey: "catalog-key",
+        nowMs: 1_000,
+      }),
+    ).toBeUndefined();
+    expect(
+      readCachedAgentModelCatalog({
+        agentDir: "/agent/main",
+        catalogKey: "catalog-key",
+        nowMs: 31 * 60 * 1_000,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("builds stable keys that change with relevant catalog inputs", () => {
+    const base = buildAgentModelCatalogCacheKey({
+      agentDir: "/agent/main",
+      workspaceDir: "/workspace",
+      config: { models: { providers: { openai: { models: [{ id: "gpt-5.5" }] } } } },
+      metadataSnapshot: {
+        policyHash: "policy",
+        configFingerprint: "config",
+        index: { policyHash: "policy", plugins: [] },
+        plugins: [],
+      } as never,
+    });
+    const same = buildAgentModelCatalogCacheKey({
+      agentDir: "/agent/main",
+      workspaceDir: "/workspace",
+      config: { models: { providers: { openai: { models: [{ id: "gpt-5.5" }] } } } },
+      metadataSnapshot: {
+        policyHash: "policy",
+        configFingerprint: "config",
+        index: { policyHash: "policy", plugins: [] },
+        plugins: [],
+      } as never,
+    });
+    const changed = buildAgentModelCatalogCacheKey({
+      agentDir: "/agent/main",
+      workspaceDir: "/workspace",
+      config: { models: { providers: { openai: { models: [{ id: "gpt-5.6" }] } } } },
+      metadataSnapshot: {
+        policyHash: "policy",
+        configFingerprint: "config",
+        index: { policyHash: "policy", plugins: [] },
+        plugins: [],
+      } as never,
+    });
+
+    expect(base).toBe(same);
+    expect(base).not.toBe(changed);
+  });
+});

--- a/src/agents/model-catalog-state-cache.test.ts
+++ b/src/agents/model-catalog-state-cache.test.ts
@@ -89,6 +89,38 @@ describe("model catalog state cache", () => {
     ).toBeUndefined();
   });
 
+  it("prunes expired agent catalog rows on write", () => {
+    const expiredEntries = [{ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" }];
+    writeCachedAgentModelCatalog({
+      agentDir: "/agent/main",
+      catalogKey: "expired-key",
+      entries: expiredEntries,
+      nowMs: 1_000,
+    });
+
+    writeCachedAgentModelCatalog({
+      agentDir: "/agent/main",
+      catalogKey: "fresh-key",
+      entries: [{ provider: "openai", id: "gpt-5.6", name: "GPT-5.6" }],
+      nowMs: 31 * 60 * 1_000,
+    });
+
+    expect(
+      readCachedAgentModelCatalog({
+        agentDir: "/agent/main",
+        catalogKey: "expired-key",
+        nowMs: 1_000,
+      }),
+    ).toBeUndefined();
+    expect(
+      readCachedAgentModelCatalog({
+        agentDir: "/agent/main",
+        catalogKey: "fresh-key",
+        nowMs: 31 * 60 * 1_000,
+      }),
+    ).toEqual([{ provider: "openai", id: "gpt-5.6", name: "GPT-5.6" }]);
+  });
+
   it("builds stable keys that change with relevant catalog inputs", () => {
     const base = buildAgentModelCatalogCacheKey({
       agentDir: "/agent/main",

--- a/src/agents/model-catalog-state-cache.ts
+++ b/src/agents/model-catalog-state-cache.ts
@@ -139,6 +139,12 @@ export function writeCachedAgentModelCatalog(params: WriteCachedAgentModelCatalo
       executeSqliteQuerySync(
         database.db,
         db
+          .deleteFrom("agent_model_catalogs")
+          .where("updated_at", "<", updatedAt - AGENT_MODEL_CATALOG_CACHE_TTL_MS),
+      );
+      executeSqliteQuerySync(
+        database.db,
+        db
           .insertInto("agent_model_catalogs")
           .values({
             catalog_key: params.catalogKey,

--- a/src/agents/model-catalog-state-cache.ts
+++ b/src/agents/model-catalog-state-cache.ts
@@ -1,0 +1,165 @@
+import { createHash } from "node:crypto";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+
+const AGENT_MODEL_CATALOG_CACHE_VERSION = 1;
+const AGENT_MODEL_CATALOG_CACHE_TTL_MS = 30 * 60 * 1000;
+
+type AgentModelCatalogDatabase = Pick<OpenClawStateKyselyDatabase, "agent_model_catalogs">;
+
+type CachedAgentModelCatalogPayload = {
+  version: typeof AGENT_MODEL_CATALOG_CACHE_VERSION;
+  entries: unknown[];
+};
+
+export type AgentModelCatalogCacheKeyInput = {
+  agentDir: string;
+  cacheScope?: unknown;
+  config: OpenClawConfig;
+  metadataSnapshot?: PluginMetadataSnapshot;
+  workspaceDir?: string;
+};
+
+export type ReadCachedAgentModelCatalogParams = {
+  agentDir: string;
+  catalogKey: string;
+  nowMs?: number;
+};
+
+export type WriteCachedAgentModelCatalogParams = {
+  agentDir: string;
+  catalogKey: string;
+  entries: ModelCatalogEntry[];
+  nowMs?: number;
+};
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .toSorted()
+      .filter((key) => record[key] !== undefined && typeof record[key] !== "function")
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function metadataSnapshotCacheShape(snapshot: PluginMetadataSnapshot | undefined): unknown {
+  if (!snapshot) {
+    return undefined;
+  }
+  return {
+    configFingerprint: snapshot.configFingerprint,
+    policyHash: snapshot.policyHash,
+    indexPolicyHash: snapshot.index?.policyHash,
+    indexPlugins: snapshot.index?.plugins?.map((plugin) => ({
+      enabled: plugin.enabled,
+      id: plugin.pluginId,
+      origin: plugin.origin,
+    })),
+    modelCatalogPlugins: snapshot.plugins.map((plugin) => ({
+      id: plugin.id,
+      modelCatalog: plugin.modelCatalog,
+      origin: plugin.origin,
+      version: plugin.version,
+    })),
+  };
+}
+
+export function buildAgentModelCatalogCacheKey(input: AgentModelCatalogCacheKeyInput): string {
+  const payload = stableJson({
+    version: AGENT_MODEL_CATALOG_CACHE_VERSION,
+    agentDir: input.agentDir,
+    cacheScope: input.cacheScope,
+    workspaceDir: input.workspaceDir,
+    config: input.config,
+    metadataSnapshot: metadataSnapshotCacheShape(input.metadataSnapshot),
+  });
+  return `agent-model-catalog:v${AGENT_MODEL_CATALOG_CACHE_VERSION}:${createHash("sha256")
+    .update(payload)
+    .digest("hex")}`;
+}
+
+function parseCachedAgentModelCatalog<Entry>(rawJson: string): Entry[] | undefined {
+  const parsed = JSON.parse(rawJson) as CachedAgentModelCatalogPayload;
+  if (parsed?.version !== AGENT_MODEL_CATALOG_CACHE_VERSION || !Array.isArray(parsed.entries)) {
+    return undefined;
+  }
+  return parsed.entries as Entry[];
+}
+
+export function readCachedAgentModelCatalog<Entry = ModelCatalogEntry>(
+  params: ReadCachedAgentModelCatalogParams,
+): Entry[] | undefined {
+  try {
+    const database = openOpenClawStateDatabase();
+    const db = getNodeSqliteKysely<AgentModelCatalogDatabase>(database.db);
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("agent_model_catalogs")
+        .select(["raw_json", "updated_at"])
+        .where("catalog_key", "=", params.catalogKey)
+        .where("agent_dir", "=", params.agentDir),
+    );
+    if (!row || (params.nowMs ?? Date.now()) - row.updated_at > AGENT_MODEL_CATALOG_CACHE_TTL_MS) {
+      return undefined;
+    }
+    return parseCachedAgentModelCatalog<Entry>(row.raw_json);
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeCachedAgentModelCatalog<Entry = ModelCatalogEntry>(
+  params: Omit<WriteCachedAgentModelCatalogParams, "entries"> & { entries: Entry[] },
+): void {
+  if (params.entries.length === 0) {
+    return;
+  }
+  try {
+    const updatedAt = params.nowMs ?? Date.now();
+    const rawJson = JSON.stringify({
+      version: AGENT_MODEL_CATALOG_CACHE_VERSION,
+      entries: params.entries,
+    } satisfies CachedAgentModelCatalogPayload);
+    runOpenClawStateWriteTransaction((database) => {
+      const db = getNodeSqliteKysely<AgentModelCatalogDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .insertInto("agent_model_catalogs")
+          .values({
+            catalog_key: params.catalogKey,
+            agent_dir: params.agentDir,
+            raw_json: rawJson,
+            updated_at: updatedAt,
+          })
+          .onConflict((conflict) =>
+            conflict.column("catalog_key").doUpdateSet({
+              agent_dir: params.agentDir,
+              raw_json: rawJson,
+              updated_at: updatedAt,
+            }),
+          ),
+      );
+    });
+  } catch {
+    // Fall back to runtime discovery if local state storage is unavailable.
+  }
+}

--- a/src/agents/model-catalog-state-cache.ts
+++ b/src/agents/model-catalog-state-cache.ts
@@ -11,8 +11,6 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import type { ModelCatalogEntry } from "./model-catalog.types.js";
-
 const AGENT_MODEL_CATALOG_CACHE_VERSION = 1;
 const AGENT_MODEL_CATALOG_CACHE_TTL_MS = 30 * 60 * 1000;
 
@@ -20,7 +18,7 @@ type AgentModelCatalogDatabase = Pick<OpenClawStateKyselyDatabase, "agent_model_
 
 type CachedAgentModelCatalogPayload = {
   version: typeof AGENT_MODEL_CATALOG_CACHE_VERSION;
-  entries: unknown[];
+  entries: readonly unknown[];
 };
 
 export type AgentModelCatalogCacheKeyInput = {
@@ -40,7 +38,7 @@ export type ReadCachedAgentModelCatalogParams = {
 export type WriteCachedAgentModelCatalogParams = {
   agentDir: string;
   catalogKey: string;
-  entries: ModelCatalogEntry[];
+  entries: readonly unknown[];
   nowMs?: number;
 };
 
@@ -95,17 +93,17 @@ export function buildAgentModelCatalogCacheKey(input: AgentModelCatalogCacheKeyI
     .digest("hex")}`;
 }
 
-function parseCachedAgentModelCatalog<Entry>(rawJson: string): Entry[] | undefined {
+function parseCachedAgentModelCatalog(rawJson: string): unknown[] | undefined {
   const parsed = JSON.parse(rawJson) as CachedAgentModelCatalogPayload;
   if (parsed?.version !== AGENT_MODEL_CATALOG_CACHE_VERSION || !Array.isArray(parsed.entries)) {
     return undefined;
   }
-  return parsed.entries as Entry[];
+  return parsed.entries;
 }
 
-export function readCachedAgentModelCatalog<Entry = ModelCatalogEntry>(
+export function readCachedAgentModelCatalog(
   params: ReadCachedAgentModelCatalogParams,
-): Entry[] | undefined {
+): unknown[] | undefined {
   try {
     const database = openOpenClawStateDatabase();
     const db = getNodeSqliteKysely<AgentModelCatalogDatabase>(database.db);
@@ -120,15 +118,13 @@ export function readCachedAgentModelCatalog<Entry = ModelCatalogEntry>(
     if (!row || (params.nowMs ?? Date.now()) - row.updated_at > AGENT_MODEL_CATALOG_CACHE_TTL_MS) {
       return undefined;
     }
-    return parseCachedAgentModelCatalog<Entry>(row.raw_json);
+    return parseCachedAgentModelCatalog(row.raw_json);
   } catch {
     return undefined;
   }
 }
 
-export function writeCachedAgentModelCatalog<Entry = ModelCatalogEntry>(
-  params: Omit<WriteCachedAgentModelCatalogParams, "entries"> & { entries: Entry[] },
-): void {
+export function writeCachedAgentModelCatalog(params: WriteCachedAgentModelCatalogParams): void {
   if (params.entries.length === 0) {
     return;
   }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -448,6 +448,24 @@ describe("loadModelCatalog", () => {
     expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
   });
 
+  it("includes injected metadata snapshots in the state cache key", async () => {
+    const cached = [{ id: "cached-fast", name: "Cached Fast", provider: "openai" }];
+    const metadataSnapshot = emptyPluginMetadataSnapshot();
+    readCachedAgentModelCatalogMock.mockReturnValueOnce(cached);
+
+    const result = await loadModelCatalog({
+      config: {} as OpenClawConfig,
+      metadataSnapshot: metadataSnapshot as never,
+    });
+
+    expect(result).toEqual(cached);
+    expect(buildAgentModelCatalogCacheKeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataSnapshot }),
+    );
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
+    expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
+  });
+
   it("bypasses the state cached catalog when a refresh is requested", async () => {
     readCachedAgentModelCatalogMock.mockReturnValue([
       { id: "cached-stale", name: "Cached Stale", provider: "openai" },

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -20,6 +20,7 @@ let currentPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown
 let loadPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let readFileMock: ReturnType<typeof vi.fn<(pathname: string) => Promise<string>>>;
 let buildAgentModelCatalogCacheKeyMock: ReturnType<typeof vi.fn>;
+let buildModelsJsonSourceFingerprintMock: ReturnType<typeof vi.fn>;
 let readCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
 let writeCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
 
@@ -246,10 +247,19 @@ describe("loadModelCatalog", () => {
       readFile: readFileMock,
     }));
     ensureOpenClawModelsJsonMock = vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false });
+    buildModelsJsonSourceFingerprintMock = vi.fn().mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "source-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
     vi.doMock("./models-config.js", () => ({
+      buildModelsJsonSourceFingerprint: buildModelsJsonSourceFingerprintMock,
       ensureOpenClawModelsJson: ensureOpenClawModelsJsonMock,
     }));
-    buildAgentModelCatalogCacheKeyMock = vi.fn(() => "test-cache-key");
+    buildAgentModelCatalogCacheKeyMock = vi.fn(
+      (input: { cacheScope?: { sourceFingerprint?: string } }) =>
+        `test-cache-key:${input.cacheScope?.sourceFingerprint ?? "none"}`,
+    );
     readCachedAgentModelCatalogMock = vi.fn(() => undefined);
     writeCachedAgentModelCatalogMock = vi.fn();
     vi.doMock("./model-catalog-state-cache.js", () => ({
@@ -324,6 +334,12 @@ describe("loadModelCatalog", () => {
     currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
     loadPluginMetadataSnapshotMock.mockReset();
     loadPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot());
+    buildModelsJsonSourceFingerprintMock.mockClear();
+    buildModelsJsonSourceFingerprintMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "source-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
     buildAgentModelCatalogCacheKeyMock.mockClear();
     readCachedAgentModelCatalogMock.mockReset();
     readCachedAgentModelCatalogMock.mockReturnValue(undefined);
@@ -414,7 +430,7 @@ describe("loadModelCatalog", () => {
     expect(result).toEqual(cached);
     expect(readCachedAgentModelCatalogMock).toHaveBeenCalledWith({
       agentDir: "/tmp/openclaw",
-      catalogKey: "test-cache-key",
+      catalogKey: "test-cache-key:source-fingerprint",
     });
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
@@ -433,7 +449,7 @@ describe("loadModelCatalog", () => {
     expect(readCachedAgentModelCatalogMock).not.toHaveBeenCalled();
     expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledWith({
       agentDir: "/tmp/openclaw",
-      catalogKey: "test-cache-key",
+      catalogKey: "test-cache-key:source-fingerprint",
       entries: result,
     });
   });
@@ -446,8 +462,46 @@ describe("loadModelCatalog", () => {
     expect(result).toEqual([{ id: "runtime-fast", name: "Runtime Fast", provider: "openai" }]);
     expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledWith({
       agentDir: "/tmp/openclaw",
-      catalogKey: "test-cache-key",
+      catalogKey: "test-cache-key:source-fingerprint",
       entries: result,
+    });
+  });
+
+  it("misses the state cached catalog when source freshness changes", async () => {
+    buildModelsJsonSourceFingerprintMock
+      .mockResolvedValueOnce({
+        agentDir: "/tmp/openclaw",
+        fingerprint: "old-source",
+        workspaceDir: "/tmp/openclaw-workspace",
+      })
+      .mockResolvedValueOnce({
+        agentDir: "/tmp/openclaw",
+        fingerprint: "new-source",
+        workspaceDir: "/tmp/openclaw-workspace",
+      });
+    readCachedAgentModelCatalogMock.mockImplementation(({ catalogKey }: { catalogKey: string }) =>
+      catalogKey.endsWith("old-source")
+        ? [{ id: "cached-stale", name: "Cached Stale", provider: "openai" }]
+        : undefined,
+    );
+    mockAgentDiscoveryModels([{ id: "fresh-fast", name: "Fresh Fast", provider: "openai" }]);
+
+    await expect(loadModelCatalog({ config: {} as OpenClawConfig })).resolves.toEqual([
+      { id: "cached-stale", name: "Cached Stale", provider: "openai" },
+    ]);
+    resetModelCatalogCacheForTest();
+    mockAgentDiscoveryModels([{ id: "fresh-fast", name: "Fresh Fast", provider: "openai" }]);
+    await expect(loadModelCatalog({ config: {} as OpenClawConfig })).resolves.toEqual([
+      { id: "fresh-fast", name: "Fresh Fast", provider: "openai" },
+    ]);
+
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(1, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:old-source",
+    });
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(2, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:new-source",
     });
   });
 

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -19,6 +19,9 @@ let ensureOpenClawModelsJsonMock: ReturnType<typeof vi.fn>;
 let currentPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let loadPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let readFileMock: ReturnType<typeof vi.fn<(pathname: string) => Promise<string>>>;
+let buildAgentModelCatalogCacheKeyMock: ReturnType<typeof vi.fn>;
+let readCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
+let writeCachedAgentModelCatalogMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./model-suppression.runtime.js", () => ({
   shouldSuppressBuiltInModel: (params: { provider?: string; id?: string }) =>
@@ -246,6 +249,14 @@ describe("loadModelCatalog", () => {
     vi.doMock("./models-config.js", () => ({
       ensureOpenClawModelsJson: ensureOpenClawModelsJsonMock,
     }));
+    buildAgentModelCatalogCacheKeyMock = vi.fn(() => "test-cache-key");
+    readCachedAgentModelCatalogMock = vi.fn(() => undefined);
+    writeCachedAgentModelCatalogMock = vi.fn();
+    vi.doMock("./model-catalog-state-cache.js", () => ({
+      buildAgentModelCatalogCacheKey: buildAgentModelCatalogCacheKeyMock,
+      readCachedAgentModelCatalog: readCachedAgentModelCatalogMock,
+      writeCachedAgentModelCatalog: writeCachedAgentModelCatalogMock,
+    }));
     vi.doMock("./agent-scope.js", () => ({
       resolveAgentWorkspaceDir: (cfg: OpenClawConfig, agentId: string) => {
         const entry = cfg.agents?.list?.find((entryEntry) => entryEntry.id === agentId);
@@ -313,6 +324,10 @@ describe("loadModelCatalog", () => {
     currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
     loadPluginMetadataSnapshotMock.mockReset();
     loadPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot());
+    buildAgentModelCatalogCacheKeyMock.mockClear();
+    readCachedAgentModelCatalogMock.mockReset();
+    readCachedAgentModelCatalogMock.mockReturnValue(undefined);
+    writeCachedAgentModelCatalogMock.mockClear();
   });
 
   afterEach(() => {
@@ -324,6 +339,7 @@ describe("loadModelCatalog", () => {
   afterAll(() => {
     vi.doUnmock("node:fs/promises");
     vi.doUnmock("./models-config.js");
+    vi.doUnmock("./model-catalog-state-cache.js");
     vi.doUnmock("./agent-scope.js");
     vi.doUnmock("../plugins/provider-runtime.runtime.js");
     vi.doUnmock("../plugins/current-plugin-metadata-snapshot.js");
@@ -381,6 +397,58 @@ describe("loadModelCatalog", () => {
       "/tmp/openclaw",
       expect.objectContaining({ workspaceDir: "/tmp/workspace-agent" }),
     );
+  });
+
+  it("uses the state cached catalog before runtime discovery", async () => {
+    const cached = [{ id: "cached-fast", name: "Cached Fast", provider: "openai" }];
+    readCachedAgentModelCatalogMock.mockReturnValueOnce(cached);
+    const importAgentDiscoveryModule = vi.fn(async () => {
+      throw new Error("provider discovery should not load");
+    });
+    setModelCatalogImportForTest(
+      importAgentDiscoveryModule as unknown as () => Promise<AgentModelDiscoveryModule>,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    expect(result).toEqual(cached);
+    expect(readCachedAgentModelCatalogMock).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key",
+    });
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
+    expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("bypasses the state cached catalog when a refresh is requested", async () => {
+    readCachedAgentModelCatalogMock.mockReturnValue([
+      { id: "cached-stale", name: "Cached Stale", provider: "openai" },
+    ]);
+    mockAgentDiscoveryModels([{ id: "fresh-fast", name: "Fresh Fast", provider: "openai" }]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig, useCache: false });
+
+    expect(result).toEqual([{ id: "fresh-fast", name: "Fresh Fast", provider: "openai" }]);
+    expect(readCachedAgentModelCatalogMock).not.toHaveBeenCalled();
+    expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key",
+      entries: result,
+    });
+  });
+
+  it("writes runtime discovery results to the state catalog cache", async () => {
+    mockAgentDiscoveryModels([{ id: "runtime-fast", name: "Runtime Fast", provider: "openai" }]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    expect(result).toEqual([{ id: "runtime-fast", name: "Runtime Fast", provider: "openai" }]);
+    expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key",
+      entries: result,
+    });
   });
 
   it("reloads dynamic registry entries after clearing the cache", async () => {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -733,6 +733,7 @@ describe("loadModelCatalog", () => {
 
     const entry = requireCatalogEntry(result, "openai", "gpt-test");
     expect(entry.name).toBe("GPT Test");
+    expect(readCachedAgentModelCatalogMock).not.toHaveBeenCalled();
     expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -15,7 +15,7 @@ let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
 let modelSupportsInput: typeof import("./model-catalog.js").modelSupportsInput;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
-let ensureOpenClawModelsJsonMock: ReturnType<typeof vi.fn>;
+let prepareOpenClawModelsJsonSourceMock: ReturnType<typeof vi.fn>;
 let currentPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let loadPluginMetadataSnapshotMock: ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
 let readFileMock: ReturnType<typeof vi.fn<(pathname: string) => Promise<string>>>;
@@ -246,7 +246,12 @@ describe("loadModelCatalog", () => {
       ...(await importOriginal<typeof import("node:fs/promises")>()),
       readFile: readFileMock,
     }));
-    ensureOpenClawModelsJsonMock = vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false });
+    prepareOpenClawModelsJsonSourceMock = vi.fn().mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "source-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+      wrote: false,
+    });
     buildModelsJsonSourceFingerprintMock = vi.fn().mockResolvedValue({
       agentDir: "/tmp/openclaw",
       fingerprint: "source-fingerprint",
@@ -254,7 +259,7 @@ describe("loadModelCatalog", () => {
     });
     vi.doMock("./models-config.js", () => ({
       buildModelsJsonSourceFingerprint: buildModelsJsonSourceFingerprintMock,
-      ensureOpenClawModelsJson: ensureOpenClawModelsJsonMock,
+      prepareOpenClawModelsJsonSource: prepareOpenClawModelsJsonSourceMock,
     }));
     buildAgentModelCatalogCacheKeyMock = vi.fn(
       (input: { cacheScope?: { sourceFingerprint?: string } }) =>
@@ -328,7 +333,13 @@ describe("loadModelCatalog", () => {
     readFileMock.mockRejectedValue(
       Object.assign(new Error("models.json missing"), { code: "ENOENT" }),
     );
-    ensureOpenClawModelsJsonMock.mockClear();
+    prepareOpenClawModelsJsonSourceMock.mockReset();
+    prepareOpenClawModelsJsonSourceMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "source-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+      wrote: false,
+    });
     augmentCatalogMock.mockClear();
     currentPluginMetadataSnapshotMock.mockReset();
     currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
@@ -432,7 +443,7 @@ describe("loadModelCatalog", () => {
       agentDir: "/tmp/openclaw",
       catalogKey: "test-cache-key:source-fingerprint",
     });
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
     expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
   });
@@ -465,6 +476,76 @@ describe("loadModelCatalog", () => {
       catalogKey: "test-cache-key:source-fingerprint",
       entries: result,
     });
+  });
+
+  it("writes runtime discovery results under the refreshed models.json fingerprint", async () => {
+    buildModelsJsonSourceFingerprintMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "pre-refresh-source",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    prepareOpenClawModelsJsonSourceMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "post-refresh-source",
+      workspaceDir: "/tmp/openclaw-workspace",
+      wrote: true,
+    });
+    mockAgentDiscoveryModels([{ id: "runtime-fast", name: "Runtime Fast", provider: "openai" }]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    expect(result).toEqual([{ id: "runtime-fast", name: "Runtime Fast", provider: "openai" }]);
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(1, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:pre-refresh-source",
+    });
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(2, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:post-refresh-source",
+    });
+    expect(writeCachedAgentModelCatalogMock).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:post-refresh-source",
+      entries: result,
+    });
+  });
+
+  it("uses a refreshed state cached catalog before runtime discovery", async () => {
+    const cached = [{ id: "cached-fast", name: "Cached Fast", provider: "openai" }];
+    buildModelsJsonSourceFingerprintMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "pre-refresh-source",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    prepareOpenClawModelsJsonSourceMock.mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "post-refresh-source",
+      workspaceDir: "/tmp/openclaw-workspace",
+      wrote: true,
+    });
+    readCachedAgentModelCatalogMock.mockImplementation(({ catalogKey }: { catalogKey: string }) =>
+      catalogKey.endsWith("post-refresh-source") ? cached : undefined,
+    );
+    const importAgentDiscoveryModule = vi.fn(async () => {
+      throw new Error("provider discovery should not load");
+    });
+    setModelCatalogImportForTest(
+      importAgentDiscoveryModule as unknown as () => Promise<AgentModelDiscoveryModule>,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    expect(result).toEqual(cached);
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(1, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:pre-refresh-source",
+    });
+    expect(readCachedAgentModelCatalogMock).toHaveBeenNthCalledWith(2, {
+      agentDir: "/tmp/openclaw",
+      catalogKey: "test-cache-key:post-refresh-source",
+    });
+    expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
+    expect(writeCachedAgentModelCatalogMock).not.toHaveBeenCalled();
   });
 
   it("misses the state cached catalog when source freshness changes", async () => {
@@ -634,7 +715,7 @@ describe("loadModelCatalog", () => {
 
     const entry = requireCatalogEntry(result, "openai", "gpt-test");
     expect(entry.name).toBe("GPT Test");
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
@@ -678,7 +759,7 @@ describe("loadModelCatalog", () => {
         compat: undefined,
       },
     ]);
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(augmentCatalogMock).not.toHaveBeenCalled();
   });
 
@@ -813,7 +894,7 @@ describe("loadModelCatalog", () => {
         reasoning: false,
       },
     ]);
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(importAgentDiscoveryModule).not.toHaveBeenCalled();
   });
 
@@ -841,7 +922,7 @@ describe("loadModelCatalog", () => {
         compat: undefined,
       },
     ]);
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(augmentCatalogMock).not.toHaveBeenCalled();
   });
 
@@ -896,7 +977,7 @@ describe("loadModelCatalog", () => {
     expect(entry.contextWindow).toBe(1_000_000);
     expect(entry.input).toEqual(["text", "image"]);
     expect(entry.reasoning).toBe(true);
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(augmentCatalogMock).not.toHaveBeenCalled();
   });
 
@@ -1102,7 +1183,7 @@ describe("loadModelCatalog", () => {
         compat: undefined,
       },
     ]);
-    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareOpenClawModelsJsonSourceMock).not.toHaveBeenCalled();
     expect(augmentCatalogMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -85,6 +85,7 @@ let manifestModelCatalogCache = new WeakMap<OpenClawConfig, ManifestModelCatalog
 function buildLoadModelCatalogStateCacheKey(params: {
   agentDir: string;
   config: OpenClawConfig;
+  metadataSnapshot?: PluginMetadataSnapshot;
   sourceFingerprint: string;
   workspaceDir?: string;
 }): string {
@@ -95,6 +96,7 @@ function buildLoadModelCatalogStateCacheKey(params: {
       sourceFingerprint: params.sourceFingerprint,
     },
     config: params.config,
+    metadataSnapshot: params.metadataSnapshot,
     workspaceDir: params.workspaceDir,
   });
 }
@@ -396,6 +398,7 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
     catalogKey: buildLoadModelCatalogStateCacheKey({
       agentDir,
       config: cfg,
+      metadataSnapshot: params?.metadataSnapshot,
       sourceFingerprint: sourceFingerprint.fingerprint,
       workspaceDir,
     }),
@@ -572,6 +575,7 @@ export async function loadModelCatalog(params?: {
       let catalogKey = buildLoadModelCatalogStateCacheKey({
         agentDir,
         config: cfg,
+        metadataSnapshot: params?.metadataSnapshot,
         sourceFingerprint: sourceFingerprint.fingerprint,
         workspaceDir,
       });
@@ -592,6 +596,7 @@ export async function loadModelCatalog(params?: {
         const preparedCatalogKey = buildLoadModelCatalogStateCacheKey({
           agentDir,
           config: cfg,
+          metadataSnapshot: params?.metadataSnapshot,
           sourceFingerprint: preparedSource.fingerprint,
           workspaceDir: preparedSource.workspaceDir ?? workspaceDir,
         });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -40,7 +40,7 @@ import {
   buildConfiguredModelCatalog,
   hasConfiguredProviderModelRows,
 } from "./model-selection-shared.js";
-import { ensureOpenClawModelsJson } from "./models-config.js";
+import { buildModelsJsonSourceFingerprint, ensureOpenClawModelsJson } from "./models-config.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
   listPluginModelCatalogFiles,
@@ -367,10 +367,18 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
     manifestPlugins ??= getMetadataSnapshot().plugins;
     return manifestPlugins;
   };
+  const sourceFingerprint = await buildModelsJsonSourceFingerprint(cfg, agentDir, {
+    pluginMetadataSnapshot: params?.metadataSnapshot,
+    workspaceDir,
+  });
   const cached = readCachedAgentModelCatalog({
     agentDir,
     catalogKey: buildAgentModelCatalogCacheKey({
       agentDir,
+      cacheScope: {
+        source: "load-model-catalog",
+        sourceFingerprint: sourceFingerprint.fingerprint,
+      },
       config: cfg,
       workspaceDir,
     }),
@@ -540,8 +548,16 @@ export async function loadModelCatalog(params?: {
         return manifestPlugins;
       };
       const agentDir = resolveDefaultAgentDir(cfg);
+      const sourceFingerprint = await buildModelsJsonSourceFingerprint(cfg, agentDir, {
+        pluginMetadataSnapshot: params?.metadataSnapshot,
+        workspaceDir,
+      });
       const catalogKey = buildAgentModelCatalogCacheKey({
         agentDir,
+        cacheScope: {
+          source: "load-model-catalog",
+          sourceFingerprint: sourceFingerprint.fingerprint,
+        },
         config: cfg,
         workspaceDir,
       });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -24,6 +24,11 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles } from "./auth-profiles.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
+import {
+  buildAgentModelCatalogCacheKey,
+  readCachedAgentModelCatalog,
+  writeCachedAgentModelCatalog,
+} from "./model-catalog-state-cache.js";
 import type { ModelCatalogEntry, ModelInputType } from "./model-catalog.types.js";
 import { resolveModelWorkspaceDir } from "./model-discovery-context.js";
 import {
@@ -362,6 +367,17 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
     manifestPlugins ??= getMetadataSnapshot().plugins;
     return manifestPlugins;
   };
+  const cached = readCachedAgentModelCatalog({
+    agentDir,
+    catalogKey: buildAgentModelCatalogCacheKey({
+      agentDir,
+      config: cfg,
+      workspaceDir,
+    }),
+  });
+  if (cached?.length) {
+    return cached;
+  }
   const providers = await loadReadOnlyPersistedProviderRows(agentDir, getMetadataSnapshot);
   for (const [providerRaw, providerConfig] of Object.entries(providers)) {
     if (!Array.isArray(providerConfig?.models)) {
@@ -523,6 +539,19 @@ export async function loadModelCatalog(params?: {
         manifestPlugins ??= getManifestMetadataSnapshot().plugins;
         return manifestPlugins;
       };
+      const agentDir = resolveDefaultAgentDir(cfg);
+      const catalogKey = buildAgentModelCatalogCacheKey({
+        agentDir,
+        config: cfg,
+        workspaceDir,
+      });
+      if (!readOnly && params?.useCache !== false) {
+        const cached = readCachedAgentModelCatalog({ agentDir, catalogKey });
+        if (cached?.length) {
+          logStage("state-cache-hit", `entries=${cached.length}`);
+          return cached;
+        }
+      }
       if (!readOnly) {
         await ensureOpenClawModelsJson(cfg);
         logStage("models-json-ready");
@@ -531,7 +560,6 @@ export async function loadModelCatalog(params?: {
       // the shared catalog cache until restart.
       const agentDiscovery = await importAgentDiscovery();
       logStage("agent-discovery-imported");
-      const agentDir = resolveDefaultAgentDir(cfg);
       const { buildShouldSuppressBuiltInModel } = await loadModelSuppression();
       logStage("catalog-deps-ready");
       const authStorage = agentDiscovery.discoverAuthStorage(
@@ -663,6 +691,13 @@ export async function loadModelCatalog(params?: {
       }
 
       const sorted = sortModels(models);
+      if (!readOnly) {
+        writeCachedAgentModelCatalog({
+          agentDir,
+          catalogKey,
+          entries: sorted,
+        });
+      }
       logStage("complete", `entries=${sorted.length}`);
       return sorted;
     } catch (error) {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -389,23 +389,6 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
     manifestPlugins ??= getMetadataSnapshot().plugins;
     return manifestPlugins;
   };
-  const sourceFingerprint = await buildModelsJsonSourceFingerprint(cfg, agentDir, {
-    pluginMetadataSnapshot: params?.metadataSnapshot,
-    workspaceDir,
-  });
-  const cached = readCachedAgentModelCatalog({
-    agentDir,
-    catalogKey: buildLoadModelCatalogStateCacheKey({
-      agentDir,
-      config: cfg,
-      metadataSnapshot: params?.metadataSnapshot,
-      sourceFingerprint: sourceFingerprint.fingerprint,
-      workspaceDir,
-    }),
-  }) as ModelCatalogEntry[] | undefined;
-  if (cached?.length) {
-    return cached;
-  }
   const providers = await loadReadOnlyPersistedProviderRows(agentDir, getMetadataSnapshot);
   for (const [providerRaw, providerConfig] of Object.entries(providers)) {
     if (!Array.isArray(providerConfig?.models)) {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -40,7 +40,10 @@ import {
   buildConfiguredModelCatalog,
   hasConfiguredProviderModelRows,
 } from "./model-selection-shared.js";
-import { buildModelsJsonSourceFingerprint, ensureOpenClawModelsJson } from "./models-config.js";
+import {
+  buildModelsJsonSourceFingerprint,
+  prepareOpenClawModelsJsonSource,
+} from "./models-config.js";
 import {
   filterGeneratedPluginModelCatalogProviders,
   listPluginModelCatalogFiles,
@@ -78,6 +81,23 @@ type ManifestModelCatalogCacheEntry = {
   rows: ModelCatalogEntry[];
 };
 let manifestModelCatalogCache = new WeakMap<OpenClawConfig, ManifestModelCatalogCacheEntry>();
+
+function buildLoadModelCatalogStateCacheKey(params: {
+  agentDir: string;
+  config: OpenClawConfig;
+  sourceFingerprint: string;
+  workspaceDir?: string;
+}): string {
+  return buildAgentModelCatalogCacheKey({
+    agentDir: params.agentDir,
+    cacheScope: {
+      source: "load-model-catalog",
+      sourceFingerprint: params.sourceFingerprint,
+    },
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+}
 const defaultImportAgentDiscovery = () => import("./agent-model-discovery.js");
 let importAgentDiscovery = defaultImportAgentDiscovery;
 const modelSuppressionLoader = createLazyImportLoader(
@@ -373,16 +393,13 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
   });
   const cached = readCachedAgentModelCatalog({
     agentDir,
-    catalogKey: buildAgentModelCatalogCacheKey({
+    catalogKey: buildLoadModelCatalogStateCacheKey({
       agentDir,
-      cacheScope: {
-        source: "load-model-catalog",
-        sourceFingerprint: sourceFingerprint.fingerprint,
-      },
       config: cfg,
+      sourceFingerprint: sourceFingerprint.fingerprint,
       workspaceDir,
     }),
-  });
+  }) as ModelCatalogEntry[] | undefined;
   if (cached?.length) {
     return cached;
   }
@@ -552,25 +569,45 @@ export async function loadModelCatalog(params?: {
         pluginMetadataSnapshot: params?.metadataSnapshot,
         workspaceDir,
       });
-      const catalogKey = buildAgentModelCatalogCacheKey({
+      let catalogKey = buildLoadModelCatalogStateCacheKey({
         agentDir,
-        cacheScope: {
-          source: "load-model-catalog",
-          sourceFingerprint: sourceFingerprint.fingerprint,
-        },
         config: cfg,
+        sourceFingerprint: sourceFingerprint.fingerprint,
         workspaceDir,
       });
       if (!readOnly && params?.useCache !== false) {
-        const cached = readCachedAgentModelCatalog({ agentDir, catalogKey });
+        const cached = readCachedAgentModelCatalog({ agentDir, catalogKey }) as
+          | ModelCatalogEntry[]
+          | undefined;
         if (cached?.length) {
           logStage("state-cache-hit", `entries=${cached.length}`);
           return cached;
         }
       }
       if (!readOnly) {
-        await ensureOpenClawModelsJson(cfg);
+        const preparedSource = await prepareOpenClawModelsJsonSource(cfg, agentDir, {
+          pluginMetadataSnapshot: params?.metadataSnapshot,
+          workspaceDir,
+        });
+        const preparedCatalogKey = buildLoadModelCatalogStateCacheKey({
+          agentDir,
+          config: cfg,
+          sourceFingerprint: preparedSource.fingerprint,
+          workspaceDir: preparedSource.workspaceDir ?? workspaceDir,
+        });
         logStage("models-json-ready");
+        if (preparedCatalogKey !== catalogKey) {
+          catalogKey = preparedCatalogKey;
+          if (params?.useCache !== false) {
+            const cached = readCachedAgentModelCatalog({ agentDir, catalogKey }) as
+              | ModelCatalogEntry[]
+              | undefined;
+            if (cached?.length) {
+              logStage("state-cache-hit", `entries=${cached.length}`);
+              return cached;
+            }
+          }
+        }
       }
       // Keep discovery inside try/catch so transient filesystem/config failures do not poison
       // the shared catalog cache until restart.

--- a/src/agents/models-config-state.ts
+++ b/src/agents/models-config-state.ts
@@ -2,12 +2,19 @@
 // module multiple times, so Symbol.for keeps write locks and ready-cache shared.
 const MODELS_JSON_STATE_KEY = Symbol.for("openclaw.modelsJsonState");
 
+export type ModelsJsonReadyResult = {
+  agentDir: string;
+  wrote: boolean;
+};
+
+export type ModelsJsonReadyState = {
+  fingerprint: string;
+  result: ModelsJsonReadyResult;
+};
+
 type ModelsJsonState = {
   writeLocks: Map<string, Promise<void>>;
-  readyCache: Map<
-    string,
-    Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
-  >;
+  readyCache: Map<string, Promise<ModelsJsonReadyState>>;
 };
 
 export const MODELS_JSON_STATE = (() => {
@@ -17,10 +24,7 @@ export const MODELS_JSON_STATE = (() => {
   if (!globalState[MODELS_JSON_STATE_KEY]) {
     globalState[MODELS_JSON_STATE_KEY] = {
       writeLocks: new Map<string, Promise<void>>(),
-      readyCache: new Map<
-        string,
-        Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
-      >(),
+      readyCache: new Map<string, Promise<ModelsJsonReadyState>>(),
     };
   }
   return globalState[MODELS_JSON_STATE_KEY];

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -270,6 +270,58 @@ function resolveModelsConfigInput(config?: OpenClawConfig): {
   };
 }
 
+/** Builds the canonical source freshness fingerprint for generated model catalogs. */
+export async function buildModelsJsonSourceFingerprint(
+  config?: OpenClawConfig,
+  agentDirOverride?: string,
+  options: {
+    pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
+    workspaceDir?: string;
+    providerDiscoveryProviderIds?: readonly string[];
+    providerDiscoveryTimeoutMs?: number;
+    providerDiscoveryEntriesOnly?: boolean;
+  } = {},
+): Promise<{ agentDir: string; fingerprint: string; workspaceDir?: string }> {
+  const resolved = resolveModelsConfigInput(config);
+  const cfg = resolved.config;
+  const workspaceDir =
+    options.workspaceDir ??
+    (agentDirOverride?.trim()
+      ? undefined
+      : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
+  const providerScopedDiscovery = Boolean(options.providerDiscoveryProviderIds?.length);
+  const pluginMetadataSnapshot =
+    options.pluginMetadataSnapshot ??
+    resolvePluginMetadataSnapshot({
+      config: cfg,
+      env: createConfigRuntimeEnv(cfg),
+      ...(workspaceDir ? { workspaceDir } : {}),
+      ...(providerScopedDiscovery ? { preferPersisted: false } : {}),
+    });
+  const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveDefaultAgentDir(cfg);
+  const fingerprint = await buildModelsJsonFingerprint({
+    config: cfg,
+    sourceConfigForSecrets: resolved.sourceConfigForSecrets,
+    agentDir,
+    ...(workspaceDir ? { workspaceDir } : {}),
+    ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
+    ...(options.providerDiscoveryProviderIds
+      ? { providerDiscoveryProviderIds: options.providerDiscoveryProviderIds }
+      : {}),
+    ...(options.providerDiscoveryTimeoutMs !== undefined
+      ? { providerDiscoveryTimeoutMs: options.providerDiscoveryTimeoutMs }
+      : {}),
+    ...(options.providerDiscoveryEntriesOnly === true
+      ? { providerDiscoveryEntriesOnly: true }
+      : {}),
+  });
+  return {
+    agentDir,
+    fingerprint,
+    ...(workspaceDir ? { workspaceDir } : {}),
+  };
+}
+
 async function withModelsJsonWriteLock<T>(targetPath: string, run: () => Promise<T>): Promise<T> {
   const prior = MODELS_JSON_STATE.writeLocks.get(targetPath) ?? Promise.resolve();
   let release: () => void = () => {};
@@ -303,38 +355,23 @@ export async function ensureOpenClawModelsJson(
 ): Promise<{ agentDir: string; wrote: boolean }> {
   const resolved = resolveModelsConfigInput(config);
   const cfg = resolved.config;
-  const workspaceDir =
-    options.workspaceDir ??
-    (agentDirOverride?.trim()
-      ? undefined
-      : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
-  const providerScopedDiscovery = Boolean(options.providerDiscoveryProviderIds?.length);
+  const sourceFingerprint = await buildModelsJsonSourceFingerprint(
+    config,
+    agentDirOverride,
+    options,
+  );
+  const workspaceDir = sourceFingerprint.workspaceDir;
   const pluginMetadataSnapshot =
     options.pluginMetadataSnapshot ??
     resolvePluginMetadataSnapshot({
       config: cfg,
       env: createConfigRuntimeEnv(cfg),
       ...(workspaceDir ? { workspaceDir } : {}),
-      ...(providerScopedDiscovery ? { preferPersisted: false } : {}),
+      ...(options.providerDiscoveryProviderIds?.length ? { preferPersisted: false } : {}),
     });
-  const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveDefaultAgentDir(cfg);
+  const agentDir = sourceFingerprint.agentDir;
   const targetPath = path.join(agentDir, "models.json");
-  const fingerprint = await buildModelsJsonFingerprint({
-    config: cfg,
-    sourceConfigForSecrets: resolved.sourceConfigForSecrets,
-    agentDir,
-    ...(workspaceDir ? { workspaceDir } : {}),
-    ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
-    ...(options.providerDiscoveryProviderIds
-      ? { providerDiscoveryProviderIds: options.providerDiscoveryProviderIds }
-      : {}),
-    ...(options.providerDiscoveryTimeoutMs !== undefined
-      ? { providerDiscoveryTimeoutMs: options.providerDiscoveryTimeoutMs }
-      : {}),
-    ...(options.providerDiscoveryEntriesOnly === true
-      ? { providerDiscoveryEntriesOnly: true }
-      : {}),
-  });
+  const fingerprint = sourceFingerprint.fingerprint;
   const cacheKey = modelsJsonReadyCacheKey(targetPath, fingerprint);
   const cached = MODELS_JSON_STATE.readyCache.get(cacheKey);
   if (cached) {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -24,7 +24,11 @@ import {
   resolveDefaultAgentId,
 } from "./agent-scope.js";
 import { resolveAuthProfileDatabasePath } from "./auth-profiles/sqlite.js";
-import { MODELS_JSON_STATE } from "./models-config-state.js";
+import {
+  MODELS_JSON_STATE,
+  type ModelsJsonReadyResult,
+  type ModelsJsonReadyState,
+} from "./models-config-state.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 import {
   decodePluginModelCatalogRelativePathPluginId,
@@ -36,6 +40,19 @@ import {
 import { stableStringify } from "./stable-stringify.js";
 
 export { resetModelsJsonReadyCacheForTest } from "./models-config-state.js";
+
+export type PreparedOpenClawModelsJsonSource = ModelsJsonReadyResult & {
+  fingerprint: string;
+  workspaceDir?: string;
+};
+
+type EnsureOpenClawModelsJsonOptions = {
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
+  workspaceDir?: string;
+  providerDiscoveryProviderIds?: readonly string[];
+  providerDiscoveryTimeoutMs?: number;
+  providerDiscoveryEntriesOnly?: boolean;
+};
 
 async function readFileMtimeMs(pathname: string): Promise<number | null> {
   try {
@@ -342,17 +359,11 @@ async function withModelsJsonWriteLock<T>(targetPath: string, run: () => Promise
 }
 
 /** Ensures models.json and plugin catalog sidecars are current for an agent. */
-export async function ensureOpenClawModelsJson(
+export async function prepareOpenClawModelsJsonSource(
   config?: OpenClawConfig,
   agentDirOverride?: string,
-  options: {
-    pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "manifestRegistry" | "owners">;
-    workspaceDir?: string;
-    providerDiscoveryProviderIds?: readonly string[];
-    providerDiscoveryTimeoutMs?: number;
-    providerDiscoveryEntriesOnly?: boolean;
-  } = {},
-): Promise<{ agentDir: string; wrote: boolean }> {
+  options: EnsureOpenClawModelsJsonOptions = {},
+): Promise<PreparedOpenClawModelsJsonSource> {
   const resolved = resolveModelsConfigInput(config);
   const cfg = resolved.config;
   const sourceFingerprint = await buildModelsJsonSourceFingerprint(
@@ -377,10 +388,14 @@ export async function ensureOpenClawModelsJson(
   if (cached) {
     const settled = await cached;
     await ensureModelsFileModeForModelsJson(targetPath);
-    return settled.result;
+    return {
+      ...settled.result,
+      fingerprint: settled.fingerprint,
+      ...(workspaceDir ? { workspaceDir } : {}),
+    };
   }
 
-  const pending = withModelsJsonWriteLock(targetPath, async () => {
+  const pending: Promise<ModelsJsonReadyState> = withModelsJsonWriteLock(targetPath, async () => {
     // Ensure config env vars (e.g. AWS_PROFILE, AWS_ACCESS_KEY_ID) are
     // are available to provider discovery without mutating process.env.
     const env = createConfigRuntimeEnv(cfg);
@@ -467,11 +482,25 @@ export async function ensureOpenClawModelsJson(
         Promise.resolve({ fingerprint: refreshedFingerprint, result: settled.result }),
       );
     }
-    return settled.result;
+    return {
+      ...settled.result,
+      fingerprint: refreshedFingerprint,
+      ...(workspaceDir ? { workspaceDir } : {}),
+    };
   } catch (error) {
     if (MODELS_JSON_STATE.readyCache.get(cacheKey) === pending) {
       MODELS_JSON_STATE.readyCache.delete(cacheKey);
     }
     throw error;
   }
+}
+
+/** Ensures models.json and plugin catalog sidecars are current for an agent. */
+export async function ensureOpenClawModelsJson(
+  config?: OpenClawConfig,
+  agentDirOverride?: string,
+  options: EnsureOpenClawModelsJsonOptions = {},
+): Promise<ModelsJsonReadyResult> {
+  const prepared = await prepareOpenClawModelsJsonSource(config, agentDirOverride, options);
+  return { agentDir: prepared.agentDir, wrote: prepared.wrote };
 }

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -8,6 +8,7 @@ import {
 
 const providerDiscoveryMocks = vi.hoisted(() => ({
   buildAgentModelCatalogCacheKey: vi.fn(),
+  buildModelsJsonSourceFingerprint: vi.fn(),
   loadPluginRegistrySnapshotWithMetadata: vi.fn(),
   readCachedAgentModelCatalog: vi.fn(),
   resolvePluginContributionOwners: vi.fn(),
@@ -23,6 +24,10 @@ vi.mock("../../agents/model-catalog-state-cache.js", () => ({
   buildAgentModelCatalogCacheKey: providerDiscoveryMocks.buildAgentModelCatalogCacheKey,
   readCachedAgentModelCatalog: providerDiscoveryMocks.readCachedAgentModelCatalog,
   writeCachedAgentModelCatalog: providerDiscoveryMocks.writeCachedAgentModelCatalog,
+}));
+
+vi.mock("../../agents/models-config.js", () => ({
+  buildModelsJsonSourceFingerprint: providerDiscoveryMocks.buildModelsJsonSourceFingerprint,
 }));
 
 vi.mock("../../plugins/plugin-registry.js", () => ({
@@ -206,7 +211,15 @@ function firstDiscoveryRequest(): {
 describe("loadProviderCatalogModelsForList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    providerDiscoveryMocks.buildAgentModelCatalogCacheKey.mockReturnValue("provider-cache-key");
+    providerDiscoveryMocks.buildAgentModelCatalogCacheKey.mockImplementation(
+      (input: { cacheScope?: { sourceFingerprint?: string } }) =>
+        `provider-cache-key:${input.cacheScope?.sourceFingerprint ?? "none"}`,
+    );
+    providerDiscoveryMocks.buildModelsJsonSourceFingerprint.mockResolvedValue({
+      agentDir: baseParams.agentDir,
+      fingerprint: "provider-source-fingerprint",
+      workspaceDir: "/tmp/provider-workspace",
+    });
     providerDiscoveryMocks.readCachedAgentModelCatalog.mockReturnValue(undefined);
     providerDiscoveryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
       source: "persisted",
@@ -281,7 +294,7 @@ describe("loadProviderCatalogModelsForList", () => {
     expect(rows.map((row) => `${row.provider}/${row.id}`)).toStrictEqual(["moonshot/cached-kimi"]);
     expect(providerDiscoveryMocks.readCachedAgentModelCatalog).toHaveBeenCalledWith({
       agentDir: baseParams.agentDir,
-      catalogKey: "provider-cache-key",
+      catalogKey: "provider-cache-key:provider-source-fingerprint",
     });
     expect(providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders).not.toHaveBeenCalled();
     expect(providerDiscoveryMocks.writeCachedAgentModelCatalog).not.toHaveBeenCalled();
@@ -296,8 +309,44 @@ describe("loadProviderCatalogModelsForList", () => {
     expect(rows.map((row) => `${row.provider}/${row.id}`)).toStrictEqual(["moonshot/kimi-k2.6"]);
     expect(providerDiscoveryMocks.writeCachedAgentModelCatalog).toHaveBeenCalledWith({
       agentDir: baseParams.agentDir,
-      catalogKey: "provider-cache-key",
+      catalogKey: "provider-cache-key:provider-source-fingerprint",
       entries: rows,
+    });
+  });
+
+  it("misses cached provider catalog rows when source freshness changes", async () => {
+    providerDiscoveryMocks.buildModelsJsonSourceFingerprint
+      .mockResolvedValueOnce({
+        agentDir: baseParams.agentDir,
+        fingerprint: "old-provider-source",
+        workspaceDir: "/tmp/provider-workspace",
+      })
+      .mockResolvedValueOnce({
+        agentDir: baseParams.agentDir,
+        fingerprint: "new-provider-source",
+        workspaceDir: "/tmp/provider-workspace",
+      });
+    providerDiscoveryMocks.readCachedAgentModelCatalog.mockImplementation(
+      ({ catalogKey }: { catalogKey: string }) =>
+        catalogKey.endsWith("old-provider-source")
+          ? [{ provider: "moonshot", id: "cached-stale", name: "Cached Stale" }]
+          : undefined,
+    );
+
+    await expect(loadProviderCatalogModelsForList({ ...baseParams })).resolves.toEqual([
+      { provider: "moonshot", id: "cached-stale", name: "Cached Stale" },
+    ]);
+    await expect(loadProviderCatalogModelsForList({ ...baseParams })).resolves.toEqual([
+      expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6" }),
+    ]);
+
+    expect(providerDiscoveryMocks.readCachedAgentModelCatalog).toHaveBeenNthCalledWith(1, {
+      agentDir: baseParams.agentDir,
+      catalogKey: "provider-cache-key:old-provider-source",
+    });
+    expect(providerDiscoveryMocks.readCachedAgentModelCatalog).toHaveBeenNthCalledWith(2, {
+      agentDir: baseParams.agentDir,
+      catalogKey: "provider-cache-key:new-provider-source",
     });
   });
 

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -208,6 +208,26 @@ function firstDiscoveryRequest(): {
   };
 }
 
+function firstCacheKeyInput(): {
+  cacheScope?: {
+    envFingerprint?: string;
+    sourceFingerprint?: string;
+  };
+  metadataSnapshot?: unknown;
+} {
+  const call = providerDiscoveryMocks.buildAgentModelCatalogCacheKey.mock.calls[0];
+  if (!call) {
+    throw new Error("expected state cache key build call");
+  }
+  return call[0] as {
+    cacheScope?: {
+      envFingerprint?: string;
+      sourceFingerprint?: string;
+    };
+    metadataSnapshot?: unknown;
+  };
+}
+
 describe("loadProviderCatalogModelsForList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -298,6 +318,35 @@ describe("loadProviderCatalogModelsForList", () => {
     });
     expect(providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders).not.toHaveBeenCalled();
     expect(providerDiscoveryMocks.writeCachedAgentModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("separates provider catalog state cache keys by environment fingerprint", async () => {
+    await loadProviderCatalogModelsForList({
+      ...baseParams,
+      env: {
+        ...baseParams.env,
+        MOONSHOT_API_KEY: "first-secret",
+      },
+      providerFilter: "moonshot",
+    });
+    const firstFingerprint = firstCacheKeyInput().cacheScope?.envFingerprint;
+
+    providerDiscoveryMocks.buildAgentModelCatalogCacheKey.mockClear();
+    await loadProviderCatalogModelsForList({
+      ...baseParams,
+      env: {
+        ...baseParams.env,
+        MOONSHOT_API_KEY: "second-secret",
+      },
+      providerFilter: "moonshot",
+    });
+    const secondFingerprint = firstCacheKeyInput().cacheScope?.envFingerprint;
+
+    expect(firstFingerprint).toEqual(expect.any(String));
+    expect(secondFingerprint).toEqual(expect.any(String));
+    expect(firstFingerprint).not.toBe(secondFingerprint);
+    expect(firstFingerprint).not.toContain("first-secret");
+    expect(secondFingerprint).not.toContain("second-secret");
   });
 
   it("writes provider catalog rows to the state cache after runtime discovery", async () => {
@@ -392,6 +441,7 @@ describe("loadProviderCatalogModelsForList", () => {
     expect(providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders).toHaveBeenCalledWith(
       expect.objectContaining({ pluginMetadataSnapshot: metadataSnapshot }),
     );
+    expect(firstCacheKeyInput()).toEqual(expect.objectContaining({ metadataSnapshot }));
   });
 
   it("uses bundled runtime provider catalogs for provider-filtered self-hosted rows", async () => {

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -7,13 +7,22 @@ import {
 } from "./list.provider-catalog.js";
 
 const providerDiscoveryMocks = vi.hoisted(() => ({
+  buildAgentModelCatalogCacheKey: vi.fn(),
   loadPluginRegistrySnapshotWithMetadata: vi.fn(),
+  readCachedAgentModelCatalog: vi.fn(),
   resolvePluginContributionOwners: vi.fn(),
   resolveProviderOwners: vi.fn(),
   resolveBundledProviderCompatPluginIds: vi.fn(),
   resolveOwningPluginIdsForProvider: vi.fn(),
   resolveRuntimePluginDiscoveryProviders: vi.fn(),
   resolveProviderContractPluginIdsForProviderAlias: vi.fn(),
+  writeCachedAgentModelCatalog: vi.fn(),
+}));
+
+vi.mock("../../agents/model-catalog-state-cache.js", () => ({
+  buildAgentModelCatalogCacheKey: providerDiscoveryMocks.buildAgentModelCatalogCacheKey,
+  readCachedAgentModelCatalog: providerDiscoveryMocks.readCachedAgentModelCatalog,
+  writeCachedAgentModelCatalog: providerDiscoveryMocks.writeCachedAgentModelCatalog,
 }));
 
 vi.mock("../../plugins/plugin-registry.js", () => ({
@@ -197,6 +206,8 @@ function firstDiscoveryRequest(): {
 describe("loadProviderCatalogModelsForList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    providerDiscoveryMocks.buildAgentModelCatalogCacheKey.mockReturnValue("provider-cache-key");
+    providerDiscoveryMocks.readCachedAgentModelCatalog.mockReturnValue(undefined);
     providerDiscoveryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
       source: "persisted",
       snapshot: {
@@ -256,6 +267,38 @@ describe("loadProviderCatalogModelsForList", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(rows.map((row) => `${row.provider}/${row.id}`)).toContain("moonshot/kimi-k2.6");
+  });
+
+  it("reuses cached provider catalog rows before runtime provider discovery", async () => {
+    providerDiscoveryMocks.readCachedAgentModelCatalog.mockReturnValueOnce([
+      { provider: "moonshot", id: "cached-kimi", name: "Cached Kimi" },
+    ]);
+
+    const rows = await loadProviderCatalogModelsForList({
+      ...baseParams,
+    });
+
+    expect(rows.map((row) => `${row.provider}/${row.id}`)).toStrictEqual(["moonshot/cached-kimi"]);
+    expect(providerDiscoveryMocks.readCachedAgentModelCatalog).toHaveBeenCalledWith({
+      agentDir: baseParams.agentDir,
+      catalogKey: "provider-cache-key",
+    });
+    expect(providerDiscoveryMocks.resolveRuntimePluginDiscoveryProviders).not.toHaveBeenCalled();
+    expect(providerDiscoveryMocks.writeCachedAgentModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("writes provider catalog rows to the state cache after runtime discovery", async () => {
+    const rows = await loadProviderCatalogModelsForList({
+      ...baseParams,
+      providerFilter: "moonshot",
+    });
+
+    expect(rows.map((row) => `${row.provider}/${row.id}`)).toStrictEqual(["moonshot/kimi-k2.6"]);
+    expect(providerDiscoveryMocks.writeCachedAgentModelCatalog).toHaveBeenCalledWith({
+      agentDir: baseParams.agentDir,
+      catalogKey: "provider-cache-key",
+      entries: rows,
+    });
   });
 
   it("requires complete discovery-entry coverage for static-only loads", async () => {

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -7,6 +7,7 @@ import {
   readCachedAgentModelCatalog,
   writeCachedAgentModelCatalog,
 } from "../../agents/model-catalog-state-cache.js";
+import { buildModelsJsonSourceFingerprint } from "../../agents/models-config.js";
 import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
@@ -350,12 +351,19 @@ export async function loadProviderCatalogModelsForList(params: {
     return [];
   }
 
+  const sourceFingerprint = await buildModelsJsonSourceFingerprint(params.cfg, params.agentDir, {
+    pluginMetadataSnapshot: params.metadataSnapshot,
+    providerDiscoveryEntriesOnly: params.staticOnly === true,
+    providerDiscoveryProviderIds: scopedPluginIds,
+    workspaceDir: params.metadataSnapshot?.workspaceDir,
+  });
   const catalogKey = buildAgentModelCatalogCacheKey({
     agentDir: params.agentDir,
     cacheScope: {
       source: "models-list-provider-catalog",
       providerFilter,
       scopedPluginIds,
+      sourceFingerprint: sourceFingerprint.fingerprint,
       staticOnly: params.staticOnly === true,
     },
     config: params.cfg,

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -1,4 +1,5 @@
 /** Provider plugin catalog loading for model-list output. */
+import { createHash } from "node:crypto";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles/store.js";
@@ -40,6 +41,14 @@ import type { ProviderPlugin } from "../../plugins/types.js";
 const DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
 const SELF_HOSTED_DISCOVERY_PROVIDER_IDS = new Set(["lmstudio", "ollama", "sglang", "vllm"]);
 const log = createSubsystemLogger("models/list-provider-catalog");
+
+function buildProviderCatalogEnvCacheFingerprint(env: NodeJS.ProcessEnv): string {
+  const entries = Object.entries(env)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([key, value]) => [key, createHash("sha256").update(value).digest("hex")])
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  return createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+}
 
 function providerMatchesFilter(params: {
   provider: Pick<ProviderPlugin, "id" | "aliases" | "hookAliases">;
@@ -360,6 +369,7 @@ export async function loadProviderCatalogModelsForList(params: {
   const catalogKey = buildAgentModelCatalogCacheKey({
     agentDir: params.agentDir,
     cacheScope: {
+      envFingerprint: buildProviderCatalogEnvCacheFingerprint(env),
       source: "models-list-provider-catalog",
       providerFilter,
       scopedPluginIds,
@@ -367,6 +377,7 @@ export async function loadProviderCatalogModelsForList(params: {
       staticOnly: params.staticOnly === true,
     },
     config: params.cfg,
+    metadataSnapshot: params.metadataSnapshot,
     workspaceDir: params.metadataSnapshot?.workspaceDir,
   });
   const cached = readCachedAgentModelCatalog({

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -369,10 +369,10 @@ export async function loadProviderCatalogModelsForList(params: {
     config: params.cfg,
     workspaceDir: params.metadataSnapshot?.workspaceDir,
   });
-  const cached = readCachedAgentModelCatalog<Model>({
+  const cached = readCachedAgentModelCatalog({
     agentDir: params.agentDir,
     catalogKey,
-  });
+  }) as Model[] | undefined;
   if (cached?.length) {
     return cached;
   }

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -3,6 +3,11 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles/store.js";
 import {
+  buildAgentModelCatalogCacheKey,
+  readCachedAgentModelCatalog,
+  writeCachedAgentModelCatalog,
+} from "../../agents/model-catalog-state-cache.js";
+import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
 } from "../../agents/models-config.providers.secrets.js";
@@ -345,6 +350,25 @@ export async function loadProviderCatalogModelsForList(params: {
     return [];
   }
 
+  const catalogKey = buildAgentModelCatalogCacheKey({
+    agentDir: params.agentDir,
+    cacheScope: {
+      source: "models-list-provider-catalog",
+      providerFilter,
+      scopedPluginIds,
+      staticOnly: params.staticOnly === true,
+    },
+    config: params.cfg,
+    workspaceDir: params.metadataSnapshot?.workspaceDir,
+  });
+  const cached = readCachedAgentModelCatalog<Model>({
+    agentDir: params.agentDir,
+    catalogKey,
+  });
+  if (cached?.length) {
+    return cached;
+  }
+
   const providers = (
     await resolveRuntimePluginDiscoveryProviders({
       config: params.cfg,
@@ -408,11 +432,17 @@ export async function loadProviderCatalogModelsForList(params: {
     }
   }
 
-  return rows.toSorted((left, right) => {
+  const sorted = rows.toSorted((left, right) => {
     const provider = left.provider.localeCompare(right.provider);
     if (provider !== 0) {
       return provider;
     }
     return left.id.localeCompare(right.id);
   });
+  writeCachedAgentModelCatalog({
+    agentDir: params.agentDir,
+    catalogKey,
+    entries: sorted,
+  });
+  return sorted;
 }


### PR DESCRIPTION
Summary

- Add a SQLite-backed agent model catalog cache using the existing `agent_model_catalogs` state table.
- Read cached catalog rows before expensive model catalog/provider catalog discovery when the cache key still matches the agent/config/plugin scope.
- Write refreshed catalog rows after runtime discovery, including the provider catalog path used by `models list` provider fanout.

Verification

- `pnpm test src/agents/model-catalog.test.ts src/agents/model-catalog-state-cache.test.ts src/commands/models/list.provider-catalog.test.ts --run`
- `pnpm format:check -- src/agents/model-catalog.ts src/agents/model-catalog-state-cache.ts src/agents/model-catalog.test.ts src/agents/model-catalog-state-cache.test.ts src/commands/models/list.provider-catalog.ts src/commands/models/list.provider-catalog.test.ts`
- `./node_modules/.bin/oxlint src/agents/model-catalog.ts src/agents/model-catalog-state-cache.ts src/agents/model-catalog.test.ts src/agents/model-catalog-state-cache.test.ts src/commands/models/list.provider-catalog.ts src/commands/models/list.provider-catalog.test.ts`
- `pnpm lint:kysely`

Real behavior proof

behavior: The fixed branch can write and read model catalog rows through the existing `agent_model_catalogs` SQLite table, and the provider catalog loader now uses that cache before runtime provider discovery.

environment: Local OpenClaw source checkout on Node 22.22.2 with temporary state rooted at `/tmp/openclaw-90368-proof-state`.

steps:
- Ran `openclaw models list --all --provider moonshot --json` from the fixed branch with temporary OpenClaw state.
- Ran a source-level cache write/read using the same cache helper used by model catalog and provider catalog list paths.
- Queried the temporary SQLite state database for `agent_model_catalogs`.

evidence:
```json
{
  "count": 5,
  "keys": [
    "moonshot/kimi-k2-thinking",
    "moonshot/kimi-k2-thinking-turbo",
    "moonshot/kimi-k2-turbo",
    "moonshot/kimi-k2.5",
    "moonshot/kimi-k2.6"
  ]
}
```

```json
{
  "keyPrefix": "agent-model-catalog:v1:be34ddd",
  "cachedRows": [
    "moonshot/kimi-k2.6"
  ]
}
```

```json
[
  {
    "key_prefix": "agent-model-catalog:v1:be34ddd",
    "agent_dir": "/tmp/openclaw-proof-agent",
    "raw_json_bytes": 85,
    "updated_at": 1000
  }
]
```

observedResult: `models list` still returns the expected provider-scoped rows, and the new cache path durably stores/readbacks catalog rows in `agent_model_catalogs`.

notTested: Full production dashboard cold-start with every external provider account was not replayed locally; focused proof covers the shared state cache and the provider-list/model-catalog code paths changed here.

Refs #90368
