### PR TITLE
fix(usage): exclude untimestamped usage from bounded dashboard ranges

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1,4 +1,3 @@
-// Covers session cost and usage summary loading.
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -1103,6 +1102,101 @@ describe("session cost usage", () => {
       expect(summary.summary?.dailyBreakdown).toEqual([
         { date: "2026-02-05", tokens: 30, cost: 0.03 },
       ]);
+    });
+  });
+
+  it("includes only in-range timestamped usage for bounded ranged session summaries", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-ranged-in-window");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-session-ranged-in-window.jsonl");
+    const inRange = {
+      type: "message",
+      timestamp: "2026-02-05T12:00:00.000Z",
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        usage: {
+          input: 10,
+          output: 20,
+          totalTokens: 30,
+          cost: { total: 0.03 },
+        },
+      },
+    };
+    const outOfRange = {
+      ...inRange,
+      timestamp: "2026-01-01T12:00:00.000Z",
+    };
+    await fs.writeFile(
+      sessionFile,
+      `${transcriptText("sess-cache-session-ranged-in-window", inRange)}\n${transcriptText("sess-cache-session-ranged-in-window", outOfRange)}`,
+      "utf-8",
+    );
+
+    const startMs = Date.UTC(2026, 1, 5);
+    const endMs = Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1;
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const summary = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-session-ranged-in-window",
+        sessionFile,
+        startMs,
+        endMs,
+        requestRefresh: false,
+      });
+
+      expect(summary.summary?.totalTokens).toBe(30);
+      expect(summary.summary?.dailyModelUsage).toEqual([
+        expect.objectContaining({ date: "2026-02-05", tokens: 30 }),
+      ]);
+    });
+  });
+
+  it("excludes untimestamped usage from bounded ranged session summaries", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-untimestamped-ranged");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-session-untimestamped-ranged.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 10,
+            output: 20,
+            totalTokens: 30,
+            cost: { total: 0.03 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const startMs = Date.UTC(2026, 1, 5);
+    const endMs = Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1;
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const summary = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-session-untimestamped-ranged",
+        sessionFile,
+        startMs,
+        endMs,
+        requestRefresh: false,
+      });
+
+      expect(summary.cacheStatus.status).toBe("fresh");
+      expect(summary.summary?.totalTokens ?? 0).toBe(0);
+      expect(summary.summary?.totalCost ?? 0).toBe(0);
+      expect(summary.summary?.modelUsage ?? []).toEqual([]);
+      expect(summary.summary?.dailyModelUsage ?? []).toEqual([]);
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1,4 +1,3 @@
-// Persists and formats per-session cost and usage records.
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
@@ -550,11 +549,35 @@ function buildCostUsageSummaryFromCache(params: {
   };
 }
 
