### PR TITLE
chore: formatDiskSpaceBytes emits "1024 MiB" instead of "1.0 GiB" a

### DIFF
--- a/src/infra/disk-space.test.ts
+++ b/src/infra/disk-space.test.ts
@@ -77,4 +77,12 @@ describe("disk-space helpers", () => {
     expect(formatDiskSpaceBytes(420 * 1024 * 1024)).toBe("420 MiB");
     expect(formatDiskSpaceBytes(1536 * 1024 * 1024)).toBe("1.5 GiB");
   });
+
+  it("promotes 1024 MiB boundary to GiB", () => {
+    // Values where unrounded mib is in [1023.5, 1024) round up to 1024 MiB
+    // and should be formatted as "1.0 GiB" instead of "1024 MiB"
+    expect(formatDiskSpaceBytes(Math.round(1023.5 * 1024 * 1024))).toBe("1.0 GiB");
+    expect(formatDiskSpaceBytes(Math.round(1023.7 * 1024 * 1024))).toBe("1.0 GiB");
+    expect(formatDiskSpaceBytes(Math.round(1023.9 * 1024 * 1024))).toBe("1.0 GiB");
+  });
 });

--- a/src/infra/disk-space.ts
+++ b/src/infra/disk-space.ts
@@ -65,8 +65,9 @@ export function tryReadDiskSpace(targetPath: string): DiskSpaceSnapshot | null {
 /** Formats byte counts for compact operator-facing disk-space warnings. */
 export function formatDiskSpaceBytes(bytes: number): string {
   const mib = bytes / (1024 * 1024);
-  if (mib < 1024) {
-    return `${Math.max(0, Math.round(mib))} MiB`;
+  const roundedMib = Math.max(0, Math.round(mib));
+  if (roundedMib < 1024) {
+    return `${roundedMib} MiB`;
   }
   const gib = mib / 1024;
   return `${gib.toFixed(gib < 10 ? 1 : 0)} GiB`;


### PR DESCRIPTION
## Summary

Fixes #90245. AI-generated fix, human-reviewed.

## Change Type / Scope / Linked Issue

- **Type**: chore
- **Scope**: infra/disk-space
- **Linked Issue**: Fixes #90245

## Motivation

`formatDiskSpaceBytes` in `src/infra/disk-space.ts` can render the impossible unit string `"1024 MiB"` instead of `"1.0 GiB"` for byte counts in the 1023.5–1023.9 MiB range. This string is operator-facing — it appears in the low-disk-space warning shown during setup/update staging (`createLowDiskSpaceWarning`).

## Real Behavior Proof

**Behavior addressed:** The unit branch tests `mib < 1024` using the unrounded value, but the MiB branch then rounds via `Math.round(mib)`, causing values in `[1023.5, 1024)` to round up to `1024` yet still be formatted as `"1024 MiB"`. The fix rounds first (`roundedMib = Math.round(mib)`), then chooses the unit based on `roundedMib < 1024`, ensuring the GiB branch is taken when the rounded value reaches 1024.

**Real environment tested:** Local development (Node 22.22.0, pnpm, Linux)

**Exact steps or command run after this patch:**

1. Check out this branch
2. Run the actual patched `formatDiskSpaceBytes` directly from `src/infra/disk-space.ts`:

```bash
$ node -e "const { formatDiskSpaceBytes } = require('./src/infra/disk-space.ts'); [Math.round(1023.5*1024*1024), Math.round(1023.7*1024*1024), Math.round(1023.9*1024*1024), Math.round(1024.0*1024*1024)].forEach(b => console.log(b + ' bytes -> \"' + formatDiskSpaceBytes(b) + '\"'));"
1073217536 bytes -> "1.0 GiB"
1073427251 bytes -> "1.0 GiB"
1073636966 bytes -> "1.0 GiB"
1073741824 bytes -> "1.0 GiB"
```

3. Run the colocated regression tests:

```bash
$ pnpm test src/infra/disk-space.test.ts

[test] starting test/vitest/vitest.infra.config.ts
 RUN  v4.1.7

 ✓ |infra| src/infra/disk-space.test.ts (4 tests) 117ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  932ms

[test] passed 1 Vitest shard in 12.54s
```

**Evidence before fix:** Reproduced on `main` with the old logic:

```bash
$ node -e "function old(bytes){ const mib=bytes/(1024*1024); if(mib<1024){ return Math.max(0,Math.round(mib))+' MiB'; } const gib=mib/1024; return gib.toFixed(gib<10?1:0)+' GiB'; } [Math.round(1023.5*1024*1024), Math.round(1023.7*1024*1024), Math.round(1023.9*1024*1024)].forEach(b => console.log(b + ' bytes -> \"' + old(b) + '\"'));"
1073217536 bytes -> "1024 MiB"
1073427251 bytes -> "1024 MiB"
1073636966 bytes -> "1024 MiB"
```

**Evidence after fix:** Actual execution of the patched helper via `require('./src/infra/disk-space.ts')`:

```bash
$ node -e "const { formatDiskSpaceBytes } = require('./src/infra/disk-space.ts'); [Math.round(1023.5*1024*1024), Math.round(1023.7*1024*1024), Math.round(1023.9*1024*1024)].forEach(b => console.log(b + ' bytes -> \"' + formatDiskSpaceBytes(b) + '\"'));"
1073217536 bytes -> "1.0 GiB"
1073427251 bytes -> "1.0 GiB"
1073636966 bytes -> "1.0 GiB"
```

**Observed result after fix:** Values that previously produced `"1024 MiB"` now correctly produce `"1.0 GiB"`. The 1024 MiB → 1.0 GiB promotion now uses the rounded MiB value for the branch decision, eliminating the off-by-rounding bug.

**What was not tested:** Full integration tests, live disk-space warnings in production.

## Security Impact

AI-generated fix, please review for security implications.

## Human Verification

Verified by running local lint suite (`pnpm lint:core`), type checks (`pnpm tsgo:test:src`), changed tests (`pnpm test:changed`), and direct execution of the patched helper as shown above.

## Compatibility / Risks

No known breaking changes. The fix only changes the internal rounding order; all existing outputs for values well below or well above the 1024 MiB boundary remain identical.
