### PR TITLE
fix(ui): hide workspace files rail by default in chat

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1,11 +1,15 @@
 /* Split View Layout */
 .chat-workbench {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
+  grid-template-columns: minmax(0, 1fr);
   gap: 0;
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+.chat-workbench--with-rail {
+  grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
 }
 
 .chat-split-container {
@@ -75,7 +79,14 @@
   line-height: 1.2;
 }
 
-.chat-workspace-rail__refresh {
+.chat-workspace-rail__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-workspace-rail__refresh,
+.chat-workspace-rail__close {
   width: 32px;
   min-width: 32px;
   height: 32px;
@@ -83,6 +94,7 @@
 }
 
 .chat-workspace-rail__refresh svg,
+.chat-workspace-rail__close svg,
 .chat-workspace-rail__file-icon svg {
   width: 15px;
   height: 15px;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -681,6 +681,7 @@ type ChatWorkspaceFilesState = {
   error: string | null;
   list: AgentsFilesListResult | null;
   loading: boolean;
+  open: boolean;
   requestId: number;
 };
 
@@ -701,6 +702,7 @@ function getChatWorkspaceFilesState(state: AppViewState, agentId: string): ChatW
     error: null,
     list: null,
     loading: false,
+    open: false,
     requestId: 0,
   };
   chatWorkspaceFilesStates.set(state, next);
@@ -3532,8 +3534,13 @@ export function renderApp(state: AppViewState) {
                     loading: chatWorkspaceFiles.loading,
                     error: chatWorkspaceFiles.error,
                     activeName: chatWorkspaceFiles.activeName,
+                    open: chatWorkspaceFiles.open,
                     onRefresh: refreshChatWorkspaceFiles,
                     onOpenFile: openChatWorkspaceFile,
+                    onToggleOpen: () => {
+                      chatWorkspaceFiles.open = !chatWorkspaceFiles.open;
+                      requestHostUpdate?.();
+                    },
                   },
                   autoExpandToolCalls: false,
                   onRefresh: () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -868,6 +868,7 @@ describe("chat composer workbench", () => {
   it("renders session controls in the composer and workspace files in the rail", () => {
     const onRefresh = vi.fn();
     const onOpenFile = vi.fn();
+    const onToggleOpen = vi.fn();
     const container = renderChatView({
       composerControls: html`<button class="test-composer-control">Model</button>`,
       workspaceFiles: {
@@ -887,8 +888,10 @@ describe("chat composer workbench", () => {
         loading: false,
         error: null,
         activeName: "AGENTS.md",
+        open: true,
         onRefresh,
         onOpenFile,
+        onToggleOpen,
       },
     });
 
@@ -905,6 +908,29 @@ describe("chat composer workbench", () => {
     file?.click();
 
     expect(onOpenFile).toHaveBeenCalledWith("AGENTS.md");
+  });
+
+  it("hides the workspace files rail by default", () => {
+    const container = renderChatView({
+      workspaceFiles: {
+        agentId: "main",
+        list: {
+          agentId: "main",
+          workspace: "/workspace",
+          files: [{ name: "AGENTS.md", path: "/workspace/AGENTS.md", missing: false, size: 2048 }],
+        },
+        loading: false,
+        error: null,
+        activeName: null,
+        open: false,
+        onRefresh: vi.fn(),
+        onOpenFile: vi.fn(),
+        onToggleOpen: vi.fn(),
+      },
+    });
+
+    expect(container.querySelector(".chat-workspace-rail")).toBeNull();
+    expect(container.querySelector(".chat-workbench--with-rail")).toBeNull();
   });
 
   it("keeps the secondary New session and Export controls suppressed in the composer", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -189,8 +189,10 @@ export type ChatProps = {
     loading: boolean;
     error: string | null;
     activeName: string | null;
+    open: boolean;
     onRefresh: () => void;
     onOpenFile: (name: string) => void;
+    onToggleOpen: () => void;
   };
 };
 
@@ -1008,7 +1010,7 @@ function formatWorkspaceFileSize(file: AgentFileEntry): string {
 function renderWorkspaceFileRail(
   workspaceFiles: NonNullable<ChatProps["workspaceFiles"]> | undefined,
 ): TemplateResult | typeof nothing {
-  if (!workspaceFiles) {
+  if (!workspaceFiles || !workspaceFiles.open) {
     return nothing;
   }
   const files = workspaceFiles.list?.files ?? [];
@@ -1019,16 +1021,27 @@ function renderWorkspaceFileRail(
           <span class="chat-workspace-rail__eyebrow">Workspace</span>
           <strong>Files</strong>
         </div>
-        <button
-          class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
-          type="button"
-          title="Refresh files"
-          aria-label="Refresh files"
-          ?disabled=${workspaceFiles.loading}
-          @click=${workspaceFiles.onRefresh}
-        >
-          ${icons.refresh}
-        </button>
+        <div class="chat-workspace-rail__actions">
+          <button
+            class="btn btn--ghost btn--sm chat-workspace-rail__refresh"
+            type="button"
+            title="Refresh files"
+            aria-label="Refresh files"
+            ?disabled=${workspaceFiles.loading}
+            @click=${workspaceFiles.onRefresh}
+          >
+            ${icons.refresh}
+          </button>
+          <button
+            class="btn btn--ghost btn--sm chat-workspace-rail__close"
+            type="button"
+            title="Hide workspace files"
+            aria-label="Hide workspace files"
+            @click=${workspaceFiles.onToggleOpen}
+          >
+            ${icons.x}
+          </button>
+        </div>
       </div>
       ${workspaceFiles.list?.workspace
         ? html`<div class="chat-workspace-rail__path" title=${workspaceFiles.list.workspace}>
@@ -1997,7 +2010,7 @@ export function renderChat(props: ChatProps) {
         : nothing}
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
-      <div class="chat-workbench">
+      <div class="chat-workbench ${props.workspaceFiles?.open ? "chat-workbench--with-rail" : ""}">
         <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
           <div
             class="chat-main"
@@ -2141,7 +2154,20 @@ export function renderChat(props: ChatProps) {
               ${icons.paperclip}
               <span class="agent-chat__control-label">${t("chat.composer.attachFile")}</span>
             </button>
-
+            ${props.workspaceFiles && !props.workspaceFiles.open
+              ? html`
+                  <button
+                    type="button"
+                    class="agent-chat__input-btn"
+                    @click=${props.workspaceFiles.onToggleOpen}
+                    title="Show workspace files"
+                    aria-label="Show workspace files"
+                  >
+                    ${icons.fileText}
+                    <span class="agent-chat__control-label">Files</span>
+                  </button>
+                `
+              : nothing}
             ${props.onToggleRealtimeTalk
               ? html`
                   <button


### PR DESCRIPTION
## Summary
Fixes #90359. The Workspace Files right sidebar (chat-workspace-rail) was shown by default after upgrading to v2026.6.1, causing the chat area to be compressed and the rail to take up space even when not needed.

This change makes the rail hidden by default and adds user controls to open/close it:
- Rail is initially closed (`open: false`)
- A "Files" button appears in the composer toolbar when the rail is closed
- A close button (X) is added to the rail header
- CSS grid only reserves the right column when the rail is open

## Changes
- `ui/src/ui/views/chat.ts`: conditionally render rail based on `workspaceFiles.open`; add toggle button in composer; add close button in rail header
- `ui/src/ui/app-render.ts`: add `open` state (default `false`) and `onToggleOpen` handler to `ChatWorkspaceFilesState`
- `ui/src/styles/chat/sidebar.css`: make `.chat-workbench` single-column by default; add `.chat-workbench--with-rail` for two-column layout
- `ui/src/ui/views/chat.test.ts`: update existing test to pass `open: true`; add regression test verifying rail is hidden by default

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`: 95 tests passed
- `node scripts/run-oxlint.mjs ui/src/ui/views/chat.ts ui/src/ui/app-render.ts`: passed
- `oxfmt` applied

## Real behavior proof

**Behavior addressed:** Workspace Files rail no longer consumes chat area space on initial load (#90359).

**Real environment tested:** Local OpenClaw source checkout on branch `fix/chat-workspace-rail-default-hidden`, Linux, Node.js 22.

**Exact steps or command run after this patch:**

```bash
node --import tsx -e '
import fs from "node:fs";
const css = fs.readFileSync("./ui/src/styles/chat/sidebar.css", "utf8");
const defaultRule = css.match(/\.chat-workbench\s*\{([^}]+)\}/s);
const withRailRule = css.match(/\.chat-workbench--with-rail\s*\{([^}]+)\}/s);
const appRender = fs.readFileSync("./ui/src/ui/app-render.ts", "utf8");
const openDefault = appRender.match(/open:\s*(false|true)/)?.[0];
console.log("CSS default grid:", defaultRule?.[1].match(/grid-template-columns:[^;]+/)?.[0] ?? "not found");
console.log("CSS with-rail grid:", withRailRule?.[1].match(/grid-template-columns:[^;]+/)?.[0] ?? "not found");
console.log("app-render initial state:", openDefault ?? "not found");
'
```

**Evidence after fix:** Terminal capture showing the patched source defaults and layout rules:

```text
CSS default grid: grid-template-columns: minmax(0, 1fr)
CSS with-rail grid: grid-template-columns: minmax(0, 1fr) minmax(230px, 280px)
app-render initial state: open: false
```

**Observed result after fix:**
- `.chat-workbench` defaults to a single-column grid, so no width is reserved for the rail on initial render.
- The rail is only shown when `workspaceFiles.open` is `true` via the new `.chat-workbench--with-rail` class.
- `app-render.ts` initializes `ChatWorkspaceFilesState.open` to `false`, confirming the rail starts closed.

**What was not tested:** Full browser integration / visual regression (the proof inspects the actual shipped source and CSS rules that produce the default-hidden behavior).
