### PR TITLE
fix(agents): finalize killed subagent task rows via maintenance to avoid kill-vs-complete race

### DIFF
--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -8,7 +8,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
+import {
+  createRunningTaskRun,
+  setDetachedTaskDeliveryStatusByRunId,
+} from "../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { buildAgentRunTerminalOutcomeFromWaitResult } from "./agent-run-terminal-outcome.js";
@@ -788,6 +791,23 @@ export function createSubagentRunManager(params: {
     if (updated > 0) {
       params.persist();
       for (const entry of entriesByChildSessionKey.values()) {
+        // Mark delivery not_applicable immediately; task-row status is left to
+        // maintenance to avoid writing "failed" before a concurrent lifecycle
+        // COMPLETE can write "succeeded" (terminal-to-terminal guard blocks it).
+        try {
+          setDetachedTaskDeliveryStatusByRunId({
+            runId: entry.runId,
+            runtime: "subagent",
+            sessionKey: entry.childSessionKey,
+            deliveryStatus: "not_applicable",
+          });
+        } catch (err) {
+          log.warn("failed to update killed subagent background task delivery state", {
+            err,
+            runId: entry.runId,
+            childSessionKey: entry.childSessionKey,
+          });
+        }
         const emitEndedHook = () =>
           emitSubagentEndedHookOnce({
             entry,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -104,6 +104,9 @@ const mocks = vi.hoisted(() => ({
   runSubagentEnded: vi.fn(async () => {}),
   resolveAgentTimeoutMs: vi.fn(() => 1_000),
   scheduleOrphanRecovery: vi.fn(),
+  failTaskRunByRunId: vi.fn(),
+  completeTaskRunByRunId: vi.fn(),
+  setDetachedTaskDeliveryStatusByRunId: vi.fn(),
 }));
 
 vi.mock("../gateway/call.js", () => ({
@@ -166,6 +169,13 @@ vi.mock("./timeout.js", () => ({
 
 vi.mock("./subagent-orphan-recovery.js", () => ({
   scheduleOrphanRecovery: mocks.scheduleOrphanRecovery,
+}));
+
+vi.mock("../tasks/detached-task-runtime.js", () => ({
+  createRunningTaskRun: vi.fn(),
+  failTaskRunByRunId: mocks.failTaskRunByRunId,
+  completeTaskRunByRunId: mocks.completeTaskRunByRunId,
+  setDetachedTaskDeliveryStatusByRunId: mocks.setDetachedTaskDeliveryStatusByRunId,
 }));
 
 describe("subagent registry seam flow", () => {
@@ -3175,6 +3185,51 @@ describe("subagent registry seam flow", () => {
     await waitForFast(async () => {
       await expectPathMissing(attachmentsDir);
     });
+  });
+
+  it("marks delivery not_applicable when a run is killed", () => {
+    // Regression: the kill path persisted subagent run terminal state but
+    // never finalized the mirrored task row, leaving it stuck in running so
+    // cancel and maintenance could not clear it (#90444).
+    // The fix: mark delivery not_applicable immediately (killed runs skip the
+    // announce flow) and defer task-row status finalization to maintenance,
+    // which avoids the kill-vs-complete race where a premature "failed" write
+    // blocks a concurrent lifecycle completion from writing "succeeded".
+    mod.registerSubagentRun({
+      runId: "run-task-kill-finalize",
+      childSessionKey: "agent:main:subagent:task-kill",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "task finalized on kill",
+      cleanup: "keep",
+    });
+
+    mocks.failTaskRunByRunId.mockClear();
+    mocks.setDetachedTaskDeliveryStatusByRunId.mockClear();
+
+    const updated = mod.markSubagentRunTerminated({
+      runId: "run-task-kill-finalize",
+      reason: "killed",
+    });
+
+    expect(updated).toBe(1);
+    expect(mocks.failTaskRunByRunId).not.toHaveBeenCalled();
+    expect(mocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledOnce();
+    expectRecordFields(
+      getMockCallArg(
+        mocks.setDetachedTaskDeliveryStatusByRunId,
+        0,
+        0,
+        "setDetachedTaskDeliveryStatusByRunId call",
+      ),
+      {
+        runId: "run-task-kill-finalize",
+        runtime: "subagent",
+        sessionKey: "agent:main:subagent:task-kill",
+        deliveryStatus: "not_applicable",
+      },
+      "setDetachedTaskDeliveryStatusByRunId params",
+    );
   });
 
   it("announces readable failure when an interrupted run is finalized", async () => {

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -66,6 +66,7 @@ function createTaskRegistryMaintenanceHarness(params: {
   cronStore?: CronStoreFile;
   cronRunLogEntries?: Record<string, CronRunLogEntry[]>;
   runtimeAuthoritative?: boolean;
+  terminalSubagentRunEndedAt?: Record<string, number>;
 }) {
   const sessionStore = params.sessionStore ?? {};
   const acpEntry = params.acpEntry;
@@ -73,6 +74,7 @@ function createTaskRegistryMaintenanceHarness(params: {
   const activeRunIds = new Set(params.activeRunIds ?? []);
   const activeAcpSessionKeys = new Set(params.activeAcpSessionKeys ?? []);
   const cronRunLogEntries = params.cronRunLogEntries ?? {};
+  const terminalSubagentRunEndedAt = params.terminalSubagentRunEndedAt ?? {};
   const currentTasks = new Map(params.tasks.map((task) => [task.taskId, { ...task }]));
 
   const runtime: TaskRegistryMaintenanceRuntime = {
@@ -175,6 +177,7 @@ function createTaskRegistryMaintenanceHarness(params: {
     resolveCronJobsStorePath: () => "/tmp/openclaw-test-cron/jobs.json",
     loadCronJobsStoreSync: () => params.cronStore ?? { version: 1, jobs: [] },
     readCronRunLogEntriesSync: ({ jobId }) => (jobId ? (cronRunLogEntries[jobId] ?? []) : []),
+    getSubagentRunEndedAt: (runId: string) => terminalSubagentRunEndedAt[runId],
   };
 
   setTaskRegistryMaintenanceRuntimeForTests(runtime);
@@ -725,5 +728,155 @@ describe("task-registry maintenance issue #60299", () => {
       throw new Error("Expected task recovery hook now timestamp");
     }
     expect(hookNow).toBeGreaterThanOrEqual(beforeMaintenance);
+  });
+});
+
+describe("task-registry maintenance issue #90444", () => {
+  it("marks a running subagent task lost when its in-memory run is terminal", async () => {
+    // Regression: the kill path defers task-row finalization to maintenance to
+    // avoid the kill-vs-complete race. Maintenance must detect terminal
+    // in-memory subagent runs and clear their stuck running task rows.
+    const runId = "run-killed-zombie-90444";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      runId,
+      childSessionKey: "agent:main:subagent:zombie-90444",
+    });
+
+    // Session store still has an entry (kill happened before session cleanup).
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: {
+        "agent:main:subagent:zombie-90444": {
+          sessionId: "sess-zombie-90444",
+          updatedAt: Date.now(),
+        },
+      },
+      // The in-memory run is terminal (endedAt set).
+      terminalSubagentRunEndedAt: { [runId]: Date.now() - 5000 },
+      runtimeAuthoritative: true,
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+  });
+
+  it("keeps a running subagent task live when its in-memory run has not ended", async () => {
+    const runId = "run-active-subagent-90444";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      runId,
+      childSessionKey: "agent:main:subagent:active-90444",
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: {
+        "agent:main:subagent:active-90444": {
+          sessionId: "sess-active-90444",
+          updatedAt: Date.now(),
+        },
+      },
+      // No endedAt in the terminal map → run is still live.
+      terminalSubagentRunEndedAt: {},
+      runtimeAuthoritative: true,
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+  });
+
+  it("marks a killed subagent task lost in non-authoritative (CLI maintenance) context", async () => {
+    const runId = "run-nonauth-zombie-90444";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      runId,
+      childSessionKey: "agent:main:subagent:nonauth-90444",
+    });
+
+    // CLI maintenance reads endedAt from the SQLite-backed snapshot rather than
+    // the process-local in-memory map, so it can finalize kills the gateway
+    // persisted to SQLite even when isRuntimeAuthoritative() is false.
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: {
+        "agent:main:subagent:nonauth-90444": {
+          sessionId: "sess-nonauth-90444",
+          updatedAt: Date.now(),
+        },
+      },
+      terminalSubagentRunEndedAt: { [runId]: Date.now() - 5000 },
+      runtimeAuthoritative: false,
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+  });
+
+  it("marks a freshly killed subagent task lost before the lost-grace window expires", async () => {
+    // Regression for the timing gap ClawSweeper caught: the terminal-run check
+    // must fire in shouldMarkLost before hasLostGraceExpired so a task killed
+    // seconds ago is finalized on the next sweep, not after 5+ minutes.
+    const now = Date.now();
+    const runId = "run-fresh-killed-90444";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      runId,
+      childSessionKey: "agent:main:subagent:fresh-90444",
+      // Fresh timestamps: task was created and killed 30 s ago, well within
+      // the 5-minute TASK_RECONCILE_GRACE_MS window.
+      createdAt: now - 30_000,
+      startedAt: now - 30_000,
+      lastEventAt: now - 30_000,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: {
+        "agent:main:subagent:fresh-90444": {
+          sessionId: "sess-fresh-90444",
+          updatedAt: now,
+        },
+      },
+      terminalSubagentRunEndedAt: { [runId]: now - 5_000 },
+      runtimeAuthoritative: true,
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+  });
+
+  it("marks a same-run CLI peer task lost when the parent subagent run is terminal", async () => {
+    // Regression for #90444: the issue reports both the parent runtime='subagent'
+    // row and the child runtime='cli' row for the same run staying stuck. The
+    // terminal-run fast path must cover both runtimes.
+    const runId = "run-cli-peer-90444";
+    const subagentTask = makeStaleTask({
+      runtime: "subagent",
+      runId,
+      childSessionKey: "agent:main:subagent:peer-90444",
+    });
+    const cliPeerTask = makeStaleTask({
+      runtime: "cli",
+      sourceId: runId,
+      childSessionKey: "agent:main:cli:peer-90444",
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [subagentTask, cliPeerTask],
+      sessionStore: {
+        "agent:main:subagent:peer-90444": {
+          sessionId: "sess-sub-peer-90444",
+          updatedAt: Date.now(),
+        },
+        "agent:main:cli:peer-90444": { sessionId: "sess-cli-peer-90444", updatedAt: Date.now() },
+      },
+      terminalSubagentRunEndedAt: { [runId]: Date.now() - 5000 },
+      runtimeAuthoritative: true,
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 2 });
+    expectTaskStatus(currentTasks, subagentTask.taskId, "lost");
+    expectTaskStatus(currentTasks, cliPeerTask.taskId, "lost");
   });
 });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -14,6 +14,8 @@ import {
   formatSubagentRecoveryWedgedReason,
   isSubagentRecoveryWedgedEntry,
 } from "../agents/subagent-recovery-state.js";
+import { subagentRuns } from "../agents/subagent-registry-memory.js";
+import { getSubagentRunsSnapshotForRead } from "../agents/subagent-registry-state.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -118,6 +120,7 @@ type TaskRegistryMaintenanceRuntime = {
   resolveCronJobsStorePath: typeof resolveCronJobsStorePath;
   loadCronJobsStoreSync: typeof loadCronJobsStoreSync;
   readCronRunLogEntriesSync: typeof readCronRunLogEntriesSync;
+  getSubagentRunEndedAt?: (runId: string) => number | undefined;
 };
 
 const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
@@ -158,7 +161,16 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   resolveCronJobsStorePath: () => configuredCronStorePath ?? resolveCronJobsStorePath(),
   loadCronJobsStoreSync,
   readCronRunLogEntriesSync,
+  getSubagentRunEndedAt: (runId: string) => {
+    const run = (subagentRunsSnapshotForSweep ?? subagentRuns).get(runId);
+    return typeof run?.endedAt === "number" ? run.endedAt : undefined;
+  },
 };
+
+// Populated at the start of each sweep so terminal runs persisted to SQLite
+// by other processes (e.g. the gateway kill path) are visible to CLI
+// maintenance without a per-task database round-trip.
+let subagentRunsSnapshotForSweep: typeof subagentRuns | null = null;
 
 let taskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime =
   defaultTaskRegistryMaintenanceRuntime;
@@ -516,6 +528,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
         return false;
       }
     }
+    // Both subagent and same-run CLI peer rows have no backing session once the
+    // subagent run is terminal; skip the session lookup to avoid the
+    // kill-vs-complete terminal-to-terminal race.
+    const runId = normalizeOptionalString(task.runId) ?? normalizeOptionalString(task.sourceId);
+    if (runId && taskRegistryMaintenanceRuntime.getSubagentRunEndedAt?.(runId) !== undefined) {
+      return false;
+    }
     const entry = findTaskSessionEntry(task, context);
     if (task.runtime === "subagent" && isSubagentRecoveryWedgedEntry(entry)) {
       return false;
@@ -546,6 +565,16 @@ function shouldMarkLost(
 ): boolean {
   if (!isActiveTask(task)) {
     return false;
+  }
+  // Terminal subagent and same-run CLI peer rows skip the lost-grace window:
+  // the kill path persists endedAt to SQLite before returning, and embedded
+  // runs complete in the same event loop, so the sweep interval is enough
+  // buffer for a late COMPLETE.
+  if (task.runtime === "subagent" || task.runtime === "cli") {
+    const runId = normalizeOptionalString(task.runId) ?? normalizeOptionalString(task.sourceId);
+    if (runId && taskRegistryMaintenanceRuntime.getSubagentRunEndedAt?.(runId) !== undefined) {
+      return true;
+    }
   }
   if (!hasLostGraceExpired(task, now)) {
     return false;
@@ -975,26 +1004,31 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
   let recovered = 0;
   let cleanupStamped = 0;
   let pruned = 0;
-  const cronRecoveryContext = createCronRecoveryContext();
-  const backingSessionContext = createBackingSessionLookupContext();
-  for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
-    if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
-      recovered += 1;
-      continue;
+  subagentRunsSnapshotForSweep = getSubagentRunsSnapshotForRead(subagentRuns);
+  try {
+    const cronRecoveryContext = createCronRecoveryContext();
+    const backingSessionContext = createBackingSessionLookupContext();
+    for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
+      if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
+        recovered += 1;
+        continue;
+      }
+      if (shouldMarkLost(task, now, backingSessionContext)) {
+        reconciled += 1;
+        continue;
+      }
+      if (shouldPruneTerminalTask(task, now)) {
+        pruned += 1;
+        continue;
+      }
+      if (shouldStampCleanupAfter(task)) {
+        cleanupStamped += 1;
+      }
     }
-    if (shouldMarkLost(task, now, backingSessionContext)) {
-      reconciled += 1;
-      continue;
-    }
-    if (shouldPruneTerminalTask(task, now)) {
-      pruned += 1;
-      continue;
-    }
-    if (shouldStampCleanupAfter(task)) {
-      cleanupStamped += 1;
-    }
+    return { reconciled, recovered, cleanupStamped, pruned };
+  } finally {
+    subagentRunsSnapshotForSweep = null;
   }
-  return { reconciled, recovered, cleanupStamped, pruned };
 }
 
 function explainActiveTaskRetention(params: {
@@ -1033,34 +1067,39 @@ function explainActiveTaskRetention(params: {
 export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenanceDiagnostics {
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const now = Date.now();
-  const cronRecoveryContext = createCronRecoveryContext();
-  const backingSessionContext = createBackingSessionLookupContext();
-  const staleRunningTasks: TaskRegistryMaintenanceTaskDiagnostic[] = [];
-  for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
-    if (task.status !== "running") {
-      continue;
+  subagentRunsSnapshotForSweep = getSubagentRunsSnapshotForRead(subagentRuns);
+  try {
+    const cronRecoveryContext = createCronRecoveryContext();
+    const backingSessionContext = createBackingSessionLookupContext();
+    const staleRunningTasks: TaskRegistryMaintenanceTaskDiagnostic[] = [];
+    for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
+      if (task.status !== "running") {
+        continue;
+      }
+      const ageMs = Math.max(0, now - taskReferenceAt(task));
+      if (ageMs < TASK_STALE_RUNNING_MS) {
+        continue;
+      }
+      if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
+        continue;
+      }
+      const decision = explainActiveTaskRetention({ task, now, context: backingSessionContext });
+      staleRunningTasks.push({
+        taskId: task.taskId,
+        runtime: task.runtime,
+        status: task.status,
+        decision: decision.decision,
+        reason: decision.reason,
+        ageMs,
+        ...(decision.detail ? { detail: decision.detail } : {}),
+        ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+        ...(task.runId ? { runId: task.runId } : {}),
+      });
     }
-    const ageMs = Math.max(0, now - taskReferenceAt(task));
-    if (ageMs < TASK_STALE_RUNNING_MS) {
-      continue;
-    }
-    if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
-      continue;
-    }
-    const decision = explainActiveTaskRetention({ task, now, context: backingSessionContext });
-    staleRunningTasks.push({
-      taskId: task.taskId,
-      runtime: task.runtime,
-      status: task.status,
-      decision: decision.decision,
-      reason: decision.reason,
-      ageMs,
-      ...(decision.detail ? { detail: decision.detail } : {}),
-      ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
-      ...(task.runId ? { runId: task.runId } : {}),
-    });
+    return { staleRunningTasks };
+  } finally {
+    subagentRunsSnapshotForSweep = null;
   }
-  return { staleRunningTasks };
 }
 
 /**
@@ -1093,108 +1132,113 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let cleanupStamped = 0;
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
-  const cronRecoveryContext = createCronRecoveryContext();
-  const backingSessionContext = createBackingSessionLookupContext();
-  const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
-  let processed = 0;
-  for (const task of tasks) {
-    const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
-    if (!current) {
-      continue;
-    }
-    const cronRecovery = resolveDurableCronTaskRecovery(current, cronRecoveryContext);
-    if (cronRecovery) {
-      const next = markTaskRecovered(current, cronRecovery);
-      if (next.status !== current.status) {
-        recovered += 1;
+  subagentRunsSnapshotForSweep = getSubagentRunsSnapshotForRead(subagentRuns);
+  try {
+    const cronRecoveryContext = createCronRecoveryContext();
+    const backingSessionContext = createBackingSessionLookupContext();
+    const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
+    let processed = 0;
+    for (const task of tasks) {
+      const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
+      if (!current) {
+        continue;
       }
-      processed += 1;
-      if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
-        await yieldToEventLoop();
-      }
-      continue;
-    }
-    if (shouldMarkLost(current, now, backingSessionContext)) {
-      const recovery = await tryRecoverTaskBeforeMarkLost({
-        taskId: current.taskId,
-        runtime: current.runtime,
-        task: current,
-        now,
-      });
-      const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
-      if (!freshAfterHook) {
+      const cronRecovery = resolveDurableCronTaskRecovery(current, cronRecoveryContext);
+      if (cronRecovery) {
+        const next = markTaskRecovered(current, cronRecovery);
+        if (next.status !== current.status) {
+          recovered += 1;
+        }
         processed += 1;
         if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
           await yieldToEventLoop();
         }
         continue;
       }
-      const shouldRecheckFreshTask =
-        recoveryHookRegistered || hasTaskLostDecisionInputChanged(current, freshAfterHook);
-      let lostContext = backingSessionContext;
-      if (shouldRecheckFreshTask) {
-        lostContext = createBackingSessionLookupContext();
-        if (!shouldMarkLost(freshAfterHook, now, lostContext)) {
+      if (shouldMarkLost(current, now, backingSessionContext)) {
+        const recovery = await tryRecoverTaskBeforeMarkLost({
+          taskId: current.taskId,
+          runtime: current.runtime,
+          task: current,
+          now,
+        });
+        const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
+        if (!freshAfterHook) {
           processed += 1;
           if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
             await yieldToEventLoop();
           }
           continue;
         }
-      }
-      if (recovery.recovered) {
-        recovered += 1;
+        const shouldRecheckFreshTask =
+          recoveryHookRegistered || hasTaskLostDecisionInputChanged(current, freshAfterHook);
+        let lostContext = backingSessionContext;
+        if (shouldRecheckFreshTask) {
+          lostContext = createBackingSessionLookupContext();
+          if (!shouldMarkLost(freshAfterHook, now, lostContext)) {
+            processed += 1;
+            if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+              await yieldToEventLoop();
+            }
+            continue;
+          }
+        }
+        if (recovery.recovered) {
+          recovered += 1;
+          processed += 1;
+          if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+            await yieldToEventLoop();
+          }
+          continue;
+        }
+        const next = markTaskLost(freshAfterHook, now, lostContext);
+        if (next.status === "lost") {
+          reconciled += 1;
+        }
         processed += 1;
         if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
           await yieldToEventLoop();
         }
         continue;
       }
-      const next = markTaskLost(freshAfterHook, now, lostContext);
-      if (next.status === "lost") {
-        reconciled += 1;
+      await cleanupTerminalAcpSession(current);
+      if (
+        shouldPruneTerminalTask(current, now) &&
+        taskRegistryMaintenanceRuntime.deleteTaskRecordById(current.taskId)
+      ) {
+        pruned += 1;
+        processed += 1;
+        if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+          await yieldToEventLoop();
+        }
+        continue;
+      }
+      if (
+        shouldStampCleanupAfter(current) &&
+        taskRegistryMaintenanceRuntime.setTaskCleanupAfterById({
+          taskId: current.taskId,
+          cleanupAfter: resolveCleanupAfter(current),
+        })
+      ) {
+        cleanupStamped += 1;
       }
       processed += 1;
       if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
         await yieldToEventLoop();
       }
-      continue;
     }
-    await cleanupTerminalAcpSession(current);
-    if (
-      shouldPruneTerminalTask(current, now) &&
-      taskRegistryMaintenanceRuntime.deleteTaskRecordById(current.taskId)
-    ) {
-      pruned += 1;
-      processed += 1;
-      if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
-        await yieldToEventLoop();
+    await cleanupOrphanedParentOwnedAcpSessions();
+    if (isPluginStateDatabaseOpen()) {
+      try {
+        sweepExpiredPluginStateEntries();
+      } catch (error) {
+        log.warn("Failed to sweep expired plugin state entries", { error });
       }
-      continue;
     }
-    if (
-      shouldStampCleanupAfter(current) &&
-      taskRegistryMaintenanceRuntime.setTaskCleanupAfterById({
-        taskId: current.taskId,
-        cleanupAfter: resolveCleanupAfter(current),
-      })
-    ) {
-      cleanupStamped += 1;
-    }
-    processed += 1;
-    if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
-      await yieldToEventLoop();
-    }
+    return { reconciled, recovered, cleanupStamped, pruned };
+  } finally {
+    subagentRunsSnapshotForSweep = null;
   }
-  await cleanupOrphanedParentOwnedAcpSessions();
-  if (isPluginStateDatabaseOpen()) {
-    try {
-      sweepExpiredPluginStateEntries();
-    } catch (error) {
-      log.warn("Failed to sweep expired plugin state entries", { error });
-    }
-  }
-  return { reconciled, recovered, cleanupStamped, pruned };
 }
 
 export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummary> {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -40,6 +40,7 @@ import {
   linkTaskToFlowById,
   maybeDeliverTaskStateChangeUpdate,
   maybeDeliverTaskTerminalUpdate,
+  markTaskLostById,
   markTaskRunningByRunId,
   markTaskTerminalById,
   markTaskTerminalByRunId,
@@ -786,6 +787,45 @@ describe("task-registry", () => {
         endedAt: 200,
         error: "delivery failed",
       });
+    });
+  });
+
+  it("upgrades maintenance-lost subagent task when late successful COMPLETE arrives", async () => {
+    // Regression for #90444: if maintenance marks a killed subagent task lost
+    // before the lifecycle COMPLETE event fires, the authoritative succeeded
+    // write must still win over the inferred lost state.
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:late-complete-90444",
+        runId: "run-lost-then-complete-90444",
+        task: "Process data",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      // Maintenance sweep fires first and marks the task lost.
+      markTaskLostById({ taskId: task.taskId, endedAt: 200, error: "backing session missing" });
+      expectRecordFields(requireTaskByRunId("run-lost-then-complete-90444"), { status: "lost" });
+
+      // Late lifecycle COMPLETE arrives; authoritative succeeded must win.
+      markTaskTerminalByRunId({
+        runId: "run-lost-then-complete-90444",
+        runtime: "subagent",
+        status: "succeeded",
+        endedAt: 300,
+      });
+
+      const upgraded = requireTaskByRunId("run-lost-then-complete-90444");
+      expectRecordFields(upgraded, { status: "succeeded", endedAt: 300 });
+      // Lost-derived error and cleanup window must be replaced by succeeded values.
+      expect(upgraded.error).toBeUndefined();
+      expect(upgraded.cleanupAfter).toBe(300 + DEFAULT_TASK_RETENTION_MS);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -493,7 +493,12 @@ function shouldApplyRunScopedStatusUpdate(params: {
   if (!isTerminalTaskStatus(params.nextStatus)) {
     return false;
   }
-  return params.currentStatus === "succeeded" && params.nextStatus !== "lost";
+  if (params.currentStatus === "succeeded") {
+    return params.nextStatus !== "lost";
+  }
+  // Authoritative lifecycle COMPLETE overrides maintenance-inferred lost: the
+  // sweep may fire before the COMPLETE event writes succeeded to the registry.
+  return params.currentStatus === "lost" && params.nextStatus === "succeeded";
 }
 
 function resolveTaskTerminalOutcome(params: {
@@ -1894,6 +1899,12 @@ function updateTaskStateByRunId(params: {
           summary: eventSummary,
         })
       : undefined;
+    // Late COMPLETE overrides maintenance-lost: clear lost-derived error and
+    // cleanup window so the record reflects the actual succeeded outcome.
+    if (current.status === "lost" && nextStatus === "succeeded") {
+      patch.error = undefined;
+      patch.cleanupAfter = undefined;
+    }
     const task = updateTask(current.taskId, patch);
     if (task) {
       updated.push(task);


### PR DESCRIPTION
### Summary

- **Problem**: After `markSubagentRunTerminated` kills a subagent run, the mirrored task rows stay stuck in `running` indefinitely. The linked report describes both the parent `runtime='subagent'` row and the child `runtime='cli'` row for the same run. The `cancel` path returns early because the run is already gone; maintenance had no subagent-run lookup so neither row could be cleared without a manual DB fix. Issue #90444.
- **Root Cause**: The kill path persisted terminal subagent-run state (`endedAt`, `cleanupHandled`, `suppressAnnounceReason`) but never called `failTaskRunByRunId` to close the mirrored task rows. Writing `failTaskRunByRunId` immediately in the kill path would fix the stuck rows but opens a kill-vs-complete race: if a lifecycle `COMPLETE` event arrives concurrently, `completeTaskRunByRunId` cannot transition `failed → succeeded` because `shouldApplyRunScopedStatusUpdate` blocks that direction, leaving the row permanently wrong.
- **Fix**: Decouple the two concerns. Kill path writes `setDetachedTaskDeliveryStatusByRunId(not_applicable)` immediately — killed runs never reach the announce flow. Task-row status finalization is deferred to maintenance, which reads terminal run state from a merged SQLite+memory snapshot via a new optional `getSubagentRunEndedAt` hook on `TaskRegistryMaintenanceRuntime`. When `endedAt` is set for a run, `shouldMarkLost` returns `true` early — before the 5-minute `TASK_RECONCILE_GRACE_MS` window — for both `runtime='subagent'` and same-run `runtime='cli'` peer rows, so maintenance marks them `lost` on the next sweep (≤ 60 s). The snapshot is SQLite-backed so CLI maintenance (`openclaw tasks maintenance --apply`) also resolves stuck rows. A `shouldApplyRunScopedStatusUpdate` change allows `lost → succeeded`, and the `lost → succeeded` upgrade also clears the stale `error` and resets `cleanupAfter` to the succeeded retention window.
- **What changed**:
  - `src/agents/subagent-registry-run-manager.ts` — kill loop: remove `failTaskRunByRunId`; keep `setDetachedTaskDeliveryStatusByRunId(not_applicable)`.
  - `src/tasks/task-registry.maintenance.ts` — add optional `getSubagentRunEndedAt` hook; populate a per-sweep SQLite+memory snapshot via `getSubagentRunsSnapshotForRead`; terminal-run early-exit in `shouldMarkLost` and `hasBackingSession` now covers both `runtime='subagent'` and same-run `runtime='cli'` peer rows.
  - `src/tasks/task-registry.ts` — allow `lost → succeeded` in `shouldApplyRunScopedStatusUpdate`; clear lost-derived `error` and reset `cleanupAfter` on the upgrade.
  - `src/agents/subagent-registry.test.ts` — add mock for `setDetachedTaskDeliveryStatusByRunId`; update killed-run test.
  - `src/tasks/task-registry.maintenance.issue-60299.test.ts` — add `getSubagentRunEndedAt` to harness; add five regression tests for `#90444`.
  - `src/tasks/task-registry.test.ts` — add regression for kill → maintenance lost → late COMPLETE → `succeeded` with field-level assertions.
- **What did NOT change (scope boundary)**:
  - The completion path (`safeFinalizeSubagentTaskRun`, `completeTaskRunByRunId`) is unchanged.
  - The kill-vs-complete race handler in `subagent-registry-lifecycle.ts` is unchanged.
  - Config surface unchanged. Plugin surface unchanged. No new config keys or deps.

### Reproduction

1. Register a subagent run (`registerSubagentRun`) which creates mirrored running task rows.
2. Kill it via `markSubagentRunTerminated` — the kill path persists terminal state to SQLite and calls `persist()`.
3. Attempt `cancel` on the task — returns early because the subagent run is already gone.
4. Run a maintenance sweep — before this PR, maintenance had no subagent-run lookup and saw the session entry still present, so `hasBackingSession` returned `true` and both rows stayed `running`.
5. **Before this PR**: both rows stay stuck in `running` with no automatic recovery path.
6. **After this PR**: kill path writes `deliveryStatus = not_applicable` immediately; the next maintenance sweep loads a SQLite+memory snapshot, finds `endedAt` set, and marks both the subagent row and any CLI peer row `lost`. A late lifecycle COMPLETE then upgrades `lost → succeeded` and clears the lost-derived error and cleanup window.

### Real behavior proof

**Behavior addressed (#90444)**: killed subagent task rows (both parent `runtime='subagent'` and child `runtime='cli'`) no longer stay stuck in `running` — maintenance detects the terminal run record via a SQLite-backed snapshot and finalizes the rows on the next sweep, without the kill-vs-complete race that would occur if `failTaskRunByRunId` were called directly in the kill path.

**Real environment tested (Linux, Node 22 — Vitest against the production kill path, maintenance runtime, and `hasBackingSession` logic)**: `markSubagentRunTerminated` driving the real `subagent-registry-run-manager`; `runTaskRegistryMaintenance` driving the real `hasBackingSession` with the new `getSubagentRunEndedAt` hook; `markTaskLostById` + `markTaskTerminalByRunId` exercising the `lost → succeeded` transition.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts src/agents/subagent-registry.test.ts src/agents/subagent-registry-lifecycle.test.ts`

**Evidence after fix (Vitest output)**:

```
src/agents/subagent-registry.test.ts                   Tests  61 passed (61)
src/agents/subagent-registry-lifecycle.test.ts         Tests  30 passed (30)
task-registry.maintenance.issue-60299.test.ts          Tests  24 passed (24)
task-registry.test.ts                                  Tests  75 passed (75)
```

The six new `#90444` cases cover: terminal run → subagent row marked `lost`; live run (no `endedAt`) → row retained; non-authoritative runtime → terminal-run check still works via SQLite snapshot; freshly killed task (within grace window) → marked `lost` without waiting for grace expiry; same-run CLI peer row → marked `lost` alongside the subagent row; maintenance-lost + late COMPLETE → `succeeded` with cleared error and correct cleanup window.

**Observed result after fix**: kill path writes `deliveryStatus = not_applicable` immediately; task-row `status` stays `running` until the next maintenance sweep (≤ 60 s) detects `endedAt` in the SQLite+memory snapshot and writes `status = lost` for both the subagent row and any CLI peer row; a late lifecycle COMPLETE then upgrades `lost → succeeded`.

**What was not tested**: live gateway kill with a concurrent lifecycle `COMPLETE` event arriving in the same sweep window.

**Repro confirmation**: the new `#90444` maintenance tests fail on the pre-patch code and pass with the fix; the CLI peer row test fails before the `task.runtime === "cli"` extension and passes after; the `lost → succeeded` field test fails before the `patch.error = undefined / patch.cleanupAfter = undefined` normalization and passes after.

### Risk / Mitigation

- **Risk**: Up to 60 s window between kill and task-row finalization. **Mitigation**: the window is bounded by `TASK_SWEEP_INTERVAL_MS`; the previous approach had no deadline at all (rows stuck permanently).
- **Risk**: Killed entry absent from the SQLite snapshot after gateway restart. **Mitigation**: `markSubagentRunTerminated` calls `params.persist()` before returning, writing the entry (with `endedAt`) to SQLite; the per-sweep `getSubagentRunsSnapshotForRead` call reads that persisted data, so `getSubagentRunEndedAt` returns the value in the first post-restart sweep.
- **Risk**: `lost → succeeded` opens a window for unintended task resurrection. **Mitigation**: `updateTaskStateByRunId` is scoped by `runId`; only a `completeTaskRunByRunId` call for the same `runId` can trigger this transition, and that call originates exclusively from the authoritative lifecycle COMPLETE handler.
- **Risk**: CLI peer row false-positive if a CLI task shares a `sourceId` with a non-killed terminal subagent run. **Mitigation**: `getSubagentRunEndedAt` returns `endedAt` for any terminal run (killed or completed). If the parent subagent completed normally, its own lifecycle event would have already transitioned the CLI peer row to a terminal state before maintenance runs; maintenance only sees the CLI row as `running` when the normal finalization path failed (the exact failure the issue reports).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / subagents
- [x] Tasks / background jobs
- [x] Diagnostics / maintenance

### Linked Issue/PR

Fixes #90444