### PR TITLE
fix(sessions): sweep orphan store temp files

### DIFF
--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -38,6 +38,10 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
 // per agent store) keeps the hot path allocation-free.
 const SESSION_STORE_TEMP_RE_CACHE = new Map<string, RegExp>();
 
+// Atomic writes normally rename within milliseconds. Every cleanup path shares this grace
+// period so none can race an in-flight session-store write.
+export const SESSION_STORE_TEMP_STALE_MS = 5 * 60 * 1000;
+
 function sessionStoreTempPattern(storeBasename: string): RegExp {
   let pattern = SESSION_STORE_TEMP_RE_CACHE.get(storeBasename);
   if (!pattern) {

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -15,6 +15,7 @@ import {
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isSessionStoreTempArtifactName,
+  SESSION_STORE_TEMP_STALE_MS,
   isTrajectorySessionArtifactName,
 } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
@@ -309,10 +310,6 @@ function isUnreferencedSessionArtifactFile(
   );
 }
 
-// An orphaned `sessions.json.<pid>.<uuid>.tmp` older than this is never a live
-// atomic write (those rename within milliseconds), so it is safe to reclaim
-// regardless of the general unreferenced-artifact age threshold (#56827).
-const SESSION_STORE_TEMP_STALE_MS = 5 * 60 * 1000;
 // Prompt blobs are written or mtime-refreshed before sessions.json points at
 // them. Treat fresh unreferenced blobs as in-flight so cleanup cannot strand a
 // durable promptRef that is about to be committed by another writer.

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,5 +1,7 @@
 import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
+import { sweepOrphanSessionStoreTemps } from "./store-temp-cleanup.js";
+import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
 
 export type SessionStartupMigrationLogger = {
   info: (message: string) => void;
@@ -7,11 +9,10 @@ export type SessionStartupMigrationLogger = {
 };
 
 /**
- * Run orphan-key session migration before runtime session store reads.
+ * Run session migration and orphan-temp cleanup before runtime store reads.
  *
- * The migration is idempotent and best-effort: startup continues if the repair
- * fails, but warnings stay visible so exact-key runtime access does not hide
- * legacy store states that still need operator attention.
+ * Both passes are idempotent and failure-isolated: startup continues if either
+ * fails, but warnings stay visible for operator follow-up.
  */
 export async function runSessionStartupMigration(params: {
   cfg: OpenClawConfig;
@@ -19,6 +20,8 @@ export async function runSessionStartupMigration(params: {
   log: SessionStartupMigrationLogger;
   deps?: {
     migrateOrphanedSessionKeys?: typeof migrateOrphanedSessionKeys;
+    resolveAllAgentSessionStoreTargetsSync?: typeof resolveAllAgentSessionStoreTargetsSync;
+    sweepOrphanSessionStoreTemps?: typeof sweepOrphanSessionStoreTemps;
   };
 }): Promise<void> {
   const migrate = params.deps?.migrateOrphanedSessionKeys ?? migrateOrphanedSessionKeys;
@@ -40,6 +43,25 @@ export async function runSessionStartupMigration(params: {
   } catch (err) {
     params.log.warn(
       `session: orphaned session key migration failed during startup; continuing: ${String(err)}`,
+    );
+  }
+
+  const resolveTargets =
+    params.deps?.resolveAllAgentSessionStoreTargetsSync ?? resolveAllAgentSessionStoreTargetsSync;
+  const sweepTemps = params.deps?.sweepOrphanSessionStoreTemps ?? sweepOrphanSessionStoreTemps;
+  try {
+    let removedFiles = 0;
+    for (const target of resolveTargets(params.cfg, {
+      env: params.env ?? process.env,
+    })) {
+      removedFiles += await sweepTemps({ storePath: target.storePath });
+    }
+    if (removedFiles > 0) {
+      params.log.info(`session: removed ${removedFiles} stale session store temp file(s)`);
+    }
+  } catch (err) {
+    params.log.warn(
+      `session: stale session store temp cleanup failed during startup; continuing: ${String(err)}`,
     );
   }
 }

--- a/src/config/sessions/store-temp-cleanup.test.ts
+++ b/src/config/sessions/store-temp-cleanup.test.ts
@@ -1,0 +1,71 @@
+// Session-store temp cleanup tests cover startup reclamation and recovery boundaries.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { SESSION_STORE_TEMP_STALE_MS } from "./artifacts.js";
+import { sweepOrphanSessionStoreTemps } from "./store-temp-cleanup.js";
+
+const UUID = "0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+const NOW_MS = 2_000_000_000_000;
+
+async function writeAt(filePath: string, contents: string, mtimeMs: number): Promise<void> {
+  await fs.writeFile(filePath, contents);
+  await fs.utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
+}
+
+describe("sweepOrphanSessionStoreTemps", () => {
+  it("removes stale current and legacy temps while preserving fresh and unrelated files", async () => {
+    await withTempDir({ prefix: "store-temp-cleanup" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const staleMtime = NOW_MS - SESSION_STORE_TEMP_STALE_MS - 1;
+      const staleCurrent = `${storePath}.123.${UUID}.tmp`;
+      const staleLegacy = `${storePath}.${UUID}.tmp`;
+      const fresh = `${storePath}.456.${UUID}.tmp`;
+      const unrelated = path.join(dir, `other.json.123.${UUID}.tmp`);
+      await fs.writeFile(storePath, "{}");
+      await Promise.all([
+        writeAt(staleCurrent, "stale", staleMtime),
+        writeAt(staleLegacy, "legacy", staleMtime),
+        writeAt(fresh, "fresh", NOW_MS),
+        writeAt(unrelated, "other", staleMtime),
+      ]);
+
+      await expect(sweepOrphanSessionStoreTemps({ storePath, nowMs: NOW_MS })).resolves.toBe(2);
+      await expect(fs.stat(staleCurrent)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(staleLegacy)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(fresh, "utf8")).resolves.toBe("fresh");
+      await expect(fs.readFile(unrelated, "utf8")).resolves.toBe("other");
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["corrupt", "{not-json"],
+    ["non-record", "[]"],
+  ])("preserves recovery candidates when the primary store is %s", async (_label, primary) => {
+    await withTempDir({ prefix: "store-temp-recovery" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const candidate = `${storePath}.123.${UUID}.tmp`;
+      if (primary !== undefined) {
+        await fs.writeFile(storePath, primary);
+      }
+      await writeAt(candidate, "recoverable", NOW_MS - SESSION_STORE_TEMP_STALE_MS - 1);
+
+      await expect(sweepOrphanSessionStoreTemps({ storePath, nowMs: NOW_MS })).resolves.toBe(0);
+      await expect(fs.readFile(candidate, "utf8")).resolves.toBe("recoverable");
+    });
+  });
+
+  it("matches a custom store basename", async () => {
+    await withTempDir({ prefix: "store-temp-custom" }, async (dir) => {
+      const storePath = path.join(dir, "custom-store.json");
+      const candidate = `${storePath}.123.${UUID}.tmp`;
+      await fs.writeFile(storePath, "{}");
+      await writeAt(candidate, "stale", NOW_MS - SESSION_STORE_TEMP_STALE_MS - 1);
+
+      await expect(sweepOrphanSessionStoreTemps({ storePath, nowMs: NOW_MS })).resolves.toBe(1);
+      await expect(fs.stat(candidate)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+});

--- a/src/config/sessions/store-temp-cleanup.ts
+++ b/src/config/sessions/store-temp-cleanup.ts
@@ -1,0 +1,68 @@
+// Session startup reclaims stale atomic-write temps without adding work to store reads.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
+import { isSessionStoreTempArtifactName, SESSION_STORE_TEMP_STALE_MS } from "./artifacts.js";
+
+const DELETE_CONCURRENCY = 16;
+
+async function hasValidPrimaryStore(storePath: string): Promise<boolean> {
+  try {
+    return isRecord(JSON.parse(await fs.readFile(storePath, "utf8")));
+  } catch {
+    return false;
+  }
+}
+
+/** Removes stale atomic-write temps only when the primary store is recoverable. */
+export async function sweepOrphanSessionStoreTemps(params: {
+  storePath: string;
+  nowMs?: number;
+}): Promise<number> {
+  const storeDir = path.dirname(params.storePath);
+  const storeBasename = path.basename(params.storePath);
+  const cutoffMs = (params.nowMs ?? Date.now()) - SESSION_STORE_TEMP_STALE_MS;
+  const entries = await fs.readdir(storeDir, { withFileTypes: true }).catch(() => []);
+  const { results: staleCandidates } = await runTasksWithConcurrency({
+    limit: DELETE_CONCURRENCY,
+    tasks: entries
+      .filter(
+        (entry) => entry.isFile() && isSessionStoreTempArtifactName(entry.name, storeBasename),
+      )
+      .map((entry) => async () => {
+        const candidatePath = path.join(storeDir, entry.name);
+        const stat = await fs.stat(candidatePath).catch(() => null);
+        if (!stat?.isFile() || stat.mtimeMs > cutoffMs) {
+          return null;
+        }
+        return candidatePath;
+      }),
+  });
+  const stalePaths = staleCandidates.filter(
+    (candidatePath): candidatePath is string => typeof candidatePath === "string",
+  );
+  if (stalePaths.length === 0 || !(await hasValidPrimaryStore(params.storePath))) {
+    // Avoid parsing large healthy stores on ordinary startups. If cleanup is needed, preserve
+    // every candidate unless the primary parses; a temp may be the only recoverable copy.
+    return 0;
+  }
+
+  const { results } = await runTasksWithConcurrency({
+    limit: DELETE_CONCURRENCY,
+    tasks: stalePaths.map((candidatePath) => async () => {
+      try {
+        await fs.unlink(candidatePath);
+        return 1;
+      } catch {
+        // Another cleanup pass or writer may have won the race.
+        return 0;
+      }
+    }),
+  });
+  let removedCount = 0;
+  for (const removed of results) {
+    removedCount += removed;
+  }
+  return removedCount;
+}

--- a/src/gateway/server-startup-session-migration.test.ts
+++ b/src/gateway/server-startup-session-migration.test.ts
@@ -4,6 +4,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { runStartupSessionMigration } from "./server-startup-session-migration.js";
 
+type StartupMigrationDeps = NonNullable<Parameters<typeof runStartupSessionMigration>[0]["deps"]>;
+type MigrateSessionKeys = NonNullable<StartupMigrationDeps["migrateOrphanedSessionKeys"]>;
+type ResolveStoreTargets = NonNullable<
+  StartupMigrationDeps["resolveAllAgentSessionStoreTargetsSync"]
+>;
+type SweepStoreTemps = NonNullable<StartupMigrationDeps["sweepOrphanSessionStoreTemps"]>;
+
 function makeLog() {
   return {
     info: vi.fn(),
@@ -17,6 +24,20 @@ function makeCfg() {
   >[0]["cfg"];
 }
 
+function makeDeps(migrate: MigrateSessionKeys, removedFiles = 0) {
+  return {
+    migrateOrphanedSessionKeys: migrate,
+    resolveAllAgentSessionStoreTargetsSync: vi.fn<ResolveStoreTargets>().mockReturnValue([
+      { agentId: "main", storePath: "/tmp/main/sessions.json" },
+      { agentId: "ops", storePath: "/tmp/ops/sessions.json" },
+    ]),
+    sweepOrphanSessionStoreTemps: vi
+      .fn<SweepStoreTemps>()
+      .mockResolvedValueOnce(removedFiles)
+      .mockResolvedValue(0),
+  };
+}
+
 function firstLogMessage(log: ReturnType<typeof vi.fn>, label: string): string {
   const [message] = log.mock.calls[0] ?? [];
   if (typeof message !== "string") {
@@ -28,14 +49,14 @@ function firstLogMessage(log: ReturnType<typeof vi.fn>, label: string): string {
 describe("runStartupSessionMigration", () => {
   it("logs changes when orphaned keys are canonicalized", async () => {
     const log = makeLog();
-    const migrate = vi.fn().mockResolvedValue({
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({
       changes: ["Canonicalized 2 orphaned session key(s) in /tmp/store.json"],
       warnings: [],
     });
     await runStartupSessionMigration({
       cfg: makeCfg(),
       log,
-      deps: { migrateOrphanedSessionKeys: migrate },
+      deps: makeDeps(migrate),
     });
     expect(migrate).toHaveBeenCalledOnce();
     expect(log.info).toHaveBeenCalledOnce();
@@ -47,14 +68,14 @@ describe("runStartupSessionMigration", () => {
 
   it("logs warnings from migration", async () => {
     const log = makeLog();
-    const migrate = vi.fn().mockResolvedValue({
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({
       changes: [],
       warnings: ["Could not read /bad/path: ENOENT"],
     });
     await runStartupSessionMigration({
       cfg: makeCfg(),
       log,
-      deps: { migrateOrphanedSessionKeys: migrate },
+      deps: makeDeps(migrate),
     });
     expect(log.info).not.toHaveBeenCalled();
     expect(log.warn).toHaveBeenCalledOnce();
@@ -63,29 +84,47 @@ describe("runStartupSessionMigration", () => {
     );
   });
 
-  it("silently continues when no changes needed", async () => {
+  it("sweeps each discovered store and logs removed temp files", async () => {
     const log = makeLog();
-    const migrate = vi.fn().mockResolvedValue({ changes: [], warnings: [] });
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const deps = makeDeps(migrate, 3);
     await runStartupSessionMigration({
       cfg: makeCfg(),
       log,
-      deps: { migrateOrphanedSessionKeys: migrate },
+      deps,
     });
-    expect(log.info).not.toHaveBeenCalled();
+    expect(deps.sweepOrphanSessionStoreTemps).toHaveBeenCalledTimes(2);
+    expect(log.info).toHaveBeenCalledWith("session: removed 3 stale session store temp file(s)");
     expect(log.warn).not.toHaveBeenCalled();
   });
 
   it("catches and logs migration errors without throwing", async () => {
     const log = makeLog();
-    const migrate = vi.fn().mockRejectedValue(new Error("disk full"));
+    const migrate = vi.fn<MigrateSessionKeys>().mockRejectedValue(new Error("disk full"));
     await runStartupSessionMigration({
       cfg: makeCfg(),
       log,
-      deps: { migrateOrphanedSessionKeys: migrate },
+      deps: makeDeps(migrate),
     });
     expect(log.warn).toHaveBeenCalledOnce();
     const warning = firstLogMessage(log.warn, "startup migration failure warning");
     expect(warning).toContain("migration failed during startup");
     expect(warning).toContain("disk full");
+  });
+
+  it("isolates temp-cleanup discovery failures from startup", async () => {
+    const log = makeLog();
+    const migrate = vi.fn<MigrateSessionKeys>().mockResolvedValue({ changes: [], warnings: [] });
+    const deps = makeDeps(migrate);
+    deps.resolveAllAgentSessionStoreTargetsSync.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    await runStartupSessionMigration({ cfg: makeCfg(), log, deps });
+
+    expect(log.warn).toHaveBeenCalledOnce();
+    const warning = firstLogMessage(log.warn, "startup cleanup failure warning");
+    expect(warning).toContain("temp cleanup failed during startup");
+    expect(warning).toContain("permission denied");
   });
 });


### PR DESCRIPTION
Fixes #89520.

## What Problem This Solves

A hard-killed atomic session-store write can leave `sessions.json.<pid>.<uuid>.tmp` artifacts behind indefinitely. Repeated crashes accumulate files in each agent session directory.

## Why This Change Was Made

The original PR scanned the session directory during uncached store reads. This maintainer rewrite moves cleanup to the existing Gateway/embedded-TUI startup migration lifecycle, so ordinary reads stay free of directory I/O.

The startup pass:

- reuses the canonical session-store target discovery and the existing five-minute stale threshold;
- bounds stat/delete concurrency;
- removes only matching stale atomic-write temps;
- preserves every candidate if the primary store is missing, corrupt, or not a JSON object;
- isolates discovery/cleanup errors so startup still proceeds.

## User Impact

Crash-orphaned session temp files are reclaimed on the next Gateway or embedded-TUI startup without risking the only recoverable copy and without adding work to session reads.

## Evidence

- 91 focused session, Gateway-startup, and embedded-TUI tests passed.
- Full `pnpm build` passed.
- `pnpm check:changed` passed for all six touched files, including core and core-test typechecks.
- Blacksmith Testbox lease: `tbx_01kww1cytcgctj7rzjm3g6rczw`.
- Live probe used the real atomic writer, killed it with `SIGKILL` after temp staging, backdated the orphan, and verified the startup migration removed it.
- Fresh autoreview reported no actionable findings.
