### PR TITLE
fix(mentions): enforce scoped regex pattern allowlists

### DIFF
--- a/extensions/discord/src/config-ui-hints.ts
+++ b/extensions/discord/src/config-ui-hints.ts
@@ -24,11 +24,11 @@ export const discordChannelConfigUiHints = {
   },
   "mentionPatterns.mode": {
     label: "Discord Mention Pattern Mode",
-    help: '"allow" enables configured regex mention patterns unless denyIn matches; "deny" disables them unless allowIn matches.',
+    help: '"allow" enables configured regex mention patterns only when allowIn matches; "deny" also requires allowIn. denyIn always wins.',
   },
   "mentionPatterns.allowIn": {
     label: "Discord Mention Pattern Allowlist",
-    help: "Discord channel IDs where configured regex mention patterns are enabled when mode is deny.",
+    help: "Discord channel IDs where configured regex mention patterns are enabled for scoped provider policies.",
   },
   "mentionPatterns.denyIn": {
     label: "Discord Mention Pattern Denylist",

--- a/extensions/matrix/src/config-ui-hints.ts
+++ b/extensions/matrix/src/config-ui-hints.ts
@@ -8,11 +8,11 @@ export const matrixChannelConfigUiHints = {
   },
   "mentionPatterns.mode": {
     label: "Matrix Mention Pattern Mode",
-    help: '"allow" enables configured regex mention patterns unless denyIn matches; "deny" disables them unless allowIn matches.',
+    help: '"allow" enables configured regex mention patterns only when allowIn matches; "deny" also requires allowIn. denyIn always wins.',
   },
   "mentionPatterns.allowIn": {
     label: "Matrix Mention Pattern Allowlist",
-    help: "Matrix room IDs where configured regex mention patterns are enabled when mode is deny.",
+    help: "Matrix room IDs where configured regex mention patterns are enabled for scoped provider policies.",
   },
   "mentionPatterns.denyIn": {
     label: "Matrix Mention Pattern Denylist",

--- a/extensions/slack/src/config-ui-hints.ts
+++ b/extensions/slack/src/config-ui-hints.ts
@@ -24,11 +24,11 @@ export const slackChannelConfigUiHints = {
   },
   "mentionPatterns.mode": {
     label: "Slack Mention Pattern Mode",
-    help: '"allow" enables configured regex mention patterns unless denyIn matches; "deny" disables them unless allowIn matches.',
+    help: '"allow" enables configured regex mention patterns only when allowIn matches; "deny" also requires allowIn. denyIn always wins.',
   },
   "mentionPatterns.allowIn": {
     label: "Slack Mention Pattern Allowlist",
-    help: "Slack channel IDs where configured regex mention patterns are enabled when mode is deny.",
+    help: "Slack channel IDs where configured regex mention patterns are enabled for scoped provider policies.",
   },
   "mentionPatterns.denyIn": {
     label: "Slack Mention Pattern Denylist",

--- a/extensions/telegram/src/config-ui-hints.ts
+++ b/extensions/telegram/src/config-ui-hints.ts
@@ -28,11 +28,11 @@ export const telegramChannelConfigUiHints = {
   },
   "mentionPatterns.mode": {
     label: "Telegram Mention Pattern Mode",
-    help: '"allow" enables configured regex mention patterns unless denyIn matches; "deny" disables them unless allowIn matches.',
+    help: '"allow" enables configured regex mention patterns only when allowIn matches; "deny" also requires allowIn. denyIn always wins.',
   },
   "mentionPatterns.allowIn": {
     label: "Telegram Mention Pattern Allowlist",
-    help: "Telegram group chat IDs or chatId:topic:threadId topic IDs where configured regex mention patterns are enabled when mode is deny.",
+    help: "Telegram group chat IDs or chatId:topic:threadId topic IDs where configured regex mention patterns are enabled for scoped provider policies.",
   },
   "mentionPatterns.denyIn": {
     label: "Telegram Mention Pattern Denylist",

--- a/extensions/whatsapp/src/config-ui-hints.ts
+++ b/extensions/whatsapp/src/config-ui-hints.ts
@@ -28,11 +28,11 @@ export const whatsAppChannelConfigUiHints = {
   },
   "mentionPatterns.mode": {
     label: "WhatsApp Mention Pattern Mode",
-    help: '"allow" enables configured regex mention patterns unless denyIn matches; "deny" disables them unless allowIn matches.',
+    help: '"allow" enables configured regex mention patterns only when allowIn matches; "deny" also requires allowIn. denyIn always wins.',
   },
   "mentionPatterns.allowIn": {
     label: "WhatsApp Mention Pattern Allowlist",
-    help: "WhatsApp conversation IDs where configured regex mention patterns are enabled when mode is deny.",
+    help: "WhatsApp conversation IDs where configured regex mention patterns are enabled for scoped provider policies.",
   },
   "mentionPatterns.denyIn": {
     label: "WhatsApp Mention Pattern Denylist",

--- a/src/channels/mention-gating.test.ts
+++ b/src/channels/mention-gating.test.ts
@@ -6,6 +6,7 @@ import {
   resolveMentionGating,
   resolveMentionGatingWithBypass,
 } from "./mention-gating.js";
+import { resolveMentionPatternPolicy } from "./mention-pattern-policy.js";
 
 describe("resolveMentionGating", () => {
   it("combines explicit, implicit, and bypass mentions", () => {
@@ -60,6 +61,80 @@ describe("resolveMentionGatingWithBypass", () => {
     });
     expect(res.shouldBypassMention).toBe(shouldBypassMention);
     expect(res.shouldSkip).toBe(shouldSkip);
+  });
+});
+
+describe("resolveMentionPatternPolicy", () => {
+  it("keeps regex mention patterns enabled when no provider policy is configured", () => {
+    const res = resolveMentionPatternPolicy({
+      provider: "matrix",
+      conversationId: "!room:example.test",
+    });
+    expect(res.enabled).toBe(true);
+  });
+
+  it("keeps regex mention patterns enabled for an empty provider policy", () => {
+    const res = resolveMentionPatternPolicy({
+      providerPolicy: {},
+      conversationId: "!room:example.test",
+    });
+    expect(res.enabled).toBe(true);
+  });
+
+  it("requires allowIn to match when provider policy explicitly uses allow mode", () => {
+    const res = resolveMentionPatternPolicy({
+      providerPolicy: {
+        mode: "allow",
+        allowIn: ["!the-donghouse:example.test"],
+      },
+      conversationId: "!bottoy:example.test",
+    });
+    expect(res.allowMatched).toBe(false);
+    expect(res.enabled).toBe(false);
+  });
+
+  it("enables explicit allow mode when allowIn matches", () => {
+    const res = resolveMentionPatternPolicy({
+      providerPolicy: {
+        mode: "allow",
+        allowIn: ["!the-donghouse:example.test"],
+      },
+      conversationId: "!the-donghouse:example.test",
+    });
+    expect(res.allowMatched).toBe(true);
+    expect(res.enabled).toBe(true);
+  });
+
+  it("keeps denyIn precedence over explicit allow mode matches", () => {
+    const res = resolveMentionPatternPolicy({
+      providerPolicy: {
+        mode: "allow",
+        allowIn: ["!the-donghouse:example.test"],
+        denyIn: ["!the-donghouse:example.test"],
+      },
+      conversationId: "!the-donghouse:example.test",
+    });
+    expect(res.allowMatched).toBe(true);
+    expect(res.denyMatched).toBe(true);
+    expect(res.enabled).toBe(false);
+  });
+
+  it("resolves provider policy from OpenClaw config", () => {
+    const res = resolveMentionPatternPolicy({
+      cfg: {
+        channels: {
+          matrix: {
+            mentionPatterns: {
+              mode: "allow",
+              allowIn: ["!the-donghouse:example.test", "!scoob-admin:example.test"],
+            },
+          },
+        },
+      },
+      provider: "matrix",
+      conversationId: "!bottoy:example.test",
+    });
+    expect(res.enabled).toBe(false);
   });
 });
 

--- a/src/channels/mention-pattern-policy.ts
+++ b/src/channels/mention-pattern-policy.ts
@@ -72,13 +72,19 @@ export function resolveMentionPatternPolicy(
     providerPolicy?.mode === "allow" || providerPolicy?.mode === "deny"
       ? providerPolicy.mode
       : "allow";
+  const hasExplicitAllowMode = providerPolicy?.mode === "allow";
   const allowMatched =
     conversationId != null && normalizeIdList(providerPolicy?.allowIn).has(conversationId);
   const denyMatched =
     conversationId != null && normalizeIdList(providerPolicy?.denyIn).has(conversationId);
-  // Deny always wins. In allow mode everything is enabled except explicit denies; in deny mode
-  // only explicitly allowed conversations are enabled.
-  const enabled = effectiveMode === "allow" ? !denyMatched : allowMatched && !denyMatched;
+  // Deny always wins. Preserve legacy permissive behavior when no provider policy is configured,
+  // but treat an explicit provider allow mode as an allowlist scoped by allowIn.
+  const enabled =
+    effectiveMode === "allow"
+      ? hasExplicitAllowMode
+        ? allowMatched && !denyMatched
+        : !denyMatched
+      : allowMatched && !denyMatched;
 
   return { effectiveMode, allowMatched, denyMatched, enabled };
 }


### PR DESCRIPTION
Follow-up to #70864.

## Summary
- Treat explicit provider `mentionPatterns.mode: "allow"` as an allowlist scoped by `allowIn` instead of enabling regex mention patterns everywhere except `denyIn`.
- Preserve backward-compatible permissive behavior when no provider mentionPatterns policy is configured, and keep `denyIn` precedence.
- Update provider config UI hints so the documented semantics match the resolver.
- Add focused channel gating coverage for legacy default, empty policy, explicit allowlist miss/match, deny precedence, and config-derived Matrix policy.

## Verification
- `pnpm test -- --run src/channels/mention-gating.test.ts`

## Runtime check
- Hotpatched and verified on Scoob/OpenClaw 2026.6.1 before opening this PR: Matrix #bottoy/geeks regex name mentions are disabled, while #the-donghouse and scoob admin remain enabled.