### PR TITLE
fix(ui): accept short tweakcn theme names

### DIFF
--- a/ui/src/ui/custom-theme.test.ts
+++ b/ui/src/ui/custom-theme.test.ts
@@ -85,6 +85,24 @@ describe("custom theme import helpers", () => {
     });
   });
 
+  it("accepts short built-in theme names like claude, zinc, and slate", () => {
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/themes/claude")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/claude",
+      fetchUrl: "https://tweakcn.com/r/themes/claude",
+      themeId: "claude",
+    });
+    expect(normalizeTweakcnThemeUrl("zinc")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/zinc",
+      fetchUrl: "https://tweakcn.com/r/themes/zinc",
+      themeId: "zinc",
+    });
+    expect(normalizeTweakcnThemeUrl("https://tweakcn.com/r/themes/slate")).toEqual({
+      sourceUrl: "https://tweakcn.com/themes/slate",
+      fetchUrl: "https://tweakcn.com/r/themes/slate",
+      themeId: "slate",
+    });
+  });
+
   it("extracts theme ids from copied tweakcn editor URLs and pasted text", () => {
     expect(
       normalizeTweakcnThemeUrl("https://tweakcn.com/editor/theme?theme=cmlhfpjhw000004l4f4ax3m7z"),

--- a/ui/src/ui/custom-theme.ts
+++ b/ui/src/ui/custom-theme.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { normalizeOptionalString } from "./string-coerce.ts";
 
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
-const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";
 const MAX_TWEAKCN_THEME_BYTES = 200_000;
 const MAX_CSS_TOKEN_LENGTH = 240;


### PR DESCRIPTION
Fixes #88987.

## What changed

- Allows short tweakcn built-in theme IDs such as `claude`, `zinc`, and `slate`.
- Adds regression coverage for canonical tweakcn URLs, registry URLs, and raw short theme names.

## Real behavior proof

Setup:

- Repository: OpenClaw checkout.
- Branch under test: `fastino-88987-theme-import`.
- Proof script imports the real `normalizeTweakcnThemeUrl` helper from each checkout and runs the reported short theme inputs through it.

Before, on current main:

```text
node_modules/.bin/tsx /private/tmp/openclaw-88987-proof.ts /Users/allahyar/Documents/fastino-tasks/openclaw
https://tweakcn.com/themes/claude Unsupported tweakcn link. Expected a theme share URL.
zinc Paste a full tweakcn URL.
https://tweakcn.com/r/themes/slate Unsupported tweakcn link. Expected a theme share URL.
```

After, on this branch:

```text
node_modules/.bin/tsx /private/tmp/openclaw-88987-proof.ts /Users/allahyar/Documents/fastino-tasks/openclaw-tui-88987b
https://tweakcn.com/themes/claude {"themeId":"claude","sourceUrl":"https://tweakcn.com/themes/claude","fetchUrl":"https://tweakcn.com/r/themes/claude"}
zinc {"themeId":"zinc","sourceUrl":"https://tweakcn.com/themes/zinc","fetchUrl":"https://tweakcn.com/r/themes/zinc"}
https://tweakcn.com/r/themes/slate {"themeId":"slate","sourceUrl":"https://tweakcn.com/themes/slate","fetchUrl":"https://tweakcn.com/r/themes/slate"}
```

## Verification

```text
git diff --check -- ui/src/ui/custom-theme.ts ui/src/ui/custom-theme.test.ts
```

No output.

```text
node scripts/test-projects.mjs ui/src/ui/custom-theme.test.ts

[test] starting test/vitest/vitest.ui.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-88987b

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  03:11:27
   Duration  647ms (transform 19ms, setup 17ms, import 46ms, tests 14ms, environment 502ms)

[test] passed 1 Vitest shard in 13.19s
```

## Platforms tested

- macOS local checkout with Node 26 and repository test runner.

## Limitations

- This validates the URL normalization path directly; it does not perform a live network fetch from tweakcn.
