### PR TITLE
fix service env placeholder collection

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1146,6 +1146,79 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     );
   });
 
+  it("retains .env values for macOS LaunchAgent env SecretRefs", async () => {
+    await writeStateDirDotEnv("MINIMAX_API_KEY=minimax-dotenv-key\n", {
+      stateDir: path.join(tmpDir, ".openclaw"),
+    });
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: { HOME: tmpDir },
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+      config: {
+        models: {
+          providers: {
+            "minimax-openai": {
+              baseUrl: "https://api.minimax.io/v1",
+              apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.MINIMAX_API_KEY).toBe("minimax-dotenv-key");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("MINIMAX_API_KEY");
+  });
+
+  it("retains .env values when config env has an unresolved self reference", async () => {
+    await writeStateDirDotEnv("MINIMAX_API_KEY=minimax-dotenv-key\n", {
+      stateDir: path.join(tmpDir, ".openclaw"),
+    });
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: { HOME: tmpDir },
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+      config: {
+        env: {
+          vars: {
+            MINIMAX_API_KEY: "${MINIMAX_API_KEY}",
+          },
+        },
+        models: {
+          providers: {
+            "minimax-openai": {
+              baseUrl: "https://api.minimax.io/v1",
+              apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.MINIMAX_API_KEY).toBe("minimax-dotenv-key");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("MINIMAX_API_KEY");
+  });
+
   it("does not retain config env values for macOS LaunchAgent env files", async () => {
     await writeStateDirDotEnv("OPENROUTER_API_KEY=or-dotenv\nTAVILY_API_KEY=dotenv-tavily\n", {
       stateDir: path.join(tmpDir, ".openclaw"),

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -31,6 +31,9 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
       if (isBlockedConfigEnvVar(key)) {
         continue;
       }
+      if (containsEnvVarReference(value)) {
+        continue;
+      }
       entries[key] = value;
     }
   }
@@ -47,6 +50,9 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
       continue;
     }
     if (isBlockedConfigEnvVar(key)) {
+      continue;
+    }
+    if (containsEnvVarReference(value)) {
       continue;
     }
     entries[key] = value;

--- a/src/config/config.env-vars.test.ts
+++ b/src/config/config.env-vars.test.ts
@@ -121,6 +121,51 @@ describe("config env vars", () => {
     });
   });
 
+  it("drops unresolved env references from config env", async () => {
+    const entries = collectConfigRuntimeEnvVars({
+      env: {
+        vars: {
+          OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}",
+          BRAVE_API_KEY: "config-key",
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(entries.OPENROUTER_API_KEY).toBeUndefined();
+    expect(entries.BRAVE_API_KEY).toBe("config-key");
+  });
+
+  it("drops unresolved env references from top-level config env", async () => {
+    const entries = collectConfigRuntimeEnvVars({
+      env: {
+        OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}",
+        BRAVE_API_KEY: "config-key",
+      },
+    } as OpenClawConfig);
+
+    expect(entries.OPENROUTER_API_KEY).toBeUndefined();
+    expect(entries.BRAVE_API_KEY).toBe("config-key");
+  });
+
+  it("keeps resolved env references from config env", async () => {
+    const resolvedConfig = resolveConfigEnvVars(
+      {
+        env: {
+          vars: {
+            OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}",
+            BRAVE_API_KEY: "config-key",
+          },
+        },
+      },
+      { OPENROUTER_API_KEY: "resolved-key" },
+    ) as OpenClawConfig;
+
+    const entries = collectConfigRuntimeEnvVars(resolvedConfig);
+
+    expect(entries.OPENROUTER_API_KEY).toBe("resolved-key");
+    expect(entries.BRAVE_API_KEY).toBe("config-key");
+  });
+
   it("loads ${VAR} substitutions from ~/.openclaw/.env on repeated runtime loads", async () => {
     await withTempHome(async (_home) => {
       await withEnvOverride({ BRAVE_API_KEY: undefined }, async () => {


### PR DESCRIPTION
## Summary

Refs #90277.

This fixes the managed gateway service env plan when config contains an unresolved env placeholder such as `${MINIMAX_API_KEY}` and the real value lives in `$OPENCLAW_STATE_DIR/.env`.

The change skips unresolved `${VAR}` references while collecting config env vars for runtime/service env. Concrete config env values still work, but placeholder values no longer mask the state-dir `.env` value during service env planning.

## Impact

- No config schema changes.
- No MiniMax-specific allowlist or provider special case.
- Existing concrete `config.env` values keep working, including values produced by config placeholder resolution.
- Env-backed SecretRefs can still resolve from the managed service environment after install/restart.
- Security behavior is slightly tighter because literal unresolved placeholders are not staged as credential-like env values.

## Verification

- `git fetch origin main`
- `git rebase origin/main`
- `git diff --check origin/main`
- `node scripts/run-vitest.mjs src/config/config.env-vars.test.ts src/commands/daemon-install-helpers.test.ts`
- `node scripts/run-vitest.mjs src/config/config.env-vars.test.ts`
- Blacksmith Testbox `tbx_01ktanqfm49ss6avf85qmqaw20`: `corepack pnpm check:test-types`

## Real Behavior Proof

Behavior addressed: `gateway install` service-env planning preserves a concrete `MINIMAX_API_KEY` from `$OPENCLAW_STATE_DIR/.env` when config also contains an unresolved self-reference `${MINIMAX_API_KEY}`.

Real environment tested: Blacksmith Testbox `tbx_01ktakr7a43sym9k546pn17y5n`, Linux Node 24.13.0, synced PR checkout for the original proof run. The current amended PR head is `3dfb9b3d06750047294e6682da9dc1fe117edcb9`; later amendments only made the MiniMax provider test fixture type-complete and added top-level unresolved plus resolved config env placeholder regression coverage. The fixture type fix was verified separately with `check:test-types` on Testbox `tbx_01ktanqfm49ss6avf85qmqaw20`; the config env collector tests were verified with `node scripts/run-vitest.mjs src/config/config.env-vars.test.ts`.

Exact steps or command run after this patch: On Testbox, created a temp state dir with `.env` containing a fake `MINIMAX_API_KEY`, built a config with both `env.vars.MINIMAX_API_KEY: "${MINIMAX_API_KEY}"` and `models.providers["minimax-openai"].apiKey` as an env SecretRef, then called the actual `buildGatewayInstallPlan` managed service env path with `platform: "darwin"`. The command used `wrapperPath: process.execPath` to bypass package CLI-entrypoint resolution in the synced source checkout; it did not bypass service-env collection or render-policy logic.

Evidence after fix:

```json
{
  "behaviorAddressed": "gateway install plan preserves state-dir .env MINIMAX_API_KEY when config env contains unresolved self-reference",
  "realEnvironmentTested": "Blacksmith Testbox tbx_01ktakr7a43sym9k546pn17y5n using isolated OPENCLAW_STATE_DIR and actual buildGatewayInstallPlan managed service env path",
  "stateDotEnvValuePreserved": true,
  "exportedKey": "MINIMAX_API_KEY",
  "managedKeys": "MINIMAX_API_KEY",
  "platformPlanned": "darwin",
  "launcherResolutionBypassedWithWrapperPath": true,
  "secretValuePrinted": false
}
```

Observed result after fix: The install plan exported `MINIMAX_API_KEY` from state-dir `.env` and kept `OPENCLAW_SERVICE_MANAGED_ENV_KEYS=MINIMAX_API_KEY`; the unresolved config placeholder did not mask the concrete `.env` value.

What was not tested: No live macOS LaunchAgent or Linux systemd service was installed, restarted, or inspected; no real MiniMax credential or provider call was used.