### PR TITLE
fix(agents): reconcile child output before lost-context sweep failure

### DIFF
--- a/src/agents/subagent-lost-context-completion.test.ts
+++ b/src/agents/subagent-lost-context-completion.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as announceOutput from "./subagent-announce-output.js";
+import {
+  LOST_ACTIVE_EXECUTION_CONTEXT_ERROR,
+  resolveStaleActiveSubagentOutcome,
+} from "./subagent-lost-context-completion.js";
+
+describe("resolveStaleActiveSubagentOutcome", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok when child session has readable assistant output", async () => {
+    vi.spyOn(announceOutput, "readSubagentOutput").mockResolvedValue("# ARCHITECTURE.md");
+    await expect(
+      resolveStaleActiveSubagentOutcome({
+        childSessionKey: "agent:main:subagent:child",
+      }),
+    ).resolves.toEqual({ status: "ok" });
+  });
+
+  it("returns lost-context error when no readable output is available", async () => {
+    vi.spyOn(announceOutput, "readSubagentOutput").mockResolvedValue(undefined);
+    await expect(
+      resolveStaleActiveSubagentOutcome({
+        childSessionKey: "agent:main:subagent:child",
+      }),
+    ).resolves.toEqual({
+      status: "error",
+      error: LOST_ACTIVE_EXECUTION_CONTEXT_ERROR,
+    });
+  });
+});

