### PR TITLE
fix: repair current main CI failures

### DIFF
--- a/src/agents/tools/pdf-tool.model-config.test.ts
+++ b/src/agents/tools/pdf-tool.model-config.test.ts
@@ -180,7 +180,7 @@ describe("resolvePdfModelConfigForTool", () => {
     } as OpenClawConfig;
 
     expect(resolvePdfModelConfigForTool({ cfg, agentDir: TEST_AGENT_DIR })).toEqual({
-      primary: "openai/gpt-5.4-mini",
+      primary: "openai/gpt-5.5",
       fallbacks: ["minimax/MiniMax-M2.7", "minimax-portal/MiniMax-M2.7"],
     });
   });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -192,6 +192,7 @@ describe("isHeartbeatContentEffectivelyEmpty", () => {
   it("returns true for comments only", () => {
     expect(isHeartbeatContentEffectivelyEmpty("# Header\n# Another comment")).toBe(true);
     expect(isHeartbeatContentEffectivelyEmpty("## Subheader\n### Another")).toBe(true);
+    expect(isHeartbeatContentEffectivelyEmpty("<!-- Runtime template marker -->")).toBe(true);
   });
 
   it("returns false when a template includes plain instructional prose", () => {
@@ -240,6 +241,9 @@ Keep this file empty unless you want a tiny checklist.
     expect(isHeartbeatContentEffectivelyEmpty("- Check email")).toBe(false);
     expect(isHeartbeatContentEffectivelyEmpty("# HEARTBEAT.md\n- Task 1")).toBe(false);
     expect(isHeartbeatContentEffectivelyEmpty("Remind me to call mom")).toBe(false);
+    expect(isHeartbeatContentEffectivelyEmpty("<!-- note --> Check deployment <!-- note -->")).toBe(
+      false,
+    );
   });
 
   it("returns false for content with tasks after header", () => {

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -31,6 +31,7 @@ export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
  * A file is considered effectively empty if it contains only:
  * - Whitespace / empty lines
  * - Markdown ATX headers (`#`, `##`, ...)
+ * - Standalone HTML comments (`<!-- ... -->`)
  * - Markdown fence markers such as ``` or ```markdown
  * - Empty list item stubs (`- `, `- [ ]`, `* `, `+ `)
  *
@@ -56,6 +57,10 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     // This intentionally does NOT skip lines like "#TODO" or "#hashtag" which might be content
     // (Those aren't valid markdown headers - ATX headers require space after #)
     if (/^#+(\s|$)/.test(trimmed)) {
+      continue;
+    }
+    // Ignore single-line HTML comments used by runtime templates.
+    if (/^<!--(?:(?!-->).)*-->$/.test(trimmed)) {
       continue;
     }
     // Skip empty markdown list items like "- [ ]" or "* [ ]" or just "- "

--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveWorkspaceTemplateDir } from "../agents/workspace-templates.js";
+import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import {
   analyzeHeartbeatTemplateForRepair,
   maybeRepairHeartbeatTemplate,
@@ -31,6 +33,11 @@ async function makeWorkspaceWithHeartbeat(content: string): Promise<{
   const heartbeatPath = path.join(workspaceDir, "HEARTBEAT.md");
   await fs.writeFile(heartbeatPath, content, "utf-8");
   return { workspaceDir, heartbeatPath };
+}
+
+async function readCleanRuntimeHeartbeatTemplate(): Promise<string> {
+  const templateDir = await resolveWorkspaceTemplateDir();
+  return await fs.readFile(path.join(templateDir, DEFAULT_HEARTBEAT_FILENAME), "utf-8");
 }
 
 describe("heartbeat template repair", () => {
@@ -207,11 +214,7 @@ Add short tasks below the comments only when you want the agent to check somethi
     });
 
     await expect(fs.readFile(heartbeatPath, "utf-8")).resolves.toBe(
-      `${[
-        "# Keep this file empty (or with only comments) to skip heartbeat API calls.",
-        "",
-        "# Add tasks below when you want the agent to check something periodically.",
-      ].join("\n")}\n`,
+      await readCleanRuntimeHeartbeatTemplate(),
     );
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("clean heartbeat template"),

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -150,7 +150,7 @@ describe("task-flow-registry store runtime", () => {
   });
 
   it("rejects corrupt persisted flow rows during sqlite restore", async () => {
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       const created = createManagedTaskFlow({
@@ -174,7 +174,7 @@ describe("task-flow-registry store runtime", () => {
   });
 
   it("drops invalid requester origins during sqlite restore", async () => {
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       const created = createManagedTaskFlow({
@@ -203,7 +203,7 @@ describe("task-flow-registry store runtime", () => {
   });
 
   it("restores persisted wait-state, revision, and cancel intent from sqlite", async () => {
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       const created = createManagedTaskFlow({
@@ -248,7 +248,7 @@ describe("task-flow-registry store runtime", () => {
   });
 
   it("round-trips explicit json null through sqlite", async () => {
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       const created = createManagedTaskFlow({
@@ -269,7 +269,7 @@ describe("task-flow-registry store runtime", () => {
   });
 
   it("prunes large sqlite snapshots without binding every flow id at once", async () => {
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       const flows = new Map<string, TaskFlowRecord>();
@@ -299,7 +299,7 @@ describe("task-flow-registry store runtime", () => {
     if (process.platform === "win32") {
       return;
     }
-    await withFlowRegistryTempDir(async (root) => {
+    await withFlowRegistryTempDir(async (_root) => {
       resetTaskFlowRegistryForTests();
 
       createManagedTaskFlow({


### PR DESCRIPTION
## Summary

- Fixes current-main CI failures unrelated to PR #90463.
- Treats the runtime `HEARTBEAT.md` HTML comment marker as non-actionable heartbeat content without hiding visible inline text.
- Keeps heartbeat doctor repair tests aligned with the actual clean runtime template.
- Updates PDF model config and oxlint expectations to match current main behavior.

## Linked context

Related #90463

Was this requested by a maintainer or owner?

Maintainer-requested split-out fix for unrelated current-main CI failures observed while reviewing #90463.

## Real behavior proof (required for external PRs)

- Behavior addressed: current-main CI failures in heartbeat template handling, PDF model config expectations, and oxlint unused-parameter checks.
- Real environment tested: local native Codex worktree on macOS, rebased onto current `upstream/main`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/heartbeat.test.ts src/agents/workspace-templates.test.ts src/commands/doctor-heartbeat-template-repair.test.ts src/agents/tools/pdf-tool.model-config.test.ts src/tasks/task-flow-registry.store.test.ts`; `node scripts/run-oxlint-shards.mjs --threads=8`; `./node_modules/.bin/oxfmt --check src/auto-reply/heartbeat.ts src/auto-reply/heartbeat.test.ts src/commands/doctor-heartbeat-template-repair.test.ts src/agents/tools/pdf-tool.model-config.test.ts src/tasks/task-flow-registry.store.test.ts`; `git diff --check upstream/main...HEAD`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Vitest passed 4 shards / 65 tests; oxlint core, extensions, and scripts shards finished cleanly; oxfmt reported all matched files use the correct format; `git diff --check` exited cleanly.
- Observed result after fix: the targeted heartbeat, PDF model config, task-flow store, lint, format, and diff checks pass on the rebased branch.
- What was not tested: full repository `pnpm check`, full Vitest suite, and live OpenClaw runtime behavior.
- Proof limitations or environment constraints: proof is local focused CI-surface validation; no remote Testbox or full CI run was started before opening this PR.
- Before evidence (optional but encouraged): `src/commands/doctor-heartbeat-template-repair.test.ts` failed because the repaired file included the new runtime HTML comment; `node scripts/run-oxlint-shards.mjs --threads=8` reproduced six unused `root` parameter errors in `src/tasks/task-flow-registry.store.test.ts`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/auto-reply/heartbeat.test.ts src/agents/workspace-templates.test.ts src/commands/doctor-heartbeat-template-repair.test.ts src/agents/tools/pdf-tool.model-config.test.ts src/tasks/task-flow-registry.store.test.ts`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `./node_modules/.bin/oxfmt --check src/auto-reply/heartbeat.ts src/auto-reply/heartbeat.test.ts src/commands/doctor-heartbeat-template-repair.test.ts src/agents/tools/pdf-tool.model-config.test.ts src/tasks/task-flow-registry.store.test.ts`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- Added heartbeat empty-content coverage for standalone HTML comments and visible text between comments.
- Updated doctor repair coverage to compare against the runtime template source.
- Updated PDF model config coverage for the current OpenAI image/PDF default.

What failed before this fix, if known?

- Heartbeat doctor repair assertion expected the old two-line runtime template.
- Runtime `HEARTBEAT.md` template was no longer effectively empty after the new HTML comment marker.
- PDF config test expected `openai/gpt-5.4-mini` while current media defaults resolve `openai/gpt-5.5`.
- Oxlint reported unused `root` parameters in task-flow registry store tests.

If no test was added, why not?

Tests were added or updated for the behavior changes. The task-flow change is lint-only.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, narrowly: a standalone HTML comment line in `HEARTBEAT.md` no longer causes heartbeat work to run.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Heartbeat empty-content classification.

How is that risk mitigated?

The matcher only accepts a single standalone HTML comment line, and tests cover visible text around comments staying actionable.

## Current review state

What is the next action?

Review and let CI verify the branch.
