### PR TITLE
Fix Windows gateway scheduled task normalization

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -359,8 +359,14 @@ describe("findExtraGatewayServices (win32)", () => {
     execSchtasksMock.mockResolvedValueOnce({
       code: 0,
       stdout: [
-        "TaskName: OpenClaw Gateway",
+        "TaskName: \\OpenClaw Gateway",
         "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
+        "",
+        "TaskName: \\OpenClaw Gateway (work)",
+        "Task To Run: C:\\work\\openclaw.exe gateway",
+        "",
+        "TaskName: \\OpenClaw Gateway Copy",
+        "Task To Run: C:\\custom\\openclaw.exe gateway",
         "",
         "TaskName: Clawdbot Legacy",
         "Task To Run: C:\\clawdbot\\clawdbot.exe run",
@@ -374,6 +380,14 @@ describe("findExtraGatewayServices (win32)", () => {
 
     const result = await findExtraGatewayServices({}, { deep: true });
     expect(result).toEqual([
+      {
+        platform: "win32",
+        label: "\\OpenClaw Gateway Copy",
+        detail: "task: \\OpenClaw Gateway Copy, run: C:\\custom\\openclaw.exe gateway",
+        scope: "system",
+        marker: "openclaw",
+        legacy: false,
+      },
       {
         platform: "win32",
         label: "Clawdbot Legacy",

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -198,13 +198,27 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
   return normalizeLowercaseStringOrEmpty(contents).includes("gateway");
 }
 
+function normalizeWindowsScheduledTaskName(name: string): string {
+  // schtasks reports root-folder tasks as \Name; compare against the durable task name.
+  return normalizeLowercaseStringOrEmpty(name.trim().replace(/^[\\/]+/u, ""));
+}
+
+function isProfiledOpenClawGatewayTaskName(name: string, defaultName: string): boolean {
+  const prefix = `${defaultName} (`;
+  if (!name.startsWith(prefix) || !name.endsWith(")")) {
+    return false;
+  }
+  const profile = name.slice(prefix.length, -1).trim();
+  return profile.length > 0 && !/[\\/]/u.test(profile);
+}
+
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  const normalized = normalizeWindowsScheduledTaskName(name);
   if (!normalized) {
     return false;
   }
   const defaultName = normalizeLowercaseStringOrEmpty(resolveGatewayWindowsTaskName());
-  return normalized === defaultName || normalized.startsWith("openclaw gateway");
+  return normalized === defaultName || isProfiledOpenClawGatewayTaskName(normalized, defaultName);
 }
 
 function tryExtractPlistLabel(contents: string): string | null {


### PR DESCRIPTION
Fixes #90494

## Summary
- Normalize Windows Scheduled Task names from `schtasks` before comparing them to managed OpenClaw Gateway task names.
- Keep managed default/profile gateway tasks ignored, including `\OpenClaw Gateway` and `\OpenClaw Gateway (work)`.
- Preserve extra-service warnings for copy-style OpenClaw gateway tasks and legacy `clawdbot` tasks.

## Root cause
`schtasks /Query /FO LIST /V` can report root-folder task names with a leading backslash, for example `\OpenClaw Gateway`. The inspector compared that raw name against the durable OpenClaw task name `OpenClaw Gateway`, so the managed gateway task could be reported as an extra service.

## Real behavior proof
Behavior addressed: Windows `schtasks` root-folder task names like `\OpenClaw Gateway` are treated as the managed OpenClaw Gateway task instead of an extra service, while copy-style tasks like `\OpenClaw Gateway Copy` still report as extra gateway jobs.

Real environment tested: Local macOS checkout on latest `origin/main` (`126ebfc99710`) using the repo Vitest wrapper with mocked `process.platform = "win32"` and mocked `schtasks` output for the Windows inspection path.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/daemon/inspect.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix: `src/daemon/inspect.test.ts` now feeds `TaskName: \OpenClaw Gateway`, `TaskName: \OpenClaw Gateway (work)`, `TaskName: \OpenClaw Gateway Copy`, `TaskName: Clawdbot Legacy`, and `TaskName: Other Task` through `findExtraGatewayServices(..., { deep: true })`.

Observed result after fix: Vitest reported `Test Files 1 passed (1)` and `Tests 13 passed | 5 skipped (18)`. The expected result includes only `\OpenClaw Gateway Copy` and `Clawdbot Legacy`; managed default/profile gateway tasks and unrelated tasks are not reported. Final autoreview was clean with no accepted/actionable findings.

What was not tested: Native Windows Task Scheduler execution was not run; this PR covers the source-level detection path with mocked `schtasks` output.

## Verification
- `node scripts/run-vitest.mjs src/daemon/inspect.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`