### PR TITLE
fix(skills): stale create proposals with existing targets

### DIFF
--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -889,4 +889,56 @@ describe("skill workshop proposals", () => {
       fs.access(path.join(workspaceDir, "skills", "tamper-guard", "SKILL.md")),
     ).rejects.toThrow();
   });
+
+  it("marks pending create proposals stale when listSkillProposals finds the target skill file already exists", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Auto-Stale Check",
+      description: "Proposal that should go stale",
+      content: "# Auto-Stale\n\nThis skill was installed manually.\n",
+    });
+
+    // Manually create the target skill file on disk (simulating manual install)
+    const skillDir = path.dirname(proposal.record.target.skillFile);
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      proposal.record.target.skillFile,
+      "---\nname: auto-stale-check\ndescription: Already installed\n---\n\n# Auto-Stale\n",
+      "utf8",
+    );
+
+    // Proposal should still be pending before reconciliation
+    expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("pending");
+
+    // listSkillProposals with workspaceDir triggers reconciliation
+    await listSkillProposals({ workspaceDir });
+
+    // Proposal should now be stale
+    expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("stale");
+  });
+
+  it("marks pending create proposals stale when inspectSkillProposal finds the target skill file already exists", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Inspect-Stale Test",
+      description: "Proposal to go stale via inspect path",
+      content: "# Inspect-Stale\n\nManually installed.\n",
+    });
+
+    // Manually create the target skill file on disk
+    const skillDir = path.dirname(proposal.record.target.skillFile);
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      proposal.record.target.skillFile,
+      "---\nname: inspect-stale-test\ndescription: Installed manually\n---\n\n# Inspect-Stale\n",
+      "utf8",
+    );
+
+    // inspectSkillProposal with workspaceDir should reconcile and return stale
+    const result = await inspectSkillProposal(proposal.record.id, { workspaceDir });
+    expect(result?.record.status).toBe("stale");
+    expect(result?.record.statusReason).toBe("Target skill was created after proposal creation.");
+  });
 });

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -22,7 +22,11 @@ import {
   resolvePendingSkillProposal,
   reviseSkillProposal,
 } from "./service.js";
-import { readSkillProposalManifest, resolveProposalDraftPath } from "./store.js";
+import {
+  readSkillProposalManifest,
+  readSkillProposalRecord,
+  resolveProposalDraftPath,
+} from "./store.js";
 
 const tempDirs = createTrackedTempDirs();
 let envSnapshot: ReturnType<typeof captureEnv>;
