### PR TITLE
fix(session): clear stale fallback model state on reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2598,6 +2598,125 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("clears source-less fallback-active model overrides on /new and /reset", async () => {
+    const storePath = await createStorePath("openclaw-reset-fallback-notice-auto-model-");
+    const sessionKey = "agent:main:discord:channel:1488013357016420522";
+    const existingSessionId = "existing-session-fallback-notice-auto-model";
+    const autoOverrides = {
+      providerOverride: "codex",
+      modelOverride: "gpt-5.4",
+      modelProvider: "codex",
+      model: "gpt-5.4",
+      contextTokens: 200_000,
+      fallbackNoticeSelectedModel: "codex/gpt-5.5",
+      fallbackNoticeActiveModel: "codex/gpt-5.4",
+      fallbackNoticeReason: "selected model unavailable",
+      verboseLevel: "on",
+    } as const;
+    const cases = [
+      { name: "new clears fallback-active override", body: "/new" },
+      { name: "reset clears fallback-active override", body: "/reset" },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...autoOverrides },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "discord:channel:1488013357016420522",
+          To: "discord:bot",
+          ChatType: "channel",
+          SessionKey: sessionKey,
+          Provider: "discord",
+          Surface: "discord",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.modelOverrideSource, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.model, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.modelProvider, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.contextTokens, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeSelectedModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeActiveModel, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeReason, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe(autoOverrides.verboseLevel);
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].modelOverride, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].providerOverride, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].model, testCase.name).toBeUndefined();
+      expect(stored[sessionKey].modelProvider, testCase.name).toBeUndefined();
+    }
+  });
+
+  it("preserves source-less legacy user overrides even when runtime fallback notice exists", async () => {
+    const storePath = await createStorePath("openclaw-reset-legacy-user-fallback-notice-");
+    const sessionKey = "agent:main:discord:channel:1488013357016420522";
+    const existingSessionId = "existing-session-legacy-user-fallback-notice";
+    const legacyUserOverride = {
+      providerOverride: "codex",
+      modelOverride: "gpt-5.5",
+      modelProvider: "codex",
+      model: "gpt-5.4",
+      contextTokens: 200_000,
+      fallbackNoticeSelectedModel: "codex/gpt-5.5",
+      fallbackNoticeActiveModel: "codex/gpt-5.4",
+      fallbackNoticeReason: "selected model unavailable",
+    } as const;
+
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: { ...legacyUserOverride },
+    });
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "discord:channel:1488013357016420522",
+        To: "discord:bot",
+        ChatType: "channel",
+        SessionKey: sessionKey,
+        Provider: "discord",
+        Surface: "discord",
+      },
+      cfg: {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.providerOverride).toBe(legacyUserOverride.providerOverride);
+    expect(result.sessionEntry.modelOverride).toBe(legacyUserOverride.modelOverride);
+    expect(result.sessionEntry.modelOverrideSource).toBe("user");
+    expect(result.sessionEntry.model).toBeUndefined();
+    expect(result.sessionEntry.modelProvider).toBeUndefined();
+    expect(result.sessionEntry.contextTokens).toBeUndefined();
+  });
+
   it("preserves spawned session ownership metadata across /new and /reset", async () => {
     const storePath = await createStorePath("openclaw-reset-spawned-metadata-");
     const sessionKey = "subagent:owned-child";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -792,12 +792,21 @@ export async function initSessionState(params: {
     sessionEntry.status = undefined;
     // Clear stale token metrics from previous session so /status doesn't
     // display the old session's context usage after /new or /reset.
+    sessionEntry.modelProvider = undefined;
+    sessionEntry.model = undefined;
+    sessionEntry.agentHarnessId = undefined;
     sessionEntry.totalTokens = undefined;
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
+    sessionEntry.cacheRead = undefined;
+    sessionEntry.cacheWrite = undefined;
     sessionEntry.contextTokens = undefined;
     sessionEntry.contextBudgetStatus = undefined;
+    sessionEntry.liveModelSwitchPending = undefined;
+    sessionEntry.fallbackNoticeSelectedModel = undefined;
+    sessionEntry.fallbackNoticeActiveModel = undefined;
+    sessionEntry.fallbackNoticeReason = undefined;
     sessionEntry.goal = undefined;
     // Skills snapshots are prompt/runtime caches. Do not preserve a stale
     // snapshot through /new; the next turn must rebuild the visible skill list.

--- a/src/config/sessions/model-override-provenance.ts
+++ b/src/config/sessions/model-override-provenance.ts
@@ -24,3 +24,64 @@ export function hasSessionAutoModelFallbackProvenance(
     normalizeOptionalString(entry?.modelOverrideFallbackOriginModel),
   );
 }
+
+function modelRefMatchesProviderModel(params: {
+  ref?: string | undefined;
+  provider?: string | undefined;
+  model?: string | undefined;
+}): boolean {
+  const ref = normalizeOptionalString(params.ref);
+  const model = normalizeOptionalString(params.model);
+  if (!ref || !model) {
+    return false;
+  }
+  if (ref === model) {
+    return true;
+  }
+  const provider = normalizeOptionalString(params.provider);
+  return Boolean(provider && ref === `${provider}/${model}`);
+}
+
+function hasFallbackNoticeModelOverrideProvenance(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "providerOverride"
+        | "modelOverride"
+        | "modelProvider"
+        | "fallbackNoticeSelectedModel"
+        | "fallbackNoticeActiveModel"
+      >
+    | undefined,
+): boolean {
+  const selected = normalizeOptionalString(entry?.fallbackNoticeSelectedModel);
+  const active = normalizeOptionalString(entry?.fallbackNoticeActiveModel);
+  if (!selected || !active || selected === active) {
+    return false;
+  }
+  return modelRefMatchesProviderModel({
+    ref: active,
+    provider: entry?.providerOverride ?? entry?.modelProvider,
+    model: entry?.modelOverride,
+  });
+}
+
+/** Detects auto-fallback model overrides persisted before modelOverrideSource was available. */
+export function hasSessionRecoveredAutoModelOverrideProvenance(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "providerOverride"
+        | "modelOverride"
+        | "modelProvider"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+        | "fallbackNoticeSelectedModel"
+        | "fallbackNoticeActiveModel"
+      >
+    | undefined,
+): boolean {
+  return (
+    hasSessionAutoModelFallbackProvenance(entry) || hasFallbackNoticeModelOverrideProvenance(entry)
+  );
+}

--- a/src/config/sessions/reset-preserved-selection.ts
+++ b/src/config/sessions/reset-preserved-selection.ts
@@ -1,5 +1,5 @@
 // Reset preservation keeps user-selected model/auth overrides while dropping automatic fallbacks.
-import { hasSessionAutoModelFallbackProvenance } from "./model-override-provenance.js";
+import { hasSessionRecoveredAutoModelOverrideProvenance } from "./model-override-provenance.js";
 import type { SessionEntry } from "./types.js";
 
 export type ResetPreservedSelectionState = Pick<
@@ -33,7 +33,8 @@ export function resolveResetPreservedSelection(params: {
 
   const preserved: Partial<ResetPreservedSelectionState> = {};
   const recoveredAutoFallbackOverride =
-    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+    entry.modelOverrideSource === undefined &&
+    hasSessionRecoveredAutoModelOverrideProvenance(entry);
   // Missing source on older entries means "user" unless fallback provenance proves the runtime
   // created the override automatically.
   const preserveLegacyUserModelOverride =

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -406,6 +406,65 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.authProfileOverrideCompactionCount).toBe(3);
     });
 
+    it("drops source-less fallback-active model overrides for fresh cron sessions", () => {
+      const result = resolveWithStoredEntry({
+        sessionKey: "session:agent:main:discord:channel:1488013357016420522",
+        entry: {
+          sessionId: "existing-session-id-789",
+          updatedAt: NOW_MS - 1000,
+          modelOverride: "gpt-5.4",
+          providerOverride: "codex",
+          modelProvider: "codex",
+          model: "gpt-5.4",
+          contextTokens: 200_000,
+          fallbackNoticeSelectedModel: "codex/gpt-5.5",
+          fallbackNoticeActiveModel: "codex/gpt-5.4",
+          fallbackNoticeReason: "selected model unavailable",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.modelOverride).toBeUndefined();
+      expect(result.sessionEntry.providerOverride).toBeUndefined();
+      expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+      expect(result.sessionEntry.model).toBeUndefined();
+      expect(result.sessionEntry.modelProvider).toBeUndefined();
+      expect(result.sessionEntry.contextTokens).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeSelectedModel).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeActiveModel).toBeUndefined();
+      expect(result.sessionEntry.fallbackNoticeReason).toBeUndefined();
+    });
+
+    it("preserves source-less legacy user model overrides for fresh cron sessions", () => {
+      const result = resolveWithStoredEntry({
+        sessionKey: "session:agent:main:discord:channel:1488013357016420522",
+        entry: {
+          sessionId: "existing-session-id-987",
+          updatedAt: NOW_MS - 1000,
+          modelOverride: "gpt-5.5",
+          providerOverride: "codex",
+          modelProvider: "codex",
+          model: "gpt-5.4",
+          contextTokens: 200_000,
+          fallbackNoticeSelectedModel: "codex/gpt-5.5",
+          fallbackNoticeActiveModel: "codex/gpt-5.4",
+          fallbackNoticeReason: "selected model unavailable",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.modelOverride).toBe("gpt-5.5");
+      expect(result.sessionEntry.providerOverride).toBe("codex");
+      expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+      expect(result.sessionEntry.model).toBeUndefined();
+      expect(result.sessionEntry.modelProvider).toBeUndefined();
+      expect(result.sessionEntry.contextTokens).toBeUndefined();
+    });
+
     it("preserves ambient session context for non-isolated expiration rollovers", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -2,7 +2,7 @@
 import crypto from "node:crypto";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
 import { resolveSessionLifecycleTimestamps } from "../../config/sessions/lifecycle.js";
-import { hasSessionAutoModelFallbackProvenance } from "../../config/sessions/model-override-provenance.js";
+import { hasSessionRecoveredAutoModelOverrideProvenance } from "../../config/sessions/model-override-provenance.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   evaluateSessionFreshness,
@@ -62,7 +62,8 @@ function copySessionFields(
 
 function preserveNonAutoModelOverride(target: SessionEntry, entry: SessionEntry): void {
   const recoveredAutoFallbackOverride =
-    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+    entry.modelOverrideSource === undefined &&
+    hasSessionRecoveredAutoModelOverrideProvenance(entry);
   if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
     if (entry.modelOverride !== undefined) {
       target.modelOverride = entry.modelOverride;


### PR DESCRIPTION
## Summary

Refs #90496.

This fixes the reset/session-target portion of the Discord oversized-session report:

- Clear stale runtime model, context-window, fallback notice, and harness metadata when `/new` or `/reset` rotates a reply session.
- Treat source-less model overrides as recovered auto-fallback state when persisted fallback-notice metadata shows the override is the fallback active model.
- Reuse that provenance in cron fresh-session sanitization so `session:<key>` jobs do not re-pin a reset channel to stale `codex/gpt-5.4` state.
- Preserve the existing compatibility rule for source-less legacy user-selected model overrides.

## Root Cause

`/new` and `/reset` created a new session id, but the session store merge could keep stale runtime fields such as `modelProvider`, `model`, `contextTokens`, and fallback notice metadata from the previous row. Source-less fallback model overrides were also treated as legacy user choices unless fallback origin metadata existed, so a stale fallback-active `codex/gpt-5.4` override could survive reset and cron fresh-session rollover.

## Real behavior proof

Behavior addressed: After `/new`/`/reset` or fresh cron session rollover, a source-less auto fallback override with fallback notice metadata no longer keeps a Discord channel/session-target lane pinned to stale `codex/gpt-5.4`; source-less legacy user-selected overrides are still preserved.

Real environment tested: Local OpenClaw checkout on macOS, using the repo Node/Vitest wrappers. No live Discord token, channel, or provider credential was used.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/cron/isolated-agent/session.test.ts
pnpm format:check src/config/sessions/model-override-provenance.ts src/config/sessions/reset-preserved-selection.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts src/cron/isolated-agent/session.ts src/cron/isolated-agent/session.test.ts
git diff --check
pnpm changed:lanes --json
.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the local fix for openclaw/openclaw#90496. The patch should clear stale source-less auto-fallback model state on /new/reset and fresh cron sessions without dropping legacy user-selected source-less model overrides.'
```

Evidence after fix:

- `node scripts/run-vitest.mjs ...` passed 2 shards: cron session tests `16 passed`; auto-reply session tests `98 passed`.
- `pnpm format:check ...` reported all matched files use the correct format.
- `git diff --check` passed.
- `pnpm changed:lanes --json` reports only core/coreTests paths for the six touched session/cron files.
- `autoreview` reported: `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: The new regression tests show `/new`/`/reset` and fresh cron rollover clear stale fallback-active `codex/gpt-5.4` state, including persisted store fields, while preserving source-less legacy user-selected `codex/gpt-5.5` overrides.

What was not tested: No live Discord repro, no live Codex provider 4xx compaction call, no automatic transcript-preserving rotate policy change, and no full `pnpm check`/remote Testbox gate.

## Dependency Contract Checked

Codex upstream was checked directly. A failed compaction emits an error and does not install replacement history; replacement history is installed only after successful compaction. This PR therefore fixes OpenClaw's reset/session state cleanup path rather than changing Codex compaction semantics. Relevant files checked: `../codex/codex-rs/core/src/compact.rs`, `../codex/codex-rs/core/src/compact_remote.rs`, and `../codex/codex-rs/core/src/compact_remote_v2.rs`.

## Verification

```text
node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts src/cron/isolated-agent/session.test.ts
pnpm format:check src/config/sessions/model-override-provenance.ts src/config/sessions/reset-preserved-selection.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts src/cron/isolated-agent/session.ts src/cron/isolated-agent/session.test.ts
git diff --check
pnpm changed:lanes --json
.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the local fix for openclaw/openclaw#90496. The patch should clear stale source-less auto-fallback model state on /new/reset and fresh cron sessions without dropping legacy user-selected source-less model overrides.'
```


## Additional Redacted Runtime Proof

Added after ClawSweeper requested real/equivalent runtime proof.

This proof ran the actual OpenClaw runtime session paths against a temporary session store with a redacted Discord channel session key:

- `initSessionState` with `/new`, `Provider: "discord"`, and `SessionKey: "agent:main:discord:channel:chan_redacted"`
- `resolveCronSession` with `session:agent:main:discord:channel:chan_redacted` and `forceNew: true`

The seeded stale row matched the reported state class: source-less `providerOverride: "codex"`, `modelOverride: "gpt-5.4"`, runtime `modelProvider/model: "codex/gpt-5.4"`, `contextTokens: 200000`, and fallback notice `selected codex/gpt-5.5 -> active codex/gpt-5.4`.

Redacted terminal output:

```json
{
  "scenario": "issue-90496 redacted runtime session proof",
  "resetPath": {
    "command": "/new",
    "provider": "discord",
    "sessionKey": "agent:main:discord:channel:chan_redacted",
    "resetTriggered": true,
    "before": {
      "sessionId": "old-session-redacted",
      "providerOverride": "codex",
      "modelOverride": "gpt-5.4",
      "modelProvider": "codex",
      "model": "gpt-5.4",
      "contextTokens": 200000,
      "fallbackNoticeSelectedModel": "codex/gpt-5.5",
      "fallbackNoticeActiveModel": "codex/gpt-5.4"
    },
    "after": {
      "rotatedSessionId": true,
      "providerOverride": null,
      "modelOverride": null,
      "modelOverrideSource": null,
      "modelProvider": null,
      "model": null,
      "contextTokens": null,
      "fallbackNoticeSelectedModel": null,
      "fallbackNoticeActiveModel": null
    }
  },
  "legacyUserOverrideGuard": {
    "beforeModelOverride": "gpt-5.5",
    "afterModelOverride": "gpt-5.5",
    "afterModelOverrideSource": "user",
    "staleRuntimeModelCleared": true
  },
  "cronFreshSession": {
    "sourceLessAutoFallbackAfter": {
      "providerOverride": null,
      "modelOverride": null,
      "modelProvider": null,
      "model": null,
      "contextTokens": null
    },
    "legacyUserOverrideAfter": {
      "providerOverride": "codex",
      "modelOverride": "gpt-5.5",
      "modelProvider": null,
      "model": null,
      "contextTokens": null
    }
  },
  "assertions": {
    "resetRotated": true,
    "resetTriggered": true,
    "resetClearedStaleFallbackOverride": true,
    "legacyUserOverridePreserved": true,
    "cronDroppedStaleFallbackOverride": true,
    "cronPreservedLegacyUserOverride": true
  }
}
```

Observed result after runtime proof: `/new` rotated the redacted Discord session and cleared the stale fallback-active `codex/gpt-5.4` override/runtime fields from the persisted row. The same proof preserved a source-less legacy user-selected `codex/gpt-5.5` override, and cron fresh-session rollover dropped the stale fallback override while preserving the legacy user override.
