### PR TITLE
fix(agents): skip foundry aliases for deepseek thinking

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -766,6 +766,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not add DeepSeek V4 thinking params on Foundry alias providers (e.g. microsoft-foundry-9433)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry-9433",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry-9433",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -786,6 +786,26 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("thinking");
   });
 
+  it("does not skip DeepSeek V4 thinking for raw-prefix providers that are not Foundry aliases (e.g. microsoft-foundrybackup)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundrybackup",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundrybackup",
+        id: "deepseek-v4-pro",
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload.thinking).toEqual({ type: "enabled" });
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -919,11 +919,14 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
   return withoutSuffix.split("/").pop();
 }
 
+/** Prefix shared by the canonical Foundry provider id and all alias ids (e.g. microsoft-foundry-9433). */
+const MICROSOFT_FOUNDRY_PROVIDER_PREFIX = "microsoft-foundry";
+
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    model.provider !== "microsoft-foundry" &&
+    !model.provider.startsWith(MICROSOFT_FOUNDRY_PROVIDER_PREFIX) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -919,16 +919,22 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
   return withoutSuffix.split("/").pop();
 }
 
-/** Prefix shared by the canonical Foundry provider id and all alias ids (e.g. microsoft-foundry-9433). */
-const MICROSOFT_FOUNDRY_PROVIDER_PREFIX = "microsoft-foundry";
+/** Canonical Foundry provider id and the alias namespace (e.g. microsoft-foundry-9433). */
+const MICROSOFT_FOUNDRY_IDS = new Set(["microsoft-foundry"]);
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
   return (
     model.api === "openai-completions" &&
-    !model.provider.startsWith(MICROSOFT_FOUNDRY_PROVIDER_PREFIX) &&
+    !isMicrosoftFoundryProvider(model.provider) &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
+}
+
+/** Returns true for the canonical microsoft-foundry provider id or any microsoft-foundry-*
+ * alias (e.g. microsoft-foundry-9433). Does not match raw prefixes like microsoft-foundrybackup. */
+function isMicrosoftFoundryProvider(provider: string): boolean {
+  return MICROSOFT_FOUNDRY_IDS.has(provider) || provider.startsWith("microsoft-foundry-");
 }
 
 const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([


### PR DESCRIPTION
Fixes #90520.

## Summary

- Treat `microsoft-foundry-*` alias providers the same as the canonical `microsoft-foundry` provider for the DeepSeek V4 thinking-parameter guard.
- Add regression coverage for `microsoft-foundry-9433` so Foundry aliases do not receive the unsupported top-level `thinking` payload field.

## Real behavior proof

Behavior addressed: `microsoft-foundry-9433/DeepSeek-V4-Pro` should not receive the DeepSeek V4 top-level `thinking` parameter that Microsoft Foundry rejects, while preserving the existing OpenAI-compatible `reasoning_effort` payload field.

Real environment tested: macOS arm64 local OpenClaw checkout, Node `v26.0.0`, pnpm `11.2.2`.

### Equivalent runtime payload trace

This probe runs OpenClaw's real `applyExtraParamsToAgent` request-wrapper path and captures the provider payload immediately before transport. Provider hook deps were replaced with no-op test hooks so the probe captures OpenClaw's core payload mutation without making an external network request.

Exact command used on the PR branch (`85a37fa8`):

```bash
node --import tsx /private/tmp/proof-90539-foundry-payload.ts /Users/allahyar/Documents/fastino-tasks/openclaw-tui-90520
```

After-fix output:

```json
{
  "provider": "microsoft-foundry-9433",
  "model": "DeepSeek-V4-Pro",
  "api": "openai-completions",
  "payloadKeys": [
    "messages",
    "reasoning_effort"
  ],
  "hasTopLevelThinking": false,
  "payload": {
    "reasoning_effort": "high",
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }
}
```

For comparison, the same runtime payload probe on clean `origin/main` (`afa04d64`) produced the rejected top-level `thinking` field:

```bash
git worktree add /private/tmp/openclaw-90539-base-proof origin/main
ln -s /Users/allahyar/Documents/fastino-tasks/openclaw-tui-90520/node_modules /private/tmp/openclaw-90539-base-proof/node_modules
node --import tsx /private/tmp/proof-90539-foundry-payload.ts /private/tmp/openclaw-90539-base-proof
```

Before-fix output:

```json
{
  "provider": "microsoft-foundry-9433",
  "model": "DeepSeek-V4-Pro",
  "api": "openai-completions",
  "payloadKeys": [
    "messages",
    "reasoning_effort",
    "thinking"
  ],
  "hasTopLevelThinking": true,
  "payload": {
    "reasoning_effort": "high",
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ],
    "thinking": {
      "type": "enabled"
    }
  }
}
```

Observed result after fix: the Foundry alias payload keeps `reasoning_effort: "high"` and no longer includes a top-level `thinking` field.

### Focused regression test

Exact command run after this patch:

```bash
pnpm test src/agents/embedded-agent-runner-extraparams.test.ts
```

Evidence after fix:

```text
$ node scripts/test-projects.mjs src/agents/embedded-agent-runner-extraparams.test.ts
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.7 /Users/allahyar/Documents/fastino-tasks/openclaw-tui-90520

 Test Files  1 passed (1)
      Tests  132 passed (132)
   Start at  05:06:55
   Duration  3.11s (transform 2.24s, setup 194ms, import 2.77s, tests 68ms, environment 0ms)

[test] passed 1 Vitest shard in 5.75s
```
