### PR TITLE
Enable session pruning by default for all providers

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -55,30 +55,42 @@ persist raw image blocks or prompt-hydration media markers in history.
 
 ## Smart defaults
 
-OpenClaw auto-enables pruning for Anthropic profiles:
+OpenClaw enables pruning by default for all providers with a 5-minute cache TTL.
+Anthropic profiles get an extended 1-hour TTL and automatic heartbeat configuration:
 
-| Profile type                                            | Pruning enabled | Heartbeat |
-| ------------------------------------------------------- | --------------- | --------- |
-| Anthropic OAuth/token auth (including Claude CLI reuse) | Yes             | 1 hour    |
-| API key                                                 | Yes             | 30 min    |
+| Profile type                                            | Pruning enabled | TTL    | Heartbeat |
+| ------------------------------------------------------- | --------------- | ------ | --------- |
+| All providers (default)                                 | Yes             | 5 min  | —         |
+| Anthropic OAuth/token auth (including Claude CLI reuse) | Yes             | 1 hour | 1 hour    |
+| Anthropic API key                                       | Yes             | 1 hour | 30 min    |
 
 If you set explicit values, OpenClaw does not override them.
 
 ## Enable or disable
 
-Pruning is off by default for non-Anthropic providers. To enable:
+Pruning is on by default. To disable:
 
 ```json5
 {
   agents: {
     defaults: {
-      contextPruning: { mode: "cache-ttl", ttl: "5m" },
+      contextPruning: { mode: "off" },
     },
   },
 }
 ```
 
-To disable: set `mode: "off"`.
+To customize the TTL or other settings:
+
+```json5
+{
+  agents: {
+    defaults: {
+      contextPruning: { mode: "cache-ttl", ttl: "10m" },
+    },
+  },
+}
+```
 
 ## Pruning vs compaction
 

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -51,14 +51,19 @@ describe("config defaults", () => {
     expect(mocks.applyProviderConfigDefaultsForConfig).not.toHaveBeenCalled();
   });
 
-  it("skips provider defaults when agent defaults have no Anthropic auth signal", () => {
+  it("enables cache-ttl pruning by default when agent defaults have no Anthropic auth signal", () => {
     const cfg = {
       agents: {
         defaults: {},
       },
     };
 
-    expect(applyContextPruningDefaults(cfg as never)).toBe(cfg);
+    const next = applyContextPruningDefaults(cfg as never);
+    expect(next).not.toBe(cfg);
+    expect(next.agents?.defaults?.contextPruning).toEqual({
+      mode: "cache-ttl",
+      ttl: "5m",
+    });
     expect(mocks.applyProviderConfigDefaultsForConfig).not.toHaveBeenCalled();
   });
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -513,17 +513,39 @@ export function applyContextPruningDefaults(
   if (!cfg.agents?.defaults) {
     return cfg;
   }
-  if (!hasAnthropicDefaultSignal(cfg, process.env)) {
-    return cfg;
+
+  let next = cfg;
+
+  // Apply Anthropic-specific defaults (1h TTL, heartbeat) if Anthropic auth is present.
+  if (hasAnthropicDefaultSignal(cfg, process.env)) {
+    next =
+      applyProviderConfigDefaultsForConfig({
+        provider: "anthropic",
+        config: cfg,
+        env: process.env,
+        manifestRegistry: options.manifestRegistry,
+      }) ?? cfg;
   }
-  return (
-    applyProviderConfigDefaultsForConfig({
-      provider: "anthropic",
-      config: cfg,
-      env: process.env,
-      manifestRegistry: options.manifestRegistry,
-    }) ?? cfg
-  );
+
+  // Enable cache-TTL pruning by default for all providers when not explicitly configured.
+  if (next.agents?.defaults?.contextPruning?.mode === undefined) {
+    const nextDefaults = { ...next.agents.defaults };
+    const contextPruning = nextDefaults.contextPruning ?? {};
+    nextDefaults.contextPruning = {
+      ...contextPruning,
+      mode: "cache-ttl",
+      ttl: contextPruning.ttl ?? "5m",
+    };
+    next = {
+      ...next,
+      agents: {
+        ...next.agents,
+        defaults: nextDefaults,
+      },
+    };
+  }
+
+  return next;
 }
 
 export function applyCompactionDefaults(cfg: OpenClawConfig): OpenClawConfig {


### PR DESCRIPTION
## Summary

Enables session pruning (`contextPruning`) by default for **all providers**, not just Anthropic.

## Problem

Currently, `contextPruning` (cache-TTL based tool result trimming) is only auto-enabled when Anthropic auth is detected. Non-Anthropic providers have pruning off by default, requiring explicit opt-in:

```json5
{
  agents: {
    defaults: {
      contextPruning: { mode: "cache-ttl", ttl: "5m" },
    },
  },
}
```

This means most OpenClaw deployments are running without pruning, accumulating unnecessary tool output in context and driving up costs.

## Solution

The `applyContextPruningDefaults` function now:

1. Still applies Anthropic-specific defaults (1h TTL, heartbeat) when Anthropic auth is detected
2. **Additionally** enables `cache-ttl` pruning with `ttl: "5m"` for all providers when the user hasn't explicitly configured `contextPruning.mode`

## User impact

- **If you haven't set `contextPruning`**: pruning is now on by default (5min TTL). This reduces context bloat from accumulated tool outputs between compaction cycles.
- **If you've explicitly set `contextPruning.mode`** (including `"off"`): no change — your explicit setting is preserved.
- **Anthropic users**: no change — the 1h TTL and heartbeat configuration continue to apply.

To disable: `contextPruning: { mode: "off" }`

## Files changed

- `src/config/defaults.ts` — Always enable default pruning when not explicitly configured
- `src/config/defaults.test.ts` — Updated test to reflect new default behavior
- `docs/concepts/session-pruning.md` — Updated docs to reflect all-provider defaults
