### PR TITLE
fix: allow Discord DM reads for allowlisted peers

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.shared.ts
+++ b/extensions/discord/src/actions/runtime.messaging.shared.ts
@@ -2,7 +2,9 @@ import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runti
 import { mergeDiscordAccountConfig, resolveDefaultDiscordAccountId } from "../accounts.js";
 import { createDiscordRuntimeAccountContext } from "../client.js";
 import {
+  allowListMatches,
   isDiscordGroupAllowedByPolicy,
+  normalizeDiscordAllowList,
   normalizeDiscordSlug,
   resolveDiscordChannelConfigWithFallback,
   type DiscordGuildEntryResolved,
@@ -100,11 +102,13 @@ function resolveDiscordActionGuildEntry(params: {
 type DiscordReadTargetContext = {
   channelId: string;
   guildId?: string;
+  channelType?: number;
   channelName?: string;
   channelSlug: string;
   parentId?: string;
   parentName?: string;
   parentSlug?: string;
+  recipientIds?: string[];
   scope?: "channel" | "thread";
 };
 
@@ -128,6 +132,19 @@ function readDiscordChannelType(value: unknown): number | undefined {
   }
   const type = (value as Record<string, unknown>).type;
   return typeof type === "number" ? type : undefined;
+}
+
+function readDiscordRecipientIds(value: unknown): string[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const recipients = (value as Record<string, unknown>).recipients;
+  if (!Array.isArray(recipients)) {
+    return [];
+  }
+  return recipients
+    .map((recipient) => readDiscordChannelStringField(recipient, "id"))
+    .filter((recipientId): recipientId is string => Boolean(recipientId));
 }
 
 function isDiscordThreadChannel(value: unknown): boolean {
@@ -201,6 +218,11 @@ export function createDiscordMessagingActionContext(params: {
   const withOpts = (extra?: Record<string, unknown>) =>
     createDiscordActionOptions({ cfg: params.cfg, accountId, extra });
   const resolvedReactionAccountId = accountId ?? resolveDefaultDiscordAccountId(params.cfg);
+  const dmAllowList = normalizeDiscordAllowList(accountConfig.allowFrom, [
+    "discord:",
+    "user:",
+    "pk:",
+  ]);
   const reactionRuntimeOptions = resolvedReactionAccountId
     ? createDiscordRuntimeAccountContext({
         cfg: params.cfg,
@@ -267,12 +289,20 @@ export function createDiscordMessagingActionContext(params: {
       channelId,
       channelSlug: channelName ? normalizeDiscordSlug(channelName) : fallback.channelSlug,
     };
+    const channelType = readDiscordChannelType(channelInfo);
+    if (channelType !== undefined) {
+      target.channelType = channelType;
+    }
     const targetGuildId = readDiscordChannelStringField(channelInfo, "guild_id", "guildId");
     if (targetGuildId) {
       target.guildId = targetGuildId;
     }
     if (channelName) {
       target.channelName = channelName;
+    }
+    const recipientIds = readDiscordRecipientIds(channelInfo);
+    if (recipientIds.length > 0) {
+      target.recipientIds = recipientIds;
     }
     if (!isDiscordThreadChannel(channelInfo)) {
       return target;
@@ -343,6 +373,14 @@ export function createDiscordMessagingActionContext(params: {
         ) {
           throw new Error("Discord read target channel is not allowed.");
         }
+        return;
+      }
+      if (
+        dmAllowList &&
+        target.channelType === 1 &&
+        target.recipientIds?.length === 1 &&
+        allowListMatches(dmAllowList, { id: target.recipientIds[0] })
+      ) {
         return;
       }
       const allowed = Object.values(guilds ?? {}).some((guildInfo) =>

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -25,6 +25,7 @@ type DiscordChannelInfoTest = {
   guild_id?: string;
   name?: string;
   parent_id?: string;
+  recipients?: Array<{ id?: string }>;
 };
 
 const discordSendMocks = {
@@ -873,6 +874,61 @@ describe("handleDiscordMessagingAction", () => {
       handleMessagingAction("listPins", { channelId: "444" }, enableAllActions, cfg),
     ).rejects.toThrow("Discord read target channel is not allowed.");
     expect(listPinsDiscord).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "123456789012345678",
+    "user:123456789012345678",
+    "discord:123456789012345678",
+    "<@123456789012345678>",
+    "<@!123456789012345678>",
+  ])("allows Discord DM reads when allowFrom includes the DM recipient (%s)", async (allowFrom) => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "DM1",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    readMessagesDiscord.mockResolvedValueOnce([{ id: "M1" }]);
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          dmPolicy: "allowlist",
+          allowFrom: [allowFrom],
+          groupPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      handleMessagingAction("readMessages", { channelId: "DM1" }, enableAllActions, cfg),
+    ).resolves.toMatchObject({
+      details: { messages: [{ id: "M1" }] },
+    });
+    expect(readMessagesDiscord).toHaveBeenCalled();
+  });
+
+  it("rejects Discord DM reads when allowFrom contains the DM channel id instead of the recipient", async () => {
+    fetchChannelInfoDiscord.mockResolvedValueOnce({
+      id: "DM1",
+      type: ChannelType.DM,
+      recipients: [{ id: "123456789012345678" }],
+    });
+    const cfg = {
+      channels: {
+        discord: {
+          token: "token",
+          dmPolicy: "allowlist",
+          allowFrom: ["DM1"],
+          groupPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      handleMessagingAction("readMessages", { channelId: "DM1" }, enableAllActions, cfg),
+    ).rejects.toThrow("Discord read target channel is not allowed.");
+    expect(readMessagesDiscord).not.toHaveBeenCalled();
   });
 
   it("adds normalized timestamps to searchMessages payloads", async () => {


### PR DESCRIPTION
## Summary

Allow Discord `readMessages` / `message.read` to authorize one-to-one DM history reads when the fetched DM recipient is already allowlisted in `channels.discord.allowFrom`.

## Changes

- normalize the Discord DM allowlist once inside the messaging read guard
- read DM `type` and `recipients` from fetched channel metadata before applying a narrow DM fallback
- keep guild/channel/thread authorization unchanged and continue rejecting DM channel-id allowlisting
- add coverage for raw id, `user:`/`discord:` prefixes, Discord mention forms, and the negative DM-channel-id case

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/actions/runtime.test.ts`

Fixes openclaw/openclaw#90499