### PR TITLE
fix(state): retire superseded plugin install index

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1408,6 +1408,83 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("archives legacy plugin install index when current npm records supersede older records", async () => {
+    const root = await makeTempRoot();
+    await writeExistingPluginInstallIndex(root, {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        installPath: "/state/npm/projects/openclaw-codex-current",
+        resolvedName: "@openclaw/codex",
+        resolvedVersion: "2026.6.1",
+        resolvedSpec: "@openclaw/codex@2026.6.1",
+        installedAt: "2026-06-01T21:04:35.000Z",
+      },
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: "/state/npm/projects/openclaw-discord-current",
+        resolvedName: "@openclaw/discord",
+        resolvedVersion: "2026.6.1",
+        resolvedSpec: "@openclaw/discord@2026.6.1",
+        installedAt: "2026-06-01T21:04:36.000Z",
+      },
+    });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex@2026.5.18",
+        version: "2026.5.18",
+      },
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@2026.5.18",
+        version: "2026.5.18",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+    await expect(readPersistedInstalledPluginIndex({ stateDir: root })).resolves.toMatchObject({
+      installRecords: {
+        codex: { resolvedVersion: "2026.6.1" },
+        discord: { resolvedVersion: "2026.6.1" },
+      },
+    });
+  });
+
+  it("keeps legacy plugin install index when npm records would replace newer metadata", async () => {
+    const root = await makeTempRoot();
+    await writeExistingPluginInstallIndex(root, {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex",
+        installPath: "/state/npm/projects/openclaw-codex-current",
+        resolvedName: "@openclaw/codex",
+        resolvedVersion: "2026.5.18",
+        resolvedSpec: "@openclaw/codex@2026.5.18",
+      },
+    });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      codex: {
+        source: "npm",
+        spec: "@openclaw/codex@2026.6.1",
+        version: "2026.6.1",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
+
+    expect(result.warnings).toStrictEqual([
+      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: codex",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+  });
+
   for (const fixture of [
     {
       label: "name different packages",

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -64,7 +64,9 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import { compareOpenClawReleaseVersions, parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import { isWithinDir } from "./path-safety.js";
+import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import {
   ensureDir,
   existsDir,
@@ -403,12 +405,94 @@ function legacyInstallRecordHasCurrentResolvedIdentity(params: {
   return Boolean(legacyResolvedSpec && currentResolvedSpec === legacyResolvedSpec);
 }
 
+function readNpmInstallRecordPackageName(
+  record: InstalledPluginIndex["installRecords"][string],
+): string | undefined {
+  const resolvedName = readInstallRecordStringField(record, "resolvedName")?.trim();
+  if (resolvedName) {
+    return resolvedName;
+  }
+  for (const key of ["resolvedSpec", "spec"]) {
+    const spec = readInstallRecordStringField(record, key);
+    if (!spec) {
+      continue;
+    }
+    const parsed = parseRegistryNpmSpec(spec);
+    if (parsed?.name) {
+      return parsed.name;
+    }
+  }
+  return undefined;
+}
+
+function readNpmInstallRecordVersion(
+  record: InstalledPluginIndex["installRecords"][string],
+): string | undefined {
+  const resolvedVersion = readInstallRecordStringField(record, "resolvedVersion")?.trim();
+  if (resolvedVersion) {
+    return resolvedVersion;
+  }
+  const version = readInstallRecordStringField(record, "version")?.trim();
+  if (version) {
+    return version;
+  }
+  for (const key of ["resolvedSpec", "spec"]) {
+    const spec = readInstallRecordStringField(record, key);
+    const parsed = spec ? parseRegistryNpmSpec(spec) : null;
+    if (parsed?.selectorKind === "exact-version" && parsed.selector) {
+      return parsed.selector;
+    }
+  }
+  return undefined;
+}
+
+function compareInstallRecordVersions(
+  currentVersion: string,
+  legacyVersion: string,
+): number | null {
+  const openClawVersionComparison = compareOpenClawReleaseVersions(currentVersion, legacyVersion);
+  if (openClawVersionComparison !== null) {
+    return openClawVersionComparison;
+  }
+  return compareComparableSemver(
+    parseComparableSemver(currentVersion, { normalizeLegacyDotBeta: true }),
+    parseComparableSemver(legacyVersion, { normalizeLegacyDotBeta: true }),
+  );
+}
+
+function legacyNpmInstallRecordSupersededByCurrent(params: {
+  currentRecord: InstalledPluginIndex["installRecords"][string];
+  legacyRecord: InstalledPluginIndex["installRecords"][string];
+}): boolean {
+  const { currentRecord, legacyRecord } = params;
+  if (currentRecord.source !== "npm" || legacyRecord.source !== "npm") {
+    return false;
+  }
+  const currentPackageName = readNpmInstallRecordPackageName(currentRecord);
+  const legacyPackageName = readNpmInstallRecordPackageName(legacyRecord);
+  if (!currentPackageName || currentPackageName !== legacyPackageName) {
+    return false;
+  }
+  if (!readInstallRecordStringField(currentRecord, "installPath")) {
+    return false;
+  }
+  const currentVersion = readNpmInstallRecordVersion(currentRecord);
+  const legacyVersion = readNpmInstallRecordVersion(legacyRecord);
+  if (!currentVersion || !legacyVersion) {
+    return false;
+  }
+  return compareInstallRecordVersions(currentVersion, legacyVersion) === 1;
+}
+
 function legacyInstallRecordCoveredByCurrent(
   currentRecord: InstalledPluginIndex["installRecords"][string],
   legacyRecord: InstalledPluginIndex["installRecords"][string],
 ): boolean {
   if (currentRecord.source !== legacyRecord.source) {
     return false;
+  }
+  if (legacyNpmInstallRecordSupersededByCurrent({ currentRecord, legacyRecord })) {
+    return true;
   }
   for (const key of Object.keys(legacyRecord).toSorted()) {
     const currentValue = readInstallRecordField(currentRecord, key);


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes repeated legacy plugin install index conflict warnings after a successful external plugin update leaves newer shared SQLite install metadata for the same npm package.
- Teaches the legacy install-index migration to treat an older legacy npm record as superseded only when the current SQLite record has the same npm package identity, a managed install path, and a strictly newer parsed version.
- Keeps true conflicts fail-safe: same-version selector drift, package-name drift, malformed metadata, or newer legacy metadata still leaves the legacy source in place with the existing warning.

Why does this matter now?

Issue #90418 reports macOS upgrades from 2026.5.18 to 2026.6.1 repeatedly warning for codex and discord even though the plugin update completed and runtime health was good.

What is the intended outcome?

After `openclaw doctor --fix` or the migration path sees newer current SQLite install records for the same npm plugins, the stale legacy `plugins/installs.json` source is archived so normal doctor/status/restart flows do not keep reporting the same conflict.

What is intentionally out of scope?

- No plugin API, config surface, or runtime fallback changes.
- No broad reconciliation for same-version floating selector differences or malformed install metadata.
- No changes to codex or discord plugin packages.

What does success look like?

A codex/discord state shaped like the reported upgrade archives the stale legacy install index once, preserves the newer SQLite records, and a second doctor run has no repeated plugin install index conflict warning.

What should reviewers focus on?

The safety boundary in `legacyNpmInstallRecordSupersededByCurrent`: same npm package identity, managed current install path, and strictly newer version are all required before archiving the legacy source.

## Linked context

Which issue does this close?

Closes #90418

Which issues, PRs, or discussions are related?

Related #90418

Was this requested by a maintainer or owner?

No direct maintainer request; this follows the open bug report and ClawSweeper source-repro guidance on the issue.

## Real behavior proof (required for external PRs)

- Behavior addressed: repeated legacy plugin install index conflict warnings for codex/discord after current shared SQLite metadata already points at newer npm installs.
- Real environment tested: local macOS source checkout with isolated `HOME`, `OPENCLAW_CONFIG`, and `OPENCLAW_STATE_DIR`; no user config or credentials used.
- Exact steps or command run after this patch: seeded an isolated shared SQLite `installed_plugin_index` with codex/discord records at `2026.6.1`, seeded legacy `plugins/installs.json` with codex/discord records at `2026.5.18`, ran `pnpm openclaw doctor --non-interactive --fix`, then ran `pnpm openclaw doctor --non-interactive` again against the same isolated state.
- Evidence after fix:

```text
legacy_json_after_fix=archived
legacy_archive_after_fix=present
second_doctor_conflict_warning=absent

--- doctor --fix excerpt ---
13:│  - Archived plugin install index legacy source →                          │

--- second doctor warning check ---
no repeated plugin install index warning
```

- Observed result after fix: the legacy install index source was archived on the fix run, and the follow-up doctor run did not emit `conflicting plugin install metadata` or `Left plugin install index`.
- What was not tested: the full reported supervised update flow with Homebrew/global pnpm package swap and LaunchAgent restart.
- Proof limitations or environment constraints: the live proof uses a synthetic isolated state matching the reported codex/discord metadata shape instead of a real 2026.5.18 to 2026.6.1 macOS upgrade. The local `$autoreview` and `$agent-transcript` skill files advertised to this Codex session were not present on disk, so I could not run those skill-specific workflows.
- Before evidence (optional but encouraged): current issue evidence and the existing conflict branch show that a legacy `plugins/installs.json` source remains pending when SQLite has conflicting install metadata, causing repeated detection on later migration/doctor paths.

## Tests and validation

Which commands did you run?

```sh
node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts
node scripts/run-vitest.mjs src/cli/update-cli/post-core-plugin-convergence.test.ts
./node_modules/.bin/oxfmt --check --threads=1 src/infra/state-migrations.ts src/commands/doctor-state-migrations.test.ts
git diff --check
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/state-migrations.ts src/commands/doctor-state-migrations.test.ts
pnpm openclaw doctor --non-interactive --fix
pnpm openclaw doctor --non-interactive
```

What regression coverage was added or updated?

Added focused migration tests for:

- archiving older codex/discord legacy npm install records when current SQLite records are newer for the same package;
- preserving the warning/source file when the current SQLite record is older than the legacy metadata.

What failed before this fix, if known?

Before this fix, the same current-vs-legacy codex/discord shape would be treated as conflicting metadata and leave `plugins/installs.json` in place, making future migration/doctor paths repeat the warning.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A stale legacy install-index warning is suppressed only after the migration archives an older superseded legacy npm record.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Legacy state migration behavior changes for superseded npm plugin install records.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Incorrectly archiving a legacy install index that still contains meaningful install metadata.

How is that risk mitigated?

The new branch requires same npm package identity, a current managed install path, and a strictly newer current version. Existing richer-match behavior and same-version conflict tests remain intact, and a new negative test covers the newer-legacy case.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

No author-side code work is pending. Full supervised upgrade proof was not run locally; CI and maintainer judgment can decide whether that broader proof is needed.

Which bot or reviewer comments were addressed?

Addresses the ClawSweeper source-repro guidance on issue #90418 by targeting the legacy state/plugin install index migration layer and adding the requested regression coverage.

