### PR TITLE
fix(agents): keep apostrophes in slash-command prompt-template arguments

### DIFF
--- a/packages/agent-core/src/harness/prompt-template-arguments.ts
+++ b/packages/agent-core/src/harness/prompt-template-arguments.ts
@@ -1,23 +1,135 @@
 import type { PromptTemplate } from "./types.js";
 
+function isWordCharacter(char: string | undefined): boolean {
+  return char !== undefined && /[\p{L}\p{N}_]/u.test(char);
+}
+
+function isBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+function canOpenApostropheSpan(chars: string[], index: number): boolean {
+  const next = chars[index + 1];
+  return next !== undefined && next !== "'" && !/\s/.test(next);
+}
+
+function closesConcatSpan(chars: string[], index: number): boolean {
+  return chars[index] === "'" && isBoundary(chars[index + 1]);
+}
+
+function nextConcatCloser(chars: string[], index: number): number {
+  for (let j = index + 1; j < chars.length; j++) {
+    if (closesConcatSpan(chars, j)) {
+      return j;
+    }
+  }
+  return -1;
+}
+
+function firstWhitespaceSpanCloser(chars: string[], index: number): number {
+  let sawWhitespace = false;
+  for (let j = index + 1; j < chars.length; j++) {
+    if (/\s/.test(chars[j])) {
+      sawWhitespace = true;
+    } else if (sawWhitespace && closesConcatSpan(chars, j)) {
+      return j;
+    }
+  }
+  return -1;
+}
+
+const proseApostropheTails = new Set(["d", "ll", "m", "re", "s", "t", "ve"]);
+
+function isProseSuffixApostrophe(chars: string[], index: number): boolean {
+  if (!isWordCharacter(chars[index - 1]) || !isWordCharacter(chars[index + 1])) {
+    return false;
+  }
+  let tail = "";
+  for (let j = index + 1; isWordCharacter(chars[j]); j++) {
+    tail += chars[j];
+  }
+  return isBoundary(chars[index + 1 + tail.length]) && proseApostropheTails.has(tail.toLowerCase());
+}
+
+function matchSingleQuoteSpan(chars: string[], index: number): number {
+  if (chars[index + 1] === "'") {
+    return index + 1;
+  }
+  if (!canOpenApostropheSpan(chars, index)) {
+    return -1;
+  }
+  if (isWordCharacter(chars[index - 1])) {
+    const closer = nextConcatCloser(chars, index);
+    if (closer < 0) {
+      return -1;
+    }
+    for (let k = index + 1; k < closer; k++) {
+      if (chars[k] === "'" && nextConcatCloser(chars, k) >= 0) {
+        return -1;
+      }
+    }
+    return closer;
+  }
+  const whitespaceCloser = firstWhitespaceSpanCloser(chars, index);
+  if (whitespaceCloser >= 0) {
+    return whitespaceCloser;
+  }
+  for (let j = index + 1; j < chars.length; j++) {
+    if (chars[j] === "'" && !isProseSuffixApostrophe(chars, j)) {
+      return j;
+    }
+  }
+  for (let j = index + 1; j < chars.length; j++) {
+    if (chars[j] === "'") {
+      return -1;
+    }
+  }
+  return chars.length;
+}
+
+function nextDoubleQuote(chars: string[], index: number): number {
+  for (let j = index + 1; j < chars.length; j++) {
+    if (chars[j] === '"') {
+      return j;
+    }
+  }
+  return -1;
+}
+
 /** Parse an argument string using simple shell-style single and double quotes. */
 export function parseCommandArgs(argsString: string): string[] {
   const args: string[] = [];
+  const chars = Array.from(argsString);
   let current = "";
   let inQuote: string | null = null;
+  let closeAt = -1;
   let hasToken = false;
 
-  for (const char of argsString) {
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i];
     if (inQuote) {
-      if (char === inQuote) {
+      if (i === closeAt) {
         inQuote = null;
+        closeAt = -1;
       } else {
         hasToken = true;
         current += char;
       }
-    } else if (char === '"' || char === "'") {
-      hasToken = true;
+    } else if (char === '"') {
+      const matchingQuote = nextDoubleQuote(chars, i);
       inQuote = char;
+      closeAt = matchingQuote >= 0 ? matchingQuote : chars.length;
+      hasToken = true;
+    } else if (char === "'") {
+      const close = matchSingleQuoteSpan(chars, i);
+      if (close >= 0) {
+        inQuote = char;
+        closeAt = close;
+        hasToken = true;
+      } else {
+        hasToken = true;
+        current += char;
+      }
     } else if (/\s/.test(char)) {
       if (hasToken) {
         args.push(current);

--- a/packages/agent-core/src/harness/prompt-templates.test.ts
+++ b/packages/agent-core/src/harness/prompt-templates.test.ts
@@ -1,6 +1,10 @@
 // Agent Core tests cover prompt templates behavior.
 import { describe, expect, it } from "vitest";
-import { parseCommandArgs, substituteArgs } from "./prompt-template-arguments.js";
+import {
+  formatPromptTemplateInvocation,
+  parseCommandArgs,
+  substituteArgs,
+} from "./prompt-template-arguments.js";
 
 describe("prompt template argument substitution", () => {
   it("parses quoted and multiline arguments", () => {
@@ -10,6 +14,178 @@ describe("prompt template argument substitution", () => {
       "delta",
       "echo one two",
     ]);
+  });
+
+  it("keeps apostrophes in prose instead of dropping them", () => {
+    expect(parseCommandArgs("fix the user's login bug")).toEqual([
+      "fix",
+      "the",
+      "user's",
+      "login",
+      "bug",
+    ]);
+    expect(parseCommandArgs("it's broken now")).toEqual(["it's", "broken", "now"]);
+  });
+
+  it("preserves apostrophes through $ARGUMENTS and positional placeholders", () => {
+    const args = parseCommandArgs("fix the user's login bug");
+    expect(substituteArgs("Please address: $ARGUMENTS", args)).toBe(
+      "Please address: fix the user's login bug",
+    );
+    const positional = parseCommandArgs("it's broken now");
+    expect(substituteArgs("[$1][$2]", positional)).toBe("[it's][broken]");
+  });
+
+  it("formats prompt template invocations with apostrophes and quoted spans", () => {
+    const template = {
+      name: "repair",
+      description: "Repair prompt",
+      content: "Args: $ARGUMENTS\nFirst: $1\nSecond: $2",
+    };
+    const args = parseCommandArgs("don't 'quoted text' next");
+
+    expect(formatPromptTemplateInvocation(template, args)).toBe(
+      "Args: don't quoted text next\nFirst: don't\nSecond: quoted text",
+    );
+  });
+
+  it("treats an unbalanced quote as a literal but still honors balanced quotes", () => {
+    expect(parseCommandArgs(`don't "quote this"`)).toEqual(["don't", "quote this"]);
+  });
+
+  it("groups an unmatched double quote to the end of input", () => {
+    expect(parseCommandArgs(`say "hello world`)).toEqual(["say", "hello world"]);
+    expect(parseCommandArgs(`"unterminated`)).toEqual(["unterminated"]);
+    expect(parseCommandArgs(`a"b`)).toEqual(["ab"]);
+    const args = parseCommandArgs(`say "hello world`);
+    expect(substituteArgs("[$1][$2]", args)).toBe("[say][hello world]");
+  });
+
+  it("groups an unmatched single quote with no later apostrophe to the end of input", () => {
+    expect(parseCommandArgs("say 'hello world")).toEqual(["say", "hello world"]);
+    expect(parseCommandArgs("'lonely")).toEqual(["lonely"]);
+    expect(parseCommandArgs("--title='hi there")).toEqual(["--title=hi there"]);
+    const args = parseCommandArgs("say 'hello world");
+    expect(substituteArgs("[$1][$2]", args)).toBe("[say][hello world]");
+  });
+
+  it("keeps apostrophes literal across multiple contractions", () => {
+    expect(parseCommandArgs("don't it's broken now")).toEqual(["don't", "it's", "broken", "now"]);
+    const args = parseCommandArgs("don't it's broken now");
+    expect(substituteArgs("$ARGUMENTS", args)).toBe("don't it's broken now");
+    expect(substituteArgs("[$1][$2][$3][$4]", args)).toBe("[don't][it's][broken][now]");
+  });
+
+  it("groups shell-style quoted spans embedded in a token", () => {
+    expect(parseCommandArgs(`--title="two words" next`)).toEqual(["--title=two words", "next"]);
+    expect(parseCommandArgs("foo='bar baz' next")).toEqual(["foo=bar baz", "next"]);
+    const args = parseCommandArgs(`--title="two words" next`);
+    expect(substituteArgs("[$1][$2]", args)).toBe("[--title=two words][next]");
+  });
+
+  it("groups bare embedded single-quote concatenation", () => {
+    expect(parseCommandArgs("foo'bar baz' next")).toEqual(["foobar baz", "next"]);
+    const args = parseCommandArgs("foo'bar baz' next");
+    expect(substituteArgs("[$1][$2]", args)).toBe("[foobar baz][next]");
+  });
+
+  it("groups single-quoted prefixes with suffix text", () => {
+    expect(parseCommandArgs("'foo'bar next")).toEqual(["foobar", "next"]);
+    expect(parseCommandArgs("'foo'bar'baz' next")).toEqual(["foobarbaz", "next"]);
+    expect(parseCommandArgs("--name='foo'bar next")).toEqual(["--name=foobar", "next"]);
+    const args = parseCommandArgs("--name='foo'bar next");
+    expect(substituteArgs("[$1][$2]", args)).toBe("[--name=foobar][next]");
+  });
+
+  it("groups a multi-word quoted span that closes before suffix text", () => {
+    expect(parseCommandArgs("'foo bar'baz next")).toEqual(["foo barbaz", "next"]);
+    expect(parseCommandArgs("--name='foo bar'baz next")).toEqual(["--name=foo barbaz", "next"]);
+    const args = parseCommandArgs("'foo bar'baz next");
+    expect(substituteArgs("[$1][$2]", args)).toBe("[foo barbaz][next]");
+  });
+
+  it("keeps a plural possessive literal next to a later quoted span", () => {
+    expect(parseCommandArgs("fix users' 'quoted text'")).toEqual(["fix", "users'", "quoted text"]);
+    const args = parseCommandArgs("fix users' 'quoted text'");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[fix][users'][quoted text]");
+  });
+
+  it("keeps prose apostrophes literal when no span can close", () => {
+    expect(parseCommandArgs("O'Brien's rock'n'roll")).toEqual(["O'Brien's", "rock'n'roll"]);
+  });
+
+  it("keeps apostrophes literal after non-ASCII word characters", () => {
+    expect(parseCommandArgs("José's don't fail")).toEqual(["José's", "don't", "fail"]);
+    const args = parseCommandArgs("José's don't fail");
+    expect(substituteArgs("$ARGUMENTS", args)).toBe("José's don't fail");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[José's][don't][fail]");
+  });
+
+  it("does not close an unmatched leading quote on a later contraction", () => {
+    expect(parseCommandArgs("'review don't fail")).toEqual(["'review", "don't", "fail"]);
+    const args = parseCommandArgs("'review don't fail");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("['review][don't][fail]");
+  });
+
+  it("keeps a contraction inside a balanced quoted phrase", () => {
+    expect(parseCommandArgs("'it's a test' next")).toEqual(["it's a test", "next"]);
+    expect(parseCommandArgs(`"don't stop" now`)).toEqual(["don't stop", "now"]);
+    const args = parseCommandArgs("'it's a test' next");
+    expect(substituteArgs("[$1][$2]", args)).toBe("[it's a test][next]");
+  });
+
+  it("keeps a contraction literal before a later standalone quoted span", () => {
+    expect(parseCommandArgs("don't 'quoted text' next")).toEqual(["don't", "quoted text", "next"]);
+    expect(parseCommandArgs("it's a 'test case' here")).toEqual(["it's", "a", "test case", "here"]);
+    const args = parseCommandArgs("don't 'quoted text' next");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[don't][quoted text][next]");
+  });
+
+  it("keeps contractions literal before a later attached single-quote span", () => {
+    expect(parseCommandArgs("don't foo'bar baz' next")).toEqual(["don't", "foobar baz", "next"]);
+    expect(parseCommandArgs("we're foo'bar baz' next")).toEqual(["we're", "foobar baz", "next"]);
+    const args = parseCommandArgs("don't foo'bar baz' next");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[don't][foobar baz][next]");
+  });
+
+  it("keeps multi-apostrophe prose words literal before a later attached span", () => {
+    expect(parseCommandArgs("O'Brien's foo'bar baz' next")).toEqual([
+      "O'Brien's",
+      "foobar baz",
+      "next",
+    ]);
+    expect(parseCommandArgs("rock'n'roll foo'bar baz' next")).toEqual([
+      "rock'n'roll",
+      "foobar baz",
+      "next",
+    ]);
+  });
+
+  it("keeps irregular contractions literal before a later attached span", () => {
+    expect(parseCommandArgs("y'all foo'bar baz' next")).toEqual(["y'all", "foobar baz", "next"]);
+    expect(parseCommandArgs("ma'am foo'bar baz' next")).toEqual(["ma'am", "foobar baz", "next"]);
+    expect(parseCommandArgs("o'clock foo'bar baz' next")).toEqual([
+      "o'clock",
+      "foobar baz",
+      "next",
+    ]);
+    expect(parseCommandArgs("Y'all 'quoted text' next")).toEqual(["Y'all", "quoted text", "next"]);
+    const args = parseCommandArgs("y'all foo'bar baz' next");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[y'all][foobar baz][next]");
+  });
+
+  it("keeps any prose contraction literal without a fixed word list", () => {
+    expect(parseCommandArgs("ne'er foo'bar baz' next")).toEqual(["ne'er", "foobar baz", "next"]);
+    expect(parseCommandArgs("cap'n foo'bar baz' next")).toEqual(["cap'n", "foobar baz", "next"]);
+    expect(parseCommandArgs("y'know foo'bar baz' next")).toEqual(["y'know", "foobar baz", "next"]);
+    expect(parseCommandArgs("fo'c'sle foo'bar baz' next")).toEqual([
+      "fo'c'sle",
+      "foobar baz",
+      "next",
+    ]);
+    expect(parseCommandArgs("'y'all here'")).toEqual(["y'all here"]);
+    const args = parseCommandArgs("ne'er foo'bar baz' next");
+    expect(substituteArgs("[$1][$2][$3]", args)).toBe("[ne'er][foobar baz][next]");
   });
 
   it("rejects unsafe positional placeholders", () => {


### PR DESCRIPTION
## Summary

- `parseCommandArgs` (`packages/agent-core/src/harness/prompt-template-arguments.ts`) expands `$ARGUMENTS` / `$@` / `$1..$N` in user prompt templates and custom slash commands. It does shell-style quote parsing with **no escape and no unbalanced-quote recovery**, so a lone `'` (an ordinary apostrophe in English prose: `user's`, `it's`, `don't`) opens a quote that runs to the next apostrophe (or end of string). The apostrophe is dropped and the following whitespace is swallowed into one token. The corrupted tokens then feed `$ARGUMENTS` (`args.join(" ")`) and the positional placeholders, so the model **silently receives a mangled instruction** with no error or warning.
  - `/cmd don't it's broken now` + a `[$1][$2]` template collapses to `ARG1=[dont its] ARG2=[broken]`: both apostrophes dropped, placeholders shifted.
- Reach: shipped and default-on. `AgentSession.prompt()` expands templates by default (`expandPromptTemplates ?? true`) and the **expanded text becomes the user message sent to the model**. Templates are real user `.md` files loaded by `loadPromptTemplates` from `<agentDir>/prompts`, `<cwd>/.openclaw/prompts`, and explicit prompt paths.
- Fix: single-quote handling becomes prose-aware while every other tokenization rule matches current main byte-for-byte. A word-attached apostrophe is a delimiter only when it opens a concatenation that closes at a later trailing apostrophe (`foo'bar baz'`), and it yields to any nearer apostrophe that owns such a closer, so a leading prose word keeps its apostrophe (`y'all foo'bar baz'`, `don't 'quoted text' next`). A standalone or assignment-attached apostrophe prefers a later whitespace-spanning quote (`'echo one two'`), otherwise closes at the first apostrophe that is not an English contraction suffix so shell-style concatenation still works before suffix text (`'foo'bar`, `'foo bar'baz` -> `foo barbaz`); with no closer at all it groups the rest of the input like the shipped parser (`say 'hello world` -> `["say", "hello world"]`) unless a later apostrophe could be prose it must not swallow, in which case it stays literal (`'review don't fail`). Irregular contractions are recognized structurally (no enumerated word list), so `y'all`, `o'clock`, `ne'er`, `cap'n`, and `y'know` are all preserved; only a small fixed set of English contraction suffixes (`d`, `ll`, `m`, `re`, `s`, `t`, `ve`) tells a contraction apostrophe from a closing quote that precedes suffix text. Double quotes and all non-apostrophe behavior are unchanged from main, including unmatched quotes (`say "hello world`). A full differential against the current-main parser confirms the only behavioral differences are the deliberate prose-apostrophe cases.
- One canonical change in `parseCommandArgs`; both consumers (`expandPromptTemplate` in `src/agents/sessions/prompt-templates.ts` and `formatPromptTemplateInvocation` in `packages/agent-core`) benefit with no API change. The separate `src/auto-reply/commands-registry.ts` `parseCommandArgs` (native channel commands) is a different function and is left untouched.

## Tests

- `packages/agent-core/src/harness/prompt-templates.test.ts`: added cases covering apostrophes preserved in parsed tokens and through `$ARGUMENTS` / positional placeholders; multiple contractions; shell-style quoted spans embedded in a token (`--title="two words"`, `foo='bar baz'`); bare embedded single-quote concatenation (`foo'bar baz'`); a multi-word quoted span that closes before suffix text (`'foo bar'baz` -> `foo barbaz`); an unmatched double quote that groups to the end of input (`say "hello world`); an unmatched single quote with no later apostrophe that groups to the end of input (`say 'hello world`, `'lonely`, `--title='hi there`); a plural possessive next to a later quoted span (`fix users' 'quoted text'`); apostrophes after non-ASCII word characters (`José's don't fail`); an unmatched leading quote that must not close on a later contraction (`'review don't fail`); a contraction inside a balanced quoted phrase (`'it's a test'`); a contraction before a later standalone single-quoted span (`don't 'quoted text' next`); irregular contractions before a later attached single-quote span (`y'all`, `ma'am`, `o'clock`); and a generality case proving any prose contraction is preserved without a fixed word list (`ne'er`, `cap'n`, `y'know`, `fo'c'sle`, plus closer-side `'y'all here'`). The existing quoted/multiline and placeholder-safety cases are unchanged and green (25/25).
- `src/agents/sessions/prompt-templates.test.ts` (`expandPromptTemplate`) unchanged and green.
- Touched suites run locally with the repo runner (`prompt-templates.test.ts` 25/25); tsgo core, type-aware oxlint, and oxfmt clean on the touched files.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a user-authored custom slash command / prompt template invoked with ordinary prose containing an apostrophe silently lost the apostrophe (and, for positional `$N` templates, collapsed arguments and shifted later placeholders), so the model received a corrupted instruction. Covers prose contractions of every shape including irregular ones the parser does not enumerate (`y'all`, `o'clock`, `ne'er`, `cap'n`, `y'know`) and a contraction inside a balanced span (`'y'all here'`). Every non-apostrophe tokenization rule is verified byte-identical to current main: multi-word concatenation (`'foo bar'baz`), unmatched double quotes (`say "hello world`), and unmatched single quotes (`say 'hello world`).
- Real environment tested: Linux, Node 22.19, exercising the actual production functions `loadPromptTemplates` + `expandPromptTemplate` (the same expansion path `AgentSession.prompt()` uses to build the outbound user message) over a real on-disk prompt directory (`<agentDir>/prompts/*.md`).
- Exact steps or command run after this patch: wrote `<tmp>/prompts/cmd.md` = `ARG1=[$1] ARG2=[$2] ARG3=[$3] ARG4=[$4]`; loaded it via `loadPromptTemplates({ cwd, agentDir, promptPaths, includeDefaults: false })`; called `expandPromptTemplate("/cmd <input>", templates)` for each input below; ran the script over the **current PR head** (`4c029c5a29`) and, for the before column, over the `origin/main` parser source (`substituteArgs` is identical, so only `parseCommandArgs` differs) with the rest of the path identical.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live output from running the real `expandPromptTemplate` over the on-disk template on the current PR head `4c029c5a29`:

```
TEMPLATES LOADED: ["cmd"]
USER TYPES : /cmd don't it's broken now
MODEL GETS : ARG1=[don't] ARG2=[it's] ARG3=[broken] ARG4=[now]

USER TYPES : /cmd say "hello world
MODEL GETS : ARG1=[say] ARG2=[hello world] ARG3=[] ARG4=[]

USER TYPES : /cmd say 'hello world
MODEL GETS : ARG1=[say] ARG2=[hello world] ARG3=[] ARG4=[]

USER TYPES : /cmd 'foo bar'baz next
MODEL GETS : ARG1=[foo barbaz] ARG2=[next] ARG3=[] ARG4=[]

USER TYPES : /cmd José's don't fail
MODEL GETS : ARG1=[José's] ARG2=[don't] ARG3=[fail] ARG4=[]

USER TYPES : /cmd 'review don't fail
MODEL GETS : ARG1=['review] ARG2=[don't] ARG3=[fail] ARG4=[]

USER TYPES : /cmd 'it's a test' next
MODEL GETS : ARG1=[it's a test] ARG2=[next] ARG3=[] ARG4=[]

USER TYPES : /cmd don't 'quoted text' next
MODEL GETS : ARG1=[don't] ARG2=[quoted text] ARG3=[next] ARG4=[]

USER TYPES : /cmd y'all foo'bar baz' next
MODEL GETS : ARG1=[y'all] ARG2=[foobar baz] ARG3=[next] ARG4=[]

USER TYPES : /cmd o'clock foo'bar baz' next
MODEL GETS : ARG1=[o'clock] ARG2=[foobar baz] ARG3=[next] ARG4=[]

USER TYPES : /cmd ne'er foo'bar baz' next
MODEL GETS : ARG1=[ne'er] ARG2=[foobar baz] ARG3=[next] ARG4=[]

USER TYPES : /cmd cap'n foo'bar baz' next
MODEL GETS : ARG1=[cap'n] ARG2=[foobar baz] ARG3=[next] ARG4=[]

USER TYPES : /cmd y'know foo'bar baz' next
MODEL GETS : ARG1=[y'know] ARG2=[foobar baz] ARG3=[next] ARG4=[]

USER TYPES : /cmd 'y'all here'
MODEL GETS : ARG1=[y'all here] ARG2=[] ARG3=[] ARG4=[]
```

- Observed result after fix: apostrophes survive end to end for prose contractions of every shape with no contraction word list in the parser, while shipped quote behavior is preserved: a multi-word quoted span before suffix text concatenates (`'foo bar'baz` -> `foo barbaz`), an unmatched double quote groups to the end of input (`say "hello world`), and an unmatched single quote with no later apostrophe groups to the end of input (`say 'hello world`). An unmatched leading quote before a contraction stays literal (`'review don't fail`). The model receives the exact instruction the user typed.
- What was not tested: the separate native-channel `src/auto-reply/commands-registry.ts` `parseCommandArgs` (a different function, untouched); a fully wired gateway round-trip through a live provider (the proof drives the exact expansion function that produces the user message rather than issuing a model call).
- Proof limitations or environment constraints: none specific; the expansion is deterministic and reproduced on demand.
- Before evidence (optional but encouraged): the same script over the `origin/main` parser (unpatched) corrupts every prose case; the preserved forms (`'foo bar'baz`, `say "hello world`, `say 'hello world`) are identical before and after, confirming compatibility:

```
TEMPLATES LOADED: ["cmd"]
USER TYPES : /cmd don't it's broken now
MODEL GETS : ARG1=[dont its] ARG2=[broken] ARG3=[now] ARG4=[]

USER TYPES : /cmd say "hello world
MODEL GETS : ARG1=[say] ARG2=[hello world] ARG3=[] ARG4=[]

USER TYPES : /cmd say 'hello world
MODEL GETS : ARG1=[say] ARG2=[hello world] ARG3=[] ARG4=[]

USER TYPES : /cmd 'foo bar'baz next
MODEL GETS : ARG1=[foo barbaz] ARG2=[next] ARG3=[] ARG4=[]

USER TYPES : /cmd José's don't fail
MODEL GETS : ARG1=[Josés dont] ARG2=[fail] ARG3=[] ARG4=[]

USER TYPES : /cmd 'review don't fail
MODEL GETS : ARG1=[review dont] ARG2=[fail] ARG3=[] ARG4=[]

USER TYPES : /cmd 'it's a test' next
MODEL GETS : ARG1=[its] ARG2=[a] ARG3=[test next] ARG4=[]

USER TYPES : /cmd don't 'quoted text' next
MODEL GETS : ARG1=[dont quoted] ARG2=[text next] ARG3=[] ARG4=[]

USER TYPES : /cmd y'all foo'bar baz' next
MODEL GETS : ARG1=[yall foobar] ARG2=[baz next] ARG3=[] ARG4=[]

USER TYPES : /cmd o'clock foo'bar baz' next
MODEL GETS : ARG1=[oclock foobar] ARG2=[baz next] ARG3=[] ARG4=[]

USER TYPES : /cmd ne'er foo'bar baz' next
MODEL GETS : ARG1=[neer foobar] ARG2=[baz next] ARG3=[] ARG4=[]

USER TYPES : /cmd cap'n foo'bar baz' next
MODEL GETS : ARG1=[capn foobar] ARG2=[baz next] ARG3=[] ARG4=[]

USER TYPES : /cmd y'know foo'bar baz' next
MODEL GETS : ARG1=[yknow foobar] ARG2=[baz next] ARG3=[] ARG4=[]

USER TYPES : /cmd 'y'all here'
MODEL GETS : ARG1=[yall] ARG2=[here] ARG3=[] ARG4=[]
```

