### PR TITLE
fix(anthropic): add haiku catalog entry

### DIFF
--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -106,7 +106,7 @@
             "maxTokens": 64000
           },
           {
-            "id": "claude-haiku-4-5-20251001",
+            "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "reasoning": true,
             "input": ["text", "image"],
@@ -134,7 +134,8 @@
           "opus-4.8": "claude-opus-4-8",
           "opus": "claude-opus-4-8",
           "opus-4.6": "claude-opus-4-6",
-          "sonnet-4.6": "claude-sonnet-4-6"
+          "sonnet-4.6": "claude-sonnet-4-6",
+          "claude-haiku-4-5-20251001": "claude-haiku-4-5"
         }
       }
     }

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -104,6 +104,17 @@
             },
             "contextWindow": 200000,
             "maxTokens": 64000
+          },
+          {
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
+            },
+            "contextWindow": 200000,
+            "maxTokens": 64000
           }
         ]
       }

--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -49,6 +49,23 @@ describe("provider model id policy normalization", () => {
     ).toBe("claude-haiku-4-5");
   });
 
+  it("maps the dated Claude Haiku 4.5 id onto the rolling catalog alias", () => {
+    // Anthropic ships Haiku 4.5 under the dated id; the static catalog row is the
+    // rolling alias, so the dated id must normalize onto it to resolve.
+    expect(
+      normalizeStaticProviderModelIdWithPolicies(
+        "anthropic",
+        "anthropic/claude-haiku-4-5-20251001",
+      ),
+    ).toBe("claude-haiku-4-5");
+    expect(
+      normalizeConfiguredProviderCatalogModelId("anthropic", "anthropic/claude-haiku-4-5-20251001"),
+    ).toBe("claude-haiku-4-5");
+    expect(
+      normalizeStaticProviderModelIdWithPolicies("anthropic", "claude-haiku-4-5-20251001"),
+    ).toBe("claude-haiku-4-5");
+  });
+
   it("normalizes provider-prefixed native catalog refs without stripping catalog prefixes", () => {
     expect(normalizeStaticProviderModelIdWithPolicies("google", "google/gemini-2.0-flash")).toBe(
       "google/gemini-2.0-flash",

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -139,6 +139,9 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
       opus: "claude-opus-4-8",
       "opus-4.6": "claude-opus-4-6",
       "sonnet-4.6": "claude-sonnet-4-6",
+      // Anthropic ships Haiku 4.5 under the dated API id; the catalog row is the
+      // rolling alias, so map the dated id onto it or it resolves as Unknown model.
+      "claude-haiku-4-5-20251001": "claude-haiku-4-5",
     };
     const anthropicPrefix = "anthropic/";
     const normalizedModel = normalizeLowercaseStringOrEmpty(model);

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -15,6 +15,11 @@ vi.mock("../../plugins/manifest.js", async (importOriginal) => ({
   loadPluginManifest: manifestMocks.loadPluginManifest,
 }));
 
+import { readFileSync } from "node:fs";
+import {
+  collectManifestModelIdNormalizationPolicies,
+  normalizeStaticProviderModelIdWithPolicies,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { resolveBundledStaticCatalogModel } from "./model.static-catalog.js";
 
 function setManifestPlugins(plugins: unknown[]) {
@@ -164,5 +169,23 @@ describe("resolveBundledStaticCatalogModel", () => {
         cfg: {},
       }),
     ).toBeUndefined();
+  });
+
+  it("resolves Claude Haiku 4.5 from the bundled anthropic manifest via rolling and dated refs", () => {
+    // Regression for #90088: both the rolling alias and the dated Anthropic id must
+    // resolve to the bundled static catalog row, the same way Sonnet/Opus do.
+    const anthropicManifest = {
+      ...JSON.parse(readFileSync("extensions/anthropic/openclaw.plugin.json", "utf8")),
+      origin: "bundled",
+    };
+    setManifestPlugins([anthropicManifest]);
+    const policies = collectManifestModelIdNormalizationPolicies([anthropicManifest]);
+
+    for (const ref of ["anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5-20251001"]) {
+      const modelId = normalizeStaticProviderModelIdWithPolicies("anthropic", ref, policies);
+      const model = resolveBundledStaticCatalogModel({ provider: "anthropic", modelId, cfg: {} });
+      expect(model?.id, `expected ${ref} to resolve`).toBe("claude-haiku-4-5");
+      expect(model?.name).toBe("Claude Haiku 4.5");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #90088 — Claude Haiku 4.5 was missing from the bundled `anthropic` static model catalog, so both `anthropic/claude-haiku-4-5` (rolling) and `anthropic/claude-haiku-4-5-20251001` (dated) failed model resolution with `Unknown model (model_not_found)`.

- Add the rolling `claude-haiku-4-5` row to `extensions/anthropic/openclaw.plugin.json`, mirroring the `claude-sonnet-4-6` / Opus rows (all bare ids).
- Map the dated `claude-haiku-4-5-20251001` onto the rolling id in the provider-owned `modelIdNormalization` aliases and in the built-in anthropic normalizer (the built-in path handles the provider-prefixed ref), so the dated API id resolves to the same catalog row.
- Add regression coverage for normalization (both ids → `claude-haiku-4-5`) and bundled static-catalog resolution (both refs resolve against the real manifest).

## Real Behavior Proof

**Behavior addressed:** On the `anthropic` api_key provider, no Claude Haiku 4.5 id resolved — both `anthropic/claude-haiku-4-5` and `anthropic/claude-haiku-4-5-20251001` failed with `Unknown model ... (model_not_found)` (#90088), because the static catalog had no Haiku row and `discovery.anthropic = "static"`. After this change both ids resolve to the bundled `Claude Haiku 4.5` catalog row.

**Real environment tested:** OpenClaw source checkout on macOS (arm64), Node v26, pnpm 11.2.2, branch `fastino-90088-haiku-model`. The proof drives the real bundled static-catalog resolver (`resolveBundledStaticCatalogModel`) plus the real provider-id normalizer against the actual `extensions/anthropic/openclaw.plugin.json` — no mocked catalog rows.

**Exact steps or command run after this patch:**

```text
node --import tsx _proof.mts
# normalizes each ref through the real anthropic normalizer, then resolves it
# against the actual bundled anthropic manifest catalog row
```

**Evidence after fix:** Copied console output from the resolver run above:

```text
anthropic/claude-haiku-4-5           ->  normalized=claude-haiku-4-5  ->  resolved=anthropic/claude-haiku-4-5 (Claude Haiku 4.5)
anthropic/claude-haiku-4-5-20251001  ->  normalized=claude-haiku-4-5  ->  resolved=anthropic/claude-haiku-4-5 (Claude Haiku 4.5)
```

**Observed result after fix:** Both the rolling alias and the dated Anthropic id normalize to `claude-haiku-4-5` and resolve to the bundled `Claude Haiku 4.5` row, instead of `Unknown model`. This matches how Sonnet/Opus already resolve on the same provider. Before this change the same resolver returned `UNKNOWN MODEL` for both refs.

**What was not tested:** A live end-to-end Anthropic API completion was not run; the bug and fix are at static-catalog model resolution (pre-request), proven against the real bundled manifest. The runtime API behavior of Haiku 4.5 itself is unchanged by adding a catalog entry.

## Regression coverage

Focused suites resolving against the real bundled manifest (no mocked catalog rows):

```text
node scripts/run-vitest.mjs \
  packages/model-catalog-core/src/provider-model-id-normalization.test.ts \
  src/agents/embedded-agent-runner/model.static-catalog.test.ts --reporter=dot
# Test Files  2 passed (2)
# Tests  11 passed (11)
```
