### PR TITLE
fix(gateway): hint missing external plugin for web login

### DIFF
--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -4,10 +4,16 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   listChannelPlugins: vi.fn(),
+  resolveMissingOfficialExternalChannelPluginRepairHint: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: mocks.listChannelPlugins,
+}));
+
+vi.mock("../../plugins/official-external-plugin-repair-hints.js", () => ({
+  resolveMissingOfficialExternalChannelPluginRepairHint:
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint,
 }));
 
 import { webHandlers } from "./web.js";
@@ -45,6 +51,7 @@ function createOptions(
       stopChannel: vi.fn(),
       startChannel: vi.fn(),
       getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+      getRuntimeConfig: vi.fn(() => ({ channels: { whatsapp: { enabled: true } } })),
     },
     ...overrides,
   } as unknown as GatewayRequestHandlerOptions;
@@ -60,6 +67,7 @@ function createRunningWhatsappContext() {
       stopChannel,
       startChannel,
       getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+      getRuntimeConfig: vi.fn(() => ({ channels: { whatsapp: { enabled: true } } })),
     } as unknown as GatewayRequestHandlerOptions["context"],
   };
 }
@@ -67,6 +75,45 @@ function createRunningWhatsappContext() {
 describe("webHandlers web.login.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
+  });
+
+  it("surfaces the missing official external plugin hint when no web-login provider is loaded", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue({
+      pluginId: "whatsapp",
+      channelId: "whatsapp",
+      label: "WhatsApp",
+      installSpec: "clawhub:@openclaw/whatsapp",
+      installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+      doctorFixCommand: "openclaw doctor --fix",
+      repairHint:
+        "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+    });
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "web login provider is not available. Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+      }),
+    );
+    expect(mocks.resolveMissingOfficialExternalChannelPluginRepairHint).toHaveBeenCalledWith({
+      config: { channels: { whatsapp: { enabled: true } } },
+      channelId: "whatsapp",
+    });
   });
 
   it("restarts a previously running channel when login start exits early without a QR", async () => {
@@ -182,6 +229,7 @@ describe("webHandlers web.login.start", () => {
 describe("webHandlers web.login.wait", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
   });
 
   it("passes refreshed QR payloads back to the client while login is still pending", async () => {

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -116,6 +116,66 @@ describe("webHandlers web.login.start", () => {
     });
   });
 
+  it("joins multiple missing official external plugin hints when more than one configured channel is missing", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockImplementation(({ channelId }) =>
+      channelId === "whatsapp"
+        ? {
+            pluginId: "whatsapp",
+            channelId: "whatsapp",
+            label: "WhatsApp",
+            installSpec: "clawhub:@openclaw/whatsapp",
+            installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+            doctorFixCommand: "openclaw doctor --fix",
+            repairHint:
+              "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+          }
+        : channelId === "signal"
+          ? {
+              pluginId: "signal",
+              channelId: "signal",
+              label: "Signal",
+              installSpec: "clawhub:@openclaw/signal",
+              installCommand: "openclaw plugins install clawhub:@openclaw/signal",
+              doctorFixCommand: "openclaw doctor --fix",
+              repairHint:
+                "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/signal, or run: openclaw doctor --fix.",
+            }
+          : null,
+    );
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+          context: {
+            stopChannel: vi.fn(),
+            startChannel: vi.fn(),
+            getRuntimeSnapshot: vi.fn(createRunningWhatsappSnapshot),
+            getRuntimeConfig: vi.fn(() => ({
+              channels: {
+                whatsapp: { enabled: true },
+                signal: { enabled: true },
+              },
+            })),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "web login provider is not available. Configured official external channel plugins are missing for WhatsApp, Signal. Install them with: openclaw plugins install clawhub:@openclaw/whatsapp; openclaw plugins install clawhub:@openclaw/signal, or run: openclaw doctor --fix.",
+      }),
+    );
+  });
+
   it("restarts a previously running channel when login start exits early without a QR", async () => {
     const loginWithQrStart = vi.fn().mockResolvedValue({
       code: "whatsapp-auth-unstable",

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -6,8 +6,9 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const WEB_LOGIN_METHODS = new Set(["web.login.start", "web.login.wait"]);
@@ -31,11 +32,35 @@ function resolveAccountId(params: unknown): string | undefined {
     : undefined;
 }
 
-function respondProviderUnavailable(respond: RespondFn) {
-  respond(
+function resolveMissingWebLoginPluginHint(context: GatewayRequestContext): string | null {
+  const cfg = context.getRuntimeConfig();
+  const channels = cfg.channels;
+  if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
+    return null;
+  }
+  const hints = Object.keys(channels)
+    .map((channelId) =>
+      resolveMissingOfficialExternalChannelPluginRepairHint({
+        config: cfg,
+        channelId,
+      }),
+    )
+    .filter((hint) => Boolean(hint));
+  return hints.length === 1 ? hints[0]?.repairHint ?? null : null;
+}
+
+function respondProviderUnavailable(params: {
+  respond: RespondFn;
+  context: GatewayRequestContext;
+}) {
+  const repairHint = resolveMissingWebLoginPluginHint(params.context);
+  const message = repairHint
+    ? `web login provider is not available. ${repairHint}`
+    : "web login provider is not available";
+  params.respond(
     false,
     undefined,
-    errorShape(ErrorCodes.INVALID_REQUEST, "web login provider is not available"),
+    errorShape(ErrorCodes.INVALID_REQUEST, message),
   );
 }
 
@@ -55,6 +80,7 @@ function respondWebLoginUnavailable(respond: RespondFn, err: unknown) {
 function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   rawParams: unknown;
   respond: RespondFn;
+  context: GatewayRequestContext;
   gatewayMethod: TMethod;
 }): {
   accountId?: string;
@@ -64,7 +90,10 @@ function resolveWebLoginRequest<TMethod extends WebLoginGatewayMethod>(params: {
   const accountId = resolveAccountId(params.rawParams);
   const provider = resolveWebLoginProvider();
   if (!provider) {
-    respondProviderUnavailable(params.respond);
+    respondProviderUnavailable({
+      respond: params.respond,
+      context: params.context,
+    });
     return null;
   }
   const gateway = provider.gateway;
@@ -106,6 +135,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const request = resolveWebLoginRequest({
         rawParams: params,
         respond,
+        context,
         gatewayMethod: "loginWithQrStart",
       });
       if (!request) {
@@ -144,6 +174,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const request = resolveWebLoginRequest({
         rawParams: params,
         respond,
+        context,
         gatewayMethod: "loginWithQrWait",
       });
       if (!request) {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -45,8 +45,17 @@ function resolveMissingWebLoginPluginHint(context: GatewayRequestContext): strin
         channelId,
       }),
     )
-    .filter((hint) => Boolean(hint));
-  return hints.length === 1 ? hints[0]?.repairHint ?? null : null;
+    .filter((hint): hint is NonNullable<typeof hint> => Boolean(hint));
+  if (hints.length === 0) {
+    return null;
+  }
+  if (hints.length === 1) {
+    return hints[0].repairHint;
+  }
+  const labels = [...new Set(hints.map((hint) => hint.label))];
+  const installCommands = [...new Set(hints.map((hint) => hint.installCommand))];
+  const doctorFixCommand = hints[0].doctorFixCommand;
+  return `Configured official external channel plugins are missing for ${labels.join(", ")}. Install them with: ${installCommands.join("; ")}, or run: ${doctorFixCommand}.`;
 }
 
 function respondProviderUnavailable(params: {


### PR DESCRIPTION
Closes #83277

## Summary
- reuse the existing official external plugin repair-hint path when `web.login.start` cannot find any loaded QR-login provider
- append the official external plugin install or `openclaw doctor --fix` guidance to the existing invalid-request error instead of returning only the generic provider-unavailable message
- keep the repair hint actionable when multiple configured official external channels are missing, instead of falling back to the generic error again

## Verification
- `node scripts/run-vitest.mjs src/gateway/server-methods/web.start.test.ts`
- `node scripts/run-vitest.mjs src/plugins/official-external-plugin-repair-hints.test.ts`
- `env OPENCLAW_STATE_DIR=/private/tmp/openclaw-90517-packaged-proof.u8MSeY/state4 OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-90517-packaged-proof.u8MSeY/openclaw.json OPENCLAW_AUTH_PROFILE_SECRET_KEY=proof-secret-key node /private/tmp/openclaw-90517-packaged-proof.u8MSeY/proof-run.mjs`
- `env OPENCLAW_STATE_DIR=/private/tmp/openclaw-90517-packaged-proof.u8MSeY/state5 OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-90517-packaged-proof.u8MSeY/openclaw-multi.json OPENCLAW_AUTH_PROFILE_SECRET_KEY=proof-secret-key node /private/tmp/openclaw-90517-packaged-proof.u8MSeY/proof-run-multi.mjs`

## Real behavior proof
Behavior addressed: Dashboard `web.login.start` now returns actionable official external plugin repair guidance when no QR-login provider is loaded, including the multi-missing-channel case raised in review.
Real environment tested: Packaged OpenClaw `2026.6.2` tarball built from this branch (`f036ad6`) and extracted outside the repo on macOS, with bundled `admin-http-rpc` enabled and configured channels whose official external plugins were intentionally absent from the packaged install.
Exact steps or command run after this patch: Started the packaged Gateway with `node /private/tmp/openclaw-90517-packaged-proof.u8MSeY/proof-run.mjs` for a WhatsApp-only config and `node /private/tmp/openclaw-90517-packaged-proof.u8MSeY/proof-run-multi.mjs` for a WhatsApp+Feishu config; each script started the real packaged Gateway on `127.0.0.1`, called `POST /api/v1/admin/rpc` with `{"method":"web.login.start","params":{"accountId":"default"}}`, printed the HTTP response body, and closed the Gateway.
Evidence after fix: The packaged WhatsApp-only run returned `{"code":"INVALID_REQUEST","message":"web login provider is not available. Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix."}`. The packaged WhatsApp+Feishu run returned `{"code":"INVALID_REQUEST","message":"web login provider is not available. Configured official external channel plugins are missing for WhatsApp, Feishu. Install them with: openclaw plugins install clawhub:@openclaw/whatsapp; openclaw plugins install @openclaw/feishu, or run: openclaw doctor --fix."}`.
Observed result after fix: The real packaged Gateway now surfaces concrete install and doctor guidance instead of the generic unavailable error, and the multi-missing case keeps both actionable install commands in the response.
What was not tested: I did not run a browser click-through of the dashboard UI; the real proof was captured at the packaged Gateway HTTP RPC layer that the dashboard uses for `web.login.start`.
