### PR TITLE
perf(terminal): reuse ANSI scanner during truncation

### DIFF
--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -60,4 +60,13 @@ describe("terminal ansi helpers", () => {
     expect(truncateToVisibleWidth("[31m表文[0m", 1)).toBe("[31m[0m");
     expect(visibleWidth(truncateToVisibleWidth("[31m表文[0m", 1))).toBe(0);
   });
+
+  it("reuses the ANSI scanner across truncation calls", () => {
+    expect(truncateToVisibleWidth("\u001B[31mabc\u001B[0m", 2)).toBe("\u001B[31mab\u001B[0m");
+    expect(truncateToVisibleWidth("plain", 3)).toBe("pla");
+    expect(
+      truncateToVisibleWidth("\u001B]8;;https://openclaw.ai\u001B\\link\u001B]8;;\u001B\\", 2),
+    ).toBe("\u001B]8;;https://openclaw.ai\u001B\\li\u001B]8;;\u001B\\");
+    expect(truncateToVisibleWidth("\u001B[32mxy\u001B[0m", 1)).toBe("\u001B[32mx\u001B[0m");
+  });
 });

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -6,6 +6,7 @@ const ANSI_OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x1b\\\\|\\x07)";
 
 const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
 const ANSI_OSC_REGEX = new RegExp(ANSI_OSC_PATTERN, "g");
+const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
 const graphemeSegmenter =
   typeof Intl !== "undefined" && "Segmenter" in Intl
     ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
@@ -134,7 +135,7 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
   if (visibleWidth(input) <= maxWidth) {
     return input;
   }
-  const ansi = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
+  ANSI_SEQUENCE_REGEX.lastIndex = 0;
   let out = "";
   let used = 0;
   let pos = 0;
@@ -157,7 +158,7 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
     }
   };
   let match: RegExpExecArray | null;
-  while ((match = ansi.exec(input)) !== null) {
+  while ((match = ANSI_SEQUENCE_REGEX.exec(input)) !== null) {
     appendVisible(input.slice(pos, match.index));
     out += match[0];
     pos = match.index + match[0].length;


### PR DESCRIPTION
## Summary

- Reuse one module-level ANSI/OSC scanner in `truncateToVisibleWidth` instead of allocating a combined `RegExp` for every truncation call.
- Reset `lastIndex` before each scan so repeated calls keep the same output as the previous per-call regex.
- Keep this PR scoped to `packages/terminal-core`; the earlier heartbeat comment-handling work was split out of this PR branch.

## Real behavior proof

- Behavior addressed: Terminal table/cell truncation no longer allocates a fresh ANSI/OSC scanner on every `truncateToVisibleWidth` call while preserving styled output, OSC-8 link truncation, plain text truncation, and repeated-call behavior.
- Real environment tested: Windows local OpenClaw worktree (user path redacted), Node v24.9.0, branch head `de073d92500cb0a928902965f6dc3674e29f7214`.
- Exact steps or command run after this patch: Ran focused terminal-core tests, lint/diff checks, Codex review, and two live Node proof commands against the patched worktree.
- Evidence after fix: Focused validation passed:

```text
git diff --check origin/main...HEAD
node scripts/run-oxlint.mjs packages/terminal-core/src/ansi.ts packages/terminal-core/src/ansi.test.ts
node scripts/run-vitest.mjs packages/terminal-core/src/ansi.test.ts packages/terminal-core/src/table.test.ts
# 2 files passed, 29 tests passed
powershell -ExecutionPolicy Bypass -File C:\Users\<user>\.codex\skills\codex-review\scripts\codex-review-windows.ps1 --uncommitted
# No actionable regressions in the OSC-8 test-only diff before amend.
powershell -ExecutionPolicy Bypass -File C:\Users\<user>\.codex\skills\codex-review\scripts\codex-review-windows.ps1 --base origin/main
# No actionable correctness issues were found in the ANSI scanner caching change.
```

Output-equivalence proof from the patched helper:

```json
{
  "first": "\^[[31mab\^[[0m",
  "firstWidth": 2,
  "second": "pla",
  "secondWidth": 3,
  "osc": "\^[]8;;https://openclaw.ai\^[\\li\^[]8;;\^[\\",
  "oscWidth": 2,
  "third": "\^[[32mx\^[[0m",
  "thirdWidth": 1
}
```

Allocation-path microbenchmark using the previous per-call scanner shape versus the shared scanner shape on short ANSI/OSC truncations:

```json
{
  "node": "v24.9.0",
  "platform": "win32-x64",
  "iterationsPerRun": 1000000,
  "outputEquivalenceChecks": 3,
  "medianBeforeMs": 946.78,
  "medianAfterMs": 398.44,
  "medianSpeedup": 2.365
}
```

- Observed result after fix: Repeated styled/plain/OSC-8 truncation calls returned the expected strings and visible widths; the allocation-focused benchmark showed the shared scanner path removing the per-call regex allocation overhead.
- What was not tested: Full local `pnpm check`/full Vitest suite was not run for this two-file terminal-core-only diff; GitHub CI is expected to run the repo shards on the pushed PR head.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-oxlint.mjs packages/terminal-core/src/ansi.ts packages/terminal-core/src/ansi.test.ts`
- `node scripts/run-vitest.mjs packages/terminal-core/src/ansi.test.ts packages/terminal-core/src/table.test.ts`
- `powershell -ExecutionPolicy Bypass -File C:\Users\<user>\.codex\skills\codex-review\scripts\codex-review-windows.ps1 --uncommitted`
- `powershell -ExecutionPolicy Bypass -File C:\Users\<user>\.codex\skills\codex-review\scripts\codex-review-windows.ps1 --base origin/main`