@@ -940,5 +944,105 @@ describe("skill workshop proposals", () => {
     const result = await inspectSkillProposal(proposal.record.id, { workspaceDir });
     expect(result?.record.status).toBe("stale");
     expect(result?.record.statusReason).toBe("Target skill was created after proposal creation.");
+  });
+
+  it("preserves concurrent applied record during listSkillProposals stale reconciliation (lock-and-reread)", async () => {
+    // Regression: when a concurrent apply changes the record to "applied" before
+    // stale reconciliation runs, the re-read inside the lock should preserve the
+    // "applied" status instead of overwriting it to "stale".
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Concurrent Apply",
+      description: "Applied before stale check",
+      content: "# Concurrent Apply\n\nApplied before stale check.\n",
+    });
+
+    // Manually create the target skill file on disk (triggers stale path)
+    const skillDir = path.dirname(proposal.record.target.skillFile);
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(proposal.record.target.skillFile, "# Concurrent Apply\n", "utf8");
+
+    // Manually apply the proposal by writing "applied" status directly to the record.
+    // This simulates what applySkillProposal does before the stale lock re-read.
+    const staleRecord = {
+      ...proposal.record,
+      status: "applied" as const,
+      appliedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const { updateSkillProposalRecord } = await import("./store.js");
+    await updateSkillProposalRecord({ record: staleRecord });
+
+    // listSkillProposals triggers reconcileStaleCreateProposals.
+    // With the lock-and-reread fix, the re-read inside the lock sees "applied"
+    // and skips marking stale. Without the fix, it would use the stale outer
+    // record and overwrite to "stale".
+    await listSkillProposals({ workspaceDir });
+
+    const record = await readSkillProposalRecord(proposal.record.id);
+    expect(record?.status).toBe("applied");
+  });
+
+  it("preserves concurrent applied record during inspectSkillProposal stale reconciliation (lock-and-reread)", async () => {
+    // Regression: same invariant as above but through the inspect path.
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Inspect Concurrent",
+      description: "Applied before inspect stale check",
+      content: "# Inspect Concurrent\n\nApplied before inspect stale check.\n",
+    });
+
+    // Manually create the target skill file on disk
+    const skillDir = path.dirname(proposal.record.target.skillFile);
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(proposal.record.target.skillFile, "# Inspect Concurrent\n", "utf8");
+
+    // Manually apply the record to "applied" status
+    const staleRecord = {
+      ...proposal.record,
+      status: "applied" as const,
+      appliedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const { updateSkillProposalRecord } = await import("./store.js");
+    await updateSkillProposalRecord({ record: staleRecord });
+
+    // inspectSkillProposal triggers its own stale check with lock-and-reread.
+    // The re-read should see "applied" and skip marking stale.
+    const result = await inspectSkillProposal(proposal.record.id, { workspaceDir });
+
+    expect(result?.record.status).toBe("applied");
+  });
+
+  it("preserves concurrent rejected record during listSkillProposals stale reconciliation (lock-and-reread)", async () => {
+    // Regression: concurrent "rejected" status should also be preserved.
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Concurrent Reject",
+      description: "Rejected before stale check",
+      content: "# Concurrent Reject\n\nRejected before stale check.\n",
+    });
+
+    // Manually create the target skill file on disk
+    const skillDir = path.dirname(proposal.record.target.skillFile);
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(proposal.record.target.skillFile, "# Concurrent Reject\n", "utf8");
+
+    // Manually reject the record
+    const staleRecord = {
+      ...proposal.record,
+      status: "rejected" as const,
+      updatedAt: new Date().toISOString(),
+    };
+    const { updateSkillProposalRecord } = await import("./store.js");
+    await updateSkillProposalRecord({ record: staleRecord });
+
+    await listSkillProposals({ workspaceDir });
+
+    const record = await readSkillProposalRecord(proposal.record.id);
+    expect(record?.status).toBe("rejected");
   });
 });

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -76,6 +76,28 @@ const MAX_PROPOSAL_DRAFT_BYTES = 1024 * 1024;
 const MAX_PROPOSAL_DIRECTORY_ENTRIES = MAX_PROPOSAL_SUPPORT_FILES * 4;
 const MAX_SKILL_PROPOSAL_DESCRIPTION_BYTES = 160;
 
