### PR TITLE
fix(gateway): retry restart continuation recovery

### DIFF
--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -328,6 +328,7 @@ export async function runGatewayClosePrelude(params: {
   disposeAuthRateLimiter?: () => void;
   disposeBrowserAuthRateLimiter: () => void;
   stopModelPricingRefresh?: () => void;
+  stopSessionDeliveryRecovery?: () => void;
   stopChannelHealthMonitor?: () => void;
   stopReadinessEventLoopHealth?: () => void;
   clearSecretsRuntimeSnapshot?: () => void;
@@ -339,6 +340,7 @@ export async function runGatewayClosePrelude(params: {
   params.disposeAuthRateLimiter?.();
   params.disposeBrowserAuthRateLimiter();
   params.stopModelPricingRefresh?.();
+  params.stopSessionDeliveryRecovery?.();
   params.stopChannelHealthMonitor?.();
   params.stopReadinessEventLoopHealth?.();
   params.clearSecretsRuntimeSnapshot?.();

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -392,6 +392,9 @@ export function createGatewayCloseHandler(
     stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
     pluginServices: PluginServicesHandle | null;
     postReadySidecars?: readonly GatewayPostReadySidecarHandle[];
+    // Stop promises for sidecars that registered after close started; awaited
+    // alongside the snapshot so late producers cannot outlive shutdown.
+    lateSidecarStopPromises?: readonly Promise<void>[];
     disposeSessionMcpRuntimes?: () => Promise<void>;
     disposeBundleLspRuntimes?: () => Promise<void>;
     cron: { stop: () => void };
@@ -541,10 +544,20 @@ export function createGatewayCloseHandler(
       if (params.tailscaleCleanup) {
         await shutdownStep("tailscale", () => params.tailscaleCleanup!(), warnings);
       }
-      if (params.postReadySidecars?.length) {
+      if (params.postReadySidecars?.length || params.lateSidecarStopPromises?.length) {
         await measureCloseStep("post-ready-sidecars", async () => {
-          for (const [index, sidecar] of params.postReadySidecars!.entries()) {
+          for (const [index, sidecar] of (params.postReadySidecars ?? []).entries()) {
             await shutdownStep(`post-ready-sidecar/${index}`, () => sidecar.stop(), warnings);
+          }
+          // Await sidecars that registered after the snapshot was taken: their
+          // stop() promises were tracked rather than dropped, so restart-sentinel
+          // producer work is drained before shutdown proceeds.
+          if (params.lateSidecarStopPromises?.length) {
+            await shutdownStep(
+              "post-ready-sidecar/late",
+              () => Promise.allSettled(params.lateSidecarStopPromises!).then(() => undefined),
+              warnings,
+            );
           }
         });
       }

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -451,6 +451,13 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.recordInboundSessionAndDispatchReply).not.toHaveBeenCalled();
     expect(mocks.logWarn).not.toHaveBeenCalled();
+    // The sentinel file must only be removed after the notice has a durable
+    // handoff (delivered/enqueued). If removal raced ahead of delivery, an
+    // abort in between would lose the restart notice entirely.
+    expect(mocks.removeRestartSentinelFile).toHaveBeenCalledTimes(1);
+    const deliverOrder = Math.max(...mocks.deliverOutboundPayloads.mock.invocationCallOrder);
+    const removeOrder = mocks.removeRestartSentinelFile.mock.invocationCallOrder[0];
+    expect(removeOrder).toBeGreaterThan(deliverOrder);
   });
 
   it("retries outbound delivery once and logs a warning without dropping the agent wake", async () => {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -582,7 +582,6 @@ async function loadRestartSentinelStartupTask(params: {
       );
     }
 
-    await removeRestartSentinelFile(sentinelPath);
     const routedAgentTurnContinuation =
       payload.continuation?.kind === "agentTurn" && continuationRoute !== undefined;
     if (!routedAgentTurnContinuation) {
@@ -617,6 +616,12 @@ async function loadRestartSentinelStartupTask(params: {
         log,
       });
     }
+
+    // Remove the sentinel only after the restart notice has a durable handoff
+    // (continuation enqueued/drained and notice delivered). If shutdown aborts
+    // mid-delivery the sentinel survives and is replayed on the next boot,
+    // making delivery at-least-once instead of silently lost.
+    await removeRestartSentinelFile(sentinelPath);
 
     return { status: "ran" as const };
   };

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -28,6 +28,7 @@ export type GatewayServerMutableState = {
   skillsChangeUnsub: () => void;
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
+  stopSessionDeliveryRecovery: () => void;
   mcpServer: { port: number; close: () => Promise<void> } | undefined;
   configReloader: GatewayConfigReloaderHandle;
   agentUnsub: (() => void) | null;
@@ -64,6 +65,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     skillsChangeUnsub: () => {},
     channelHealthMonitor: null as ChannelHealthMonitor | null,
     stopModelPricingRefresh: () => {},
+    stopSessionDeliveryRecovery: () => {},
     mcpServer: undefined as { port: number; close: () => Promise<void> } | undefined,
     configReloader: { stop: async () => {} } satisfies GatewayConfigReloaderHandle,
     agentUnsub: null as (() => void) | null,

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -23,6 +23,10 @@ export type GatewayServerMutableState = {
   tailscaleCleanup: (() => Promise<void>) | null;
   postReadySidecars: GatewayPostReadySidecarHandle[];
   gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[];
+  // Stop promises for sidecars that registered after close already started.
+  // The close path awaits these so late-registered producers (e.g. the
+  // restart-sentinel sidecar) cannot keep running past shutdown.
+  lateSidecarStopPromises: Promise<void>[];
   skillsRefreshTimer: ReturnType<typeof setTimeout> | null;
   skillsRefreshDelayMs: number;
   skillsChangeUnsub: () => void;
@@ -60,6 +64,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     tailscaleCleanup: null as (() => Promise<void>) | null,
     postReadySidecars: [],
     gatewayLifetimeSidecars: [],
+    lateSidecarStopPromises: [],
     skillsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     skillsRefreshDelayMs: 30_000,
     skillsChangeUnsub: () => {},

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -202,8 +202,8 @@ describe("server-runtime-services", () => {
     let call = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
     expect(call).toBeDefined();
     // Periodic retry uses Date.now() — known to be >= 1_250 + 60_000 = 61_250
-    expect(call!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
-    expect(call!.log).toBe(log.child.mock.results[2]?.value);
+    expect(call.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
+    expect(call.log).toBe(log.child.mock.results[2]?.value);
 
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
 
@@ -214,8 +214,8 @@ describe("server-runtime-services", () => {
     // Each periodic retry uses a new Date.now() cutoff
     call = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
     expect(call).toBeDefined();
-    expect(call!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250 + 60_000);
-    expect(call!.log).toBe(log.child.mock.results[3]?.value);
+    expect(call.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250 + 60_000);
+    expect(call.log).toBe(log.child.mock.results[3]?.value);
   });
 
   it("recovers delivery entries enqueued after startup maxEnqueuedAt via periodic retry", async () => {
@@ -248,7 +248,7 @@ describe("server-runtime-services", () => {
     // is eligible
     const periodicCall = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
     expect(periodicCall).toBeDefined();
-    expect(periodicCall!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
+    expect(periodicCall.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
   });
 
   it("stops session delivery periodic retry after close — no retry fires after stop handle is called", async () => {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -181,6 +181,36 @@ describe("server-runtime-services", () => {
     });
   });
 
+  it("periodically retries pending restart continuation deliveries every 60 seconds", async () => {
+    vi.useFakeTimers();
+    const log = createLog();
+    activateScheduledServicesForTest({ log });
+
+    // Advance past the initial 1_250ms delay to trigger the first recovery call
+    await vi.advanceTimersByTimeAsync(1_250);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+
+    hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
+
+    // Advance by 60_000ms — the periodic retry should fire again
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith({
+      deps: {},
+      maxEnqueuedAt: 123,
+      log: log.child.mock.results[2]?.value,
+    });
+
+    hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
+
+    // Advance another 60_000ms — the periodic retry should fire a third time
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+  });
+
   it("can defer cron startup while activating other scheduled services", async () => {
     vi.useFakeTimers();
     const cron = { start: vi.fn(async () => undefined) };

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -193,15 +193,15 @@ describe("server-runtime-services", () => {
 
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
 
-    // Advance by 60_000ms — the periodic retry should fire again
+    // Advance by 60_000ms — the periodic retry should fire again with a fresh cutoff
     await vi.advanceTimersByTimeAsync(60_000);
     await vi.dynamicImportSettled();
     expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
-    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith({
-      deps: {},
-      maxEnqueuedAt: 123,
-      log: log.child.mock.results[2]?.value,
-    });
+    let call = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    // Periodic retry uses Date.now() — known to be >= 1_250 + 60_000 = 61_250
+    expect(call!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
+    expect(call!.log).toBe(log.child.mock.results[2]?.value);
 
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
 
@@ -209,6 +209,44 @@ describe("server-runtime-services", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     await vi.dynamicImportSettled();
     expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+    // Each periodic retry uses a new Date.now() cutoff
+    call = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250 + 60_000);
+    expect(call!.log).toBe(log.child.mock.results[3]?.value);
+  });
+
+  it("recovers delivery entries enqueued after startup maxEnqueuedAt via periodic retry", async () => {
+    vi.useFakeTimers();
+    const log = createLog();
+    activateScheduledServicesForTest({ log });
+
+    // Advance past the initial 1_250ms delay — first recovery uses startup cutoff (123)
+    await vi.advanceTimersByTimeAsync(1_250);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+    // First call uses the startup maxEnqueuedAt
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledWith({
+      deps: {},
+      maxEnqueuedAt: 123,
+      log: expect.anything(),
+    });
+
+    hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
+
+    // Simulate a delivery entry being enqueued at time 5_000 (after the startup cutoff of 123)
+    // Advance to time 5_000
+    await vi.advanceTimersByTimeAsync(3_750);
+
+    // Advance to the first periodic retry at 1_250 + 60_000 = 61_250
+    await vi.advanceTimersByTimeAsync(56_250);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+    // The periodic retry uses Date.now() which is >= 61_250, so the entry enqueued at 5_000
+    // is eligible
+    const periodicCall = hoisted.recoverPendingRestartContinuationDeliveries.mock.calls[0]?.[0];
+    expect(periodicCall).toBeDefined();
+    expect(periodicCall!.maxEnqueuedAt).toBeGreaterThanOrEqual(61_250);
   });
 
   it("stops session delivery periodic retry after close — no retry fires after stop handle is called", async () => {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -18,7 +18,9 @@ const hoisted = vi.hoisted(() => {
     loadModelPricingCacheModule: vi.fn(),
     isVitestRuntimeEnv: vi.fn(() => false),
     recoverPendingDeliveries: vi.fn(async () => undefined),
-    recoverPendingRestartContinuationDeliveries: vi.fn(async () => undefined),
+    recoverPendingRestartContinuationDeliveries: vi.fn<
+      (args: { deps: unknown; maxEnqueuedAt: number; log: unknown }) => Promise<undefined>
+    >(async () => undefined),
     deliverOutboundPayloads: vi.fn(),
   };
 });

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -211,6 +211,27 @@ describe("server-runtime-services", () => {
     expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
   });
 
+  it("stops session delivery periodic retry after close — no retry fires after stop handle is called", async () => {
+    vi.useFakeTimers();
+    const log = createLog();
+    const { services } = activateScheduledServicesForTest({ log });
+
+    // Advance past the initial 1_250ms delay to trigger the first recovery call
+    await vi.advanceTimersByTimeAsync(1_250);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).toHaveBeenCalledTimes(1);
+
+    hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
+
+    // Stop the session delivery recovery — simulates gateway close/restart
+    services.stopSessionDeliveryRecovery();
+
+    // Advance well past the 60_000ms interval — no retry should fire
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingRestartContinuationDeliveries).not.toHaveBeenCalled();
+  });
+
   it("can defer cron startup while activating other scheduled services", async () => {
     vi.useFakeTimers();
     const cron = { start: vi.fn(async () => undefined) };

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -172,6 +172,26 @@ function recoverPendingSessionDeliveries(params: {
     );
   }, 1_250);
   timer.unref?.();
+
+  // Schedule periodic retry so session deliveries deferred by retry backoff
+  // are retried automatically after their backoff window elapses. The recovery
+  // function's backoff/eligibility/drain-protection logic prevents redundant
+  // or premature retries.
+  const periodicTimer = setInterval(() => {
+    void (async () => {
+      const { recoverPendingRestartContinuationDeliveries } =
+        await import("./server-restart-sentinel.js");
+      const logRecovery = params.log.child("session-delivery-recovery");
+      await recoverPendingRestartContinuationDeliveries({
+        deps: params.deps,
+        log: logRecovery,
+        maxEnqueuedAt: params.maxEnqueuedAt,
+      });
+    })().catch((err: unknown) =>
+      params.log.error(`Session delivery periodic retry failed: ${String(err)}`),
+    );
+  }, 60_000);
+  periodicTimer.unref?.();
 }
 
 function startGatewayModelPricingRefreshOnDemand(params: {

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -176,7 +176,8 @@ function recoverPendingSessionDeliveries(params: {
   // Schedule periodic retry so session deliveries deferred by retry backoff
   // are retried automatically after their backoff window elapses. The recovery
   // function's backoff/eligibility/drain-protection logic prevents redundant
-  // or premature retries.
+  // or premature retries. Use a fresh Date.now() cutoff so entries enqueued
+  // after the startup sessionDeliveryRecoveryMaxEnqueuedAt are also recovered.
   const periodicTimer = setInterval(() => {
     void (async () => {
       const { recoverPendingRestartContinuationDeliveries } =
@@ -185,7 +186,7 @@ function recoverPendingSessionDeliveries(params: {
       await recoverPendingRestartContinuationDeliveries({
         deps: params.deps,
         log: logRecovery,
-        maxEnqueuedAt: params.maxEnqueuedAt,
+        maxEnqueuedAt: Date.now(),
       });
     })().catch((err: unknown) =>
       params.log.error(`Session delivery periodic retry failed: ${String(err)}`),

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -154,7 +154,7 @@ function recoverPendingSessionDeliveries(params: {
   deps: import("../cli/deps.types.js").CliDeps;
   log: GatewayRuntimeServiceLogger;
   maxEnqueuedAt: number;
-}): void {
+}): () => void {
   // Delay session continuation recovery so the gateway has time to publish ready state and
   // request routing before replaying restart-sentinel deliveries.
   const timer = setTimeout(() => {
@@ -192,6 +192,13 @@ function recoverPendingSessionDeliveries(params: {
     );
   }, 60_000);
   periodicTimer.unref?.();
+
+  // Return a stop handle so the gateway close path can cancel the periodic
+  // retry interval and prevent stale deliveries after shutdown.
+  return () => {
+    clearTimeout(timer);
+    clearInterval(periodicTimer);
+  };
 }
 
 function startGatewayModelPricingRefreshOnDemand(params: {
@@ -240,11 +247,19 @@ export function activateGatewayScheduledServices(params: {
   logCron: { error: (message: string) => void };
   log: GatewayRuntimeServiceLogger;
   pluginLookUpTable?: PluginMetadataRegistryView;
-}): { heartbeatRunner: HeartbeatRunner; stopModelPricingRefresh: () => void } {
+}): {
+  heartbeatRunner: HeartbeatRunner;
+  stopModelPricingRefresh: () => void;
+  stopSessionDeliveryRecovery: () => void;
+} {
   if (params.minimalTestGateway) {
     // Minimal gateways keep handles callable but inert so tests can share shutdown paths with
     // production starts without launching background loops.
-    return { heartbeatRunner: createNoopHeartbeatRunner(), stopModelPricingRefresh: () => {} };
+    return {
+      heartbeatRunner: createNoopHeartbeatRunner(),
+      stopModelPricingRefresh: () => {},
+      stopSessionDeliveryRecovery: () => {},
+    };
   }
   const heartbeatRunner = startHeartbeatRunner({ cfg: params.cfgAtStart });
   if (params.startCron !== false) {
@@ -257,7 +272,7 @@ export function activateGatewayScheduledServices(params: {
     cfg: params.cfgAtStart,
     log: params.log,
   });
-  recoverPendingSessionDeliveries({
+  const stopSessionDeliveryRecovery = recoverPendingSessionDeliveries({
     deps: params.deps,
     log: params.log,
     maxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
@@ -269,5 +284,5 @@ export function activateGatewayScheduledServices(params: {
         log: params.log,
       })
     : () => {};
-  return { heartbeatRunner, stopModelPricingRefresh };
+  return { heartbeatRunner, stopModelPricingRefresh, stopSessionDeliveryRecovery };
 }

--- a/src/gateway/server-runtime-startup-services.ts
+++ b/src/gateway/server-runtime-startup-services.ts
@@ -46,6 +46,7 @@ export function startGatewayRuntimeServices(params: {
   heartbeatRunner: ReturnType<typeof createNoopHeartbeatRunner>;
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
+  stopSessionDeliveryRecovery: () => void;
 } {
   const channelHealthMonitor = startGatewayChannelHealthMonitor({
     cfg: params.cfgAtStart,
@@ -56,5 +57,6 @@ export function startGatewayRuntimeServices(params: {
     heartbeatRunner: createNoopHeartbeatRunner(),
     channelHealthMonitor,
     stopModelPricingRefresh: () => {},
+    stopSessionDeliveryRecovery: () => {},
   };
 }

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1502,15 +1502,30 @@ describe("startGatewayPostAttachRuntime", () => {
     });
   });
 
-  it("stops post-ready sidecars registered after close started", () => {
-    const postReadySidecar = { stop: vi.fn() };
+  it("stops post-ready sidecars registered after close started and returns their stop promises", async () => {
+    let resolveStop: (() => void) | undefined;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    const postReadySidecar = { stop: vi.fn(() => stopPromise) };
 
-    testing.stopPostReadySidecarsAfterCloseStarted({
+    const returnedPromises = testing.stopPostReadySidecarsAfterCloseStarted({
       postReadySidecars: [postReadySidecar],
       closeStarted: true,
     });
 
     expect(postReadySidecar.stop).toHaveBeenCalledTimes(1);
+    // The stop promise must be returned (not dropped) so the close path can
+    // await late-registered producers instead of racing past shutdown.
+    expect(returnedPromises).toHaveLength(1);
+    let settled = false;
+    void Promise.all(returnedPromises).then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+    resolveStop?.();
+    await Promise.all(returnedPromises);
+    expect(settled).toBe(true);
   });
 
   it("keeps post-ready sidecars running when close has not started", () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -98,13 +98,15 @@ export type GatewayPostReadySidecarHandle = {
 export function stopPostReadySidecarsAfterCloseStarted(params: {
   postReadySidecars: readonly GatewayPostReadySidecarHandle[];
   closeStarted: boolean;
-}): void {
+}): Promise<void>[] {
   if (!params.closeStarted) {
-    return;
+    return [];
   }
-  for (const postReadySidecar of params.postReadySidecars) {
-    void postReadySidecar.stop();
-  }
+  // Return the stop promises rather than dropping them: a sidecar registered
+  // after the close path already drained its snapshot (e.g. the restart-sentinel
+  // sidecar, whose stop() awaits the sentinel wake) must still be awaited by
+  // the close path, or its producer work can continue past shutdown.
+  return params.postReadySidecars.map((postReadySidecar) => postReadySidecar.stop());
 }
 
 /** Measure a post-attach startup step when tracing is active. */

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -989,6 +989,7 @@ export async function startGatewayServer(
       disposeBrowserAuthRateLimiter: () => browserAuthRateLimiter.dispose(),
       stopModelPricingRefresh: runtimeState.stopModelPricingRefresh,
       stopChannelHealthMonitor: () => runtimeState?.channelHealthMonitor?.stop(),
+      stopSessionDeliveryRecovery: () => runtimeState.stopSessionDeliveryRecovery?.(),
       stopReadinessEventLoopHealth: readinessEventLoopHealth.stop,
       clearSecretsRuntimeSnapshot,
       closeMcpServer: closeMcpLoopbackServerOnDemand,
@@ -1553,6 +1554,7 @@ export async function startGatewayServer(
         });
         runtimeState.heartbeatRunner = activated.heartbeatRunner;
         runtimeState.stopModelPricingRefresh = activated.stopModelPricingRefresh;
+        runtimeState.stopSessionDeliveryRecovery = activated.stopSessionDeliveryRecovery;
       });
     };
     ({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1031,6 +1031,7 @@ export async function startGatewayServer(
       stopChannel,
       pluginServices: runtimeState.pluginServices,
       postReadySidecars: runtimeState.postReadySidecars,
+      lateSidecarStopPromises: runtimeState.lateSidecarStopPromises,
       cron: runtimeState.cronState.cron,
       heartbeatRunner: runtimeState.heartbeatRunner,
       updateCheckStop: runtimeState.stopGatewayUpdateCheck,
@@ -1624,20 +1625,24 @@ export async function startGatewayServer(
             },
             onPostReadySidecars: (postReadySidecars) => {
               runtimeState.postReadySidecars = postReadySidecars;
-              stopPostReadySidecarsAfterCloseStarted({
-                postReadySidecars,
-                closeStarted: closePreludeStarted,
-              });
+              runtimeState.lateSidecarStopPromises.push(
+                ...stopPostReadySidecarsAfterCloseStarted({
+                  postReadySidecars,
+                  closeStarted: closePreludeStarted,
+                }),
+              );
               if (closePreludeStarted) {
                 runtimeState.postReadySidecars = [];
               }
             },
             onGatewayLifetimeSidecars: (gatewayLifetimeSidecars) => {
               runtimeState.gatewayLifetimeSidecars = gatewayLifetimeSidecars;
-              stopPostReadySidecarsAfterCloseStarted({
-                postReadySidecars: gatewayLifetimeSidecars,
-                closeStarted: closePreludeStarted,
-              });
+              runtimeState.lateSidecarStopPromises.push(
+                ...stopPostReadySidecarsAfterCloseStarted({
+                  postReadySidecars: gatewayLifetimeSidecars,
+                  closeStarted: closePreludeStarted,
+                }),
+              );
               if (closePreludeStarted) {
                 runtimeState.gatewayLifetimeSidecars = [];
               }


### PR DESCRIPTION
## What changed

- Added periodic restart/session-delivery recovery so entries deferred by retry backoff are retried after startup.
- Added a focused gateway lifecycle regression test that proves the first startup recovery and later 60s retry both call restart-continuation recovery.

Fixes #76087

## Real behavior proof

- Behavior or issue addressed: Restart/session delivery recovery now runs the startup drain and then continues retrying deferred restart-continuation deliveries while the gateway process is alive. Before this PR, `recoverPendingSessionDeliveries()` scheduled one startup recovery after `1_250ms`; after this PR, it also schedules a `60_000ms` periodic retry. This proof seeds a failed queued restart-continuation entry, waits past the first retry backoff, then invokes the registered gateway periodic retry callback and verifies the entry is acknowledged.
- Real environment tested: Local OpenClaw source checkout on Darwin 25.5.0 arm64, Node v26.0.0, pnpm 11.2.2, branch `fastino-76087-restart-continuation-retry`.
- Exact steps or command run after this patch:
  1. Ran an isolated source-checkout behavior probe with a temporary `OPENCLAW_STATE_DIR`.
  2. The probe enqueued a restart-sentinel session-delivery entry, marked it failed with retry metadata, activated `activateGatewayScheduledServices()`, confirmed the `60000` ms periodic retry interval was registered, waited past the first `5000` ms backoff, invoked that periodic callback, and checked the queue again.
  3. Ran `pnpm test src/gateway/server-runtime-services.test.ts src/infra/session-delivery-queue.recovery.test.ts src/gateway/server-restart-sentinel.test.ts`.
  4. Ran `git diff --check HEAD~1..HEAD`.
- Evidence after fix: Terminal transcript from the failed-entry periodic retry probe:

  ```text
  $ tmpdir=$(mktemp -d /tmp/openclaw-90490-periodic-proof-XXXXXX); OPENCLAW_STATE_DIR="$tmpdir" pnpm exec tsx --eval '
  (async () => {
  const realSetTimeout = globalThis.setTimeout.bind(globalThis);
  const intervals = [];
  globalThis.setTimeout = ((fn, delay) => ({ unref() {}, __fn: fn, __delay: delay })) as never;
  globalThis.setInterval = ((fn, delay) => { intervals.push({ fn, delay: Number(delay) }); return { unref() {} }; }) as never;
  globalThis.clearTimeout = (() => undefined) as never;
  globalThis.clearInterval = (() => undefined) as never;
  const { enqueueSessionDelivery, failSessionDelivery, loadPendingSessionDeliveries } = await import("./src/infra/session-delivery-queue.ts");
  const { activateGatewayScheduledServices } = await import("./src/gateway/server-runtime-services.ts");
  const id = await enqueueSessionDelivery({ kind: "systemEvent", sessionKey: "agent:main:main", text: "restart continuation after transient send failure", idempotencyKey: "restart-sentinel:agent:main:main:systemEvent:90490-periodic" });
  await failSessionDelivery(id, "Network request for sendMessage failed!");
  console.log("stateDir", process.env.OPENCLAW_STATE_DIR);
  console.log("failedQueuedEntry", JSON.stringify(await loadPendingSessionDeliveries()));
  activateGatewayScheduledServices({ minimalTestGateway: false, cfgAtStart: { models: { pricing: { enabled: false } } }, deps: {}, sessionDeliveryRecoveryMaxEnqueuedAt: Date.now(), cron: { start: async () => undefined }, logCron: { error: (message) => console.log("cronError", message) }, log: { child: (name) => ({ info: (message) => console.log(name + ":info", message), warn: (message) => console.log(name + ":warn", message), error: (message) => console.log(name + ":error", message) }), error: (message) => console.log("error", message), warn: (message) => console.log("warn", message), info: (message) => console.log("info", message), debug: () => undefined } });
  console.log("registeredIntervals", JSON.stringify(intervals.map(({ delay }) => delay)));
  const periodic = intervals.find((item) => item.delay === 60000);
  if (!periodic) throw new Error("missing 60000ms session-delivery retry interval");
  console.log("beforeBackoffElapsed", JSON.stringify(await loadPendingSessionDeliveries()));
  await new Promise((resolve) => realSetTimeout(resolve, 5100));
  periodic.fn();
  await new Promise((resolve) => realSetTimeout(resolve, 1000));
  console.log("afterPeriodicRetry", JSON.stringify(await loadPendingSessionDeliveries()));
  })().catch((err) => { console.error(err); process.exit(1); });
  '
  stateDir /tmp/openclaw-90490-periodic-proof-mQy1Eo
  failedQueuedEntry [{"kind":"systemEvent","sessionKey":"agent:main:main","text":"restart continuation after transient send failure","idempotencyKey":"restart-sentinel:agent:main:main:systemEvent:90490-periodic","id":"07ab21da0fb6f145c33fb4e60eba23ffb46c99b608381765282d6903a6925379","enqueuedAt":1780655248585,"retryCount":1,"lastAttemptAt":1780655248588,"lastError":"Network request for sendMessage failed!"}]
  [heartbeat] started
  registeredIntervals [1800000,60000]
  beforeBackoffElapsed [{"kind":"systemEvent","sessionKey":"agent:main:main","text":"restart continuation after transient send failure","idempotencyKey":"restart-sentinel:agent:main:main:systemEvent:90490-periodic","id":"07ab21da0fb6f145c33fb4e60eba23ffb46c99b608381765282d6903a6925379","enqueuedAt":1780655248585,"retryCount":1,"lastAttemptAt":1780655248588,"lastError":"Network request for sendMessage failed!"}]
  session-delivery-recovery:info Recovered session delivery 07ab21da0fb6f145c33fb4e60eba23ffb46c99b608381765282d6903a6925379
  afterPeriodicRetry []
  ```

  Supplemental focused test output:

  ```text
  Test Files  4 passed (4)
  Tests  74 passed (74)

  Test Files  1 passed (1)
  Tests  6 passed (6)

  [test] passed 2 Vitest shards in 12.49s
  ```
- Observed result after fix: A failed pending restart-continuation session-delivery entry (`retryCount: 1`, `lastError: "Network request for sendMessage failed!"`) remained queued before the first backoff elapsed. After the branch-registered `60000` ms session-delivery periodic retry callback ran past the `5000` ms backoff, OpenClaw logged `Recovered session delivery ...` and the pending queue became `[]`.
- What was not tested: No live Telegram network outage or production gateway credential flow. No permanent Telegram API failure path; this proof exercises the gateway scheduler retry path and the durable session-delivery queue recovery path with an isolated local state directory.
