### PR TITLE
docs: map guanbear clawtributor emails

### DIFF
--- a/scripts/clawtributors-map.json
+++ b/scripts/clawtributors-map.json
@@ -31,6 +31,8 @@
     "django navarro": "djangonavarro220"
   },
   "emailToLogin": {
+    "123guan@gmail.com": "guanbear",
+    "guanbear@macmini.bearhome": "guanbear",
     "steipete@gmail.com": "steipete",
     "sbarrios93@gmail.com": "sebslight",
     "rltorres26+github@gmail.com": "RandyVentures",


### PR DESCRIPTION
## Summary
- Map the commit author emails used by already-merged guanbear contributions to the `guanbear` GitHub login in `scripts/clawtributors-map.json`.
- This keeps the clawtributors generator attribution-based instead of adding a manual `ensureLogins` entry.

## Context
- Existing merged PRs authored by `guanbear` include #80037 and #85904.
- GitHub contributors API currently reports the relevant author as anonymous (`guanbear <123guan@gmail.com>`), and the original commits also used `guanbear@macmini.bearhome`, so the generated README clawtributors wall cannot resolve the login without this mapping.

## Verification
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("scripts/clawtributors-map.json","utf8")); console.log("json ok")'`
- `git diff --check`

Note: I attempted to run `pnpm exec tsx scripts/update-clawtributors.ts`, but the local shallow worktree first missed seed commit `d6863f87`; after fetching that object, the generator stalled while resolving user metadata through GitHub API. This PR therefore keeps the change to the attribution mapping only, so the README can be regenerated in maintainer/CI environment.

## Real behavior proof

Behavior addressed: The clawtributors generator can resolve the existing merged OpenClaw contribution author emails used by guanbear to the GitHub login `guanbear`, instead of leaving those contributions as anonymous contributor entries.

Real environment tested: Local OpenClaw checkout on macOS, PR branch `clawtributors-guanbear-map` at head `8dea78191cea9e1a17ec725e285fc2c76181ed85`, using GitHub API responses from `openclaw/openclaw` and the real `scripts/clawtributors-map.json` file.

Exact steps or command run after this patch: Verified Git author config now uses the GitHub-associated email; queried GitHub commits for the merged PRs #80037 and #85904; queried the OpenClaw contributors API; parsed `scripts/clawtributors-map.json` as JSON; checked whitespace with `git diff --check`.

Evidence after fix:

```text
git config --global user.name
guanbear

git config --global user.email
123guan@gmail.com

node -e 'const fs=require("fs"); const map=JSON.parse(fs.readFileSync("scripts/clawtributors-map.json","utf8")); console.log(JSON.stringify({"123guan@gmail.com":map.emailToLogin["123guan@gmail.com"],"guanbear@macmini.bearhome":map.emailToLogin["guanbear@macmini.bearhome"]}))'
{"123guan@gmail.com":"guanbear","guanbear@macmini.bearhome":"guanbear"}

gh api repos/openclaw/openclaw/commits/044f5a814e35288c0b70014cac71aec98de81d14 --jq '{author_login:(.author.login // null), email:.commit.author.email, name:.commit.author.name}'
{"author_login":"guanbear","email":"123guan@gmail.com","name":"guanbear"}

gh api repos/openclaw/openclaw/contributors?per_page=100\&anon=1 --paginate --jq '.[] | select(.email=="123guan@gmail.com") | {login,name,email,contributions}'
{"login":null,"name":"guanbear","email":"123guan@gmail.com","contributions":2}

git diff --check
exit 0
```

Observed result after fix: The map now contains both author emails used by the already-merged guanbear contributions, and those emails resolve to `guanbear` through the same `emailToLogin` mechanism the clawtributors generator already uses for attribution correction.

What was not tested: I attempted to run the full README generator locally. The local shallow worktree first lacked seed commit `d6863f87`; after fetching that seed object, the generator stalled while resolving GitHub user metadata. I did not commit a regenerated README from the partial local run; this PR intentionally keeps the patch to the attribution map only.

