### PR TITLE
docs(plugins): clarify codex report-mode approvals

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -106,9 +106,19 @@ returns `requireApproval` while the native payload sets report approval mode
 (`openclaw_approval_mode` is `"report"`), the native hook relay records the
 plugin approval requirement and returns no native decision. When Codex sends the
 app-server approval request for the same tool use, OpenClaw opens the plugin
-approval prompt and maps the decision back to Codex. Codex `PermissionRequest`
-events are a separate approval path and can still route through OpenClaw
-approvals when the runtime is configured for that bridge.
+approval prompt and maps the decision back to Codex.
+
+**For report-mode paths that are not relayed through the native hook relay's
+deferral** (e.g. when the approval arrives directly on the OpenClaw tool
+execution path), a plugin hook returning `requireApproval` is silently cancelled
+and the tool call is denied without an interactive approval prompt. A runtime
+warning is emitted in this case. Plugin authors should avoid returning
+`requireApproval` for tools that may execute in report mode; use `block` with
+user-facing instructions or an out-of-band durable approval workflow instead.
+
+Codex `PermissionRequest` events are a separate approval path and can still
+route through OpenClaw approvals when the runtime is configured for that
+bridge.
 
 Codex app-server item notifications also provide async `after_tool_call`
 observations for native tool completions that are not already covered by the

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -52,6 +52,14 @@ export default definePluginEntry({
 Hook handlers run sequentially in descending `priority`. Same-priority hooks
 keep registration order.
 
+> **Note for Codex native tools**: When a `before_tool_call` hook returns
+> `requireApproval` in report approval mode (`openclaw_approval_mode` is
+> `"report"`), the approval requirement is cancelled and the tool call is
+> denied without an interactive approval prompt. A runtime warning is emitted.
+> Use `block` with user-facing instructions instead of `requireApproval` on
+> this path. See the [Codex harness runtime docs](/plugins/codex-harness-runtime)
+> for details.
+
 `api.on(name, handler, opts?)` accepts:
 
 - `priority` - handler ordering (higher runs first).

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -13,6 +13,10 @@ import { PluginApprovalResolutions } from "../plugins/types.js";
 import { runBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
+const { mockPluginApprovalWarn } = vi.hoisted(() => ({
+  mockPluginApprovalWarn: vi.fn(),
+}));
+
 vi.mock("../plugins/hook-runner-global.js", async () => {
   const actual = await vi.importActual<typeof import("../plugins/hook-runner-global.js")>(
     "../plugins/hook-runner-global.js",
@@ -20,6 +24,15 @@ vi.mock("../plugins/hook-runner-global.js", async () => {
   return {
     ...actual,
     getGlobalHookRunner: vi.fn(),
+  };
+});
+vi.mock("../logging/subsystem.js", () => {
+  const fakeLogger = {
+    warn: mockPluginApprovalWarn,
+    child: () => fakeLogger,
+  };
+  return {
+    createSubsystemLogger: () => fakeLogger,
   };
 });
 vi.mock("./tools/gateway.js", () => ({
@@ -76,6 +89,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     };
     mockGetGlobalHookRunner.mockReturnValue(hookRunner as HookRunner);
     mockCallGatewayTool.mockReset();
+    mockPluginApprovalWarn.mockReset();
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
@@ -163,6 +177,39 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       params: { command: "ls" },
     });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("emits a warning when requireApproval is returned in report mode", async () => {
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "test-plugin",
+        title: "Needs approval",
+        description: "Review before running",
+        severity: "info",
+      },
+      params: { adjusted: true },
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "exec",
+      params: { command: "ls" },
+      toolCallId: "call-report-warn",
+      approvalMode: "report",
+    });
+
+    expect(result).toEqual({
+      blocked: true,
+      kind: "failure",
+      deniedReason: "plugin-approval",
+      reason: "Review before running",
+      params: { command: "ls" },
+    });
+    expect(mockPluginApprovalWarn).toHaveBeenCalledTimes(1);
+    expect(mockPluginApprovalWarn).toHaveBeenCalledWith(
+      "Plugin returned requireApproval but approvalMode is 'report'; " +
+        "plugin approval requirement is denied without an interactive prompt. " +
+        "Use 'block' with user-facing instructions or an out-of-band approval workflow instead.",
+    );
   });
 
   it("defers approval-required tools without opening an approval request", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -642,6 +642,11 @@ async function resolveBeforeToolCallApprovalOutcome(params: {
   }
   if (params.approvalMode === "report") {
     notifyPluginApprovalResolution(approval, PluginApprovalResolutions.CANCELLED);
+    log.warn(
+      "Plugin returned requireApproval but approvalMode is 'report'; " +
+        "plugin approval requirement is denied without an interactive prompt. " +
+        "Use 'block' with user-facing instructions or an out-of-band approval workflow instead.",
+    );
     return {
       blocked: true,
       kind: "failure",


### PR DESCRIPTION
Fixes #86777.

## What Changed

- Clarifies the Codex native/report-mode plugin approval boundary in the Codex harness runtime docs.
- Adds a plugin hook docs note warning that `requireApproval` in report mode is denied without an interactive OpenClaw approval prompt on the direct report-mode path.
- Emits a runtime warning when a plugin returns `requireApproval` while `approvalMode` is `report`, so plugin authors get an actionable diagnostic.
- Adds focused regression coverage for the warning and fail-closed result.

## Real Behavior Proof

Behavior addressed: plugin authors can return `requireApproval` from a `before_tool_call` hook in report mode and expect an interactive approval prompt, but the direct report-mode path denies the call instead. The patch now documents the boundary and emits a warning when the runtime encounters that path.

Setup:

- Repository: OpenClaw checkout.
- Branch under test: `fastino-86777-codex-report-docs-b`.
- Test path exercises the actual `runBeforeToolCallHook` report-mode approval branch with a plugin hook returning `requireApproval`.

After fix, focused regression proof:

```text
$ node scripts/test-projects.mjs src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-86777b


 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  03:42:49
   Duration  1.23s (transform 565ms, setup 116ms, import 997ms, tests 48ms, environment 0ms)

[test] passed 1 Vitest shard in 3.82s
```

Observed result after fix: the regression test confirms `approvalMode: "report"` still returns the existing fail-closed `plugin-approval` block result and logs the new warning telling plugin authors to use `block` or an out-of-band approval workflow.

## Verification

```text
$ pnpm docs:list
Listing all markdown files in docs folder:
...
Reminder: keep docs up to date as behavior changes.
```

```text
$ pnpm docs:check-mdx
$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (676 files, 1948ms).
```

```text
$ pnpm docs:check-links
$ node scripts/docs-link-audit.mjs
checked_internal_links=4562
broken_links=0
```

```text
$ git diff --check
# no output
```

## Platforms Tested

- macOS local checkout with the repository docs and Vitest runners.

## Limitations

- This does not add a new interactive Codex-native approval bridge. It documents and warns for the existing fail-closed direct report-mode behavior.
