### PR TITLE
fix(daemon): ignore active scheduled gateway task

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -359,8 +359,10 @@ describe("findExtraGatewayServices (win32)", () => {
     execSchtasksMock.mockResolvedValueOnce({
       code: 0,
       stdout: [
-        "TaskName: OpenClaw Gateway",
-        "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
+        // schtasks /Query /FO LIST /V prefixes task paths with \.
+        // The canonical launcher task must be skipped despite the leading \.
+        "TaskName: \\OpenClaw Gateway",
+        "Task To Run: C:\\Users\\test\\.openclaw\\gateway.cmd",
         "",
         "TaskName: Clawdbot Legacy",
         "Task To Run: C:\\clawdbot\\clawdbot.exe run",
@@ -378,6 +380,46 @@ describe("findExtraGatewayServices (win32)", () => {
         platform: "win32",
         label: "Clawdbot Legacy",
         detail: "task: Clawdbot Legacy, run: C:\\clawdbot\\clawdbot.exe run",
+        scope: "system",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
+
+  it("skips the active launcher scheduled task with \\-prefixed name", async () => {
+    execSchtasksMock.mockResolvedValueOnce({
+      code: 0,
+      stdout: [
+        // Real-world output from schtasks: task name is \OpenClaw Gateway
+        "TaskName: \\OpenClaw Gateway",
+        "Task To Run: C:\\Users\\test\\.openclaw\\gateway.cmd",
+        "",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const result = await findExtraGatewayServices({}, { deep: true });
+    expect(result).toStrictEqual([]);
+  });
+
+  it("does not skip genuinely orphaned tasks named after the old clawdbot", async () => {
+    execSchtasksMock.mockResolvedValueOnce({
+      code: 0,
+      stdout: [
+        "TaskName: \\Clawdbot Legacy Runner",
+        "Task To Run: C:\\clawdbot\\clawdbot.exe run",
+        "",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const result = await findExtraGatewayServices({}, { deep: true });
+    expect(result).toEqual([
+      {
+        platform: "win32",
+        label: "\\Clawdbot Legacy Runner",
+        detail: "task: \\Clawdbot Legacy Runner, run: C:\\clawdbot\\clawdbot.exe run",
         scope: "system",
         marker: "clawdbot",
         legacy: true,

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -199,7 +199,10 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
 }
 
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  // schtasks /Query prefixes task names with \ (e.g. \OpenClaw Gateway).
+  // Strip it before comparing against the canonical name.
+  const cleaned = name.startsWith("\\") ? name.slice(1) : name;
+  const normalized = normalizeLowercaseStringOrEmpty(cleaned);
   if (!normalized) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Treat `schtasks` task names with a leading `\` as the same canonical Windows launcher task name.
- Keep genuinely separate legacy gateway-like tasks visible in the duplicate-service detector.
- Add focused Windows scheduled-task regression coverage.

Fixes #90494.

## Real behavior proof

- Behavior addressed: `findExtraGatewayServices` no longer reports the active Windows Scheduled Task launcher as an extra gateway-like service when `schtasks /Query /FO LIST /V` returns `TaskName: \OpenClaw Gateway`.
- Real environment tested: local OpenClaw checkout on macOS, branch `fastino-90494-doctor-windows-task-b`, daemon test shard with mocked Windows `schtasks` output.
- Exact steps or command run after this patch:

```bash
git diff --check
node scripts/test-projects.mjs src/daemon/inspect.test.ts
```

- Evidence after fix:

```text
git diff --check
# no output

[test] starting test/vitest/vitest.daemon.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-90494b

 Test Files  1 passed (1)
      Tests  15 passed | 5 skipped (20)
   Start at  02:19:43
   Duration  202ms (transform 94ms, setup 97ms, import 11ms, tests 27ms, environment 0ms)

[test] passed 1 Vitest shard in 2.81s
```

- Observed result after fix: the new regression test verifies `\OpenClaw Gateway` is skipped as the canonical active launcher task, while a distinct legacy `\Clawdbot Legacy Runner` task is still reported.
- What was not tested: full CI matrix was not run locally.
