### PR TITLE
fix(matrix): prune finished fake-indexeddb transactions

### DIFF
--- a/extensions/matrix/src/matrix/sdk/fake-indexeddb-transaction-cleanup.test.ts
+++ b/extensions/matrix/src/matrix/sdk/fake-indexeddb-transaction-cleanup.test.ts
@@ -1,0 +1,88 @@
+import "fake-indexeddb/auto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const DB_NAME = "openclaw-fake-idb-cleanup-test";
+
+/**
+ * Regression test for issue #90455: finished IndexedDB transactions
+ * retained in fake-indexeddb's internal transactions array, causing
+ * unbounded heap growth under Matrix E2EE usage.
+ */
+describe("fake-indexeddb transaction cleanup", () => {
+  beforeAll(async () => {
+    await deleteDatabase(DB_NAME);
+  });
+
+  afterAll(async () => {
+    await deleteDatabase(DB_NAME);
+  });
+
+  it("removes finished transactions from the internal array after commit", async () => {
+    const db = await openWithStore(DB_NAME, "test");
+
+    const rawDb = (db as unknown as { _rawDatabase: { transactions: unknown[] } })._rawDatabase;
+    expect(rawDb.transactions).toHaveLength(0);
+
+    // Run several transactions sequentially
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction("test", "readwrite");
+        tx.objectStore("test").put({ val: i }, `key-${i}`);
+        tx.addEventListener("complete", () => resolve(), { once: true });
+        tx.addEventListener("error", () => reject(tx.error), { once: true });
+      });
+    }
+
+    // After all transactions complete, the internal array must be empty
+    // (the patch prunes finished transactions in processTransactions)
+    expect(rawDb.transactions).toHaveLength(0);
+  });
+
+  it("removes finished transactions from the internal array after abort", async () => {
+    const db = await openWithStore(DB_NAME, "test");
+
+    const rawDb = (db as unknown as { _rawDatabase: { transactions: unknown[] } })._rawDatabase;
+    expect(rawDb.transactions).toHaveLength(0);
+
+    // Open and abort a transaction
+    const tx1 = db.transaction("test", "readwrite");
+    tx1.objectStore("test").put({ val: 1 }, "key-1");
+    tx1.abort();
+
+    // In real usage, another transaction follows and triggers processTransactions which prunes finished ones
+    const tx2 = db.transaction("test", "readwrite");
+
+    // The aborted (finished) transaction should be pruned when a new transaction is opened
+    expect(rawDb.transactions).toHaveLength(1);
+    // Only tx2 remains
+    expect(rawDb.transactions[0]).toBe(tx2);
+
+    // Clean up: wait for tx2 to be pruned too
+    await new Promise<void>((resolve) => {
+      tx2.addEventListener("complete", () => resolve(), { once: true });
+    });
+    expect(rawDb.transactions).toHaveLength(0);
+  });
+});
+
+function openWithStore(name: string, storeName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.addEventListener("upgradeneeded", () => {
+      if (!req.result.objectStoreNames.contains(storeName)) {
+        req.result.createObjectStore(storeName);
+      }
+    });
+    req.addEventListener("success", () => resolve(req.result), { once: true });
+    req.addEventListener("error", () => reject(req.error), { once: true });
+  });
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.addEventListener("success", () => resolve(), { once: true });
+    req.addEventListener("blocked", () => resolve(), { once: true });
+    req.addEventListener("error", () => reject(req.error), { once: true });
+  });
+}

