### PR TITLE
feat(reply-payload): tag cron-driven payloads with origin metadata

### DIFF
--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -59,7 +59,22 @@ export type ReplyPayload = {
   isStatusNotice?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
+  /**
+   * Identifies the runtime that produced this payload, so channel adapters and
+   * `message_sending` plugin hooks can distinguish scheduler-driven sends from
+   * normal assistant replies. Optional and additive — older callers never set
+   * it; consumers should treat absence as "unknown / regular reply".
+   */
+  origin?: ReplyPayloadOrigin;
 };
+
+/**
+ * Discriminated union describing what triggered an outbound payload. Currently
+ * only cron is named, but the shape is intentionally open so heartbeat,
+ * follow-up, and other scheduler-style runtimes can extend it without breaking
+ * existing consumers.
+ */
+export type ReplyPayloadOrigin = { kind: "cron"; jobId: string };
 
 /** Metadata for audio-only media that supplements already-visible assistant text. */
 export type ReplyPayloadTtsSupplement = {

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -112,7 +112,9 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(deliveryRequest.to).toBe("123");
     expect(deliveryRequest.accountId).toBe("bot-a");
     expect(deliveryRequest.threadId).toBe(42);
-    expect(deliveryRequest.payloads).toEqual([{ text: "Cron failed" }]);
+    expect(deliveryRequest.payloads).toEqual([
+      { text: "Cron failed", origin: { kind: "cron", jobId: "job-1" } },
+    ]);
     expect(deliveryRequest.session).toEqual({ kind: "session" });
     expect(deliveryRequest.identity).toEqual({ kind: "identity" });
     expect(deliveryRequest.bestEffort).toBe(false);

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -90,6 +90,7 @@ async function resolveCronAnnounceDelivery(params: {
 async function deliverCronAnnouncePayload(params: {
   deps: CliDeps;
   cfg: OpenClawConfig;
+  jobId: string;
   delivery: {
     resolvedTarget: SuccessfulDeliveryTarget;
     session: ReturnType<typeof buildOutboundSessionContext>;
@@ -106,7 +107,15 @@ async function deliverCronAnnouncePayload(params: {
     to: params.delivery.resolvedTarget.to,
     accountId: params.delivery.resolvedTarget.accountId,
     threadId: params.delivery.resolvedTarget.threadId,
-    payloads: [{ text: params.message }],
+    payloads: [
+      {
+        text: params.message,
+        // Tag the payload so channel outbound adapters and message_sending
+        // plugin hooks can tell scheduler-driven sends apart from regular
+        // assistant replies. See ReplyPayload.origin docstring.
+        origin: { kind: "cron", jobId: params.jobId },
+      },
+    ],
     session: params.delivery.session,
     identity: params.delivery.identity,
     bestEffort: false,
@@ -135,6 +144,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   await deliverCronAnnouncePayload({
     deps: params.deps,
     cfg: params.cfg,
+    jobId: params.jobId,
     delivery,
     message: params.message,
     abortSignal: params.abortSignal,
@@ -172,6 +182,7 @@ export async function sendFailureNotificationAnnounce(
     await deliverCronAnnouncePayload({
       deps,
       cfg,
+      jobId,
       delivery,
       message,
       abortSignal: abortController.signal,


### PR DESCRIPTION
## Summary

Adds an optional `ReplyPayload.origin` discriminated union and populates it
from cron announce/failure delivery, so channel outbound adapters and the
`message_sending` plugin hook can tell scheduler-driven sends apart from
regular assistant replies.

### Why

Today there is no field on `ReplyPayload`, `ChannelOutboundContext`, or
`PluginHookMessageSendingEvent` that lets a channel implementation
distinguish a cron-triggered message from a normal one. The only available
signal is the bespoke `cron:<jobId>:failure` sessionKey shape resolved by
`resolveCronNotificationSessionKey` (see `src/cron/session-target.ts`), which
is unstable across cron jobs that bind to a real persistent session — in
that case the sessionKey looks identical to a normal user-driven turn.

`PluginHookMessageContext` (`src/plugins/hook-message.types.ts`) already
acknowledges this gap: its `runId` doc explicitly notes that
\"cron/heartbeat/followup-triggered run\" ids are **not yet** plumbed through
the outbound delivery path, so plugins observing `message_sending` /
`message_sent` cannot use `runId` to correlate against `agent_end`.

### Change

- `src/auto-reply/reply-payload.ts`: new `ReplyPayloadOrigin` discriminated
  union (`{ kind: \"cron\"; jobId: string }`) and an optional `origin?` field
  on `ReplyPayload`.
- `src/cron/delivery.ts`: cron `deliverCronAnnouncePayload` writes
  `origin: { kind: \"cron\", jobId }` onto the announce payload it hands to
  `sendDurableMessageBatch`. Both `sendCronAnnouncePayloadStrict` and
  `sendFailureNotificationAnnounce` now flow `jobId` through.
- `src/cron/delivery.failure-notify.test.ts`: existing payload-shape
  assertion updated to require origin propagation; this also covers the
  full `cron → sendDurableMessageBatch → deliverOutboundPayloads` chain.

The shape is intentionally additive and extensible: existing callers do
not set `origin`, existing consumers ignore the field, and the union can
later grow `kind: \"heartbeat\"` / `\"followup\"` / etc. without breaking
consumers.

### Scope / follow-up

Channel adapters that need this signal today can read `ctx.payload.origin`
from `ChannelOutboundAdapter.sendPayload`. Reading `origin` from `sendText`
or the `message_sending` hook still requires propagating it into
`ChannelOutboundContext` and the `PluginHookMessageSendingEvent.metadata`
respectively. That's intentionally **left out of this PR** to keep the
public-contract change minimal and easier to review. Happy to follow up
with a second PR for those two surfaces if maintainers approve the
direction.

### Compatibility

Per \`AGENTS.md\` (Plugin SDK additive-first rule): this is purely additive
on a shipped public type. No removals, renames, or semantic changes; no
migration needed.

## Verification

- \`node scripts/run-vitest.mjs src/cron/delivery.test.ts src/cron/delivery.failure-notify.test.ts\` — 22/22 pass
- \`pnpm tsgo:core --noEmit\` — clean
- \`git diff --numstat\` — \`+30 / -2\` across 3 files

Owner review explicitly requested for the new public field on \`ReplyPayload\`.