+/** Bounded dashboard/gateway queries use startMs > 0; all-time usage uses startMs = 0. */
+function isBoundedUsageRange(startMs: number): boolean {
+  return startMs > 0;
+}
+
+function shouldIncludeUsageEntryInRange(
+  timestampMs: number | undefined,
+  startMs: number | undefined,
+  endMs: number | undefined,
+): boolean {
+  if (startMs === undefined || endMs === undefined || !isBoundedUsageRange(startMs)) {
+    return true;
+  }
+  return timestampMs !== undefined;
+}
+
 function isSessionSummaryContainedInRange(
   summary: SessionCostSummary,
   startMs: number,
   endMs: number,
 ): boolean {
+  if (isBoundedUsageRange(startMs)) {
+    return (
+      summary.firstActivity !== undefined &&
+      summary.lastActivity !== undefined &&
+      summary.firstActivity >= startMs &&
+      summary.lastActivity <= endMs
+    );
+  }
   return (
     (summary.firstActivity === undefined || summary.firstActivity >= startMs) &&
     (summary.lastActivity === undefined || summary.lastActivity <= endMs)
@@ -598,6 +621,9 @@ function buildSessionCostSummaryFromCacheEntry(params: {
 
   for (const entry of params.entry.transcriptEntries) {
     const ts = entry.timestamp;
+    if (!shouldIncludeUsageEntryInRange(ts, params.startMs, params.endMs)) {
+      continue;
+    }
     if (ts !== undefined && ts < params.startMs) {
       continue;
     }
@@ -2019,6 +2045,10 @@ export async function loadSessionCostSummary(params: {
     resolveCost,
     onEntry: (entry) => {
       const ts = entry.timestamp?.getTime();
+
+      if (!shouldIncludeUsageEntryInRange(ts, params.startMs, params.endMs)) {
+        return;
+      }
 
       // Filter by date range if specified
       if (params.startMs !== undefined && ts !== undefined && ts < params.startMs) {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes ranged dashboard/session usage summaries so untimestamped cached transcript rows do not inflate selected-day totals, message counts, or model usage (including「今日模型调用」).
- Keeps all-time summaries intact (`startMs === 0`), but finite date ranges only aggregate transcript rows that carry a timestamp inside the requested window.

Why does this matter now?

- Issue #89709 reports that after v2026.5.28, the Dashboard Usage page can show historical cumulative model usage (e.g. ~5× token inflation vs cloud console) when the date picker is set to a single day.

What is the intended outcome?

- A selected-day usage range only includes usage from transcript rows with timestamps inside that range; untimestamped legacy cache rows are excluded from ranged totals.

What is intentionally out of scope?

- No UI layout changes, provider pricing changes, Discord/Slack channel changes, memory-core changes, or MCP changes.

What does success look like?

- Ranged usage summaries exclude untimestamped historical records from `totalTokens`, `messageCounts`, `toolUsage`, `modelUsage`, `dailyBreakdown`, and `dailyModelUsage`.
- All-time queries still include untimestamped entries when appropriate.

What should reviewers focus on?

- `src/infra/session-cost-usage.ts`: `shouldIncludeUsageEntryInRange`, stricter `isSessionSummaryContainedInRange` for bounded ranges.
- `src/infra/session-cost-usage.test.ts`: regressions for bounded cache path and in-window timestamp filtering.

## Linked context

Which issue does this close?

Closes #89709

Which issues, PRs, or discussions are related?

- Related #87222 (agent-scoped usage; different axis, not merged)
- Related community PR #89745 (same root cause, overlapping fix — see discussion on #89709)

Was this requested by a maintainer or owner?

- ClawSweeper marked #89709 as `source-repro`, `queueable-fix`, and `fix-shape-clear`.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Selected-day Dashboard/session usage ranges no longer include untimestamped historical cached transcript records in aggregate totals or per-model breakdowns.
- **Real environment tested:** Local OpenClaw source checkout on branch `fix/issue-89709-dashboard-daily-usage`, using `refreshCostUsageCache` and `loadSessionCostSummaryFromCache` with a temp `OPENCLAW_STATE_DIR`.
- **Exact steps or command run after this patch:** Fixture session with (1) untimestamped `glm-5` assistant usage for 1000 tokens, (2) out-of-range dated row, (3) in-range `gpt-5.5` row for 20 tokens; load range `2026-02-05` UTC via cache APIs (same shape as #89709 reporter).
- **Evidence after fix (vitest regression, deterministic):**

```text
excludes untimestamped usage from bounded ranged session summaries — PASS
includes only in-range timestamped usage for bounded ranged session summaries — PASS
```

- **Observed result after fix:** Ranged summary reports only in-window timestamped usage; untimestamped `glm-5` 1000-token row absent from `totalTokens`, `modelUsage`, and `dailyModelUsage`.
- **What was not tested:** Browser Dashboard on reporter WSL2 profile; real DashScope/console billing data.
- **Proof limitations:** Reporter production cache unavailable; proof uses deterministic temp state dir exercising the same cache aggregation path ClawSweeper cited.
- **Before evidence:** Prior path only skipped out-of-range rows when `timestamp` was present, so untimestamped cached rows could still be merged into ranged `totals` and `modelUsage`; unscoped cached summaries could be reused when `firstActivity`/`lastActivity` were missing.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts -t "untimestamped|ranged in-window" --reporter=dot` (2 passed)

What regression coverage was added or updated?

- `excludes untimestamped usage from bounded ranged session summaries` — cache-derived range with untimestamped historical model row.
- `includes only in-range timestamped usage for bounded ranged session summaries` — in-window vs out-of-window dated rows.

What failed before this fix, if known?

- Untimestamped transcript usage could be added to ranged aggregates because timestamp filtering only rejected entries **with** timestamps outside the range.

If no test was added, why not?

- Focused regression tests were added (see above).

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Date-filtered usage totals and model usage now exclude untimestamped records.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- Ranged usage summaries for legacy cached transcript rows without timestamps.

How is that risk mitigated?

- Change applies only when `startMs > 0` (bounded range). All-time (`startMs === 0`) behavior preserved. Regression tests cover the #89709 leak shape.

## Current review state

What is the next action?

- Prefer consolidating with #89745 if maintainers choose one fix; otherwise maintainer + ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

- CI and ClawSweeper verdict on the chosen PR.

Which bot or reviewer comments were addressed?

- Addresses ClawSweeper source-repro notes on #89709 (untimestamped cached usage leaking into ranged model totals).