--- a/patches/fake-indexeddb@6.2.5.patch
+++ b/patches/fake-indexeddb@6.2.5.patch
@@ -1,0 +1,29 @@
+diff --git a/build/cjs/lib/Database.js b/build/cjs/lib/Database.js
+index 55f95ce0d2d8e6a668f2a86929bfa97974785f35..53b9a39bb4acc3291ff5e5da83638a5f57ce427e 100644
+--- a/build/cjs/lib/Database.js
++++ b/build/cjs/lib/Database.js
+@@ -17,6 +17,8 @@ class Database {
+     this.processTransactions = this.processTransactions.bind(this);
+   }
+   processTransactions() {
++    // Prune finished transactions to prevent unbounded heap growth
++    this.transactions = this.transactions.filter((t) => t._state !== "finished");
+     (0, _scheduling.queueTask)(() => {
+       const running = this.transactions.filter(transaction => transaction._started && transaction._state !== "finished");
+       const waiting = this.transactions.filter(transaction => !transaction._started && transaction._state !== "finished");
+diff --git a/build/esm/lib/Database.js b/build/esm/lib/Database.js
+index fb9c97e0326b7efb4bbff3dee5c2d484dae7745c..4ca5e48eede6471c27f2f88c887c33894c90da3d 100644
+--- a/build/esm/lib/Database.js
++++ b/build/esm/lib/Database.js
+@@ -11,6 +11,11 @@ class Database {
+     this.processTransactions = this.processTransactions.bind(this);
+   }
+   processTransactions() {
++    // Prune finished transactions to prevent unbounded heap growth
++    // (finished transactions are never used again by processTransactions or the IndexedDB spec)
++    this.transactions = this.transactions.filter(
++      (t) => t._state !== "finished",
++    );
+     queueTask(() => {
+       const running = this.transactions.filter(transaction => transaction._started && transaction._state !== "finished");
+       const waiting = this.transactions.filter(transaction => !transaction._started && transaction._state !== "finished");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
   '@agentclientprotocol/claude-agent-acp@0.39.0': 8ce79a079ca223290aeaa8d61063853d8e021ce5d35690f28ac998dbca9bcb4b
+  fake-indexeddb@6.2.5: e4ff73bd82bffa012023ad773b1c21d125bfe770a6c878dc1bb8c61b2987e5e9
 
 importers:
 
@@ -958,7 +959,7 @@ importers:
         version: 18.3.0
       fake-indexeddb:
         specifier: 6.2.5
-        version: 6.2.5
+        version: 6.2.5(patch_hash=e4ff73bd82bffa012023ad773b1c21d125bfe770a6c878dc1bb8c61b2987e5e9)
       markdown-it:
         specifier: 14.2.0
         version: 14.2.0
@@ -10509,7 +10510,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  fake-indexeddb@6.2.5: {}
+  fake-indexeddb@6.2.5(patch_hash=e4ff73bd82bffa012023ad773b1c21d125bfe770a6c878dc1bb8c61b2987e5e9): {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -121,3 +121,4 @@ packageExtensions:
 
 patchedDependencies:
   "@agentclientprotocol/claude-agent-acp@0.39.0": patches/@agentclientprotocol__claude-agent-acp@0.39.0.patch
+  fake-indexeddb@6.2.5: patches/fake-indexeddb@6.2.5.patch


### PR DESCRIPTION
Fixes #90455.

## What Changed

- Adds a `pnpm` patch for `fake-indexeddb@6.2.5` so finished transactions are pruned at the start of `processTransactions()`.
- Covers both completed and aborted transaction cleanup in a focused Matrix fake-indexeddb regression test.
- Wires the patch through `pnpm-workspace.yaml` and the lockfile.

## Real Behavior Proof

Behavior addressed: Matrix E2EE usage with fake-indexeddb can retain finished IndexedDB transactions in the internal transaction array, causing unbounded heap growth over time.

Setup:

- Repository: OpenClaw checkout.
- Base checkout: `/Users/allahyar/Documents/fastino-tasks/openclaw`.
- Patched checkout: `/Users/allahyar/Documents/fastino-tasks/openclaw-tui-90455c`.
- Proof script: imports `fake-indexeddb/auto`, creates a real IndexedDB database, runs five sequential readwrite transactions, then inspects fake-indexeddb's internal `_rawDatabase.transactions.length`.

Before, on current main:

```text
$ node -e 'async function main(){await import("fake-indexeddb/auto"); const name="openclaw-proof-90455-main-"+Date.now(); await new Promise((resolve,reject)=>{const req=indexedDB.open(name,1); req.onupgradeneeded=()=>req.result.createObjectStore("test"); req.onsuccess=()=>resolve(req.result); req.onerror=()=>reject(req.error)}).then(async db=>{const raw=db._rawDatabase; for(let i=0;i<5;i++){await new Promise((resolve,reject)=>{const tx=db.transaction("test","readwrite"); tx.objectStore("test").put({val:i},"key-"+i); tx.oncomplete=()=>resolve(); tx.onerror=()=>reject(tx.error);});} console.log(JSON.stringify({transactionsAfterFiveSequentialCommits:raw.transactions.length})); db.close(); await new Promise(resolve=>{const del=indexedDB.deleteDatabase(name); del.onsuccess=()=>resolve(); del.onerror=()=>resolve();});});} main().catch(err=>{console.error(err); process.exit(1);})'
{"transactionsAfterFiveSequentialCommits":6}
```

After, on this branch:

```text
$ node -e 'async function main(){await import("fake-indexeddb/auto"); const name="openclaw-proof-90455-branch-"+Date.now(); await new Promise((resolve,reject)=>{const req=indexedDB.open(name,1); req.onupgradeneeded=()=>req.result.createObjectStore("test"); req.onsuccess=()=>resolve(req.result); req.onerror=()=>reject(req.error)}).then(async db=>{const raw=db._rawDatabase; for(let i=0;i<5;i++){await new Promise((resolve,reject)=>{const tx=db.transaction("test","readwrite"); tx.objectStore("test").put({val:i},"key-"+i); tx.oncomplete=()=>resolve(); tx.onerror=()=>reject(tx.error);});} console.log(JSON.stringify({transactionsAfterFiveSequentialCommits:raw.transactions.length})); db.close(); await new Promise(resolve=>{const del=indexedDB.deleteDatabase(name); del.onsuccess=()=>resolve(); del.onerror=()=>resolve();});});} main().catch(err=>{console.error(err); process.exit(1);})'
{"transactionsAfterFiveSequentialCommits":0}
```

Observed result after fix: finished fake-indexeddb transactions no longer remain in the internal transaction array after sequential Matrix-style IndexedDB work.

## Verification

```text
$ node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/fake-indexeddb-transaction-cleanup.test.ts extensions/matrix/src/matrix/sdk/idb-persistence.test.ts
[test] starting test/vitest/vitest.extension-matrix.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-90455c


 Test Files  2 passed (2)
      Tests  9 passed (9)
   Start at  03:37:16
   Duration  1.86s (transform 1.11s, setup 128ms, import 1.52s, tests 103ms, environment 0ms)

[test] passed 1 Vitest shard in 4.51s
```

```text
$ git diff --check origin/main...HEAD
# no output
```

```text
$ pnpm exec oxfmt --check --threads=1 extensions/matrix/src/matrix/sdk/fake-indexeddb-transaction-cleanup.test.ts pnpm-workspace.yaml pnpm-lock.yaml
Checking formatting...

All matched files use the correct format.
Finished in 82ms on 2 files using 1 threads.
```

## Platforms Tested

- macOS local checkout with Node and the repository Vitest wrapper.

## Limitations

- This validates the fake-indexeddb transaction-retention behavior directly and through the Matrix persistence shard; it does not run a long-lived Matrix E2EE sync session.
