### PR TITLE
fix: harden ChatGPT Responses missing content-type streams

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -665,6 +665,50 @@ describe("openai transport stream", () => {
       version: "2026.3.22",
       "User-Agent": "openclaw/2026.3.22",
     });
+    expect(headers.Accept).toBeUndefined();
+    expect(headers.accept).toBeUndefined();
+  });
+
+  it("adds SSE Accept only to native ChatGPT/Codex Responses stream requests", () => {
+    const codexModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 400000,
+      maxTokens: 128000,
+    } satisfies Model<"openai-chatgpt-responses">;
+    const transportAliasModel = {
+      ...codexModel,
+      api: "openclaw-openai-responses-transport" as Api,
+    } satisfies Model;
+    const nonNativeChatGPTModel = {
+      ...codexModel,
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies Model<"openai-chatgpt-responses">;
+    const openAIModel = {
+      ...codexModel,
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies Model<"openai-responses">;
+
+    expect(testing.buildOpenAISdkRequestOptions(codexModel, undefined, { stream: true })).toEqual({
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(
+      testing.buildOpenAISdkRequestOptions(transportAliasModel, undefined, { stream: true }),
+    ).toEqual({ headers: { Accept: "text/event-stream" } });
+    expect(testing.buildOpenAISdkRequestOptions(codexModel)).toBeUndefined();
+    expect(
+      testing.buildOpenAISdkRequestOptions(nonNativeChatGPTModel, undefined, { stream: true }),
+    ).toBeUndefined();
+    expect(
+      testing.buildOpenAISdkRequestOptions(openAIModel, undefined, { stream: true }),
+    ).toBeUndefined();
   });
 
   it("moves Azure OpenAI completions api-version headers into default query params", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1875,12 +1875,18 @@ function buildOpenAISdkClientOptions(model: Model): { timeout?: number } {
 function buildOpenAISdkRequestOptions(
   model: Model,
   signal?: AbortSignal,
-): { signal?: AbortSignal; timeout?: number } | undefined {
+  options?: { stream?: boolean },
+): { signal?: AbortSignal; timeout?: number; headers?: Record<string, string> } | undefined {
   const timeout = resolveOpenAISdkTimeoutMs(model);
-  if (timeout === undefined && !signal) {
+  const headers =
+    options?.stream === true && usesNativeOpenAICodexResponsesBackend(model)
+      ? { Accept: "text/event-stream" }
+      : undefined;
+  if (timeout === undefined && !signal && !headers) {
     return undefined;
   }
   return {
+    ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
   };
@@ -1967,7 +1973,9 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           assertCodeModeResponsesToolSurface(params);
         }
         const requestStartedAt = Date.now();
-        const requestOptions = buildOpenAISdkRequestOptions(model, options?.signal);
+        const requestOptions = buildOpenAISdkRequestOptions(model, options?.signal, {
+          stream: true,
+        });
         emitModelTransportDebug(
           log,
           `[responses] start provider=${model.provider} api=${model.api} model=${model.id} ` +


### PR DESCRIPTION
## Summary

Builds on #90399 and narrows the missing-`Content-Type` workaround to the native ChatGPT/Codex Responses stream path.

- send `Accept: text/event-stream` for native ChatGPT/Codex Responses SDK stream requests, including the transport-aware alias path
- only synthesize `text/event-stream` when the response is `2xx`, has a body, targets the expected `chatgpt.com/backend-api` or `/codex` backend, and the body prefix sniffs as SSE
- fail closed for missing-header JSON/HTML/unknown bodies and for non-native OpenAI-compatible providers

## Why

#90399 covers the direct `openai-chatgpt-responses` API value, but the transport-aware stream path can route through `openclaw-openai-responses-transport`. Matching only the direct API value leaves that path without the proactive SSE `Accept` header.

The response-side guard also should not treat every missing `Content-Type` as acceptable. A missing header is only safe to normalize for the native ChatGPT/Codex Responses backend after the body confirms it is SSE.

Related: #90083. Current `main` already contains the central body-sniffing normalization for this missing-`Content-Type` SSE failure mode; this PR keeps the native ChatGPT/Codex SSE path working while tightening the missing-header normalization boundary and adding the scoped SSE `Accept` header. It does not claim coverage for unrelated payload-shape/provider failures.

## Tests

- `pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/provider-transport-fetch.test.ts src/agents/openai-transport-stream.test.ts`
- `pnpm exec oxlint src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/provider-transport-fetch.ts src/agents/provider-transport-fetch.test.ts`
- `pnpm tsgo:core`
- `pnpm exec tsgo -p test/tsconfig/tsconfig.core.test.agents.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-agents.tsbuildinfo`
- `pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/provider-transport-fetch.ts src/agents/provider-transport-fetch.test.ts`

## Real behavior proof

- Behavior addressed: Native ChatGPT/Codex Responses streaming through the transport-aware alias should send `Accept: text/event-stream` on the SDK stream request. When that native path receives an SSE body with a missing `Content-Type`, the SDK stream should still parse events successfully. Missing-header bodies that do not sniff as SSE should fail closed; this is intentional for non-SSE/native responses and for non-native provider routes.

- Real setup tested: Source checkout at PR commit `90cbbeebc449` using this branch's actual OpenAI SDK path, `buildGuardedModelFetch`, and `buildOpenAISdkRequestOptions` output. Non-production local harness: a loopback CONNECT proxy routed `https://chatgpt.com/backend-api/codex/responses` to a local TLS server with a generated `chatgpt.com` certificate. This kept traffic off external endpoints and used no real provider credentials. The local harness disabled TLS verification only for the generated local certificate; this proof is about request headers, missing-header SSE normalization, and fail-closed body classification, not TLS trust behavior. Model route under test: `provider=openai`, `api=openclaw-openai-responses-transport`, `baseUrl=https://chatgpt.com/backend-api/codex`.

- Exact steps or command run after this patch: Ran a temporary proof harness with `node --import tsx` from this PR branch. The harness generated a local certificate for `chatgpt.com`, started a loopback CONNECT proxy and local TLS server, created an OpenAI SDK client using this branch's guarded fetch, passed this branch's stream request options into `client.responses.create({ stream: true })`, and repeated the request with a non-SSE missing-header body to verify fail-closed behavior.

- Evidence after fix: copied terminal output from the non-production proof harness:

  ```text
  commit=90cbbeebc449
  real_setup=local CONNECT proxy + generated local TLS server for chatgpt.com SAN; TLS verification disabled only for this local proof harness
  model_api=openclaw-openai-responses-transport
  model_base_url=https://chatgpt.com/backend-api/codex
  sse_request=POST /backend-api/codex/responses HTTP/1.1
  sse_server_accept=text/event-stream
  sse_server_content_type=<missing>
  sse_sdk_result=ok
  sse_sdk_events=response.created | response.output_text.delta delta=proof-ok | response.completed
  unknown_request=POST /backend-api/codex/responses HTTP/1.1
  unknown_server_accept=text/event-stream
  unknown_server_content_type=<missing>
  unknown_sdk_result=name=Error causeName=ProviderHttpError causeCode=invalid_provider_content_type causeStatus=200 message=Connection error.
  ```

- Observed result after fix: The transport-aware alias path sent `Accept: text/event-stream` on the actual SDK request. The SDK parsed a missing-`Content-Type` SSE response successfully after guarded-fetch normalization. A missing-`Content-Type` non-SSE body was rejected through `ProviderHttpError` with `invalid_provider_content_type`, confirming the stricter fail-closed behavior is intentional.

- What was not tested: No live ChatGPT OAuth/provider endpoint was called. No production Gateway/runtime state, user session, or real credential was used. This proof does not claim coverage for arbitrary OpenAI-compatible providers; those routes intentionally remain fail-closed for missing-header non-native streams.