+/** Reconcile pending `create` proposals whose target skill file already exists
+ * on disk (e.g. manually installed) by marking them stale. */
+async function reconcileStaleCreateProposals(workspaceDir: string): Promise<void> {
+  const manifest = await readSkillProposalManifest();
+  for (const proposal of manifest.proposals) {
+    if (proposal.status !== "pending") {
+      continue;
+    }
+    const record = await readSkillProposalRecord(proposal.id);
+    if (!record || !isProposalInWorkspace(record, workspaceDir)) {
+      continue;
+    }
+    if (record.kind !== "create") {
+      continue;
+    }
+    const currentContent = await readWorkspaceSkillFile(record.target.skillFile);
+    if (currentContent !== null) {
+      await markProposalStale(record, "Target skill was created after proposal creation.");
+    }
+  }
+}
+
 /** Lists skill workshop proposals, optionally scoped to a workspace. */
 export async function listSkillProposals(
   options: SkillProposalScopeOptions = {},
@@ -84,14 +106,44 @@ export async function listSkillProposals(
   if (!options.workspaceDir) {
     return manifest;
   }
+  // Reconcile stale create proposals before listing so returned
+  // manifest reflects current disk state.
+  await reconcileStaleCreateProposals(options.workspaceDir);
+  const refreshed = await readSkillProposalManifest();
   const proposals: SkillProposalManifest["proposals"] = [];
-  for (const proposal of manifest.proposals) {
+  for (const proposal of refreshed.proposals) {
     const record = await readSkillProposalRecord(proposal.id);
     if (record && isProposalInWorkspace(record, options.workspaceDir)) {
       proposals.push(proposal);
     }
   }
-  return { ...manifest, proposals };
+  return { ...refreshed, proposals };
+}
+
+export async function inspectSkillProposal(
+  proposalId: string,
+  options: SkillProposalScopeOptions = {},
+): Promise<SkillProposalReadResult | null> {
+  const read = await readSkillProposal(proposalId);
+  if (!read) {
+    return null;
+  }
+  if (options.workspaceDir && !isProposalInWorkspace(read.record, options.workspaceDir)) {
+    return null;
+  }
+  // Reconcile a pending create proposal whose target skill file now
+  // exists on disk (manually installed).
+  if (read.record.status === "pending" && read.record.kind === "create" && options.workspaceDir) {
+    const currentContent = await readWorkspaceSkillFile(read.record.target.skillFile);
+    if (currentContent !== null) {
+      await markProposalStale(read.record, "Target skill was created after proposal creation.");
+      const refreshed = await readSkillProposal(proposalId);
+      if (refreshed) {
+        return await hydrateProposalSupportFiles(refreshed);
+      }
+    }
+  }
+  return await hydrateProposalSupportFiles(read);
 }
 
 export async function readSkillProposalDraftFile(filePath: string): Promise<string> {
@@ -180,20 +232,6 @@ function normalizeProposalOrigin(
     ...(runId ? { runId } : {}),
     ...(messageId ? { messageId } : {}),
   };
-}
-
-export async function inspectSkillProposal(
-  proposalId: string,
-  options: SkillProposalScopeOptions = {},
-): Promise<SkillProposalReadResult | null> {
-  const read = await readSkillProposal(proposalId);
-  if (!read) {
-    return null;
-  }
-  if (options.workspaceDir && !isProposalInWorkspace(read.record, options.workspaceDir)) {
-    return null;
-  }
-  return await hydrateProposalSupportFiles(read);
 }
 
 export async function resolvePendingSkillProposal(input: {

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -77,7 +77,9 @@ const MAX_PROPOSAL_DIRECTORY_ENTRIES = MAX_PROPOSAL_SUPPORT_FILES * 4;
 const MAX_SKILL_PROPOSAL_DESCRIPTION_BYTES = 160;
 
 /** Reconcile pending `create` proposals whose target skill file already exists
- * on disk (e.g. manually installed) by marking them stale. */
+ * on disk (e.g. manually installed) by marking them stale.
+ * Uses the proposal target lock and re-reads the record inside the lock to
+ * avoid racing with concurrent apply/mutate operations. */
 async function reconcileStaleCreateProposals(workspaceDir: string): Promise<void> {
   const manifest = await readSkillProposalManifest();
   for (const proposal of manifest.proposals) {
@@ -91,10 +93,22 @@ async function reconcileStaleCreateProposals(workspaceDir: string): Promise<void
     if (record.kind !== "create") {
       continue;
     }
-    const currentContent = await readWorkspaceSkillFile(record.target.skillFile);
-    if (currentContent !== null) {
-      await markProposalStale(record, "Target skill was created after proposal creation.");
-    }
+    await withSkillProposalTargetLock(record, async () => {
+      // Re-read the record inside the lock so we see the latest state
+      const lockedRecord = await readSkillProposalRecord(proposal.id);
+      if (
+        !lockedRecord ||
+        lockedRecord.status !== "pending" ||
+        lockedRecord.kind !== "create" ||
+        !isProposalInWorkspace(lockedRecord, workspaceDir)
+      ) {
+        return;
+      }
+      const currentContent = await readWorkspaceSkillFile(lockedRecord.target.skillFile);
+      if (currentContent !== null) {
+        await markProposalStale(lockedRecord, "Target skill was created after proposal creation.");
+      }
+    });
   }
 }
 
@@ -132,15 +146,27 @@ export async function inspectSkillProposal(
     return null;
   }
   // Reconcile a pending create proposal whose target skill file now
-  // exists on disk (manually installed).
+  // exists on disk (manually installed). Uses the proposal target lock and
+  // re-reads the record inside the lock to avoid racing with concurrent apply.
   if (read.record.status === "pending" && read.record.kind === "create" && options.workspaceDir) {
-    const currentContent = await readWorkspaceSkillFile(read.record.target.skillFile);
-    if (currentContent !== null) {
-      await markProposalStale(read.record, "Target skill was created after proposal creation.");
-      const refreshed = await readSkillProposal(proposalId);
-      if (refreshed) {
-        return await hydrateProposalSupportFiles(refreshed);
+    await withSkillProposalTargetLock(read.record, async () => {
+      const lockedRecord = await readSkillProposalRecord(proposalId);
+      if (
+        !lockedRecord ||
+        lockedRecord.status !== "pending" ||
+        lockedRecord.kind !== "create" ||
+        !isProposalInWorkspace(lockedRecord, options.workspaceDir!)
+      ) {
+        return;
       }
+      const currentContent = await readWorkspaceSkillFile(lockedRecord.target.skillFile);
+      if (currentContent !== null) {
+        await markProposalStale(lockedRecord, "Target skill was created after proposal creation.");
+      }
+    });
+    const refreshed = await readSkillProposal(proposalId);
+    if (refreshed) {
+      return await hydrateProposalSupportFiles(refreshed);
     }
   }
   return await hydrateProposalSupportFiles(read);


### PR DESCRIPTION
## Summary

- Reconciles pending Skill Workshop `create` proposals when their target skill file already exists in the workspace.
- Marks those proposals `stale` during scoped list/inspect flows so the UI and tool surface stop presenting an already-installed skill as still waiting to be used.
- Adds regression coverage for both list and inspect reconciliation paths.

Fixes #90388

## Verification

- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts`
- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/gateway/server-methods/skills.proposals.test.ts src/agents/tools/skill-workshop-tool.test.ts`
- `git diff --check`

## Real behavior proof

- Behavior addressed: A pending Skill Workshop create proposal whose target `skills/<name>/SKILL.md` already exists is reconciled to `stale` instead of remaining actionable/waiting.
- Real environment tested: macOS 15.5 arm64, Node v26.0.0, pnpm v11.2.2, current OpenClaw source checkout on branch `fastino-90388-skill-proposal-stale-c`.
- Exact steps or command run after this patch: `pnpm exec tsx --eval 'async function main() { const fs = await import("node:fs/promises"); const os = await import("node:os"); const path = await import("node:path"); const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-state-")); const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-workspace-")); process.env.OPENCLAW_STATE_DIR = stateDir; const service = await import("./src/skills/workshop/service.ts"); const proposal = await service.proposeCreateSkill({ workspaceDir, name: "Manual Install Proof", description: "Shows stale reconciliation", content: "# Manual Install Proof\n\nProposed content.\n" }); console.log("before", (await service.inspectSkillProposal(proposal.record.id))?.record.status); await fs.mkdir(path.dirname(proposal.record.target.skillFile), { recursive: true }); await fs.writeFile(proposal.record.target.skillFile, "---\nname: manual-install-proof\ndescription: Already installed\n---\n\n# Manual Install Proof\n", "utf8"); await service.listSkillProposals({ workspaceDir }); const after = await service.inspectSkillProposal(proposal.record.id); console.log("after", after?.record.status, after?.record.statusReason); } main();'`
- Evidence after fix: copied terminal output from the command:

```text
before pending
after stale Target skill was created after proposal creation.
```

- Observed result after fix: Listing scoped proposals after the skill file exists updates the proposal record to `stale`, and a later inspect call returns that stale status/reason.
- What was not tested: A live Control UI browser session was not opened; the tested path exercises the shared Skill Workshop service APIs used by the UI, gateway proposal methods, and skill-workshop tool tests.

## Platforms tested

- macOS 15.5 arm64
