### PR TITLE
fix(gateway): surface pending subagent timeouts

### DIFF
--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -471,7 +471,12 @@ export async function waitForAgentJob(params: {
 
     const timer = setSafeTimeout(() => {
       const pendingError = getPendingAgentRunError(runId);
-      finish(pendingError ? createPendingErrorTimeoutSnapshot(pendingError.snapshot) : null);
+      if (pendingError) {
+        finish(createPendingErrorTimeoutSnapshot(pendingError.snapshot));
+        return;
+      }
+      const pendingTimeout = getPendingAgentRunTimeout(runId);
+      finish(pendingTimeout ? pendingTimeout.snapshot : null);
     }, timeoutMs);
     const onAbort: (() => void) | undefined = () => finish(null);
     signal?.addEventListener("abort", onAbort, { once: true });

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -2,6 +2,7 @@
 // recent run outcomes even after the live event stream has moved on.
 import {
   buildAgentRunTerminalOutcome,
+  isHardAgentRunTimeoutPhase,
   mergeAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
 } from "../../agents/agent-run-terminal-outcome.js";
@@ -476,7 +477,11 @@ export async function waitForAgentJob(params: {
         return;
       }
       const pendingTimeout = getPendingAgentRunTimeout(runId);
-      finish(pendingTimeout ? pendingTimeout.snapshot : null);
+      if (pendingTimeout && isHardAgentRunTimeoutPhase(pendingTimeout.snapshot.timeoutPhase)) {
+        finish(pendingTimeout.snapshot);
+        return;
+      }
+      finish(null);
     }, timeoutMs);
     const onAbort: (() => void) | undefined = () => finish(null);
     signal?.addEventListener("abort", onAbort, { once: true });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -590,6 +590,44 @@ describe("waitForAgentJob", () => {
       vi.useRealTimers();
     }
   });
+
+  it("surfaces pending timeout snapshot when outer timeout fires before timeout grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-pending-timeout-asymmetric-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 5_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 10_000 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 10_000,
+          endedAt: 11_000,
+          aborted: true,
+          timeoutPhase: "provider",
+        },
+      });
+
+      // Advance past the wait-timer timeout (5_000ms) but before the grace window (15_000ms)
+      // The wait-timer fallback must find the pending timeout snapshot and return it.
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      const result = await waitPromise;
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe("timeout");
+      expect(result?.endedAt).toBe(11_000);
+      expect(result?.timeoutPhase).toBe("provider");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("augmentChatHistoryWithCanvasBlocks", () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -628,6 +628,49 @@ describe("waitForAgentJob", () => {
       vi.useRealTimers();
     }
   });
+
+  it("preserves retry grace for soft timeout before grace window expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = `run-soft-timeout-retry-grace-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const waitPromise = waitForAgentJob({ runId, timeoutMs: 5_000 });
+
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 10_000 },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          startedAt: 10_000,
+          endedAt: 11_000,
+          aborted: true,
+          // No timeoutPhase: this is a soft/retry timeout, not a hard one.
+        },
+      });
+
+      // Advance past the wait-timer timeout (5_000ms) but before the grace window (15_000ms)
+      // The soft timeout must NOT be surfaced yet; the outer timer must return null.
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      const result = await waitPromise;
+      expect(result).toBeNull();
+
+      // After the grace window expires, the pending soft timeout should be recorded.
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const cached = await waitForAgentJob({ runId, timeoutMs: 1_000 });
+      expect(cached).not.toBeNull();
+      expect(cached?.status).toBe("timeout");
+      expect(cached?.endedAt).toBe(11_000);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("augmentChatHistoryWithCanvasBlocks", () => {


### PR DESCRIPTION
## Summary

- Preserve pending sub-agent timeout snapshots when `waitForAgentJob` reaches its outer wait timeout.
- Add regression coverage for the case where the run timeout snapshot exists before the timeout grace cleanup window expires.

Fixes #89095.

## Real behavior proof

- Behavior addressed: a sub-agent run that emits a timeout lifecycle event before the caller's `waitForAgentJob` timeout now returns the pending timeout snapshot instead of `null`, so downstream parent-session timeout notification paths can see the terminal timeout.
- Real environment tested: local OpenClaw checkout on macOS, branch `fastino-89095-subagent-timeout-parent-b`, Node/Vitest through the repository test runner.
- Exact steps or command run after this patch:

```bash
git diff --check
node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts
```

- Evidence after fix:

```text
git diff --check
# no output

[test] starting test/vitest/vitest.gateway.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-89095b

 Test Files  1 passed (1)
      Tests  126 passed (126)
   Start at  02:12:11
   Duration  1.62s (transform 593ms, setup 104ms, import 930ms, tests 515ms, environment 0ms)

[test] passed 1 Vitest shard in 7.05s
```

- Observed result after fix: the new regression test `surfaces pending timeout snapshot when outer timeout fires before timeout grace period` passes and asserts the wait result is a non-null `timeout` snapshot with `endedAt` and `timeoutPhase` preserved.
- What was not tested: full CI matrix was not run locally.
