### PR TITLE
fix(telegram): keep bot reply answers anchored to current message

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1136,6 +1136,39 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectRecordFields((delivery.replies as Array<unknown>)[0], { replyToId: "9001" });
   });
 
+  it("keeps bot-reply answers anchored to the current user message", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Hello", replyToId: "1001" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        msg: {
+          message_id: 1001,
+          reply_to_message: {
+            message_id: 9001,
+            from: { is_bot: true },
+          },
+        } as unknown as TelegramMessageContext["msg"],
+        ctxPayload: {
+          MessageSid: "1001",
+          ReplyToId: "9001",
+          ReplyToBody: "quoted bot reply",
+          ReplyToQuoteText: " quoted bot reply\n",
+          ReplyToIsQuote: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    const delivery = expectDeliverRepliesParams({
+      replyQuoteMessageId: 9001,
+      replyQuoteText: " quoted bot reply\n",
+    });
+    expectRecordFields((delivery.replies as Array<unknown>)[0], { replyToId: "1001" });
+  });
+
   it("keeps answer draft stream for current message replies with native quote candidates", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -912,6 +912,7 @@ export const dispatchTelegramMessage = async ({
     replyQuoteText && !ctxPayload.ReplyToIsExternal
       ? resolveTelegramReplyId(ctxPayload.ReplyToId)
       : undefined;
+  const replyQuoteTargetsBotMessage = msg.reply_to_message?.from?.is_bot === true;
   const replyQuoteByMessageId: TelegramNativeQuoteCandidateByMessageId = {};
   if (replyToMode !== "off") {
     if (replyQuoteText && replyQuoteMessageId != null) {
@@ -957,7 +958,9 @@ export const dispatchTelegramMessage = async ({
     !isRoomEvent && streamReasoningDraft && !streamReasoningInProgressDraft;
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number"
-      ? (replyQuoteMessageId ?? msg.message_id)
+      ? replyQuoteTargetsBotMessage
+        ? msg.message_id
+        : (replyQuoteMessageId ?? msg.message_id)
       : undefined;
   const draftMinInitialChars = streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS;
   const progressSeed = `${route.accountId}:${chatId}:${threadSpec.id ?? ""}`;
@@ -1405,7 +1408,9 @@ export const dispatchTelegramMessage = async ({
   });
 
   const implicitQuoteReplyTargetId =
-    replyQuoteMessageId != null ? String(replyQuoteMessageId) : undefined;
+    !replyQuoteTargetsBotMessage && replyQuoteMessageId != null
+      ? String(replyQuoteMessageId)
+      : undefined;
   const currentMessageIdForQuoteReply =
     implicitQuoteReplyTargetId && ctxPayload.MessageSid ? ctxPayload.MessageSid : undefined;
   const replyQuotePosition =


### PR DESCRIPTION
## Summary

- Keep Telegram answers anchored to the current inbound message when the user replies to a bot/assistant message with selected quote text.
- Preserve native quote-target behaviour for non-bot quoted replies.
- Add a regression test covering the bot-reply case.

## Why

In Telegram groups, a user can reply to a bot message while asking a new question. With `replyToMode` enabled and selected quote metadata present, the final answer can be retargeted to the quoted bot message instead of the current user message. That makes the assistant visually reply to itself, which breaks traceability in busy forum topics.

The existing native settings cover either disabling native reply tags (`replyToMode=off`) or using the selected quote target (`first`/`all`/`batched`). They do not cover the bot-reply edge case where the correct visible anchor is the current user message.

## Test

- `pnpm exec vitest run extensions/telegram/src/bot-message-dispatch.test.ts`
- Result: 1 file passed, 104 tests passed.

## Real behavior proof

Behavior or issue addressed:
Telegram replies should remain visibly anchored to the current inbound user message when the user replies to a bot/assistant message. They should not retarget the final assistant answer to the quoted bot/assistant message.

Real environment tested:
Real OpenClaw Telegram forum setup running OpenClaw 2026.6.1 with `channels.telegram.replyToMode = first`. The installed-runtime containment patch was applied before this source PR was opened.

Exact steps or command run after this patch:
1. In a real Telegram forum topic, the user replied to an assistant/bot message.
2. The user’s reply was the new message that needed an answer.
3. The assistant answered while `replyToMode` remained `first`.
4. The visible Telegram reply tag was checked against the current user message, not the older assistant/bot message.

Evidence after fix:

Real setup configuration:

```text
OpenClaw 2026.6.1
channels.telegram.replyToMode = first
```

Installed runtime evidence from the real setup after the patch:

```text
replyQuoteTargetsBotMessage = msg.reply_to_message?.from?.is_bot === true
draftReplyToMessageId = replyQuoteTargetsBotMessage ? msg.message_id : replyQuoteMessageId ?? msg.message_id
implicitQuoteReplyTargetId = !replyQuoteTargetsBotMessage && replyQuoteMessageId != null ? String(replyQuoteMessageId) : undefined
```

Observed result after fix:
After the patch, the assistant response was natively tagged to the user’s current message in the Telegram topic. The topic stayed on `replyToMode=first`, so normal visible reply tagging remained enabled.

What was not tested:
No screenshot or recording is attached. The proof above is redacted live-runtime output and observed live Telegram behaviour from the real setup. Unit tests are supplemental and included separately.
