### PR TITLE
fix: ignore canonical Windows gateway task names

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -384,4 +384,31 @@ describe("findExtraGatewayServices (win32)", () => {
       },
     ]);
   });
+
+  it("ignores the canonical OpenClaw scheduled task when schtasks prefixes it with a backslash", async () => {
+    execSchtasksMock.mockResolvedValueOnce({
+      code: 0,
+      stdout: [
+        "TaskName: \\OpenClaw Gateway",
+        "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
+        "",
+        "TaskName: \\Clawdbot Legacy",
+        "Task To Run: C:\\clawdbot\\clawdbot.exe run",
+        "",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    const result = await findExtraGatewayServices({}, { deep: true });
+    expect(result).toEqual([
+      {
+        platform: "win32",
+        label: "\\Clawdbot Legacy",
+        detail: "task: \\Clawdbot Legacy, run: C:\\clawdbot\\clawdbot.exe run",
+        scope: "system",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
 });

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -385,30 +385,32 @@ describe("findExtraGatewayServices (win32)", () => {
     ]);
   });
 
-  it("ignores the canonical OpenClaw scheduled task when schtasks prefixes it with a backslash", async () => {
-    execSchtasksMock.mockResolvedValueOnce({
-      code: 0,
-      stdout: [
-        "TaskName: \\OpenClaw Gateway",
-        "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
-        "",
-        "TaskName: \\Clawdbot Legacy",
-        "Task To Run: C:\\clawdbot\\clawdbot.exe run",
-        "",
-      ].join("\n"),
-      stderr: "",
-    });
+  it("ignores the canonical OpenClaw scheduled task when schtasks prefixes it with a slash or backslash", async () => {
+    for (const canonicalTaskName of ["\\OpenClaw Gateway", "/OpenClaw Gateway"]) {
+      execSchtasksMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: [
+          `TaskName: ${canonicalTaskName}`,
+          "Task To Run: C:\\Program Files\\OpenClaw\\openclaw.exe gateway run",
+          "",
+          "TaskName: \\Clawdbot Legacy",
+          "Task To Run: C:\\clawdbot\\clawdbot.exe run",
+          "",
+        ].join("\n"),
+        stderr: "",
+      });
 
-    const result = await findExtraGatewayServices({}, { deep: true });
-    expect(result).toEqual([
-      {
-        platform: "win32",
-        label: "\\Clawdbot Legacy",
-        detail: "task: \\Clawdbot Legacy, run: C:\\clawdbot\\clawdbot.exe run",
-        scope: "system",
-        marker: "clawdbot",
-        legacy: true,
-      },
-    ]);
+      const result = await findExtraGatewayServices({}, { deep: true });
+      expect(result).toEqual([
+        {
+          platform: "win32",
+          label: "\\Clawdbot Legacy",
+          detail: "task: \\Clawdbot Legacy, run: C:\\clawdbot\\clawdbot.exe run",
+          scope: "system",
+          marker: "clawdbot",
+          legacy: true,
+        },
+      ]);
+    }
   });
 });

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -199,7 +199,7 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
 }
 
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  const normalized = normalizeLowercaseStringOrEmpty(name).replace(/^[/\\]+/, "");
   if (!normalized) {
     return false;
   }


### PR DESCRIPTION
## Summary

Stop the Windows gateway-service detector from flagging the canonical `\OpenClaw Gateway` scheduled task as an extra service just because `schtasks` prefixes the task name with a backslash.

## Changes

- strip leading slash and backslash prefixes before canonical scheduled-task name matching
- preserve legacy-task detection for genuinely different task names
- add a focused regression test covering `TaskName: \OpenClaw Gateway` alongside a legacy task in the same `schtasks` output

## Testing

- `node scripts/run-vitest.mjs run src/daemon/inspect.test.ts src/commands/doctor-gateway-services.test.ts src/cli/daemon-cli/status.print.test.ts`

Fixes openclaw/openclaw#90494