--- a/src/agents/subagent-lost-context-completion.ts
+++ b/src/agents/subagent-lost-context-completion.ts
@@ -1,0 +1,24 @@
+/**
+ * Reconcile stale active subagent runs that lost live execution context.
+ *
+ * When the sweeper cannot resolve terminal state from the session store, readable child
+ * assistant output is treated as ground truth and completes as ok instead of a plain failure.
+ */
+import type { SubagentRunOutcome } from "./subagent-announce-output.js";
+import { readSubagentOutput } from "./subagent-announce-output.js";
+
+export const LOST_ACTIVE_EXECUTION_CONTEXT_ERROR = "subagent run lost active execution context";
+
+/** Resolve terminal outcome for a stale active run with no live agent.run context. */
+export async function resolveStaleActiveSubagentOutcome(params: {
+  childSessionKey: string;
+}): Promise<SubagentRunOutcome> {
+  const output = await readSubagentOutput(params.childSessionKey);
+  if (output?.trim()) {
+    return { status: "ok" };
+  }
+  return {
+    status: "error",
+    error: LOST_ACTIVE_EXECUTION_CONTEXT_ERROR,
+  };
+}

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2218,6 +2218,67 @@ describe("subagent registry seam flow", () => {
     expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
+  it("completes stale active runs as ok when child session has readable output", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "# ARCHITECTURE.md\nrelease readiness design" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: 1,
+        status: "running",
+      },
+    });
+
+    const createdAt = Date.parse("2026-03-24T11:00:00Z");
+    vi.setSystemTime(createdAt);
+    mod.registerSubagentRun({
+      runId: "run-lost-context-with-output",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "deliver architecture doc",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    vi.setSystemTime(createdAt + 65_000);
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => {
+      const announceParams = findRecordCallArg(
+        mocks.runSubagentAnnounceFlow,
+        0,
+        "lost context recovered announce",
+        (record) => record.childRunId === "run-lost-context-with-output",
+      );
+      expectRecordFields(
+        announceParams.outcome,
+        { status: "ok" },
+        "lost context recovered announce outcome",
+      );
+    });
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-lost-context-with-output");
+    expectRecordFields(run?.outcome, { status: "ok" }, "lost context recovered run outcome");
+    expect(run?.outcome?.error).toBeUndefined();
+  });
+
   it("uses session-store start time when sweeping stale explicit-timeout runs", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -40,6 +40,7 @@ import {
   SUBAGENT_ENDED_REASON_KILLED,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
+import { resolveStaleActiveSubagentOutcome } from "./subagent-lost-context-completion.js";
 import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
@@ -958,20 +959,25 @@ async function sweepSubagentRuns() {
             continue;
           }
 
+          const lostContextOutcome = await resolveStaleActiveSubagentOutcome({
+            childSessionKey: entry.childSessionKey,
+          });
           await completeSubagentRunWithRecovery(
             {
               runId,
               endedAt: now,
-              outcome: {
-                status: "error",
-                error: "subagent run lost active execution context",
-              },
-              reason: SUBAGENT_ENDED_REASON_ERROR,
+              outcome: lostContextOutcome,
+              reason:
+                lostContextOutcome.status === "ok"
+                  ? SUBAGENT_ENDED_REASON_COMPLETE
+                  : SUBAGENT_ENDED_REASON_ERROR,
               sendFarewell: true,
               accountId: entry.requesterOrigin?.accountId,
               triggerCleanup: true,
             },
-            "sweeper-lost-context",
+            lostContextOutcome.status === "ok"
+              ? "sweeper-lost-context-recovered"
+              : "sweeper-lost-context",
           );
           continue;
         }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Agent Teams could announce `failed: subagent run lost active execution context` while the same completion event still contained readable child assistant output, so parents treated successful work as a plain failure.

Why does this matter now?

- Issue [#90299](https://github.com/openclaw/openclaw/issues/90299): `sessions_spawn` / `sessions_yield` orchestration depends on terminal status matching delivered child results; a false failed status breaks multi-agent trust and can trigger unnecessary retries or stalled workflows.

What is the intended outcome?

- When the subagent sweeper loses live run context and session-store reconciliation cannot settle terminal state, reconcile readable child transcript output first and complete as `ok` instead of emitting a plain lost-context failure.

What is intentionally out of scope?

- No new shared-memory layer, Agent Teams plugin changes, or announce formatting changes for unrelated error paths; true failures without usable child output still complete as errors.

What does success look like?

- Stale active runs with captured assistant output complete with `outcome.status: "ok"`; runs without output still report `subagent run lost active execution context`.

What should reviewers focus on?

- `resolveStaleActiveSubagentOutcome` in `subagent-lost-context-completion.ts` and the sweeper branch in `subagent-registry.ts` that calls it before `sweeper-lost-context` completion.

## Linked context

Which issue does this close?

Closes #90299

Which issues, PRs, or discussions are related?

- ClawSweeper review on #90299 (`clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`)
- Related lifecycle work in subagent registry / announce surfaces (no duplicate open PR for this issue at submission time)

Was this requested by a maintainer or owner?

- Community report; user confirmed fix in automation workflow.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Lost-context sweeper fallback vs. child output mismatch on Agent Teams completion events.
- **Real environment tested:** Local checkout `E:\Projects\skills\work\openclaw` on branch `fix/issue-90299-lost-context-with-output`, Node via `node scripts/run-vitest.mjs`.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/agents/subagent-lost-context-completion.test.ts`
  - `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts -t "completes stale active runs as ok when child session has readable output"`
- **Evidence after fix:**

```text
 Test Files  2 passed (2)
      Tests  2 passed | 120 skipped (122)
   Duration  17.80s
```

- **Observed result after fix:** Unit tests assert `resolveStaleActiveSubagentOutcome` returns `ok` when `readSubagentOutput` yields text, and the registry sweep test completes `run-lost-context-with-output` with `outcome.status: "ok"` (no lost-context error) when `chat.history` contains assistant output.
- **What was not tested:** Live Agent Teams `sessions_spawn` + `sessions_yield` end-to-end on a gateway host (read-only review path per ClawSweeper).
- **Proof limitations:** Regression coverage is source-level via vitest mocks for `chat.history` and sweep timing, not a reproduced bench transcript from the original report.
- **Before evidence (optional):** Sweeper always completed stale active runs without session terminal state using `outcome.status: "error"` and `error: "subagent run lost active execution context"` even when announce later read the same child output for the parent message.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/subagent-lost-context-completion.test.ts`
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts -t "completes stale active runs as ok when child session has readable output"`

What regression coverage was added or updated?

- `subagent-lost-context-completion.test.ts` — outcome resolver with/without output.
- `subagent-registry.test.ts` — sweep completes stale active run as `ok` when `chat.history` has assistant text.

What failed before this fix, if known?

- Sweeper `sweeper-lost-context` path emitted error outcome regardless of readable child transcript.

If no test was added, why not?

- N/A — regression tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

- False-positive `ok` completion if stale transcript output is unrelated to the current run.

How is that risk mitigated?

- Output is read only for the specific `childSessionKey`; session-store terminal reconciliation and `notBeforeMs` freshness checks still run first; empty/non-readable output keeps the existing lost-context error.

## Current review state

What is the next action?

- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?

- CI on fork PR

Which bot or reviewer comments were addressed?

- ClawSweeper narrow fix recommendation: reconcile child output before lost-context failure.
